### PR TITLE
[fix](nereids) Fix infer name is invalid when the child output select field of union all is literal

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/MappingSlot.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/MappingSlot.java
@@ -38,7 +38,7 @@ public class MappingSlot extends Slot {
     private final Expression mappingExpression;
 
     public MappingSlot(Slot slot, Expression mappingExpression) {
-        super(Optional.empty());
+        super(Optional.empty(), true);
         this.slot = slot;
         this.mappingExpression = mappingExpression;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundAlias.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundAlias.java
@@ -53,11 +53,11 @@ public class UnboundAlias extends NamedExpression implements UnaryExpression, Un
     }
 
     private UnboundAlias(List<Expression> children, Optional<String> alias) {
-        this(children, alias, false);
+        this(children, alias, !alias.isPresent());
     }
 
     private UnboundAlias(List<Expression> children, Optional<String> alias, boolean nameFromChild) {
-        super(children);
+        super(children, nameFromChild);
         this.alias = alias;
         this.nameFromChild = nameFromChild;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundSlot.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundSlot.java
@@ -46,7 +46,7 @@ public class UnboundSlot extends Slot implements Unbound, PropagateNullable {
     }
 
     public UnboundSlot(List<String> nameParts, Optional<Pair<Integer, Integer>> indexInSqlString) {
-        super(indexInSqlString);
+        super(indexInSqlString, true);
         this.nameParts = ImmutableList.copyOf(Objects.requireNonNull(nameParts, "nameParts can not be null"));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundStar.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundStar.java
@@ -47,7 +47,7 @@ public class UnboundStar extends Slot implements LeafExpression, Unbound, Propag
     private final List<NamedExpression> replacedAlias;
 
     public UnboundStar(List<String> qualifier) {
-        super(Optional.empty());
+        super(Optional.empty(), false);
         this.qualifier = Objects.requireNonNull(ImmutableList.copyOf(qualifier), "qualifier can not be null");
         this.indexInSqlString = Optional.empty();
         this.exceptedSlots = ImmutableList.of();
@@ -55,7 +55,7 @@ public class UnboundStar extends Slot implements LeafExpression, Unbound, Propag
     }
 
     public UnboundStar(List<String> qualifier, Optional<Pair<Integer, Integer>> indexInSqlString) {
-        super(Optional.empty());
+        super(Optional.empty(), false);
         this.qualifier = Objects.requireNonNull(ImmutableList.copyOf(qualifier), "qualifier can not be null");
         this.indexInSqlString = indexInSqlString;
         this.exceptedSlots = ImmutableList.of();
@@ -71,7 +71,7 @@ public class UnboundStar extends Slot implements LeafExpression, Unbound, Propag
      */
     public UnboundStar(List<String> qualifier, List<NamedExpression> exceptedSlots,
             List<NamedExpression> replacedAlias) {
-        super(Optional.empty());
+        super(Optional.empty(), false);
         this.qualifier = Objects.requireNonNull(ImmutableList.copyOf(qualifier), "qualifier can not be null");
         this.indexInSqlString = Optional.empty();
         this.exceptedSlots = Objects.requireNonNull(ImmutableList.copyOf(exceptedSlots),
@@ -90,7 +90,7 @@ public class UnboundStar extends Slot implements LeafExpression, Unbound, Propag
      */
     public UnboundStar(List<String> qualifier, List<NamedExpression> exceptedSlots, List<NamedExpression> replacedAlias,
             Optional<Pair<Integer, Integer>> indexInSqlString) {
-        super(Optional.empty());
+        super(Optional.empty(), false);
         this.qualifier = Objects.requireNonNull(ImmutableList.copyOf(qualifier), "qualifier can not be null");
         this.indexInSqlString = indexInSqlString;
         this.exceptedSlots = Objects.requireNonNull(ImmutableList.copyOf(exceptedSlots),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -2917,7 +2917,8 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
                 // and the original exprId should be retained at this time.
                 groupSlots.add((SlotReference) e);
             } else {
-                groupSlots.add(new SlotReference(e.toSql(), e.getDataType(), e.nullable(), ImmutableList.of()));
+                groupSlots.add(new SlotReference(e.toSql(), e.getDataType(), e.nullable(), ImmutableList.of(),
+                        true));
             }
         }
         return groupSlots;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindExpression.java
@@ -287,7 +287,7 @@ public class BindExpression implements AnalysisRuleFactory {
             boundGenerators.add(generator);
 
             Slot boundSlot = new SlotReference(slot.getNameParts().get(1), generator.getDataType(),
-                    generator.nullable(), ImmutableList.of(slot.getNameParts().get(0)));
+                    generator.nullable(), ImmutableList.of(slot.getNameParts().get(0)), slot.isNameFromChild());
             outputSlots.add(boundSlot);
             // the boundSlot may has two situation:
             // 1. the expandColumnsAlias is not empty, we should use make boundSlot expand to multi alias

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
@@ -407,7 +407,7 @@ public class ExpressionAnalyzer extends SubExprAnalyzer<ExpressionRewriteContext
                     && unboundFunction.child(0) instanceof UnboundSlot) {
                 SlotReference slotReference = new SlotReference(new ExprId(-1),
                         ((UnboundSlot) unboundFunction.child(0)).getName(),
-                        TinyIntType.INSTANCE, false, ImmutableList.of());
+                        TinyIntType.INSTANCE, false, ImmutableList.of(), true);
                 ImmutableList.Builder<Expression> newChildrenBuilder = ImmutableList.builder();
                 newChildrenBuilder.add(slotReference);
                 for (int i = 1; i < unboundFunction.arity(); i++) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ColumnPruning.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ColumnPruning.java
@@ -427,7 +427,7 @@ public class ColumnPruning extends DefaultPlanRewriter<PruneContext> implements 
             // process prune all columns
             NamedExpression originSlot = originOutput.get(0);
             prunedOutputs = ImmutableList.of(new SlotReference(originSlot.getExprId(), originSlot.getName(),
-                    TinyIntType.INSTANCE, false, originSlot.getQualifier()));
+                    TinyIntType.INSTANCE, false, originSlot.getQualifier(), originSlot.isNameFromChild()));
             regularChildrenOutputs = Lists.newArrayListWithCapacity(regularChildrenOutputs.size());
             children = Lists.newArrayListWithCapacity(children.size());
             for (int i = 0; i < union.getArity(); i++) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushCountIntoUnionAll.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushCountIntoUnionAll.java
@@ -110,7 +110,8 @@ public class PushCountIntoUnionAll implements RewriteRuleFactory {
         List<NamedExpression> newLogicalUnionOutputs = Lists.newArrayList();
         for (NamedExpression ce : upperOutputExpressions) {
             if (ce instanceof Alias) {
-                newLogicalUnionOutputs.add(new SlotReference(ce.getName(), ce.getDataType(), ce.nullable()));
+                newLogicalUnionOutputs.add(new SlotReference(ce.getName(), ce.getDataType(), ce.nullable(),
+                        ce.isNameFromChild()));
             } else if (ce instanceof SlotReference) {
                 newLogicalUnionOutputs.add(ce);
             } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushProjectThroughUnion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushProjectThroughUnion.java
@@ -111,7 +111,8 @@ public class PushProjectThroughUnion extends OneRewriteRuleFactory {
                         = ExpressionUtils.replaceNameExpression(selectItem, replaceMap);
                 NamedExpression childProject = newSelectItem;
                 if (newSelectItem instanceof Alias) {
-                    childProject = new Alias(((Alias) newSelectItem).child(), newSelectItem.getName());
+                    childProject = new Alias(((Alias) newSelectItem).child(), newSelectItem.getName(),
+                            newSelectItem.isNameFromChild());
                 }
                 childProjections.add(childProject);
                 childOutputSlots.add((SlotReference) childProject.toSlot());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/VariantSubPathPruning.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/VariantSubPathPruning.java
@@ -341,7 +341,7 @@ public class VariantSubPathPruning extends DefaultPlanRewriter<PruneContext> imp
                     }
                     SlotReference outputSlot = new SlotReference(StatementScopeIdGenerator.newExprId(),
                             entry.getValue().get(0).getName(), entry.getValue().get(0).getDataType(),
-                            true, ImmutableList.of());
+                            true, ImmutableList.of(), entry.getValue().get(0).isNameFromChild());
                     outputs.add(outputSlot);
                     // update element to slot map
                     Map<List<String>, SlotReference> s = oriSlotToSubPathToSlot.computeIfAbsent(

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/copier/ExpressionDeepCopier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/copier/ExpressionDeepCopier.java
@@ -99,7 +99,7 @@ public class ExpressionDeepCopier extends DefaultExpressionRewriter<DeepCopierCo
         VirtualSlotReference newOne = new VirtualSlotReference(newExprId,
                 virtualSlotReference.getName(), virtualSlotReference.getDataType(),
                 virtualSlotReference.nullable(), virtualSlotReference.getQualifier(),
-                newOriginExpression, newFunction);
+                newOriginExpression, newFunction, virtualSlotReference.isNameFromChild());
         exprIdReplaceMap.put(virtualSlotReference.getExprId(), newOne.getExprId());
         return newOne;
     }
@@ -111,9 +111,9 @@ public class ExpressionDeepCopier extends DefaultExpressionRewriter<DeepCopierCo
         ArrayItemReference newOne;
         if (exprIdReplaceMap.containsKey(arrayItemSlot.getExprId())) {
             newOne = new ArrayItemReference(exprIdReplaceMap.get(arrayItemSlot.getExprId()),
-                    arrayItemSlot.getName(), arrayExpression);
+                    arrayItemSlot.getName(), arrayExpression, arrayItemSlot.isNameFromChild());
         } else {
-            newOne = new ArrayItemReference(arrayItemSlot.getName(), arrayExpression);
+            newOne = new ArrayItemReference(arrayItemSlot.getName(), arrayExpression, arrayItemSlot.isNameFromChild());
             exprIdReplaceMap.put(arrayItemSlot.getExprId(), newOne.getExprId());
         }
         return newOne;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Alias.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Alias.java
@@ -40,7 +40,6 @@ public class Alias extends NamedExpression implements UnaryExpression {
     private final ExprId exprId;
     private final Supplier<String> name;
     private final List<String> qualifier;
-    private final boolean nameFromChild;
 
     /**
      * constructor of Alias.
@@ -83,11 +82,10 @@ public class Alias extends NamedExpression implements UnaryExpression {
 
     private Alias(ExprId exprId, List<Expression> child, Supplier<String> name,
             List<String> qualifier, boolean nameFromChild) {
-        super(child);
+        super(child, nameFromChild);
         this.exprId = exprId;
         this.name = name;
         this.qualifier = qualifier;
-        this.nameFromChild = nameFromChild;
     }
 
     @Override
@@ -100,7 +98,8 @@ public class Alias extends NamedExpression implements UnaryExpression {
                 slotReference != null ? slotReference.getOriginalColumn().orElse(null) : null,
                 slotReference != null ? ((SlotReference) child()).getOneLevelTable().orElse(null) : null,
                 slotReference != null ? slotReference.getOriginalColumn().orElse(null) : null,
-                slotReference != null ? slotReference.getSubPath() : ImmutableList.of(), Optional.empty()
+                slotReference != null ? slotReference.getSubPath() : ImmutableList.of(), Optional.empty(),
+                nameFromChild
         );
     }
 
@@ -175,6 +174,7 @@ public class Alias extends NamedExpression implements UnaryExpression {
         return visitor.visitAlias(this, context);
     }
 
+    @Override
     public boolean isNameFromChild() {
         return nameFromChild;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ArrayItemReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ArrayItemReference.java
@@ -39,12 +39,12 @@ public class ArrayItemReference extends NamedExpression implements ExpectsInputT
     protected final String name;
 
     /** ArrayItemReference */
-    public ArrayItemReference(String name, Expression arrayExpression) {
-        this(StatementScopeIdGenerator.newExprId(), name, arrayExpression);
+    public ArrayItemReference(String name, Expression arrayExpression, boolean nameFromChild) {
+        this(StatementScopeIdGenerator.newExprId(), name, arrayExpression, nameFromChild);
     }
 
-    public ArrayItemReference(ExprId exprId, String name, Expression arrayExpression) {
-        super(ImmutableList.of(arrayExpression));
+    public ArrayItemReference(ExprId exprId, String name, Expression arrayExpression, boolean nameFromChild) {
+        super(ImmutableList.of(arrayExpression), nameFromChild);
         Preconditions.checkArgument(arrayExpression.getDataType() instanceof ArrayType,
                 String.format("ArrayItemReference' child %s must return array", child(0)));
         this.exprId = exprId;
@@ -82,7 +82,7 @@ public class ArrayItemReference extends NamedExpression implements ExpectsInputT
 
     @Override
     public ArrayItemReference withChildren(List<Expression> expressions) {
-        return new ArrayItemReference(exprId, name, expressions.get(0));
+        return new ArrayItemReference(exprId, name, expressions.get(0), nameFromChild);
     }
 
     @Override
@@ -97,7 +97,7 @@ public class ArrayItemReference extends NamedExpression implements ExpectsInputT
 
     @Override
     public Slot toSlot() {
-        return new ArrayItemSlot(exprId, name, getDataType(), nullable());
+        return new ArrayItemSlot(exprId, name, getDataType(), nullable(), nameFromChild);
     }
 
     @Override
@@ -141,29 +141,31 @@ public class ArrayItemReference extends NamedExpression implements ExpectsInputT
          * @param dataType slot reference logical data type
          * @param nullable true if nullable
          */
-        public ArrayItemSlot(ExprId exprId, String name, DataType dataType, boolean nullable) {
+        public ArrayItemSlot(ExprId exprId, String name, DataType dataType, boolean nullable, boolean nameFromChild) {
             super(exprId, name, dataType, nullable, ImmutableList.of(),
-                    null, null, null, null, ImmutableList.of());
+                    null, null, null, null, ImmutableList.of(),
+                    nameFromChild);
         }
 
         @Override
         public ArrayItemSlot withExprId(ExprId exprId) {
-            return new ArrayItemSlot(exprId, name.get(), dataType, nullable);
+            return new ArrayItemSlot(exprId, name.get(), dataType, nullable, nameFromChild);
         }
 
         @Override
         public ArrayItemSlot withName(String name) {
-            return new ArrayItemSlot(exprId, name, dataType, nullable);
+            return new ArrayItemSlot(exprId, name, dataType, nullable,
+                    nameFromChild);
         }
 
         @Override
         public SlotReference withNullable(boolean nullable) {
-            return new ArrayItemSlot(exprId, name.get(), dataType, this.nullable);
+            return new ArrayItemSlot(exprId, name.get(), dataType, this.nullable, nameFromChild);
         }
 
         @Override
         public Slot withNullableAndDataType(boolean nullable, DataType dataType) {
-            return new ArrayItemSlot(exprId, name.get(), dataType, nullable);
+            return new ArrayItemSlot(exprId, name.get(), dataType, nullable, nameFromChild);
         }
 
         @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/BoundStar.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/BoundStar.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 public class BoundStar extends NamedExpression implements PropagateNullable {
     /** BoundStar */
     public BoundStar(List<Slot> children) {
-        super((List) children);
+        super((List) children, true);
 
         for (Slot slot : children) {
             if (slot instanceof UnboundSlot) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/DefaultValueSlot.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/DefaultValueSlot.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 public class DefaultValueSlot extends Slot {
 
     public DefaultValueSlot() {
-        super(Optional.empty());
+        super(Optional.empty(), true);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/MarkJoinSlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/MarkJoinSlotReference.java
@@ -30,17 +30,17 @@ public class MarkJoinSlotReference extends SlotReference {
     final boolean existsHasAgg;
 
     public MarkJoinSlotReference(String name) {
-        super(name, BooleanType.INSTANCE, true);
+        super(name, BooleanType.INSTANCE, true, false);
         this.existsHasAgg = false;
     }
 
     public MarkJoinSlotReference(String name, boolean existsHasAgg) {
-        super(name, BooleanType.INSTANCE, true);
+        super(name, BooleanType.INSTANCE, true, false);
         this.existsHasAgg = existsHasAgg;
     }
 
     public MarkJoinSlotReference(ExprId exprId, String name, boolean existsHasAgg) {
-        super(exprId, name, BooleanType.INSTANCE, true, ImmutableList.of());
+        super(exprId, name, BooleanType.INSTANCE, true, ImmutableList.of(), false);
         this.existsHasAgg = existsHasAgg;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/NamedExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/NamedExpression.java
@@ -28,8 +28,14 @@ import java.util.Optional;
  */
 public abstract class NamedExpression extends Expression {
 
-    protected NamedExpression(List<Expression> children) {
+    // Identify whether the name in NamedExpression comes from the child or is custom-defined. This field is
+    // used for column name derivation, and the derived column name must be valid.
+    // It will be used when creating views and tables
+    protected final boolean nameFromChild;
+
+    protected NamedExpression(List<Expression> children, boolean nameFromChild) {
         super(children);
+        this.nameFromChild = nameFromChild;
     }
 
     public Slot toSlot() throws UnboundException {
@@ -50,6 +56,11 @@ public abstract class NamedExpression extends Expression {
 
     public String getJoinQualifier() {
         return String.join(".", getQualifier());
+    }
+
+    //
+    public boolean isNameFromChild() {
+        return nameFromChild;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Slot.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Slot.java
@@ -36,8 +36,8 @@ public abstract class Slot extends NamedExpression implements LeafExpression {
     // (e.g. "col1", "t1.col1", "db1.t1.col1", "ctl1.db1.t1.col1")
     protected final Optional<Pair<Integer, Integer>> indexInSqlString;
 
-    protected Slot(Optional<Pair<Integer, Integer>> indexInSqlString) {
-        super(ImmutableList.of());
+    protected Slot(Optional<Pair<Integer, Integer>> indexInSqlString, boolean nameFromChild) {
+        super(ImmutableList.of(), nameFromChild);
         this.indexInSqlString = indexInSqlString;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
@@ -57,39 +57,45 @@ public class SlotReference extends Slot {
     private final TableIf oneLevelTable;
     private final Column oneLevelColumn;
 
-    public SlotReference(String name, DataType dataType) {
+    public SlotReference(String name, DataType dataType, boolean nameFromChild) {
         this(StatementScopeIdGenerator.newExprId(), name, dataType, true, ImmutableList.of(),
-                null, null, null, null, ImmutableList.of());
+                null, null, null, null, ImmutableList.of(),
+                nameFromChild);
     }
 
-    public SlotReference(String name, DataType dataType, boolean nullable) {
+    public SlotReference(String name, DataType dataType, boolean nullable, boolean nameFromChild) {
         this(StatementScopeIdGenerator.newExprId(), name, dataType, nullable, ImmutableList.of(),
-                null, null, null, null, ImmutableList.of());
+                null, null, null, null, ImmutableList.of(),
+                nameFromChild);
     }
 
-    public SlotReference(String name, DataType dataType, boolean nullable, List<String> qualifier) {
+    public SlotReference(String name, DataType dataType, boolean nullable, List<String> qualifier,
+            boolean nameFromChild) {
         this(StatementScopeIdGenerator.newExprId(), name, dataType, nullable,
-                qualifier, null, null, null, null, ImmutableList.of());
+                qualifier, null, null, null, null,
+                ImmutableList.of(), nameFromChild);
     }
 
-    public SlotReference(ExprId exprId, String name, DataType dataType, boolean nullable, List<String> qualifier) {
-        this(exprId, name, dataType, nullable, qualifier, null, null, null, null, ImmutableList.of());
+    public SlotReference(ExprId exprId, String name, DataType dataType, boolean nullable, List<String> qualifier,
+            boolean nameFromChild) {
+        this(exprId, name, dataType, nullable, qualifier, null, null, null,
+                null, ImmutableList.of(), nameFromChild);
     }
 
     public SlotReference(ExprId exprId, String name, DataType dataType, boolean nullable, List<String> qualifier,
             @Nullable TableIf originalTable, @Nullable Column originalColumn,
-            @Nullable TableIf oneLevelTable, @Nullable Column oneLevelColumn) {
+            @Nullable TableIf oneLevelTable, @Nullable Column oneLevelColumn, boolean nameFromChild) {
         this(exprId, name, dataType, nullable, qualifier,
-                originalTable, originalColumn, oneLevelTable, oneLevelColumn, ImmutableList.of());
+                originalTable, originalColumn, oneLevelTable, oneLevelColumn, ImmutableList.of(), nameFromChild);
     }
 
     public SlotReference(ExprId exprId, String name, DataType dataType, boolean nullable, List<String> qualifier,
             @Nullable TableIf originalTable, @Nullable Column originalColumn,
             @Nullable TableIf oneLevelTable, @Nullable Column oneLevelColumn,
-            List<String> subPath) {
+            List<String> subPath, boolean nameFromChild) {
         this(exprId, () -> name, dataType, nullable, qualifier,
                 originalTable, originalColumn, oneLevelTable, oneLevelColumn,
-                subPath, Optional.empty());
+                subPath, Optional.empty(), nameFromChild);
     }
 
     /**
@@ -106,8 +112,8 @@ public class SlotReference extends Slot {
     public SlotReference(ExprId exprId, Supplier<String> name, DataType dataType, boolean nullable,
             List<String> qualifier, @Nullable TableIf originalTable, @Nullable Column originalColumn,
             @Nullable TableIf oneLevelTable, Column oneLevelColumn,
-            List<String> subPath, Optional<Pair<Integer, Integer>> indexInSql) {
-        super(indexInSql);
+            List<String> subPath, Optional<Pair<Integer, Integer>> indexInSql, boolean nameFromChild) {
+        super(indexInSql, nameFromChild);
         this.exprId = exprId;
         this.name = name;
         this.dataType = dataType;
@@ -121,8 +127,8 @@ public class SlotReference extends Slot {
         this.subPath = Objects.requireNonNull(subPath, "subPath can not be null");
     }
 
-    public static SlotReference of(String name, DataType type) {
-        return new SlotReference(name, type);
+    public static SlotReference of(String name, DataType type, boolean nameFromChild) {
+        return new SlotReference(name, type, nameFromChild);
     }
 
     /**
@@ -138,7 +144,7 @@ public class SlotReference extends Slot {
             ExprId exprId, TableIf table, Column column, String name, List<String> qualifier) {
         DataType dataType = DataType.fromCatalogType(column.getType());
         return new SlotReference(exprId, name, dataType,
-            column.isAllowNull(), qualifier, table, column, table, column, ImmutableList.of());
+            column.isAllowNull(), qualifier, table, column, table, column, ImmutableList.of(), false);
     }
 
     @Override
@@ -260,7 +266,7 @@ public class SlotReference extends Slot {
         }
         return new SlotReference(exprId, name, dataType, nullable, qualifier,
                 originalTable, originalColumn, oneLevelTable, oneLevelColumn,
-                subPath, indexInSqlString);
+                subPath, indexInSqlString, nameFromChild);
     }
 
     @Override
@@ -270,14 +276,14 @@ public class SlotReference extends Slot {
         }
         return new SlotReference(exprId, name, dataType, nullable, qualifier,
                 originalTable, originalColumn, oneLevelTable, oneLevelColumn,
-                subPath, indexInSqlString);
+                subPath, indexInSqlString, nameFromChild);
     }
 
     @Override
     public SlotReference withQualifier(List<String> qualifier) {
         return new SlotReference(exprId, name, dataType, nullable, qualifier,
                 originalTable, originalColumn, oneLevelTable, oneLevelColumn,
-                subPath, indexInSqlString);
+                subPath, indexInSqlString, nameFromChild);
     }
 
     @Override
@@ -287,40 +293,40 @@ public class SlotReference extends Slot {
         }
         return new SlotReference(exprId, () -> name, dataType, nullable, qualifier,
                 originalTable, originalColumn, oneLevelTable, oneLevelColumn,
-                subPath, indexInSqlString);
+                subPath, indexInSqlString, nameFromChild);
     }
 
     @Override
     public SlotReference withExprId(ExprId exprId) {
         return new SlotReference(exprId, name, dataType, nullable, qualifier,
                 originalTable, originalColumn, oneLevelTable, oneLevelColumn,
-                subPath, indexInSqlString);
+                subPath, indexInSqlString, nameFromChild);
     }
 
     public SlotReference withSubPath(List<String> subPath) {
         return new SlotReference(exprId, name, dataType, !subPath.isEmpty() || nullable, qualifier,
                 originalTable, originalColumn, oneLevelTable, oneLevelColumn,
-                subPath, indexInSqlString);
+                subPath, indexInSqlString, nameFromChild);
     }
 
     @Override
     public Slot withIndexInSql(Pair<Integer, Integer> index) {
         return new SlotReference(exprId, name, dataType, nullable, qualifier,
                 originalTable, originalColumn, oneLevelTable, oneLevelColumn,
-                subPath, Optional.ofNullable(index));
+                subPath, Optional.ofNullable(index), nameFromChild);
     }
 
     public SlotReference withColumn(Column column) {
         return new SlotReference(exprId, name, dataType, nullable, qualifier,
                 originalTable, column, oneLevelTable, column,
-                subPath, indexInSqlString);
+                subPath, indexInSqlString, nameFromChild);
     }
 
     @Override
     public Slot withOneLevelTableAndColumnAndQualifier(TableIf oneLevelTable, Column column, List<String> qualifier) {
         return new SlotReference(exprId, name, dataType, nullable, qualifier,
                 originalTable, column, oneLevelTable, column,
-                subPath, indexInSqlString);
+                subPath, indexInSqlString, nameFromChild);
     }
 
     public boolean isVisible() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/VirtualSlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/VirtualSlotReference.java
@@ -46,16 +46,16 @@ public class VirtualSlotReference extends SlotReference implements SlotNotFromCh
     private final Function<GroupingSetShapes, List<Long>> computeLongValueMethod;
 
     public VirtualSlotReference(String name, DataType dataType, Optional<GroupingScalarFunction> originExpression,
-            Function<GroupingSetShapes, List<Long>> computeLongValueMethod) {
+            Function<GroupingSetShapes, List<Long>> computeLongValueMethod, boolean nameFromChild) {
         this(StatementScopeIdGenerator.newExprId(), name, dataType, false, ImmutableList.of(),
-                originExpression, computeLongValueMethod);
+                originExpression, computeLongValueMethod, nameFromChild);
     }
 
     /** VirtualSlotReference */
     public VirtualSlotReference(ExprId exprId, String name, DataType dataType,
             boolean nullable, List<String> qualifier, Optional<GroupingScalarFunction> originExpression,
-            Function<GroupingSetShapes, List<Long>> computeLongValueMethod) {
-        super(exprId, name, dataType, nullable, qualifier);
+            Function<GroupingSetShapes, List<Long>> computeLongValueMethod, boolean nameFromChild) {
+        super(exprId, name, dataType, nullable, qualifier, nameFromChild);
         this.originExpression = Objects.requireNonNull(originExpression, "originExpression can not be null");
         this.realExpressions = originExpression.isPresent()
                 ? ImmutableList.copyOf(originExpression.get().getArguments())
@@ -126,7 +126,7 @@ public class VirtualSlotReference extends SlotReference implements SlotNotFromCh
             return this;
         }
         return new VirtualSlotReference(exprId, name.get(), dataType, nullable, qualifier,
-                originExpression, computeLongValueMethod);
+                originExpression, computeLongValueMethod, nameFromChild);
     }
 
     @Override
@@ -135,25 +135,25 @@ public class VirtualSlotReference extends SlotReference implements SlotNotFromCh
             return this;
         }
         return new VirtualSlotReference(exprId, name.get(), dataType, nullable, qualifier,
-                originExpression, computeLongValueMethod);
+                originExpression, computeLongValueMethod, nameFromChild);
     }
 
     @Override
     public VirtualSlotReference withQualifier(List<String> qualifier) {
         return new VirtualSlotReference(exprId, name.get(), dataType, nullable, qualifier,
-                originExpression, computeLongValueMethod);
+                originExpression, computeLongValueMethod, nameFromChild);
     }
 
     @Override
     public VirtualSlotReference withName(String name) {
         return new VirtualSlotReference(exprId, name, dataType, nullable, qualifier,
-                originExpression, computeLongValueMethod);
+                originExpression, computeLongValueMethod, nameFromChild);
     }
 
     @Override
     public VirtualSlotReference withExprId(ExprId exprId) {
         return new VirtualSlotReference(exprId, name.get(), dataType, nullable, qualifier,
-                originExpression, computeLongValueMethod);
+                originExpression, computeLongValueMethod, nameFromChild);
     }
 
     public VirtualSlotReference withOriginExpressionAndComputeLongValueMethod(

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/AggCombinerFunctionBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/AggCombinerFunctionBuilder.java
@@ -95,7 +95,7 @@ public class AggCombinerFunctionBuilder extends FunctionBuilder {
                         "foreach must be input array type: '" + nestedName);
             }
             DataType itemType = ((ArrayType) arrayType).getItemType();
-            return new SlotReference("mocked", itemType, (((ArrayType) arrayType).containsNull()));
+            return new SlotReference("mocked", itemType, (((ArrayType) arrayType).containsNull()), false);
         }).collect(Collectors.toList());
         return (AggregateFunction) nestedBuilder.build(nestedName, forEachargs).first;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Lambda.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Lambda.java
@@ -75,7 +75,7 @@ public class Lambda extends Expression {
                 throw new AnalysisException(String.format("lambda argument must be array but is %s", array));
             }
             String name = argumentNames.get(i);
-            builder.add(new ArrayItemReference(name, array));
+            builder.add(new ArrayItemReference(name, array, true));
         }
         return builder.build();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdaf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdaf.java
@@ -144,7 +144,7 @@ public class JavaUdaf extends AggregateFunction implements ExplicitlyCastableSig
 
         VirtualSlotReference[] virtualSlots = argTypes.stream()
                 .map(type -> new VirtualSlotReference(type.toString(), type, Optional.empty(),
-                        (shape) -> ImmutableList.of()))
+                        (shape) -> ImmutableList.of(), true))
                 .toArray(VirtualSlotReference[]::new);
 
         DataType intermediateType = null;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdf.java
@@ -129,7 +129,7 @@ public class JavaUdf extends ScalarFunction implements ExplicitlyCastableSignatu
 
         VirtualSlotReference[] virtualSlots = argTypes.stream()
                 .map(type -> new VirtualSlotReference(type.toString(), type, Optional.empty(),
-                        (shape) -> ImmutableList.of()))
+                        (shape) -> ImmutableList.of(), true))
                 .toArray(VirtualSlotReference[]::new);
 
         JavaUdf udf = new JavaUdf(fnName, scalar.getId(), dbName, scalar.getBinaryType(), sig,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdtf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdtf.java
@@ -150,7 +150,7 @@ public class JavaUdtf extends TableGeneratingFunction implements ExplicitlyCasta
 
         VirtualSlotReference[] virtualSlots = argTypes.stream()
                 .map(type -> new VirtualSlotReference(type.toString(), type, Optional.empty(),
-                        (shape) -> ImmutableList.of()))
+                        (shape) -> ImmutableList.of(), true))
                 .toArray(VirtualSlotReference[]::new);
 
         JavaUdtf udf = new JavaUdtf(fnName, scalar.getId(), dbName, scalar.getBinaryType(), sig,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/algebra/Repeat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/algebra/Repeat.java
@@ -92,13 +92,13 @@ public interface Repeat<CHILD_PLAN extends Plan> extends Aggregate<CHILD_PLAN> {
 
     static VirtualSlotReference generateVirtualGroupingIdSlot() {
         return new VirtualSlotReference(COL_GROUPING_ID, BigIntType.INSTANCE, Optional.empty(),
-                GroupingSetShapes::computeVirtualGroupingIdValue);
+                GroupingSetShapes::computeVirtualGroupingIdValue, false);
     }
 
     static VirtualSlotReference generateVirtualSlotByFunction(GroupingScalarFunction function) {
         return new VirtualSlotReference(
                 generateVirtualSlotName(function), function.getDataType(), Optional.of(function),
-                function::computeVirtualSlotValue);
+                function::computeVirtualSlotValue, false);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateFunctionCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateFunctionCommand.java
@@ -1053,7 +1053,7 @@ public class CreateFunctionCommand extends Command implements ForwardWithSync {
                 throw new org.apache.doris.nereids.exceptions.AnalysisException(
                         String.format("param %s's datatype is missed", unboundSlot.getName()));
             }
-            return new SlotReference(unboundSlot.getName(), dataType);
+            return new SlotReference(unboundSlot.getName(), dataType, unboundSlot.isNameFromChild());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/PrepareCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/PrepareCommand.java
@@ -123,7 +123,7 @@ public class PrepareCommand extends Command {
             ResultSetMetaData md = ((Command) logicalPlan).getResultSetMetaData();
             slots = Lists.newArrayList();
             for (Column c : md.getColumns()) {
-                slots.add(new SlotReference(c.getName(), DataType.fromCatalogType(c.getType())));
+                slots.add(new SlotReference(c.getName(), DataType.fromCatalogType(c.getType()), false));
             }
         } else {
             slots = executor.planPrepareStatementSlots();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateTableInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateTableInfo.java
@@ -1094,7 +1094,7 @@ public class CreateTableInfo {
         Map<Slot, SlotRefAndIdx> translateMap = Maps.newHashMap();
         for (int i = 0; i < columns.size(); i++) {
             ColumnDefinition column = columns.get(i);
-            Slot slot = new SlotReference(column.getName(), column.getType());
+            Slot slot = new SlotReference(column.getName(), column.getType(), false);
             columnToSlotReference.put(column.getName(), slot);
             nameToColumnDefinition.put(column.getName(), column);
             SlotRef slotRef = new SlotRef(null, column.getName());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoValuesAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoValuesAnalyzer.java
@@ -125,7 +125,7 @@ public class InsertIntoValuesAnalyzer extends AbstractBatchJobExecutor {
                     for (int columnId = 0; columnId < firstRow.size(); columnId++) {
                         String name = firstRow.get(columnId).getName();
                         DataType commonDataType = castedRows.get(0).get(columnId).getDataType();
-                        outputs.add(new SlotReference(name, commonDataType, nullables.get(columnId)));
+                        outputs.add(new SlotReference(name, commonDataType, nullables.get(columnId), false));
                     }
                     return new LogicalUnion(Qualifier.ALL, castedRows, ImmutableList.of()).withNewOutputs(outputs);
                 } else if (originConstants.size() == 1) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCTEConsumer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCTEConsumer.java
@@ -111,7 +111,8 @@ public class LogicalCTEConsumer extends LogicalRelation implements BlockFuncDeps
                 slotRef != null ? slotRef.getOriginalTable().orElse(null) : null,
                 slotRef != null ? slotRef.getOriginalColumn().orElse(null) : null,
                 slotRef != null ? slotRef.getOneLevelTable().orElse(null) : null,
-                slotRef != null ? slotRef.getOneLevelColumn().orElse(null) : null);
+                slotRef != null ? slotRef.getOneLevelColumn().orElse(null) : null,
+                producerOutputSlot.isNameFromChild());
     }
 
     public Map<Slot, Slot> getConsumerToProducerOutputMap() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalInlineTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalInlineTable.java
@@ -112,7 +112,8 @@ public class LogicalInlineTable extends LogicalLeaf implements InlineTable, Bloc
                     break;
                 }
             }
-            output.add(new SlotReference(firstRowColumn.getName(), firstRowColumn.getDataType(), nullable));
+            output.add(new SlotReference(firstRowColumn.getName(), firstRowColumn.getDataType(), nullable,
+                    false));
         }
         return output.build();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSetOperation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSetOperation.java
@@ -125,7 +125,8 @@ public abstract class LogicalSetOperation extends AbstractLogicalPlan
             Slot slot = slots.get(i);
             ExprId exprId = i < outputs.size() ? outputs.get(i).getExprId() : StatementScopeIdGenerator.newExprId();
             newOutputs.add(
-                    new SlotReference(exprId, slot.toSql(), slot.getDataType(), slot.nullable(), ImmutableList.of())
+                    new SlotReference(exprId, slot.toSql(), slot.getDataType(), slot.nullable(), ImmutableList.of(),
+                            slot.isNameFromChild())
             );
         }
         return newOutputs.build();
@@ -167,10 +168,10 @@ public abstract class LogicalSetOperation extends AbstractLogicalPlan
             Expression newLeft = TypeCoercionUtils.castIfNotSameTypeStrict(left, compatibleType);
             Expression newRight = TypeCoercionUtils.castIfNotSameTypeStrict(right, compatibleType);
             if (newLeft instanceof Cast) {
-                newLeft = new Alias(newLeft, left.getName());
+                newLeft = new Alias(newLeft, left.getName(), left.isNameFromChild());
             }
             if (newRight instanceof Cast) {
-                newRight = new Alias(newRight, right.getName());
+                newRight = new Alias(newRight, right.getName(), right.isNameFromChild());
             }
             newLeftOutputs.add((NamedExpression) newLeft);
             newRightOutputs.add((NamedExpression) newRight);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/InferPlanOutputAlias.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/InferPlanOutputAlias.java
@@ -22,21 +22,30 @@ import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalSetOperation;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
  * Infer output column name when it refers an expression and not has an alias manually.
  */
 public class InferPlanOutputAlias {
+
+    public static final Logger LOG = LogManager.getLogger(InferPlanOutputAlias.class);
 
     private final List<Slot> currentOutputs;
     private final List<NamedExpression> finalOutputs;
@@ -55,10 +64,44 @@ public class InferPlanOutputAlias {
     /** infer */
     public List<NamedExpression> infer(Plan plan, ImmutableMultimap<ExprId, Integer> currentExprIdAndIndexMap) {
         ImmutableSet<ExprId> currentOutputExprIdSet = currentExprIdAndIndexMap.keySet();
+        final Map<ExprId, ExprId> childToParentMapping = new HashMap<>();
         // Breath First Search
         plan.foreachBreath(childPlan -> {
             if (shouldProcessOutputIndex.isEmpty()) {
                 return true;
+            }
+            if (childPlan instanceof LogicalSetOperation) {
+                // Such as LogicalUnion(finalOutputs=['back'#41, 'we'#42], regularChildrenOutputs=
+                // [['back'#38, 'we'#40],['back'#36, 'we'#37])
+                //         -- LogicalUnion(finalOutputs=['back'#38, 'we'#40], regularChildrenOutputs=
+                //         [['back'#35, 'we'#36], ['back'#33, 'we'#34]])
+                //           -- LogicalProject(finalOutputs=['back'#35, 'we'#36])
+                //           -- LogicalProject(finalOutputs=['back'#33, 'we'#34])
+                List<SlotReference> regularChildOutputs = ((LogicalSetOperation) childPlan).getRegularChildOutput(0);
+                List<NamedExpression> currentOutputs = ((LogicalSetOperation) childPlan).getOutputs();
+                if (regularChildOutputs.size() != currentOutputs.size()) {
+                    // set current output size is different from currentOutputs, not excepted
+                    LOG.error("InferPlanOutputAlias infer regularChildOutputs is different from currentOutputs,"
+                            + "child plan is {}", ((LogicalSetOperation) childPlan).treeString());
+                    return true;
+                }
+                if (childToParentMapping.isEmpty()) {
+                    // if multi union, this handle first set only
+                    // childToParentMapping is {{back'#38 : back'#41},{'we'#40 : 'we'#42}}
+                    for (int index = 0; index < regularChildOutputs.size(); index++) {
+                        childToParentMapping.put(regularChildOutputs.get(index).getExprId(),
+                                currentOutputs.get(index).getExprId());
+                    }
+                } else {
+                    // this handle child set
+                    Map<ExprId, ExprId> tmpChildToParentMapping = Maps.newHashMap(childToParentMapping);
+                    childToParentMapping.clear();
+                    // childToParentMapping is {{back'#35 : back'#41},{'we'#36 : 'we'#42}}
+                    for (int index = 0; index < regularChildOutputs.size(); index++) {
+                        childToParentMapping.put(regularChildOutputs.get(index).getExprId(),
+                                tmpChildToParentMapping.get(currentOutputs.get(index).getExprId()));
+                    }
+                }
             }
             for (Expression expression : ((Plan) childPlan).getExpressions()) {
                 if (!(expression instanceof Alias)) {
@@ -67,10 +110,11 @@ public class InferPlanOutputAlias {
                 Alias projectItem = (Alias) expression;
                 ExprId exprId = projectItem.getExprId();
                 // Infer name when alias child is expression and alias's name is from child
-                if (currentOutputExprIdSet.contains(projectItem.getExprId())
-                        && projectItem.isNameFromChild()) {
+                if (contains(currentOutputExprIdSet, exprId, childToParentMapping)
+                        && (projectItem.isNameFromChild())) {
                     String inferredAliasName = projectItem.child().getExpressionName();
-                    ImmutableCollection<Integer> outputExprIndexes = currentExprIdAndIndexMap.get(exprId);
+                    ImmutableCollection<Integer> outputExprIndexes = getOutputSlotIndex(currentExprIdAndIndexMap,
+                            exprId, childToParentMapping);
                     // replace output name by inferred name
                     for (Integer index : outputExprIndexes) {
                         Slot slot = currentOutputs.get(index);
@@ -88,5 +132,51 @@ public class InferPlanOutputAlias {
             return false;
         });
         return finalOutputs;
+    }
+
+    /**
+     * Such as LogicalIntersect, targetExprIdSet is ['back'#41, 'we'#42], but child is ['back'#38, 'we'#40]
+     * should construct childToParentMapping {
+     *     'back'#38 : 'back'#41,
+     *     'we'#40 : 'we'#42
+     * }
+     * LogicalIntersect ( qualifier=DISTINCT,
+     * outputs=['back'#41, 'we'#42],
+     * regularChildrenOutputs=[['back'#38, 'we'#40],
+     * [col_char_25__undef_signed#39, col_varchar_25__undef_signed_not_null#27]] )
+     */
+    private static boolean contains(ImmutableSet<ExprId> targetExprIdSet, ExprId exprId,
+            Map<ExprId, ExprId> childToParentMapping) {
+        if (targetExprIdSet.contains(exprId)) {
+            return true;
+        }
+        return targetExprIdSet.contains(childToParentMapping.get(exprId));
+    }
+
+    /**
+     * Such as LogicalIntersect, currentExprIdAndIndexMap is
+     * {
+     *     'back'#38 : [0],
+     *     'we'#40 : [1]
+     * }
+     * LogicalIntersect ( qualifier=DISTINCT,
+     * outputs=['back'#41, 'we'#42],
+     * regularChildrenOutputs=[['back'#38, 'we'#40],
+     * [col_char_25__undef_signed#39, col_varchar_25__undef_signed_not_null#27]] )
+     * exprId is 'back'#38
+     * childToParentMapping {
+     *     'back'#38 : 'back'#41,
+     *     'we'#40 : 'we'#42
+     * }
+     */
+    private static ImmutableCollection<Integer> getOutputSlotIndex(
+            ImmutableMultimap<ExprId, Integer> currentExprIdAndIndexMap,
+            ExprId exprId,
+            Map<ExprId, ExprId> childToParentMapping) {
+        ImmutableCollection<Integer> indexes = currentExprIdAndIndexMap.get(exprId);
+        if (!indexes.isEmpty()) {
+            return indexes;
+        }
+        return currentExprIdAndIndexMap.get(childToParentMapping.get(exprId));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/AggStateType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/AggStateType.java
@@ -87,7 +87,7 @@ public class AggStateType extends DataType {
     public List<Expression> getMockedExpressions() {
         List<Expression> result = new ArrayList<Expression>();
         for (int i = 0; i < subTypes.size(); i++) {
-            result.add(new SlotReference("mocked", subTypes.get(i), subTypeNullables.get(i)));
+            result.add(new SlotReference("mocked", subTypes.get(i), subTypeNullables.get(i), false));
         }
         return result;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -419,7 +419,8 @@ public class ExpressionUtils {
         if (newExpr instanceof NamedExpression) {
             return (NamedExpression) newExpr;
         } else {
-            return new Alias(expr.getExprId(), newExpr, expr.getName());
+            return new Alias(expr.getExprId(), newExpr, expr.getName(),
+                    expr.isNameFromChild());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/PlanUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/PlanUtils.java
@@ -419,7 +419,7 @@ public class PlanUtils {
         @Override
         public Expression visitUnboundSlot(UnboundSlot unboundSlot, ExpressionRewriteContext context) {
             DataType dataType = columnTypes.getOrDefault(unboundSlot.getName(), VarcharType.MAX_VARCHAR_TYPE);
-            return new SlotReference(unboundSlot.getName(), dataType);
+            return new SlotReference(unboundSlot.getName(), dataType, unboundSlot.isNameFromChild());
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslatorTest.java
@@ -58,9 +58,9 @@ public class PhysicalPlanTranslatorTest {
         List<String> qualifier = new ArrayList<>();
         qualifier.add("test");
         List<Slot> t1Output = new ArrayList<>();
-        SlotReference col1 = new SlotReference("col1", IntegerType.INSTANCE);
-        SlotReference col2 = new SlotReference("col2", IntegerType.INSTANCE);
-        SlotReference col3 = new SlotReference("col2", IntegerType.INSTANCE);
+        SlotReference col1 = new SlotReference("col1", IntegerType.INSTANCE, false);
+        SlotReference col2 = new SlotReference("col2", IntegerType.INSTANCE, false);
+        SlotReference col3 = new SlotReference("col2", IntegerType.INSTANCE, false);
         t1Output.add(col1);
         t1Output.add(col2);
         t1Output.add(col3);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/RewriteTopDownJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/RewriteTopDownJobTest.java
@@ -73,7 +73,8 @@ public class RewriteTopDownJobTest {
     public void testSimplestScene() {
         Plan leaf = new UnboundRelation(StatementScopeIdGenerator.newRelationId(), Lists.newArrayList("test"));
         LogicalProject<Plan> project = new LogicalProject<>(ImmutableList.of(
-                new SlotReference("name", StringType.INSTANCE, true, ImmutableList.of("test"))),
+                new SlotReference("name", StringType.INSTANCE, true, ImmutableList.of("test"),
+                        false)),
                 leaf
         );
         PlanChecker.from(MemoTestUtils.createConnectContext(), project)

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/cascades/DeriveStatsJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/cascades/DeriveStatsJobTest.java
@@ -83,7 +83,7 @@ public class DeriveStatsJobTest {
         List<String> qualifier = ImmutableList.of("test", "t");
         slot1 = new SlotReference(new ExprId(1), "c1", IntegerType.INSTANCE, true, qualifier,
                 table1, new Column("e", PrimitiveType.INT),
-                table1, new Column("e", PrimitiveType.INT));
+                table1, new Column("e", PrimitiveType.INT), false);
         new Expectations() {{
                 ConnectContext.get();
                 result = context;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/MemoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/MemoTest.java
@@ -1065,11 +1065,13 @@ class MemoTest implements MemoPatternMatchSupported {
     void testRewriteMiddlePlans() {
         UnboundRelation unboundRelation = new UnboundRelation(StatementScopeIdGenerator.newRelationId(), Lists.newArrayList("test"));
         LogicalProject insideProject = new LogicalProject<>(
-                ImmutableList.of(new SlotReference("name", StringType.INSTANCE, true, ImmutableList.of("test"))),
+                ImmutableList.of(new SlotReference("name", StringType.INSTANCE, true, ImmutableList.of("test"),
+                        false)),
                 unboundRelation
         );
         LogicalProject rootProject = new LogicalProject<>(
-                ImmutableList.of(new SlotReference("name", StringType.INSTANCE, true, ImmutableList.of("test"))),
+                ImmutableList.of(new SlotReference("name", StringType.INSTANCE, true, ImmutableList.of("test"),
+                        false)),
                 insideProject
         );
 
@@ -1079,12 +1081,12 @@ class MemoTest implements MemoPatternMatchSupported {
         Group targetGroup = memo.getGroups().stream().filter(g -> g.getGroupId().asInt() == 1).findFirst().get();
         LogicalProject rewriteInsideProject = new LogicalProject<>(
                 ImmutableList.of(new SlotReference("rewrite_inside", StringType.INSTANCE,
-                        false, ImmutableList.of("test"))),
+                        false, ImmutableList.of("test"), false)),
                 new GroupPlan(leafGroup)
         );
         LogicalProject rewriteProject = new LogicalProject<>(
                 ImmutableList.of(new SlotReference("rewrite", StringType.INSTANCE,
-                        true, ImmutableList.of("test"))),
+                        true, ImmutableList.of("test"), false)),
                 rewriteInsideProject
         );
         memo.copyIn(rewriteProject, targetGroup, true);
@@ -1122,11 +1124,13 @@ class MemoTest implements MemoPatternMatchSupported {
     void testEliminateRootWithChildPlanThreeLevels() {
         UnboundRelation unboundRelation = new UnboundRelation(StatementScopeIdGenerator.newRelationId(), Lists.newArrayList("test"));
         LogicalProject<UnboundRelation> insideProject = new LogicalProject<>(
-                ImmutableList.of(new SlotReference("inside", StringType.INSTANCE, true, ImmutableList.of("test"))),
+                ImmutableList.of(new SlotReference("inside", StringType.INSTANCE, true,
+                        ImmutableList.of("test"), false)),
                 unboundRelation
         );
         LogicalProject<LogicalProject<UnboundRelation>> rootProject = new LogicalProject<>(
-                ImmutableList.of(new SlotReference("outside", StringType.INSTANCE, true, ImmutableList.of("test"))),
+                ImmutableList.of(new SlotReference("outside", StringType.INSTANCE, true,
+                        ImmutableList.of("test"), false)),
                 insideProject
         );
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/pattern/GroupExpressionMatchingTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/pattern/GroupExpressionMatchingTest.java
@@ -67,7 +67,7 @@ class GroupExpressionMatchingTest {
 
         Plan leaf = new UnboundRelation(StatementScopeIdGenerator.newRelationId(), Lists.newArrayList("test"));
         LogicalProject root = new LogicalProject(ImmutableList
-                .of(new SlotReference("name", StringType.INSTANCE, true, ImmutableList.of("test"))),
+                .of(new SlotReference("name", StringType.INSTANCE, true, ImmutableList.of("test"), false)),
                 leaf);
         Memo memo = new Memo(null, root);
 
@@ -98,7 +98,7 @@ class GroupExpressionMatchingTest {
 
         Plan leaf = new UnboundRelation(StatementScopeIdGenerator.newRelationId(), Lists.newArrayList("test"));
         LogicalProject root = new LogicalProject(ImmutableList
-                .of(new SlotReference("name", StringType.INSTANCE, true, ImmutableList.of("test"))),
+                .of(new SlotReference("name", StringType.INSTANCE, true, ImmutableList.of("test"), false)),
                 leaf);
         Memo memo = new Memo(null, root);
 
@@ -138,7 +138,7 @@ class GroupExpressionMatchingTest {
     void testAnyWithChild() {
         Plan root = new LogicalProject(
                 ImmutableList.of(new SlotReference("name", StringType.INSTANCE, true,
-                        ImmutableList.of("test"))),
+                        ImmutableList.of("test"), false)),
                 new UnboundRelation(StatementScopeIdGenerator.newRelationId(), Lists.newArrayList("test")));
         Memo memo = new Memo(null, root);
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/CommonSubExpressionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/CommonSubExpressionTest.java
@@ -66,7 +66,7 @@ public class CommonSubExpressionTest extends ExpressionRewriteTestHelper {
     @Test
     void testLambdaExpression() {
         ArrayItemReference ref = new ArrayItemReference("x", new SlotReference(new ExprId(1), "y",
-                ArrayType.of(IntegerType.INSTANCE), true, ImmutableList.of()));
+                ArrayType.of(IntegerType.INSTANCE), true, ImmutableList.of(), false), false);
         Expression add = new Add(ref.toSlot(), Literal.of(1));
         Expression and = new And(add, add);
         ArrayMap arrayMap = new ArrayMap(new Lambda(ImmutableList.of("x"), and, ImmutableList.of(ref)));
@@ -143,7 +143,7 @@ public class CommonSubExpressionTest extends ExpressionRewriteTestHelper {
             if (exitsSlot != null) {
                 return exitsSlot;
             } else {
-                SlotReference slotReference = new SlotReference(slot.getName(), IntegerType.INSTANCE);
+                SlotReference slotReference = new SlotReference(slot.getName(), IntegerType.INSTANCE, false);
                 slotMap.put(slot.getName(), slotReference);
                 return slotReference;
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/MergeProjectPostProcessTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/MergeProjectPostProcessTest.java
@@ -69,9 +69,9 @@ public class MergeProjectPostProcessTest {
         List<String> qualifier = new ArrayList<>();
         qualifier.add("test");
         List<Slot> t1Output = new ArrayList<>();
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, false);
         t1Output.add(a);
         t1Output.add(b);
         t1Output.add(c);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/PushDownFilterThroughProjectTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/PushDownFilterThroughProjectTest.java
@@ -83,9 +83,9 @@ public class PushDownFilterThroughProjectTest {
         List<String> qualifier = new ArrayList<>();
         qualifier.add("test");
         List<Slot> t1Output = new ArrayList<>();
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, false);
         t1Output.add(a);
         t1Output.add(b);
         t1Output.add(c);
@@ -123,9 +123,9 @@ public class PushDownFilterThroughProjectTest {
         List<String> qualifier = new ArrayList<>();
         qualifier.add("test");
         List<Slot> t1Output = new ArrayList<>();
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, false);
         t1Output.add(a);
         t1Output.add(b);
         t1Output.add(c);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriverTest.java
@@ -139,7 +139,7 @@ class ChildOutputPropertyDeriverTest {
                         Sets.newHashSet(0L)
                 ),
                 new OrderSpec(
-                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE),
+                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE, false),
                                 true, true)))
         );
 
@@ -178,7 +178,7 @@ class ChildOutputPropertyDeriverTest {
                         Sets.newHashSet(0L)
                 ),
                 new OrderSpec(
-                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE),
+                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE, false),
                                 true, true)))
         );
 
@@ -217,7 +217,7 @@ class ChildOutputPropertyDeriverTest {
                         Sets.newHashSet(0L)
                 ),
                 new OrderSpec(
-                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE),
+                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE, false),
                                 true, true)))
         );
 
@@ -257,7 +257,7 @@ class ChildOutputPropertyDeriverTest {
                         Sets.newHashSet(0L)
                 ),
                 new OrderSpec(
-                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE),
+                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE, false),
                                 true, true)))
         );
 
@@ -297,7 +297,7 @@ class ChildOutputPropertyDeriverTest {
                         Sets.newHashSet(0L)
                 ),
                 new OrderSpec(
-                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE),
+                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE, false),
                                 true, true)))
         );
 
@@ -337,7 +337,7 @@ class ChildOutputPropertyDeriverTest {
                         Sets.newHashSet(0L)
                 ),
                 new OrderSpec(
-                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE),
+                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE, false),
                                 true, true)))
         );
 
