### PR TITLE
[opt](name_format) let column and table name accept any character under unicode mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
@@ -34,18 +34,19 @@ public class FeNameFormat {
     // please modify error msg when FeNameFormat.checkCommonName throw exception in CreateRoutineLoadStmt
     private static final String COMMON_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9\\-_]{0,63}$";
     private static final String UNDERSCORE_COMMON_NAME_REGEX = "^[_a-zA-Z][a-zA-Z0-9\\-_]{0,63}$";
-    private static final String TABLE_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9\\-_]*$";
+    private static final String TABLE_NAME_REGEX = "^[a-zA-Z0-9\\-_$]*$";
     private static final String USER_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9.\\-_]*$";
     private static final String REPOSITORY_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9\\-_]{0,255}$";
-    private static final String COLUMN_NAME_REGEX = "^[.a-zA-Z0-9_+\\-/?@#$%^&*\"\\s,:]{1,256}$";
+    private static final String COLUMN_NAME_REGEX
+            = "^[.a-zA-Z0-9_+\\-/?@#$%^&*\"\\s,:]{0,255}[.a-zA-Z0-9_+\\-/?@#$%^&*\",:]$";
 
     private static final String UNICODE_LABEL_REGEX = "^[\\-_A-Za-z0-9:\\p{L}]{1," + Config.label_regex_length + "}$";
     private static final String UNICODE_COMMON_NAME_REGEX = "^[a-zA-Z\\p{L}][a-zA-Z0-9\\-_\\p{L}]{0,63}$";
     private static final String UNICODE_UNDERSCORE_COMMON_NAME_REGEX = "^[_a-zA-Z\\p{L}][a-zA-Z0-9\\-_\\p{L}]{0,63}$";
-    private static final String UNICODE_TABLE_NAME_REGEX = "^[a-zA-Z\\p{L}][a-zA-Z0-9\\-_\\p{L}]*$";
+    private static final String UNICODE_TABLE_NAME_REGEX = "^[\\s\\S]*[\\S]$";
     private static final String UNICODE_USER_NAME_REGEX = "^[a-zA-Z\\p{L}][a-zA-Z0-9.\\-_\\p{L}]*$";
     private static final String UNICODE_COLUMN_NAME_REGEX
-            = "^[.a-zA-Z0-9_+\\-/?@#$%^&*\"\\s,:\\p{L}]{1,256}$";
+            = "^[\\s\\S]{0,255}[\\S]$";
     private static final String UNICODE_REPOSITORY_NAME_REGEX = "^[a-zA-Z\\p{L}][a-zA-Z0-9\\-_\\p{L}]{0,255}$";
 
     public static final String FORBIDDEN_PARTITION_NAME = "placeholder_";
@@ -97,14 +98,19 @@ public class FeNameFormat {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_COLUMN_NAME,
                     columnName, getColumnNameRegex());
         }
