### PR TITLE
[fix](nereids)avoid to derive negative row count

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InitJoinOrder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InitJoinOrder.java
@@ -75,7 +75,9 @@ public class InitJoinOrder extends OneRewriteRuleFactory {
             right.accept(derive, new DeriveContext());
         }
 
-        if (left.getStats().getRowCount() < right.getStats().getRowCount() * SWAP_THRESHOLD) {
+        // requires "left.getStats().getRowCount() > 0" to avoid dead loop when negative row count is estimated.
+        if (left.getStats().getRowCount() < right.getStats().getRowCount() * SWAP_THRESHOLD
+                && left.getStats().getRowCount() > 0) {
             join = join.withTypeChildren(swapType, right, left,
                     join.getJoinReorderContext());
             return join;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/FilterEstimationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/FilterEstimationTest.java
@@ -1591,4 +1591,22 @@ class FilterEstimationTest {
         Assertions.assertTrue(stats.findColumnStatistics(a).isUnKnown());
         Assertions.assertFalse(stats.findColumnStatistics(b).isUnKnown());
     }
+
+    @Test
+    public void testAvoidNegativeRowCount() {
+        Double row = 0.0;
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        ColumnStatisticBuilder columnStatisticBuilderA = new ColumnStatisticBuilder(row)
+                .setNdv(1)
+                .setAvgSizeByte(4)
+                .setNumNulls(0);
+        Statistics inputStats = new StatisticsBuilder()
+                .setRowCount(row)
+                .putColumnStatistics(a, columnStatisticBuilderA.build())
+                .build();
+        FilterEstimation filterEstimation = new FilterEstimation();
+        Statistics outputStats = filterEstimation.estimate(new IsNull(a), inputStats);
+        // make sure when input is 0, output is also 0
+        Assertions.assertEquals(0.0, outputStats.getRowCount());
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?
there is a lower bound row count for is_null(A), which is 1.
But if input rows is zero, the output should be zero, the lower bound should not work.
By the way, we add some check to avoid negative row count in FilterEstimation.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

