### PR TITLE
[fix](catalog)  hadoop.username does not take effect in the HMS catalog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/HMSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/HMSProperties.java
@@ -128,7 +128,7 @@ public class HMSProperties extends AbstractHMSProperties {
             return;
         }
         origProps.forEach((key, value) -> {
-            if (key.startsWith("hive.")) {
+            if (key.startsWith("hive.") || key.startsWith("hadoop.")) {
                 userOverriddenHiveConfig.put(key, value);
             }
         });


### PR DESCRIPTION
### What problem does this PR solve?

come from: https://github.com/apache/doris/pull/52363

Create hms catalog use another `hadoop.username`, but not take effect:
```
CREATE CATALOG `hive` PROPERTIES (
"type" = "hms",
"uri" = "thrift://hive:19083",
"hadoop.username" = "root",
"fs.defaultFS" = "hdfs://127.0.0.1:60070"
);

```

The error message is like:
```
> create database example_db;
ERROR 1105 (HY000): errCode = 2, detailMessage = failed to create database from hms client. reason: org.apache.hadoop.hive.metastore.api.MetaException: Got exception: org.apache.hadoop.security.AccessControlException Permission denied: user=hadoop, access=WRITE, inode="/user/hive/warehouse/example_db.db":root:hdfs:drwxrwxr-x
        at org.apache.hadoop.hdfs.server.namenode.FSPermissionChecker.check(FSPermissionChecker.java:319)
        at org.apache.hadoop.hdfs.server.namenode.FSPermissionChecker.check(FSPermissionChecker.java:292)
```


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

