### PR TITLE
[fix](nereids) fix insert overwrite statement plan twice

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertOverwriteTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertOverwriteTableCommand.java
@@ -290,7 +290,7 @@ public class InsertOverwriteTableCommand extends Command implements NeedAuditEnc
     private void runInsertCommand(LogicalPlan logicalQuery, InsertCommandContext insertCtx,
             ConnectContext ctx, StmtExecutor executor) throws Exception {
         InsertIntoTableCommand insertCommand = new InsertIntoTableCommand(logicalQuery, labelName,
-                Optional.of(insertCtx), Optional.empty());
+                Optional.of(insertCtx), Optional.empty(), false);
         insertCommand.run(ctx, executor);
         if (ctx.getState().getStateType() == MysqlStateType.ERR) {
             String errMsg = Strings.emptyToNull(ctx.getState().getErrorMessage());


### PR DESCRIPTION
### What problem does this PR solve?

the `InsertOverwriteTableCommand` will normalize plan twice, maybe cause some strange problems

first:
```java
this.logicalQuery = Optional.of((LogicalPlan) InsertUtils.normalizePlan(
    originLogicalQuery, targetTableIf, analyzeContext, Optional.empty()));
```

second:
```java
InsertIntoTableCommand insertCommand = new InsertIntoTableCommand(logicalQuery, labelName,
    Optional.of(insertCtx), Optional.empty(), false);
insertCommand.run(ctx, executor);
```

we should skip normalize plan in the `InsertIntoTableCommand`

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

