### PR TITLE
[fix](warmup) prevent NPE when upgrading from older versions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/CloudWarmUpJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/CloudWarmUpJob.java
@@ -199,7 +199,7 @@ public class CloudWarmUpJob implements Writable {
         info.add(Long.toString(maxBatchSize));
         info.add(TimeUtils.longToTimeStringWithms(finishedTimeMs));
         info.add(errMsg);
-        info.add(tables.stream()
+        info.add(tables == null ? "" : tables.stream()
                 .map(t -> StringUtils.isEmpty(t.getRight())
                         ? t.getLeft() + "." + t.getMiddle()
                         : t.getLeft() + "." + t.getMiddle() + "." + t.getRight())


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: DORIS-21489

Problem Summary:

In older versions, the `tables` field doesn't exist.
When a newer version reads this data, the field becomes `null`, leading to a `NullPointerException`.
This fix adds a null check to handle the upgrade path safely.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

