### PR TITLE
[fix](warmup) avoid calling recycle_cache after rebalance

### DIFF
--- a/be/src/cloud/cloud_tablet.h
+++ b/be/src/cloud/cloud_tablet.h
@@ -290,6 +290,8 @@ public:
     void add_unused_rowsets(const std::vector<RowsetSharedPtr>& rowsets);
     void remove_unused_rowsets();
 
+    // For each given rowset not in active use, clears its file cache and returns its
+    // ID, segment count, and index file names as RecycledRowsets entries.
     static std::vector<RecycledRowsets> recycle_cached_data(
             const std::vector<RowsetSharedPtr>& rowsets);
 

--- a/be/src/cloud/cloud_tablet.h
+++ b/be/src/cloud/cloud_tablet.h
@@ -49,6 +49,12 @@ struct SyncOptions {
     int64_t query_version = -1;
 };
 
+struct RecycledRowsets {
+    RowsetId rowset_id;
+    int64_t num_segments;
+    std::vector<std::string> index_file_names;
+};
+
 class CloudTablet final : public BaseTablet {
 public:
     CloudTablet(CloudStorageEngine& engine, TabletMetaSharedPtr tablet_meta);
@@ -284,7 +290,8 @@ public:
     void add_unused_rowsets(const std::vector<RowsetSharedPtr>& rowsets);
     void remove_unused_rowsets();
 
-    static void recycle_cached_data(const std::vector<RowsetSharedPtr>& rowsets);
+    static std::vector<RecycledRowsets> recycle_cached_data(
+            const std::vector<RowsetSharedPtr>& rowsets);
 
 private:
     // FIXME(plat1ko): No need to record base size if rowsets are ordered by version

--- a/be/src/cloud/cloud_warm_up_manager.cpp
+++ b/be/src/cloud/cloud_warm_up_manager.cpp
@@ -581,36 +581,30 @@ void CloudWarmUpManager::warm_up_rowset(RowsetMeta& rs_meta) {
     }
 }
 
-void CloudWarmUpManager::recycle_cache(
-        int64_t tablet_id, const std::vector<RowsetId>& rowset_ids,
-        const std::vector<int64_t>& num_segments,
-        const std::vector<std::vector<std::string>>& index_file_names) {
-    LOG(INFO) << "recycle_cache: tablet_id=" << tablet_id << ", num_rowsets=" << rowset_ids.size();
+void CloudWarmUpManager::recycle_cache(int64_t tablet_id,
+                                       const std::vector<RecycledRowsets>& rowsets) {
+    LOG(INFO) << "recycle_cache: tablet_id=" << tablet_id << ", num_rowsets=" << rowsets.size();
     auto replicas = get_replica_info(tablet_id);
     if (replicas.empty()) {
         return;
     }
-    if (rowset_ids.size() != num_segments.size()) {
-        LOG(WARNING) << "recycle_cache: rowset_ids size mismatch with num_segments";
-        return;
-    }
 
     PRecycleCacheRequest request;
-    for (int i = 0; i < rowset_ids.size(); i++) {
+    for (const auto& rowset : rowsets) {
         RecycleCacheMeta* meta = request.add_cache_metas();
         meta->set_tablet_id(tablet_id);
-        meta->set_rowset_id(rowset_ids[i].to_string());
-        meta->set_num_segments(num_segments[i]);
-        for (const auto& name : index_file_names[i]) {
+        meta->set_rowset_id(rowset.rowset_id.to_string());
+        meta->set_num_segments(rowset.num_segments);
+        for (const auto& name : rowset.index_file_names) {
             meta->add_index_file_names(name);
         }
-        g_file_cache_recycle_cache_requested_segment_num << num_segments[i];
-        g_file_cache_recycle_cache_requested_index_num << index_file_names[i].size();
+        g_file_cache_recycle_cache_requested_segment_num << rowset.num_segments;
+        g_file_cache_recycle_cache_requested_index_num << rowset.index_file_names.size();
     }
+    auto dns_cache = ExecEnv::GetInstance()->dns_cache();
     for (auto& replica : replicas) {
         // send sync request
         std::string host = replica.host;
-        auto dns_cache = ExecEnv::GetInstance()->dns_cache();
         if (dns_cache == nullptr) {
             LOG(WARNING) << "DNS cache is not initialized, skipping hostname resolve";
         } else if (!is_valid_ip(replica.host)) {

--- a/be/src/cloud/cloud_warm_up_manager.h
+++ b/be/src/cloud/cloud_warm_up_manager.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "cloud/cloud_storage_engine.h"
+#include "cloud/cloud_tablet.h"
 #include "common/status.h"
 #include "gen_cpp/BackendService.h"
 
@@ -73,9 +74,7 @@ public:
 
     void warm_up_rowset(RowsetMeta& rs_meta);
 
-    void recycle_cache(int64_t tablet_id, const std::vector<RowsetId>& rowset_ids,
-                       const std::vector<int64_t>& num_segments,
-                       const std::vector<std::vector<std::string>>& index_file_names);
+    void recycle_cache(int64_t tablet_id, const std::vector<RecycledRowsets>& rowsets);
 
 private:
     void handle_jobs();


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

`recycle_cached_data()` should not call `recycle_cache()`. Because rebalance will also call `recycle_cached_data()`. For compaction, we should call `recycle_cache()` in `delete_expired_stale_rowsets()` and `clear_cache()`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

