### PR TITLE
[refactory](nereids)use nereids literal for hot values in col stats

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
@@ -64,7 +64,7 @@ import java.util.Optional;
 
 /**
  * All data type literal expression in Nereids.
- * TODO: Increase the implementation of sub expression. such as Integer.
+ * TODO: Increase the implementation of sub expression. such as Integer.z
  */
 public abstract class Literal extends Expression implements LeafExpression {
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteral.java
@@ -25,7 +25,7 @@ import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.DateTimeType;
 import org.apache.doris.nereids.types.DateTimeV2Type;
 import org.apache.doris.nereids.types.TimeV2Type;
-import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.base.Preconditions;
 
@@ -126,7 +126,7 @@ public abstract class StringLikeLiteral extends Literal implements ComparableLit
         if (this.dataType.equals(targetType)) {
             return this;
         }
-        boolean strictCast = ConnectContext.get().getSessionVariable().enableStrictCast();
+        boolean strictCast = SessionVariable.enableStrictCast();
         if (targetType.isIntegralType()) {
             return castToIntegral(targetType, strictCast);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
@@ -55,6 +55,32 @@ public abstract class DataType {
     public static final int DEFAULT_SCALE = 0;
     public static final int DEFAULT_PRECISION = 9;
 
+    public static final Map<Type, DataType> legacyTypeToNereidsType
+            = ImmutableMap.<Type, DataType>builder()
+            .put(Type.BOOLEAN, BooleanType.INSTANCE)
+            .put(Type.TINYINT, TinyIntType.INSTANCE)
+            .put(Type.SMALLINT, SmallIntType.INSTANCE)
+            .put(Type.INT, IntegerType.INSTANCE)
+            .put(Type.BIGINT, BigIntType.INSTANCE)
+            .put(Type.LARGEINT, LargeIntType.INSTANCE)
+            .put(Type.FLOAT, FloatType.INSTANCE)
+            .put(Type.DOUBLE, DoubleType.INSTANCE)
+            .put(Type.CHAR, StringType.INSTANCE)
+            .put(Type.VARCHAR, StringType.INSTANCE)
+            .put(Type.STRING, StringType.INSTANCE)
+            .put(Type.DATE, DateType.INSTANCE)
+            .put(Type.DATEV2, DateType.INSTANCE)
+            .put(Type.DATETIME, DateTimeType.INSTANCE)
+            .put(Type.DATETIMEV2, DateTimeV2Type.SYSTEM_DEFAULT)
+            .put(Type.DECIMALV2, DecimalV2Type.SYSTEM_DEFAULT)
+            .put(Type.DECIMAL32, DecimalV3Type.SYSTEM_DEFAULT)
+            .put(Type.DECIMAL64, DecimalV3Type.SYSTEM_DEFAULT)
+            .put(Type.DECIMAL128, DecimalV3Type.SYSTEM_DEFAULT)
+            .put(Type.DECIMAL256, DecimalV3Type.SYSTEM_DEFAULT)
+            .put(Type.IPV4, IPv4Type.INSTANCE)
+            .put(Type.IPV6, IPv6Type.INSTANCE)
+            .build();
+
     protected static final NereidsParser PARSER = new NereidsParser();
 
     // use class and supplier here to avoid class load deadlock.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
@@ -58,32 +58,32 @@ public abstract class DataType {
     protected static final NereidsParser PARSER = new NereidsParser();
 
     private static class TypeMapLoader {
-        static final Map<Type, DataType> LEGACY_MAP = initMap();
+        static final Map<org.apache.doris.catalog.PrimitiveType, DataType> LEGACY_MAP = initMap();
 
-        private static Map<Type, DataType> initMap() {
-            return ImmutableMap.<Type, DataType>builder()
-                    .put(Type.BOOLEAN, BooleanType.INSTANCE)
-                    .put(Type.TINYINT, TinyIntType.INSTANCE)
-                    .put(Type.SMALLINT, SmallIntType.INSTANCE)
-                    .put(Type.INT, IntegerType.INSTANCE)
-                    .put(Type.BIGINT, BigIntType.INSTANCE)
-                    .put(Type.LARGEINT, LargeIntType.INSTANCE)
-                    .put(Type.FLOAT, FloatType.INSTANCE)
-                    .put(Type.DOUBLE, DoubleType.INSTANCE)
-                    .put(Type.CHAR, StringType.INSTANCE)
-                    .put(Type.VARCHAR, StringType.INSTANCE)
-                    .put(Type.STRING, StringType.INSTANCE)
-                    .put(Type.DATE, DateType.INSTANCE)
-                    .put(Type.DATEV2, DateType.INSTANCE)
-                    .put(Type.DATETIME, DateTimeType.INSTANCE)
-                    .put(Type.DATETIMEV2, DateTimeV2Type.SYSTEM_DEFAULT)
-                    .put(Type.DECIMALV2, DecimalV2Type.SYSTEM_DEFAULT)
-                    .put(Type.DECIMAL32, DecimalV3Type.SYSTEM_DEFAULT)
-                    .put(Type.DECIMAL64, DecimalV3Type.SYSTEM_DEFAULT)
-                    .put(Type.DECIMAL128, DecimalV3Type.SYSTEM_DEFAULT)
-                    .put(Type.DECIMAL256, DecimalV3Type.SYSTEM_DEFAULT)
-                    .put(Type.IPV4, IPv4Type.INSTANCE)
-                    .put(Type.IPV6, IPv6Type.INSTANCE)
+        private static Map<org.apache.doris.catalog.PrimitiveType, DataType> initMap() {
+            return ImmutableMap.<org.apache.doris.catalog.PrimitiveType, DataType>builder()
+                    .put(Type.BOOLEAN.getPrimitiveType(), BooleanType.INSTANCE)
+                    .put(Type.TINYINT.getPrimitiveType(), TinyIntType.INSTANCE)
+                    .put(Type.SMALLINT.getPrimitiveType(), SmallIntType.INSTANCE)
+                    .put(Type.INT.getPrimitiveType(), IntegerType.INSTANCE)
+                    .put(Type.BIGINT.getPrimitiveType(), BigIntType.INSTANCE)
+                    .put(Type.LARGEINT.getPrimitiveType(), LargeIntType.INSTANCE)
+                    .put(Type.FLOAT.getPrimitiveType(), FloatType.INSTANCE)
+                    .put(Type.DOUBLE.getPrimitiveType(), DoubleType.INSTANCE)
+                    .put(Type.CHAR.getPrimitiveType(), StringType.INSTANCE)
+                    .put(Type.VARCHAR.getPrimitiveType(), StringType.INSTANCE)
+                    .put(Type.STRING.getPrimitiveType(), StringType.INSTANCE)
+                    .put(Type.DATE.getPrimitiveType(), DateType.INSTANCE)
+                    .put(Type.DATEV2.getPrimitiveType(), DateType.INSTANCE)
+                    .put(Type.DATETIME.getPrimitiveType(), DateTimeType.INSTANCE)
+                    .put(Type.DATETIMEV2.getPrimitiveType(), DateTimeV2Type.SYSTEM_DEFAULT)
+                    .put(Type.DECIMALV2.getPrimitiveType(), DecimalV2Type.SYSTEM_DEFAULT)
+                    .put(Type.DECIMAL32.getPrimitiveType(), DecimalV3Type.SYSTEM_DEFAULT)
+                    .put(Type.DECIMAL64.getPrimitiveType(), DecimalV3Type.SYSTEM_DEFAULT)
+                    .put(Type.DECIMAL128.getPrimitiveType(), DecimalV3Type.SYSTEM_DEFAULT)
+                    .put(Type.DECIMAL256.getPrimitiveType(), DecimalV3Type.SYSTEM_DEFAULT)
+                    .put(Type.IPV4.getPrimitiveType(), IPv4Type.INSTANCE)
+                    .put(Type.IPV6.getPrimitiveType(), IPv6Type.INSTANCE)
                     .build();
         }
     }
@@ -119,7 +119,7 @@ public abstract class DataType {
             .add(TimeV2Type.class, () -> ImmutableList.of(DateTimeV2Type.MAX, StringType.INSTANCE))
             .build();
 
-    public static Map<Type, DataType> legacyTypeToNereidsType() {
+    public static Map<org.apache.doris.catalog.PrimitiveType, DataType> legacyTypeToNereidsType() {
         return TypeMapLoader.LEGACY_MAP;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
@@ -55,33 +55,38 @@ public abstract class DataType {
     public static final int DEFAULT_SCALE = 0;
     public static final int DEFAULT_PRECISION = 9;
 
-    public static final Map<Type, DataType> legacyTypeToNereidsType
-            = ImmutableMap.<Type, DataType>builder()
-            .put(Type.BOOLEAN, BooleanType.INSTANCE)
-            .put(Type.TINYINT, TinyIntType.INSTANCE)
-            .put(Type.SMALLINT, SmallIntType.INSTANCE)
-            .put(Type.INT, IntegerType.INSTANCE)
-            .put(Type.BIGINT, BigIntType.INSTANCE)
-            .put(Type.LARGEINT, LargeIntType.INSTANCE)
-            .put(Type.FLOAT, FloatType.INSTANCE)
-            .put(Type.DOUBLE, DoubleType.INSTANCE)
-            .put(Type.CHAR, StringType.INSTANCE)
-            .put(Type.VARCHAR, StringType.INSTANCE)
-            .put(Type.STRING, StringType.INSTANCE)
-            .put(Type.DATE, DateType.INSTANCE)
-            .put(Type.DATEV2, DateType.INSTANCE)
-            .put(Type.DATETIME, DateTimeType.INSTANCE)
-            .put(Type.DATETIMEV2, DateTimeV2Type.SYSTEM_DEFAULT)
-            .put(Type.DECIMALV2, DecimalV2Type.SYSTEM_DEFAULT)
-            .put(Type.DECIMAL32, DecimalV3Type.SYSTEM_DEFAULT)
-            .put(Type.DECIMAL64, DecimalV3Type.SYSTEM_DEFAULT)
-            .put(Type.DECIMAL128, DecimalV3Type.SYSTEM_DEFAULT)
-            .put(Type.DECIMAL256, DecimalV3Type.SYSTEM_DEFAULT)
-            .put(Type.IPV4, IPv4Type.INSTANCE)
-            .put(Type.IPV6, IPv6Type.INSTANCE)
-            .build();
-
     protected static final NereidsParser PARSER = new NereidsParser();
+
+    private static class TypeMapLoader {
+        static final Map<Type, DataType> LEGACY_MAP = initMap();
+
+        private static Map<Type, DataType> initMap() {
+            return ImmutableMap.<Type, DataType>builder()
+                    .put(Type.BOOLEAN, BooleanType.INSTANCE)
+                    .put(Type.TINYINT, TinyIntType.INSTANCE)
+                    .put(Type.SMALLINT, SmallIntType.INSTANCE)
+                    .put(Type.INT, IntegerType.INSTANCE)
+                    .put(Type.BIGINT, BigIntType.INSTANCE)
+                    .put(Type.LARGEINT, LargeIntType.INSTANCE)
+                    .put(Type.FLOAT, FloatType.INSTANCE)
+                    .put(Type.DOUBLE, DoubleType.INSTANCE)
+                    .put(Type.CHAR, StringType.INSTANCE)
+                    .put(Type.VARCHAR, StringType.INSTANCE)
+                    .put(Type.STRING, StringType.INSTANCE)
+                    .put(Type.DATE, DateType.INSTANCE)
+                    .put(Type.DATEV2, DateType.INSTANCE)
+                    .put(Type.DATETIME, DateTimeType.INSTANCE)
+                    .put(Type.DATETIMEV2, DateTimeV2Type.SYSTEM_DEFAULT)
+                    .put(Type.DECIMALV2, DecimalV2Type.SYSTEM_DEFAULT)
+                    .put(Type.DECIMAL32, DecimalV3Type.SYSTEM_DEFAULT)
+                    .put(Type.DECIMAL64, DecimalV3Type.SYSTEM_DEFAULT)
+                    .put(Type.DECIMAL128, DecimalV3Type.SYSTEM_DEFAULT)
+                    .put(Type.DECIMAL256, DecimalV3Type.SYSTEM_DEFAULT)
+                    .put(Type.IPV4, IPv4Type.INSTANCE)
+                    .put(Type.IPV6, IPv6Type.INSTANCE)
+                    .build();
+        }
+    }
 
     // use class and supplier here to avoid class load deadlock.
     private static final Map<Class<? extends PrimitiveType>, Supplier<DataType>> PROMOTION_MAP
@@ -113,6 +118,10 @@ public abstract class DataType {
             .add(DateV2Type.class, () -> ImmutableList.of(DateTimeV2Type.SYSTEM_DEFAULT, StringType.INSTANCE))
             .add(TimeV2Type.class, () -> ImmutableList.of(DateTimeV2Type.MAX, StringType.INSTANCE))
             .build();
+
+    public static Map<Type, DataType> legacyTypeToNereidsType() {
+        return TypeMapLoader.LEGACY_MAP;
+    }
 
     /**
      * create a specific Literal for a given dataType

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -754,6 +754,23 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String SKEW_REWRITE_AGG_BUCKET_NUM = "skew_rewrite_agg_bucket_num";
 
+    public static final String HOT_VALUE_THRESHOLD = "hot_value_threshold";
+
+    @VariableMgr.VarAttr(name = HOT_VALUE_THRESHOLD, needForward = true)
+    private double hotValueThreshold = 0.33;
+
+    public void setHotValueThreshold(double threshold) {
+        this.hotValueThreshold = threshold;
+    }
+
+    public static double getHotValueThreshold() {
+        if (ConnectContext.get() != null) {
+            return ConnectContext.get().getSessionVariable().hotValueThreshold;
+        } else {
+            return 0.5;
+        }
+    }
+
     public static final String ENABLE_STRICT_CAST = "enable_strict_cast";
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -767,7 +767,7 @@ public class SessionVariable implements Serializable, Writable {
         if (ConnectContext.get() != null) {
             return ConnectContext.get().getSessionVariable().hotValueThreshold;
         } else {
-            return 0.5;
+            return Double.parseDouble(VariableMgr.getDefaultValue(HOT_VALUE_THRESHOLD));
         }
     }
 
@@ -5032,7 +5032,11 @@ public class SessionVariable implements Serializable, Writable {
         this.enableAddIndexForNewData = enableAddIndexForNewData;
     }
 
-    public boolean enableStrictCast() {
-        return enableStrictCast;
+    public static boolean enableStrictCast() {
+        if (ConnectContext.get() != null) {
+            return ConnectContext.get().getSessionVariable().enableStrictCast;
+        } else {
+            return Boolean.parseBoolean(VariableMgr.getDefaultValue("ENABLE_STRICT_CAST"));
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -756,8 +756,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String HOT_VALUE_THRESHOLD = "hot_value_threshold";
 
-    @VariableMgr.VarAttr(name = HOT_VALUE_THRESHOLD, needForward = true)
-    private double hotValueThreshold = 0.33;
+    @VariableMgr.VarAttr(name = HOT_VALUE_THRESHOLD, needForward = true,
+            description = {"value 在每百行中的最低出现次数",
+                    "The minimum number of occurrences of 'value' per hundred lines"})
+    private double hotValueThreshold = 33; // by percentage
 
     public void setHotValueThreshold(double threshold) {
         this.hotValueThreshold = threshold;
@@ -765,7 +767,11 @@ public class SessionVariable implements Serializable, Writable {
 
     public static double getHotValueThreshold() {
         if (ConnectContext.get() != null) {
-            return ConnectContext.get().getSessionVariable().hotValueThreshold;
+            if (ConnectContext.get().getState().isInternal()) {
+                return 0.0;
+            } else {
+                return ConnectContext.get().getSessionVariable().hotValueThreshold;
+            }
         } else {
             return Double.parseDouble(VariableMgr.getDefaultValue(HOT_VALUE_THRESHOLD));
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.coercion.CharacterType;
 import org.apache.doris.persist.gson.GsonUtils;
@@ -96,12 +97,12 @@ public class ColumnStatistic {
     public final String updatedTime;
 
     @SerializedName("hotValues")
-    public final Map<LiteralExpr, Float> hotValues;
+    public final Map<Literal, Float> hotValues;
 
     public ColumnStatistic(double count, double ndv, ColumnStatistic original, double avgSizeByte,
             double numNulls, double dataSize, double minValue, double maxValue,
             LiteralExpr minExpr, LiteralExpr maxExpr, boolean isUnKnown,
-            String updatedTime, Map<LiteralExpr, Float> hotValues) {
+            String updatedTime, Map<Literal, Float> hotValues) {
         this.count = count;
         this.ndv = ndv;
         this.original = original;
@@ -422,5 +423,9 @@ public class ColumnStatistic {
             sb.setLength(sb.length() - 1);
         }
         return sb.toString();
+    }
+
+    public Map<Literal, Float> getHotValues() {
+        return hotValues;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatisticBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatisticBuilder.java
@@ -19,6 +19,7 @@ package org.apache.doris.statistics;
 
 import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.types.coercion.CharacterType;
 
 import java.util.Map;
@@ -39,7 +40,7 @@ public class ColumnStatisticBuilder {
     private ColumnStatistic original;
 
     private String updatedTime;
-    private Map<LiteralExpr, Float> hotValues;
+    private Map<Literal, Float> hotValues;
 
     public ColumnStatisticBuilder() {
     }
@@ -131,7 +132,7 @@ public class ColumnStatisticBuilder {
         return this;
     }
 
-    public ColumnStatisticBuilder setHotValues(Map<LiteralExpr, Float> hotValues) {
+    public ColumnStatisticBuilder setHotValues(Map<Literal, Float> hotValues) {
         this.hotValues = hotValues;
         return this;
     }
@@ -185,7 +186,7 @@ public class ColumnStatisticBuilder {
         return this;
     }
 
-    public Map<LiteralExpr, Float> getHotValues() {
+    public Map<Literal, Float> getHotValues() {
         return hotValues;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -1291,7 +1291,7 @@ public class StatisticsUtil {
                             new org.apache.doris.nereids.trees.expressions.literal.StringLiteral(
                                     oneRowSplit[0].replaceAll("\\\\:", ":")
                                             .replaceAll("\\\\;", ";"));
-                    DataType dataType = DataType.legacyTypeToNereidsType().get(type);
+                    DataType dataType = DataType.legacyTypeToNereidsType().get(type.getPrimitiveType());
                     if (dataType != null) {
                         try {
                             Literal hotValue = (Literal) stringLiteral.checkedCastTo(dataType);

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -1291,7 +1291,7 @@ public class StatisticsUtil {
                         new org.apache.doris.nereids.trees.expressions.literal.StringLiteral(
                                 oneRowSplit[0].replaceAll("\\\\:", ":")
                                         .replaceAll("\\\\;", ";"));
-                DataType dataType = DataType.legacyTypeToNereidsType.get(type);
+                DataType dataType = DataType.legacyTypeToNereidsType().get(type);
                 if (dataType != null) {
                     try {
                         Literal hotValue = (Literal) stringLiteral.checkedCastTo(dataType);

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -1281,29 +1281,32 @@ public class StatisticsUtil {
         if (stringValues == null) {
             return null;
         }
-
-        LinkedHashMap<Literal, Float> ret = Maps.newLinkedHashMap();
-        for (String oneRow : stringValues.split(" ;")) {
-            String[] oneRowSplit = oneRow.split(" :");
-            float value = Float.parseFloat(oneRowSplit[1]);
-            if (value > SessionVariable.getHotValueThreshold()) {
-                org.apache.doris.nereids.trees.expressions.literal.StringLiteral stringLiteral =
-                        new org.apache.doris.nereids.trees.expressions.literal.StringLiteral(
-                                oneRowSplit[0].replaceAll("\\\\:", ":")
-                                        .replaceAll("\\\\;", ";"));
-                DataType dataType = DataType.legacyTypeToNereidsType().get(type);
-                if (dataType != null) {
-                    try {
-                        Literal hotValue = (Literal) stringLiteral.checkedCastTo(dataType);
-                        ret.put(hotValue, value);
-                    } catch (Exception e) {
-                        LOG.info("Failed to parse hot value [{}]. {}", oneRowSplit[0], e.getMessage());
+        try {
+            LinkedHashMap<Literal, Float> ret = Maps.newLinkedHashMap();
+            for (String oneRow : stringValues.split(" ;")) {
+                String[] oneRowSplit = oneRow.split(" :");
+                float value = Float.parseFloat(oneRowSplit[1]);
+                if (value > SessionVariable.getHotValueThreshold()) {
+                    org.apache.doris.nereids.trees.expressions.literal.StringLiteral stringLiteral =
+                            new org.apache.doris.nereids.trees.expressions.literal.StringLiteral(
+                                    oneRowSplit[0].replaceAll("\\\\:", ":")
+                                            .replaceAll("\\\\;", ";"));
+                    DataType dataType = DataType.legacyTypeToNereidsType().get(type);
+                    if (dataType != null) {
+                        try {
+                            Literal hotValue = (Literal) stringLiteral.checkedCastTo(dataType);
+                            ret.put(hotValue, value);
+                        } catch (Exception e) {
+                            LOG.info("Failed to parse hot value [{}]. {}", oneRowSplit[0], e.getMessage());
+                        }
                     }
                 }
             }
-        }
-        if (!ret.isEmpty()) {
-            return ret;
+            if (!ret.isEmpty()) {
+                return ret;
+            }
+        } catch (Exception e) {
+            LOG.info("Failed to parse hot values [{}]. {}", stringValues, e.getMessage());
         }
         return null;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -64,8 +64,10 @@ import org.apache.doris.datasource.hive.HMSExternalTable.DLAType;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.IPv4Literal;
 import org.apache.doris.nereids.trees.expressions.literal.IPv6Literal;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 import org.apache.doris.nereids.trees.plans.commands.info.TableNameInfo;
+import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.qe.AuditLogHelper;
 import org.apache.doris.qe.AutoCloseConnectContext;
 import org.apache.doris.qe.ConnectContext;
@@ -1275,23 +1277,33 @@ public class StatisticsUtil {
      * value1 :percent1 ;value2 :percent2 ;value3 :percent3
      * @return Map of LiteralExpr -> percentage.
      */
-    public static LinkedHashMap<LiteralExpr, Float> getHotValues(String stringValues, Type type) {
+    public static LinkedHashMap<Literal, Float> getHotValues(String stringValues, Type type) {
         if (stringValues == null) {
             return null;
         }
-        try {
-            LinkedHashMap<LiteralExpr, Float> ret = Maps.newLinkedHashMap();
-            for (String oneRow : stringValues.split(" ;")) {
-                String[] oneRowSplit = oneRow.split(" :");
-                float value = Float.parseFloat(oneRowSplit[1]);
-                String stringLiteral = oneRowSplit[0].replaceAll("\\\\:", ":").replaceAll("\\\\;", ";");
-                ret.put(readableValue(type, stringLiteral), value);
+
+        LinkedHashMap<Literal, Float> ret = Maps.newLinkedHashMap();
+        for (String oneRow : stringValues.split(" ;")) {
+            String[] oneRowSplit = oneRow.split(" :");
+            float value = Float.parseFloat(oneRowSplit[1]);
+            if (value > SessionVariable.getHotValueThreshold()) {
+                org.apache.doris.nereids.trees.expressions.literal.StringLiteral stringLiteral =
+                        new org.apache.doris.nereids.trees.expressions.literal.StringLiteral(
+                                oneRowSplit[0].replaceAll("\\\\:", ":")
+                                        .replaceAll("\\\\;", ";"));
+                DataType dataType = DataType.legacyTypeToNereidsType.get(type);
+                if (dataType != null) {
+                    try {
+                        Literal hotValue = (Literal) stringLiteral.checkedCastTo(dataType);
+                        ret.put(hotValue, value);
+                    } catch (Exception e) {
+                        LOG.info("Failed to parse hot value [{}]. {}", oneRowSplit[0], e.getMessage());
+                    }
+                }
             }
-            if (!ret.isEmpty()) {
-                return ret;
-            }
-        } catch (Exception e) {
-            LOG.info("Failed to parse hot values [{}]. {}", stringValues, e.getMessage());
+        }
+        if (!ret.isEmpty()) {
+            return ret;
         }
         return null;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/CacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/CacheTest.java
@@ -108,10 +108,15 @@ public class CacheTest extends TestWithFeService {
         ColumnStatistic columnStatistic = statisticsCache.getColumnStatistics(-1, -1, 0, -1, "col", connectContext);
         // load not finished yet, should return unknown
         Assertions.assertTrue(columnStatistic.isUnKnown);
-        // wait 1 sec to ensure `execStatisticQuery` is finished as much as possible.
-        Thread.sleep(1000);
-        // load has finished, return corresponding stats.
-        columnStatistic = statisticsCache.getColumnStatistics(-1, -1, 0, -1, "col", connectContext);
+        int retry = 0;
+        while (columnStatistic.isUnKnown() && retry < 10) {
+            // wait 1 sec to ensure `execStatisticQuery` is finished as much as possible.
+            Thread.sleep(1000);
+            // load has finished, return corresponding stats.
+            columnStatistic = statisticsCache.getColumnStatistics(-1, -1, 0, -1, "col", connectContext);
+            retry++;
+        }
+        System.out.println("wait for " + retry + " seconds");
         Assertions.assertEquals(7, columnStatistic.count);
         Assertions.assertEquals(8, columnStatistic.ndv);
         Assertions.assertEquals(11, columnStatistic.maxValue);

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/StatsMockUtil.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/StatsMockUtil.java
@@ -42,9 +42,9 @@ public class StatsMockUtil {
                 // 11
                 add("11");
                 add("12");
-                add(null);
                 add(String.valueOf(System.currentTimeMillis()));
-            }};
+                add(null); // hot values
+        }};
         return new ResultRow(vals);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/StatsMockUtil.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/StatsMockUtil.java
@@ -44,7 +44,7 @@ public class StatsMockUtil {
                 add("12");
                 add(String.valueOf(System.currentTimeMillis()));
                 add(null); // hot values
-        }};
+            }};
         return new ResultRow(vals);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/util/StatisticsUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/util/StatisticsUtilTest.java
@@ -569,7 +569,7 @@ class StatisticsUtilTest {
 
     @Test
     void testGetHotValues() {
-        String value1 = "1234 :0.33 ;222 :0.22";
+        String value1 = "1234 :0.35 ;222 :0.34";
         Map<Literal, Float> hotValues = StatisticsUtil.getHotValues(value1, Type.INT);
         Assertions.assertEquals(2, hotValues.size());
 
@@ -577,11 +577,11 @@ class StatisticsUtilTest {
         for (Map.Entry<Literal, Float> entry : hotValues.entrySet()) {
             if (i == 0) {
                 Assertions.assertEquals("1234", entry.getKey().getStringValue());
-                Assertions.assertEquals("0.33", entry.getValue().toString());
+                Assertions.assertEquals("0.35", entry.getValue().toString());
                 i++;
             } else {
                 Assertions.assertEquals("222", entry.getKey().getStringValue());
-                Assertions.assertEquals("0.22", entry.getValue().toString());
+                Assertions.assertEquals("0.34", entry.getValue().toString());
             }
         }
 
@@ -594,19 +594,12 @@ class StatisticsUtilTest {
             Assertions.assertEquals("0.33", entry.getValue().toString());
         }
 
-        String value3 = "aabbcc\\:\\; :0.33 ; dd :0.22";
+        String value3 = "aabbcc\\:\\; :0.34 ; dd :0.22";
         hotValues = StatisticsUtil.getHotValues(value3, Type.STRING);
-        Assertions.assertEquals(2, hotValues.size());
-        i = 0;
+        Assertions.assertEquals(1, hotValues.size());
         for (Map.Entry<Literal, Float> entry : hotValues.entrySet()) {
-            if (i == 0) {
-                Assertions.assertEquals("aabbcc:;", entry.getKey().getStringValue());
-                Assertions.assertEquals("0.33", entry.getValue().toString());
-                i++;
-            } else {
-                Assertions.assertEquals(" dd", entry.getKey().getStringValue());
-                Assertions.assertEquals("0.22", entry.getValue().toString());
-            }
+            Assertions.assertEquals("aabbcc:;", entry.getKey().getStringValue());
+            Assertions.assertEquals("0.34", entry.getValue().toString());
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/util/StatisticsUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/util/StatisticsUtilTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.statistics.util;
 
-import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.MaterializedIndexMeta;
@@ -43,6 +42,7 @@ import org.apache.doris.datasource.iceberg.IcebergHadoopExternalCatalog;
 import org.apache.doris.datasource.jdbc.JdbcExternalCatalog;
 import org.apache.doris.datasource.jdbc.JdbcExternalDatabase;
 import org.apache.doris.datasource.jdbc.JdbcExternalTable;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.statistics.AnalysisManager;
 import org.apache.doris.statistics.ColStatsMeta;
@@ -570,17 +570,17 @@ class StatisticsUtilTest {
     @Test
     void testGetHotValues() {
         String value1 = "1234 :0.33 ;222 :0.22";
-        Map<LiteralExpr, Float> hotValues = StatisticsUtil.getHotValues(value1, Type.INT);
+        Map<Literal, Float> hotValues = StatisticsUtil.getHotValues(value1, Type.INT);
         Assertions.assertEquals(2, hotValues.size());
 
         int i = 0;
-        for (Map.Entry<LiteralExpr, Float> entry : hotValues.entrySet()) {
+        for (Map.Entry<Literal, Float> entry : hotValues.entrySet()) {
             if (i == 0) {
-                Assertions.assertEquals(1234, entry.getKey().getLongValue());
+                Assertions.assertEquals("1234", entry.getKey().getStringValue());
                 Assertions.assertEquals("0.33", entry.getValue().toString());
                 i++;
             } else {
-                Assertions.assertEquals(222, entry.getKey().getLongValue());
+                Assertions.assertEquals("222", entry.getKey().getStringValue());
                 Assertions.assertEquals("0.22", entry.getValue().toString());
             }
         }
@@ -589,8 +589,8 @@ class StatisticsUtilTest {
         hotValues = StatisticsUtil.getHotValues(value2, Type.INT);
         Assertions.assertEquals(1, hotValues.size());
 
-        for (Map.Entry<LiteralExpr, Float> entry : hotValues.entrySet()) {
-            Assertions.assertEquals(1234, entry.getKey().getLongValue());
+        for (Map.Entry<Literal, Float> entry : hotValues.entrySet()) {
+            Assertions.assertEquals("1234", entry.getKey().getStringValue());
             Assertions.assertEquals("0.33", entry.getValue().toString());
         }
 
@@ -598,7 +598,7 @@ class StatisticsUtilTest {
         hotValues = StatisticsUtil.getHotValues(value3, Type.STRING);
         Assertions.assertEquals(2, hotValues.size());
         i = 0;
-        for (Map.Entry<LiteralExpr, Float> entry : hotValues.entrySet()) {
+        for (Map.Entry<Literal, Float> entry : hotValues.entrySet()) {
             if (i == 0) {
                 Assertions.assertEquals("aabbcc:;", entry.getKey().getStringValue());
                 Assertions.assertEquals("0.33", entry.getValue().toString());

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/util/StatisticsUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/util/StatisticsUtilTest.java
@@ -569,7 +569,7 @@ class StatisticsUtilTest {
 
     @Test
     void testGetHotValues() {
-        String value1 = "1234 :0.35 ;222 :0.34";
+        String value1 = "1234 :35 ;222 :34";
         Map<Literal, Float> hotValues = StatisticsUtil.getHotValues(value1, Type.INT);
         Assertions.assertEquals(2, hotValues.size());
 
@@ -577,29 +577,29 @@ class StatisticsUtilTest {
         for (Map.Entry<Literal, Float> entry : hotValues.entrySet()) {
             if (i == 0) {
                 Assertions.assertEquals("1234", entry.getKey().getStringValue());
-                Assertions.assertEquals("0.35", entry.getValue().toString());
+                Assertions.assertEquals("35.0", entry.getValue().toString());
                 i++;
             } else {
                 Assertions.assertEquals("222", entry.getKey().getStringValue());
-                Assertions.assertEquals("0.34", entry.getValue().toString());
+                Assertions.assertEquals("34.0", entry.getValue().toString());
             }
         }
 
-        String value2 = "1234 :0.33";
+        String value2 = "1234 :34";
         hotValues = StatisticsUtil.getHotValues(value2, Type.INT);
         Assertions.assertEquals(1, hotValues.size());
 
         for (Map.Entry<Literal, Float> entry : hotValues.entrySet()) {
             Assertions.assertEquals("1234", entry.getKey().getStringValue());
-            Assertions.assertEquals("0.33", entry.getValue().toString());
+            Assertions.assertEquals("34.0", entry.getValue().toString());
         }
 
-        String value3 = "aabbcc\\:\\; :0.34 ; dd :0.22";
+        String value3 = "aabbcc\\:\\; :34 ; dd :22";
         hotValues = StatisticsUtil.getHotValues(value3, Type.STRING);
         Assertions.assertEquals(1, hotValues.size());
         for (Map.Entry<Literal, Float> entry : hotValues.entrySet()) {
             Assertions.assertEquals("aabbcc:;", entry.getKey().getStringValue());
-            Assertions.assertEquals("0.34", entry.getValue().toString());
+            Assertions.assertEquals("34.0", entry.getValue().toString());
         }
     }
 }

--- a/regression-test/suites/statistics/test_hot_value.groovy
+++ b/regression-test/suites/statistics/test_hot_value.groovy
@@ -52,6 +52,7 @@ suite("test_hot_value") {
     sql """create database test_hot_value"""
     sql """use test_hot_value"""
     sql """set global enable_auto_analyze=false"""
+    sql " set hot_value_threshold = 0.01"
 
     sql """CREATE TABLE test1 (
             key1 int NULL,
@@ -113,16 +114,16 @@ suite("test_hot_value") {
     assertEquals("10000.0", result[0][2])
     String[] hotValues = result[0][17].split(";")
     assertEquals(2, hotValues.length)
-    assertTrue(hotValues[0] == "1:50.0" || hotValues[0] == "0:50.0")
-    assertTrue(hotValues[1] == "1:50.0" || hotValues[1] == "0:50.0")
+    assertTrue(hotValues[0] == "'1':50.0" || hotValues[0] == "'0':50.0")
+    assertTrue(hotValues[1] == "'1':50.0" || hotValues[1] == "'0':50.0")
     result = sql """show column cached stats test1(value1)"""
     logger.info("result " + result)
     assertEquals(1, result.size())
     assertEquals("10000.0", result[0][2])
     hotValues = result[0][17].split(";")
     assertEquals(2, hotValues.length)
-    assertTrue(hotValues[0] == "1:50.0" || hotValues[0] == "0:50.0")
-    assertTrue(hotValues[1] == "1:50.0" || hotValues[1] == "0:50.0")
+    assertTrue(hotValues[0] == "'1':50.0" || hotValues[0] == "'0':50.0")
+    assertTrue(hotValues[1] == "'1':50.0" || hotValues[1] == "'0':50.0")
 
     sql """drop stats test1"""
     sql """analyze table test1 with sample rows 40000 with sync"""
@@ -136,61 +137,61 @@ suite("test_hot_value") {
     assertEquals("10000.0", result[0][2])
     hotValues = result[0][17].split(";")
     assertEquals(2, hotValues.length)
-    assertTrue(hotValues[0] == "1:50.0" || hotValues[0] == "0:50.0")
-    assertTrue(hotValues[1] == "1:50.0" || hotValues[1] == "0:50.0")
+    assertTrue(hotValues[0] == "'1':50.0" || hotValues[0] == "'0':50.0")
+    assertTrue(hotValues[1] == "'1':50.0" || hotValues[1] == "'0':50.0")
     result = sql """show column cached stats test1(value1)"""
     logger.info("result " + result)
     assertEquals(1, result.size())
     assertEquals("10000.0", result[0][2])
     hotValues = result[0][17].split(";")
     assertEquals(2, hotValues.length)
-    assertTrue(hotValues[0] == "1:50.0" || hotValues[0] == "0:50.0")
-    assertTrue(hotValues[1] == "1:50.0" || hotValues[1] == "0:50.0")
+    assertTrue(hotValues[0] == "'1':50.0" || hotValues[0] == "'0':50.0")
+    assertTrue(hotValues[1] == "'1':50.0" || hotValues[1] == "'0':50.0")
 
     sql """alter table test1 modify column value1 set stats ('row_count'='5.0', 'ndv'='5.0', 'num_nulls'='0.0', 'data_size'='34.0', 'min_value'='AFRICA', 'max_value'='MIDDLE EAST', 'hot_values'='aaa :22.33');"""
     result = sql """show column stats test1(value1)"""
     assertEquals(1, result.size())
     assertEquals("5.0", result[0][2])
-    assertEquals("aaa:22.33", result[0][17])
+    assertEquals("'aaa':22.33", result[0][17])
     result = sql """show column cached stats test1(value1)"""
     assertEquals(1, result.size())
     assertEquals("5.0", result[0][2])
-    assertEquals("aaa:22.33", result[0][17])
+    assertEquals("'aaa':22.33", result[0][17])
     explain {
         sql("memo plan select * from test1")
-        contains "hotValues=(aaa:22.33)"
+        contains "hotValues=('aaa':22.33)"
     }
 
     sql """alter table test1 modify column value1 set stats ('row_count'='5.0', 'ndv'='5.0', 'num_nulls'='0.0', 'data_size'='34.0', 'min_value'='AFRICA', 'max_value'='MIDDLE EAST', 'hot_values'='a \\\\;a \\\\:a :22.33');"""
     result = sql """show column stats test1(value1)"""
     assertEquals(1, result.size())
     assertEquals("5.0", result[0][2])
-    assertEquals("a ;a :a:22.33", result[0][17])
+    assertEquals("'a ;a :a':22.33", result[0][17])
     result = sql """show column cached stats test1(value1)"""
     assertEquals(1, result.size())
     assertEquals("5.0", result[0][2])
-    assertEquals("a ;a :a:22.33", result[0][17])
+    assertEquals("'a ;a :a':22.33", result[0][17])
     explain {
         sql("memo plan select * from test1")
-        contains "hotValues=(a ;a :a:22.33)"
+        contains "hotValues=('a ;a :a':22.33)"
     }
 
     sql """analyze table test2 with sample rows 100 with sync"""
     result = sql """show column stats test2(value1)"""
     assertEquals(1, result.size())
-    assertEquals(" : ;a:100.0", result[0][17])
+    assertEquals("' : ;a':100.0", result[0][17])
     result = sql """show column cached stats test2(value1)"""
     assertEquals(1, result.size())
-    assertEquals(" : ;a:100.0", result[0][17])
+    assertEquals("' : ;a':100.0", result[0][17])
 
     sql """drop stats test2"""
     sql """analyze table test2 with sample rows 4000000 with sync"""
     result = sql """show column stats test2(value1)"""
     assertEquals(1, result.size())
-    assertEquals(" : ;a:100.0", result[0][17])
+    assertEquals("' : ;a':100.0", result[0][17])
     result = sql """show column cached stats test2(value1)"""
     assertEquals(1, result.size())
-    assertEquals(" : ;a:100.0", result[0][17])
+    assertEquals("' : ;a':100.0", result[0][17])
 
     sql """drop database if exists test_hot_value"""
 }


### PR DESCRIPTION
### What problem does this PR solve?
1. ColumnStatistics.hotValues currently use leagacy catalog literal. It is not suit for nereids planner. This pr changes the hotValues to nereids Literal.
2. for stats derive effeciency, filter the hot values whose percentage is less than org.apache.doris.statistics.util.StatisticsUtil#HOT_VALUE_THRESHOLD

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

