### PR TITLE
[minor](pipeline) catch exception if task queue is closed

### DIFF
--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -324,22 +324,26 @@ void PipelineTask::terminate() {
     std::unique_lock<std::mutex> lc(_dependency_lock);
     auto fragment = _fragment_context.lock();
     if (!is_finalized() && fragment) {
-        DCHECK(_wake_up_early || fragment->is_canceled());
-        std::for_each(_spill_dependencies.begin(), _spill_dependencies.end(),
-                      [&](Dependency* dep) { dep->set_always_ready(); });
-        std::for_each(_write_dependencies.begin(), _write_dependencies.end(),
-                      [&](Dependency* dep) { dep->set_always_ready(); });
-        std::for_each(_finish_dependencies.begin(), _finish_dependencies.end(),
-                      [&](Dependency* dep) { dep->set_always_ready(); });
-        std::for_each(_read_dependencies.begin(), _read_dependencies.end(),
-                      [&](std::vector<Dependency*>& deps) {
-                          std::for_each(deps.begin(), deps.end(),
-                                        [&](Dependency* dep) { dep->set_always_ready(); });
-                      });
-        // All `_execution_deps` will never be set blocking from ready. So we just set ready here.
-        std::for_each(_execution_dependencies.begin(), _execution_dependencies.end(),
-                      [&](Dependency* dep) { dep->set_ready(); });
-        _memory_sufficient_dependency->set_ready();
+        try {
+            DCHECK(_wake_up_early || fragment->is_canceled());
+            std::for_each(_spill_dependencies.begin(), _spill_dependencies.end(),
+                          [&](Dependency* dep) { dep->set_always_ready(); });
+            std::for_each(_write_dependencies.begin(), _write_dependencies.end(),
+                          [&](Dependency* dep) { dep->set_always_ready(); });
+            std::for_each(_finish_dependencies.begin(), _finish_dependencies.end(),
+                          [&](Dependency* dep) { dep->set_always_ready(); });
+            std::for_each(_read_dependencies.begin(), _read_dependencies.end(),
+                          [&](std::vector<Dependency*>& deps) {
+                              std::for_each(deps.begin(), deps.end(),
+                                            [&](Dependency* dep) { dep->set_always_ready(); });
+                          });
+            // All `_execution_deps` will never be set blocking from ready. So we just set ready here.
+            std::for_each(_execution_dependencies.begin(), _execution_dependencies.end(),
+                          [&](Dependency* dep) { dep->set_ready(); });
+            _memory_sufficient_dependency->set_ready();
+        } catch (const doris::Exception& e) {
+            LOG(WARNING) << "Terminate failed: " << e.code() << ", " << e.to_string();
+        }
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?
what(): [E6] WorkTaskQueue closed
0# doris::Exception::Exception(int, std::basic_string_view<char, std::char_traits<char> > const&) at /root/doris/be/src/common/exception.cpp:0
11:58:08 
    1# doris::Exception::Exception(doris::Status const&) at /root/doris/be/src/common/exception.h:39
11:58:08 
    2# doris::pipeline::Dependency::set_ready() at /root/doris/be/src/pipeline/dependency.cpp:88
11:58:08 
    3# doris::pipeline::Dependency::set_always_ready() at /usr/local/ldb-toolchain-v0.25/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/unique_lock.h:113
11:58:08 
    4# doris::pipeline::PipelineTask::terminate() at /usr/local/ldb-toolchain-v0.25/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/stl_iterator.h:1103
11:58:08 
    5# doris::pipeline::PipelineFragmentContext::cancel(doris::Status) at /usr/local/ldb-toolchain-v0.25/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/stl_iterator.h:1103
11:58:08 
    6# doris::QueryContext::cancel_all_pipeline_context(doris::Status const&, int) at /root/doris/be/src/runtime/query_context.cpp:0
11:58:08 
    7# doris::QueryContext::cancel(doris::Status, int) at /root/doris/be/src/runtime/query_context.cpp:0
11:58:08 
    8# doris::FragmentMgr::_check_brpc_available(std::shared_ptr<doris::PBackendService_Stub> const&, doris::FragmentMgr::BrpcItem const&) at /root/doris/be/src/runtime/fragment_mgr.cpp:0
11:58:08 
    9# doris::FragmentMgr::cancel_worker() at /root/doris/be/src/runtime/fragment_mgr.cpp:0
11:58:08 
    10# doris::Thread::supervise_thread(void*) at /usr/local/ldb-toolchain-v0.25/bin/../usr/include/pthread.h:563
11:58:08 

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