-        if (columnName.startsWith(SchemaChangeHandler.SHADOW_NAME_PREFIX)) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_COLUMN_NAME,
-                    columnName, getColumnNameRegex());
+        checkColumnNamePrefix(columnName, SchemaChangeHandler.SHADOW_NAME_PREFIX);
+        checkColumnNamePrefix(columnName, CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX);
+        checkColumnNamePrefix(columnName, CreateMaterializedViewStmt.MATERIALIZED_VIEW_AGGREGATE_NAME_PREFIX);
+    }
+
+    private static void checkColumnNamePrefix(String columnName, String prefix) throws AnalysisException {
+        int prefixLength = prefix.length();
+        if (columnName.length() < prefixLength) {
+            return;
         }
-        if (columnName.startsWith(CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX)
-                || columnName.startsWith(CreateMaterializedViewStmt.MATERIALIZED_VIEW_AGGREGATE_NAME_PREFIX)) {
+        if (columnName.substring(0, prefixLength).equalsIgnoreCase(prefix)) {
             throw new AnalysisException(
-                    "Incorrect column name " + columnName + ", column name can't start with 'mv_'/'mva_'");
+                    "Incorrect column name " + columnName + ", column name can't start with '" + prefix + "'");
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1763,7 +1763,7 @@ public class SessionVariable implements Serializable, Writable {
     public boolean enableShareHashTableForBroadcastJoin = true;
 
     @VariableMgr.VarAttr(name = ENABLE_UNICODE_NAME_SUPPORT, needForward = true)
-    public boolean enableUnicodeNameSupport = false;
+    public boolean enableUnicodeNameSupport = true;
 
     @VariableMgr.VarAttr(name = GROUP_CONCAT_MAX_LEN, affectQueryResult = true)
     public long groupConcatMaxLen = 2147483646;

--- a/fe/fe-core/src/test/java/org/apache/doris/common/FeNameFormatTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/FeNameFormatTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.qe.VariableMgr;
 
 import com.google.common.collect.Lists;
 import org.apache.ivy.util.StringUtils;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -85,25 +86,32 @@ public class FeNameFormatTest {
                 "test",      // Letters only
                 "a_b_c",     // Multiple underscores
                 "a_1",       // Underscore + number
-                "B2"         // Uppercase letter + number
+                "B2",        // Uppercase letter + number
+                "1abc",      // Starts with digit
+                "abc$",      // Contains invalid symbol $
+                "-abc",      // Starts with hyphen
+                "_abc"       // Starts with underscore
         );
 
         List<String> alwaysInvalid = Lists.newArrayList(
-                "1abc",      // Starts with digit
-                "@test",     // Contains invalid symbol @
                 "",          // Empty string
-                "a b",       // Contains space
-                "abc!",      // Contains invalid symbol !
-                "a\nb",      // Contains newline
-                "abc$",      // Contains invalid symbol $
-                "-abc",      // Starts with hyphen
-                "_abc",      // Starts with underscore
-                "a*b",       // Contains asterisk
-                "a.b",       // Contains dot
-                "a#b"        // Contains hash
+                "x ",          // space character as last one
+                "x\t",         // table character as last one
+                "x\n"          // enter character as last one
         );
 
         List<String> unicodeValid = Lists.newArrayList(
+                "@test",     // Contains invalid symbol @
+                "a b",       // Contains space
+                "a\tb",      // Contains space
+                "a\nb",      // Contains space
+                "a\rb",      // Contains space
+                " ab",       // Contains space
+                "a*b",       // Contains asterisk
+                "a.b",       // Contains dot
+                "a#b",       // Contains hash
+                "abc!",      // Contains invalid symbol !
+                "a\nb",      // Contains newline
                 "éclair",    // Contains French letter
                 "über",      // Contains German umlaut
                 "北京",      // Chinese characters
@@ -140,7 +148,12 @@ public class FeNameFormatTest {
                 "?id_",
                 "#id_",
                 "$id_",
-                "a-zA-Z0-9.+-/?@#$%^&*\" ,:"
+                "a-zA-Z0-9.+-/?@#$%^&*\" ,:",
+                " x",
+                "y x",
+                "y\tx",
+                "y\nx",
+                "y\rx"
         );
 
         List<String> alwaysInvalid = Lists.newArrayList(
@@ -148,15 +161,18 @@ public class FeNameFormatTest {
                 "mv_",
                 "mva_",
                 "__doris_shadow_",
-
-                // invalid
                 "",
-                "\\",
-                "column\\",
+                " ",
+                "x ",
+                "x\t",
+                "x\n",
+                "x\r",
                 StringUtils.repeat("a", 257)
         );
 
         List<String> unicodeValid = Lists.newArrayList(
+                "\\",
+                "column\\",
                 "中文",
                 "語言",
                 "язык",
@@ -379,13 +395,16 @@ public class FeNameFormatTest {
                     ExceptionChecker.expectThrowsNoException(() -> validator.accept(s));
                 }
                 for (String s : alwaysInvalid) {
-                    ExceptionChecker.expectThrows(AnalysisException.class, () -> validator.accept(s));
+                    Assertions.assertThrowsExactly(AnalysisException.class, () -> validator.accept(s),
+                            "name should be invalid: " + s);
                 }
                 for (String s : unicodeValid) {
                     if (unicode) {
                         ExceptionChecker.expectThrowsNoException(() -> validator.accept(s));
                     } else {
-                        ExceptionChecker.expectThrows(AnalysisException.class, () -> validator.accept(s));
+                        Assertions.assertThrowsExactly(AnalysisException.class, () -> validator.accept(s),
+                                "name should be invalid: " + s);
+
                     }
                 }
             }

--- a/regression-test/suites/ddl_p0/test_drop_view_nereids.groovy
+++ b/regression-test/suites/ddl_p0/test_drop_view_nereids.groovy
@@ -18,6 +18,7 @@
 suite("test_drop_view_nereids") {
     sql "SET enable_nereids_planner=true;"
     sql "SET enable_fallback_to_original_planner=false;"
+    sql "SET enable_unicode_name_support=true;"
     sql """DROP TABLE IF EXISTS count_distinct_drop_nereids"""
     sql """
         CREATE TABLE IF NOT EXISTS count_distinct_drop_nereids
@@ -260,13 +261,12 @@ suite("test_drop_view_nereids") {
     qt_test_create_view_from_view "select * from test_view_from_view_drop order by c1,c2,c3"
 
     // test backquote in name
-    try {
-        sql "create view test_backquote_in_view_define_drop(`ab``c`, c2) as select a,b from mal_test_view_drop;"
-    } catch (Exception e) {
-        assertTrue(e.getMessage().contains("Incorrect column name 'ab`c'"))
+    sql "drop view if exists test_backquote_in_view_define_drop;"
+    test {
+        sql "create view test_backquote_in_view_define_drop(`mva_hello`, c2) as select a,b from mal_test_view_drop;"
+        exception "Incorrect column name"
     }
 
-    sql "drop view if exists test_backquote_in_view_define_drop;"
     sql "create view test_backquote_in_view_define_drop(`abc`, c2) as select a,b from mal_test_view_drop;"
     qt_test_backquote_in_view_define_drop "select * from test_backquote_in_view_define_drop order by abc, c2;"
 
@@ -277,21 +277,19 @@ suite("test_drop_view_nereids") {
     // test invalid column name
     sql """set enable_unicode_name_support = true;"""
     sql "drop view if exists test_invalid_column_name_in_table_drop;"
-    try {
+    test {
         // create view should fail if contains invalid column name
-        sql "create view test_invalid_column_name_in_table_drop as select a as '(第一列)',b from mal_test_view_drop;"
-    } catch (Exception e) {
-        assertTrue(e.getMessage().contains("Incorrect column name '(第一列)'"))
+        sql "create view test_invalid_column_name_in_table_drop as select a as 'mv_hello',b from mal_test_view_drop;"
+        exception "Incorrect column name"
     }
 
     sql "create view test_invalid_column_name_in_table_drop as select a ,b from mal_test_view_drop;"
     order_qt_test_invalid_column_name_in_table_drop "select * from test_invalid_column_name_in_table_drop"
 
-    try {
+    test {
         // alter view should fail if contains invalid column name
-        sql "alter view test_invalid_column_name_in_table_drop as select a as '(第一列)',b from mal_test_view_drop;"
-    } catch (Exception e) {
-        assertTrue(e.getMessage().contains("Incorrect column name '(第一列)'"))
+        sql "alter view test_invalid_column_name_in_table_drop as select a as 'mv_hello',b from mal_test_view_drop;"
+        exception "Incorrect column name"
     }
     sql """set enable_unicode_name_support = false;"""
 

--- a/regression-test/suites/nereids_p0/create_table/test_create_table.groovy
+++ b/regression-test/suites/nereids_p0/create_table/test_create_table.groovy
@@ -22,6 +22,8 @@ suite("nereids_create_table") {
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'
     sql 'set enable_nereids_dml=true'
+    sql "set enable_unicode_name_support = true"
+
 
     def str = new File("""${context.file.parent}/ddl/table.sql""").text
     for (String table in str.split(';')) {
@@ -48,7 +50,7 @@ suite("nereids_create_table") {
             CREATE TABLE region  (
                 r_regionkey      int NOT NULL,
                 r_name       VARCHAR(25) NOT NULL,
-                `CAST(``o_custkey`` AS BIGINT)` VARCHAR(152)
+                `__DORIS_hello` VARCHAR(152)
             )ENGINE=OLAP
             DUPLICATE KEY(`r_regionkey`)
             COMMENT "OLAP"
@@ -58,7 +60,7 @@ suite("nereids_create_table") {
             );
         """
 
-        exception "Incorrect column name"
+        exception "Disable to create table column with name start with __DORIS_"
     }
 
     test {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

1. identifier format follow mysql doc: https://dev.mysql.com/doc/refman/8.4/en/identifiers.html
2. set default value of 'enable_unicode_name_support' to 'true'

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