@@ -377,7 +377,7 @@ class ChildOutputPropertyDeriverTest {
                         Sets.newHashSet(0L)
                 ),
                 new OrderSpec(
-                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE),
+                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE, false),
                                 true, true)))
         );
 
@@ -419,7 +419,7 @@ class ChildOutputPropertyDeriverTest {
                         Sets.newHashSet(0L)
                 ),
                 new OrderSpec(
-                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE),
+                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE, false),
                                 true, true)))
         );
 
@@ -464,7 +464,7 @@ class ChildOutputPropertyDeriverTest {
                         Sets.newHashSet(0L)
                 ),
                 new OrderSpec(
-                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE),
+                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE, false),
                                 true, true)))
         );
 
@@ -505,7 +505,7 @@ class ChildOutputPropertyDeriverTest {
                         Sets.newHashSet(0L)
                 ),
                 new OrderSpec(
-                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE),
+                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE, false),
                                 true, true)))
         );
 
@@ -540,7 +540,7 @@ class ChildOutputPropertyDeriverTest {
                         Sets.newHashSet(0L)
                 ),
                 new OrderSpec(
-                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE),
+                        Lists.newArrayList(new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE, false),
                                 true, true)))
         );
 
@@ -561,8 +561,8 @@ class ChildOutputPropertyDeriverTest {
 
     @Test
     void testBroadcastJoin(@Injectable LogicalProperties p1, @Injectable GroupPlan p2) {
-        SlotReference leftSlot = new SlotReference(new ExprId(0), "left", IntegerType.INSTANCE, false, Collections.emptyList());
-        SlotReference rightSlot = new SlotReference(new ExprId(2), "right", IntegerType.INSTANCE, false, Collections.emptyList());
+        SlotReference leftSlot = new SlotReference(new ExprId(0), "left", IntegerType.INSTANCE, false, Collections.emptyList(), false);
+        SlotReference rightSlot = new SlotReference(new ExprId(2), "right", IntegerType.INSTANCE, false, Collections.emptyList(), false);
         List<Slot> leftOutput = new ArrayList<>();
         List<Slot> rightOutput = new ArrayList<>();
         leftOutput.add(leftSlot);
@@ -596,7 +596,7 @@ class ChildOutputPropertyDeriverTest {
 
         PhysicalProperties right = new PhysicalProperties(DistributionSpecReplicated.INSTANCE,
                 new OrderSpec(Lists.newArrayList(
-                        new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE), true, true))));
+                        new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE, false), true, true))));
 
         List<PhysicalProperties> childrenOutputProperties = Lists.newArrayList(left, right);
         ChildOutputPropertyDeriver deriver = new ChildOutputPropertyDeriver(childrenOutputProperties);
@@ -622,9 +622,9 @@ class ChildOutputPropertyDeriverTest {
 
         PhysicalHashJoin<GroupPlan, GroupPlan> join = new PhysicalHashJoin<>(JoinType.INNER_JOIN,
                 Lists.newArrayList(new EqualTo(
-                        new SlotReference(new ExprId(0), "left", IntegerType.INSTANCE, false, Collections.emptyList()),
+                        new SlotReference(new ExprId(0), "left", IntegerType.INSTANCE, false, Collections.emptyList(), false),
                         new SlotReference(new ExprId(2), "right", IntegerType.INSTANCE, false,
-                                Collections.emptyList()))),
+                                Collections.emptyList(), false))),
                 ExpressionUtils.EMPTY_CONDITION, new DistributeHint(DistributeType.NONE), Optional.empty(), logicalProperties, groupPlan, groupPlan);
         GroupExpression groupExpression = new GroupExpression(join);
         new Group(null, groupExpression, null);
@@ -693,7 +693,7 @@ class ChildOutputPropertyDeriverTest {
 
     @Test
     void testLocalPhaseAggregate() {
-        SlotReference key = new SlotReference("col1", IntegerType.INSTANCE);
+        SlotReference key = new SlotReference("col1", IntegerType.INSTANCE, false);
         PhysicalHashAggregate<GroupPlan> aggregate = new PhysicalHashAggregate<>(
                 Lists.newArrayList(key),
                 Lists.newArrayList(key),
@@ -706,7 +706,7 @@ class ChildOutputPropertyDeriverTest {
         new Group(null, groupExpression, null);
         PhysicalProperties child = new PhysicalProperties(DistributionSpecReplicated.INSTANCE,
                 new OrderSpec(Lists.newArrayList(
-                        new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE), true, true))));
+                        new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE, false), true, true))));
 
         ChildOutputPropertyDeriver deriver = new ChildOutputPropertyDeriver(Lists.newArrayList(child));
         PhysicalProperties result = deriver.getOutputProperties(null, groupExpression);
@@ -716,8 +716,8 @@ class ChildOutputPropertyDeriverTest {
 
     @Test
     void testGlobalPhaseAggregate() {
-        SlotReference key = new SlotReference("col1", IntegerType.INSTANCE);
-        SlotReference partition = new SlotReference("col2", BigIntType.INSTANCE);
+        SlotReference key = new SlotReference("col1", IntegerType.INSTANCE, false);
+        SlotReference partition = new SlotReference("col2", BigIntType.INSTANCE, false);
         PhysicalHashAggregate<GroupPlan> aggregate = new PhysicalHashAggregate<>(
                 Lists.newArrayList(key),
                 Lists.newArrayList(key),
@@ -732,7 +732,7 @@ class ChildOutputPropertyDeriverTest {
                 ShuffleType.EXECUTION_BUCKETED);
         PhysicalProperties child = new PhysicalProperties(childHash,
                 new OrderSpec(Lists.newArrayList(
-                        new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE), true, true))));
+                        new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE, false), true, true))));
 
         ChildOutputPropertyDeriver deriver = new ChildOutputPropertyDeriver(Lists.newArrayList(child));
         PhysicalProperties result = deriver.getOutputProperties(null, groupExpression);
@@ -760,7 +760,7 @@ class ChildOutputPropertyDeriverTest {
         new Group(null, groupExpression, null);
         PhysicalProperties child = new PhysicalProperties(DistributionSpecGather.INSTANCE,
                 new OrderSpec(Lists.newArrayList(
-                        new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE), true, true))));
+                        new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE, false), true, true))));
 
         ChildOutputPropertyDeriver deriver = new ChildOutputPropertyDeriver(Lists.newArrayList(child));
         PhysicalProperties result = deriver.getOutputProperties(null, groupExpression);
