### PR TITLE
[opt](nereids) use one fragment to execute point query

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriver.java
@@ -169,6 +169,10 @@ public class ChildOutputPropertyDeriver extends PlanVisitor<PhysicalProperties, 
 
     @Override
     public PhysicalProperties visitPhysicalOlapScan(PhysicalOlapScan olapScan, PlanContext context) {
+        // make sure only one fragment when use point query
+        if (context.getStatementContext().isShortCircuitQuery() && olapScan.getSelectedTabletIds().size() == 1) {
+            return PhysicalProperties.GATHER;
+        }
         return new PhysicalProperties(olapScan.getDistributionSpec());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShortCircuitQueryContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShortCircuitQueryContext.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 public class ShortCircuitQueryContext {
     // Cached for better CPU performance, since serialize DescriptorTable and
     // outputExprs are heavy work
+    public final Planner planner;
     public final ByteString serializedDescTable;
     public final ByteString serializedOutputExpr;
     public final ByteString serializedQueryOptions;
@@ -79,13 +80,14 @@ public class ShortCircuitQueryContext {
     }
 
     public ShortCircuitQueryContext(Planner planner, Queriable analzyedQuery) throws TException {
+        this.planner = planner;
         this.serializedDescTable = ByteString.copyFrom(
                 new TSerializer().serialize(planner.getDescTable().toThrift()));
         TQueryOptions options = planner.getQueryOptions() != null ? planner.getQueryOptions() : new TQueryOptions();
         this.serializedQueryOptions = ByteString.copyFrom(
                 new TSerializer().serialize(options));
         List<TExpr> exprs = new ArrayList<>();
-        OlapScanNode olapScanNode = (OlapScanNode) planner.getFragments().get(1).getPlanRoot();
+        OlapScanNode olapScanNode = (OlapScanNode) planner.getScanNodes().get(0);
         if (olapScanNode.getProjectList() != null) {
             // project on scan node
             exprs.addAll(olapScanNode.getProjectList().stream()
@@ -99,7 +101,7 @@ public class ShortCircuitQueryContext {
         serializedOutputExpr = ByteString.copyFrom(
                 new TSerializer().serialize(exprList));
         this.cacheID = UUID.randomUUID();
-        this.scanNode = ((OlapScanNode) planner.getScanNodes().get(0));
+        this.scanNode = olapScanNode;
         this.tbl = this.scanNode.getOlapTable();
         this.schemaVersion = this.tbl.getBaseSchemaVersion();
         this.analzyedQuery = analzyedQuery;

--- a/regression-test/suites/point_query_p0/test_point_query.groovy
+++ b/regression-test/suites/point_query_p0/test_point_query.groovy
@@ -445,6 +445,16 @@ suite("test_point_query", "nonConcurrent") {
     sql "set enable_short_circuit_query = true"
     qt_sql "select length(loc3) from table_with_chars where col1 = 10"
 
+    def ensure_one_fragment = {
+        sql "set enable_nereids_planner=true"
+        explain {
+            sql "select * from table_with_chars where col1 = 10"
+            check { explainStr ->
+                assertEquals(1, explainStr.count("PLAN FRAGMENT"))
+            }
+        }
+    }()
+
     // test variant type
     sql "DROP TABLE IF EXISTS test_with_variant"
     sql """


### PR DESCRIPTION
### What problem does this PR solve?

the nereids planner use two fragments to execute point query and cause some performance degradation, this pr optimize it by generate one fragment

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

