### PR TITLE
[fix](mtmv)Fix the mapping issue where base tables could still reference a dropped MTMV

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -463,9 +463,6 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table>,
         }
         Table table = getTableNullable(tableName);
         if (table != null) {
-            if (table instanceof MTMV) {
-                Env.getCurrentEnv().getMtmvService().unregisterMTMV((MTMV) table);
-            }
             this.nameToTable.remove(tableName);
             this.lowerCaseToTableName.remove(tableName.toLowerCase());
             this.idToTable.remove(table.getId());
@@ -473,6 +470,10 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table>,
                 Env.getCurrentEnv().unregisterTempTable(table);
             }
             table.markDropped();
+            // will check mtmv if exist by markDrop, so unregisterMTMV() need after markDropped()
+            if (table instanceof MTMV) {
+                Env.getCurrentEnv().getMtmvService().unregisterMTMV((MTMV) table);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRelationManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRelationManager.java
@@ -235,6 +235,9 @@ public class MTMVRelationManager implements MTMVHookService {
     public void refreshComplete(MTMV mtmv, MTMVRelation relation, MTMVTask task) {
         if (task.getStatus() == TaskStatus.SUCCESS) {
             Objects.requireNonNull(relation);
+            if (mtmv.isDropped) {
+                return;
+            }
             refreshMTMVCache(relation, new BaseTableInfo(mtmv));
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVService.java
@@ -86,8 +86,13 @@ public class MTMVService implements EventListener {
     public void unregisterMTMV(MTMV mtmv) {
         Objects.requireNonNull(mtmv, "mtmv can not be null");
         LOG.info("deregisterMTMV: " + mtmv.getName());
-        for (MTMVHookService mtmvHookService : hooks.values()) {
-            mtmvHookService.unregisterMTMV(mtmv);
+        mtmv.writeMvLock();
+        try {
+            for (MTMVHookService mtmvHookService : hooks.values()) {
+                mtmvHookService.unregisterMTMV(mtmv);
+            }
+        } finally {
+            mtmv.writeMvUnlock();
         }
     }
 
@@ -121,8 +126,13 @@ public class MTMVService implements EventListener {
         Objects.requireNonNull(mtmv, "mtmv can not be null");
         Objects.requireNonNull(task, "task can not be null");
         LOG.info("refreshComplete: " + mtmv.getName());
-        for (MTMVHookService mtmvHookService : hooks.values()) {
-            mtmvHookService.refreshComplete(mtmv, cache, task);
+        mtmv.writeMvLock();
+        try {
+            for (MTMVHookService mtmvHookService : hooks.values()) {
+                mtmvHookService.refreshComplete(mtmv, cache, task);
+            }
+        } finally {
+            mtmv.writeMvUnlock();
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVConcurrentTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVConcurrentTest.java
@@ -1,0 +1,85 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.mtmv;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.MTMV;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.job.common.TaskStatus;
+import org.apache.doris.job.extensions.mtmv.MTMVTask;
+import org.apache.doris.utframe.TestWithFeService;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+public class MTMVConcurrentTest extends TestWithFeService {
+    @Test
+    public void testAlterMTMV() throws Exception {
+        createDatabaseAndUse("mtmv_concurrent_test");
+
+        createTable("CREATE TABLE `stu` (`sid` int(32) NULL, `sname` varchar(32) NULL)\n"
+                + "ENGINE=OLAP\n"
+                + "DUPLICATE KEY(`sid`)\n"
+                + "DISTRIBUTED BY HASH(`sid`) BUCKETS 1\n"
+                + "PROPERTIES ('replication_allocation' = 'tag.location.default: 1')");
+
+        createMvByNereids("CREATE MATERIALIZED VIEW mv_a BUILD DEFERRED REFRESH COMPLETE ON MANUAL\n"
+                + "DISTRIBUTED BY HASH(`sid`) BUCKETS 1\n"
+                + "PROPERTIES ('replication_allocation' = 'tag.location.default: 1') "
+                + "AS select * from stu limit 1");
+
+
+        MTMVRelationManager relationManager = Env.getCurrentEnv().getMtmvService().getRelationManager();
+        Table table = Env.getCurrentInternalCatalog().getDb("mtmv_concurrent_test").get()
+                .getTableOrMetaException("stu");
+        BaseTableInfo baseTableInfo = new BaseTableInfo(table);
+        MTMV mtmv = (MTMV) Env.getCurrentInternalCatalog().getDb("mtmv_concurrent_test").get()
+                .getTableOrMetaException("mv_a");
+        MTMVRelation relation = mtmv.getRelation();
+        Set<BaseTableInfo> mtmvsByBaseTable = relationManager.getMtmvsByBaseTable(baseTableInfo);
+        Assertions.assertEquals(1, mtmvsByBaseTable.size());
+        MTMVTask mtmvTask = new MTMVTask(mtmv, relation, null);
+        mtmvTask.setStatus(TaskStatus.SUCCESS);
+
+        // Create threads for concurrent operations
+        Thread dropThread = new Thread(() -> {
+            try {
+                dropMvByNereids("drop materialized view mv_a");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        Thread refreshThread = new Thread(() -> {
+            relationManager.refreshComplete(mtmv, relation, mtmvTask);
+        });
+
+        // Start both threads
+        dropThread.start();
+        refreshThread.start();
+
+        // Wait for both threads to complete
+        dropThread.join();
+        refreshThread.join();
+
+        mtmvsByBaseTable = relationManager.getMtmvsByBaseTable(baseTableInfo);
+        Assertions.assertEquals(0, mtmvsByBaseTable.size());
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

**Background:**

The MTMVRelationManager maintains a mapping relationship between base tables and materialized views (MTMVs).

When an MTMV is dropped, this relationship is maintained by removing the relevant mappings.

When an MTMV is successfully refreshed, the mapping is updated (old mappings are removed and new ones are added).

**Suspected Issue Scenario:**

The MTMV is refreshed successfully.

The MTMV is dropped.

The mapping relationship is refreshed (potentially causing inconsistent state).


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
Fix the mapping issue where base tables could still reference a dropped MTMV
### Release note

Fix the mapping issue where base tables could still reference a dropped MTMV

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