@@ -769,14 +769,14 @@ class ChildOutputPropertyDeriverTest {
 
     @Test
     void testLocalQuickSort() {
-        SlotReference key = new SlotReference("col1", IntegerType.INSTANCE);
+        SlotReference key = new SlotReference("col1", IntegerType.INSTANCE, false);
         List<OrderKey> orderKeys = Lists.newArrayList(new OrderKey(key, true, true));
         PhysicalQuickSort<GroupPlan> sort = new PhysicalQuickSort<>(orderKeys, SortPhase.LOCAL_SORT, logicalProperties, groupPlan);
         GroupExpression groupExpression = new GroupExpression(sort);
         new Group(null, groupExpression, null);
         PhysicalProperties child = new PhysicalProperties(DistributionSpecReplicated.INSTANCE,
                 new OrderSpec(Lists.newArrayList(
-                        new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE), true, true))));
+                        new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE, false), true, true))));
 
         ChildOutputPropertyDeriver deriver = new ChildOutputPropertyDeriver(Lists.newArrayList(child));
         PhysicalProperties result = deriver.getOutputProperties(null, groupExpression);
@@ -786,14 +786,14 @@ class ChildOutputPropertyDeriverTest {
 
     @Test
     void testQuickSort() {
-        SlotReference key = new SlotReference("col1", IntegerType.INSTANCE);
+        SlotReference key = new SlotReference("col1", IntegerType.INSTANCE, false);
         List<OrderKey> orderKeys = Lists.newArrayList(new OrderKey(key, true, true));
         PhysicalQuickSort<GroupPlan> sort = new PhysicalQuickSort<>(orderKeys, SortPhase.MERGE_SORT, logicalProperties, groupPlan);
         GroupExpression groupExpression = new GroupExpression(sort);
         new Group(null, groupExpression, null);
         PhysicalProperties child = new PhysicalProperties(DistributionSpecReplicated.INSTANCE,
                 new OrderSpec(Lists.newArrayList(
-                        new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE), true, true))));
+                        new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE, false), true, true))));
 
         ChildOutputPropertyDeriver deriver = new ChildOutputPropertyDeriver(Lists.newArrayList(child));
         PhysicalProperties result = deriver.getOutputProperties(null, groupExpression);
@@ -803,7 +803,7 @@ class ChildOutputPropertyDeriverTest {
 
     @Test
     void testTopN() {
-        SlotReference key = new SlotReference("col1", IntegerType.INSTANCE);
+        SlotReference key = new SlotReference("col1", IntegerType.INSTANCE, false);
         List<OrderKey> orderKeys = Lists.newArrayList(new OrderKey(key, true, true));
         // localSort require any
         PhysicalTopN<GroupPlan> sort = new PhysicalTopN<>(orderKeys, 10, 10, SortPhase.LOCAL_SORT, logicalProperties, groupPlan);
@@ -811,7 +811,7 @@ class ChildOutputPropertyDeriverTest {
         new Group(null, groupExpression, null);
         PhysicalProperties child = new PhysicalProperties(DistributionSpecReplicated.INSTANCE,
                 new OrderSpec(Lists.newArrayList(
-                        new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE), true, true))));
+                        new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE, false), true, true))));
 
         ChildOutputPropertyDeriver deriver = new ChildOutputPropertyDeriver(Lists.newArrayList(child));
         PhysicalProperties result = deriver.getOutputProperties(null, groupExpression);
@@ -823,7 +823,7 @@ class ChildOutputPropertyDeriverTest {
         new Group(null, groupExpression, null);
         child = new PhysicalProperties(DistributionSpecReplicated.INSTANCE,
                 new OrderSpec(Lists.newArrayList(
-                        new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE), true, true))));
+                        new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE, false), true, true))));
 
         deriver = new ChildOutputPropertyDeriver(Lists.newArrayList(child));
         result = deriver.getOutputProperties(null, groupExpression);
@@ -833,7 +833,7 @@ class ChildOutputPropertyDeriverTest {
 
     @Test
     void testLimit() {
-        SlotReference key = new SlotReference("col1", IntegerType.INSTANCE);
+        SlotReference key = new SlotReference("col1", IntegerType.INSTANCE, false);
         List<OrderKey> orderKeys = Lists.newArrayList(new OrderKey(key, true, true));
         PhysicalLimit<GroupPlan> limit = new PhysicalLimit<>(10, 10, LimitPhase.ORIGIN, logicalProperties, groupPlan);
         GroupExpression groupExpression = new GroupExpression(limit);
@@ -865,11 +865,11 @@ class ChildOutputPropertyDeriverTest {
     @Test
     void testRepeatReturnAny() {
         SlotReference c1 = new SlotReference(
-                new ExprId(1), "c1", TinyIntType.INSTANCE, true, ImmutableList.of());
+                new ExprId(1), "c1", TinyIntType.INSTANCE, true, ImmutableList.of(), false);
         SlotReference c2 = new SlotReference(
-                new ExprId(2), "c2", TinyIntType.INSTANCE, true, ImmutableList.of());
+                new ExprId(2), "c2", TinyIntType.INSTANCE, true, ImmutableList.of(), false);
         SlotReference c3 = new SlotReference(
-                new ExprId(3), "c3", TinyIntType.INSTANCE, true, ImmutableList.of());
+                new ExprId(3), "c3", TinyIntType.INSTANCE, true, ImmutableList.of(), false);
         PhysicalRepeat<GroupPlan> repeat = new PhysicalRepeat<>(
                 ImmutableList.of(ImmutableList.of(c1, c2), ImmutableList.of(c1), ImmutableList.of(c1, c3)),
                 ImmutableList.of(c1, c2, c3),
@@ -888,11 +888,11 @@ class ChildOutputPropertyDeriverTest {
     @Test
     void testRepeatReturnChild() {
         SlotReference c1 = new SlotReference(
-                new ExprId(1), "c1", TinyIntType.INSTANCE, true, ImmutableList.of());
+                new ExprId(1), "c1", TinyIntType.INSTANCE, true, ImmutableList.of(), false);
         SlotReference c2 = new SlotReference(
-                new ExprId(2), "c2", TinyIntType.INSTANCE, true, ImmutableList.of());
+                new ExprId(2), "c2", TinyIntType.INSTANCE, true, ImmutableList.of(), false);
         SlotReference c3 = new SlotReference(
-                new ExprId(3), "c3", TinyIntType.INSTANCE, true, ImmutableList.of());
+                new ExprId(3), "c3", TinyIntType.INSTANCE, true, ImmutableList.of(), false);
         PhysicalRepeat<GroupPlan> repeat = new PhysicalRepeat<>(
                 ImmutableList.of(ImmutableList.of(c1, c2), ImmutableList.of(c1), ImmutableList.of(c1, c3)),
                 ImmutableList.of(c1, c2, c3),
@@ -911,11 +911,11 @@ class ChildOutputPropertyDeriverTest {
     @Test
     void testRepeatReturnChild2() {
         SlotReference c1 = new SlotReference(
-                new ExprId(1), "c1", TinyIntType.INSTANCE, true, ImmutableList.of());
+                new ExprId(1), "c1", TinyIntType.INSTANCE, true, ImmutableList.of(), false);
         SlotReference c2 = new SlotReference(
-                new ExprId(2), "c2", TinyIntType.INSTANCE, true, ImmutableList.of());
+                new ExprId(2), "c2", TinyIntType.INSTANCE, true, ImmutableList.of(), false);
         SlotReference c3 = new SlotReference(
-                new ExprId(3), "c3", TinyIntType.INSTANCE, true, ImmutableList.of());
+                new ExprId(3), "c3", TinyIntType.INSTANCE, true, ImmutableList.of(), false);
         PhysicalRepeat<GroupPlan> repeat = new PhysicalRepeat<>(
                 ImmutableList.of(ImmutableList.of(c1, c2, c3), ImmutableList.of(c1, c2), ImmutableList.of(c1, c2)),
                 ImmutableList.of(c1, c2, c3),

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DataTraitTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DataTraitTest.java
@@ -32,10 +32,10 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class DataTraitTest extends TestWithFeService {
-    Slot slot1 = new SlotReference("1", IntegerType.INSTANCE, false);
-    Slot slot2 = new SlotReference("2", IntegerType.INSTANCE, false);
-    Slot slot3 = new SlotReference("1", IntegerType.INSTANCE, false);
-    Slot slot4 = new SlotReference("1", IntegerType.INSTANCE, false);
+    Slot slot1 = new SlotReference("1", IntegerType.INSTANCE, false, false);
+    Slot slot2 = new SlotReference("2", IntegerType.INSTANCE, false, false);
+    Slot slot3 = new SlotReference("1", IntegerType.INSTANCE, false, false);
+    Slot slot4 = new SlotReference("1", IntegerType.INSTANCE, false, false);
 
     @Override
     protected void runBeforeAll() throws Exception {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/FuncDepsDGTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/FuncDepsDGTest.java
@@ -32,8 +32,8 @@ class FuncDepsDGTest {
     @Test
     void testBasic() {
         FuncDepsDG.Builder dg = new FuncDepsDG.Builder();
-        Slot s1 = new SlotReference("s1", IntegerType.INSTANCE);
-        Slot s2 = new SlotReference("s2", IntegerType.INSTANCE);
+        Slot s1 = new SlotReference("s1", IntegerType.INSTANCE, false);
+        Slot s2 = new SlotReference("s2", IntegerType.INSTANCE, false);
         dg.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
         FuncDeps res = dg.build().findValidFuncDeps(Sets.newHashSet(s1, s2));
         Assertions.assertEquals(1, res.size());
@@ -42,9 +42,9 @@ class FuncDepsDGTest {
     @Test
     void testTrans() {
         FuncDepsDG.Builder dg = new FuncDepsDG.Builder();
-        Slot s1 = new SlotReference("s1", IntegerType.INSTANCE);
-        Slot s2 = new SlotReference("s2", IntegerType.INSTANCE);
-        Slot s3 = new SlotReference("s3", IntegerType.INSTANCE);
+        Slot s1 = new SlotReference("s1", IntegerType.INSTANCE, false);
+        Slot s2 = new SlotReference("s2", IntegerType.INSTANCE, false);
+        Slot s3 = new SlotReference("s3", IntegerType.INSTANCE, false);
         dg.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
         dg.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s3));
         FuncDeps res = dg.build().findValidFuncDeps(Sets.newHashSet(s1, s3));
@@ -55,8 +55,8 @@ class FuncDepsDGTest {
     @Test
     void testCircle() {
         FuncDepsDG.Builder dg = new FuncDepsDG.Builder();
-        Slot s1 = new SlotReference("s1", IntegerType.INSTANCE);
-        Slot s2 = new SlotReference("s2", IntegerType.INSTANCE);
+        Slot s1 = new SlotReference("s1", IntegerType.INSTANCE, false);
+        Slot s2 = new SlotReference("s2", IntegerType.INSTANCE, false);
         dg.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
         dg.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s1));
         FuncDeps res = dg.build().findValidFuncDeps(Sets.newHashSet(s1, s2));
@@ -66,10 +66,10 @@ class FuncDepsDGTest {
     @Test
     void testTree() {
         FuncDepsDG.Builder dg = new FuncDepsDG.Builder();
-        Slot s1 = new SlotReference("s1", IntegerType.INSTANCE);
-        Slot s2 = new SlotReference("s2", IntegerType.INSTANCE);
-        Slot s3 = new SlotReference("s3", IntegerType.INSTANCE);
-        Slot s4 = new SlotReference("s4", IntegerType.INSTANCE);
+        Slot s1 = new SlotReference("s1", IntegerType.INSTANCE, false);
+        Slot s2 = new SlotReference("s2", IntegerType.INSTANCE, false);
+        Slot s3 = new SlotReference("s3", IntegerType.INSTANCE, false);
+        Slot s4 = new SlotReference("s4", IntegerType.INSTANCE, false);
         dg.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
         dg.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s3));
         dg.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s4));
@@ -80,9 +80,9 @@ class FuncDepsDGTest {
     @Test
     void testPruneTrans() {
         FuncDepsDG.Builder dg = new FuncDepsDG.Builder();
-        Slot s1 = new SlotReference("s1", IntegerType.INSTANCE);
-        Slot s2 = new SlotReference("s2", IntegerType.INSTANCE);
-        Slot s3 = new SlotReference("s3", IntegerType.INSTANCE);
+        Slot s1 = new SlotReference("s1", IntegerType.INSTANCE, false);
+        Slot s2 = new SlotReference("s2", IntegerType.INSTANCE, false);
+        Slot s3 = new SlotReference("s3", IntegerType.INSTANCE, false);
         dg.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
         dg.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s3));
         dg.removeNotContain(Sets.newHashSet(s1, s3));
@@ -94,9 +94,9 @@ class FuncDepsDGTest {
     @Test
     void testPruneCircle() {
         FuncDepsDG.Builder dg = new FuncDepsDG.Builder();
-        Slot s1 = new SlotReference("s1", IntegerType.INSTANCE);
-        Slot s2 = new SlotReference("s2", IntegerType.INSTANCE);
-        Slot s3 = new SlotReference("s3", IntegerType.INSTANCE);
+        Slot s1 = new SlotReference("s1", IntegerType.INSTANCE, false);
+        Slot s2 = new SlotReference("s2", IntegerType.INSTANCE, false);
+        Slot s3 = new SlotReference("s3", IntegerType.INSTANCE, false);
         dg.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
         dg.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s3));
         dg.addDeps(Sets.newHashSet(s3), Sets.newHashSet(s1));
@@ -108,10 +108,10 @@ class FuncDepsDGTest {
     @Test
     void testPruneTree() {
         FuncDepsDG.Builder dg = new FuncDepsDG.Builder();
-        Slot s1 = new SlotReference("s1", IntegerType.INSTANCE);
-        Slot s2 = new SlotReference("s2", IntegerType.INSTANCE);
-        Slot s3 = new SlotReference("s3", IntegerType.INSTANCE);
-        Slot s4 = new SlotReference("s4", IntegerType.INSTANCE);
+        Slot s1 = new SlotReference("s1", IntegerType.INSTANCE, false);
+        Slot s2 = new SlotReference("s2", IntegerType.INSTANCE, false);
+        Slot s3 = new SlotReference("s3", IntegerType.INSTANCE, false);
+        Slot s4 = new SlotReference("s4", IntegerType.INSTANCE, false);
         dg.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
         dg.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s3));
         dg.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s4));
@@ -123,10 +123,10 @@ class FuncDepsDGTest {
     @Test
     void testReplaceTrans() {
         FuncDepsDG.Builder dg = new FuncDepsDG.Builder();
-        Slot s1 = new SlotReference("s1", IntegerType.INSTANCE);
-        Slot s2 = new SlotReference("s2", IntegerType.INSTANCE);
-        Slot s3 = new SlotReference("s3", IntegerType.INSTANCE);
-        Slot s5 = new SlotReference("s5", IntegerType.INSTANCE);
+        Slot s1 = new SlotReference("s1", IntegerType.INSTANCE, false);
+        Slot s2 = new SlotReference("s2", IntegerType.INSTANCE, false);
+        Slot s3 = new SlotReference("s3", IntegerType.INSTANCE, false);
+        Slot s5 = new SlotReference("s5", IntegerType.INSTANCE, false);
         dg.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
         dg.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s3));
         Map<Slot, Slot> replaceMap = new HashMap<>();
@@ -140,9 +140,9 @@ class FuncDepsDGTest {
     @Test
     void testReplaceCircle() {
         FuncDepsDG.Builder dg = new FuncDepsDG.Builder();
-        Slot s1 = new SlotReference("s1", IntegerType.INSTANCE);
-        Slot s2 = new SlotReference("s2", IntegerType.INSTANCE);
-        Slot s5 = new SlotReference("s5", IntegerType.INSTANCE);
+        Slot s1 = new SlotReference("s1", IntegerType.INSTANCE, false);
+        Slot s2 = new SlotReference("s2", IntegerType.INSTANCE, false);
+        Slot s5 = new SlotReference("s5", IntegerType.INSTANCE, false);
         dg.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
         dg.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s1));
         Map<Slot, Slot> replaceMap = new HashMap<>();
@@ -155,11 +155,11 @@ class FuncDepsDGTest {
     @Test
     void testReplaceTree() {
         FuncDepsDG.Builder dg = new FuncDepsDG.Builder();
-        Slot s1 = new SlotReference("s1", IntegerType.INSTANCE);
-        Slot s2 = new SlotReference("s2", IntegerType.INSTANCE);
-        Slot s3 = new SlotReference("s3", IntegerType.INSTANCE);
-        Slot s4 = new SlotReference("s4", IntegerType.INSTANCE);
-        Slot s5 = new SlotReference("s5", IntegerType.INSTANCE);
+        Slot s1 = new SlotReference("s1", IntegerType.INSTANCE, false);
+        Slot s2 = new SlotReference("s2", IntegerType.INSTANCE, false);
+        Slot s3 = new SlotReference("s3", IntegerType.INSTANCE, false);
+        Slot s4 = new SlotReference("s4", IntegerType.INSTANCE, false);
+        Slot s5 = new SlotReference("s5", IntegerType.INSTANCE, false);
         dg.addDeps(Sets.newHashSet(s1), Sets.newHashSet(s2));
         dg.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s3));
         dg.addDeps(Sets.newHashSet(s2), Sets.newHashSet(s4));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/RequestPropertyDeriverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/RequestPropertyDeriverTest.java
@@ -193,7 +193,7 @@ class RequestPropertyDeriverTest {
 
     @Test
     void testLocalAggregate() {
-        SlotReference key = new SlotReference("col1", IntegerType.INSTANCE);
+        SlotReference key = new SlotReference("col1", IntegerType.INSTANCE, false);
         PhysicalHashAggregate<GroupPlan> aggregate = new PhysicalHashAggregate<>(
                 Lists.newArrayList(key),
                 Lists.newArrayList(key),
@@ -214,8 +214,8 @@ class RequestPropertyDeriverTest {
 
     @Test
     void testGlobalAggregate() {
-        SlotReference key = new SlotReference("col1", IntegerType.INSTANCE);
-        SlotReference partition = new SlotReference("partition", IntegerType.INSTANCE);
+        SlotReference key = new SlotReference("col1", IntegerType.INSTANCE, false);
+        SlotReference partition = new SlotReference("partition", IntegerType.INSTANCE, false);
         PhysicalHashAggregate<GroupPlan> aggregate = new PhysicalHashAggregate<>(
                 Lists.newArrayList(key),
                 Lists.newArrayList(key),
@@ -239,7 +239,7 @@ class RequestPropertyDeriverTest {
 
     @Test
     void testGlobalAggregateWithoutPartition() {
-        SlotReference key = new SlotReference("col1", IntegerType.INSTANCE);
+        SlotReference key = new SlotReference("col1", IntegerType.INSTANCE, false);
         PhysicalHashAggregate<GroupPlan> aggregate = new PhysicalHashAggregate<>(
                 Lists.newArrayList(),
                 Lists.newArrayList(key),
@@ -277,8 +277,8 @@ class RequestPropertyDeriverTest {
 
     @Test
     void testWindowWithPartitionKeyAndOrderKey() {
-        SlotReference col1 = new SlotReference("col1", IntegerType.INSTANCE);
-        SlotReference col2 = new SlotReference("col2", IntegerType.INSTANCE);
+        SlotReference col1 = new SlotReference("col1", IntegerType.INSTANCE, false);
+        SlotReference col2 = new SlotReference("col2", IntegerType.INSTANCE, false);
         Expression rowNumber = new RowNumber();
         WindowExpression windowExpression = new WindowExpression(rowNumber, ImmutableList.of(col1),
                 ImmutableList.of(new OrderExpression(new OrderKey(col2, true, false))),
@@ -302,7 +302,7 @@ class RequestPropertyDeriverTest {
 
     @Test
     void testWindowWithPartitionKeyAndNoOrderKey() {
-        SlotReference col1 = new SlotReference("col1", IntegerType.INSTANCE);
+        SlotReference col1 = new SlotReference("col1", IntegerType.INSTANCE, false);
         Expression rowNumber = new RowNumber();
         WindowExpression windowExpression = new WindowExpression(rowNumber, ImmutableList.of(col1),
                 ImmutableList.of(),
@@ -326,7 +326,7 @@ class RequestPropertyDeriverTest {
 
     @Test
     void testWindowWithNoPartitionKeyAndOrderKey() {
-        SlotReference col2 = new SlotReference("col2", IntegerType.INSTANCE);
+        SlotReference col2 = new SlotReference("col2", IntegerType.INSTANCE, false);
         Expression rowNumber = new RowNumber();
         WindowExpression windowExpression = new WindowExpression(rowNumber, ImmutableList.of(),
                 ImmutableList.of(new OrderExpression(new OrderKey(col2, true, false))),

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/AnalyzeSubQueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/AnalyzeSubQueryTest.java
@@ -131,12 +131,12 @@ public class AnalyzeSubQueryTest extends TestWithFeService implements MemoPatter
                                 )
                             )
                         ).when(FieldChecker.check("projects", ImmutableList.of(
-                            new SlotReference(new ExprId(0), "id", BigIntType.INSTANCE, true, ImmutableList.of("T")),
-                            new SlotReference(new ExprId(1), "score", BigIntType.INSTANCE, true, ImmutableList.of("T"))))
+                            new SlotReference(new ExprId(0), "id", BigIntType.INSTANCE, true, ImmutableList.of("T"), false),
+                            new SlotReference(new ExprId(1), "score", BigIntType.INSTANCE, true, ImmutableList.of("T"), false)))
                         )
                     ).when(FieldChecker.check("projects", ImmutableList.of(
-                        new SlotReference(new ExprId(0), "id", BigIntType.INSTANCE, true, ImmutableList.of("T2")),
-                        new SlotReference(new ExprId(1), "score", BigIntType.INSTANCE, true, ImmutableList.of("T2"))))
+                        new SlotReference(new ExprId(0), "id", BigIntType.INSTANCE, true, ImmutableList.of("T2"), false),
+                        new SlotReference(new ExprId(1), "score", BigIntType.INSTANCE, true, ImmutableList.of("T2"), false)))
                     )
                 );
     }
@@ -159,20 +159,20 @@ public class AnalyzeSubQueryTest extends TestWithFeService implements MemoPatter
                                     )
                                 )
                             ).when(FieldChecker.check("projects", ImmutableList.of(
-                                new SlotReference(new ExprId(2), "id", BigIntType.INSTANCE, true, ImmutableList.of("TT2")),
-                                new SlotReference(new ExprId(3), "score", BigIntType.INSTANCE, true, ImmutableList.of("TT2"))))
+                                new SlotReference(new ExprId(2), "id", BigIntType.INSTANCE, true, ImmutableList.of("TT2"), false),
+                                new SlotReference(new ExprId(3), "score", BigIntType.INSTANCE, true, ImmutableList.of("TT2"), false)))
                             )
                         )
                         .when(FieldChecker.check("otherJoinConjuncts",
                                 ImmutableList.of(new EqualTo(
-                                        new SlotReference(new ExprId(0), "id", BigIntType.INSTANCE, true, ImmutableList.of("TT1")),
-                                        new SlotReference(new ExprId(2), "id", BigIntType.INSTANCE, true, ImmutableList.of("T")))))
+                                        new SlotReference(new ExprId(0), "id", BigIntType.INSTANCE, true, ImmutableList.of("TT1"), false),
+                                        new SlotReference(new ExprId(2), "id", BigIntType.INSTANCE, true, ImmutableList.of("T"), false))))
                         )
                     ).when(FieldChecker.check("projects", ImmutableList.of(
-                        new SlotReference(new ExprId(0), "id", BigIntType.INSTANCE, true, ImmutableList.of("TT1")),
-                        new SlotReference(new ExprId(1), "score", BigIntType.INSTANCE, true, ImmutableList.of("TT1")),
-                        new SlotReference(new ExprId(2), "id", BigIntType.INSTANCE, true, ImmutableList.of("T")),
-                        new SlotReference(new ExprId(3), "score", BigIntType.INSTANCE, true, ImmutableList.of("T"))))
+                        new SlotReference(new ExprId(0), "id", BigIntType.INSTANCE, true, ImmutableList.of("TT1"), false),
+                        new SlotReference(new ExprId(1), "score", BigIntType.INSTANCE, true, ImmutableList.of("TT1"), false),
+                        new SlotReference(new ExprId(2), "id", BigIntType.INSTANCE, true, ImmutableList.of("T"), false),
+                        new SlotReference(new ExprId(3), "score", BigIntType.INSTANCE, true, ImmutableList.of("T"), false)))
                     )
                 );
     }
@@ -191,14 +191,14 @@ public class AnalyzeSubQueryTest extends TestWithFeService implements MemoPatter
                             )
                         )
                         .when(FieldChecker.check("otherJoinConjuncts", ImmutableList.of(new EqualTo(
-                                new SlotReference(new ExprId(0), "id", BigIntType.INSTANCE, true, ImmutableList.of("test", "T1")),
-                                new SlotReference(new ExprId(2), "id", BigIntType.INSTANCE, true, ImmutableList.of("T2")))))
+                                new SlotReference(new ExprId(0), "id", BigIntType.INSTANCE, true, ImmutableList.of("test", "T1"), false),
+                                new SlotReference(new ExprId(2), "id", BigIntType.INSTANCE, true, ImmutableList.of("T2"), false))))
                         )
                     ).when(FieldChecker.check("projects", ImmutableList.of(
-                        new SlotReference(new ExprId(0), "id", BigIntType.INSTANCE, true, ImmutableList.of("test", "T1")),
-                        new SlotReference(new ExprId(1), "score", BigIntType.INSTANCE, true, ImmutableList.of("test", "T1")),
-                        new SlotReference(new ExprId(2), "id", BigIntType.INSTANCE, true, ImmutableList.of("T2")),
-                        new SlotReference(new ExprId(3), "score", BigIntType.INSTANCE, true, ImmutableList.of("T2"))))
+                        new SlotReference(new ExprId(0), "id", BigIntType.INSTANCE, true, ImmutableList.of("test", "T1"), false),
+                        new SlotReference(new ExprId(1), "score", BigIntType.INSTANCE, true, ImmutableList.of("test", "T1"), false),
+                        new SlotReference(new ExprId(2), "id", BigIntType.INSTANCE, true, ImmutableList.of("T2"), false),
+                        new SlotReference(new ExprId(3), "score", BigIntType.INSTANCE, true, ImmutableList.of("T2"), false)))
                     )
                 );
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/AnalyzeWhereSubqueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/AnalyzeWhereSubqueryTest.java
@@ -167,13 +167,13 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements MemoP
                                                                     BigIntType.INSTANCE, true,
                                                                     ImmutableList.of(
                                                                             "test",
-                                                                            "t7")))).withAlwaysNullable(
+                                                                            "t7"), true))).withAlwaysNullable(
                                                                                     true),
                                                     "sum(t7.k3)"))))
                                 )
                         ).when(FieldChecker.check("correlationSlot", ImmutableList.of(
                                 new SlotReference(new ExprId(1), "k2", BigIntType.INSTANCE, true,
-                                        ImmutableList.of("test", "t6"))
+                                        ImmutableList.of("test", "t6"), true)
                         )))
                 );
     }
@@ -194,24 +194,24 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements MemoP
                                 logicalAggregate().when(FieldChecker.check("outputExpressions", ImmutableList.of(
                                                 new Alias(new ExprId(7), (new Sum(
                                                         new SlotReference(new ExprId(4), "k3", BigIntType.INSTANCE, true,
-                                                                ImmutableList.of("test", "t7")))),
+                                                                ImmutableList.of("test", "t7"), true))),
                                                         "sum(t7.k3)"),
                                                 new SlotReference(new ExprId(6), "v2", BigIntType.INSTANCE, true,
-                                                        ImmutableList.of("test", "t7"))
+                                                        ImmutableList.of("test", "t7"), true)
                                         )))
                                         .when(FieldChecker.check("groupByExpressions", ImmutableList.of(
                                                 new SlotReference(new ExprId(6), "v2", BigIntType.INSTANCE, true,
-                                                        ImmutableList.of("test", "t7"))
+                                                        ImmutableList.of("test", "t7"), true)
                                         )))
                         ).when(FieldChecker.check("correlationSlot", ImmutableList.of(
                                         new SlotReference(new ExprId(1), "k2", BigIntType.INSTANCE, true,
-                                                ImmutableList.of("test", "t6"))
+                                                ImmutableList.of("test", "t6"), true)
                                 )))
                                 .when(FieldChecker.check("correlationFilter", Optional.of(
                                         new EqualTo(new SlotReference(new ExprId(6), "v2", BigIntType.INSTANCE, true,
-                                                ImmutableList.of("test", "t7")),
+                                                ImmutableList.of("test", "t7"), true),
                                                 new SlotReference(new ExprId(1), "k2", BigIntType.INSTANCE, true,
-                                                        ImmutableList.of("test", "t6"))
+                                                        ImmutableList.of("test", "t6"), true)
                                         ))))
                 );
     }
@@ -235,9 +235,9 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements MemoP
                                 .when(FieldChecker.check("otherJoinConjuncts",
                                         ImmutableList.of(new EqualTo(
                                                 new SlotReference(new ExprId(6), "v2", BigIntType.INSTANCE, true,
-                                                        ImmutableList.of("test", "t7")),
+                                                        ImmutableList.of("test", "t7"), true),
                                                 new SlotReference(new ExprId(1), "k2", BigIntType.INSTANCE, true,
-                                                        ImmutableList.of("test", "t6"))))))
+                                                        ImmutableList.of("test", "t6"), true)))))
                 );
     }
 
@@ -251,11 +251,11 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements MemoP
                                 any(),
                                 logicalProject().when(FieldChecker.check("projects", ImmutableList.of(
                                         new SlotReference(new ExprId(4), "k3", BigIntType.INSTANCE, true,
-                                                ImmutableList.of("test", "t7"))))
+                                                ImmutableList.of("test", "t7"), true)))
                                 )
                         ).when(FieldChecker.check("correlationSlot", ImmutableList.of(
                                 new SlotReference(new ExprId(1), "k2", BigIntType.INSTANCE, true,
-                                        ImmutableList.of("test", "t6")))))
+                                        ImmutableList.of("test", "t6"), true))))
                 );
     }
 
@@ -269,17 +269,17 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements MemoP
                                 any(),
                                 logicalProject().when(FieldChecker.check("projects", ImmutableList.of(
                                         new SlotReference(new ExprId(4), "k3", BigIntType.INSTANCE, true,
-                                                ImmutableList.of("test", "t7")),
+                                                ImmutableList.of("test", "t7"), true),
                                         new SlotReference(new ExprId(6), "v2", BigIntType.INSTANCE, true,
-                                                ImmutableList.of("test", "t7")))))
+                                                ImmutableList.of("test", "t7"), true))))
                         ).when(FieldChecker.check("correlationFilter", Optional.of(
                                 new EqualTo(new SlotReference(new ExprId(6), "v2", BigIntType.INSTANCE, true,
-                                        ImmutableList.of("test", "t7")),
+                                        ImmutableList.of("test", "t7"), true),
                                         new SlotReference(new ExprId(1), "k2", BigIntType.INSTANCE, true,
-                                                ImmutableList.of("test", "t6"))))))
+                                                ImmutableList.of("test", "t6"), true)))))
                                 .when(FieldChecker.check("correlationSlot", ImmutableList.of(
                                         new SlotReference(new ExprId(1), "k2", BigIntType.INSTANCE, true,
-                                                ImmutableList.of("test", "t6")))))
+                                                ImmutableList.of("test", "t6"), true))))
                 );
     }
 
