### PR TITLE
[opt](bitmap) improve the bitmap union execute function

### DIFF
--- a/be/benchmark/benchmark_fastunion.hpp
+++ b/be/benchmark/benchmark_fastunion.hpp
@@ -1,0 +1,126 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <benchmark/benchmark.h>
+
+#include <string>
+
+#include "util/bitmap_value.h"
+
+using Roaring64Map = doris::detail::Roaring64Map;
+
+namespace doris::vectorized {
+
+const uint32_t num_bitmaps = 100;
+const uint32_t num_outer_slots = 1000;
+const uint32_t num_inner_values = 2000;
+const uint32_t overlap_percent = 30; // 重叠比例
+
+std::vector<Roaring64Map> makeMaps() {
+    std::vector<Roaring64Map> result;
+    const uint32_t shared_slots = num_outer_slots * overlap_percent / 100;
+
+    Roaring64Map shared;
+    for (uint32_t slot = 0; slot < shared_slots; ++slot) {
+        auto value = (uint64_t(slot) << 32);
+        for (uint32_t i = 0; i < num_inner_values; ++i) {
+            shared.add(value + i);
+        }
+    }
+
+    for (uint32_t bm_index = 0; bm_index < num_bitmaps; ++bm_index) {
+        Roaring64Map roaring = shared;
+
+        for (uint32_t slot = shared_slots; slot < num_outer_slots; ++slot) {
+            auto value = (uint64_t(slot) << 32) + bm_index;
+            for (uint32_t i = 0; i < num_inner_values; ++i) {
+                roaring.add(value + i * num_bitmaps);
+            }
+        }
+        result.push_back(std::move(roaring));
+    }
+    return result;
+}
+
+Roaring64Map legacy_fastunion(size_t n, const Roaring64Map** inputs) {
+    Roaring64Map ans;
+    for (size_t lcv = 0; lcv < n; ++lcv) {
+        ans |= *(inputs[lcv]);
+    }
+    return ans;
+}
+
+static std::vector<Roaring64Map> test_maps = makeMaps();
+static std::vector<const Roaring64Map*> test_map_ptrs = []() {
+    std::vector<const Roaring64Map*> ptrs;
+    ptrs.reserve(test_maps.size());
+    for (const auto& map : test_maps) {
+        ptrs.push_back(&map);
+    }
+    return ptrs;
+}();
+
+static void CustomCounters(benchmark::State& state) {
+    state.counters["Bitmaps"] = num_bitmaps;
+    state.counters["TotalValues"] = num_bitmaps * num_outer_slots * num_inner_values;
+    state.counters["Overlap%"] = overlap_percent;
+}
+} // namespace doris::vectorized
+
+static void BM_FastUnionOptimized(benchmark::State& state) {
+    for (auto _ : state) {
+        auto result = Roaring64Map::fastunion(doris::vectorized::test_map_ptrs.size(),
+                                              doris::vectorized::test_map_ptrs.data());
+        benchmark::DoNotOptimize(result);
+    }
+    doris::vectorized::CustomCounters(state);
+    state.SetComplexityN(doris::vectorized::num_bitmaps);
+}
+
+static void BM_FastUnionLegacy(benchmark::State& state) {
+    for (auto _ : state) {
+        auto result = doris::vectorized::legacy_fastunion(doris::vectorized::test_map_ptrs.size(),
+                                                          doris::vectorized::test_map_ptrs.data());
+        benchmark::DoNotOptimize(result);
+    }
+    doris::vectorized::CustomCounters(state);
+    state.SetComplexityN(doris::vectorized::num_bitmaps);
+}
+
+BENCHMARK(BM_FastUnionOptimized)
+        ->Unit(benchmark::kMillisecond)
+        ->Repetitions(5)
+        ->DisplayAggregatesOnly()
+        ->ComputeStatistics("min",
+                            [](const std::vector<double>& v) -> double {
+                                return *std::min_element(v.begin(), v.end());
+                            })
+        ->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+            return *std::max_element(v.begin(), v.end());
+        });
+
+BENCHMARK(BM_FastUnionLegacy)
+        ->Unit(benchmark::kMillisecond)
+        ->Repetitions(5)
+        ->DisplayAggregatesOnly()
+        ->ComputeStatistics("min",
+                            [](const std::vector<double>& v) -> double {
+                                return *std::min_element(v.begin(), v.end());
+                            })
+        ->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+            return *std::max_element(v.begin(), v.end());
+        });

