### PR TITLE
[bugfix](show) fix empty result when show partitions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/PartitionsProcDir.java
@@ -247,7 +247,7 @@ public class PartitionsProcDir implements ProcDirInterface {
                 return !filterSubExpression(subExpr, element);
             }
         } else {
-            return like((String) element, ((StringLikeLiteral) subExpr.child(1)).getStringValue());
+            return like(element.toString(), ((StringLikeLiteral) subExpr.child(1)).getStringValue());
         }
         return false;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/PartitionsProcDir.java
@@ -188,7 +188,7 @@ public class PartitionsProcDir implements ProcDirInterface {
         }
 
         if (expr instanceof EqualTo && expr.child(1) instanceof StringLikeLiteral) {
-            return ((StringLikeLiteral) expr.child(1)).getValue().equals(element);
+            return ((StringLikeLiteral) expr.child(1)).getValue().equals(element.toString());
         }
         long leftVal;
         long rightVal;

--- a/regression-test/suites/nereids_p0/show/test_nereids_show_partitions.groovy
+++ b/regression-test/suites/nereids_p0/show/test_nereids_show_partitions.groovy
@@ -140,6 +140,9 @@ suite("test_nereids_show_partitions") {
     checkNereidsExecute("show partitions from test_show_partitions.test_show_partitions_tbl " +
             "where Buckets = 16 and PartitionName = 'p_dongbei' and PartitionId != 1748353297225 limit 100,1")
 
+    // state
+    checkNereidsExecute("show partitions from test_show_partitions.test_show_partitions_tbl where state = 'NORMAL'")
+
    def res1 = sql """show partitions from test_show_partitions.test_show_partitions_tbl"""
    assertEquals(3, res1.size())
    def res2 = sql """show partitions from test_show_partitions.test_show_partitions_tbl limit 1"""
@@ -189,6 +192,10 @@ suite("test_nereids_show_partitions") {
    // test for offset value is bigger than partitions' number
    def res23 = sql """show partitions from test_show_partitions.test_show_partitions_tbl where Buckets = 16 limit 100,1"""
    assertEquals(0, res23.size())
+
+    // test for state
+    def res24 = sql """show partitions from test_show_partitions.test_show_partitions_tbl where state = 'NORMAL'"""
+    assertEquals(3, res24.size())
 
    assertThrows(Exception.class, {
       sql """show partitions from test_show_partitions.test_show_partitions_tbl where VisibleVersion = 1"""

--- a/regression-test/suites/nereids_p0/show/test_nereids_show_partitions.groovy
+++ b/regression-test/suites/nereids_p0/show/test_nereids_show_partitions.groovy
@@ -142,6 +142,7 @@ suite("test_nereids_show_partitions") {
 
     // state
     checkNereidsExecute("show partitions from test_show_partitions.test_show_partitions_tbl where state = 'NORMAL'")
+    checkNereidsExecute("show partitions from test_show_partitions.test_show_partitions_tbl where state like '%NORMAL%'")
 
    def res1 = sql """show partitions from test_show_partitions.test_show_partitions_tbl"""
    assertEquals(3, res1.size())
@@ -196,6 +197,8 @@ suite("test_nereids_show_partitions") {
     // test for state
     def res24 = sql """show partitions from test_show_partitions.test_show_partitions_tbl where state = 'NORMAL'"""
     assertEquals(3, res24.size())
+    def res25 = sql """show partitions from test_show_partitions.test_show_partitions_tbl where state like '%NORMAL%'"""
+    assertEquals(3, res25.size())
 
    assertThrows(Exception.class, {
       sql """show partitions from test_show_partitions.test_show_partitions_tbl where VisibleVersion = 1"""


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
when execute the SQL like :
`show partitions from your_table_name where state like 'NORMAL';`
you will get an empty set even if the partitions' state is all **NORMAL**, so I fix this problem.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

