### PR TITLE
[fix](warmup) ensure warmup only triggers if tablet exists on target backend (#53852)

### DIFF
--- a/be/src/cloud/cloud_internal_service.cpp
+++ b/be/src/cloud/cloud_internal_service.cpp
@@ -162,7 +162,10 @@ void CloudInternalServiceImpl::warm_up_rowset(google::protobuf::RpcController* c
             continue;
         }
         int64_t tablet_id = rs_meta.tablet_id();
-        auto res = _engine.tablet_mgr().get_tablet(tablet_id);
+        auto res = _engine.tablet_mgr().get_tablet(tablet_id, /* warmup_data = */ false,
+                                                   /* sync_delete_bitmap = */ true,
+                                                   /* sync_stats = */ nullptr,
+                                                   /* local_only = */ true);
         if (!res.has_value()) {
             LOG_WARNING("Warm up error ").tag("tablet_id", tablet_id).error(res.error());
             continue;


### PR DESCRIPTION
### What problem does this PR solve?

Cherry-pick: #53852

Problem Summary:

For event-driven warmup jobs, ensure warmup only triggers if tablet exists on the target backend.
Because the source BE will cache the tablet location for a short time,
after rebalancing, the old target BE will still receive warm up requests during that time.
This PR prevents the old target BE to re-fetch the tablet cache when it no longer holds the tablet.
For the new target BE, it will take a different path (`warm_up_cache_async`) to do the warm up.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

