### PR TITLE
[fix](hudi) fix quering hudi table with timestamp key

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiPartitionProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiPartitionProcessor.java
@@ -19,6 +19,7 @@ package org.apache.doris.datasource.hudi.source;
 
 import org.apache.doris.datasource.ExternalTable;
 
+import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
@@ -98,8 +99,8 @@ public abstract class HudiPartitionProcessor {
                 } else {
                     partitionValue = partitionPath;
                 }
-                // TODO: In hive, the specific characters like '=', '/' will be url encoded
-                return Collections.singletonList(partitionValue);
+                // In hive, the specific characters like '=', '/' will be url encoded
+                return Collections.singletonList(FileUtils.unescapePathName(partitionValue));
             } else {
                 // If the partition column size is not equal to the partition fragments size
                 // and the partition column size > 1, we do not know how to map the partition
@@ -119,9 +120,9 @@ public abstract class HudiPartitionProcessor {
             for (int i = 0; i < partitionFragments.length; i++) {
                 String prefix = partitionColumns.get(i) + "=";
                 if (partitionFragments[i].startsWith(prefix)) {
-                    partitionValues.add(partitionFragments[i].substring(prefix.length()));
+                    partitionValues.add(FileUtils.unescapePathName(partitionFragments[i].substring(prefix.length())));
                 } else {
-                    partitionValues.add(partitionFragments[i]);
+                    partitionValues.add(FileUtils.unescapePathName(partitionFragments[i]));
                 }
             }
             return partitionValues;

--- a/regression-test/data/external_table_p2/hudi/test_hudi_partition_prune.out
+++ b/regression-test/data/external_table_p2/hudi/test_hudi_partition_prune.out
@@ -177,6 +177,10 @@
 1	Alice	2023-12-01
 2	Bob	2023-12-01
 
+-- !one_partition_timestamp --
+1	Alice	2023-12-01T08:00
+2	Bob	2023-12-01T08:00
+
 -- !one_partition_1_1 --
 1	Alice	2024
 2	Bob	2024
@@ -354,4 +358,8 @@
 -- !one_partition_date --
 1	Alice	2023-12-01
 2	Bob	2023-12-01
+
+-- !one_partition_timestamp --
+1	Alice	2023-12-01T08:00
+2	Bob	2023-12-01T08:00
 

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_partition_prune.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_partition_prune.groovy
@@ -320,11 +320,11 @@ suite("test_hudi_partition_prune", "p2,external,hudi,external_remote,external_re
             sql("${one_partition_date}")
             contains "partition=1/2"
         }
-        // qt_one_partition_timestamp one_partition_timestamp
-        // explain {
-        //     sql("${one_partition_timestamp}")
-        //     contains "partition=1/2"
-        // }
+        qt_one_partition_timestamp one_partition_timestamp
+        explain {
+            sql("${one_partition_timestamp}")
+            contains "partition=1/2"
+        }
 
         sql """drop catalog if exists ${catalog_name};"""
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
When querying a Hudi table with timestamp type as the partition key in Doris, an error will occur: 
<img width="1280" height="455" alt="image" src="https://github.com/user-attachments/assets/1ea05e75-9713-46b0-99e4-95584309a1a2" />
Issue Details:
- Hudi tables with timestamp partition columns (e.g., 2023-12-01T08:00) store partition paths in HMS with URL encoding
- Special characters like : in timestamps get encoded as %3A, and in some cases may be double-encoded as %253A

**The Solution:** The changes add proper URL unescaping using `FileUtils.unescapePathName()` from Hadoop Hive common library to handle encoded partition paths correctly.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