--- a/be/benchmark/benchmark_main.cpp
+++ b/be/benchmark/benchmark_main.cpp
@@ -18,7 +18,9 @@
 #include <benchmark/benchmark.h>
 
 #include "benchmark_bit_pack.hpp"
+#include "benchmark_fastunion.hpp"
 #include "binary_cast_benchmark.hpp"
+#include "vec/columns/column_string.h"
 #include "vec/core/block.h"
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_string.h"

--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -664,15 +664,6 @@ public:
      * computes the logical or (union) between "n" bitmaps (referenced by a
      * pointer).
      */
-    // static Roaring64Map fastunion(size_t n, const Roaring64Map** inputs) {
-    //     Roaring64Map ans;
-    //     // not particularly fast
-    //     for (size_t lcv = 0; lcv < n; ++lcv) {
-    //         ans |= *(inputs[lcv]);
-    //     }
-    //     return ans;
-    // }
-
     static Roaring64Map fastunion(size_t n, const Roaring64Map** inputs) {
         struct pq_entry {
             phmap::btree_map<uint32_t, roaring::Roaring>::const_iterator iterator;

--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <new>
 #include <numeric>
+#include <queue>
 #include <roaring/roaring.hh>
 #include <set>
 #include <stdexcept>
@@ -663,13 +664,72 @@ public:
      * computes the logical or (union) between "n" bitmaps (referenced by a
      * pointer).
      */
+    // static Roaring64Map fastunion(size_t n, const Roaring64Map** inputs) {
+    //     Roaring64Map ans;
+    //     // not particularly fast
+    //     for (size_t lcv = 0; lcv < n; ++lcv) {
+    //         ans |= *(inputs[lcv]);
+    //     }
+    //     return ans;
+    // }
+
     static Roaring64Map fastunion(size_t n, const Roaring64Map** inputs) {
-        Roaring64Map ans;
-        // not particularly fast
-        for (size_t lcv = 0; lcv < n; ++lcv) {
-            ans |= *(inputs[lcv]);
+        struct pq_entry {
+            phmap::btree_map<uint32_t, roaring::Roaring>::const_iterator iterator;
+            phmap::btree_map<uint32_t, roaring::Roaring>::const_iterator end;
+        };
+
+        struct pq_comp {
+            bool operator()(const pq_entry& lhs, const pq_entry& rhs) const {
+                auto left_key = lhs.iterator->first;
+                auto right_key = rhs.iterator->first;
+                // We compare in the opposite direction than normal because priority
+                // queues normally order from largest to smallest, but we want
+                // smallest to largest.
+                return left_key > right_key;
+            }
+        };
+
+        std::priority_queue<pq_entry, std::vector<pq_entry>, pq_comp> pq;
+
+        for (auto i = 0; i < n; ++i) {
+            const auto& roaring = inputs[i]->roarings;
+            if (roaring.begin() != roaring.end()) {
+                pq.push({roaring.begin(), roaring.end()});
+            }
         }
-        return ans;
+
+        std::vector<const roaring::api::roaring_bitmap_t*> group_bitmaps;
+        Roaring64Map result;
+        while (!pq.empty()) {
+            auto group_key = pq.top().iterator->first;
+            group_bitmaps.clear();
+
+            while (!pq.empty()) {
+                auto candidate_current_iter = pq.top().iterator;
+                auto candidate_end_iter = pq.top().end;
+
+                auto candidate_key = candidate_current_iter->first;
+                const auto& candidate_bitmap = candidate_current_iter->second;
+
+                if (candidate_key != group_key) {
+                    break;
+                }
+
+                group_bitmaps.push_back(&candidate_bitmap.roaring);
+                pq.pop();
+                ++candidate_current_iter;
+                if (candidate_current_iter != candidate_end_iter) {
+                    pq.push({candidate_current_iter, candidate_end_iter});
+                }
+            }
+            auto* inner_result = roaring::api::roaring_bitmap_or_many(group_bitmaps.size(),
+                                                                      group_bitmaps.data());
+            result.roarings.insert(result.roarings.end(),
+                                   std::make_pair(group_key, roaring::Roaring(inner_result)));
+        }
+
+        return result;
     }
 
     friend class Roaring64MapSetBitForwardIterator;

--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
@@ -277,6 +277,7 @@ public:
 
     void add_many(AggregateDataPtr __restrict place, const IColumn** columns,
                   std::vector<int>& rows, Arena&) const override {
+        // now this only for bitmap_union function
         if constexpr (std::is_same_v<Op, AggregateFunctionBitmapUnionOp>) {
             const auto& column = assert_cast<const ColVecType&>(*columns[0]);
             std::vector<const BitmapValue*> values;
@@ -289,6 +290,7 @@ public:
 
     void add_batch_range(size_t batch_begin, size_t batch_end, AggregateDataPtr place,
                          const IColumn** columns, Arena& arena, bool has_null) override {
+        // now this only for bitmap_union function
         if constexpr (std::is_same_v<Op, AggregateFunctionBitmapUnionOp>) {
             const auto& column = assert_cast<const ColVecType&>(*columns[0]);
             std::vector<const BitmapValue*> values;
@@ -370,6 +372,7 @@ public:
 
     void add_many(AggregateDataPtr __restrict place, const IColumn** columns,
                   std::vector<int>& rows, Arena&) const override {
+        // now this only for bitmap_union_count function
         if constexpr (arg_is_nullable && std::is_same_v<ColVecType, ColumnBitmap>) {
             const auto& nullable_column = assert_cast<const ColumnNullable&>(*columns[0]);
             const auto& column =
@@ -393,6 +396,7 @@ public:
 
     void add_batch_single_place(size_t batch_size, AggregateDataPtr place, const IColumn** columns,
                                 Arena& arena) const override {
+        // now this only for bitmap_union_count function
         if constexpr (std::is_same_v<ColVecType, ColumnBitmap>) {
             auto lambda_function = [&](const IColumn& data_column, const NullMap* null_map) {
                 const auto& column = assert_cast<const ColVecType&>(data_column);

--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
@@ -187,9 +187,9 @@ public:
 
     void deserialize_and_merge_from_column(AggregateDataPtr __restrict place, const IColumn& column,
                                            Arena&) const override {
-        auto& col = assert_cast<const ColumnBitmap&>(column);
+        const auto& col = assert_cast<const ColumnBitmap&>(column);
         const size_t num_rows = column.size();
-        auto* data = col.get_data().data();
+        const auto* data = col.get_data().data();
 
         for (size_t i = 0; i != num_rows; ++i) {
             this->data(place).merge(data[i]);
@@ -201,8 +201,8 @@ public:
                                                  Arena&) const override {
         DCHECK(end <= column.size() && begin <= end)
                 << ", begin:" << begin << ", end:" << end << ", column.size():" << column.size();
-        auto& col = assert_cast<const ColumnBitmap&>(column);
-        auto* data = col.get_data().data();
+        const auto& col = assert_cast<const ColumnBitmap&>(column);
+        const auto* data = col.get_data().data();
         for (size_t i = begin; i <= end; ++i) {
             this->data(place).merge(data[i]);
         }
@@ -280,10 +280,26 @@ public:
         if constexpr (std::is_same_v<Op, AggregateFunctionBitmapUnionOp>) {
             const auto& column = assert_cast<const ColVecType&>(*columns[0]);
             std::vector<const BitmapValue*> values;
-            for (int i = 0; i < rows.size(); ++i) {
-                values.push_back(&(column.get_data()[rows[i]]));
+            for (auto row : rows) {
+                values.push_back(&(column.get_data()[row]));
             }
             this->data(place).add_batch(values);
+        }
+    }
+
+    void add_batch_range(size_t batch_begin, size_t batch_end, AggregateDataPtr place,
+                         const IColumn** columns, Arena& arena, bool has_null) override {
+        if constexpr (std::is_same_v<Op, AggregateFunctionBitmapUnionOp>) {
+            const auto& column = assert_cast<const ColVecType&>(*columns[0]);
+            std::vector<const BitmapValue*> values;
+            for (size_t i = batch_begin; i <= batch_end; ++i) {
+                values.push_back(&(column.get_data()[i]));
+            }
+            this->data(place).add_batch(values);
+        } else {
+            for (size_t i = batch_begin; i <= batch_end; ++i) {
+                this->add(place, columns, i, arena);
+            }
         }
     }
 
@@ -326,13 +342,20 @@ public:
                       AggregateFunctionBitmapData<AggregateFunctionBitmapUnionOp>,
                       AggregateFunctionBitmapCount<arg_is_nullable, ColVecType>>(argument_types_) {}
 
-    String get_name() const override { return "count"; }
+    String get_name() const override {
+        if constexpr (std::is_same_v<ColVecType, ColumnBitmap>) {
+            return "bitmap_union_count";
+        } else {
+            return "bitmap_union_int";
+        }
+    }
+
     DataTypePtr get_return_type() const override { return std::make_shared<DataTypeInt64>(); }
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena&) const override {
         if constexpr (arg_is_nullable) {
-            auto& nullable_column = assert_cast<const ColumnNullable&>(*columns[0]);
+            const auto& nullable_column = assert_cast<const ColumnNullable&>(*columns[0]);
             if (!nullable_column.is_null_at(row_num)) {
                 const auto& column = assert_cast<const ColVecType&, TypeCheckOnRelease::DISABLE>(
                         nullable_column.get_nested_column());
@@ -348,23 +371,54 @@ public:
     void add_many(AggregateDataPtr __restrict place, const IColumn** columns,
                   std::vector<int>& rows, Arena&) const override {
         if constexpr (arg_is_nullable && std::is_same_v<ColVecType, ColumnBitmap>) {
-            auto& nullable_column = assert_cast<const ColumnNullable&>(*columns[0]);
+            const auto& nullable_column = assert_cast<const ColumnNullable&>(*columns[0]);
             const auto& column =
                     assert_cast<const ColVecType&>(nullable_column.get_nested_column());
             std::vector<const BitmapValue*> values;
-            for (int i = 0; i < rows.size(); ++i) {
-                if (!nullable_column.is_null_at(rows[i])) {
-                    values.push_back(&(column.get_data()[rows[i]]));
+            for (auto row : rows) {
+                if (!nullable_column.is_null_at(row)) {
+                    values.push_back(&(column.get_data()[row]));
                 }
             }
             this->data(place).add_batch(values);
         } else if constexpr (std::is_same_v<ColVecType, ColumnBitmap>) {
             const auto& column = assert_cast<const ColVecType&>(*columns[0]);
             std::vector<const BitmapValue*> values;
-            for (int i = 0; i < rows.size(); ++i) {
-                values.push_back(&(column.get_data()[rows[i]]));
+            for (auto row : rows) {
+                values.push_back(&(column.get_data()[row]));
             }
             this->data(place).add_batch(values);
+        }
+    }
+
+    void add_batch_single_place(size_t batch_size, AggregateDataPtr place, const IColumn** columns,
+                                Arena& arena) const override {
+        if constexpr (std::is_same_v<ColVecType, ColumnBitmap>) {
+            auto lambda_function = [&](const IColumn& data_column, const NullMap* null_map) {
+                const auto& column = assert_cast<const ColVecType&>(data_column);
+                std::vector<const BitmapValue*> values;
+                for (size_t i = 0; i < batch_size; ++i) {
+                    if constexpr (arg_is_nullable) {
+                        if ((*null_map)[i]) {
+                            continue; // skip null value
+                        }
+                    }
+                    values.push_back(&(column.get_data()[i]));
+                }
+                this->data(place).add_batch(values);
+            };
+
+            if constexpr (arg_is_nullable) {
+                const auto& nullable_column = assert_cast<const ColumnNullable&>(*columns[0]);
+                lambda_function(nullable_column.get_nested_column(),
+                                &(nullable_column.get_null_map_data()));
+            } else {
+                lambda_function(*columns[0], nullptr);
+            }
+        } else {
+            for (size_t i = 0; i < batch_size; ++i) {
+                this->add(place, columns, i, arena);
+            }
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
could override the add_batch_single_place/add_batch_range function,
so could call the bitmap fastunion funciton, once caller calacaute many bitmaps
the fastunion opt is coming from https://github.com/RoaringBitmap/CRoaring/pull/405

before and after exectue time
```
select bitmap_union(fan_key1) from fan_data_tmp2;
+------------------------+
| bitmap_union(fan_key1) |
+------------------------+
| NULL                   |
+------------------------+
1 row in set (4.57 sec)

select bitmap_union(fan_key1) from fan_data_tmp2;
+------------------------+
| bitmap_union(fan_key1) |
+------------------------+
| NULL                   |
+------------------------+
1 row in set (5.38 sec)
```

```
2025-07-21T22:07:26+08:00
Running /mnt/disk8/zhangsida/doris/output/be/lib/benchmark_test
Run on (96 X 3039.6 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x48)
  L1 Instruction 32 KiB (x48)
  L2 Unified 1024 KiB (x48)
  L3 Unified 36608 KiB (x2)
Load Average: 17.97, 20.54, 30.31
---------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations
---------------------------------------------------------------------------------
Example1                               6.5103e+13 ns   6975201340 ns            1
BM_FastUnionOptimized/repeats:5_mean          242 ms          241 ms            5 Bitmaps=100 Overlap%=30 TotalValues=200M
BM_FastUnionOptimized/repeats:5_median        239 ms          239 ms            5 Bitmaps=100 Overlap%=30 TotalValues=200M
BM_FastUnionOptimized/repeats:5_stddev       6.19 ms         6.18 ms            5 Bitmaps=0 Overlap%=0 TotalValues=0
BM_FastUnionOptimized/repeats:5_cv           2.56 %          2.56 %             5 Bitmaps=0.00% Overlap%=0.00% TotalValues=0.00%
BM_FastUnionOptimized/repeats:5_min           236 ms          236 ms            5 Bitmaps=100 Overlap%=30 TotalValues=200M
BM_FastUnionOptimized/repeats:5_max           251 ms          251 ms            5 Bitmaps=100 Overlap%=30 TotalValues=200M
BM_FastUnionLegacy/repeats:5_mean             545 ms          545 ms            5 Bitmaps=100 Overlap%=30 TotalValues=200M
BM_FastUnionLegacy/repeats:5_median           543 ms          543 ms            5 Bitmaps=100 Overlap%=30 TotalValues=200M
BM_FastUnionLegacy/repeats:5_stddev          17.5 ms         17.5 ms            5 Bitmaps=0 Overlap%=0 TotalValues=0
BM_FastUnionLegacy/repeats:5_cv              3.20 %          3.20 %             5 Bitmaps=0.00% Overlap%=0.00% TotalValues=0.00%
BM_FastUnionLegacy/repeats:5_min              519 ms          519 ms            5 Bitmaps=100 Overlap%=30 TotalValues=200M
BM_FastUnionLegacy/repeats:5_max              566 ms          566 ms            5 Bitmaps=100 Overlap%=30 TotalValues=200M
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