@@ -293,13 +293,13 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements MemoP
                         logicalJoin().when(FieldChecker.check("joinType", JoinType.LEFT_SEMI_JOIN))
                                 .when(FieldChecker.check("otherJoinConjuncts", ImmutableList.of(
                                         new EqualTo(new SlotReference(new ExprId(0), "k1", BigIntType.INSTANCE, true,
-                                                ImmutableList.of("test", "t6")),
+                                                ImmutableList.of("test", "t6"), true),
                                                 new SlotReference(new ExprId(4), "k3", BigIntType.INSTANCE, false,
-                                                        ImmutableList.of("test", "t7"))),
+                                                        ImmutableList.of("test", "t7"), true)),
                                         new EqualTo(new SlotReference(new ExprId(6), "v2", BigIntType.INSTANCE, true,
-                                                ImmutableList.of("test", "t7")),
+                                                ImmutableList.of("test", "t7"), true),
                                                 new SlotReference(new ExprId(1), "k2", BigIntType.INSTANCE, true,
-                                                        ImmutableList.of("test", "t6")))
+                                                        ImmutableList.of("test", "t6"), true))
                                 )))
                 );
     }
@@ -314,11 +314,11 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements MemoP
                                 any(),
                                 logicalProject().when(FieldChecker.check("projects", ImmutableList.of(
                                         new SlotReference(new ExprId(4), "k3", BigIntType.INSTANCE, true,
-                                                ImmutableList.of("test", "t7"))))
+                                                ImmutableList.of("test", "t7"), true)))
                                 )
                         ).when(FieldChecker.check("correlationSlot", ImmutableList.of(
                                 new SlotReference(new ExprId(1), "k2", BigIntType.INSTANCE, true,
-                                        ImmutableList.of("test", "t6")))))
+                                        ImmutableList.of("test", "t6"), true))))
                 );
     }
 
@@ -332,12 +332,12 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements MemoP
                                 logicalApply().when(FieldChecker.check("correlationFilter", Optional.empty()))
                                         .when(FieldChecker.check("correlationSlot", ImmutableList.of(
                                                 new SlotReference(new ExprId(1), "k2", BigIntType.INSTANCE, true,
-                                                        ImmutableList.of("test", "t6")))))
+                                                        ImmutableList.of("test", "t6"), true))))
                         ).when(FieldChecker.check("projects", ImmutableList.of(
                                 new SlotReference(new ExprId(0), "k1", BigIntType.INSTANCE, true,
-                                        ImmutableList.of("test", "t6")),
+                                        ImmutableList.of("test", "t6"), true),
                                 new SlotReference(new ExprId(1), "k2", BigIntType.INSTANCE, true,
-                                        ImmutableList.of("test", "t6")))))
+                                        ImmutableList.of("test", "t6"), true))))
                 );
     }
 
@@ -350,9 +350,9 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements MemoP
                 .matches(
                         logicalApply().when(FieldChecker.check("correlationFilter", Optional.of(
                                 new EqualTo(new SlotReference(new ExprId(1), "k2", BigIntType.INSTANCE, true,
-                                        ImmutableList.of("test", "t6")),
+                                        ImmutableList.of("test", "t6"), true),
                                         new SlotReference(new ExprId(6), "v2", BigIntType.INSTANCE, true,
-                                                ImmutableList.of("test", "t7"))))))
+                                                ImmutableList.of("test", "t7"), true)))))
                 );
     }
 
@@ -367,9 +367,9 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements MemoP
                         logicalJoin().when(FieldChecker.check("joinType", JoinType.LEFT_SEMI_JOIN))
                                 .when(FieldChecker.check("otherJoinConjuncts", ImmutableList.of(
                                         new EqualTo(new SlotReference(new ExprId(1), "k2", BigIntType.INSTANCE, true,
-                                                ImmutableList.of("test", "t6")),
+                                                ImmutableList.of("test", "t6"), true),
                                                 new SlotReference(new ExprId(6), "v2", BigIntType.INSTANCE, true,
-                                                        ImmutableList.of("test", "t7")))
+                                                        ImmutableList.of("test", "t7"), true))
                                 )))
                 );
     }
@@ -396,27 +396,27 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements MemoP
                                                         ).when(p -> p.getProjects().equals(ImmutableList.of(
                                                             new Alias(new ExprId(7), new SlotReference(new ExprId(5), "v1", BigIntType.INSTANCE,
                                                                     true,
-                                                                    ImmutableList.of("test", "t7")), "aa")
+                                                                    ImmutableList.of("test", "t7"), true), "aa")
                                                         )))
                                                     )
                                                     .when(a -> a.getAlias().equals("t2"))
                                                     .when(a -> a.getOutput().equals(ImmutableList.of(
                                                             new SlotReference(new ExprId(7), "aa", BigIntType.INSTANCE,
-                                                                    true, ImmutableList.of("t2"))
+                                                                    true, ImmutableList.of("t2"), true)
                                                     )))
                                                 )
                                             ).when(agg -> agg.getOutputExpressions().equals(ImmutableList.of(
                                                 new Alias(new ExprId(8),
                                                         (new Max(new SlotReference(new ExprId(7), "aa", BigIntType.INSTANCE,
                                                                 true,
-                                                                ImmutableList.of("t2")))).withAlwaysNullable(true), "max(aa)")
+                                                                ImmutableList.of("t2"), true))).withAlwaysNullable(true), "max(aa)")
                                             )))
                                             .when(agg -> agg.getGroupByExpressions().equals(ImmutableList.of()))
                                         )
                                     )
                                     .when(apply -> apply.getCorrelationSlot().equals(ImmutableList.of(
                                             new SlotReference(new ExprId(1), "k2", BigIntType.INSTANCE, true,
-                                                    ImmutableList.of("test", "t6")))))
+                                                    ImmutableList.of("test", "t6"), true))))
                                 )
                             )
                         )
@@ -439,17 +439,17 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements MemoP
                                         logicalFilter(
                                                 logicalProject().when(FieldChecker.check("projects", ImmutableList.of(
                                                         new Alias(new ExprId(7), new SlotReference(new ExprId(5), "v1", BigIntType.INSTANCE, true,
-                                                                ImmutableList.of("test", "t7")), "aa"),
+                                                                ImmutableList.of("test", "t7"), true), "aa"),
                                                         new SlotReference(new ExprId(2), "k1", BigIntType.INSTANCE, false,
-                                                                ImmutableList.of("test", "t7")),
+                                                                ImmutableList.of("test", "t7"), true),
                                                         new SlotReference(new ExprId(3), "k2", new VarcharType(128), true,
-                                                                ImmutableList.of("test", "t7")),
+                                                                ImmutableList.of("test", "t7"), true),
                                                         new SlotReference(new ExprId(4), "k3", BigIntType.INSTANCE, true,
-                                                                ImmutableList.of("test", "t7")),
+                                                                ImmutableList.of("test", "t7"), true),
                                                         new SlotReference(new ExprId(5), "v1", BigIntType.INSTANCE, true,
-                                                                ImmutableList.of("test", "t7")),
+                                                                ImmutableList.of("test", "t7"), true),
                                                         new SlotReference(new ExprId(6), "v2", BigIntType.INSTANCE, true,
-                                                                ImmutableList.of("test", "t7"))
+                                                                ImmutableList.of("test", "t7"), true)
                                                 )))
                                         )
                                 )
@@ -473,12 +473,12 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements MemoP
                                         logicalProject()
                                 ).when(FieldChecker.check("outputExpressions", ImmutableList.of(
                                         new Alias(new ExprId(8), (new Max(new SlotReference(new ExprId(7), "aa", BigIntType.INSTANCE, true,
-                                                ImmutableList.of("t2")))), "max(aa)"),
+                                                ImmutableList.of("t2"), true))), "max(aa)"),
                                         new SlotReference(new ExprId(6), "v2", BigIntType.INSTANCE, true,
-                                                ImmutableList.of("test", "t7")))))
+                                                ImmutableList.of("test", "t7"), true))))
                                         .when(FieldChecker.check("groupByExpressions", ImmutableList.of(
                                                 new SlotReference(new ExprId(6), "v2", BigIntType.INSTANCE, true,
-                                                        ImmutableList.of("test", "t7"))
+                                                        ImmutableList.of("test", "t7"), true)
                                         )))
                         )
                 );
@@ -494,19 +494,19 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements MemoP
                                                 new SlotReference(new ExprId(0), "k1",
                                                         BigIntType.INSTANCE, true,
                                                         ImmutableList.of("test",
-                                                                "t6")),
+                                                                "t6"), true),
                                                 new SlotReference(
                                                         new ExprId(8), "max(aa)",
                                                         BigIntType.INSTANCE, true,
-                                                        ImmutableList.of()))))
+                                                        ImmutableList.of(), true))))
                                 && j.getHashJoinConjuncts()
                                         .equals(ImmutableList.of(new EqualTo(
                                                 new SlotReference(new ExprId(1), "k2",
                                                         BigIntType.INSTANCE, true,
                                                         ImmutableList.of("test",
-                                                                "t6")),
+                                                                "t6"), true),
                                                 new SlotReference(new ExprId(6), "v2",
                                                         BigIntType.INSTANCE, true, ImmutableList.of(
-                                                                "test", "t7")))))));
+                                                                "test", "t7"), true))))));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/DatetimeFunctionBinderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/DatetimeFunctionBinderTest.java
@@ -95,23 +95,23 @@ public class DatetimeFunctionBinderTest {
     private final Interval secondInterval = new Interval(tinyIntLiteral, "SECOND");
 
     private final SlotReference yearUnit = new SlotReference(new ExprId(-1), "YEAR",
-            TinyIntType.INSTANCE, false, ImmutableList.of());
+            TinyIntType.INSTANCE, false, ImmutableList.of(), true);
     private final SlotReference quarterUnit = new SlotReference(new ExprId(-1), "QUARTER",
-            TinyIntType.INSTANCE, false, ImmutableList.of());
+            TinyIntType.INSTANCE, false, ImmutableList.of(), true);
     private final SlotReference monthUnit = new SlotReference(new ExprId(-1), "MONTH",
-            TinyIntType.INSTANCE, false, ImmutableList.of());
+            TinyIntType.INSTANCE, false, ImmutableList.of(), true);
     private final SlotReference weekUnit = new SlotReference(new ExprId(-1), "WEEK",
-            TinyIntType.INSTANCE, false, ImmutableList.of());
+            TinyIntType.INSTANCE, false, ImmutableList.of(), true);
     private final SlotReference dayUnit = new SlotReference(new ExprId(-1), "DAY",
-            TinyIntType.INSTANCE, false, ImmutableList.of());
+            TinyIntType.INSTANCE, false, ImmutableList.of(), true);
     private final SlotReference hourUnit = new SlotReference(new ExprId(-1), "HOUR",
-            TinyIntType.INSTANCE, false, ImmutableList.of());
+            TinyIntType.INSTANCE, false, ImmutableList.of(), true);
     private final SlotReference minuteUnit = new SlotReference(new ExprId(-1), "MINUTE",
-            TinyIntType.INSTANCE, false, ImmutableList.of());
+            TinyIntType.INSTANCE, false, ImmutableList.of(), true);
     private final SlotReference secondUnit = new SlotReference(new ExprId(-1), "SECOND",
-            TinyIntType.INSTANCE, false, ImmutableList.of());
+            TinyIntType.INSTANCE, false, ImmutableList.of(), true);
     private final SlotReference invalidUnit = new SlotReference(new ExprId(-1), "INVALID",
-            TinyIntType.INSTANCE, false, ImmutableList.of());
+            TinyIntType.INSTANCE, false, ImmutableList.of(), true);
 
     private final DateTimeV2Literal dateTimeV2Literal1 = new DateTimeV2Literal("2024-12-01");
     private final DateTimeV2Literal dateTimeV2Literal2 = new DateTimeV2Literal("2024-12-26");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/FillUpMissingSlotsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/FillUpMissingSlotsTest.java
