### PR TITLE
[test](p2) allow protocol prefix in S3 endpoint format in test_broker_load

### DIFF
--- a/regression-test/suites/load_p2/broker_load/test_broker_load.groovy
+++ b/regression-test/suites/load_p2/broker_load/test_broker_load.groovy
@@ -310,37 +310,37 @@ suite("test_broker_load_p2", "p2") {
                     "unselected.rows=0; dpp.abnorm.ALL=0; dpp.norm.ALL=10000"    // case 30
                     ]
 
-    def task_info = ["cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 0
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 1
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 2
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 3
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 4
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 5
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 6
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 7
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 8
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 9
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 10
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 11
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 12
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 13
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 14
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 15
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 16
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 17
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 18
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 19
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 20
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 21
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 22
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 23
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 24
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 25
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 26
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 27
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 28
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 29
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0"   // case 30
+    def task_info = ["${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 0
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 1
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 2
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 3
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 4
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 5
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 6
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 7
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 8
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 9
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 10
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 11
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 12
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 13
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 14
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 15
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 16
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 17
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 18
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 19
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 20
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 21
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 22
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 23
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 24
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 25
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 26
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 27
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 28
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 29
+                     "${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0"   // case 30
     ]
 
     def error_msg = ["",                                                         // case 0
@@ -448,7 +448,7 @@ suite("test_broker_load_p2", "p2") {
                     logger.info("Load status: " + logStr + ", label: $label")
                     if (result[0][2].equals("FINISHED")) {
                         logger.info("Load FINISHED " + label)
-                        assertTrue(result[0][6].contains(task_info[i]))
+                        assertTrue(result[0][6].contains(task_info[i]), "expected: " + task_info[i] + ", actual: " + result[0][6] + ", label: $label")
                         def load_counters = etl_info[i].split('; ');
                         for (String counter : load_counters) {
                             assertTrue(result[0][5].contains(counter), "expected: " + counter + ", actual: " + result[0][5] + ", label: $label")
@@ -457,7 +457,7 @@ suite("test_broker_load_p2", "p2") {
                     }
                     if (result[0][2].equals("CANCELLED")) {
                         logger.info("Load result: " + result[0])
-                        assertTrue(result[0][6].contains(task_info[i]))
+                        assertTrue(result[0][6].contains(task_info[i]), "expected: " + task_info[i] + ", actual: " + result[0][6] + ", label: $label")
                         assertTrue(result[0][7].contains(error_msg[i]), "expected: " + error_msg[i] + ", actual: " + result[0][7] + ", label: $label")
                         break;
                     }

--- a/regression-test/suites/load_p2/broker_load/test_broker_load.groovy
+++ b/regression-test/suites/load_p2/broker_load/test_broker_load.groovy
@@ -310,37 +310,37 @@ suite("test_broker_load_p2", "p2") {
                     "unselected.rows=0; dpp.abnorm.ALL=0; dpp.norm.ALL=10000"    // case 30
                     ]
 
-    def task_info = ["cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 0
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 1
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 2
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 3
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 4
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 5
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 6
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 7
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 8
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 9
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 10
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 11
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 12
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 13
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 14
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 15
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 16
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 17
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 18
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 19
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 20
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 21
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 22
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 23
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 24
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 25
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 26
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 27
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 28
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 29
-                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0"   // case 30
+    def s3EndpointPattern = s3Endpoint.replace(".", "\\.")
+    def task_info = ["cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 0
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 1
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 2
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 3
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 4
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 5
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 6
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 7
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 8
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 9
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 10
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 11
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 12
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 13
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 14
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 15
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 16
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 17
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 18
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 19
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 21
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 22
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 23
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 24
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 25
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 26
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 27
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 28
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 29
+                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0"   // case 30
     ]
 
     def error_msg = ["",                                                         // case 0
@@ -448,7 +448,7 @@ suite("test_broker_load_p2", "p2") {
                     logger.info("Load status: " + logStr + ", label: $label")
                     if (result[0][2].equals("FINISHED")) {
                         logger.info("Load FINISHED " + label)
-                        assertTrue(result[0][6].contains(task_info[i]))
+                        assertTrue(result[0][6] ==~ /.*${task_info[i]}.*/, "expected (pattern): " + task_info[i] + ", actual: " + result[0][6] + ", label: $label")
                         def load_counters = etl_info[i].split('; ');
                         for (String counter : load_counters) {
                             assertTrue(result[0][5].contains(counter), "expected: " + counter + ", actual: " + result[0][5] + ", label: $label")
@@ -457,7 +457,7 @@ suite("test_broker_load_p2", "p2") {
                     }
                     if (result[0][2].equals("CANCELLED")) {
                         logger.info("Load result: " + result[0])
-                        assertTrue(result[0][6].contains(task_info[i]))
+                        assertTrue(result[0][6] ==~ /.*${task_info[i]}.*/, "expected (pattern): " + task_info[i] + ", actual: " + result[0][6] + ", label: $label")
                         assertTrue(result[0][7].contains(error_msg[i]), "expected: " + error_msg[i] + ", actual: " + result[0][7] + ", label: $label")
                         break;
                     }

--- a/regression-test/suites/load_p2/broker_load/test_broker_load.groovy
+++ b/regression-test/suites/load_p2/broker_load/test_broker_load.groovy
@@ -310,37 +310,37 @@ suite("test_broker_load_p2", "p2") {
                     "unselected.rows=0; dpp.abnorm.ALL=0; dpp.norm.ALL=10000"    // case 30
                     ]
 
-    def s3EndpointPattern = s3Endpoint.replace(".", "\\.")
-    def task_info = ["cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 0
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 1
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 2
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 3
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 4
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 5
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 6
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 7
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 8
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 9
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 10
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 11
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 12
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 13
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 14
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 15
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 16
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 17
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 18
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 19
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 21
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 22
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 23
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 24
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 25
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 26
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 27
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 28
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0",  // case 29
-                     "cluster:(http[s]?://)?${s3EndpointPattern}; timeout\\(s\\):14400; max_filter_ratio:0\\.0"   // case 30
+    def task_info = ["cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 0
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 1
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 2
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 3
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 4
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 5
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 6
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 7
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 8
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 9
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 10
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 11
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 12
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 13
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 14
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 15
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 16
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 17
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 18
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 19
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 20
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 21
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 22
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 23
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 24
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 25
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 26
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 27
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 28
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0",  // case 29
+                     "cluster:${s3Endpoint}; timeout(s):14400; max_filter_ratio:0.0"   // case 30
     ]
 
     def error_msg = ["",                                                         // case 0
@@ -448,7 +448,7 @@ suite("test_broker_load_p2", "p2") {
                     logger.info("Load status: " + logStr + ", label: $label")
                     if (result[0][2].equals("FINISHED")) {
                         logger.info("Load FINISHED " + label)
-                        assertTrue(result[0][6] ==~ /.*${task_info[i]}.*/, "expected (pattern): " + task_info[i] + ", actual: " + result[0][6] + ", label: $label")
+                        assertTrue(result[0][6].contains(task_info[i]))
                         def load_counters = etl_info[i].split('; ');
                         for (String counter : load_counters) {
                             assertTrue(result[0][5].contains(counter), "expected: " + counter + ", actual: " + result[0][5] + ", label: $label")
@@ -457,7 +457,7 @@ suite("test_broker_load_p2", "p2") {
                     }
                     if (result[0][2].equals("CANCELLED")) {
                         logger.info("Load result: " + result[0])
-                        assertTrue(result[0][6] ==~ /.*${task_info[i]}.*/, "expected (pattern): " + task_info[i] + ", actual: " + result[0][6] + ", label: $label")
+                        assertTrue(result[0][6].contains(task_info[i]))
                         assertTrue(result[0][7].contains(error_msg[i]), "expected: " + error_msg[i] + ", actual: " + result[0][7] + ", label: $label")
                         break;
                     }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #51529

Problem Summary:

PR #51529 introduced a change that adds `http://` to S3 endpoints if no protocol is specified.
For example, `cluster:${s3Endpoint}` could become `cluster:http://${s3Endpoint}`.
This PR updates the test logic to accept S3 endpoints with extra protocol prefix .

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

