### PR TITLE
[fix](rpc) robust retry and exception handling for MetaService RPC

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/MetaServiceProxy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/rpc/MetaServiceProxy.java
@@ -22,7 +22,6 @@ import org.apache.doris.common.Config;
 import org.apache.doris.rpc.RpcException;
 
 import com.google.common.collect.Maps;
-import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -176,46 +175,51 @@ public class MetaServiceProxy {
         }
 
         public <Response> Response executeRequest(Function<MetaServiceClient, Response> function) throws RpcException {
-            int tried = 0;
-            while (tried++ < Config.meta_service_rpc_retry_cnt) {
+            long maxRetries = Config.meta_service_rpc_retry_cnt;
+            for (long tried = 1; tried <= maxRetries; tried++) {
                 MetaServiceClient client = null;
                 try {
                     client = proxy.getProxy();
                     return function.apply(client);
                 } catch (StatusRuntimeException sre) {
-                    LOG.info("failed to request meta servive code {}, msg {}, trycnt {}", sre.getStatus().getCode(),
+                    LOG.warn("failed to request meta service code {}, msg {}, trycnt {}", sre.getStatus().getCode(),
                             sre.getMessage(), tried);
-                    if ((tried > Config.meta_service_rpc_retry_cnt
-                                || (sre.getStatus().getCode() != Status.Code.UNAVAILABLE
-                                    && sre.getStatus().getCode() != Status.Code.UNKNOWN))
-                            && (tried > Config.meta_service_rpc_timeout_retry_times
-                                || sre.getStatus().getCode() != Status.Code.DEADLINE_EXCEEDED)) {
+                    boolean shouldRetry = false;
+                    switch (sre.getStatus().getCode()) {
+                        case UNAVAILABLE:
+                        case UNKNOWN:
+                            shouldRetry = true;
+                            break;
+                        case DEADLINE_EXCEEDED:
+                            shouldRetry = tried <= Config.meta_service_rpc_timeout_retry_times;
+                            break;
+                        default:
+                            shouldRetry = false;
+                    }
+                    if (!shouldRetry || tried >= maxRetries) {
                         throw new RpcException("", sre.getMessage(), sre);
                     }
                 } catch (Exception e) {
-                    LOG.info("failed to request meta servive trycnt {}", tried, e);
-                    if (tried > Config.meta_service_rpc_retry_cnt) {
+                    LOG.warn("failed to request meta servive trycnt {}", tried, e);
+                    if (tried >= maxRetries) {
                         throw new RpcException("", e.getMessage(), e);
                     }
-                } catch (Throwable t) {
-                    LOG.info("failed to request meta servive trycnt {}", tried, t);
-                    if (tried > Config.meta_service_rpc_retry_cnt) {
-                        throw new RpcException("", t.getMessage());
+                } finally {
+                    if (proxy.needReconn() && client != null) {
+                        client.shutdown(true);
                     }
-                }
-
-                if (proxy.needReconn() && client != null) {
-                    client.shutdown(true);
                 }
 
                 int delay = 20 + random.nextInt(200 - 20 + 1);
                 try {
                     Thread.sleep(delay);
                 } catch (InterruptedException interruptedException) {
-                    // ignore
+                    Thread.currentThread().interrupt();
+                    throw new RpcException("", interruptedException.getMessage(), interruptedException);
                 }
             }
-            return null; // impossible and unreachable, just make the compiler happy
+            // impossible and unreachable, just make the compiler happy
+            throw new RpcException("", "All retries exhausted", null);
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

- Ensure correct retry behavior for gRPC StatusRuntimeException:
    - Only retry on UNAVAILABLE, UNKNOWN, or DEADLINE_EXCEEDED (with limited times).
    - Throw RpcException after all retries are exhausted or on non-retryable errors.
- Move resource cleanup (client.shutdown) to finally block for better reliability.
- Correctly handle InterruptdEException exceptions rather than ingore.
- Improve log messages for clarity and typo fix ("servive" -> "service").
- Remove unreachable return null, always throw RpcException if all retries fail.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

