### PR TITLE
[Bug](function) fix to_ipv6 cause stack-buffer-overflow error

### DIFF
--- a/be/src/vec/common/format_ip.h
+++ b/be/src/vec/common/format_ip.h
@@ -125,12 +125,12 @@ inline void format_ipv4(const unsigned char* src, char*& dst, uint8_t mask_tail_
  */
 template <typename T, typename EOFfunction>
     requires(std::is_same<typename std::remove_cv<T>::type, char>::value)
-inline bool parse_ipv4(T*& src, EOFfunction eof, unsigned char* dst, int64_t first_octet = -1) {
+inline bool parse_ipv4(T*& src, EOFfunction eof, unsigned char* dst, int32_t first_octet = -1) {
     if (src == nullptr || first_octet > IPV4_MAX_OCTET_VALUE) {
         return false;
     }
 
-    int64_t result = 0;
+    UInt32 result = 0;
     int offset = (IPV4_BINARY_LENGTH - 1) * IPV4_OCTET_BITS;
     if (first_octet >= 0) {
         result |= first_octet << offset;
@@ -142,7 +142,7 @@ inline bool parse_ipv4(T*& src, EOFfunction eof, unsigned char* dst, int64_t fir
             return false;
         }
 
-        int64_t value = 0;
+        UInt32 value = 0;
         size_t len = 0;
         while (is_numeric_ascii(*src) && len <= 3) {
             value = value * DECIMAL_BASE + (*src - '0');

--- a/be/src/vec/functions/function_ip.h
+++ b/be/src/vec/functions/function_ip.h
@@ -151,10 +151,8 @@ ColumnPtr convert_to_ipv4(ColumnPtr column, const PaddedPODArray<UInt8>* null_ma
         vec_null_map_to = &col_null_map_to->get_data();
     }
 
-    auto col_res = ToColumn::create();
-
+    auto col_res = ToColumn::create(column_size, 0);
     auto& vec_res = col_res->get_data();
-    vec_res.resize(column_size);
 
     const ColumnString::Chars& vec_src = column_string->get_chars();
     const ColumnString::Offsets& offsets_src = column_string->get_offsets();

--- a/be/test/vec/columns/column_ip_test.cpp
+++ b/be/test/vec/columns/column_ip_test.cpp
@@ -20,12 +20,12 @@
 #include <gtest/gtest.h>
 
 #include "vec/columns/column.h"
-#include "vec/columns/column_array.h"
 #include "vec/columns/common_column_test.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_factory.hpp"
 #include "vec/data_types/data_type_nullable.h"
+#include "vec/functions/function_ip.h"
 
 // this test is gonna to make a template ColumnTest
 // for example column_ip should test these functions
@@ -317,6 +317,20 @@ TEST_F(ColumnIPTest, IPv6ValueFromStringTest) {
     IPv6 ipv6_val = 0;
     ASSERT_EQ(IPv6Value::from_string(ipv6_val, ipv6_str.data(), ipv6_str.size()), true);
     ASSERT_EQ("1111:2222:3333:4444:5555:6666:7b7b:7b7b", IPv6Value(ipv6_val).to_string());
+};
+
+TEST_F(ColumnIPTest, IPv4ValueFromStringTest) {
+    std::string ipv4_str = "127.0.0.1";
+    IPv4 ipv4_val = 0;
+    ASSERT_EQ(IPv4Value::from_string(ipv4_val, ipv4_str.data(), ipv4_str.size()), true);
+    ASSERT_EQ("127.0.0.1", IPv4Value(ipv4_val).to_string());
+};
+
+TEST_F(ColumnIPTest, IPv4Parse) {
+    std::string ipv4_str = "127.0.0.1";
+    Int64 result_value = 0;
+    ASSERT_EQ(try_parse_ipv4(ipv4_str.data(), result_value), true);
+    ASSERT_EQ(2130706433, result_value);
 };
 
 } // namespace doris::vectorized

--- a/be/test/vec/columns/column_ip_test.cpp
+++ b/be/test/vec/columns/column_ip_test.cpp
@@ -312,4 +312,11 @@ TEST_F(ColumnIPTest, HashTest) {
     assert_update_crc_hashes_callback(ip_cols, serde, pts);
 };
 
+TEST_F(ColumnIPTest, IPv6ValueFromStringTest) {
+    std::string ipv6_str = "1111:2222:3333:4444:5555:6666:123.123.123.123";
+    IPv6 ipv6_val = 0;
+    ASSERT_EQ(IPv6Value::from_string(ipv6_val, ipv6_str.data(), ipv6_str.size()), true);
+    ASSERT_EQ("1111:2222:3333:4444:5555:6666:7b7b:7b7b", IPv6Value(ipv6_val).to_string());
+};
+
 } // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:

memcpy(dst, &result, sizeof(result));
when use memcpy, it's size if sizeof(result), so use int64 maybe overflow of dst

```
==3524968==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7f18404e1d73 at pc 0x559e2c162b01 bp 0x7f18439e5dc0 sp 0x7f18439e5db8
WRITE of size 8 at 0x7f18404e1d73 thread T1265 (brpc_light)
    #0 0x559e2c162b00 in bool doris::vectorized::parse_ipv4<char const, doris::vectorized::parse_ipv6(char const*, char const*, unsigned char*)::'lambda'()>(char const*&, doris::vectorized::parse_ipv6(char const*, char const*, unsigned char*)::'lambda'(), unsigned char*, long) /mnt/disk8/zhangsida/doris/be/src/vec/common/format_ip.h:165:5
    #1 0x559e2c161eb3 in bool doris::vectorized::parse_ipv6<char const, doris::vectorized::parse_ipv6(char const*, char const*, unsigned char*)::'lambda'()>(char const*&, doris::vectorized::parse_ipv6(char const*, char const*, unsigned char*)::'lambda'(), unsigned char*, int) /mnt/disk8/zhangsida/doris/be/src/vec/common/format_ip.h:416:18
    #2 0x559e2c160c44 in doris::vectorized::parse_ipv6(char const*, char const*, unsigned char*) /mnt/disk8/zhangsida/doris/be/src/vec/common/format_ip.h:467:9
    #3 0x559e2c160c44 in doris::vectorized::parse_ipv6_whole(char const*, char const*, unsigned char*) /mnt/disk8/zhangsida/doris/be/src/vec/common/format_ip.h:475:12
    #4 0x559e2c160c44 in doris::IPv6Value::from_string(unsigned __int128&, char const*, unsigned long) /mnt/disk8/zhangsida/doris/be/src/vec/runtime/ipv6_value.h:71:16
    #5 0x559e4fdb05f3 in doris::vectorized::FunctionToIP<(doris::vectorized::IPConvertExceptionMode)0, (doris::PrimitiveType)37>::execute_impl(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned int, std::allocator<unsigned int>> const&, unsigned int, unsigned long) const /mnt/disk8/zhangsida/doris/be/src/vec/functions/function_ip.h:1180:21
    #6 0x559e4c233b1e in doris::vectorized::DefaultExecutable::execute_impl(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned int, std::allocator<unsigned int>> const&, unsigned int, unsigned long) const /mnt/disk8/zhangsida/doris/be/src/vec/functions/function.h:447:26
    #7 0x559e4eebcef3 in doris::vectorized::PreparedFunctionImpl::_execute_skipped_constant_deal(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned int, std::allocator<unsigned int>> const&, unsigned int, unsigned long, bool) const /mnt/disk8/zhangsida/doris/be/src/vec/functions/function.cpp
    #8 0x559e4eeb68c4 in doris::vectorized::PreparedFunctionImpl::default_implementation_for_constant_arguments(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned int, std::allocator<unsigned int>> const&, unsigned int, unsigned long, bool, bool*) const /mnt/disk8/zhangsida/doris/be/src/vec/functions/function.cpp:168:5
    #9 0x559e4eeb8fc4 in doris::vectorized::PreparedFunctionImpl::execute_without_low_cardinality_columns(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned int, std::allocator<unsigned int>> const&, unsigned int, unsigned long, bool) const /mnt/disk8/zhangsida/doris/be/src/vec/functions/function.cpp:237:5
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