@@ -95,7 +95,7 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
         String sql = "SELECT a1 FROM t1 GROUP BY a1 HAVING a1 > 0";
         SlotReference a1 = new SlotReference(
                 new ExprId(1), "a1", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         PlanChecker.from(connectContext).analyze(sql)
                 .matches(
@@ -106,7 +106,7 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
 
         sql = "SELECT a1 as value FROM t1 GROUP BY a1 HAVING a1 > 0";
         SlotReference value = new SlotReference(new ExprId(3), "value", TinyIntType.INSTANCE, true,
-                ImmutableList.of());
+                ImmutableList.of(), true);
         PlanChecker.from(connectContext).analyze(sql)
                 .applyBottomUp(new ExpressionRewrite(ExpressionAnalyzer.FUNCTION_ANALYZER_RULE))
                 .matches(
@@ -134,11 +134,11 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
         sql = "SELECT sum(a2) FROM t1 GROUP BY a1 HAVING a1 > 0";
         a1 = new SlotReference(
                 new ExprId(1), "a1", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         SlotReference a2 = new SlotReference(
                 new ExprId(2), "a2", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         Alias sumA2 = new Alias(new ExprId(3), new Sum(a2), "sum(a2)");
         PlanChecker.from(connectContext).analyze(sql)
@@ -159,11 +159,11 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
         String sql = "SELECT a1 FROM t1 GROUP BY a1 HAVING sum(a2) > 0";
         SlotReference a1 = new SlotReference(
                 new ExprId(1), "a1", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         SlotReference a2 = new SlotReference(
                 new ExprId(2), "a2", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         Alias sumA2 = new Alias(new ExprId(3), new Sum(a2), "sum(a2)");
         PlanChecker.from(connectContext).analyze(sql)
@@ -193,11 +193,11 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
         sql = "SELECT a1, sum(a2) as value FROM t1 GROUP BY a1 HAVING sum(a2) > 0";
         a1 = new SlotReference(
                 new ExprId(1), "a1", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         a2 = new SlotReference(
                 new ExprId(2), "a2", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         Alias value = new Alias(new ExprId(3), new Sum(a2), "value");
         PlanChecker.from(connectContext).analyze(sql)
@@ -223,16 +223,16 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
         sql = "SELECT a1, sum(a2) FROM t1 GROUP BY a1 HAVING MIN(pk) > 0";
         a1 = new SlotReference(
                 new ExprId(1), "a1", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         a2 = new SlotReference(
                 new ExprId(2), "a2", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         sumA2 = new Alias(new ExprId(3), new Sum(a2), "sum(a2)");
         SlotReference pk = new SlotReference(
                 new ExprId(0), "pk", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         Alias minPK = new Alias(new ExprId(4), new Min(pk), "min(pk)");
         PlanChecker.from(connectContext).analyze(sql)
@@ -290,15 +290,15 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
         String sql = "SELECT a1, sum(a2) FROM t1, t2 WHERE t1.pk = t2.pk GROUP BY a1 HAVING a1 > sum(b1)";
         SlotReference a1 = new SlotReference(
                 new ExprId(1), "a1", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         SlotReference a2 = new SlotReference(
                 new ExprId(2), "a2", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         SlotReference b1 = new SlotReference(
                 new ExprId(4), "b1", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t2")
+                ImmutableList.of("test_resolve_aggregate_functions", "t2"), true
         );
         Alias sumA2 = new Alias(new ExprId(6), new Sum(a2), "sum(a2)");
         Alias sumB1 = new Alias(new ExprId(7), new Sum(b1), "sum(b1)");
@@ -354,19 +354,19 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
                 + "HAVING t1.pk > 0 AND count(a1) + 1 > 0 AND sum(a1 + a2) + 1 > 0 AND v1 + 1 > 0 AND v1 > 0";
         SlotReference pk = new SlotReference(
                 new ExprId(0), "pk", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         SlotReference pk1 = new SlotReference(
                 new ExprId(6), "(pk + 1)", IntegerType.INSTANCE, true,
-                ImmutableList.of()
+                ImmutableList.of(), true
         );
         SlotReference a1 = new SlotReference(
                 new ExprId(1), "a1", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         SlotReference a2 = new SlotReference(
                 new ExprId(2), "a2", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         Alias pk11 = new Alias(new ExprId(7), new Add(new Cast(new Add(new Cast(pk, SmallIntType.INSTANCE), Literal.of((short) 1)), IntegerType.INSTANCE), Literal.of(1)), "((pk + 1) + 1)");
         Alias pk2 = new Alias(new ExprId(8), new Add(new Cast(pk, SmallIntType.INSTANCE), Literal.of((short) 2)), "(pk + 2)");
@@ -411,11 +411,11 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
         String sql = "SELECT a1 FROM t1 GROUP BY a1 ORDER BY sum(a2)";
         SlotReference a1 = new SlotReference(
                 new ExprId(1), "a1", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         SlotReference a2 = new SlotReference(
                 new ExprId(2), "a2", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         Alias sumA2 = new Alias(new ExprId(3), new Sum(a2), "sum(a2)");
         PlanChecker.from(connectContext).analyze(sql)
@@ -443,11 +443,11 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
         sql = "SELECT a1, sum(a2) as value FROM t1 GROUP BY a1 ORDER BY sum(a2)";
         a1 = new SlotReference(
                 new ExprId(1), "a1", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         a2 = new SlotReference(
                 new ExprId(2), "a2", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         Alias value = new Alias(new ExprId(3), new Sum(a2), "value");
         PlanChecker.from(connectContext).analyze(sql)
@@ -462,16 +462,16 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
         sql = "SELECT a1, sum(a2) FROM t1 GROUP BY a1 ORDER BY MIN(pk)";
         a1 = new SlotReference(
                 new ExprId(1), "a1", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         a2 = new SlotReference(
                 new ExprId(2), "a2", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         sumA2 = new Alias(new ExprId(3), new Sum(a2), "sum(a2)");
         SlotReference pk = new SlotReference(
                 new ExprId(0), "pk", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         Alias minPK = new Alias(new ExprId(4), new Min(pk), "min(pk)");
         PlanChecker.from(connectContext).analyze(sql)
@@ -525,12 +525,12 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
         sql = "SELECT abs(a1) xx, sum(a2) FROM t1 GROUP BY xx ORDER BY MIN(xx)";
         a1 = new SlotReference(
                 new ExprId(1), "a1", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         Alias xx = new Alias(new ExprId(3), new Abs(a1), "xx");
         a2 = new SlotReference(
                 new ExprId(2), "a2", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         sumA2 = new Alias(new ExprId(4), new Sum(a2), "sum(a2)");
 
@@ -553,19 +553,19 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
                 + "ORDER BY t1.pk, count(a1) + 1, sum(a1 + a2) + 1, v1 + 1, v1";
         SlotReference pk = new SlotReference(
                 new ExprId(0), "pk", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         SlotReference pk1 = new SlotReference(
                 new ExprId(6), "(pk + 1)", IntegerType.INSTANCE, true,
-                ImmutableList.of()
+                ImmutableList.of(), true
         );
         SlotReference a1 = new SlotReference(
                 new ExprId(1), "a1", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         SlotReference a2 = new SlotReference(
                 new ExprId(2), "a2", TinyIntType.INSTANCE, true,
-                ImmutableList.of("test_resolve_aggregate_functions", "t1")
+                ImmutableList.of("test_resolve_aggregate_functions", "t1"), true
         );
         Alias pk11 = new Alias(new ExprId(7), new Add(new Add(pk, Literal.of((byte) 1)), Literal.of((byte) 1)), "((pk + 1) + 1)");
         Alias pk2 = new Alias(new ExprId(8), new Add(pk, Literal.of((short) 2)), "(pk + 2)");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/ReplaceExpressionByChildOutputTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/ReplaceExpressionByChildOutputTest.java
@@ -44,7 +44,7 @@ public class ReplaceExpressionByChildOutputTest implements MemoPatternMatchSuppo
 
     @Test
     void testSortProject() {
-        SlotReference slotReference = new SlotReference("col1", IntegerType.INSTANCE);
+        SlotReference slotReference = new SlotReference("col1", IntegerType.INSTANCE, false);
         Alias alias = new Alias(slotReference, "a");
         LogicalOlapScan logicalOlapScan = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
         LogicalProject<Plan> logicalProject = new LogicalProject<>(ImmutableList.of(alias), logicalOlapScan);
@@ -61,7 +61,7 @@ public class ReplaceExpressionByChildOutputTest implements MemoPatternMatchSuppo
 
     @Test
     void testSortAggregate() {
-        SlotReference slotReference = new SlotReference("col1", IntegerType.INSTANCE);
+        SlotReference slotReference = new SlotReference("col1", IntegerType.INSTANCE, false);
         Alias alias = new Alias(slotReference, "a");
         LogicalOlapScan logicalOlapScan = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
         LogicalAggregate<Plan> logicalAggregate = new LogicalAggregate<>(
@@ -79,7 +79,7 @@ public class ReplaceExpressionByChildOutputTest implements MemoPatternMatchSuppo
 
     @Test
     void testSortHavingAggregate() {
-        SlotReference slotReference = new SlotReference("col1", IntegerType.INSTANCE);
+        SlotReference slotReference = new SlotReference("col1", IntegerType.INSTANCE, false);
         Alias alias = new Alias(slotReference, "a");
         LogicalOlapScan logicalOlapScan = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
         LogicalAggregate<Plan> logicalAggregate = new LogicalAggregate<>(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/SubqueryToApplyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/SubqueryToApplyTest.java
@@ -45,7 +45,7 @@ public class SubqueryToApplyTest {
 
     @Test
     void testAddNvlAggregate() {
-        SlotReference slotReference = new SlotReference("col1", IntegerType.INSTANCE);
+        SlotReference slotReference = new SlotReference("col1", IntegerType.INSTANCE, false);
         NamedExpression aggregateFunction = new Alias(new ExprId(12345), new Count(slotReference), "count");
         LogicalOlapScan logicalOlapScan = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
         LogicalAggregate<Plan> logicalAggregate = new LogicalAggregate<>(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/ExpressionRewriteTestHelper.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/ExpressionRewriteTestHelper.java
@@ -121,7 +121,7 @@ public abstract class ExpressionRewriteTestHelper extends ExpressionRewrite {
             DataType dataType = getType(name.charAt(0));
             boolean notNullable = name.charAt(0) == 'X' || name.length() >= 2 && name.charAt(1) == 'X';
             Column column = new Column(name, dataType.toCatalogDataType());
-            mem.putIfAbsent(name, new SlotReference(exprId, name, dataType, !notNullable, qualifier, null, column, null, null));
+            mem.putIfAbsent(name, new SlotReference(exprId, name, dataType, !notNullable, qualifier, null, column, null, null, true));
             return mem.get(name);
         }
         return hasNewChildren ? expression.withChildren(children) : expression;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
@@ -1083,7 +1083,7 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
         assertRewriteAfterTypeCoercion("10 * 2 / 1 + 1 > (1 + 1) - 100", "true");
 
         // a + 1 > 2
-        Slot a = SlotReference.of("a", IntegerType.INSTANCE);
+        Slot a = SlotReference.of("a", IntegerType.INSTANCE, false);
 
         // a > (1 + 10) / 2 * (10 + 1)
         Expression e3 = PARSER.parseExpression("(1 + 10) / 2 * (10 + 1)");
@@ -1165,7 +1165,7 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
         assertRewrite(e7, e8);
 
         // a + interval 1 day
-        Slot a = SlotReference.of("a", DateTimeV2Type.SYSTEM_DEFAULT);
+        Slot a = SlotReference.of("a", DateTimeV2Type.SYSTEM_DEFAULT, false);
         TimestampArithmetic arithmetic = new TimestampArithmetic(Operator.ADD, a, Literal.of(1), TimeUnit.DAY);
         Expression process = process(arithmetic);
         assertRewrite(process, process);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/MergeDateTruncTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/MergeDateTruncTest.java
@@ -37,7 +37,7 @@ public class MergeDateTruncTest extends ExpressionRewriteTestHelper {
         executor = new ExpressionRuleExecutor(ImmutableList.of(
                 bottomUp(MergeDateTrunc.INSTANCE)
         ));
-        Slot dataSlot = new SlotReference("data_slot", DateV2Type.INSTANCE);
+        Slot dataSlot = new SlotReference("data_slot", DateV2Type.INSTANCE, false);
         assertRewrite(new DateTrunc(new DateTrunc(dataSlot, new VarcharLiteral("HOUR")),
                         new VarcharLiteral("DAY")),
                 new DateTrunc(dataSlot, new VarcharLiteral("DAY")));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/PartitionPruneExpressionExtractorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/PartitionPruneExpressionExtractorTest.java
@@ -216,7 +216,7 @@ public class PartitionPruneExpressionExtractorTest {
         }
         if (expression instanceof UnboundSlot) {
             String name = ((UnboundSlot) expression).getName();
-            mem.putIfAbsent(name, new SlotReference(name, getType(name.charAt(0))));
+            mem.putIfAbsent(name, new SlotReference(name, getType(name.charAt(0)), false));
             return mem.get(name);
         }
         return hasNewChildren ? expression.withChildren(children) : expression;
@@ -241,11 +241,11 @@ public class PartitionPruneExpressionExtractorTest {
     }
 
     private Map<String, Slot> createPartitionSlots() {
-        SlotReference slotReference1 = new SlotReference("P1", StringType.INSTANCE);
-        SlotReference slotReference2 = new SlotReference("P2", IntegerType.INSTANCE);
-        SlotReference slotReference3 = new SlotReference("P3", StringType.INSTANCE);
-        SlotReference slotReference4 = new SlotReference("P4", IntegerType.INSTANCE);
-        SlotReference slotReference5 = new SlotReference("P5", StringType.INSTANCE);
+        SlotReference slotReference1 = new SlotReference("P1", StringType.INSTANCE, false);
+        SlotReference slotReference2 = new SlotReference("P2", IntegerType.INSTANCE, false);
+        SlotReference slotReference3 = new SlotReference("P3", StringType.INSTANCE, false);
+        SlotReference slotReference4 = new SlotReference("P4", IntegerType.INSTANCE, false);
+        SlotReference slotReference5 = new SlotReference("P5", StringType.INSTANCE, false);
         return ImmutableMap.of(
             "P1", slotReference1,
             "P2", slotReference2,

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
@@ -466,7 +466,7 @@ public class SimplifyRangeTest extends ExpressionRewrite {
         }
         if (expression instanceof UnboundSlot) {
             String name = ((UnboundSlot) expression).getName();
-            mem.putIfAbsent(name, new SlotReference(name, getType(name.charAt(0))));
+            mem.putIfAbsent(name, new SlotReference(name, getType(name.charAt(0)), false));
             return mem.get(name);
         }
         return hasNewChildren ? expression.withChildren(children) : expression;
@@ -484,7 +484,7 @@ public class SimplifyRangeTest extends ExpressionRewrite {
         }
         if (expression instanceof UnboundSlot) {
             String name = ((UnboundSlot) expression).getName();
-            mem.putIfAbsent(name, new SlotReference(name, getType(name.charAt(0)), false));
+            mem.putIfAbsent(name, new SlotReference(name, getType(name.charAt(0)), false,false));
             return mem.get(name);
         }
         return hasNewChildren ? expression.withChildren(children) : expression;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
@@ -484,7 +484,7 @@ public class SimplifyRangeTest extends ExpressionRewrite {
         }
         if (expression instanceof UnboundSlot) {
             String name = ((UnboundSlot) expression).getName();
-            mem.putIfAbsent(name, new SlotReference(name, getType(name.charAt(0)), false,false));
+            mem.putIfAbsent(name, new SlotReference(name, getType(name.charAt(0)), false, false));
             return mem.get(name);
         }
         return hasNewChildren ? expression.withChildren(children) : expression;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicateTest.java
@@ -131,10 +131,10 @@ class SimplifyComparisonPredicateTest extends ExpressionRewriteTestHelper {
                 )
         ));
 
-        Expression bigIntSlot = new SlotReference("a", BigIntType.INSTANCE);
-        Expression intSlot = new SlotReference("a", IntegerType.INSTANCE);
-        Expression smallIntSlot = new SlotReference("a", SmallIntType.INSTANCE);
-        Expression tinyIntSlot = new SlotReference("a", TinyIntType.INSTANCE);
+        Expression bigIntSlot = new SlotReference("a", BigIntType.INSTANCE, false);
+        Expression intSlot = new SlotReference("a", IntegerType.INSTANCE, false);
+        Expression smallIntSlot = new SlotReference("a", SmallIntType.INSTANCE, false);
+        Expression tinyIntSlot = new SlotReference("a", TinyIntType.INSTANCE, false);
 
         assertRewrite(new LessThan(new Cast(bigIntSlot, LargeIntType.INSTANCE), new LargeIntLiteral(new BigInteger("10"))),
                 new LessThan(bigIntSlot, new BigIntLiteral(10L)));
@@ -172,11 +172,11 @@ class SimplifyComparisonPredicateTest extends ExpressionRewriteTestHelper {
         rewrittenExpression = executor.rewrite(typeCoercion(expression), context);
         Assertions.assertEquals(dt.getDataType(), rewrittenExpression.child(0).getDataType());
 
-        Expression date = new SlotReference("a", DateV2Type.INSTANCE);
-        Expression datev1 = new SlotReference("a", DateType.INSTANCE);
-        Expression datetime0 = new SlotReference("a", DateTimeV2Type.of(0));
-        Expression datetime2 = new SlotReference("a", DateTimeV2Type.of(2));
-        Expression datetimev1 = new SlotReference("a", DateTimeType.INSTANCE);
+        Expression date = new SlotReference("a", DateV2Type.INSTANCE, false);
+        Expression datev1 = new SlotReference("a", DateType.INSTANCE, false);
+        Expression datetime0 = new SlotReference("a", DateTimeV2Type.of(0), false);
+        Expression datetime2 = new SlotReference("a", DateTimeV2Type.of(2), false);
+        Expression datetimev1 = new SlotReference("a", DateTimeType.INSTANCE, false);
 
         // date
         // cast (date as datetimev1) cmp datetimev1
@@ -502,10 +502,10 @@ class SimplifyComparisonPredicateTest extends ExpressionRewriteTestHelper {
         Assertions.assertEquals(left.child(0).getDataType(), rewrittenExpression.child(1).getDataType());
         Assertions.assertEquals(rewrittenExpression.child(0).getDataType(), rewrittenExpression.child(1).getDataType());
 
-        Expression tinyIntSlot = new SlotReference("a", TinyIntType.INSTANCE);
-        Expression smallIntSlot = new SlotReference("a", SmallIntType.INSTANCE);
-        Expression intSlot = new SlotReference("a", IntegerType.INSTANCE);
-        Expression bigIntSlot = new SlotReference("a", BigIntType.INSTANCE);
+        Expression tinyIntSlot = new SlotReference("a", TinyIntType.INSTANCE, false);
+        Expression smallIntSlot = new SlotReference("a", SmallIntType.INSTANCE, false);
+        Expression intSlot = new SlotReference("a", IntegerType.INSTANCE, false);
+        Expression bigIntSlot = new SlotReference("a", BigIntType.INSTANCE, false);
 
         // tiny int, literal not exceeds data type limit
         assertRewrite(new EqualTo(new Cast(tinyIntSlot, FloatType.INSTANCE), new FloatLiteral(12.0f)),
@@ -647,10 +647,10 @@ class SimplifyComparisonPredicateTest extends ExpressionRewriteTestHelper {
                 bottomUp(SimplifyComparisonPredicate.INSTANCE)
         ));
 
-        Expression tinyIntSlot = new SlotReference("a", TinyIntType.INSTANCE);
-        Expression smallIntSlot = new SlotReference("a", SmallIntType.INSTANCE);
-        Expression intSlot = new SlotReference("a", IntegerType.INSTANCE);
-        Expression bigIntSlot = new SlotReference("a", BigIntType.INSTANCE);
+        Expression tinyIntSlot = new SlotReference("a", TinyIntType.INSTANCE, false);
+        Expression smallIntSlot = new SlotReference("a", SmallIntType.INSTANCE, false);
+        Expression intSlot = new SlotReference("a", IntegerType.INSTANCE, false);
+        Expression bigIntSlot = new SlotReference("a", BigIntType.INSTANCE, false);
 
         // tiny int, literal not exceeds data type limit
         DecimalV3Type tinyDecimalType = DecimalV3Type.createDecimalV3Type(4, 1);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifyConditionalFunctionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifyConditionalFunctionTest.java
@@ -36,8 +36,9 @@ public class SimplifyConditionalFunctionTest extends ExpressionRewriteTestHelper
     @Test
     public void testCoalesce() {
         executor = new ExpressionRuleExecutor(ImmutableList.of(bottomUp((SimplifyConditionalFunction.INSTANCE))));
-        SlotReference slot = new SlotReference("a", StringType.INSTANCE, true);
-        SlotReference nonNullableSlot = new SlotReference("b", StringType.INSTANCE, false);
+        SlotReference slot = new SlotReference("a", StringType.INSTANCE, true, false);
+        SlotReference nonNullableSlot = new SlotReference("b", StringType.INSTANCE, false,
+                false);
 
         // coalesce(null, null, nullable_slot) -> nullable_slot
         assertRewrite(new Coalesce(NullLiteral.INSTANCE, NullLiteral.INSTANCE, slot), slot);
@@ -72,7 +73,8 @@ public class SimplifyConditionalFunctionTest extends ExpressionRewriteTestHelper
         // coalesce(null, nullable_slot, literal) -> coalesce(nullable_slot, slot, literal)
         assertRewrite(new Coalesce(slot, nonNullableSlot), new Coalesce(slot, nonNullableSlot));
 
-        SlotReference datetimeSlot = new SlotReference("dt", DateTimeV2Type.of(0), false);
+        SlotReference datetimeSlot = new SlotReference("dt", DateTimeV2Type.of(0), false,
+                false);
         // coalesce(null_datetime(0), non-nullable_slot_datetime(6))
         assertRewrite(
                 new Coalesce(new NullLiteral(DateTimeV2Type.of(6)), datetimeSlot),
@@ -88,8 +90,10 @@ public class SimplifyConditionalFunctionTest extends ExpressionRewriteTestHelper
     @Test
     public void testNvl() {
         executor = new ExpressionRuleExecutor(ImmutableList.of(bottomUp((SimplifyConditionalFunction.INSTANCE))));
-        SlotReference slot = new SlotReference("a", StringType.INSTANCE, true);
-        SlotReference nonNullableSlot = new SlotReference("b", StringType.INSTANCE, false);
+        SlotReference slot = new SlotReference("a", StringType.INSTANCE, true,
+                false);
+        SlotReference nonNullableSlot = new SlotReference("b", StringType.INSTANCE, false,
+                false);
         // nvl(null, nullable_slot) -> nullable_slot
         assertRewrite(new Nvl(NullLiteral.INSTANCE, slot), slot);
 
@@ -105,7 +109,8 @@ public class SimplifyConditionalFunctionTest extends ExpressionRewriteTestHelper
         // nvl(null, null) -> null
         assertRewrite(new Nvl(NullLiteral.INSTANCE, NullLiteral.INSTANCE), NullLiteral.INSTANCE);
 
-        SlotReference datetimeSlot = new SlotReference("dt", DateTimeV2Type.of(0), false);
+        SlotReference datetimeSlot = new SlotReference("dt", DateTimeV2Type.of(0), false,
+                false);
         // nvl(null_datetime(0), non-nullable_slot_datetime(6))
         assertRewrite(
                 new Nvl(new NullLiteral(DateTimeV2Type.of(6)), datetimeSlot),
@@ -121,8 +126,9 @@ public class SimplifyConditionalFunctionTest extends ExpressionRewriteTestHelper
     @Test
     public void testNullIf() {
         executor = new ExpressionRuleExecutor(ImmutableList.of(bottomUp((SimplifyConditionalFunction.INSTANCE))));
-        SlotReference slot = new SlotReference("a", StringType.INSTANCE, true);
-        SlotReference nonNullableSlot = new SlotReference("b", StringType.INSTANCE, false);
+        SlotReference slot = new SlotReference("a", StringType.INSTANCE, true, false);
+        SlotReference nonNullableSlot = new SlotReference("b", StringType.INSTANCE, false,
+                false);
         // nullif(null, slot) -> null
         assertRewrite(new NullIf(NullLiteral.INSTANCE, slot),
                 new Nullable(new NullLiteral(StringType.INSTANCE)));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/TopnToMaxTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/TopnToMaxTest.java
@@ -36,7 +36,7 @@ class TopnToMaxTest extends ExpressionRewriteTestHelper {
                 bottomUp(TopnToMax.INSTANCE)
         ));
 
-        Slot slot = new SlotReference("a", StringType.INSTANCE);
+        Slot slot = new SlotReference("a", StringType.INSTANCE, false);
         assertRewrite(new TopN(slot, Literal.of(1)), new Max(slot));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/implementation/ImplementationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/implementation/ImplementationTest.java
@@ -95,8 +95,8 @@ public class ImplementationTest {
 
     @Test
     public void toPhysicalProjectTest() {
-        SlotReference col1 = new SlotReference("col1", BigIntType.INSTANCE);
-        SlotReference col2 = new SlotReference("col2", IntegerType.INSTANCE);
+        SlotReference col1 = new SlotReference("col1", BigIntType.INSTANCE, false);
+        SlotReference col2 = new SlotReference("col2", IntegerType.INSTANCE, false);
         LogicalPlan project = new LogicalProject<>(Lists.newArrayList(col1, col2), groupPlan);
 
         PhysicalPlan physicalPlan = executeImplementationRule(project);
@@ -111,8 +111,10 @@ public class ImplementationTest {
     public void toPhysicalTopNTest() {
         int limit = 10;
         int offset = 100;
-        OrderKey key1 = new OrderKey(new SlotReference("col1", IntegerType.INSTANCE), true, true);
-        OrderKey key2 = new OrderKey(new SlotReference("col2", IntegerType.INSTANCE), true, true);
+        OrderKey key1 = new OrderKey(new SlotReference("col1", IntegerType.INSTANCE, false),
+                true, true);
+        OrderKey key2 = new OrderKey(new SlotReference("col2", IntegerType.INSTANCE, false),
+                true, true);
         LogicalTopN<GroupPlan> topN = new LogicalTopN<>(Lists.newArrayList(key1, key2), limit, offset, groupPlan);
 
         PhysicalPlan physicalPlan = executeImplementationRule(topN);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateEmptyRelationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateEmptyRelationTest.java
@@ -50,8 +50,8 @@ class EliminateEmptyRelationTest implements MemoPatternMatchSupported {
     @Test
     void testEliminateUnionEmptyChild() {
         List<SlotReference> emptyOutput = new ArrayList<>();
-        emptyOutput.add(new SlotReference("k", IntegerType.INSTANCE));
-        emptyOutput.add(new SlotReference("v", StringType.INSTANCE));
+        emptyOutput.add(new SlotReference("k", IntegerType.INSTANCE, false));
+        emptyOutput.add(new SlotReference("v", StringType.INSTANCE, false));
         LogicalEmptyRelation emptyRelation = new LogicalEmptyRelation(new RelationId(1000), emptyOutput);
 
         List<Plan> children = new ArrayList<>();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateJoinByFkTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateJoinByFkTest.java
@@ -250,11 +250,11 @@ class EliminateJoinByFkTest extends TestWithFeService implements MemoPatternMatc
 
     @Test
     void testReplaceMap() {
-        Slot a = new SlotReference("a", IntegerType.INSTANCE);
-        Slot b = new SlotReference("b", IntegerType.INSTANCE);
-        Slot x = new SlotReference("x", IntegerType.INSTANCE);
-        Slot y = new SlotReference("y", IntegerType.INSTANCE);
-        Slot z = new SlotReference("z", IntegerType.INSTANCE);
+        Slot a = new SlotReference("a", IntegerType.INSTANCE, false);
+        Slot b = new SlotReference("b", IntegerType.INSTANCE, false);
+        Slot x = new SlotReference("x", IntegerType.INSTANCE, false);
+        Slot y = new SlotReference("y", IntegerType.INSTANCE, false);
+        Slot z = new SlotReference("z", IntegerType.INSTANCE, false);
         Map<Slot, Slot> outputToForeign = Maps.newHashMap();
         outputToForeign.put(a, x);
         outputToForeign.put(b, y);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateUnnecessaryProjectTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateUnnecessaryProjectTest.java
@@ -93,8 +93,8 @@ class EliminateUnnecessaryProjectTest extends TestWithFeService implements MemoP
     void testEliminateProjectWhenEmptyRelationChild() {
         LogicalPlan unnecessaryProject = new LogicalPlanBuilder(new LogicalEmptyRelation(new RelationId(1),
                 ImmutableList.of(
-                        new SlotReference("k1", IntegerType.INSTANCE),
-                        new SlotReference("k2", IntegerType.INSTANCE))))
+                        new SlotReference("k1", IntegerType.INSTANCE, false),
+                        new SlotReference("k2", IntegerType.INSTANCE, false))))
                 .project(ImmutableList.of(1, 0))
                 .build();
         PlanChecker.from(MemoTestUtils.createConnectContext(), unnecessaryProject)

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/InferPredicateByReplaceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/InferPredicateByReplaceTest.java
@@ -50,8 +50,8 @@ import java.util.Set;
 public class InferPredicateByReplaceTest {
     @Test
     public void testInferWithEqualTo() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         EqualTo equalTo = new EqualTo(a, b);
         Set<Expression> inputs = new HashSet<>();
         inputs.add(equalTo);
@@ -63,8 +63,8 @@ public class InferPredicateByReplaceTest {
     @Test
     public void testInferWithInPredicate() {
         // abs(a) IN (1, 2, 3)
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         InPredicate inPredicate = new InPredicate(new Abs(a),
                 ImmutableList.of(new IntegerLiteral(1), new IntegerLiteral(2), new IntegerLiteral(3)));
         EqualTo equalTo = new EqualTo(a, b);
@@ -79,8 +79,8 @@ public class InferPredicateByReplaceTest {
     @Test
     public void testInferWithInPredicateNotSupport() {
         // a IN (1, b)
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         InPredicate inPredicate = new InPredicate(a,
                 ImmutableList.of(new IntegerLiteral(1), b));
         EqualTo equalTo = new EqualTo(a, b);
@@ -94,8 +94,8 @@ public class InferPredicateByReplaceTest {
 
     @Test
     public void testInferWithNotPredicate() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         InPredicate inPredicate = new InPredicate(a, ImmutableList.of(new IntegerLiteral(1), new IntegerLiteral(2)));
         Not notPredicate = new Not(inPredicate);
         EqualTo equalTo = new EqualTo(a, b);
@@ -111,8 +111,8 @@ public class InferPredicateByReplaceTest {
     @Test
     public void testInferWithLikePredicate() {
         // a LIKE 'test%'
-        SlotReference a = new SlotReference("a", StringType.INSTANCE);
-        SlotReference b = new SlotReference("b", StringType.INSTANCE);
+        SlotReference a = new SlotReference("a", StringType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", StringType.INSTANCE, false);
         EqualTo equalTo = new EqualTo(a, b);
         Like like = new Like(a, new StringLiteral("test%"));
         Set<Expression> inputs = new HashSet<>();
@@ -128,8 +128,8 @@ public class InferPredicateByReplaceTest {
     @Test
     public void testInferWithLikePredicateNotSupport() {
         // a LIKE b
-        SlotReference a = new SlotReference("a", StringType.INSTANCE);
-        SlotReference b = new SlotReference("b", StringType.INSTANCE);
+        SlotReference a = new SlotReference("a", StringType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", StringType.INSTANCE, false);
         EqualTo equalTo = new EqualTo(a, b);
         Like like = new Like(a, b);
         Set<Expression> inputs = new HashSet<>();
@@ -142,8 +142,8 @@ public class InferPredicateByReplaceTest {
 
     @Test
     public void testInferWithOrPredicate() {
-        SlotReference a = new SlotReference("a", DateTimeV2Type.SYSTEM_DEFAULT);
-        SlotReference b = new SlotReference("b", DateTimeV2Type.SYSTEM_DEFAULT);
+        SlotReference a = new SlotReference("a", DateTimeV2Type.SYSTEM_DEFAULT, false);
+        SlotReference b = new SlotReference("b", DateTimeV2Type.SYSTEM_DEFAULT, false);
         EqualTo equalTo = new EqualTo(a, b);
         Or or = new Or(new GreaterThan(a, new DateTimeV2Literal("2022-02-01 10:00:00")),
                 new LessThan(a, new DateTimeV2Literal("2022-01-01 10:00:00")));
@@ -157,8 +157,8 @@ public class InferPredicateByReplaceTest {
 
     @Test
     public void testInferWithPredicateDateTrunc() {
-        SlotReference a = new SlotReference("a", DateTimeV2Type.SYSTEM_DEFAULT);
-        SlotReference b = new SlotReference("b", DateTimeV2Type.SYSTEM_DEFAULT);
+        SlotReference a = new SlotReference("a", DateTimeV2Type.SYSTEM_DEFAULT, false);
+        SlotReference b = new SlotReference("b", DateTimeV2Type.SYSTEM_DEFAULT, false);
         EqualTo equalTo = new EqualTo(a, b);
         GreaterThan greaterThan = new GreaterThan(new DateTrunc(a, new VarcharLiteral("year")), new DateTimeV2Literal("2022-02-01 10:00:00"));
         Set<Expression> inputs = new HashSet<>();
@@ -171,11 +171,11 @@ public class InferPredicateByReplaceTest {
 
     @Test
     public void testValidForInfer() {
-        SlotReference a = new SlotReference("a", TinyIntType.INSTANCE);
+        SlotReference a = new SlotReference("a", TinyIntType.INSTANCE, false);
         Cast castExprA = new Cast(a, IntegerType.INSTANCE);
-        SlotReference b = new SlotReference("b", BigIntType.INSTANCE);
+        SlotReference b = new SlotReference("b", BigIntType.INSTANCE, false);
         Cast castExprB = new Cast(b, IntegerType.INSTANCE);
-        SlotReference c = new SlotReference("c", DateType.INSTANCE);
+        SlotReference c = new SlotReference("c", DateType.INSTANCE, false);
         Cast castExprC = new Cast(c, IntegerType.INSTANCE);
 
         EqualTo equalTo1 = new EqualTo(castExprA, castExprB);
@@ -189,9 +189,9 @@ public class InferPredicateByReplaceTest {
     @Test
     public void testNotInferWithTransitiveEqualitySameTable() {
         // a = b, b = c
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
         EqualTo equalTo1 = new EqualTo(a, b);
         EqualTo equalTo2 = new EqualTo(b, c);
         Set<Expression> inputs = new HashSet<>();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/NormalizeToSlotTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/NormalizeToSlotTest.java
@@ -36,7 +36,7 @@ public class NormalizeToSlotTest {
 
     @Test
     void testSlotReferenceWithItsAlias() {
-        SlotReference slotReference = new SlotReference("c1", StringType.INSTANCE);
+        SlotReference slotReference = new SlotReference("c1", StringType.INSTANCE, false);
         Alias alias = new Alias(slotReference, "a1");
         Set<Alias> existsAliases = ImmutableSet.of(alias);
         List<Expression> sourceExpressions = ImmutableList.of(slotReference, alias);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownVirtualColumnsIntoOlapScanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownVirtualColumnsIntoOlapScanTest.java
@@ -89,11 +89,11 @@ public class PushDownVirtualColumnsIntoOlapScanTest implements MemoPatternMatchS
         // SELECT a, b FROM table WHERE (x + y) > 10 AND (x + y) < 100 AND z = (x + y)
 
         DataType intType = IntegerType.INSTANCE;
-        SlotReference x = new SlotReference("x", intType);
-        SlotReference y = new SlotReference("y", intType);
-        SlotReference z = new SlotReference("z", intType);
-        SlotReference a = new SlotReference("a", intType);
-        SlotReference b = new SlotReference("b", intType);
+        SlotReference x = new SlotReference("x", intType, false);
+        SlotReference y = new SlotReference("y", intType, false);
+        SlotReference z = new SlotReference("z", intType, false);
+        SlotReference a = new SlotReference("a", intType, false);
+        SlotReference b = new SlotReference("b", intType, false);
 
         // Create repeated sub-expression: x + y
         Add xyAdd1 = new Add(x, y);
@@ -149,8 +149,8 @@ public class PushDownVirtualColumnsIntoOlapScanTest implements MemoPatternMatchS
         connectContext.getSessionVariable().experimentalEnableVirtualSlotForCse = true;
         // Test the existing distance function extraction functionality
         DataType intType = IntegerType.INSTANCE;
-        SlotReference vector1 = new SlotReference("vector1", intType);
-        SlotReference vector2 = new SlotReference("vector2", intType);
+        SlotReference vector1 = new SlotReference("vector1", intType, false);
+        SlotReference vector2 = new SlotReference("vector2", intType, false);
 
         // Create distance function
         L2Distance distance = new L2Distance(vector1, vector2);
@@ -226,9 +226,9 @@ public class PushDownVirtualColumnsIntoOlapScanTest implements MemoPatternMatchS
         // SELECT * FROM table WHERE (x * y + z) > 10 AND (x * y + z) < 100
 
         DataType intType = IntegerType.INSTANCE;
-        SlotReference x = new SlotReference("x", intType);
-        SlotReference y = new SlotReference("y", intType);
-        SlotReference z = new SlotReference("z", intType);
+        SlotReference x = new SlotReference("x", intType, false);
+        SlotReference y = new SlotReference("y", intType, false);
+        SlotReference z = new SlotReference("z", intType, false);
 
         // Create complex repeated expression: x * y + z
         Multiply xy1 = new Multiply(x, y);
@@ -373,7 +373,7 @@ public class PushDownVirtualColumnsIntoOlapScanTest implements MemoPatternMatchS
 
         // Create a lambda expression
         Array arr = new Array(y);
-        ArrayItemReference refA = new ArrayItemReference("a", arr);
+        ArrayItemReference refA = new ArrayItemReference("a", arr, false);
         Add lambdaAdd = new Add(refA.toSlot(), xyAdd);
         Lambda lambda = new Lambda(ImmutableList.of("a"), lambdaAdd, ImmutableList.of(refA));
 
@@ -421,9 +421,9 @@ public class PushDownVirtualColumnsIntoOlapScanTest implements MemoPatternMatchS
 
         DataType intType = IntegerType.INSTANCE;
         DataType varcharType = VarcharType.SYSTEM_DEFAULT;
-        SlotReference x = new SlotReference("x", intType);
-        SlotReference y = new SlotReference("y", intType);
-        SlotReference z = new SlotReference("z", intType);
+        SlotReference x = new SlotReference("x", intType, false);
+        SlotReference y = new SlotReference("y", intType, false);
+        SlotReference z = new SlotReference("z", intType, false);
 
         // Create optimizable repeated expressions
         Add xyAdd1 = new Add(x, y);
@@ -478,9 +478,9 @@ public class PushDownVirtualColumnsIntoOlapScanTest implements MemoPatternMatchS
         // SELECT * FROM table WHERE x > 10 AND y < 100 AND z = 50
 
         DataType intType = IntegerType.INSTANCE;
-        SlotReference x = new SlotReference("x", intType);
-        SlotReference y = new SlotReference("y", intType);
-        SlotReference z = new SlotReference("z", intType);
+        SlotReference x = new SlotReference("x", intType, false);
+        SlotReference y = new SlotReference("y", intType, false);
+        SlotReference z = new SlotReference("z", intType, false);
 
         // Create unique expressions (no repetition)
         GreaterThan gt = new GreaterThan(x, new IntegerLiteral(10));
@@ -521,8 +521,8 @@ public class PushDownVirtualColumnsIntoOlapScanTest implements MemoPatternMatchS
         // Test that rules correctly match different plan patterns
 
         DataType intType = IntegerType.INSTANCE;
-        SlotReference x = new SlotReference("x", intType);
-        SlotReference a = new SlotReference("a", intType);
+        SlotReference x = new SlotReference("x", intType, false);
+        SlotReference a = new SlotReference("a", intType, false);
 
         // Create a simple expression
         Add expr = new Add(x, new IntegerLiteral(1));
@@ -568,7 +568,7 @@ public class PushDownVirtualColumnsIntoOlapScanTest implements MemoPatternMatchS
         // Test that comparison predicates can be converted to ColumnPredicate
 
         DataType intType = IntegerType.INSTANCE;
-        SlotReference x = new SlotReference("x", intType);
+        SlotReference x = new SlotReference("x", intType, false);
         IntegerLiteral ten = new IntegerLiteral(10);
 
         // Create comparison predicates
@@ -595,7 +595,7 @@ public class PushDownVirtualColumnsIntoOlapScanTest implements MemoPatternMatchS
         // Test IN and IS NULL predicates
 
         DataType intType = IntegerType.INSTANCE;
-        SlotReference x = new SlotReference("x", intType);
+        SlotReference x = new SlotReference("x", intType, false);
 
         // Create IN predicate
         InPredicate inPred = new InPredicate(x,
@@ -621,7 +621,7 @@ public class PushDownVirtualColumnsIntoOlapScanTest implements MemoPatternMatchS
         // Test IP address range function detection
 
         DataType varcharType = VarcharType.SYSTEM_DEFAULT;
-        SlotReference ipColumn = new SlotReference("ip_addr", varcharType);
+        SlotReference ipColumn = new SlotReference("ip_addr", varcharType, false);
         StringLiteral cidr = new StringLiteral("192.168.1.0/24");
 
         IsIpAddressInRange ipRangeFunc = new IsIpAddressInRange(ipColumn, cidr);
@@ -641,7 +641,7 @@ public class PushDownVirtualColumnsIntoOlapScanTest implements MemoPatternMatchS
         // Test multi-match function detection
 
         DataType varcharType = VarcharType.SYSTEM_DEFAULT;
-        SlotReference textColumn = new SlotReference("content", varcharType);
+        SlotReference textColumn = new SlotReference("content", varcharType, false);
         StringLiteral query = new StringLiteral("search query");
 
         MultiMatch multiMatchFunc = new MultiMatch(textColumn, query);
@@ -664,8 +664,8 @@ public class PushDownVirtualColumnsIntoOlapScanTest implements MemoPatternMatchS
 
         DataType varcharType = VarcharType.SYSTEM_DEFAULT;
         DataType intType = IntegerType.INSTANCE;
-        SlotReference ipColumn = new SlotReference("ip_addr", varcharType);
-        SlotReference countColumn = new SlotReference("count", intType);
+        SlotReference ipColumn = new SlotReference("ip_addr", varcharType, false);
+        SlotReference countColumn = new SlotReference("count", intType, false);
         StringLiteral cidr = new StringLiteral("192.168.1.0/24");
         IntegerLiteral threshold = new IntegerLiteral(100);
 
@@ -699,8 +699,8 @@ public class PushDownVirtualColumnsIntoOlapScanTest implements MemoPatternMatchS
         DataType varcharType = VarcharType.createVarcharType(100);
 
         // Test supported types
-        SlotReference intSlot = new SlotReference("int_col", intType);
-        SlotReference varcharSlot = new SlotReference("varchar_col", varcharType);
+        SlotReference intSlot = new SlotReference("int_col", intType, false);
+        SlotReference varcharSlot = new SlotReference("varchar_col", varcharType, false);
         // Test basic arithmetic expression with supported types (should return integer)
         Add intAddition = new Add(intSlot, new IntegerLiteral(1));
         boolean intSupported = (boolean) method.invoke(rule, intAddition);
@@ -738,7 +738,7 @@ public class PushDownVirtualColumnsIntoOlapScanTest implements MemoPatternMatchS
             // Test expression that might return an unsupported type
             // Create a lambda function expression which should not be supported
             DataType intType = IntegerType.INSTANCE;
-            SlotReference intSlot = new SlotReference("int_col", intType);
+            SlotReference intSlot = new SlotReference("int_col", intType, false);
 
             // Test expressions that should fail type detection or return false
             // We create an expression that might fail during type determination
@@ -769,8 +769,8 @@ public class PushDownVirtualColumnsIntoOlapScanTest implements MemoPatternMatchS
         extractMethod.setAccessible(true);
 
         DataType intType = IntegerType.INSTANCE;
-        SlotReference x = new SlotReference("x", intType);
-        SlotReference y = new SlotReference("y", intType);
+        SlotReference x = new SlotReference("x", intType, false);
+        SlotReference y = new SlotReference("y", intType, false);
 
         // Create expressions that should be supported (arithmetic operations return int)
         Add supportedAdd1 = new Add(x, y);
@@ -835,8 +835,8 @@ public class PushDownVirtualColumnsIntoOlapScanTest implements MemoPatternMatchS
             typeCheckMethod.setAccessible(true);
 
             DataType intType = IntegerType.INSTANCE;
-            SlotReference x = new SlotReference("x", intType);
-            SlotReference y = new SlotReference("y", intType);
+            SlotReference x = new SlotReference("x", intType, false);
+            SlotReference y = new SlotReference("y", intType, false);
 
             // Create supported repeated expressions (arithmetic operations)
             Add supportedExpr1 = new Add(x, y);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/UnequalPredicateInferTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/UnequalPredicateInferTest.java
@@ -50,9 +50,9 @@ public class UnequalPredicateInferTest {
     @Test
     public void testInferWithTransitiveEqualitySameTable() {
         // t1.a = t1.b, t1.b = t1.c  only output 2 predicates
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
         EqualTo equalTo1 = new EqualTo(a, b);
         EqualTo equalTo2 = new EqualTo(b, c);
         Set<Expression> inputs = new LinkedHashSet<>();
@@ -67,9 +67,9 @@ public class UnequalPredicateInferTest {
 
     @Test
     public void testTopoSort() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
         // a b c has index 0 1 2 (sort by toSql())
         // a>b b>c
         ComparisonPredicate gt1 = new GreaterThan(a, b);
@@ -120,9 +120,9 @@ public class UnequalPredicateInferTest {
 
     @Test
     public void testTopoSortWithEqual() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
         // a=b b>c
         ComparisonPredicate gt1 = new EqualTo(a, b);
         ComparisonPredicate gt2 = new GreaterThan(b, c);
@@ -139,9 +139,9 @@ public class UnequalPredicateInferTest {
 
     @Test
     public void testTopoSortWithEqualMulti() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
         Literal d = new IntegerLiteral(1);
         // a=b b>c 1<c
         ComparisonPredicate eq = new EqualTo(a, b);
@@ -176,8 +176,8 @@ public class UnequalPredicateInferTest {
     // t1.a = 1, t1.b = 1 -> t1.a = 1, t1.b = 1
     @Test
     public void testChooseEqualPredicatesSameTable1() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
         Literal d = new IntegerLiteral(1);
         ComparisonPredicate eq1 = new EqualTo(a, d);
         ComparisonPredicate eq2 = new EqualTo(b, d);
@@ -201,9 +201,9 @@ public class UnequalPredicateInferTest {
     // t1.a = 1, t1.b = 1, t1.c = 1 -> t1.a = 1, t1.b = 1, t1.c = 1
     @Test
     public void testChooseEqualPredicatesSameTable2() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
         Literal d = new IntegerLiteral(1);
         ComparisonPredicate eq1 = new EqualTo(a, d);
         ComparisonPredicate eq2 = new EqualTo(b, d);
@@ -232,8 +232,8 @@ public class UnequalPredicateInferTest {
     // t1.a = 1, t1.b = t1.a -> t1.a = 1, t1.b = 1
     @Test
     public void testChooseEqualPredicatesSameTable3() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
         Literal d = new IntegerLiteral(1);
         ComparisonPredicate eq1 = new EqualTo(a, d);
         ComparisonPredicate eq2 = new EqualTo(b, a);
@@ -257,9 +257,9 @@ public class UnequalPredicateInferTest {
     // t1.a = 1, t1.b = t1.a, t1.a = t1.c -> t1.a = 1, t1.b = 1, t1.c = 1
     @Test
     public void testChooseEqualPredicatesSameTable4() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
         Literal d = new IntegerLiteral(1);
         ComparisonPredicate eq1 = new EqualTo(a, d);
         ComparisonPredicate eq2 = new EqualTo(b, a);
@@ -288,10 +288,10 @@ public class UnequalPredicateInferTest {
     // t1.a = 1, t1.b = t1.a, t1.d = t1.c -> t1.a = 1, t1.b = 1, t1.c = t1.d
     @Test
     public void testChooseEqualPredicatesSameTable5() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference d = new SlotReference("d", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference d = new SlotReference("d", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
         Literal literal = new IntegerLiteral(1);
         ComparisonPredicate eq1 = new EqualTo(a, literal);
         ComparisonPredicate eq2 = new EqualTo(b, a);
@@ -319,8 +319,8 @@ public class UnequalPredicateInferTest {
     @Test
     // t1.a = 1, t2.b = 1 -> t1.a = 1, t2.b = 1
     public void testChooseEqualPredicatesDiffTable1() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t2"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t2"), false);
         Literal d = new IntegerLiteral(1);
         ComparisonPredicate eq1 = new EqualTo(a, d);
         ComparisonPredicate eq2 = new EqualTo(b, d);
@@ -344,9 +344,9 @@ public class UnequalPredicateInferTest {
     // t1.a = 1, t2.b = 1, t3.c = 1 -> t1.a = 1, t2.b = 1, t2.c = 1
     @Test
     public void testChooseEqualPredicatesDiffTable2() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t2"));
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t3"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t2"), false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t3"), false);
         Literal d = new IntegerLiteral(1);
         ComparisonPredicate eq1 = new EqualTo(a, d);
         ComparisonPredicate eq2 = new EqualTo(b, d);
@@ -375,9 +375,9 @@ public class UnequalPredicateInferTest {
     // t1.a = 1, t2.b = t1.a, t1.a = t3.c -> t1.a = 1, t2.b = 1, t3.c = 1
     @Test
     public void testChooseEqualPredicatesDiffTable3() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t2"));
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t3"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t2"), false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t3"), false);
         Literal d = new IntegerLiteral(1);
         ComparisonPredicate eq1 = new EqualTo(a, d);
         ComparisonPredicate eq2 = new EqualTo(b, a);
@@ -406,10 +406,10 @@ public class UnequalPredicateInferTest {
     // t1.a = 1, t2.b = t1.a, t4.d = t3.c -> t1.a = 1, t2.b = 1, t4.d = t3.c
     @Test
     public void testChooseEqualPredicatesDiffTable5() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t2"));
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t3"));
-        SlotReference d = new SlotReference("d", IntegerType.INSTANCE, true, ImmutableList.of("t4"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t2"), false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t3"), false);
+        SlotReference d = new SlotReference("d", IntegerType.INSTANCE, true, ImmutableList.of("t4"), false);
         Literal literal = new IntegerLiteral(1);
         ComparisonPredicate eq1 = new EqualTo(a, literal);
         ComparisonPredicate eq2 = new EqualTo(b, a);
@@ -440,8 +440,8 @@ public class UnequalPredicateInferTest {
     // a>1 b>a -> a>1 b>a
     @Test
     public void testChooseUnequalPredicatesSameTable1() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
         Literal literal = new IntegerLiteral(1);
         ComparisonPredicate cmp1 = new GreaterThan(a, literal);
         ComparisonPredicate cmp2 = new GreaterThan(b, a);
@@ -465,8 +465,8 @@ public class UnequalPredicateInferTest {
     // a<1 b=a -> b<1 b=a
     @Test
     public void testChooseUnequalPredicatesSameTable2() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
         Literal literal = new IntegerLiteral(1);
         ComparisonPredicate cmp1 = new LessThan(a, literal);
         ComparisonPredicate cmp2 = new EqualTo(b, a);
@@ -499,8 +499,8 @@ public class UnequalPredicateInferTest {
     // t1.a>1 t1.b>t1.a -> t1.a>1,t1.b>1,t1.b>t1.a
     @Test
     public void testChooseUnequalPredicatesDiffTable1() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t2"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t2"), false);
         Literal literal = new IntegerLiteral(1);
         ComparisonPredicate cmp1 = new GreaterThan(a, literal);
         ComparisonPredicate cmp2 = new GreaterThan(b, a);
@@ -525,8 +525,8 @@ public class UnequalPredicateInferTest {
     // t1.a<1 t2.b=t1.a -> t2.b<1 t2.a<1 t2.b=t1.a
     @Test
     public void testChooseUnequalPredicatesDiffTable2() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t2"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t2"), false);
         Literal literal = new IntegerLiteral(1);
         ComparisonPredicate cmp1 = new LessThan(b, literal);
         ComparisonPredicate cmp2 = new EqualTo(b, a);
@@ -560,9 +560,9 @@ public class UnequalPredicateInferTest {
     // t1.a=t2.b t1.a=t3.c t2.b=t3.c -> t1.a=t2.b t1.a=t3.c t2.b=t3.c
     @Test
     public void testInferWithTransitiveEqualityDifferentTableThreeConjuncts1() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t2"));
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t3"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t2"), false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t3"), false);
         ComparisonPredicate cmp1 = new EqualTo(a, b);
         ComparisonPredicate cmp2 = new EqualTo(a, c);
         ComparisonPredicate cmp3 = new EqualTo(b, c);
@@ -579,9 +579,9 @@ public class UnequalPredicateInferTest {
     // t1.a=t3.c t1.a=t2.b t1.b=t3.c -> t1.a=t2.b t1.a=t3.c t2.b=t3.c
     @Test
     public void testInferWithTransitiveEqualityDifferentTableTwoConjuncts() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t2"));
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t3"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t2"), false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t3"), false);
         ComparisonPredicate cmp1 = new EqualTo(a, c);
         ComparisonPredicate cmp2 = new EqualTo(a, b);
         ComparisonPredicate cmp3 = new EqualTo(b, c);
@@ -597,9 +597,9 @@ public class UnequalPredicateInferTest {
     // t1.a=t3.c t1.a=t2.b t1.b=t3.c -> t1.a=t2.b t1.a=t3.c t2.b=t3.c
     @Test
     public void testUtilChooseMultiEquals() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t2"));
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t3"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t2"), false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t3"), false);
         ComparisonPredicate cmp1 = new EqualTo(a, c);
         ComparisonPredicate cmp2 = new EqualTo(a, b);
         ComparisonPredicate cmp3 = new EqualTo(b, c);
@@ -616,9 +616,9 @@ public class UnequalPredicateInferTest {
     // t1.a=t3.c t1.a=t2.b -> t1.a=t2.b t1.a=t3.c t2.b=t3.c
     @Test
     public void testUtilChooseMultiEquals2() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t2"));
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t3"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t2"), false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true, ImmutableList.of("t3"), false);
         ComparisonPredicate cmp1 = new EqualTo(a, c);
         ComparisonPredicate cmp2 = new EqualTo(a, b);
         ComparisonPredicate cmp3 = new EqualTo(b, c);
@@ -633,8 +633,8 @@ public class UnequalPredicateInferTest {
 
     @Test
     public void testPredicateUtils() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"));
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true, ImmutableList.of("t1"), false);
         Literal literal = new IntegerLiteral(1);
         ComparisonPredicate cmp1 = new LessThan(a, literal);
         ComparisonPredicate cmp2 = new EqualTo(b, a);
@@ -656,9 +656,9 @@ public class UnequalPredicateInferTest {
     @Test
     public void testInferWithTransitiveEqualityWithCastDateToDateTime() {
         // cast(d_datev2 as datetime) = cast(d_datev2 as datetime)
-        SlotReference a = new SlotReference("a", DateV2Type.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", DateV2Type.INSTANCE, true, ImmutableList.of("t2"));
-        SlotReference c = new SlotReference("c", DateTimeType.INSTANCE, true, ImmutableList.of("t3"));
+        SlotReference a = new SlotReference("a", DateV2Type.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", DateV2Type.INSTANCE, true, ImmutableList.of("t2"), false);
+        SlotReference c = new SlotReference("c", DateTimeType.INSTANCE, true, ImmutableList.of("t3"), false);
         EqualTo equalTo1 = new EqualTo(new Cast(a, DateTimeType.INSTANCE), c);
         EqualTo equalTo2 = new EqualTo(new Cast(b, DateTimeType.INSTANCE), c);
         Set<Expression> inputs = new HashSet<>();
@@ -672,9 +672,9 @@ public class UnequalPredicateInferTest {
     @Test
     public void testInferWithTransitiveEqualityWithCastDatev2andDate() {
         // cast(d_datev2 as date) = cast(d_date as d_datev2)
-        SlotReference a = new SlotReference("a", DateV2Type.INSTANCE, true, ImmutableList.of("t1"));
-        SlotReference b = new SlotReference("b", DateV2Type.INSTANCE, true, ImmutableList.of("t2"));
-        SlotReference c = new SlotReference("c", DateType.INSTANCE, true, ImmutableList.of("t3"));
+        SlotReference a = new SlotReference("a", DateV2Type.INSTANCE, true, ImmutableList.of("t1"), false);
+        SlotReference b = new SlotReference("b", DateV2Type.INSTANCE, true, ImmutableList.of("t2"), false);
+        SlotReference c = new SlotReference("c", DateType.INSTANCE, true, ImmutableList.of("t3"), false);
         EqualTo equalTo1 = new EqualTo(new Cast(a, DateType.INSTANCE), c);
         EqualTo equalTo2 = new EqualTo(b, new Cast(c, DateV2Type.INSTANCE));
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/ExpressionEstimationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/ExpressionEstimationTest.java
@@ -64,7 +64,7 @@ class ExpressionEstimationTest {
     // a belongs to [0, 500]
     @Test
     public void test1() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         Max max = new Max(a);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
 
@@ -88,7 +88,7 @@ class ExpressionEstimationTest {
     // a belongs to [0, 500]
     @Test
     public void test2() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
 
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder()
@@ -112,7 +112,7 @@ class ExpressionEstimationTest {
     // b belongs to [300, 1000]
     @Test
     public void test3() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
 
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder()
@@ -129,7 +129,7 @@ class ExpressionEstimationTest {
                 .setMaxValue(1000);
         slotToColumnStat.put(a, builder.build());
         Statistics stat = new Statistics(1000, slotToColumnStat);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         slotToColumnStat.put(b, builder1.build());
         Add add = new Add(a, b);
         ColumnStatistic estimated = ExpressionEstimation.estimate(add, stat);
@@ -142,7 +142,7 @@ class ExpressionEstimationTest {
     // b belongs to [300, 1000]
     @Test
     public void test4() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder()
                 .setNdv(500)
@@ -152,7 +152,7 @@ class ExpressionEstimationTest {
                 .setMaxValue(500);
         slotToColumnStat.put(a, builder.build());
         Statistics stat = new Statistics(1000, slotToColumnStat);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         builder.setMinValue(300);
         builder.setMaxValue(1000);
         slotToColumnStat.put(b, builder.build());
@@ -167,7 +167,7 @@ class ExpressionEstimationTest {
     // b belongs to [-300, 1000]
     @Test
     public void test5() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder()
                 .setNdv(500)
@@ -177,7 +177,7 @@ class ExpressionEstimationTest {
                 .setMaxValue(-100);
         slotToColumnStat.put(a, builder.build());
         Statistics stat = new Statistics(1000, slotToColumnStat);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         builder.setMinValue(-300);
         builder.setMaxValue(1000);
         slotToColumnStat.put(b, builder.build());
@@ -192,7 +192,7 @@ class ExpressionEstimationTest {
     // b belongs to [-1000, -300]
     @Test
     public void test6() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder()
                 .setNdv(500)
@@ -202,7 +202,7 @@ class ExpressionEstimationTest {
                 .setMaxValue(-100);
         slotToColumnStat.put(a, builder.build());
         Statistics stat = new Statistics(1000, slotToColumnStat);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         builder.setMinValue(-1000);
         builder.setMaxValue(-300);
         slotToColumnStat.put(b, builder.build());
@@ -217,7 +217,7 @@ class ExpressionEstimationTest {
     // b belongs to [-300, 1000]
     @Test
     public void test7() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
 
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder()
@@ -234,7 +234,7 @@ class ExpressionEstimationTest {
                 .setMaxValue(1000);
         slotToColumnStat.put(a, builder.build());
         Statistics stat = new Statistics(1000, slotToColumnStat);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         slotToColumnStat.put(b, builder1.build());
         Divide divide = new Divide(a, b);
         ColumnStatistic estimated = ExpressionEstimation.estimate(divide, stat);
@@ -247,7 +247,7 @@ class ExpressionEstimationTest {
     // b belongs to [-1000, -100]
     @Test
     public void test8() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
 
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder()
@@ -264,7 +264,7 @@ class ExpressionEstimationTest {
                 .setMaxValue(-100);
         slotToColumnStat.put(a, builder.build());
         Statistics stat = new Statistics(1000, slotToColumnStat);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         slotToColumnStat.put(b, builder1.build());
         Divide divide = new Divide(a, b);
         ColumnStatistic estimated = ExpressionEstimation.estimate(divide, stat);
@@ -275,7 +275,7 @@ class ExpressionEstimationTest {
     // cast(str to double) = double
     @Test
     public void testCastStrToDouble() {
-        SlotReference a = new SlotReference("a", StringType.INSTANCE);
+        SlotReference a = new SlotReference("a", StringType.INSTANCE, false);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder()
                 .setNdv(100)
@@ -297,7 +297,7 @@ class ExpressionEstimationTest {
     // both min and max can be converted to date
     @Test
     public void testCastStrToDateSuccess() {
-        SlotReference a = new SlotReference("a", StringType.INSTANCE);
+        SlotReference a = new SlotReference("a", StringType.INSTANCE, false);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder()
                 .setNdv(100)
@@ -319,7 +319,7 @@ class ExpressionEstimationTest {
     // min or max cannot be converted to date
     @Test
     public void testCastStrToDateFail() {
-        SlotReference a = new SlotReference("a", StringType.INSTANCE);
+        SlotReference a = new SlotReference("a", StringType.INSTANCE, false);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder()
                 .setNdv(100)
@@ -339,7 +339,7 @@ class ExpressionEstimationTest {
 
     @Test
     public void testCaseWhen() {
-        SlotReference a = new SlotReference("a", StringType.INSTANCE);
+        SlotReference a = new SlotReference("a", StringType.INSTANCE, false);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder()
                 .setNdv(100)
@@ -348,7 +348,7 @@ class ExpressionEstimationTest {
                 .setMaxExpr(new StringLiteral("2021abcdefg"))
                 .setMaxValue(20210101000000.0);
         slotToColumnStat.put(a, builder.build());
-        SlotReference b = new SlotReference("b", StringType.INSTANCE);
+        SlotReference b = new SlotReference("b", StringType.INSTANCE, false);
         builder = new ColumnStatisticBuilder()
                 .setNdv(10)
                 .setMinExpr(new StringLiteral("2020-01-01"))
@@ -371,7 +371,7 @@ class ExpressionEstimationTest {
 
     @Test
     public void testIf() {
-        SlotReference a = new SlotReference("a", StringType.INSTANCE);
+        SlotReference a = new SlotReference("a", StringType.INSTANCE, false);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder()
                 .setNdv(100)
@@ -380,7 +380,7 @@ class ExpressionEstimationTest {
                 .setMaxExpr(new StringLiteral("2021abcdefg"))
                 .setMaxValue(20210101000000.0);
         slotToColumnStat.put(a, builder.build());
-        SlotReference b = new SlotReference("b", StringType.INSTANCE);
+        SlotReference b = new SlotReference("b", StringType.INSTANCE, false);
         builder = new ColumnStatisticBuilder()
                 .setNdv(10)
                 .setMinExpr(new StringLiteral("2020-01-01"))
@@ -398,7 +398,7 @@ class ExpressionEstimationTest {
 
     @Test
     public void testNonNullable() {
-        SlotReference a = new SlotReference("a", StringType.INSTANCE);
+        SlotReference a = new SlotReference("a", StringType.INSTANCE, false);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder()
                 .setNdv(100)
@@ -472,7 +472,7 @@ class ExpressionEstimationTest {
 
     @Test
     public void testThrowException() {
-        SlotReference a = new SlotReference("a", StringType.INSTANCE);
+        SlotReference a = new SlotReference("a", StringType.INSTANCE, false);
         Cast cast = new Cast(a, DateType.INSTANCE);
         // do not throw any exception
         ColumnStatistic est = ExpressionEstimation.estimate(cast, null);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/FilterEstimationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/FilterEstimationTest.java
@@ -65,10 +65,10 @@ class FilterEstimationTest {
     // b isNaN
     @Test
     public void testOrNaN() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         IntegerLiteral int500 = new IntegerLiteral(500);
         GreaterThan greaterThan1 = new GreaterThan(a, int500);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         IntegerLiteral int100 = new IntegerLiteral(100);
         LessThan lessThan = new LessThan(b, int100);
         Or or = new Or(greaterThan1, lessThan);
@@ -94,10 +94,10 @@ class FilterEstimationTest {
     // b isNaN
     @Test
     public void testAndNaN() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         IntegerLiteral int500 = new IntegerLiteral(500);
         GreaterThan greaterThan1 = new GreaterThan(a, int500);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         IntegerLiteral int100 = new IntegerLiteral(100);
         LessThan lessThan = new LessThan(b, int100);
         And and = new And(greaterThan1, lessThan);
@@ -121,7 +121,7 @@ class FilterEstimationTest {
 
     @Test
     public void testInNaN() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         IntegerLiteral int500 = new IntegerLiteral(500);
         InPredicate in = new InPredicate(a, Lists.newArrayList(int500));
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
@@ -137,7 +137,7 @@ class FilterEstimationTest {
 
     @Test
     public void testNotInNaN() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         IntegerLiteral int500 = new IntegerLiteral(500);
         InPredicate in = new InPredicate(a, Lists.newArrayList(int500));
         Not notIn = new Not(in);
@@ -161,7 +161,7 @@ class FilterEstimationTest {
      */
     @Test
     public void testRelatedAnd() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         IntegerLiteral int100 = new IntegerLiteral(100);
         IntegerLiteral int200 = new IntegerLiteral(200);
         GreaterThan ge = new GreaterThan(a, int100);
@@ -184,7 +184,7 @@ class FilterEstimationTest {
 
     @Test
     public void knownEqualToUnknown() {
-        SlotReference ym = new SlotReference("a", new VarcharType(7));
+        SlotReference ym = new SlotReference("a", new VarcharType(7), false);
         double rowCount = 404962.0;
         double ndv = 14.0;
         ColumnStatistic ymStats = new ColumnStatisticBuilder(rowCount)
@@ -210,7 +210,7 @@ class FilterEstimationTest {
 
     @Test
     public void knownEqualToUnknownWithLittleNdv() {
-        SlotReference ym = new SlotReference("a", new VarcharType(7));
+        SlotReference ym = new SlotReference("a", new VarcharType(7), false);
         double rowCount = 404962.0;
         double ndv = 0.5;
         ColumnStatistic ymStats = new ColumnStatisticBuilder(rowCount)
@@ -237,7 +237,7 @@ class FilterEstimationTest {
 
     @Test
     public void unknownEqualToUnknown() {
-        SlotReference ym = new SlotReference("a", new VarcharType(7));
+        SlotReference ym = new SlotReference("a", new VarcharType(7), false);
         ColumnStatistic ymStats = ColumnStatistic.UNKNOWN;
         double rowCount = 404962.0;
         Statistics stats = new StatisticsBuilder()
@@ -257,13 +257,13 @@ class FilterEstimationTest {
     // a > 500 and b < 100 or a = c
     @Test
     public void test1() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         IntegerLiteral int500 = new IntegerLiteral(500);
         GreaterThan greaterThan1 = new GreaterThan(a, int500);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         IntegerLiteral int100 = new IntegerLiteral(100);
         LessThan lessThan = new LessThan(b, int100);
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, false);
         EqualTo equalTo = new EqualTo(a, c);
         And and = new And(greaterThan1, lessThan);
         Or or = new Or(and, equalTo);
@@ -289,13 +289,13 @@ class FilterEstimationTest {
     // a > 500 and b < 100 or a > c
     @Test
     public void test2() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         IntegerLiteral int500 = new IntegerLiteral(500);
         GreaterThan greaterThan1 = new GreaterThan(a, int500);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         IntegerLiteral int100 = new IntegerLiteral(100);
         LessThan lessThan = new LessThan(b, int100);
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, false);
         GreaterThan greaterThan = new GreaterThan(a, c);
         And and = new And(greaterThan1, lessThan);
         Or or = new Or(and, greaterThan);
@@ -322,7 +322,7 @@ class FilterEstimationTest {
     @Test
     public void test3() {
         double rowCount = 1000;
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         IntegerLiteral int500 = new IntegerLiteral(500);
         GreaterThanEqual ge = new GreaterThanEqual(a, int500);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
@@ -345,7 +345,7 @@ class FilterEstimationTest {
     @Test
     public void test4() {
         double rowCount = 1000;
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         IntegerLiteral int500 = new IntegerLiteral(500);
         LessThanEqual le = new LessThanEqual(a, int500);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
@@ -369,7 +369,7 @@ class FilterEstimationTest {
     public void test5() {
         double rowCount = 1000;
             {
-                SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+                SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
                 IntegerLiteral int500 = new IntegerLiteral(500);
                 LessThan less = new LessThan(a, int500);
                 Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
@@ -386,7 +386,7 @@ class FilterEstimationTest {
                 Assertions.assertEquals(0, expected.getRowCount());
             }
             {
-                SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+                SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
                 IntegerLiteral int500 = new IntegerLiteral(500);
                 LessThanEqual less = new LessThanEqual(a, int500);
                 Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
@@ -409,7 +409,7 @@ class FilterEstimationTest {
     @Test
     public void test6() {
         double rowCount = 1000;
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         IntegerLiteral int1000 = new IntegerLiteral(1000);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder()
@@ -436,8 +436,8 @@ class FilterEstimationTest {
     // b belongs to [501, 100]
     @Test
     public void test7() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         GreaterThan ge = new GreaterThan(a, b);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
         ColumnStatisticBuilder builder1 = new ColumnStatisticBuilder()
@@ -465,8 +465,8 @@ class FilterEstimationTest {
     // b belongs to [501, 100]
     @Test
     public void test8() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         LessThan less = new LessThan(a, b);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
         ColumnStatisticBuilder builder1 = new ColumnStatisticBuilder()
@@ -494,8 +494,8 @@ class FilterEstimationTest {
     // b belongs to [0, 500]
     @Test
     public void test9() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         GreaterThan ge = new GreaterThan(a, b);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
         ColumnStatisticBuilder builder1 = new ColumnStatisticBuilder()
@@ -522,7 +522,7 @@ class FilterEstimationTest {
     // a belongs to [1, 10]
     @Test
     public void test10() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         IntegerLiteral i1 = new IntegerLiteral(1);
         IntegerLiteral i3 = new IntegerLiteral(3);
         IntegerLiteral i5 = new IntegerLiteral(5);
@@ -547,7 +547,7 @@ class FilterEstimationTest {
     // a belongs to [1, 10]
     @Test
     public void test11() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         IntegerLiteral i1 = new IntegerLiteral(1);
         IntegerLiteral i3 = new IntegerLiteral(3);
         IntegerLiteral i5 = new IntegerLiteral(5);
@@ -573,9 +573,9 @@ class FilterEstimationTest {
     // c.selectivity is still 1, but its range becomes half
     @Test
     public void test12() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, false);
         IntegerLiteral i100 = new IntegerLiteral(100);
         GreaterThan ge = new GreaterThan(c, i100);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
@@ -623,9 +623,9 @@ class FilterEstimationTest {
      */
     @Test
     public void testFilterInsideMinMax() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, false);
         IntegerLiteral i10 = new IntegerLiteral(10);
         IntegerLiteral i20 = new IntegerLiteral(20);
         GreaterThan ge1 = new GreaterThan(c, i10);
@@ -685,9 +685,9 @@ class FilterEstimationTest {
     @Test
     public void testFilterOutofMinMax() {
         double origNdv = 1000;
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, false);
         IntegerLiteral i300 = new IntegerLiteral(300);
         GreaterThan ge = new GreaterThan(c, i300);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
@@ -753,9 +753,9 @@ class FilterEstimationTest {
      */
     @Test
     public void testInPredicateEstimationForColumns() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, false);
         IntegerLiteral i10 = new IntegerLiteral(10);
         IntegerLiteral i20 = new IntegerLiteral(20);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
@@ -820,9 +820,9 @@ class FilterEstimationTest {
      */
     @Test
     public void testInPredicateEstimationForColumnsOutofRange() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, false);
         IntegerLiteral i10 = new IntegerLiteral(10);
         IntegerLiteral i15 = new IntegerLiteral(15);
         IntegerLiteral i200 = new IntegerLiteral(200);
@@ -888,9 +888,9 @@ class FilterEstimationTest {
      */
     @Test
     public void testFilterEstimationForColumnsNotChanged() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, false);
         IntegerLiteral i10 = new IntegerLiteral(10);
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
 
@@ -936,7 +936,7 @@ class FilterEstimationTest {
 
     @Test
     public void testBetweenCastFilter() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder(100)
                 .setNdv(100)
                 .setAvgSizeByte(4)
@@ -964,7 +964,7 @@ class FilterEstimationTest {
     public void testDateRangeSelectivity() {
         DateLiteral from = new DateLiteral("1990-01-01");
         DateLiteral to = new DateLiteral("2000-01-01");
-        SlotReference a = new SlotReference("a", DateType.INSTANCE);
+        SlotReference a = new SlotReference("a", DateType.INSTANCE, false);
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder(100)
                 .setNdv(100)
                 .setAvgSizeByte(4)
@@ -982,7 +982,7 @@ class FilterEstimationTest {
 
     @Test
     public void testIsNull() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder(100)
                 .setNdv(100)
                 .setAvgSizeByte(4)
@@ -999,7 +999,7 @@ class FilterEstimationTest {
 
     @Test
     public void testIsNotNull() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder(100)
                 .setNdv(100)
                 .setAvgSizeByte(4)
@@ -1020,7 +1020,7 @@ class FilterEstimationTest {
      */
     @Test
     public void testNumNullsEqualTo() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder(10)
                 .setNdv(2)
                 .setAvgSizeByte(4)
@@ -1041,7 +1041,7 @@ class FilterEstimationTest {
      */
     @Test
     public void testNumNullsComparable() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder(10)
                 .setNdv(2)
                 .setAvgSizeByte(4)
@@ -1062,7 +1062,7 @@ class FilterEstimationTest {
      */
     @Test
     public void testNumNullsIn() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder(10)
                 .setNdv(2)
                 .setAvgSizeByte(4)
@@ -1084,7 +1084,7 @@ class FilterEstimationTest {
      */
     @Test
     public void testNumNullsNotEqualTo() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder(10)
                 .setNdv(2)
                 .setAvgSizeByte(4)
@@ -1106,7 +1106,7 @@ class FilterEstimationTest {
      */
     @Test
     public void testNumNullsNotIn() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder(10)
                 .setNdv(2)
                 .setAvgSizeByte(4)
@@ -1129,7 +1129,7 @@ class FilterEstimationTest {
      */
     @Test
     public void testNumNullsAnd() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder(10)
                 .setNdv(2)
                 .setAvgSizeByte(4)
@@ -1153,7 +1153,7 @@ class FilterEstimationTest {
      */
     @Test
     public void testNumNullsAndTwoCol() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         ColumnStatisticBuilder builderA = new ColumnStatisticBuilder(10)
                 .setNdv(2)
                 .setAvgSizeByte(4)
@@ -1162,7 +1162,7 @@ class FilterEstimationTest {
                 .setMinValue(1);
         IntegerLiteral int1 = new IntegerLiteral(1);
         EqualTo equalTo = new EqualTo(a, int1);
-        SlotReference b = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference b = new SlotReference("a", IntegerType.INSTANCE, false);
         ColumnStatisticBuilder builderB = new ColumnStatisticBuilder(10)
                 .setNdv(2)
                 .setAvgSizeByte(4)
@@ -1188,7 +1188,7 @@ class FilterEstimationTest {
      */
     @Test
     void testMultiAndWithNull() {
-        SlotReference dt = new SlotReference("dt", DateTimeType.INSTANCE);
+        SlotReference dt = new SlotReference("dt", DateTimeType.INSTANCE, false);
         ColumnStatisticBuilder dtBuilder = new ColumnStatisticBuilder(1000000)
                 .setNdv(783813.0)
                 .setNumNulls(50833.0)
@@ -1200,7 +1200,7 @@ class FilterEstimationTest {
         LessThan dtLess = new LessThan(dt, dtMax);
         And dtAnd = new And(dtLess, dtGreater);
 
-        SlotReference day = new SlotReference("day", DateType.INSTANCE);
+        SlotReference day = new SlotReference("day", DateType.INSTANCE, false);
         ColumnStatisticBuilder dayBuilder = new ColumnStatisticBuilder(1000000)
                 .setNdv(31.0)
                 .setNumNulls(49699.0)
@@ -1212,7 +1212,7 @@ class FilterEstimationTest {
         LessThan dayLess = new LessThan(day, dayMax);
         And dayAnd = new And(dayLess, dayGreater);
 
-        SlotReference game = new SlotReference("game", new VarcharType(500));
+        SlotReference game = new SlotReference("game", new VarcharType(500), false);
         ColumnStatisticBuilder gameBuilder = new ColumnStatisticBuilder(1000000)
                 .setNdv(1.0)
                 .setNumNulls(49813.0)
@@ -1223,7 +1223,7 @@ class FilterEstimationTest {
         VarcharLiteral mus = new VarcharLiteral("mus");
         EqualTo gameEqualTo = new EqualTo(game, mus);
 
-        SlotReference plat = new SlotReference("plat", new VarcharType(500));
+        SlotReference plat = new SlotReference("plat", new VarcharType(500), false);
         ColumnStatisticBuilder platBuilder = new ColumnStatisticBuilder(1000000)
                 .setNdv(1.0)
                 .setNumNulls(49691.0)
@@ -1254,7 +1254,7 @@ class FilterEstimationTest {
      */
     @Test
     public void testNumNullsOr() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder(10)
                 .setNdv(2)
                 .setAvgSizeByte(4)
@@ -1278,7 +1278,7 @@ class FilterEstimationTest {
      */
     @Test
     public void testNumNullsOrIsNull() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder(10)
                 .setNdv(2)
                 .setAvgSizeByte(4)
@@ -1307,7 +1307,7 @@ class FilterEstimationTest {
                 .setMaxValue(2)
                 .setMinValue(1);
         ColumnStatistic aStats = columnStatisticBuilder.build();
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
 
         ColumnStatisticBuilder columnStatisticBuilder2 = new ColumnStatisticBuilder(10)
                 .setNdv(2)
@@ -1316,7 +1316,7 @@ class FilterEstimationTest {
                 .setMaxValue(2)
                 .setMinValue(1);
         ColumnStatistic bStats = columnStatisticBuilder2.build();
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
 
         StatisticsBuilder statsBuilder = new StatisticsBuilder();
         statsBuilder.setRowCount(100);
@@ -1337,7 +1337,7 @@ class FilterEstimationTest {
      */
     @Test
     public void testStringRangeColToLiteral() {
-        SlotReference a = new SlotReference("a", new VarcharType(25));
+        SlotReference a = new SlotReference("a", new VarcharType(25), false);
         ColumnStatisticBuilder columnStatisticBuilder = new ColumnStatisticBuilder(100)
                 .setNdv(100)
                 .setAvgSizeByte(25)
@@ -1380,7 +1380,7 @@ class FilterEstimationTest {
 
     @Test
     public void testStringRangeColToDateLiteral() {
-        SlotReference a = new SlotReference("a", new VarcharType(25));
+        SlotReference a = new SlotReference("a", new VarcharType(25), false);
         ColumnStatisticBuilder columnStatisticBuilder = new ColumnStatisticBuilder(100)
                 .setNdv(100)
                 .setAvgSizeByte(25)
@@ -1408,7 +1408,7 @@ class FilterEstimationTest {
 
     @Test
     public void testStringRangeColToCol() {
-        SlotReference a = new SlotReference("a", new VarcharType(25));
+        SlotReference a = new SlotReference("a", new VarcharType(25), false);
         ColumnStatisticBuilder columnStatisticBuilderA = new ColumnStatisticBuilder(100)
                 .setNdv(100)
                 .setAvgSizeByte(25)
@@ -1418,7 +1418,7 @@ class FilterEstimationTest {
                 .setMinExpr(new StringLiteral("2020-01-01").toLegacyLiteral())
                 .setMinValue(new VarcharLiteral("2020-01-01").getDouble());
 
-        SlotReference b = new SlotReference("b", new VarcharType(25));
+        SlotReference b = new SlotReference("b", new VarcharType(25), false);
         ColumnStatisticBuilder columnStatisticBuilderB = new ColumnStatisticBuilder(100)
                 .setNdv(100)
                 .setAvgSizeByte(25)
@@ -1428,7 +1428,7 @@ class FilterEstimationTest {
                 .setMinExpr(new StringLiteral("2010-01-01").toLegacyLiteral())
                 .setMinValue(new VarcharLiteral("2010-01-01").getDouble());
 
-        SlotReference c = new SlotReference("c", new VarcharType(25));
+        SlotReference c = new SlotReference("c", new VarcharType(25), false);
         ColumnStatisticBuilder columnStatisticBuilderC = new ColumnStatisticBuilder(100)
                 .setNdv(100)
                 .setAvgSizeByte(25)
@@ -1461,7 +1461,7 @@ class FilterEstimationTest {
 
     @Test
     public void testStringRangeColToColDateType() {
-        SlotReference a = new SlotReference("a", DateType.INSTANCE);
+        SlotReference a = new SlotReference("a", DateType.INSTANCE, false);
         ColumnStatisticBuilder columnStatisticBuilderA = new ColumnStatisticBuilder(100)
                 .setNdv(100)
                 .setAvgSizeByte(25)
@@ -1471,7 +1471,7 @@ class FilterEstimationTest {
                 .setMinExpr(new StringLiteral("2020-01-01").toLegacyLiteral())
                 .setMinValue(new DateLiteral("2020-01-01").getDouble());
 
-        SlotReference b = new SlotReference("b", DateType.INSTANCE);
+        SlotReference b = new SlotReference("b", DateType.INSTANCE, false);
         ColumnStatisticBuilder columnStatisticBuilderB = new ColumnStatisticBuilder(100)
                 .setNdv(100)
                 .setAvgSizeByte(25)
@@ -1481,7 +1481,7 @@ class FilterEstimationTest {
                 .setMinExpr(new StringLiteral("2010-01-01").toLegacyLiteral())
                 .setMinValue(new DateLiteral("2010-01-01").getDouble());
 
-        SlotReference c = new SlotReference("c", DateType.INSTANCE);
+        SlotReference c = new SlotReference("c", DateType.INSTANCE, false);
         ColumnStatisticBuilder columnStatisticBuilderC = new ColumnStatisticBuilder(100)
                 .setNdv(100)
                 .setAvgSizeByte(25)
@@ -1512,7 +1512,7 @@ class FilterEstimationTest {
 
     @Test
     public void testLargeRange() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         long tenB = 1000000000;
         long row = 1600000000;
         ColumnStatistic colStats = new ColumnStatisticBuilder(row)
@@ -1540,13 +1540,13 @@ class FilterEstimationTest {
     @Test
     void testAndWithInfinity() {
         Double row = 1000.0;
-        SlotReference a = new SlotReference("a", new VarcharType(25));
+        SlotReference a = new SlotReference("a", new VarcharType(25), false);
         ColumnStatisticBuilder columnStatisticBuilderA = new ColumnStatisticBuilder(row)
                 .setNdv(10)
                 .setAvgSizeByte(4)
                 .setNumNulls(0);
 
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         ColumnStatisticBuilder columnStatisticBuilderB = new ColumnStatisticBuilder(row)
                 .setNdv(488)
                 .setAvgSizeByte(25)
@@ -1574,13 +1574,13 @@ class FilterEstimationTest {
     void testEqualAndIsNull() {
         // avoid to normalize num-nulls twice
         Double row = 1000.0;
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         ColumnStatisticBuilder columnStatisticBuilderA = new ColumnStatisticBuilder(row)
                 .setNdv(10)
                 .setAvgSizeByte(4)
                 .setNumNulls(0);
 
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         ColumnStatisticBuilder columnStatisticBuilderB = new ColumnStatisticBuilder(row)
                 .setNdv(10)
                 .setAvgSizeByte(4)
@@ -1614,14 +1614,14 @@ class FilterEstimationTest {
     @Test
     void testDeltaRow() {
         double row = 1000.0;
-        SlotReference a = new SlotReference("a", DateType.INSTANCE);
+        SlotReference a = new SlotReference("a", DateType.INSTANCE, false);
         ColumnStatisticBuilder columnStatisticBuilderA = new ColumnStatisticBuilder(row)
                 .setNdv(10)
                 .setAvgSizeByte(4)
                 .setNumNulls(0)
                 .setMaxExpr(new org.apache.doris.analysis.DateLiteral(2020, 1, 1))
                 .setMaxValue(new DateLiteral(2020, 1, 1).getDouble());
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         ColumnStatisticBuilder columnStatisticBuilderB = new ColumnStatisticBuilder(row)
                 .setNdv(10)
                 .setAvgSizeByte(4)
@@ -1906,7 +1906,7 @@ class FilterEstimationTest {
     @Test
     public void testAvoidNegativeRowCount() {
         Double row = 0.0;
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
         ColumnStatisticBuilder columnStatisticBuilderA = new ColumnStatisticBuilder(row)
                 .setNdv(1)
                 .setAvgSizeByte(4)

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/JoinEstimateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/JoinEstimateTest.java
@@ -50,8 +50,8 @@ public class JoinEstimateTest {
      */
     @Test
     public void testInnerJoinStats() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
         EqualTo eq = new EqualTo(a, b);
         Statistics leftStats = new StatisticsBuilder().setRowCount(100).build();
         leftStats.addColumnStats(a,
@@ -93,9 +93,9 @@ public class JoinEstimateTest {
 
     @Test
     public void testOuterJoinStats() {
-        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
-        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
-        SlotReference c = new SlotReference("c", IntegerType.INSTANCE);
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE, false);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, false);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, false);
         EqualTo eq = new EqualTo(a, b);
         Statistics leftStats = new StatisticsBuilder().setRowCount(100).build();
         leftStats.addColumnStats(a,

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
@@ -92,8 +92,8 @@ public class StatsCalculatorTest {
         List<String> qualifier = Lists.newArrayList();
         qualifier.add("test");
         qualifier.add("t");
-        SlotReference slot1 = new SlotReference("c1", IntegerType.INSTANCE, true, qualifier);
-        SlotReference slot2 = new SlotReference("c2", IntegerType.INSTANCE, true, qualifier);
+        SlotReference slot1 = new SlotReference("c1", IntegerType.INSTANCE, true, qualifier, false);
+        SlotReference slot2 = new SlotReference("c2", IntegerType.INSTANCE, true, qualifier, false);
 
         ColumnStatisticBuilder columnStat1 = new ColumnStatisticBuilder();
         columnStat1.setNdv(10);
@@ -140,8 +140,8 @@ public class StatsCalculatorTest {
     @org.junit.Test
     public void testFilterOutofRange() {
         List<String> qualifier = ImmutableList.of("test", "t");
-        SlotReference slot1 = new SlotReference("c1", IntegerType.INSTANCE, true, qualifier);
-        SlotReference slot2 = new SlotReference("c2", IntegerType.INSTANCE, true, qualifier);
+        SlotReference slot1 = new SlotReference("c1", IntegerType.INSTANCE, true, qualifier, false);
+        SlotReference slot2 = new SlotReference("c2", IntegerType.INSTANCE, true, qualifier, false);
 
         ColumnStatisticBuilder columnStat1 = new ColumnStatisticBuilder();
         columnStat1.setNdv(10);
@@ -191,7 +191,7 @@ public class StatsCalculatorTest {
         List<String> qualifier = ImmutableList.of("test", "t");
         SlotReference slot1 = new SlotReference(new ExprId(0), "c1", IntegerType.INSTANCE, true, qualifier,
                 table1, new Column("c1", PrimitiveType.INT),
-                table1, new Column("c1", PrimitiveType.INT));
+                table1, new Column("c1", PrimitiveType.INT), false);
 
         LogicalOlapScan logicalOlapScan1 = (LogicalOlapScan) new LogicalOlapScan(
                 StatementScopeIdGenerator.newRelationId(), table1,
@@ -211,7 +211,7 @@ public class StatsCalculatorTest {
         List<String> qualifier = ImmutableList.of("test", "t");
         SlotReference slot1 = new SlotReference(new ExprId(0), "c1", IntegerType.INSTANCE, true, qualifier,
                 null, new Column("c1", PrimitiveType.INT),
-                null, new Column("c1", PrimitiveType.INT));
+                null, new Column("c1", PrimitiveType.INT), false);
         ColumnStatisticBuilder columnStat1 = new ColumnStatisticBuilder();
         columnStat1.setNdv(10);
         columnStat1.setNumNulls(5);
@@ -238,7 +238,7 @@ public class StatsCalculatorTest {
     @Test
     public void testTopN() {
         List<String> qualifier = ImmutableList.of("test", "t");
-        SlotReference slot1 = new SlotReference("c1", IntegerType.INSTANCE, true, qualifier);
+        SlotReference slot1 = new SlotReference("c1", IntegerType.INSTANCE, true, qualifier, false);
         ColumnStatisticBuilder columnStat1 = new ColumnStatisticBuilder();
         columnStat1.setNdv(10);
         columnStat1.setNumNulls(5);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
@@ -274,7 +274,7 @@ public class StatsCalculatorTest {
         ColumnStatistic ibStats = StatsTestUtil.instance.createColumnStatistic("ib", 10,
                 rowCount, "1", "10", 0, new String[]{"2", "3", "4"});
 
-        SlotReference ic = new SlotReference("ic", IntegerType.INSTANCE);
+        SlotReference ic = new SlotReference("ic", IntegerType.INSTANCE, false);
         ColumnStatistic icStats = StatsTestUtil.instance.createColumnStatistic("ic", 10,
                 rowCount, "1", "10", 0, new String[]{"6", "7", "8", "9", "10"});
 
@@ -342,7 +342,7 @@ public class StatsCalculatorTest {
         ColumnStatistic ibStats = StatsTestUtil.instance.createColumnStatistic("ib", 10,
                 rowCount, "1", "10", 0, new String[]{"2", "3", "4"});
 
-        SlotReference ic = new SlotReference("ic", IntegerType.INSTANCE);
+        SlotReference ic = new SlotReference("ic", IntegerType.INSTANCE, false);
         ColumnStatistic icStats = StatsTestUtil.instance.createColumnStatistic("ic", 10,
                 rowCount, "1", "10", 0, new String[]{"4", "5", "6", "7"});
 
@@ -382,7 +382,7 @@ public class StatsCalculatorTest {
         ColumnStatistic ibStats = StatsTestUtil.instance.createColumnStatistic("ib", 10,
                 rowCount, "1", "10", 0, new String[]{"2", "3", "4"});
 
-        SlotReference ic = new SlotReference("ic", IntegerType.INSTANCE);
+        SlotReference ic = new SlotReference("ic", IntegerType.INSTANCE, false);
         ColumnStatistic icStats = StatsTestUtil.instance.createColumnStatistic("ic", 10,
                 rowCount, "1", "10", 0, new String[]{"4", "5", "6", "7"});
 
@@ -422,7 +422,7 @@ public class StatsCalculatorTest {
         ColumnStatistic ibStats = StatsTestUtil.instance.createColumnStatistic("ib", 10,
                 rowCount, "1", "10", 0, new String[]{"2", "3", "4"});
 
-        SlotReference ic = new SlotReference("ic", IntegerType.INSTANCE);
+        SlotReference ic = new SlotReference("ic", IntegerType.INSTANCE, false);
         ColumnStatistic icStats = StatsTestUtil.instance.createColumnStatistic("ic", 10,
                 rowCount, "1", "10", 0, new String[]{"4", "5", "6", "7"});
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsTestUtil.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsTestUtil.java
@@ -181,7 +181,7 @@ public class StatsTestUtil {
                 String colName = ((UnboundSlot) e).getName();
                 SlotReference slot = slotNameMap.get(colName);
                 if (slot == null) {
-                    slot = new SlotReference(colName, guessDataType(colName));
+                    slot = new SlotReference(colName, guessDataType(colName), false);
                     slots.add(slot);
                 }
                 return slot;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/ExpressionEqualsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/ExpressionEqualsTest.java
@@ -31,18 +31,18 @@ import org.junit.jupiter.api.Test;
 public class ExpressionEqualsTest {
     private final ExprId exprId = new ExprId(1);
     private final Expression child1 = new SlotReference(exprId, "child",
-            IntegerType.INSTANCE, false, Lists.newArrayList());
+            IntegerType.INSTANCE, false, Lists.newArrayList(), false);
     private final Expression left1 = new SlotReference(exprId, "left",
-            IntegerType.INSTANCE, false, Lists.newArrayList());
+            IntegerType.INSTANCE, false, Lists.newArrayList(), false);
     private final Expression right1 = new SlotReference(exprId, "right",
-            IntegerType.INSTANCE, false, Lists.newArrayList());
+            IntegerType.INSTANCE, false, Lists.newArrayList(), false);
 
     private final Expression child2 = new SlotReference(exprId, "child",
-            IntegerType.INSTANCE, false, Lists.newArrayList());
+            IntegerType.INSTANCE, false, Lists.newArrayList(), false);
     private final Expression left2 = new SlotReference(exprId, "left",
-            IntegerType.INSTANCE, false, Lists.newArrayList());
+            IntegerType.INSTANCE, false, Lists.newArrayList(), false);
     private final Expression right2 = new SlotReference(exprId, "right",
-            IntegerType.INSTANCE, false, Lists.newArrayList());
+            IntegerType.INSTANCE, false, Lists.newArrayList(), false);
 
     @Test
     public void testComparisonPredicate() {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/ExpressionTest.java
@@ -36,14 +36,14 @@ public class ExpressionTest {
         Assertions.assertTrue(new StringLiteral("abc").isConstant());
 
         // slot reference is not constant
-        Assertions.assertFalse(new SlotReference("a", IntegerType.INSTANCE).isConstant());
+        Assertions.assertFalse(new SlotReference("a", IntegerType.INSTANCE, false).isConstant());
 
         // `1 + 2` is constant
         Assertions.assertTrue(new Add(new IntegerLiteral(1), new IntegerLiteral(2)).isConstant());
 
         // `a + 1` is not constant
         Assertions.assertFalse(
-                new Add(new SlotReference("a", IntegerType.INSTANCE), new IntegerLiteral(1)).isConstant());
+                new Add(new SlotReference("a", IntegerType.INSTANCE, false), new IntegerLiteral(1)).isConstant());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeOuterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeOuterTest.java
@@ -41,8 +41,8 @@ public class ExplodeOuterTest {
     @Test
     public void testGetSignatures() {
         // build explode_outer(array<int>, array<str>) expression
-        Expression[] args = {SlotReference.of("int", ArrayType.of(IntegerType.INSTANCE)),
-            SlotReference.of("str", ArrayType.of(StringType.INSTANCE))};
+        Expression[] args = {SlotReference.of("int", ArrayType.of(IntegerType.INSTANCE), false),
+            SlotReference.of("str", ArrayType.of(StringType.INSTANCE), false)};
         ExplodeOuter explode = new ExplodeOuter(args);
 
         // check signature
@@ -64,7 +64,7 @@ public class ExplodeOuterTest {
     @Test
     public void testGetSignaturesWithNull() {
         // build explode(null, array<int>) expression
-        Expression[] args = { SlotReference.of("null", NullType.INSTANCE), SlotReference.of("int", ArrayType.of(IntegerType.INSTANCE))};
+        Expression[] args = { SlotReference.of("null", NullType.INSTANCE, false), SlotReference.of("int", ArrayType.of(IntegerType.INSTANCE), false)};
         ExplodeOuter explode = new ExplodeOuter(args);
 
         // check signature
@@ -86,7 +86,7 @@ public class ExplodeOuterTest {
     @Test
     public void testGetSignaturesWithInvalidArgument() {
         // build explode_outer(int)
-        Expression[] args = { SlotReference.of("int", IntegerType.INSTANCE) };
+        Expression[] args = { SlotReference.of("int", IntegerType.INSTANCE, false) };
         ExplodeOuter explode = new ExplodeOuter(args);
 
         Assertions.assertThrows(AnalysisException.class, explode::getSignatures);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeTest.java
@@ -41,8 +41,8 @@ public class ExplodeTest {
     @Test
     public void testGetSignatures() {
         // build explode(array<int>, array<str>) expression
-        Expression[] args = {SlotReference.of("int", ArrayType.of(IntegerType.INSTANCE)),
-            SlotReference.of("str", ArrayType.of(StringType.INSTANCE))};
+        Expression[] args = {SlotReference.of("int", ArrayType.of(IntegerType.INSTANCE), false),
+            SlotReference.of("str", ArrayType.of(StringType.INSTANCE), false)};
         Explode explode = new Explode(args);
 
         // check signature
@@ -64,7 +64,7 @@ public class ExplodeTest {
     @Test
     public void testGetSignaturesWithNull() {
         // build explode(null, array<int>) expression
-        Expression[] args = { SlotReference.of("null", NullType.INSTANCE), SlotReference.of("int", ArrayType.of(IntegerType.INSTANCE))};
+        Expression[] args = { SlotReference.of("null", NullType.INSTANCE, false), SlotReference.of("int", ArrayType.of(IntegerType.INSTANCE), false)};
         Explode explode = new Explode(args);
 
         // check signature
@@ -86,7 +86,7 @@ public class ExplodeTest {
     @Test
     public void testGetSignaturesWithInvalidArgument() {
         // build explode(int)
-        Expression[] args = { SlotReference.of("int", IntegerType.INSTANCE) };
+        Expression[] args = { SlotReference.of("int", IntegerType.INSTANCE, false) };
         Explode explode = new Explode(args);
 
         Assertions.assertThrows(AnalysisException.class, explode::getSignatures);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeVariantArrayTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeVariantArrayTest.java
@@ -39,7 +39,8 @@ public class ExplodeVariantArrayTest {
     @Test
     public void testGetSignatures() {
         // build explode_variant_array(variant, variant) expression
-        Expression[] args = { SlotReference.of("int", VariantType.INSTANCE), SlotReference.of("int", VariantType.INSTANCE) };
+        Expression[] args = { SlotReference.of("int", VariantType.INSTANCE, false),
+                SlotReference.of("int", VariantType.INSTANCE, false) };
         ExplodeVariantArray explode = new ExplodeVariantArray(args);
 
         // check signature
@@ -59,7 +60,7 @@ public class ExplodeVariantArrayTest {
     @Test
     public void testGetSignaturesWithInvalidArgument() {
         // build explode_variant_array(int)
-        Expression[] args = { SlotReference.of("int", IntegerType.INSTANCE) };
+        Expression[] args = { SlotReference.of("int", IntegerType.INSTANCE, false) };
         ExplodeVariantArray explode = new ExplodeVariantArray(args);
 
         Assertions.assertThrows(AnalysisException.class, explode::getSignatures);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanEqualsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanEqualsTest.java
@@ -69,32 +69,26 @@ class PlanEqualsTest {
                     )
         );
         LogicalAggregate<Plan> actual = new LogicalAggregate<>(Lists.newArrayList(), ImmutableList.of(
-                new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList())),
-                child);
+                new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false)), child);
 
         LogicalAggregate<Plan> expected = new LogicalAggregate<>(Lists.newArrayList(), ImmutableList.of(
-                new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList())),
-                child);
+                new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false)), child);
         Assertions.assertEquals(expected, actual);
 
         LogicalAggregate<Plan> unexpected = new LogicalAggregate<>(Lists.newArrayList(), ImmutableList.of(
-                new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList())),
-                child);
+                new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList(), false)), child);
         Assertions.assertNotEquals(unexpected, actual);
 
         unexpected = new LogicalAggregate<>(Lists.newArrayList(), ImmutableList.of(
-                new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList())),
-                false, Optional.empty(), child);
+                new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList(), false)), false, Optional.empty(), child);
         Assertions.assertNotEquals(unexpected, actual);
 
         unexpected = new LogicalAggregate<>(Lists.newArrayList(), ImmutableList.of(
-                new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList())),
-                true, Optional.empty(), child);
+                new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList(), false)), true, Optional.empty(), child);
         Assertions.assertNotEquals(unexpected, actual);
 
         unexpected = new LogicalAggregate<>(Lists.newArrayList(), ImmutableList.of(
-                new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList())),
-                false, Optional.empty(), child);
+                new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList(), false)), false, Optional.empty(), child);
         Assertions.assertNotEquals(unexpected, actual);
     }
 
@@ -131,19 +125,19 @@ class PlanEqualsTest {
                 )
         );
         LogicalJoin<Plan, Plan> actual = new LogicalJoin<>(JoinType.INNER_JOIN, Lists.newArrayList(new EqualTo(
-                new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList()),
-                new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList()))),
+                new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false),
+                new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList(), false))),
                 left, right, null);
 
         LogicalJoin<Plan, Plan> expected = new LogicalJoin<>(JoinType.INNER_JOIN, Lists.newArrayList(new EqualTo(
-                new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList()),
-                new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList()))),
+                new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false),
+                new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList(), false))),
                 left, right, null);
         Assertions.assertEquals(expected, actual);
 
         LogicalJoin<Plan, Plan> unexpected = new LogicalJoin<>(JoinType.INNER_JOIN, Lists.newArrayList(new EqualTo(
-                new SlotReference(new ExprId(2), "a", BigIntType.INSTANCE, false, Lists.newArrayList()),
-                new SlotReference(new ExprId(3), "b", BigIntType.INSTANCE, true, Lists.newArrayList()))),
+                new SlotReference(new ExprId(2), "a", BigIntType.INSTANCE, false, Lists.newArrayList(), false),
+                new SlotReference(new ExprId(3), "b", BigIntType.INSTANCE, true, Lists.newArrayList(), false))),
                 left, right, null);
         Assertions.assertNotEquals(unexpected, actual);
     }
@@ -159,24 +153,24 @@ class PlanEqualsTest {
         );
         LogicalProject<Plan> actual = new LogicalProject<>(
                 ImmutableList.of(
-                        new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList())),
+                        new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false)),
                 child);
 
         LogicalProject<Plan> expected = new LogicalProject<>(
                 ImmutableList.of(
-                        new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList())),
+                        new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false)),
                 child);
         Assertions.assertEquals(expected, actual);
 
         LogicalProject<Plan> unexpected1 = new LogicalProject<>(
                 ImmutableList.of(
-                        new SlotReference(new ExprId(1), "a", BigIntType.INSTANCE, true, Lists.newArrayList())),
+                        new SlotReference(new ExprId(1), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false)),
                 child);
         Assertions.assertNotEquals(unexpected1, actual);
 
         LogicalProject<Plan> unexpected2 = new LogicalProject<>(
                 ImmutableList.of(
-                        new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList())),
+                        new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList(), false)),
                 child);
         Assertions.assertNotEquals(unexpected2, actual);
     }
@@ -192,20 +186,20 @@ class PlanEqualsTest {
         );
         LogicalSort<Plan> actual = new LogicalSort<>(
                 ImmutableList.of(new OrderKey(
-                        new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList()), true,
+                        new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList(), false), true,
                         true)),
                 child);
 
         LogicalSort<Plan> expected = new LogicalSort<>(
                 ImmutableList.of(new OrderKey(
-                        new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList()), true,
+                        new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList(), false), true,
                         true)),
                 child);
         Assertions.assertEquals(expected, actual);
 
         LogicalSort<Plan> unexpected = new LogicalSort<>(
                 ImmutableList.of(new OrderKey(
-                        new SlotReference(new ExprId(2), "a", BigIntType.INSTANCE, true, Lists.newArrayList()), true,
+                        new SlotReference(new ExprId(2), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false), true,
                         true)),
                 child);
         Assertions.assertNotEquals(unexpected, actual);
@@ -221,16 +215,16 @@ class PlanEqualsTest {
                 )
         );
         LogicalResultSink<Plan> actual = new LogicalResultSink<>(
-                ImmutableList.of(new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList())),
+                ImmutableList.of(new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false)),
                 child);
 
         LogicalResultSink<Plan> expected = new LogicalResultSink<>(
-                ImmutableList.of(new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList())),
+                ImmutableList.of(new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false)),
                 child);
         Assertions.assertEquals(expected, actual);
 
         LogicalResultSink<Plan> unexpected = new LogicalResultSink<>(
-                ImmutableList.of(new SlotReference(new ExprId(1), "a", BigIntType.INSTANCE, true, Lists.newArrayList())),
+                ImmutableList.of(new SlotReference(new ExprId(1), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false)),
                 child);
         Assertions.assertNotEquals(unexpected, actual);
     }
@@ -246,13 +240,13 @@ class PlanEqualsTest {
                 )
         );
         List<NamedExpression> outputExpressionList = ImmutableList.of(
-                new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList()));
+                new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false));
         PhysicalHashAggregate<Plan> actual = new PhysicalHashAggregate<>(Lists.newArrayList(), outputExpressionList,
                 new AggregateParam(AggPhase.LOCAL, AggMode.INPUT_TO_RESULT), true, logicalProperties,
                 child);
 
         List<NamedExpression> outputExpressionList1 = ImmutableList.of(
-                new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList()));
+                new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false));
         PhysicalHashAggregate<Plan> expected = new PhysicalHashAggregate<>(Lists.newArrayList(),
                 outputExpressionList1,
                 new AggregateParam(AggPhase.LOCAL, AggMode.INPUT_TO_RESULT), true, logicalProperties,
@@ -260,7 +254,7 @@ class PlanEqualsTest {
         Assertions.assertEquals(expected, actual);
 
         List<NamedExpression> outputExpressionList2 = ImmutableList.of(
-                new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList()));
+                new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false));
         PhysicalHashAggregate<Plan> unexpected = new PhysicalHashAggregate<>(Lists.newArrayList(),
                 outputExpressionList2,
                 new AggregateParam(AggPhase.LOCAL, AggMode.INPUT_TO_RESULT), false, logicalProperties,
@@ -305,21 +299,21 @@ class PlanEqualsTest {
         );
         PhysicalHashJoin<Plan, Plan> actual = new PhysicalHashJoin<>(JoinType.INNER_JOIN,
                 Lists.newArrayList(new EqualTo(
-                        new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList()),
-                        new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList()))),
+                        new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false),
+                        new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList(), false))),
                 ExpressionUtils.EMPTY_CONDITION, new DistributeHint(DistributeType.NONE), Optional.empty(), logicalProperties, left, right);
 
         PhysicalHashJoin<Plan, Plan> expected = new PhysicalHashJoin<>(JoinType.INNER_JOIN,
                 Lists.newArrayList(new EqualTo(
-                        new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList()),
-                        new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList()))),
+                        new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false),
+                        new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList(), false))),
                 ExpressionUtils.EMPTY_CONDITION, new DistributeHint(DistributeType.NONE), Optional.empty(), logicalProperties, left, right);
         Assertions.assertEquals(expected, actual);
 
         PhysicalHashJoin<Plan, Plan> unexpected = new PhysicalHashJoin<>(JoinType.INNER_JOIN,
                 Lists.newArrayList(new EqualTo(
-                        new SlotReference(new ExprId(2), "a", BigIntType.INSTANCE, false, Lists.newArrayList()),
-                        new SlotReference(new ExprId(3), "b", BigIntType.INSTANCE, true, Lists.newArrayList()))),
+                        new SlotReference(new ExprId(2), "a", BigIntType.INSTANCE, false, Lists.newArrayList(), false),
+                        new SlotReference(new ExprId(3), "b", BigIntType.INSTANCE, true, Lists.newArrayList(), false))),
                 ExpressionUtils.EMPTY_CONDITION, new DistributeHint(DistributeType.NONE), Optional.empty(), logicalProperties, left, right);
         Assertions.assertNotEquals(unexpected, actual);
     }
@@ -372,27 +366,27 @@ class PlanEqualsTest {
         );
         PhysicalProject<Plan> actual = new PhysicalProject<>(
                 ImmutableList.of(
-                        new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList())),
+                        new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false)),
                 logicalProperties,
                 child);
 
         PhysicalProject<Plan> expected = new PhysicalProject<>(
                 ImmutableList.of(
-                        new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList())),
+                        new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false)),
                 logicalProperties,
                 child);
         Assertions.assertEquals(expected, actual);
 
         PhysicalProject<Plan> unexpected1 = new PhysicalProject<>(
                 ImmutableList.of(
-                        new SlotReference(new ExprId(1), "a", BigIntType.INSTANCE, true, Lists.newArrayList())),
+                        new SlotReference(new ExprId(1), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false)),
                 logicalProperties,
                 child);
         Assertions.assertNotEquals(unexpected1, actual);
 
         PhysicalProject<Plan> unexpected2 = new PhysicalProject<>(
                 ImmutableList.of(
-                        new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList())),
+                        new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList(), false)),
                 logicalProperties,
                 child);
         Assertions.assertNotEquals(unexpected2, actual);
@@ -410,14 +404,14 @@ class PlanEqualsTest {
 
         PhysicalQuickSort<Plan> actual = new PhysicalQuickSort<>(
                 ImmutableList.of(new OrderKey(
-                        new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList()), true,
+                        new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList(), false), true,
                         true)),
                 SortPhase.LOCAL_SORT, logicalProperties,
                 child);
 
         PhysicalQuickSort<Plan> expected = new PhysicalQuickSort<>(
                 ImmutableList.of(new OrderKey(
-                        new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList()), true,
+                        new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList(), false), true,
                         true)),
                 SortPhase.LOCAL_SORT, logicalProperties,
                 child);
@@ -425,7 +419,7 @@ class PlanEqualsTest {
 
         PhysicalQuickSort<Plan> unexpected = new PhysicalQuickSort<>(
                 ImmutableList.of(new OrderKey(
-                        new SlotReference(new ExprId(2), "a", BigIntType.INSTANCE, true, Lists.newArrayList()), true,
+                        new SlotReference(new ExprId(2), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false), true,
                         true)),
                 SortPhase.LOCAL_SORT, logicalProperties,
                 child);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanToStringTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanToStringTest.java
@@ -69,7 +69,7 @@ public class PlanToStringTest {
                 )
         );
         LogicalAggregate<Plan> plan = new LogicalAggregate<>(Lists.newArrayList(), ImmutableList.of(
-                new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList())), child);
+                new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false)), child);
 
         Assertions.assertTrue(plan.toString()
                 .matches("LogicalAggregate\\[\\d+\\] \\( groupByExpr=\\[], outputExpr=\\[a#\\d+], hasRepeat=false.*"));
@@ -104,8 +104,8 @@ public class PlanToStringTest {
                 )
         );
         LogicalJoin<Plan, Plan> plan = new LogicalJoin<>(JoinType.INNER_JOIN, Lists.newArrayList(
-                new EqualTo(new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList()),
-                        new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList()))),
+                new EqualTo(new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false),
+                        new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList(), false))),
                 left, right, null);
         System.out.println(plan.toString());
         Assertions.assertTrue(plan.toString().matches(
@@ -131,7 +131,7 @@ public class PlanToStringTest {
                 )
         );
         LogicalProject<Plan> plan = new LogicalProject<>(ImmutableList.of(
-                new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList())), child);
+                new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList(), false)), child);
         Assertions.assertTrue(plan.toString().matches("LogicalProject\\[\\d+\\] \\( distinct=false, projects=\\[a#\\d+].*"));
     }
 
@@ -145,8 +145,8 @@ public class PlanToStringTest {
                 )
         );
         List<OrderKey> orderKeyList = Lists.newArrayList(
-                new OrderKey(new SlotReference("col1", IntegerType.INSTANCE), true, true),
-                new OrderKey(new SlotReference("col2", IntegerType.INSTANCE), true, true));
+                new OrderKey(new SlotReference("col1", IntegerType.INSTANCE, false), true, true),
+                new OrderKey(new SlotReference("col2", IntegerType.INSTANCE, false), true, true));
 
         LogicalSort<Plan> plan = new LogicalSort<>(orderKeyList, child);
         Assertions.assertTrue(plan.toString().matches("LogicalSort\\[\\d+\\] \\( orderKeys=\\[col1#\\d+ asc null first, col2#\\d+ asc null first] \\)"));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowDataCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowDataCommandTest.java
@@ -101,7 +101,7 @@ public class ShowDataCommandTest {
             }
         };
 
-        SlotReference tableName = new SlotReference("TableName", IntegerType.INSTANCE);
+        SlotReference tableName = new SlotReference("TableName", IntegerType.INSTANCE, false);
         List<OrderKey> keys = ImmutableList.of(
                 new OrderKey(tableName, true, false)
         );
@@ -149,7 +149,7 @@ public class ShowDataCommandTest {
             }
         };
 
-        SlotReference tableName = new SlotReference("TableName", IntegerType.INSTANCE);
+        SlotReference tableName = new SlotReference("TableName", IntegerType.INSTANCE, false);
         List<OrderKey> keys = ImmutableList.of(
                 new OrderKey(tableName, true, false)
         );

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/physical/PhysicalTopNTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/physical/PhysicalTopNTest.java
@@ -40,7 +40,7 @@ public class PhysicalTopNTest {
         LogicalOneRowRelation oneRowRelation
                 = new LogicalOneRowRelation(new RelationId(1), ImmutableList.of(new Alias(Literal.of(1))));
         SlotReference a = new SlotReference(new ExprId(0), "a",
-                BigIntType.INSTANCE, true, Lists.newArrayList());
+                BigIntType.INSTANCE, true, Lists.newArrayList(), false);
         List<OrderKey> orderKeysA = Lists.newArrayList();
         orderKeysA.add(new OrderKey(a, true, true));
         PhysicalTopN topn1 = new PhysicalTopN(orderKeysA, 1, 1, SortPhase.LOCAL_SORT,
@@ -50,7 +50,7 @@ public class PhysicalTopNTest {
         Assertions.assertNotEquals(topn1, topn2);
 
         SlotReference b = new SlotReference(new ExprId(0), "b",
-                BigIntType.INSTANCE, true, Lists.newArrayList());
+                BigIntType.INSTANCE, true, Lists.newArrayList(), false);
         List<OrderKey> orderKeysB = Lists.newArrayList();
         orderKeysB.add(new OrderKey(b, true, true));
         PhysicalTopN topn3 = new PhysicalTopN(orderKeysB, 1, 1, SortPhase.LOCAL_SORT,

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/CanInferNotNullForMarkSlotTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/CanInferNotNullForMarkSlotTest.java
@@ -41,7 +41,7 @@ public class CanInferNotNullForMarkSlotTest extends ExpressionRewriteTestHelper 
 
     @Test
     public void test() {
-        SlotReference slot = new SlotReference("slot", BooleanType.INSTANCE);
+        SlotReference slot = new SlotReference("slot", BooleanType.INSTANCE, false);
         MarkJoinSlotReference markSlot1 = new MarkJoinSlotReference("markSlot1");
         MarkJoinSlotReference markSlot2 = new MarkJoinSlotReference("markSlot2");
         MarkJoinSlotReference markSlot3 = new MarkJoinSlotReference("markSlot1");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/ExpressionUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/ExpressionUtilsTest.java
@@ -193,9 +193,9 @@ public class ExpressionUtilsTest extends TestWithFeService {
 
     @Test
     public void testExtractUniformSlot() {
-        Slot a = new SlotReference("a", IntegerType.INSTANCE);
-        Slot b = new SlotReference("b", IntegerType.INSTANCE);
-        Slot c = new SlotReference("c", IntegerType.INSTANCE);
+        Slot a = new SlotReference("a", IntegerType.INSTANCE, false);
+        Slot b = new SlotReference("b", IntegerType.INSTANCE, false);
+        Slot c = new SlotReference("c", IntegerType.INSTANCE, false);
         Expression va = Literal.of(1);
         Expression vb = Literal.of(2);
         Expression vc = Literal.of(3);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/JoinUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/JoinUtilsTest.java
@@ -51,13 +51,13 @@ public class JoinUtilsTest {
                 1L, 1L, Collections.emptySet());
 
         Expression leftKey1 = new SlotReference(new ExprId(1), "c1",
-                TinyIntType.INSTANCE, false, Lists.newArrayList());
+                TinyIntType.INSTANCE, false, Lists.newArrayList(), false);
         Expression rightKey1 = new SlotReference(new ExprId(2), "c1",
-                TinyIntType.INSTANCE, false, Lists.newArrayList());
+                TinyIntType.INSTANCE, false, Lists.newArrayList(), false);
         Expression leftKey2 = new SlotReference(new ExprId(3), "c1",
-                TinyIntType.INSTANCE, false, Lists.newArrayList());
+                TinyIntType.INSTANCE, false, Lists.newArrayList(), false);
         Expression rightKey2 = new SlotReference(new ExprId(4), "c1",
-                TinyIntType.INSTANCE, false, Lists.newArrayList());
+                TinyIntType.INSTANCE, false, Lists.newArrayList(), false);
 
         List<Expression> conjuncts;
 
@@ -98,13 +98,13 @@ public class JoinUtilsTest {
                     ShuffleType.NATURAL, 2L, 2L, Collections.emptySet());
 
             Expression leftKey1 = new SlotReference(new ExprId(1), "c1",
-                    TinyIntType.INSTANCE, false, Lists.newArrayList());
+                    TinyIntType.INSTANCE, false, Lists.newArrayList(), false);
             Expression rightKey1 = new SlotReference(new ExprId(2), "c1",
-                    TinyIntType.INSTANCE, false, Lists.newArrayList());
+                    TinyIntType.INSTANCE, false, Lists.newArrayList(), false);
             Expression leftKey2 = new SlotReference(new ExprId(3), "c1",
-                    TinyIntType.INSTANCE, false, Lists.newArrayList());
+                    TinyIntType.INSTANCE, false, Lists.newArrayList(), false);
             Expression rightKey2 = new SlotReference(new ExprId(4), "c1",
-                    TinyIntType.INSTANCE, false, Lists.newArrayList());
+                    TinyIntType.INSTANCE, false, Lists.newArrayList(), false);
 
             List<Expression> conjuncts;
 
@@ -146,13 +146,13 @@ public class JoinUtilsTest {
                     ShuffleType.EXECUTION_BUCKETED, 2L, 2L, Collections.emptySet());
 
             Expression leftKey1 = new SlotReference(new ExprId(1), "c1",
-                    TinyIntType.INSTANCE, false, Lists.newArrayList());
+                    TinyIntType.INSTANCE, false, Lists.newArrayList(), false);
             Expression rightKey1 = new SlotReference(new ExprId(2), "c1",
-                    TinyIntType.INSTANCE, false, Lists.newArrayList());
+                    TinyIntType.INSTANCE, false, Lists.newArrayList(), false);
             Expression leftKey2 = new SlotReference(new ExprId(3), "c1",
-                    TinyIntType.INSTANCE, false, Lists.newArrayList());
+                    TinyIntType.INSTANCE, false, Lists.newArrayList(), false);
             Expression rightKey2 = new SlotReference(new ExprId(4), "c1",
-                    TinyIntType.INSTANCE, false, Lists.newArrayList());
+                    TinyIntType.INSTANCE, false, Lists.newArrayList(), false);
 
             List<Expression> conjuncts;
 
@@ -194,13 +194,13 @@ public class JoinUtilsTest {
                     ShuffleType.NATURAL, 2L, 2L, Collections.emptySet());
 
             Expression leftKey1 = new SlotReference(new ExprId(1), "c1",
-                    TinyIntType.INSTANCE, false, Lists.newArrayList());
+                    TinyIntType.INSTANCE, false, Lists.newArrayList(), false);
             Expression rightKey1 = new SlotReference(new ExprId(2), "c1",
-                    TinyIntType.INSTANCE, false, Lists.newArrayList());
+                    TinyIntType.INSTANCE, false, Lists.newArrayList(), false);
             Expression leftKey2 = new SlotReference(new ExprId(3), "c1",
-                    TinyIntType.INSTANCE, false, Lists.newArrayList());
+                    TinyIntType.INSTANCE, false, Lists.newArrayList(), false);
             Expression rightKey2 = new SlotReference(new ExprId(4), "c1",
-                    TinyIntType.INSTANCE, false, Lists.newArrayList());
+                    TinyIntType.INSTANCE, false, Lists.newArrayList(), false);
 
             List<Expression> conjuncts;
 
@@ -242,13 +242,13 @@ public class JoinUtilsTest {
                     2L, 2L, Collections.emptySet());
 
             Expression leftKey1 = new SlotReference(new ExprId(1), "c1",
-                    TinyIntType.INSTANCE, false, Lists.newArrayList());
+                    TinyIntType.INSTANCE, false, Lists.newArrayList(), false);
             Expression rightKey1 = new SlotReference(new ExprId(2), "c1",
-                    TinyIntType.INSTANCE, false, Lists.newArrayList());
+                    TinyIntType.INSTANCE, false, Lists.newArrayList(), false);
             Expression leftKey2 = new SlotReference(new ExprId(3), "c1",
-                    TinyIntType.INSTANCE, false, Lists.newArrayList());
+                    TinyIntType.INSTANCE, false, Lists.newArrayList(), false);
             Expression rightKey2 = new SlotReference(new ExprId(4), "c1",
-                    TinyIntType.INSTANCE, false, Lists.newArrayList());
+                    TinyIntType.INSTANCE, false, Lists.newArrayList(), false);
 
             List<Expression> conjuncts;
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
@@ -190,7 +190,7 @@ public class TypeCoercionUtilsTest {
     public void testProcessInDowngrade() {
         // DecimalV2 slot vs DecimalV3 literal
         InPredicate decimalDowngrade = new InPredicate(
-                new SlotReference("c1", DecimalV2Type.createDecimalV2Type(15, 6)),
+                new SlotReference("c1", DecimalV2Type.createDecimalV2Type(15, 6), false),
                 ImmutableList.of(
                         new DecimalV3Literal(BigDecimal.valueOf(12345.1234567)),
                         new DecimalLiteral(BigDecimal.valueOf(12345.1234))));
@@ -199,7 +199,7 @@ public class TypeCoercionUtilsTest {
 
         // DateV1 slot vs DateV2 literal
         InPredicate dateDowngrade = new InPredicate(
-                new SlotReference("c1", DateType.INSTANCE),
+                new SlotReference("c1", DateType.INSTANCE, false),
                 ImmutableList.of(
                         new DateLiteral(2024, 4, 12),
                         new DateV2Literal(2024, 4, 12)));
@@ -208,7 +208,7 @@ public class TypeCoercionUtilsTest {
 
         // DatetimeV1 slot vs DateLike literal
         InPredicate datetimeDowngrade = new InPredicate(
-                new SlotReference("c1", DateTimeType.INSTANCE),
+                new SlotReference("c1", DateTimeType.INSTANCE, false),
                 ImmutableList.of(
                         new DateLiteral(2024, 4, 12),
                         new DateV2Literal(2024, 4, 12),
@@ -222,7 +222,7 @@ public class TypeCoercionUtilsTest {
     public void testProcessComparisonPredicateDowngrade() {
         // DecimalV2 slot vs DecimalV3 literal
         EqualTo decimalDowngrade = new EqualTo(
-                new SlotReference("c1", DecimalV2Type.createDecimalV2Type(15, 6)),
+                new SlotReference("c1", DecimalV2Type.createDecimalV2Type(15, 6), false),
                 new DecimalV3Literal(BigDecimal.valueOf(12345.1234567))
         );
         decimalDowngrade = (EqualTo) TypeCoercionUtils.processComparisonPredicate(decimalDowngrade);
@@ -231,14 +231,14 @@ public class TypeCoercionUtilsTest {
         // DateV1 slot vs DateV2 literal (this case cover right slot vs left literal)
         EqualTo dateDowngrade = new EqualTo(
                 new DateV2Literal(2024, 4, 12),
-                new SlotReference("c1", DateType.INSTANCE)
+                new SlotReference("c1", DateType.INSTANCE, false)
         );
         dateDowngrade = (EqualTo) TypeCoercionUtils.processComparisonPredicate(dateDowngrade);
         Assertions.assertEquals(DateType.INSTANCE, dateDowngrade.left().getDataType());
 
         // DatetimeV1 slot vs DateLike literal
         EqualTo datetimeDowngrade = new EqualTo(
-                new SlotReference("c1", DateTimeType.INSTANCE),
+                new SlotReference("c1", DateTimeType.INSTANCE, false),
                 new DateTimeV2Literal(2024, 4, 12, 18, 25, 30, 0)
         );
         datetimeDowngrade = (EqualTo) TypeCoercionUtils.processComparisonPredicate(datetimeDowngrade);
@@ -249,7 +249,7 @@ public class TypeCoercionUtilsTest {
     public void testProcessInStringCoercion() {
         // BigInt slot vs String literal
         InPredicate bigintString = new InPredicate(
-                new SlotReference("c1", BigIntType.INSTANCE),
+                new SlotReference("c1", BigIntType.INSTANCE, false),
                 ImmutableList.of(
                         new VarcharLiteral("200"),
                         new VarcharLiteral("922337203685477001")));
@@ -259,7 +259,7 @@ public class TypeCoercionUtilsTest {
 
         // SmallInt slot vs String literal
         InPredicate smallIntString = new InPredicate(
-                new SlotReference("c1", SmallIntType.INSTANCE),
+                new SlotReference("c1", SmallIntType.INSTANCE, false),
                 ImmutableList.of(
                         new DecimalLiteral(new BigDecimal("987654.321")),
                         new VarcharLiteral("922337203685477001")));

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisManagerTest.java
@@ -161,11 +161,11 @@ public class AnalysisManagerTest {
         };
 
         SlotReference slot1 = new SlotReference(new ExprId(1), "slot1", IntegerType.INSTANCE, true,
-                new ArrayList<>(), table, column1, table, column1, ImmutableList.of());
+                new ArrayList<>(), table, column1, table, column1, ImmutableList.of(), false);
         SlotReference slot2 = new SlotReference(new ExprId(2), "slot2", IntegerType.INSTANCE, true,
-                new ArrayList<>(), table, column2, table, column2, ImmutableList.of());
+                new ArrayList<>(), table, column2, table, column2, ImmutableList.of(), false);
         SlotReference slot3 = new SlotReference(new ExprId(3), "slot3", IntegerType.INSTANCE, true,
-                new ArrayList<>(), table, column3, table, column3, ImmutableList.of());
+                new ArrayList<>(), table, column3, table, column3, ImmutableList.of(), false);
         Set<Slot> set1 = new HashSet<>();
         set1.add(slot1);
         set1.add(slot2);

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class StatisticsTest {
     @Test
     public void testAvgSizeAbnormal() {
-        SlotReference slot = SlotReference.of("a", IntegerType.INSTANCE);
+        SlotReference slot = SlotReference.of("a", IntegerType.INSTANCE, false);
         ColumnStatisticBuilder colBuilder = new ColumnStatisticBuilder();
         colBuilder.setAvgSizeByte(Double.NaN);
         Statistics stats = new Statistics(1, 1, ImmutableMap.of(slot, colBuilder.build()));

--- a/regression-test/suites/nereids_p0/infer_expr_name/load.groovy
+++ b/regression-test/suites/nereids_p0/infer_expr_name/load.groovy
@@ -17,7 +17,7 @@ package infer_expr_name
 // under the License.
 
 suite("load") {
-    String database = context.config.getDbNameByFile(context.file)
+    String database = context.config.getDbNameByFile(context.file) + "_test"
     sql "drop database if exists ${database}"
     sql "create database ${database}"
     sql "use ${database}"

--- a/regression-test/suites/nereids_p0/infer_expr_name/test/query13.groovy
+++ b/regression-test/suites/nereids_p0/infer_expr_name/test/query13.groovy
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package infer_expr_name
-
 suite("nereids_test_create_blocked") {
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'

--- a/regression-test/suites/nereids_p0/infer_expr_name/test/query14.groovy
+++ b/regression-test/suites/nereids_p0/infer_expr_name/test/query14.groovy
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package infer_expr_name
-
 suite("nereids_test_create_blocked") {
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'

--- a/regression-test/suites/nereids_p0/infer_expr_name/test/query15.groovy
+++ b/regression-test/suites/nereids_p0/infer_expr_name/test/query15.groovy
@@ -15,36 +15,33 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package infer_expr_name
-
 suite("nereids_test_create_blocked") {
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'
 
     def queryResult = sql """
 explain analyzed plan
-select  ca_zip, ca_city, sum(ws_sales_price)
- from web_sales, customer, customer_address, date_dim, item
- where ws_bill_customer_sk = c_customer_sk
- 	and c_current_addr_sk = ca_address_sk 
- 	and ws_item_sk = i_item_sk 
- 	and ( substr(ca_zip,1,5) in ('85669', '86197','88274','83405','86475', '85392', '85460', '80348', '81792')
- 	      or 
- 	      i_item_id in (select i_item_id
-                             from item
-                             where i_item_sk in (2, 3, 5, 7, 11, 13, 17, 19, 23, 29)
-                             )
- 	    )
- 	and ws_sold_date_sk = d_date_sk
- 	and d_qoy = 2 and d_year = 2000
- group by ca_zip, ca_city
- order by ca_zip, ca_city
+select  ca_zip
+       ,sum(cs_sales_price)
+ from catalog_sales
+     ,customer
+     ,customer_address
+     ,date_dim
+ where cs_bill_customer_sk = c_customer_sk
+ 	and c_current_addr_sk = ca_address_sk
+ 	and ( substr(ca_zip,1,5) in ('85669', '86197','88274','83405','86475',
+                                   '85392', '85460', '80348', '81792')
+ 	      or ca_state in ('CA','WA','GA')
+ 	      or cs_sales_price > 500)
+ 	and cs_sold_date_sk = d_date_sk
+ 	and d_qoy = 1 and d_year = 2001
+ group by ca_zip
+ order by ca_zip
  limit 100;
 """
 
     def topPlan = queryResult[0][0].toString()
     assertTrue(topPlan.contains("LogicalResultSink"))
     assertTrue(topPlan.contains("ca_zip"))
-    assertTrue(topPlan.contains("ca_city"))
-    assertTrue(topPlan.contains("__sum_2"))
+    assertTrue(topPlan.contains("__sum_1"))
 }

--- a/regression-test/suites/nereids_p0/infer_expr_name/test/query2.groovy
+++ b/regression-test/suites/nereids_p0/infer_expr_name/test/query2.groovy
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package infer_expr_name
-
 suite("nereids_test_create_blocked") {
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'

--- a/regression-test/suites/nereids_p0/infer_expr_name/test/query23.groovy
+++ b/regression-test/suites/nereids_p0/infer_expr_name/test/query23.groovy
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package infer_expr_name
-
 suite("nereids_test_create_blocked") {
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'

--- a/regression-test/suites/nereids_p0/infer_expr_name/test/query35.groovy
+++ b/regression-test/suites/nereids_p0/infer_expr_name/test/query35.groovy
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package infer_expr_name
-
 suite("nereids_test_create_blocked") {
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'

--- a/regression-test/suites/nereids_p0/infer_expr_name/test/query41.groovy
+++ b/regression-test/suites/nereids_p0/infer_expr_name/test/query41.groovy
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package infer_expr_name
-
 suite("nereids_test_create_blocked") {
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'

--- a/regression-test/suites/nereids_p0/infer_expr_name/test/query45.groovy
+++ b/regression-test/suites/nereids_p0/infer_expr_name/test/query45.groovy
@@ -15,37 +15,34 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package infer_expr_name
-
 suite("nereids_test_create_blocked") {
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'
 
     def queryResult = sql """
 explain analyzed plan
-select  count(*) from (
-    select distinct c_last_name, c_first_name, d_date
-    from store_sales, date_dim, customer
-          where store_sales.ss_sold_date_sk = date_dim.d_date_sk
-      and store_sales.ss_customer_sk = customer.c_customer_sk
-      and d_month_seq between 1183 and 1183 + 11
-  intersect
-    select distinct c_last_name, c_first_name, d_date
-    from catalog_sales, date_dim, customer
-          where catalog_sales.cs_sold_date_sk = date_dim.d_date_sk
-      and catalog_sales.cs_bill_customer_sk = customer.c_customer_sk
-      and d_month_seq between 1183 and 1183 + 11
-  intersect
-    select distinct c_last_name, c_first_name, d_date
-    from web_sales, date_dim, customer
-          where web_sales.ws_sold_date_sk = date_dim.d_date_sk
-      and web_sales.ws_bill_customer_sk = customer.c_customer_sk
-      and d_month_seq between 1183 and 1183 + 11
-) hot_cust
-limit 100;
+select  ca_zip, ca_city, sum(ws_sales_price)
+ from web_sales, customer, customer_address, date_dim, item
+ where ws_bill_customer_sk = c_customer_sk
+ 	and c_current_addr_sk = ca_address_sk 
+ 	and ws_item_sk = i_item_sk 
+ 	and ( substr(ca_zip,1,5) in ('85669', '86197','88274','83405','86475', '85392', '85460', '80348', '81792')
+ 	      or 
+ 	      i_item_id in (select i_item_id
+                             from item
+                             where i_item_sk in (2, 3, 5, 7, 11, 13, 17, 19, 23, 29)
+                             )
+ 	    )
+ 	and ws_sold_date_sk = d_date_sk
+ 	and d_qoy = 2 and d_year = 2000
+ group by ca_zip, ca_city
+ order by ca_zip, ca_city
+ limit 100;
 """
 
     def topPlan = queryResult[0][0].toString()
     assertTrue(topPlan.contains("LogicalResultSink"))
-    assertTrue(topPlan.contains("__count_0"))
+    assertTrue(topPlan.contains("ca_zip"))
+    assertTrue(topPlan.contains("ca_city"))
+    assertTrue(topPlan.contains("__sum_2"))
 }

--- a/regression-test/suites/nereids_p0/infer_expr_name/test/query59.groovy
+++ b/regression-test/suites/nereids_p0/infer_expr_name/test/query59.groovy
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package infer_expr_name
-
 suite("nereids_test_create_blocked") {
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'

--- a/regression-test/suites/nereids_p0/infer_expr_name/test/query61.groovy
+++ b/regression-test/suites/nereids_p0/infer_expr_name/test/query61.groovy
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package infer_expr_name
-
 suite("nereids_test_create_blocked") {
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'

--- a/regression-test/suites/nereids_p0/infer_expr_name/test/query62.groovy
+++ b/regression-test/suites/nereids_p0/infer_expr_name/test/query62.groovy
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package infer_expr_name
-
 suite("nereids_test_create_blocked") {
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'

--- a/regression-test/suites/nereids_p0/infer_expr_name/test/query8.groovy
+++ b/regression-test/suites/nereids_p0/infer_expr_name/test/query8.groovy
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package infer_expr_name
-
 suite("nereids_test_create_blocked") {
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'

--- a/regression-test/suites/nereids_p0/infer_expr_name/test/query85.groovy
+++ b/regression-test/suites/nereids_p0/infer_expr_name/test/query85.groovy
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package infer_expr_name
-
 suite("nereids_test_create_blocked") {
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'

--- a/regression-test/suites/nereids_p0/infer_expr_name/test/set_operation.groovy
+++ b/regression-test/suites/nereids_p0/infer_expr_name/test/set_operation.groovy
@@ -1,0 +1,85 @@
+package infer_expr_name.test
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("set_operation") {
+    // test union all
+    def table_prefix = "set_operation";
+
+    def checkColNames = { String tableName, List<String> expectedNames ->
+        def colNames = sql "desc ${tableName}";
+        List<String> firstColNames = colNames.collect { it[0] }
+        assertEquals(firstColNames.size(), expectedNames.size())
+        for (int i = 0; i < firstColNames.size(); i++) {
+            assertEquals(firstColNames[i], expectedNames[i])
+        }
+    }
+
+    sql """
+    CREATE TABLE IF NOT EXISTS set_operation_table_test1
+    PROPERTIES (  "replication_num" = "1")
+    AS
+    SELECT 'STORE', 
+           date_add(ss_sold_date_sk, INTERVAL 2 DAY),
+           ss_item_sk as item_sk,
+           ss_sales_price as sales_price,
+           'STORE()##'
+    FROM store_sales
+    UNION ALL
+    SELECT 'WEB',
+           ws_sold_date_sk as date_sk,
+           ws_item_sk as item_sk,
+           ws_sales_price as sales_price,
+           ''
+    FROM web_sales
+    UNION ALL
+    SELECT 'CATALOG' as channel,
+           cs_sold_date_sk as date_sk,
+           cs_item_sk as item_sk,
+           cs_sales_price as sales_price,
+           ''
+    FROM catalog_sales;
+    """
+
+    checkColNames("set_operation_table_test1",
+            ["__cast_0", "__cast_1", "item_sk", "sales_price", "__literal_4"])
+
+
+    sql """
+    CREATE TABLE IF NOT EXISTS set_operation_table_test2
+    PROPERTIES (  "replication_num" = "1")
+    AS
+    SELECT 'STORE', 
+           date_add(ss_sold_date_sk, INTERVAL 2 DAY),
+           ss_item_sk as item_sk,
+           ss_sales_price as sales_price,
+           'STORE()##'
+    FROM store_sales
+    UNION ALL
+    SELECT 'WEB',
+           ws_sold_date_sk as date_sk,
+           ws_item_sk as item_sk,
+           ws_sales_price as sales_price,
+           ''
+    FROM web_sales;
+    """
+
+    checkColNames("set_operation_table_test2",
+            ["__literal_0", "__cast_1", "item_sk", "sales_price", "__literal_4"])
+
+}
+

--- a/regression-test/suites/nereids_p0/infer_expr_name/test/set_operation.groovy
+++ b/regression-test/suites/nereids_p0/infer_expr_name/test/set_operation.groovy
@@ -81,5 +81,74 @@ suite("set_operation") {
     checkColNames("set_operation_table_test2",
             ["__literal_0", "__cast_1", "item_sk", "sales_price", "__literal_4"])
 
+
+    sql """
+    CREATE TABLE IF NOT EXISTS set_operation_table_test3
+    PROPERTIES (  "replication_num" = "1")
+    AS
+    SELECT 'STORE', 
+           date_add(ss_sold_date_sk, INTERVAL 2 DAY),
+           ss_item_sk as item_sk,
+           ss_sales_price as sales_price,
+           'STORE()##'
+    FROM store_sales
+    INTERSECT
+    SELECT 'WEB',
+           ws_sold_date_sk as date_sk,
+           ws_item_sk as item_sk,
+           ws_sales_price as sales_price,
+           ''
+    FROM web_sales;
+    """
+
+    checkColNames("set_operation_table_test2",
+            ["__literal_0", "__cast_1", "item_sk", "sales_price", "__literal_4"])
+
+
+    sql """
+    CREATE TABLE IF NOT EXISTS set_operation_table_test4
+    PROPERTIES (  "replication_num" = "1")
+    AS
+    SELECT 'STORE', 
+           date_add(ss_sold_date_sk, INTERVAL 2 DAY),
+           ss_item_sk as item_sk,
+           ss_sales_price as sales_price,
+           'STORE()##'
+    FROM store_sales
+    EXCEPT
+    SELECT 'WEB',
+           ws_sold_date_sk as date_sk,
+           ws_item_sk as item_sk,
+           ws_sales_price as sales_price,
+           ''
+    FROM web_sales;
+    """
+
+    checkColNames("set_operation_table_test2",
+            ["__literal_0", "__cast_1", "item_sk", "sales_price", "__literal_4"])
+
+
+    sql """
+    CREATE TABLE IF NOT EXISTS set_operation_table_test5
+    PROPERTIES (  "replication_num" = "1")
+    AS
+    SELECT 'STORE', 
+           date_add(ss_sold_date_sk, INTERVAL 2 DAY),
+           ss_item_sk as item_sk,
+           ss_sales_price as sales_price,
+           'STORE()##'
+    FROM store_sales
+    MINUS
+    SELECT 'WEB',
+           ws_sold_date_sk as date_sk,
+           ws_item_sk as item_sk,
+           ws_sales_price as sales_price,
+           ''
+    FROM web_sales;
+    """
+
+    checkColNames("set_operation_table_test2",
+            ["__literal_0", "__cast_1", "item_sk", "sales_price", "__literal_4"])
+
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

the table def is as following, the first final field col name is 'STORE', the col name is invalid because it contains '''
```sql
    CREATE TABLE IF NOT EXISTS set_operation_table_test2
    PROPERTIES (  "replication_num" = "1")
    AS
    SELECT 'STORE', 
           date_add(ss_sold_date_sk, INTERVAL 2 DAY),
           ss_item_sk as item_sk,
           ss_sales_price as sales_price,
           'STORE()##'
    FROM store_sales
    UNION ALL
    SELECT 'WEB',
           ws_sold_date_sk as date_sk,
           ws_item_sk as item_sk,
           ws_sales_price as sales_price,
           ''
    FROM web_sales;
```

the pr fix this , the final output col names are as following
`"__literal_0", "__cast_1", "item_sk", "sales_price", "__literal_4"`


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

