### PR TITLE
[test](p2) reduce broker_load_batch_size in compaction_width_array_column

### DIFF
--- a/regression-test/suites/compaction/compaction_width_array_column.groovy
+++ b/regression-test/suites/compaction/compaction_width_array_column.groovy
@@ -16,6 +16,7 @@
 // under the License.
 
 suite('compaction_width_array_column', "p2") {
+    sql """set global broker_load_batch_size = 4062;"""
     String backend_id;
     def backendId_to_backendIP = [:]
     def backendId_to_backendHttpPort = [:]


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #36477

Problem Summary:

The default broker_load_batch_size is `16352`, which is causing OOM cancel for this particular case.
Reduce it to `4062` in this case.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

