### PR TITLE
[refractor](filecache) clean file cache profile code

### DIFF
--- a/be/src/io/cache/block_file_cache_profile.cpp
+++ b/be/src/io/cache/block_file_cache_profile.cpp
@@ -25,40 +25,111 @@
 
 namespace doris::io {
 
-std::shared_ptr<AtomicStatistics> FileCacheProfile::report() {
-    std::shared_ptr<AtomicStatistics> stats = std::make_shared<AtomicStatistics>();
+std::shared_ptr<AtomicStatistics> FileCacheMetrics::report() {
+    std::shared_ptr<AtomicStatistics> output_stats = std::make_shared<AtomicStatistics>();
     std::lock_guard lock(_mtx);
-    stats->num_io_bytes_read_from_cache += _profile->num_io_bytes_read_from_cache;
-    stats->num_io_bytes_read_from_remote += _profile->num_io_bytes_read_from_remote;
-    return stats;
+    output_stats->num_io_bytes_read_from_cache += _statistics->num_io_bytes_read_from_cache;
+    output_stats->num_io_bytes_read_from_remote += _statistics->num_io_bytes_read_from_remote;
+    return output_stats;
 }
 
-void FileCacheProfile::update(FileCacheStatistics* stats) {
-    if (_profile == nullptr) {
+void FileCacheMetrics::update(FileCacheStatistics* input_stats) {
+    if (_statistics == nullptr) {
         std::lock_guard<std::mutex> lock(_mtx);
-        if (_profile == nullptr) {
-            _profile = std::make_shared<AtomicStatistics>();
-            _file_cache_metric = std::make_shared<FileCacheMetric>(this);
-            _file_cache_metric->register_entity();
+        if (_statistics == nullptr) {
+            _statistics = std::make_shared<AtomicStatistics>();
+            register_entity();
         }
     }
-    _profile->num_io_bytes_read_from_cache += stats->bytes_read_from_local;
-    _profile->num_io_bytes_read_from_remote += stats->bytes_read_from_remote;
+    _statistics->num_io_bytes_read_from_cache += input_stats->bytes_read_from_local;
+    _statistics->num_io_bytes_read_from_remote += input_stats->bytes_read_from_remote;
 }
 
-void FileCacheMetric::register_entity() {
-    DorisMetrics::instance()->server_entity()->register_hook("block_file_cache",
-                                                             [this]() { update_table_metrics(); });
+void FileCacheMetrics::register_entity() {
+    DorisMetrics::instance()->server_entity()->register_hook(
+            "block_file_cache", [this]() { update_metrics_callback(); });
 }
 
-void FileCacheMetric::update_table_metrics() const {
-    auto stats = profile->report();
+void FileCacheMetrics::update_metrics_callback() {
+    std::shared_ptr<AtomicStatistics> stats = report();
     DorisMetrics::instance()->num_io_bytes_read_from_cache->set_value(
             stats->num_io_bytes_read_from_cache);
     DorisMetrics::instance()->num_io_bytes_read_from_remote->set_value(
             stats->num_io_bytes_read_from_remote);
     DorisMetrics::instance()->num_io_bytes_read_total->set_value(
             stats->num_io_bytes_read_from_cache + stats->num_io_bytes_read_from_remote);
+}
+
+FileCacheProfileReporter::FileCacheProfileReporter(RuntimeProfile* profile) {
+    static const char* cache_profile = "FileCache";
+    ADD_TIMER_WITH_LEVEL(profile, cache_profile, 1);
+    num_local_io_total =
+            ADD_CHILD_COUNTER_WITH_LEVEL(profile, "NumLocalIOTotal", TUnit::UNIT, cache_profile, 1);
+    num_remote_io_total = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "NumRemoteIOTotal", TUnit::UNIT,
+                                                       cache_profile, 1);
+    local_io_timer = ADD_CHILD_TIMER_WITH_LEVEL(profile, "LocalIOUseTimer", cache_profile, 1);
+    remote_io_timer = ADD_CHILD_TIMER_WITH_LEVEL(profile, "RemoteIOUseTimer", cache_profile, 1);
+    write_cache_io_timer =
+            ADD_CHILD_TIMER_WITH_LEVEL(profile, "WriteCacheIOUseTimer", cache_profile, 1);
+    bytes_write_into_cache = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "BytesWriteIntoCache",
+                                                          TUnit::BYTES, cache_profile, 1);
+    num_skip_cache_io_total = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "NumSkipCacheIOTotal",
+                                                           TUnit::UNIT, cache_profile, 1);
+    bytes_scanned_from_cache = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "BytesScannedFromCache",
+                                                            TUnit::BYTES, cache_profile, 1);
+    bytes_scanned_from_remote = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "BytesScannedFromRemote",
+                                                             TUnit::BYTES, cache_profile, 1);
+    read_cache_file_directly_timer =
+            ADD_CHILD_TIMER_WITH_LEVEL(profile, "ReadCacheFileDirectlyTimer", cache_profile, 1);
+    cache_get_or_set_timer =
+            ADD_CHILD_TIMER_WITH_LEVEL(profile, "CacheGetOrSetTimer", cache_profile, 1);
+    lock_wait_timer = ADD_CHILD_TIMER_WITH_LEVEL(profile, "LockWaitTimer", cache_profile, 1);
+    get_timer = ADD_CHILD_TIMER_WITH_LEVEL(profile, "GetTimer", cache_profile, 1);
+    set_timer = ADD_CHILD_TIMER_WITH_LEVEL(profile, "SetTimer", cache_profile, 1);
+
+    inverted_index_num_local_io_total = ADD_CHILD_COUNTER_WITH_LEVEL(
+            profile, "InvertedIndexNumLocalIOTotal", TUnit::UNIT, cache_profile, 1);
+    inverted_index_num_remote_io_total = ADD_CHILD_COUNTER_WITH_LEVEL(
+            profile, "InvertedIndexNumRemoteIOTotal", TUnit::UNIT, cache_profile, 1);
+    inverted_index_bytes_scanned_from_cache = ADD_CHILD_COUNTER_WITH_LEVEL(
+            profile, "InvertedIndexBytesScannedFromCache", TUnit::BYTES, cache_profile, 1);
+    inverted_index_bytes_scanned_from_remote = ADD_CHILD_COUNTER_WITH_LEVEL(
+            profile, "InvertedIndexBytesScannedFromRemote", TUnit::BYTES, cache_profile, 1);
+    inverted_index_local_io_timer =
+            ADD_CHILD_TIMER_WITH_LEVEL(profile, "InvertedIndexLocalIOUseTimer", cache_profile, 1);
+    inverted_index_remote_io_timer =
+            ADD_CHILD_TIMER_WITH_LEVEL(profile, "InvertedIndexRemoteIOUseTimer", cache_profile, 1);
+    inverted_index_io_timer =
+            ADD_CHILD_TIMER_WITH_LEVEL(profile, "InvertedIndexIOTimer", cache_profile, 1);
+}
+
+void FileCacheProfileReporter::update(const FileCacheStatistics* statistics) const {
+    COUNTER_UPDATE(num_local_io_total, statistics->num_local_io_total);
+    COUNTER_UPDATE(num_remote_io_total, statistics->num_remote_io_total);
+    COUNTER_UPDATE(local_io_timer, statistics->local_io_timer);
+    COUNTER_UPDATE(remote_io_timer, statistics->remote_io_timer);
+    COUNTER_UPDATE(write_cache_io_timer, statistics->write_cache_io_timer);
+    COUNTER_UPDATE(bytes_write_into_cache, statistics->bytes_write_into_cache);
+    COUNTER_UPDATE(num_skip_cache_io_total, statistics->num_skip_cache_io_total);
+    COUNTER_UPDATE(bytes_scanned_from_cache, statistics->bytes_read_from_local);
+    COUNTER_UPDATE(bytes_scanned_from_remote, statistics->bytes_read_from_remote);
+    COUNTER_UPDATE(read_cache_file_directly_timer, statistics->read_cache_file_directly_timer);
+    COUNTER_UPDATE(cache_get_or_set_timer, statistics->cache_get_or_set_timer);
+    COUNTER_UPDATE(lock_wait_timer, statistics->lock_wait_timer);
+    COUNTER_UPDATE(get_timer, statistics->get_timer);
+    COUNTER_UPDATE(set_timer, statistics->set_timer);
+
+    COUNTER_UPDATE(inverted_index_num_local_io_total,
+                   statistics->inverted_index_num_local_io_total);
+    COUNTER_UPDATE(inverted_index_num_remote_io_total,
+                   statistics->inverted_index_num_remote_io_total);
+    COUNTER_UPDATE(inverted_index_bytes_scanned_from_cache,
+                   statistics->inverted_index_bytes_read_from_local);
+    COUNTER_UPDATE(inverted_index_bytes_scanned_from_remote,
+                   statistics->inverted_index_bytes_read_from_remote);
+    COUNTER_UPDATE(inverted_index_local_io_timer, statistics->inverted_index_local_io_timer);
+    COUNTER_UPDATE(inverted_index_remote_io_timer, statistics->inverted_index_remote_io_timer);
+    COUNTER_UPDATE(inverted_index_io_timer, statistics->inverted_index_io_timer);
 }
 
 } // namespace doris::io

--- a/be/src/io/cache/block_file_cache_profile.h
+++ b/be/src/io/cache/block_file_cache_profile.h
@@ -38,38 +38,29 @@ struct AtomicStatistics {
     std::atomic<int64_t> num_io_bytes_read_from_cache = 0;
     std::atomic<int64_t> num_io_bytes_read_from_remote = 0;
 };
-
-struct FileCacheProfile;
-
-struct FileCacheMetric {
-    FileCacheMetric(FileCacheProfile* profile) : profile(profile) {}
-
-    void register_entity();
-    void update_table_metrics() const;
-
-    FileCacheMetric& operator=(const FileCacheMetric&) = delete;
-    FileCacheMetric(const FileCacheMetric&) = delete;
-    FileCacheProfile* profile = nullptr;
-};
-
-struct FileCacheProfile {
-    static FileCacheProfile& instance() {
-        static FileCacheProfile s_profile;
-        return s_profile;
+class FileCacheMetrics {
+public:
+    static FileCacheMetrics& instance() {
+        static FileCacheMetrics s_metrics;
+        return s_metrics;
     }
 
-    FileCacheProfile() {
+    FileCacheMetrics() {
         FileCacheStatistics stats;
         update(&stats);
     }
 
     void update(FileCacheStatistics* stats);
 
+private:
+    std::shared_ptr<AtomicStatistics> report();
+    void register_entity();
+    void update_metrics_callback();
+
+private:
     std::mutex _mtx;
     // use shared_ptr for concurrent
-    std::shared_ptr<AtomicStatistics> _profile;
-    std::shared_ptr<FileCacheMetric> _file_cache_metric;
-    std::shared_ptr<AtomicStatistics> report();
+    std::shared_ptr<AtomicStatistics> _statistics;
 };
 
 struct FileCacheProfileReporter {
@@ -96,77 +87,8 @@ struct FileCacheProfileReporter {
     RuntimeProfile::Counter* inverted_index_remote_io_timer = nullptr;
     RuntimeProfile::Counter* inverted_index_io_timer = nullptr;
 
-    FileCacheProfileReporter(RuntimeProfile* profile) {
-        static const char* cache_profile = "FileCache";
-        ADD_TIMER_WITH_LEVEL(profile, cache_profile, 1);
-        num_local_io_total = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "NumLocalIOTotal", TUnit::UNIT,
-                                                          cache_profile, 1);
-        num_remote_io_total = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "NumRemoteIOTotal", TUnit::UNIT,
-                                                           cache_profile, 1);
-        local_io_timer = ADD_CHILD_TIMER_WITH_LEVEL(profile, "LocalIOUseTimer", cache_profile, 1);
-        remote_io_timer = ADD_CHILD_TIMER_WITH_LEVEL(profile, "RemoteIOUseTimer", cache_profile, 1);
-        write_cache_io_timer =
-                ADD_CHILD_TIMER_WITH_LEVEL(profile, "WriteCacheIOUseTimer", cache_profile, 1);
-        bytes_write_into_cache = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "BytesWriteIntoCache",
-                                                              TUnit::BYTES, cache_profile, 1);
-        num_skip_cache_io_total = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "NumSkipCacheIOTotal",
-                                                               TUnit::UNIT, cache_profile, 1);
-        bytes_scanned_from_cache = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "BytesScannedFromCache",
-                                                                TUnit::BYTES, cache_profile, 1);
-        bytes_scanned_from_remote = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "BytesScannedFromRemote",
-                                                                 TUnit::BYTES, cache_profile, 1);
-        read_cache_file_directly_timer =
-                ADD_CHILD_TIMER_WITH_LEVEL(profile, "ReadCacheFileDirectlyTimer", cache_profile, 1);
-        cache_get_or_set_timer =
-                ADD_CHILD_TIMER_WITH_LEVEL(profile, "CacheGetOrSetTimer", cache_profile, 1);
-        lock_wait_timer = ADD_CHILD_TIMER_WITH_LEVEL(profile, "LockWaitTimer", cache_profile, 1);
-        get_timer = ADD_CHILD_TIMER_WITH_LEVEL(profile, "GetTimer", cache_profile, 1);
-        set_timer = ADD_CHILD_TIMER_WITH_LEVEL(profile, "SetTimer", cache_profile, 1);
-
-        inverted_index_num_local_io_total = ADD_CHILD_COUNTER_WITH_LEVEL(
-                profile, "InvertedIndexNumLocalIOTotal", TUnit::UNIT, cache_profile, 1);
-        inverted_index_num_remote_io_total = ADD_CHILD_COUNTER_WITH_LEVEL(
-                profile, "InvertedIndexNumRemoteIOTotal", TUnit::UNIT, cache_profile, 1);
-        inverted_index_bytes_scanned_from_cache = ADD_CHILD_COUNTER_WITH_LEVEL(
-                profile, "InvertedIndexBytesScannedFromCache", TUnit::BYTES, cache_profile, 1);
-        inverted_index_bytes_scanned_from_remote = ADD_CHILD_COUNTER_WITH_LEVEL(
-                profile, "InvertedIndexBytesScannedFromRemote", TUnit::BYTES, cache_profile, 1);
-        inverted_index_local_io_timer = ADD_CHILD_TIMER_WITH_LEVEL(
-                profile, "InvertedIndexLocalIOUseTimer", cache_profile, 1);
-        inverted_index_remote_io_timer = ADD_CHILD_TIMER_WITH_LEVEL(
-                profile, "InvertedIndexRemoteIOUseTimer", cache_profile, 1);
-        inverted_index_io_timer =
-                ADD_CHILD_TIMER_WITH_LEVEL(profile, "InvertedIndexIOTimer", cache_profile, 1);
-    }
-
-    void update(const FileCacheStatistics* statistics) const {
-        COUNTER_UPDATE(num_local_io_total, statistics->num_local_io_total);
-        COUNTER_UPDATE(num_remote_io_total, statistics->num_remote_io_total);
-        COUNTER_UPDATE(local_io_timer, statistics->local_io_timer);
-        COUNTER_UPDATE(remote_io_timer, statistics->remote_io_timer);
-        COUNTER_UPDATE(write_cache_io_timer, statistics->write_cache_io_timer);
-        COUNTER_UPDATE(bytes_write_into_cache, statistics->bytes_write_into_cache);
-        COUNTER_UPDATE(num_skip_cache_io_total, statistics->num_skip_cache_io_total);
-        COUNTER_UPDATE(bytes_scanned_from_cache, statistics->bytes_read_from_local);
-        COUNTER_UPDATE(bytes_scanned_from_remote, statistics->bytes_read_from_remote);
-        COUNTER_UPDATE(read_cache_file_directly_timer, statistics->read_cache_file_directly_timer);
-        COUNTER_UPDATE(cache_get_or_set_timer, statistics->cache_get_or_set_timer);
-        COUNTER_UPDATE(lock_wait_timer, statistics->lock_wait_timer);
-        COUNTER_UPDATE(get_timer, statistics->get_timer);
-        COUNTER_UPDATE(set_timer, statistics->set_timer);
-
-        COUNTER_UPDATE(inverted_index_num_local_io_total,
-                       statistics->inverted_index_num_local_io_total);
-        COUNTER_UPDATE(inverted_index_num_remote_io_total,
-                       statistics->inverted_index_num_remote_io_total);
-        COUNTER_UPDATE(inverted_index_bytes_scanned_from_cache,
-                       statistics->inverted_index_bytes_read_from_local);
-        COUNTER_UPDATE(inverted_index_bytes_scanned_from_remote,
-                       statistics->inverted_index_bytes_read_from_remote);
-        COUNTER_UPDATE(inverted_index_local_io_timer, statistics->inverted_index_local_io_timer);
-        COUNTER_UPDATE(inverted_index_remote_io_timer, statistics->inverted_index_remote_io_timer);
-        COUNTER_UPDATE(inverted_index_io_timer, statistics->inverted_index_io_timer);
-    }
+    FileCacheProfileReporter(RuntimeProfile* profile);
+    void update(const FileCacheStatistics* statistics) const;
 };
 
 } // namespace io

--- a/be/src/io/cache/cached_remote_file_reader.cpp
+++ b/be/src/io/cache/cached_remote_file_reader.cpp
@@ -134,7 +134,7 @@ Status CachedRemoteFileReader::read_at_impl(size_t offset, Slice result, size_t*
             // update stats increment in this reading procedure for file cache metrics
             FileCacheStatistics fcache_stats_increment;
             _update_stats(stats, &fcache_stats_increment, io_ctx->is_inverted_index);
-            io::FileCacheProfile::instance().update(&fcache_stats_increment);
+            io::FileCacheMetrics::instance().update(&fcache_stats_increment);
         }
     };
     std::unique_ptr<int, decltype(defer_func)> defer((int*)0x01, std::move(defer_func));


### PR DESCRIPTION
Rename FileCacheProfile from its misleading name to proper one 'FileCacheMetrics', and simplify the metrics updating structure by eliminating the unnecessary class 'FileCacheMetric'

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

