### PR TITLE
[fix](load) quorum success write should consider data skew

### DIFF
--- a/be/src/vec/sink/load_stream_stub.cpp
+++ b/be/src/vec/sink/load_stream_stub.cpp
@@ -229,7 +229,6 @@ Status LoadStreamStub::append_data(int64_t partition_id, int64_t index_id, int64
     header.set_offset(offset);
     header.set_opcode(doris::PStreamHeader::APPEND_DATA);
     header.set_file_type(file_type);
-    add_write_tablets(tablet_id);
     return _encode_and_send(header, data);
 }
 
@@ -254,7 +253,6 @@ Status LoadStreamStub::add_segment(int64_t partition_id, int64_t index_id, int64
     if (flush_schema != nullptr) {
         flush_schema->to_schema_pb(header.mutable_flush_schema());
     }
-    add_write_tablets(tablet_id);
     return _encode_and_send(header);
 }
 

--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -226,16 +226,6 @@ public:
         return _bytes_written;
     }
 
-    void add_write_tablets(int64_t tablet_id) {
-        std::lock_guard<bthread::Mutex> lock(_write_mutex);
-        _write_tablets.insert(tablet_id);
-    }
-
-    std::set<int64_t> write_tablets() {
-        std::lock_guard<bthread::Mutex> lock(_write_mutex);
-        return _write_tablets;
-    }
-
     Status check_cancel() {
         DBUG_EXECUTE_IF("LoadStreamStub._check_cancel.cancelled",
                         { return Status::InternalError("stream cancelled"); });
@@ -288,7 +278,6 @@ protected:
     bool _is_incremental = false;
 
     bthread::Mutex _write_mutex;
-    std::set<int64_t> _write_tablets;
     size_t _bytes_written = 0;
 };
 

--- a/be/src/vec/sink/writer/vtablet_writer.h
+++ b/be/src/vec/sink/writer/vtablet_writer.h
@@ -329,10 +329,6 @@ public:
     bool is_incremental() const { return _is_incremental; }
 
     int64_t write_bytes() const { return _write_bytes.load(); }
-    std::unordered_set<int64_t> write_tablets() {
-        std::lock_guard<std::mutex> l(_write_tablets_lock);
-        return _write_tablets;
-    }
 
 protected:
     // make a real open request for relative BE's load channel.
@@ -437,9 +433,7 @@ protected:
 
     bool _is_incremental;
 
-    std::mutex _write_tablets_lock;
     std::atomic<int64_t> _write_bytes {0};
-    std::unordered_set<int64_t> _write_tablets;
 };
 
 // an IndexChannel is related to specific table and its rollup and mv
@@ -571,7 +565,7 @@ private:
     int _load_required_replicas_num(int64_t tablet_id);
 
     bool _quorum_success(const std::unordered_set<int64_t>& unfinished_node_channel_ids,
-                         const std::unordered_set<int64_t>& write_tablets);
+                         const std::unordered_set<int64_t>& need_finish_tablets);
 
     int64_t _calc_max_wait_time_ms(const std::unordered_set<int64_t>& unfinished_node_channel_ids);
 

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -108,6 +108,7 @@ Status VTabletWriterV2::_incremental_open_streams(
                         continue;
                     }
                     _indexes_from_node[node].emplace_back(tablet);
+                    _tablets_by_node[node].emplace(tablet_id);
                     known_indexes.insert(index.index_id);
                     VLOG_DEBUG << "incremental open stream (" << partition->id << ", " << tablet_id
                                << ")";
@@ -346,6 +347,7 @@ Status VTabletWriterV2::_build_tablet_node_mapping() {
                         continue;
                     }
                     _indexes_from_node[node].emplace_back(tablet);
+                    _tablets_by_node[node].emplace(tablet_id);
                     known_indexes.insert(index.index_id);
                 }
                 _build_tablet_replica_info(tablet_id, partition);
