### PR TITLE
[fix](filecache) handle duplicated block when enable lru persist

### DIFF
--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -785,10 +785,13 @@ BlockFileCache::FileBlockCell* BlockFileCache::add_cell(const UInt128Wrapper& ha
     }
 
     auto& offsets = _files[hash];
-    DCHECK_EQ(offsets.count(offset), 0)
-            << "Cache already exists for hash: " << hash.to_string() << ", offset: " << offset
-            << ", size: " << size
-            << ".\nCurrent cache structure: " << dump_structure_unlocked(hash, cache_lock);
+    auto itr = offsets.find(offset);
+    if (itr != offsets.end()) {
+        VLOG_DEBUG << "Cache already exists for hash: " << hash.to_string()
+                   << ", offset: " << offset << ", size: " << size
+                   << ".\nCurrent cache structure: " << dump_structure_unlocked(hash, cache_lock);
+        return &(itr->second);
+    }
 
     FileCacheKey key;
     key.hash = hash;
@@ -2277,10 +2280,11 @@ void BlockFileCache::run_background_lru_dump() {
 }
 
 void BlockFileCache::restore_lru_queues_from_disk(std::lock_guard<std::mutex>& cache_lock) {
-    _lru_dumper->restore_queue(_disposable_queue, "disposable", cache_lock);
+    // keep this order coz may be duplicated in different queue, we use the first appearence
+    _lru_dumper->restore_queue(_ttl_queue, "ttl", cache_lock);
     _lru_dumper->restore_queue(_index_queue, "index", cache_lock);
     _lru_dumper->restore_queue(_normal_queue, "normal", cache_lock);
-    _lru_dumper->restore_queue(_ttl_queue, "ttl", cache_lock);
+    _lru_dumper->restore_queue(_disposable_queue, "disposable", cache_lock);
 }
 
 std::map<std::string, double> BlockFileCache::get_stats() {

--- a/be/test/io/cache/cache_lru_dumper_test.cpp
+++ b/be/test/io/cache/cache_lru_dumper_test.cpp
@@ -41,6 +41,16 @@ public:
     FileBlockCell* add_cell(const UInt128Wrapper& hash, const CacheContext& ctx, size_t offset,
                             size_t size, FileBlock::State state,
                             std::lock_guard<std::mutex>& lock) {
+        static std::unordered_set<std::string> added_entries;
+        std::string key = hash.to_string() + ":" + std::to_string(offset);
+
+        if (added_entries.find(key) != added_entries.end()) {
+            std::cerr << "Error: Duplicate entry detected for hash: " << key << std::endl;
+            EXPECT_TRUE(false);
+            return nullptr;
+        }
+
+        added_entries.insert(key);
         dst_queue->add(hash, offset, size, lock);
         return nullptr;
     }


### PR DESCRIPTION
Duplicate elements may occur during the transition between TTL and normal states.
- Replay and dump operations are periodic, which means there could be a time window that leads to capturing the addition of an element to a queue but not its removal from the previous queue.
- The issue stems from the use of non-order-assure current queue in the log queue for record operations.

The above two are currently unavoidable, so a fallback logic is necessary to remove duplicates when elements are added repeatedly.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

