### PR TITLE
[chore](compile) fix not found symbol in ARM

### DIFF
--- a/be/src/glibc-compatibility/glibc-compatibility.c
+++ b/be/src/glibc-compatibility/glibc-compatibility.c
@@ -175,6 +175,7 @@ void __explicit_bzero_chk(void * buf, size_t len, size_t unused)
     explicit_bzero(buf, len);
 }
 
+#ifndef __ARM_NEON
 int snprintf(char* __restrict __s, size_t __maxlen, const char* __restrict __format, ...);
 
 int strfromf128(char* restrict string, size_t size, const char* restrict format, __float128 value) {
@@ -184,6 +185,7 @@ int strfromf128(char* restrict string, size_t size, const char* restrict format,
     // weak_alias (strfroml, strfromf128)
     return snprintf(string, size, format, value);
 }
+#endif
 
 #if defined (__cplusplus)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

strfromf128 only exists in x64 platform. conditional compile it.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