@@ -501,10 +503,6 @@ Status VTabletWriterV2::write(RuntimeState* state, Block& input_block) {
     // For each tablet, send its input_rows from block to delta writer
     for (const auto& [tablet_id, rows] : rows_for_tablet) {
         RETURN_IF_ERROR(_write_memtable(block, tablet_id, rows));
-        {
-            std::lock_guard<std::mutex> l(_write_tablets_lock);
-            _write_tablets.insert(tablet_id);
-        }
     }
 
     COUNTER_SET(_input_rows_counter, _number_input_rows);
@@ -759,13 +757,24 @@ Status VTabletWriterV2::_close_wait(
     Status status;
     auto streams_for_node = _load_stream_map->get_streams_for_node();
     // 1. first wait for quorum success
+    std::unordered_set<int64_t> need_finish_tablets;
+    auto partition_ids = _tablet_finder->partition_ids();
+    for (const auto& part : _vpartition->get_partitions()) {
+        if (partition_ids.contains(part->id)) {
+            for (const auto& index : part->indexes) {
+                for (const auto& tablet_id : index.tablets) {
+                    need_finish_tablets.insert(tablet_id);
+                }
+            }
+        }
+    }
     while (true) {
         RETURN_IF_ERROR(_check_timeout());
         RETURN_IF_ERROR(_check_streams_finish(unfinished_streams, status, streams_for_node));
-        bool quorum_success = _quorum_success(unfinished_streams);
+        bool quorum_success = _quorum_success(unfinished_streams, need_finish_tablets);
         if (quorum_success || unfinished_streams.empty()) {
             LOG(INFO) << "quorum_success: " << quorum_success
-                      << ", is all unfinished: " << unfinished_streams.empty()
+                      << ", is all finished: " << unfinished_streams.empty()
                       << ", txn_id: " << _txn_id << ", load_id: " << print_id(_load_id);
             break;
         }
@@ -805,21 +814,19 @@ Status VTabletWriterV2::_close_wait(
 }
 
 bool VTabletWriterV2::_quorum_success(
-        const std::unordered_set<std::shared_ptr<LoadStreamStub>>& unfinished_streams) {
+        const std::unordered_set<std::shared_ptr<LoadStreamStub>>& unfinished_streams,
+        const std::unordered_set<int64_t>& need_finish_tablets) {
     if (!config::enable_quorum_success_write) {
         return false;
     }
-    {
-        std::lock_guard<std::mutex> l(_write_tablets_lock);
-        if (_write_tablets.empty()) {
-            return false;
-        }
-    }
-    std::unordered_map<int64_t, int64_t> finished_tablets_replica;
     auto streams_for_node = _load_stream_map->get_streams_for_node();
-    std::unordered_set<int64_t> finished_dst_ids;
+    if (need_finish_tablets.empty()) [[unlikely]] {
+        return false;
+    }
 
     // 1. calculate finished tablets replica num
+    std::unordered_set<int64_t> finished_dst_ids;
+    std::unordered_map<int64_t, int64_t> finished_tablets_replica;
     for (const auto& [dst_id, streams] : streams_for_node) {
         bool finished = true;
         for (const auto& stream : streams->streams()) {
@@ -832,24 +839,19 @@ bool VTabletWriterV2::_quorum_success(
             finished_dst_ids.insert(dst_id);
         }
     }
-    for (const auto& [dst_id, streams] : streams_for_node) {
+    for (const auto& [dst_id, _] : streams_for_node) {
         if (!finished_dst_ids.contains(dst_id)) {
             continue;
         }
-        for (const auto& stream : streams->streams()) {
-            for (auto tablet_id : stream->write_tablets()) {
-                finished_tablets_replica[tablet_id]++;
-            }
+        for (const auto& tablet_id : _tablets_by_node[dst_id]) {
+            finished_tablets_replica[tablet_id]++;
         }
     }
 
     // 2. check if quorum success
-    {
-        std::lock_guard<std::mutex> l(_write_tablets_lock);
-        for (const auto& tablet_id : _write_tablets) {
-            if (finished_tablets_replica[tablet_id] < _load_required_replicas_num(tablet_id)) {
-                return false;
-            }
+    for (const auto& tablet_id : need_finish_tablets) {
+        if (finished_tablets_replica[tablet_id] < _load_required_replicas_num(tablet_id)) {
+            return false;
         }
     }
     return true;

--- a/be/src/vec/sink/writer/vtablet_writer_v2.h
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.h
@@ -156,7 +156,8 @@ private:
                        bool need_wait_after_quorum_success);
 
     bool _quorum_success(
-            const std::unordered_set<std::shared_ptr<LoadStreamStub>>& unfinished_streams);
+            const std::unordered_set<std::shared_ptr<LoadStreamStub>>& unfinished_streams,
+            const std::unordered_set<int64_t>& need_finish_tablets);
 
     int _load_required_replicas_num(int64_t tablet_id);
 
@@ -243,6 +244,7 @@ private:
 
     std::unordered_map<int64_t, std::unordered_map<int64_t, PTabletID>> _tablets_for_node;
     std::unordered_map<int64_t, std::vector<PTabletID>> _indexes_from_node;
+    std::unordered_map<int64_t, std::unordered_set<int64_t>> _tablets_by_node;
 
     std::shared_ptr<LoadStreamMap> _load_stream_map;
 
@@ -254,8 +256,6 @@ private:
 
     // tablet_id -> <total replicas num, load required replicas num>
     std::unordered_map<int64_t, std::pair<int, int>> _tablet_replica_info;
-    std::mutex _write_tablets_lock;
-    std::unordered_set<int64_t> _write_tablets;
 };
 
 } // namespace vectorized


### PR DESCRIPTION
### What problem does this PR solve?

Under the condition of data skewing, if only a portion of the partitioned tablets are written, success can only be returned after all the partitioned tablets meet the majority success criteria.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

