### PR TITLE
[fix](result-sink)Fix the correctness of the results when multiple be and dry_run_query=true.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -1190,9 +1190,11 @@ public class Coordinator implements CoordInterface {
         }
 
         if (ConnectContext.get() != null && ConnectContext.get().getSessionVariable().dryRunQuery) {
-            if (resultBatch.isEos()) {
-                numReceivedRows += resultBatch.getQueryStatistics().getReturnedRows();
-            }
+            // In BE: vmysql_result_writer.cpp:GetResultBatchCtx::on_close()
+            //      statistics->set_returned_rows(returned_rows);
+            // In a multi-mysql_result_writer scenario, since each mysql_result_writer will set this rows, in order
+            // to avoid missing rows when dry_run_query = true, they should all be added up.
+            numReceivedRows += resultBatch.getQueryStatistics().getReturnedRows();
         } else if (resultBatch.getBatch() != null) {
             numReceivedRows += resultBatch.getBatch().getRowsSize();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/QueryProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/QueryProcessor.java
@@ -142,9 +142,11 @@ public class QueryProcessor extends AbstractJobProcessor {
 
         ConnectContext connectContext = coordinatorContext.connectContext;
         if (connectContext != null && connectContext.getSessionVariable().dryRunQuery) {
-            if (resultBatch.isEos()) {
-                numReceivedRows += resultBatch.getQueryStatistics().getReturnedRows();
-            }
+            // In BE: vmysql_result_writer.cpp:GetResultBatchCtx::on_close()
+            //      statistics->set_returned_rows(returned_rows);
+            // In a multi-mysql_result_writer scenario, since each mysql_result_writer will set this rows, in order
+            // to avoid missing rows when dry_run_query = true, they should all be added up.
+            numReceivedRows += resultBatch.getQueryStatistics().getReturnedRows();
         } else if (resultBatch.getBatch() != null) {
             numReceivedRows += resultBatch.getBatch().getRowsSize();
         }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #36053 && #53209

Problem Summary:

Fixed the issue that the result of `dry_run_query=true` is wrong in multi-be scenarios (the number of rows is less)

I think this may be related to the multi result sink introduced in pr #36053 && #53209. 
Reason:
```cpp
vmysql_result_writer.cpp
GetResultBatchCtx::on_close() {
    ...
    statistics->set_returned_rows(returned_rows);  // Set only once per result_writer.
    ...
}
```
``` java
if (connectContext != null && connectContext.getSessionVariable().dryRunQuery) {
    if (resultBatch.isEos()) {     // This will only be counted once. 
        numReceivedRows += resultBatch.getQueryStatistics().getReturnedRows();
    }
} else if (resultBatch.getBatch() != null) {
    numReceivedRows += resultBatch.getBatch().getRowsSize();
}
```
If there are multiple be, there will be multiple result sinks, and each result sink will update its own row count at the end. Since `resultBatch.isEos()` is only triggered once, the row count information is less.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

