### PR TITLE
[feature](metric):add labels for metric doris_fe_version

### DIFF
--- a/gensrc/script/gen_build_version.sh
+++ b/gensrc/script/gen_build_version.sh
@@ -38,7 +38,9 @@ build_version="${build_version_prefix}-${build_version_major}.${build_version_mi
 if [[ ${build_version_hotfix} -gt 0 ]]; then
     build_version+=".${build_version_hotfix}"
 fi
-build_version+="-${build_version_rc_version}"
+if [[ -n "${build_version_rc_version}" ]]; then
+    build_version+="-${build_version_rc_version}"
+fi
 
 # This version is used to check FeMetaVersion is not changed during release
 build_fe_meta_version=0

--- a/regression-test/suites/metrics_p0/test_version_metrics.groovy
+++ b/regression-test/suites/metrics_p0/test_version_metrics.groovy
@@ -1,3 +1,6 @@
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
@@ -25,8 +28,12 @@ suite("test_version_metrics") {
             assertEquals(200, code)
             assertTrue(body.contains("doris_fe_version"))
             for (final def line in body.split("\n")) {
-                if (line.contains("doris_fe_version") && !line.contains("#")) {
-                    assertTrue(Long.parseLong(line.split(" ")[1]) >= 0)
+                if (line.startsWith("doris_fe_version")) {
+                    Pattern pattern = Pattern.compile(/^doris_fe_version\{.*}\s+(\d+)$/)
+                    Matcher matcher = pattern.matcher(line)
+                    assertTrue(matcher.matches())
+                    assertTrue(Long.parseLong(matcher.group(1)) >= 0)
+                    break
                 }
             }
         }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

The value of `doris_fe_version` of Doris FE Metrics is a long number, which cannot accurately reflect the current version of Doris. This problem can be solved by adding labels to the metric. The following is the metric I added：
```
version: it tells you doris released version
major: it tells you doris build major version
minjor: it tells you doris build minor version
patch: it tells you doris build patch version
hotfix: it tells you doris build hotfix version
short_hash: it telss you doris build commit's short hash
```
for example：
```
doris_fe_version{"version":"doris-3.0.6.1", major="3","minor":"0","patch":"6","hotfix":"1",short_hash="xxxxxxxx"} 3000601
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

