### PR TITLE
[enhancement](be_metrics) update scan bytes metric in file_scanner.

### DIFF
--- a/be/src/io/fs/tracing_file_reader.h
+++ b/be/src/io/fs/tracing_file_reader.h
@@ -44,6 +44,9 @@ public:
     bool closed() const override { return _inner->closed(); }
     const std::string& get_data_dir_path() override { return _inner->get_data_dir_path(); }
 
+    void _collect_profile_at_runtime() override { return _inner->collect_profile_at_runtime(); }
+    void _collect_profile_before_close() override { return _inner->collect_profile_before_close(); }
+
     FileReaderStats* stats() const { return _stats; }
 
 private:

--- a/be/src/io/fs/tracing_file_reader.h
+++ b/be/src/io/fs/tracing_file_reader.h
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+#include "common/status.h"
+#include "io/fs/file_reader.h"
+#include "util/runtime_profile.h"
+
+namespace doris {
+
+namespace io {
+
+class TracingFileReader : public FileReader {
+public:
+    TracingFileReader(doris::io::FileReaderSPtr inner, FileReaderStats* stats)
+            : _inner(std::move(inner)), _stats(stats) {}
+
+    Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,
+                        const IOContext* io_ctx) override {
+        SCOPED_RAW_TIMER(&_stats->read_time_ns);
+        Status st = _inner->read_at(offset, result, bytes_read, io_ctx);
+        _stats->read_calls++;
+        _stats->read_bytes += *bytes_read;
+        return st;
+    }
+
+    Status close() override { return _inner->close(); }
+    const doris::io::Path& path() const override { return _inner->path(); }
+    size_t size() const override { return _inner->size(); }
+    bool closed() const override { return _inner->closed(); }
+    const std::string& get_data_dir_path() override { return _inner->get_data_dir_path(); }
+
+    FileReaderStats* stats() const { return _stats; }
+
+private:
+    doris::io::FileReaderSPtr _inner;
+    FileReaderStats* _stats;
+};
+
+} // namespace io
+} // namespace doris

