### PR TITLE
[fix](nereids)alter sql block rule lost sql pattern info

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRuleMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRuleMgr.java
@@ -46,6 +46,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -173,6 +174,7 @@ public class SqlBlockRuleMgr implements Writable {
             if (sqlBlockRule.getEnable() == null) {
                 sqlBlockRule.setEnable(originRule.getEnable());
             }
+            sqlBlockRule.setSqlPattern(Pattern.compile(sqlBlockRule.getSql()));
             verifyLimitations(sqlBlockRule);
             SqlBlockUtil.checkAlterValidate(sqlBlockRule);
 

--- a/regression-test/suites/sql_block_rule_p0/test_sql_block_rule.groovy
+++ b/regression-test/suites/sql_block_rule_p0/test_sql_block_rule.groovy
@@ -272,4 +272,17 @@ suite("test_sql_block_rule", "nonConcurrent") {
         """
     }
 
+    multi_sql """
+        drop SQL_BLOCK_RULE if exists rule_drop_r;
+
+        CREATE SQL_BLOCK_RULE rule_drop
+        PROPERTIES(
+        "sql"="select \\* from order_analysis",
+        "global"="true",
+        "enable"="true");
+
+        ALTER SQL_BLOCK_RULE rule_drop PROPERTIES("global"="true");
+
+        select NULL;
+    """
 }


### PR DESCRIPTION
```
CREATE SQL_BLOCK_RULE rule_drop
        PROPERTIES(
        "sql"="select \\* from order_analysis",
        "global"="true",
        "enable"="true");

ALTER SQL_BLOCK_RULE rule_drop PROPERTIES("global"="true");
```
when ALTER SQL_BLOCK_RULE, we use new properties in the command and keep other properties unchanged, but we need call setSqlPattern to fill the new sql pattern or it will be 'NULL' which is a wrong pattern

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

