### PR TITLE
[fix](DateLiteral)Fix fromDateFormatStr always contain microseconds part.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -1173,6 +1173,7 @@ public class DateLiteral extends LiteralExpr {
         final int secondPart = 1 << 8;
         final int fracPart = 1 << 9;
         final int timePart = hourPart | minutePart | secondPart | fracPart;
+        final int timePartWithoutFrac = hourPart | minutePart | secondPart;
 
         int halfDay = 0; // 0 for am/none, 12 for pm.
         long weekday = -1;
@@ -1393,12 +1394,12 @@ public class DateLiteral extends LiteralExpr {
                     case 'r':
                         tmp = fromDateFormatStr("%I:%i:%S %p", value.substring(pValue, endValue), true);
                         pValue = tmp;
-                        partUsed |= timePart;
+                        partUsed |= timePartWithoutFrac;
                         break;
                     case 'T':
                         tmp = fromDateFormatStr("%H:%i:%S", value.substring(pValue, endValue), true);
                         pValue = tmp;
-                        partUsed |= timePart;
+                        partUsed |= timePartWithoutFrac;
                         break;
                     case '.':
                         while (pValue < endValue && Character.toString(value.charAt(pValue)).matches("\\p{Punct}")) {
@@ -1456,6 +1457,9 @@ public class DateLiteral extends LiteralExpr {
                     case 'S':
                     case 'p':
                     case 'T':
+                        partUsed |= timePartWithoutFrac;
+                        break;
+                    case 'f':
                         partUsed |= timePart;
                         break;
                     default:

--- a/fe/fe-core/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
@@ -337,9 +337,16 @@ public class FEFunctionsTest {
     @Test
     public void dateParseTest() {
         try {
-            // TODO: "2019-05-09 00:00:00" need to get type datetime(0), not datetime(6)
-            // Assert.assertEquals("2019-05-09 00:00:00", FEFunctions.dateParse(new StringLiteral("2019-05-09"),
-            //         new StringLiteral("%Y-%m-%d %H:%i:%s")).getStringValue());
+            Assert.assertEquals("2019-05-09 00:00:00", FEFunctions.dateParse(new StringLiteral("2019-05-09"),
+                    new StringLiteral("%Y-%m-%d %H:%i:%s")).getStringValue());
+            Assert.assertEquals("2019-05-09 00:00:00.000000", FEFunctions.dateParse(new StringLiteral("2019-05-09"),
+                    new StringLiteral("%Y-%m-%d %H:%i:%s.%f")).getStringValue());
+            Assert.assertEquals("2019-05-09 21:22:13", FEFunctions.dateParse(new StringLiteral("2019-05-09 21:22:13"),
+                    new StringLiteral("%Y-%m-%d %H:%i:%s")).getStringValue());
+            Assert.assertEquals("2019-05-09 21:22:13", FEFunctions.dateParse(new StringLiteral("2019-05-09 21:22:13.33449"),
+                    new StringLiteral("%Y-%m-%d %H:%i:%s")).getStringValue());
+            Assert.assertEquals("2019-05-09 21:22:13.334490", FEFunctions.dateParse(new StringLiteral("2019-05-09 21:22:13.33449"),
+                    new StringLiteral("%Y-%m-%d %H:%i:%s.%f")).getStringValue());
             Assert.assertEquals("2013-05-10", FEFunctions.dateParse(new StringLiteral("2013,05,10"),
                     new StringLiteral("%Y,%m,%d")).getStringValue());
             Assert.assertEquals("2013-05-17 00:35:10", FEFunctions.dateParse(
@@ -365,8 +372,8 @@ public class FEFunctionsTest {
                     new StringLiteral("%Y,%j")).getStringValue());
             Assert.assertEquals("2019-05-09", FEFunctions.dateParse(new StringLiteral("2019,19,Thursday"),
                     new StringLiteral("%x,%v,%W")).getStringValue());
-            // Assert.assertEquals("2019-05-09 12:10:45", FEFunctions.dateParse(new StringLiteral("12:10:45-20190509"),
-            //         new StringLiteral("%T-%Y%m%d")).getStringValue());
+            Assert.assertEquals("2019-05-09 12:10:45", FEFunctions.dateParse(new StringLiteral("12:10:45-20190509"),
+                    new StringLiteral("%T-%Y%m%d")).getStringValue());
             Assert.assertEquals("2019-05-09 09:10:45", FEFunctions.dateParse(new StringLiteral("20190509-9:10:45"),
                     new StringLiteral("%Y%m%d-%k:%i:%S")).getStringValue());
             Assert.assertEquals("0000-00-20", FEFunctions.dateParse(new StringLiteral("2013-05-17"),
@@ -383,10 +390,10 @@ public class FEFunctionsTest {
                     new StringLiteral("%x")).getStringValue());
             Assert.assertEquals("0000-00-00", FEFunctions.dateParse(new StringLiteral("2013-05-17"),
                     new StringLiteral("%X")).getStringValue());
-            // Assert.assertEquals("2013-05-17 20:07:05", FEFunctions.dateParse(
-            //         new StringLiteral("2013-05-17 08:07:05 PM"), new StringLiteral("%Y-%m-%d %r")).getStringValue());
-            // Assert.assertEquals("2013-05-17 08:07:05", FEFunctions.dateParse(new StringLiteral("2013-05-17 08:07:05"),
-            //         new StringLiteral("%Y-%m-%d %T")).getStringValue());
+            Assert.assertEquals("2013-05-17 20:07:05", FEFunctions.dateParse(
+                    new StringLiteral("2013-05-17 08:07:05 PM"), new StringLiteral("%Y-%m-%d %r")).getStringValue());
+            Assert.assertEquals("2013-05-17 08:07:05", FEFunctions.dateParse(new StringLiteral("2013-05-17 08:07:05"),
+                    new StringLiteral("%Y-%m-%d %T")).getStringValue());
             Assert.assertEquals("2021 52 2021 52", FEFunctions.dateFormat(new DateLiteral("2022-01-01 00:12:42", Type.DATETIMEV2),
                     new StringLiteral("%x %v %X %V")).getStringValue());
             Assert.assertEquals("2023 18 2023 19", FEFunctions.dateFormat(new DateLiteral("2023-05-07 02:41:42", Type.DATETIMEV2),


### PR DESCRIPTION
### What problem does this PR solve?
Fix fromDateFormatStr always contain microseconds part.
This is a legacy method, but still need to fix the logic.
For example, datetime with this format "%Y-%m-%d %H:%i:%s" shouldn't contain microseconds part.
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