--- a/be/src/io/io_common.h
+++ b/be/src/io/io_common.h
@@ -35,6 +35,13 @@ enum class ReaderType : uint8_t {
 
 namespace io {
 
+struct FileReaderStats {
+    size_t read_calls = 0;
+    size_t read_bytes = 0;
+    int64_t read_time_ns = 0;
+    size_t read_rows = 0;
+};
+
 struct FileCacheStatistics {
     int64_t num_local_io_total = 0;
     int64_t num_remote_io_total = 0;
@@ -73,6 +80,7 @@ struct IOContext {
     int64_t expiration_time = 0;
     const TUniqueId* query_id = nullptr;             // Ref
     FileCacheStatistics* file_cache_stats = nullptr; // Ref
+    FileReaderStats* file_reader_stats = nullptr;    // Ref
     bool is_inverted_index = false;
     // if is_dryrun, read IO will download data to cache but return no data to reader
     // useful to skip cache data read from local disk to accelarate warm up

--- a/be/src/pipeline/exec/file_scan_operator.h
+++ b/be/src/pipeline/exec/file_scan_operator.h
@@ -56,6 +56,7 @@ public:
     std::string name_suffix() const override;
 
 private:
+    friend class vectorized::FileScanner;
     std::shared_ptr<vectorized::SplitSourceConnector> _split_source = nullptr;
     int _max_scanners;
     // A in memory cache to save some common components

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -1096,10 +1096,10 @@ Status ScanLocalState<Derived>::_init_profile() {
 
     // Rows read from storage.
     // Include the rows read from doris page cache.
-    _scan_rows = ADD_COUNTER(custom_profile(), "ScanRows", TUnit::UNIT);
+    _scan_rows = ADD_COUNTER_WITH_LEVEL(custom_profile(), "ScanRows", TUnit::UNIT, 1);
     // Size of data that read from storage.
     // Does not include rows that are cached by doris page cache.
-    _scan_bytes = ADD_COUNTER(custom_profile(), "ScanBytes", TUnit::BYTES);
+    _scan_bytes = ADD_COUNTER_WITH_LEVEL(custom_profile(), "ScanBytes", TUnit::BYTES, 1);
     return Status::OK();
 }
 

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -842,6 +842,8 @@ void PInternalService::fetch_table_schema(google::protobuf::RpcController* contr
         io::IOContext io_ctx;
         io::FileCacheStatistics file_cache_statis;
         io_ctx.file_cache_stats = &file_cache_statis;
+        io::FileReaderStats file_reader_stats;
+        io_ctx.file_reader_stats = &file_reader_stats;
         // file_slots is no use, but the lifetime should be longer than reader
         std::vector<SlotDescriptor*> file_slots;
         switch (params.format_type) {

--- a/be/src/vec/exec/format/arrow/arrow_stream_reader.cpp
+++ b/be/src/vec/exec/format/arrow/arrow_stream_reader.cpp
@@ -26,6 +26,7 @@
 #include "common/logging.h"
 #include "common/status.h"
 #include "io/fs/stream_load_pipe.h"
+#include "io/fs/tracing_file_reader.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
 #include "vec/core/block.h"
@@ -44,14 +45,22 @@ ArrowStreamReader::ArrowStreamReader(RuntimeState* state, RuntimeProfile* profil
                                      const TFileRangeDesc& range,
                                      const std::vector<SlotDescriptor*>& file_slot_descs,
                                      io::IOContext* io_ctx)
-        : _state(state), _range(range), _file_slot_descs(file_slot_descs), _file_reader(nullptr) {
+        : _state(state),
+          _range(range),
+          _file_slot_descs(file_slot_descs),
+          _io_ctx(io_ctx),
+          _file_reader(nullptr) {
     TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, _ctzz);
 }
 
 ArrowStreamReader::~ArrowStreamReader() = default;
 
 Status ArrowStreamReader::init_reader() {
-    RETURN_IF_ERROR(FileFactory::create_pipe_reader(_range.load_id, &_file_reader, _state, false));
+    io::FileReaderSPtr file_reader;
+    RETURN_IF_ERROR(FileFactory::create_pipe_reader(_range.load_id, &file_reader, _state, false));
+    _file_reader = _io_ctx ? std::make_shared<io::TracingFileReader>(std::move(file_reader),
+                                                                     _io_ctx->file_reader_stats)
+                           : file_reader;
     _pip_stream = ArrowPipInputStream::create_unique(_file_reader);
     return Status::OK();
 }

--- a/be/src/vec/exec/format/arrow/arrow_stream_reader.h
+++ b/be/src/vec/exec/format/arrow/arrow_stream_reader.h
@@ -65,6 +65,7 @@ private:
     RuntimeState* _state;
     const TFileRangeDesc& _range;
     const std::vector<SlotDescriptor*>& _file_slot_descs;
+    io::IOContext* _io_ctx;
     io::FileReaderSPtr _file_reader;
     std::unique_ptr<doris::vectorized::ArrowPipInputStream> _pip_stream;
     cctz::time_zone _ctzz;

--- a/be/src/vec/exec/format/file_reader/new_plain_text_line_reader.cpp
+++ b/be/src/vec/exec/format/file_reader/new_plain_text_line_reader.cpp
@@ -219,12 +219,8 @@ NewPlainTextLineReader::NewPlainTextLineReader(RuntimeProfile* profile,
           _more_input_bytes(0),
           _more_output_bytes(0),
           _current_offset(current_offset),
-          _bytes_read_counter(nullptr),
-          _read_timer(nullptr),
           _bytes_decompress_counter(nullptr),
           _decompress_timer(nullptr) {
-    _bytes_read_counter = ADD_COUNTER(_profile, "BytesRead", TUnit::BYTES);
-    _read_timer = ADD_TIMER(_profile, "FileReadTime");
     _bytes_decompress_counter = ADD_COUNTER(_profile, "BytesDecompressed", TUnit::BYTES);
     _decompress_timer = ADD_TIMER(_profile, "DecompressTime");
 }
@@ -382,16 +378,12 @@ Status NewPlainTextLineReader::read_line(const uint8_t** ptr, size_t* size, bool
                     }
                 }
 
-                {
-                    SCOPED_TIMER(_read_timer);
-                    Slice file_slice(file_buf, buffer_len);
-                    RETURN_IF_ERROR(
-                            _file_reader->read_at(_current_offset, file_slice, &read_len, io_ctx));
-                    _current_offset += read_len;
-                    if (read_len == 0) {
-                        _file_eof = true;
-                    }
-                    COUNTER_UPDATE(_bytes_read_counter, read_len);
+                Slice file_slice(file_buf, buffer_len);
+                RETURN_IF_ERROR(
+                        _file_reader->read_at(_current_offset, file_slice, &read_len, io_ctx));
+                _current_offset += read_len;
+                if (read_len == 0) {
+                    _file_eof = true;
                 }
                 if (_file_eof || read_len == 0) {
                     if (!stream_end) {

--- a/be/src/vec/exec/format/file_reader/new_plain_text_line_reader.h
+++ b/be/src/vec/exec/format/file_reader/new_plain_text_line_reader.h
@@ -332,8 +332,6 @@ private:
     size_t _current_offset;
 
     // Profile counters
-    RuntimeProfile::Counter* _bytes_read_counter = nullptr;
-    RuntimeProfile::Counter* _read_timer = nullptr;
     RuntimeProfile::Counter* _bytes_decompress_counter = nullptr;
     RuntimeProfile::Counter* _decompress_timer = nullptr;
 };

--- a/be/src/vec/exec/format/generic_reader.h
+++ b/be/src/vec/exec/format/generic_reader.h
@@ -81,6 +81,11 @@ public:
         return _set_read_one_line_impl();
     }
 
+    /// The reader is responsible for counting the number of rows read,
+    /// because some readers, such as parquet/orc,
+    /// can skip some pages/rowgroups through indexes.
+    virtual bool count_read_rows() { return false; }
+
 protected:
     virtual Status _set_read_one_line_impl() {
         return Status::NotSupported("set_read_lines_mode is not implemented for this reader.");

--- a/be/src/vec/exec/format/json/new_json_reader.cpp
+++ b/be/src/vec/exec/format/json/new_json_reader.cpp
@@ -45,6 +45,7 @@
 #include "io/fs/buffered_reader.h"
 #include "io/fs/file_reader.h"
 #include "io/fs/stream_load_pipe.h"
+#include "io/fs/tracing_file_reader.h"
 #include "runtime/define_primitive_type.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
@@ -99,9 +100,7 @@ NewJsonReader::NewJsonReader(RuntimeState* state, RuntimeProfile* profile, Scann
           _scanner_eof(scanner_eof),
           _current_offset(0),
           _io_ctx(io_ctx) {
-    _bytes_read_counter = ADD_COUNTER(_profile, "BytesRead", TUnit::BYTES);
     _read_timer = ADD_TIMER(_profile, "ReadTime");
-    _file_read_timer = ADD_TIMER(_profile, "FileReadTime");
     if (_range.__isset.compress_type) {
         // for compatibility
         _file_compress_type = _range.compress_type;
@@ -443,10 +442,13 @@ Status NewJsonReader::_open_file_reader(bool need_schema) {
         _file_description.mtime = _range.__isset.modification_time ? _range.modification_time : 0;
         io::FileReaderOptions reader_options =
                 FileFactory::get_reader_options(_state, _file_description);
-        _file_reader = DORIS_TRY(io::DelegateReader::create_file_reader(
+        auto file_reader = DORIS_TRY(io::DelegateReader::create_file_reader(
                 _profile, _system_properties, _file_description, reader_options,
                 io::DelegateReader::AccessMode::SEQUENTIAL, _io_ctx,
                 io::PrefetchRange(_range.start_offset, _range.size)));
+        _file_reader = _io_ctx ? std::make_shared<io::TracingFileReader>(std::move(file_reader),
+                                                                         _io_ctx->file_reader_stats)
+                               : file_reader;
     }
     return Status::OK();
 }
@@ -667,7 +669,7 @@ Status NewJsonReader::_parse_json(bool* is_empty_row, bool* eof) {
 // return Status::OK() if parse succeed or reach EOF.
 Status NewJsonReader::_parse_json_doc(size_t* size, bool* eof) {
     // read a whole message
-    SCOPED_TIMER(_file_read_timer);
+    SCOPED_TIMER(_read_timer);
     const uint8_t* json_str = nullptr;
     std::unique_ptr<uint8_t[]> json_str_ptr;
     if (_line_reader != nullptr) {
@@ -680,7 +682,6 @@ Status NewJsonReader::_parse_json_doc(size_t* size, bool* eof) {
         }
     }
 
-    _bytes_read_counter += *size;
     if (*eof) {
         return Status::OK();
     }
@@ -1956,7 +1957,7 @@ Status NewJsonReader::_append_error_msg(simdjson::ondemand::object* obj, std::st
 
 Status NewJsonReader::_simdjson_parse_json(size_t* size, bool* is_empty_row, bool* eof,
                                            simdjson::error_code* error) {
-    SCOPED_TIMER(_file_read_timer);
+    SCOPED_TIMER(_read_timer);
     // step1: read buf from pipe.
     if (_line_reader != nullptr) {
         RETURN_IF_ERROR(_line_reader->read_line(&_json_str, size, eof, _io_ctx));
@@ -2017,7 +2018,7 @@ Status NewJsonReader::_judge_empty_row(size_t size, bool eof, bool* is_empty_row
 
 Status NewJsonReader::_get_json_value(size_t* size, bool* eof, simdjson::error_code* error,
                                       bool* is_empty_row) {
-    SCOPED_TIMER(_file_read_timer);
+    SCOPED_TIMER(_read_timer);
     auto return_quality_error = [&](fmt::memory_buffer& error_msg,
                                     const std::string& doc_info) -> Status {
         _counter->num_rows_filtered++;

--- a/be/src/vec/exec/format/json/new_json_reader.h
+++ b/be/src/vec/exec/format/json/new_json_reader.h
@@ -259,9 +259,7 @@ private:
 
     io::IOContext* _io_ctx = nullptr;
 
-    RuntimeProfile::Counter* _bytes_read_counter = nullptr;
     RuntimeProfile::Counter* _read_timer = nullptr;
-    RuntimeProfile::Counter* _file_read_timer = nullptr;
 
     // ======SIMD JSON======
     // name mapping

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -116,9 +116,6 @@ static constexpr int decimal_scale_for_hive11 = 10;
     M(PrimitiveType::TYPE_DOUBLE, Float64, orc::DoubleVectorBatch)
 
 void ORCFileInputStream::read(void* buf, uint64_t length, uint64_t offset) {
-    _statistics->fs_read_calls++;
-    _statistics->fs_read_bytes += length;
-    SCOPED_RAW_TIMER(&_statistics->fs_read_time);
     uint64_t has_read = 0;
     char* out = reinterpret_cast<char*>(buf);
     while (has_read < length) {
@@ -127,7 +124,7 @@ void ORCFileInputStream::read(void* buf, uint64_t length, uint64_t offset) {
         }
         size_t loop_read;
         Slice result(out + has_read, length - has_read);
-        Status st = _file_reader->read_at(offset + has_read, result, &loop_read, _io_ctx);
+        Status st = _tracing_file_reader->read_at(offset + has_read, result, &loop_read, _io_ctx);
         if (!st.ok()) {
             throw orc::ParseError(
                     absl::Substitute("Failed to read $0: $1", _file_name, st.to_string()));
@@ -144,9 +141,6 @@ void ORCFileInputStream::read(void* buf, uint64_t length, uint64_t offset) {
 }
 
 void StripeStreamInputStream::read(void* buf, uint64_t length, uint64_t offset) {
-    _statistics->fs_read_calls++;
-    _statistics->fs_read_bytes += length;
-    SCOPED_RAW_TIMER(&_statistics->fs_read_time);
     uint64_t has_read = 0;
     char* out = reinterpret_cast<char*>(buf);
     while (has_read < length) {
@@ -220,9 +214,6 @@ OrcReader::~OrcReader() {
 
 void OrcReader::_collect_profile_before_close() {
     if (_profile != nullptr) {
-        COUNTER_UPDATE(_orc_profile.read_time, _statistics.fs_read_time);
-        COUNTER_UPDATE(_orc_profile.read_calls, _statistics.fs_read_calls);
-        COUNTER_UPDATE(_orc_profile.read_bytes, _statistics.fs_read_bytes);
         COUNTER_UPDATE(_orc_profile.column_read_time, _statistics.column_read_time);
         COUNTER_UPDATE(_orc_profile.get_batch_time, _statistics.get_batch_time);
         COUNTER_UPDATE(_orc_profile.create_reader_time, _statistics.create_reader_time);
@@ -248,11 +239,6 @@ void OrcReader::_init_profile() {
     if (_profile != nullptr) {
         static const char* orc_profile = "OrcReader";
         ADD_TIMER_WITH_LEVEL(_profile, orc_profile, 1);
-        _orc_profile.read_time =
-                ADD_TIMER_WITH_LEVEL(_profile, FileScanner::FileReadTimeProfile, 1);
-        _orc_profile.read_calls = ADD_COUNTER_WITH_LEVEL(_profile, "FileReadCalls", TUnit::UNIT, 1);
-        _orc_profile.read_bytes = ADD_COUNTER_WITH_LEVEL(
-                _profile, FileScanner::FileReadBytesProfile, TUnit::BYTES, 1);
         _orc_profile.column_read_time =
                 ADD_CHILD_TIMER_WITH_LEVEL(_profile, "ColumnReadTime", orc_profile, 1);
         _orc_profile.get_batch_time =
@@ -294,7 +280,7 @@ Status OrcReader::_create_file_reader() {
                 _profile, _system_properties, _file_description, reader_options,
                 io::DelegateReader::AccessMode::RANDOM, _io_ctx));
         _file_input_stream = std::make_unique<ORCFileInputStream>(
-                _scan_range.path, std::move(inner_reader), &_statistics, _io_ctx, _profile,
+                _scan_range.path, std::move(inner_reader), _io_ctx, _profile,
                 _orc_once_max_read_bytes, _orc_max_merge_distance_bytes);
     }
     if (_file_input_stream->getLength() == 0) {
@@ -1127,8 +1113,10 @@ Status OrcReader::set_fill_columns(
                 orc_input_stream_ptr->set_all_tiny_stripes();
                 auto& orc_file_reader = orc_input_stream_ptr->get_file_reader();
                 auto orc_inner_reader = orc_input_stream_ptr->get_inner_reader();
-                orc_file_reader = std::make_shared<io::RangeCacheFileReader>(
-                        _profile, orc_inner_reader, range_finder);
+                orc_file_reader = std::make_shared<io::TracingFileReader>(
+                        std::make_shared<io::RangeCacheFileReader>(_profile, orc_inner_reader,
+                                                                   range_finder),
+                        _io_ctx->file_reader_stats);
             }
         }
 
@@ -1865,6 +1853,9 @@ Status OrcReader::get_next_block(Block* block, size_t* read_rows, bool* eof) {
                        _reader_metrics.SelectedRowGroupCount);
         COUNTER_UPDATE(_orc_profile.evaluated_row_group_count,
                        _reader_metrics.EvaluatedRowGroupCount);
+        if (_io_ctx) {
+            _io_ctx->file_reader_stats->read_rows += _reader_metrics.ReadRowCount;
+        }
     }
     if (_orc_filter) {
         RETURN_IF_ERROR(_orc_filter->get_status());
@@ -2791,6 +2782,8 @@ void ORCFileInputStream::_build_small_ranges_input_stripe_streams(
     for (const auto& merged_range : merged_ranges) {
         auto merge_range_file_reader =
                 std::make_shared<OrcMergeRangeFileReader>(_profile, _file_reader, merged_range);
+        auto tracing_file_reader = std::make_shared<io::TracingFileReader>(
+                std::move(merge_range_file_reader), _io_ctx->file_reader_stats);
 
         // Use binary search to find the starting point in sorted_ranges
         auto it =
@@ -2804,7 +2797,7 @@ void ORCFileInputStream::_build_small_ranges_input_stripe_streams(
              ++it) {
             if (it->second.end_offset <= merged_range.end_offset) {
                 auto stripe_stream_input_stream = std::make_shared<StripeStreamInputStream>(
-                        getName(), merge_range_file_reader, _statistics, _io_ctx, _profile);
+                        getName(), tracing_file_reader, _io_ctx, _profile);
                 streams.emplace(it->first, stripe_stream_input_stream);
                 _stripe_streams.emplace_back(stripe_stream_input_stream);
             }
@@ -2817,10 +2810,10 @@ void ORCFileInputStream::_build_large_ranges_input_stripe_streams(
         std::unordered_map<orc::StreamId, std::shared_ptr<InputStream>>& streams) {
     for (const auto& range : ranges) {
         auto stripe_stream_input_stream = std::make_shared<StripeStreamInputStream>(
-                getName(), _file_reader, _statistics, _io_ctx, _profile);
-        streams.emplace(range.first,
-                        std::make_shared<StripeStreamInputStream>(getName(), _file_reader,
-                                                                  _statistics, _io_ctx, _profile));
+                getName(),
+                std::make_shared<io::TracingFileReader>(_file_reader, _io_ctx->file_reader_stats),
+                _io_ctx, _profile);
+        streams.emplace(range.first, stripe_stream_input_stream);
         _stripe_streams.emplace_back(stripe_stream_input_stream);
     }
 }

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -121,6 +121,7 @@ ParquetReader::~ParquetReader() {
     _close_internal();
 }
 
+// for unit test
 void ParquetReader::set_file_reader(io::FileReaderSPtr file_reader) {
     _file_reader = file_reader;
     _tracing_file_reader = file_reader;

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -32,6 +32,7 @@
 #include "io/fs/buffered_reader.h"
 #include "io/fs/file_reader.h"
 #include "io/fs/file_reader_writer_fwd.h"
+#include "io/fs/tracing_file_reader.h"
 #include "parquet_pred_cmp.h"
 #include "parquet_thrift_util.h"
 #include "runtime/define_primitive_type.h"
@@ -120,6 +121,11 @@ ParquetReader::~ParquetReader() {
     _close_internal();
 }
 
+void ParquetReader::set_file_reader(io::FileReaderSPtr file_reader) {
+    _file_reader = file_reader;
+    _tracing_file_reader = file_reader;
+}
+
 void ParquetReader::_init_profile() {
     if (_profile != nullptr) {
         static const char* parquet_profile = "ParquetReader";
@@ -159,15 +165,8 @@ void ParquetReader::_init_profile() {
                 ADD_CHILD_TIMER_WITH_LEVEL(_profile, "PageIndexParseTime", parquet_profile, 1);
         _parquet_profile.row_group_filter_time =
                 ADD_CHILD_TIMER_WITH_LEVEL(_profile, "RowGroupFilterTime", parquet_profile, 1);
-
-        _parquet_profile.file_read_time =
-                ADD_TIMER_WITH_LEVEL(_profile, FileScanner::FileReadTimeProfile, 1);
-        _parquet_profile.file_read_calls =
-                ADD_COUNTER_WITH_LEVEL(_profile, "FileReadCalls", TUnit::UNIT, 1);
         _parquet_profile.file_meta_read_calls =
                 ADD_COUNTER_WITH_LEVEL(_profile, "FileMetaReadCalls", TUnit::UNIT, 1);
-        _parquet_profile.file_read_bytes = ADD_COUNTER_WITH_LEVEL(
-                _profile, FileScanner::FileReadBytesProfile, TUnit::BYTES, 1);
         _parquet_profile.decompress_time =
                 ADD_CHILD_TIMER_WITH_LEVEL(_profile, "DecompressTime", parquet_profile, 1);
         _parquet_profile.decompress_cnt = ADD_CHILD_COUNTER_WITH_LEVEL(
@@ -218,18 +217,22 @@ Status ParquetReader::_open_file() {
         _file_reader = DORIS_TRY(io::DelegateReader::create_file_reader(
                 _profile, _system_properties, _file_description, reader_options,
                 io::DelegateReader::AccessMode::RANDOM, _io_ctx));
+        _tracing_file_reader = _io_ctx ? std::make_shared<io::TracingFileReader>(
+                                                 _file_reader, _io_ctx->file_reader_stats)
+                                       : _file_reader;
     }
     if (_file_metadata == nullptr) {
         SCOPED_RAW_TIMER(&_statistics.parse_footer_time);
-        if (_file_reader->size() <= sizeof(PARQUET_VERSION_NUMBER)) {
+        if (_tracing_file_reader->size() <= sizeof(PARQUET_VERSION_NUMBER)) {
             // Some system may generate parquet file with only 4 bytes: PAR1
             // Should consider it as empty file.
             return Status::EndOfFile("open file failed, empty parquet file {} with size: {}",
-                                     _scan_range.path, _file_reader->size());
+                                     _scan_range.path, _tracing_file_reader->size());
         }
         size_t meta_size = 0;
         if (_meta_cache == nullptr) {
-            auto st = parse_thrift_footer(_file_reader, &_file_metadata, &meta_size, _io_ctx);
+            auto st =
+                    parse_thrift_footer(_tracing_file_reader, &_file_metadata, &meta_size, _io_ctx);
             // wrap it with unique ptr, so that it can be released finally.
             _file_metadata_ptr.reset(_file_metadata);
             RETURN_IF_ERROR(st);
@@ -238,7 +241,7 @@ Status ParquetReader::_open_file() {
             // parse magic number & parse meta data
             _column_statistics.meta_read_calls += 1;
         } else {
-            RETURN_IF_ERROR(_meta_cache->get_parquet_footer(_file_reader, _io_ctx,
+            RETURN_IF_ERROR(_meta_cache->get_parquet_footer(_tracing_file_reader, _io_ctx,
                                                             _file_description.mtime, &meta_size,
                                                             &_meta_cache_handle));
             _column_statistics.read_bytes += meta_size;
@@ -617,9 +620,12 @@ Status ParquetReader::_next_row_group_reader() {
                                               _profile, _file_reader, io_ranges)
                                     : _file_reader;
     }
-    _current_group_reader.reset(new RowGroupReader(
-            group_file_reader, _read_table_columns, row_group_index.row_group_id, row_group, _ctz,
-            _io_ctx, position_delete_ctx, _lazy_read_ctx, _state));
+    _current_group_reader.reset(
+            new RowGroupReader(_io_ctx ? std::make_shared<io::TracingFileReader>(
+                                                 group_file_reader, _io_ctx->file_reader_stats)
+                                       : group_file_reader,
+                               _read_table_columns, row_group_index.row_group_id, row_group, _ctz,
+                               _io_ctx, position_delete_ctx, _lazy_read_ctx, _state));
     _row_group_eof = false;
 
     _current_group_reader->set_current_row_group_idx(row_group_index);
@@ -771,6 +777,9 @@ Status ParquetReader::_process_page_index(const tparquet::RowGroup& row_group,
     std::function<void()> read_whole_row_group = [&]() {
         candidate_row_ranges.emplace_back(0, row_group.num_rows);
         _statistics.read_rows += row_group.num_rows;
+        if (_io_ctx) {
+            _io_ctx->file_reader_stats->read_rows += row_group.num_rows;
+        }
     };
 
     if ((!_enable_filter_by_min_max) || _lazy_read_ctx.has_complex_type ||
@@ -789,8 +798,8 @@ Status ParquetReader::_process_page_index(const tparquet::RowGroup& row_group,
     Slice result(col_index_buff.data(), page_index._column_index_size);
     {
         SCOPED_RAW_TIMER(&_statistics.read_page_index_time);
-        RETURN_IF_ERROR(_file_reader->read_at(page_index._column_index_start, result, &bytes_read,
-                                              _io_ctx));
+        RETURN_IF_ERROR(_tracing_file_reader->read_at(page_index._column_index_start, result,
+                                                      &bytes_read, _io_ctx));
     }
     _column_statistics.read_bytes += bytes_read;
     auto& schema_desc = _file_metadata->schema();
@@ -799,8 +808,8 @@ Status ParquetReader::_process_page_index(const tparquet::RowGroup& row_group,
     Slice res(off_index_buff.data(), page_index._offset_index_size);
     {
         SCOPED_RAW_TIMER(&_statistics.read_page_index_time);
-        RETURN_IF_ERROR(
-                _file_reader->read_at(page_index._offset_index_start, res, &bytes_read, _io_ctx));
+        RETURN_IF_ERROR(_tracing_file_reader->read_at(page_index._offset_index_start, res,
+                                                      &bytes_read, _io_ctx));
     }
     _column_statistics.read_bytes += bytes_read;
     // read twice: parse column index & parse offset index
@@ -879,6 +888,9 @@ Status ParquetReader::_process_page_index(const tparquet::RowGroup& row_group,
         read_rows += row_group.num_rows - skip_end;
     }
     _statistics.read_rows += read_rows;
+    if (_io_ctx) {
+        _io_ctx->file_reader_stats->read_rows += read_rows;
+    }
     _statistics.filtered_page_rows += row_group.num_rows - read_rows;
     return Status::OK();
 }
@@ -1050,10 +1062,7 @@ void ParquetReader::_collect_profile() {
                    _column_statistics.parse_page_header_num);
     COUNTER_UPDATE(_parquet_profile.predicate_filter_time, _statistics.predicate_filter_time);
     COUNTER_UPDATE(_parquet_profile.dict_filter_rewrite_time, _statistics.dict_filter_rewrite_time);
-    COUNTER_UPDATE(_parquet_profile.file_read_time, _column_statistics.read_time);
-    COUNTER_UPDATE(_parquet_profile.file_read_calls, _column_statistics.read_calls);
     COUNTER_UPDATE(_parquet_profile.file_meta_read_calls, _column_statistics.meta_read_calls);
-    COUNTER_UPDATE(_parquet_profile.file_read_bytes, _column_statistics.read_bytes);
     COUNTER_UPDATE(_parquet_profile.decompress_time, _column_statistics.decompress_time);
     COUNTER_UPDATE(_parquet_profile.decompress_cnt, _column_statistics.decompress_cnt);
     COUNTER_UPDATE(_parquet_profile.decode_header_time, _column_statistics.decode_header_time);

--- a/be/src/vec/exec/format/parquet/vparquet_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.h
@@ -104,7 +104,7 @@ public:
                   io::IOContext* io_ctx, RuntimeState* state, bool enable_lazy_mat = true);
 
     ~ParquetReader() override;
-    // for test
+    // for unit test
     void set_file_reader(io::FileReaderSPtr file_reader);
 
     Status init_reader(
@@ -251,6 +251,10 @@ private:
     FileMetaData* _file_metadata = nullptr;
     const tparquet::FileMetaData* _t_metadata = nullptr;
 
+    // _tracing_file_reader wraps _file_reader.
+    // _file_reader is original file reader.
+    // _tracing_file_reader is tracing file reader with io context.
+    // If io_ctx is null, _tracing_file_reader will be the same as file_reader.
     io::FileReaderSPtr _file_reader = nullptr;
     io::FileReaderSPtr _tracing_file_reader = nullptr;
     std::unique_ptr<RowGroupReader> _current_group_reader;

--- a/be/src/vec/exec/format/parquet/vparquet_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.h
@@ -105,7 +105,7 @@ public:
 
     ~ParquetReader() override;
     // for test
-    void set_file_reader(io::FileReaderSPtr file_reader) { _file_reader = file_reader; }
+    void set_file_reader(io::FileReaderSPtr file_reader);
 
     Status init_reader(
             const std::vector<std::string>& all_column_names,
@@ -157,6 +157,8 @@ public:
         _row_id_column_iterator_pair = iterator_pair;
     }
 
+    bool count_read_rows() override { return true; }
+
 protected:
     void _collect_profile_before_close() override;
 
@@ -180,10 +182,7 @@ private:
         RuntimeProfile::Counter* read_page_index_time = nullptr;
         RuntimeProfile::Counter* parse_page_index_time = nullptr;
 
-        RuntimeProfile::Counter* file_read_time = nullptr;
-        RuntimeProfile::Counter* file_read_calls = nullptr;
         RuntimeProfile::Counter* file_meta_read_calls = nullptr;
-        RuntimeProfile::Counter* file_read_bytes = nullptr;
         RuntimeProfile::Counter* decompress_time = nullptr;
         RuntimeProfile::Counter* decompress_cnt = nullptr;
         RuntimeProfile::Counter* decode_header_time = nullptr;
@@ -253,6 +252,7 @@ private:
     const tparquet::FileMetaData* _t_metadata = nullptr;
 
     io::FileReaderSPtr _file_reader = nullptr;
+    io::FileReaderSPtr _tracing_file_reader = nullptr;
     std::unique_ptr<RowGroupReader> _current_group_reader;
     // read to the end of current reader
     bool _row_group_eof = true;

--- a/be/src/vec/exec/format/table/table_format_reader.h
+++ b/be/src/vec/exec/format/table/table_format_reader.h
@@ -103,6 +103,8 @@ public:
 
     virtual Status init_row_filters() = 0;
 
+    bool count_read_rows() override { return _file_format_reader->count_read_rows(); }
+
 protected:
     std::string _table_format;                          // hudi, iceberg, paimon
     std::unique_ptr<GenericReader> _file_format_reader; // parquet, orc

--- a/be/src/vec/exec/scan/file_scanner.h
+++ b/be/src/vec/exec/scan/file_scanner.h
@@ -99,6 +99,8 @@ public:
 
     Status prepare_for_read_lines(const TFileRangeDesc& range);
 
+    void update_realtime_counters() override;
+
 protected:
     Status _get_block_impl(RuntimeState* state, Block* block, bool* eof) override;
 
@@ -183,6 +185,7 @@ protected:
     Block _runtime_filter_partition_prune_block;
 
     std::unique_ptr<io::FileCacheStatistics> _file_cache_statistics;
+    std::unique_ptr<io::FileReaderStats> _file_reader_stats;
     std::unique_ptr<io::IOContext> _io_ctx;
 
     std::unordered_map<std::string, std::tuple<std::string, const SlotDescriptor*>>
@@ -204,6 +207,9 @@ private:
     RuntimeProfile::Counter* _empty_file_counter = nullptr;
     RuntimeProfile::Counter* _not_found_file_counter = nullptr;
     RuntimeProfile::Counter* _file_counter = nullptr;
+    RuntimeProfile::Counter* _file_read_bytes_counter = nullptr;
+    RuntimeProfile::Counter* _file_read_calls_counter = nullptr;
+    RuntimeProfile::Counter* _file_read_time_counter = nullptr;
     RuntimeProfile::Counter* _runtime_filter_partition_pruned_range_counter = nullptr;
 
     const std::unordered_map<std::string, int>* _col_name_to_slot_id = nullptr;

--- a/be/src/vec/exec/scan/olap_scanner.cpp
+++ b/be/src/vec/exec/scan/olap_scanner.cpp
@@ -553,17 +553,22 @@ void OlapScanner::update_realtime_counters() {
     _state->get_query_ctx()->resource_ctx()->io_context()->update_scan_rows(stats.raw_rows_read);
     _state->get_query_ctx()->resource_ctx()->io_context()->update_scan_bytes(
             stats.uncompressed_bytes_read);
-    _state->get_query_ctx()->resource_ctx()->io_context()->update_scan_bytes_from_local_storage(
-            stats.file_cache_stats.bytes_read_from_local);
-    _state->get_query_ctx()->resource_ctx()->io_context()->update_scan_bytes_from_remote_storage(
-            stats.file_cache_stats.bytes_read_from_remote);
 
     // In case of no cache, we still need to update the IO stats. uncompressed bytes read == local + remote
     if (stats.file_cache_stats.bytes_read_from_local == 0 &&
         stats.file_cache_stats.bytes_read_from_remote == 0) {
+        _state->get_query_ctx()->resource_ctx()->io_context()->update_scan_bytes_from_local_storage(
+                stats.compressed_bytes_read);
         DorisMetrics::instance()->query_scan_bytes_from_local->increment(
                 stats.compressed_bytes_read);
     } else {
+        _state->get_query_ctx()->resource_ctx()->io_context()->update_scan_bytes_from_local_storage(
+                stats.file_cache_stats.bytes_read_from_local);
+        _state->get_query_ctx()
+                ->resource_ctx()
+                ->io_context()
+                ->update_scan_bytes_from_remote_storage(
+                        stats.file_cache_stats.bytes_read_from_remote);
         DorisMetrics::instance()->query_scan_bytes_from_local->increment(
                 stats.file_cache_stats.bytes_read_from_local);
         DorisMetrics::instance()->query_scan_bytes_from_remote->increment(

--- a/be/test/vec/exec/orc/orc_read_lines.cpp
+++ b/be/test/vec/exec/orc/orc_read_lines.cpp
@@ -115,6 +115,8 @@ static void read_orc_line(int64_t line, std::string block_dump) {
     range.__isset.table_format_params = true;
 
     io::IOContext io_ctx;
+    io::FileReaderStats file_reader_stats;
+    io_ctx.file_reader_stats = &file_reader_stats;
     std::string time_zone = "CST";
     auto reader = OrcReader::create_unique(nullptr, runtime_state.get(), params, range, 100,
                                            time_zone, &io_ctx, true);


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

### Release note

The external part is implemented according to the framework defined by the unified audit log, Doris metrics, and scanbytes and scan rows in Profile in #52232.

However,
- Scan bytes in the external table currently represents the bytes counted by **the top-level File Reader** called by the scan reader layer. 
- Scan rows represents the number of scanned rows of the underlying storage. The number of scanned rows of parquet/orc does not include the number of rows of skipped page/rowgroup. **Note: However, there is still a problem that `jni_reader` has not yet implemented the number of rows that only contain the storage to be read.**

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

