### PR TITLE
[opt](nereids) use one instance per be to execute simple query

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -3164,7 +3164,13 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
             return false;
         }
         Plan child = root.child(0);
+        if (child instanceof PhysicalLimit) {
+            child = child.child(0);
+        }
         if (child instanceof PhysicalDistribute) {
+            child = child.child(0);
+        }
+        if (child instanceof PhysicalLimit) {
             child = child.child(0);
         }
         if (child instanceof PhysicalProject) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -154,6 +154,7 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalPartitionTopN;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalQuickSort;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalRelation;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalRepeat;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalResultSink;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalSchemaScan;
@@ -304,6 +305,14 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
                 scanNode.finalizeForNereids();
             } catch (Exception e) {
                 throw new RuntimeException(e.getMessage(), e);
+            }
+        }
+
+        if (isSimpleQuery(physicalPlan)) {
+            // the simple query maybe has two fragments or one fragment
+            rootFragment.setForceSingleInstance();
+            for (PlanFragment child : rootFragment.getChildren()) {
+                child.setForceSingleInstance();
             }
         }
         return rootFragment;
@@ -3145,5 +3154,25 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
             return partitionExprs;
         }
         return Lists.newArrayList();
+    }
+
+    // matching the simple query:
+    // 1. select xxx from tbl
+    // 2. select xxx from tbl where xxx=yyy
+    private boolean isSimpleQuery(PhysicalPlan root) {
+        if (!(root instanceof PhysicalResultSink)) {
+            return false;
+        }
+        Plan child = root.child(0);
+        if (child instanceof PhysicalDistribute) {
+            child = child.child(0);
+        }
+        if (child instanceof PhysicalProject) {
+            child = child.child(0);
+        }
+        if (child instanceof PhysicalFilter) {
+            child = child.child(0);
+        }
+        return child instanceof PhysicalRelation;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanFragment.java
@@ -163,6 +163,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
 
     public TQueryCacheParam queryCacheParam;
     private int numBackends = 0;
+    private boolean forceSingleInstance = false;
 
     /**
      * C'tor for fragment with specific partition; the output is by default broadcast.
@@ -312,6 +313,9 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     }
 
     public int getParallelExecNum() {
+        if (forceSingleInstance) {
+            return 1;
+        }
         return parallelExecNum;
     }
 
@@ -529,5 +533,9 @@ public class PlanFragment extends TreeNode<PlanFragment> {
 
     public boolean hasSerialScanNode() {
         return planRoot.hasSerialScanChildren();
+    }
+
+    public void setForceSingleInstance() {
+        this.forceSingleInstance = true;
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/NereidsCoordinatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/NereidsCoordinatorTest.java
@@ -63,24 +63,29 @@ public class NereidsCoordinatorTest extends TestWithFeService {
 
     @Test
     public void testSimpleQueryUseOneInstance() throws IOException {
-        NereidsPlanner planner = plan("select * from test.tbl");
+        ConnectContext connectContext = createDefaultCtx();
+        connectContext.getSessionVariable().parallelPipelineTaskNum = 10;
+        NereidsPlanner planner = plan("select * from test.tbl", connectContext);
         for (PlanFragment fragment : planner.getFragments()) {
             Assertions.assertEquals(1, fragment.getParallelExecNum());
         }
 
-        planner = plan("select * from test.tbl where id=1");
+        planner = plan("select * from test.tbl where id=1", connectContext);
         for (PlanFragment fragment : planner.getFragments()) {
             Assertions.assertEquals(1, fragment.getParallelExecNum());
         }
 
-        planner = plan("select id, id + 1 from test.tbl where id = 2 limit 1");
+        planner = plan("select id, id + 1 from test.tbl where id = 2 limit 1", connectContext);
         for (PlanFragment fragment : planner.getFragments()) {
             Assertions.assertEquals(1, fragment.getParallelExecNum());
         }
     }
 
     private NereidsPlanner plan(String sql) throws IOException {
-        ConnectContext connectContext = createDefaultCtx();
+        return plan(sql, createDefaultCtx());
+    }
+
+    private NereidsPlanner plan(String sql, ConnectContext connectContext) throws IOException {
         connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION,OLAP_SCAN_TABLET_PRUNE");
         connectContext.setThreadLocalInfo();
 


### PR DESCRIPTION
### What problem does this PR solve?

The simple query not need to use multiple instances to compute, we should use one instance to save resources.

the simple query support these cases, `select ... from tbl [where yyy=k]  [limit n]`
for example
```sql
select xxx from tbl;
select xxx, yyy from tbl where id=1;
select xxx from tbl limit 1;
select xxx from tbl where id=1 limit 1;
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

