### PR TITLE
[fix](column label) generate label for string literal as MySQL

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -1057,6 +1057,7 @@ import java.util.stream.Collectors;
 public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
     private static String JOB_NAME = "jobName";
     private static String TASK_ID = "taskId";
+
     // Sort the parameters with token position to keep the order with original placeholders
     // in prepared statement.Otherwise, the order maybe broken
     private final Map<Token, Placeholder> tokenPosToParameters = Maps.newTreeMap((pos1, pos2) -> {
@@ -2586,14 +2587,16 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
             if (ctx.identifierOrText() == null) {
                 if (expression instanceof NamedExpression) {
                     return (NamedExpression) expression;
-                } else if (expression instanceof Literal) {
-                    return new Alias(expression);
                 } else {
                     int start = ctx.expression().start.getStartIndex();
                     int stop = ctx.expression().stop.getStopIndex();
                     String alias = ctx.start.getInputStream()
                             .getText(new org.antlr.v4.runtime.misc.Interval(start, stop));
                     if (expression instanceof Literal) {
+                        if (expression instanceof StringLikeLiteral) {
+                            alias = LogicalPlanBuilderAssistant.getStringLiteralAlias((
+                                    (StringLikeLiteral) expression).getStringValue());
+                        }
                         return new Alias(expression, alias, true);
                     } else {
                         return new UnboundAlias(expression, alias, true);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/LogicalPlanBuilderAssistantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/LogicalPlanBuilderAssistantTest.java
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.parser;
+
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class LogicalPlanBuilderAssistantTest {
+
+    @Test
+    public void testGetStringLiteralAlias() {
+        String expected = "A";
+
+        List<String> values = Lists.newArrayList(
+                "\tA",
+                "\nA",
+                "\bA",
+                "\rA",
+                "\0A",
+                "\032A",
+                " A",
+                "\t\r\b\n\0\032    A",
+                "     \t\r\b\n\0\032    A",
+                "     \t\r\b\n\0\032    A\0BCDEF"
+        );
+
+        for (String value : values) {
+            Assertions.assertEquals(expected, LogicalPlanBuilderAssistant.getStringLiteralAlias(value));
+        }
+
+        Assertions.assertEquals("A\t\n\b\n\032    A",
+                LogicalPlanBuilderAssistant.getStringLiteralAlias("A\t\n\b\n\032    A"));
+        Assertions.assertEquals("A\t\n\b",
+                LogicalPlanBuilderAssistant.getStringLiteralAlias("A\t\n\b\0\n\032    A"));
+        Assertions.assertEquals("A\t\n\b\n\032    A",
+                LogicalPlanBuilderAssistant.getStringLiteralAlias("A\t\n\b\n\032    A\0BCDEF"));
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

MySQL will trim any inviable char and blank at the beginning of the string, and stop at the first \0 if it exists. we follow the behavior.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

