### PR TITLE
[fix](job) fix NullPointerException when replay job

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -1684,7 +1684,7 @@ public abstract class RoutineLoadJob
     }
 
     public void setCloudCluster() {
-        if (this.cloudCluster.isEmpty()) {
+        if (Strings.isNullOrEmpty(cloudCluster)) {
             this.cloudCluster = ((CloudSystemInfoService) Env.getCurrentSystemInfo())
                     .getClusterNameByClusterId(cloudClusterId);
         }


### PR DESCRIPTION
### What problem does this PR solve?

introduce by https://github.com/apache/doris/pull/52911

fix NullPointerException when replay job
```
java.lang.NullPointerException: Cannot invoke "String.isEmpty()" because "this.cloudCluster" is null
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

