### PR TITLE
[fix](mtmv)Fix incorrect result of show create MTMV when partition by date_trunc

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -164,6 +164,7 @@ import org.apache.doris.master.PartitionInfoCollector;
 import org.apache.doris.meta.MetaContext;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.mtmv.MTMVAlterOpType;
+import org.apache.doris.mtmv.MTMVPartitionExprFactory;
 import org.apache.doris.mtmv.MTMVPartitionInfo;
 import org.apache.doris.mtmv.MTMVPartitionInfo.MTMVPartitionType;
 import org.apache.doris.mtmv.MTMVRefreshPartitionSnapshot;
@@ -3595,7 +3596,7 @@ public class Env {
         }
     }
 
-    private static void addMTMVPartitionInfo(MTMV mtmv, StringBuilder sb) {
+    private static void addMTMVPartitionInfo(MTMV mtmv, StringBuilder sb) throws AnalysisException {
         MTMVPartitionInfo mvPartitionInfo = mtmv.getMvPartitionInfo();
         if (mvPartitionInfo.getPartitionType() == MTMVPartitionType.SELF_MANAGE) {
             return;
@@ -3604,7 +3605,7 @@ public class Env {
         if (mvPartitionInfo.getPartitionType() == MTMVPartitionType.FOLLOW_BASE_TABLE) {
             sb.append("`" + mvPartitionInfo.getPartitionCol() + "`");
         } else {
-            sb.append(mvPartitionInfo.getExpr().toSql());
+            sb.append(MTMVPartitionExprFactory.getExprService(mvPartitionInfo.getExpr()).toSql(mvPartitionInfo));
         }
         sb.append(")");
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPartitionExprDateTrunc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPartitionExprDateTrunc.java
@@ -85,6 +85,11 @@ public class MTMVPartitionExprDateTrunc implements MTMVPartitionExprService {
     }
 
     @Override
+    public String toSql(MTMVPartitionInfo mvPartitionInfo) {
+        return String.format("date_trunc(`%s`, '%s')", mvPartitionInfo.getPartitionCol(), timeUnit);
+    }
+
+    @Override
     public String getRollUpIdentity(PartitionKeyDesc partitionKeyDesc, Map<String, String> mvProperties)
             throws AnalysisException {
         String res = null;

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPartitionExprService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPartitionExprService.java
@@ -57,4 +57,11 @@ public interface MTMVPartitionExprService {
      * @throws AnalysisException
      */
     void analyze(MTMVPartitionInfo mtmvPartitionInfo) throws AnalysisException;
+
+    /**
+     * for show create MTMV
+     * @param mvPartitionInfo
+     * @return
+     */
+    String toSql(MTMVPartitionInfo mvPartitionInfo);
 }

--- a/regression-test/suites/mtmv_p0/test_show_create_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_show_create_mtmv.groovy
@@ -121,6 +121,28 @@ suite("test_show_create_mtmv","mtmv") {
     def showCreateMTMVResultAgain = sql """show CREATE MATERIALIZED VIEW ${mvName}"""
     logger.info("showCreateMTMVAgainResult: " + showCreateMTMVResultAgain.toString())
     assertEquals(showCreateMTMVResult.toString(), showCreateMTMVResultAgain.toString())
+    sql """drop materialized view if exists ${mvName};"""
+
+    sql """
+        CREATE MATERIALIZED VIEW ${mvName}
+        BUILD DEFERRED REFRESH AUTO ON MANUAL
+        partition by(date_trunc(`col1`, 'day'))
+        DISTRIBUTED BY RANDOM BUCKETS 2
+        PROPERTIES (
+        'replication_num' = '1'
+        )
+        AS select date_trunc(`k2`, 'day') as col1  from ${tableName};
+    """
+    showCreateMTMVResult = sql """show CREATE MATERIALIZED VIEW ${mvName}"""
+    logger.info("showCreateMTMVResult: " + showCreateMTMVResult.toString())
+    assertTrue(showCreateMTMVResult.toString().contains("date_trunc(`col1`, 'day')"))
+    sql """drop materialized view if exists ${mvName};"""
+    sql """
+            ${showCreateMTMVResult[0][1]}
+        """
+    def showCreateMTMVResultAgain = sql """show CREATE MATERIALIZED VIEW ${mvName}"""
+    logger.info("showCreateMTMVAgainResult: " + showCreateMTMVResultAgain.toString())
+    assertEquals(showCreateMTMVResult.toString(), showCreateMTMVResultAgain.toString())
 
     sql """drop table if exists `${tableName}`"""
     sql """drop materialized view if exists ${mvName};"""

--- a/regression-test/suites/mtmv_p0/test_show_create_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_show_create_mtmv.groovy
@@ -140,7 +140,7 @@ suite("test_show_create_mtmv","mtmv") {
     sql """
             ${showCreateMTMVResult[0][1]}
         """
-    def showCreateMTMVResultAgain = sql """show CREATE MATERIALIZED VIEW ${mvName}"""
+    showCreateMTMVResultAgain = sql """show CREATE MATERIALIZED VIEW ${mvName}"""
     logger.info("showCreateMTMVAgainResult: " + showCreateMTMVResultAgain.toString())
     assertEquals(showCreateMTMVResult.toString(), showCreateMTMVResultAgain.toString())
 


### PR DESCRIPTION
### What problem does this PR solve?
create table
```
CREATE TABLE `t6` (
          `k1` LARGEINT NOT NULL COMMENT '\"用户id\"',
          `k2` DATE NOT NULL COMMENT '\"数据灌入日期时间\"'
        ) ENGINE=OLAP
        DUPLICATE KEY(`k1`)
        COMMENT 'OLAP'
        PARTITION BY range(`k2`)
        (
        PARTITION p_20200101 VALUES [("2020-01-01"),("2020-01-02")),
        PARTITION p_20200102 VALUES [("2020-01-02"),("2020-01-03")),
        PARTITION p_20200201 VALUES [("2020-02-01"),("2020-02-02"))
        )
        DISTRIBUTED BY HASH(`k1`) BUCKETS 2
        PROPERTIES ('replication_num' = '1') ;
```
create mtmv
```
CREATE MATERIALIZED VIEW mv6
BUILD IMMEDIATE REFRESH AUTO ON MANUAL 
partition by(date_trunc(`col1`, 'day')) 
DISTRIBUTED BY RANDOM BUCKETS 2 
PROPERTIES ('replication_num' = '1') 
AS select date_trunc(`k2`, 'day') as col1  from t6;  
```

show create mtmv will be
```
CREATE MATERIALIZED VIEW mv6
BUILD IMMEDIATE REFRESH AUTO ON MANUAL 
partition by(date_trunc(`k2`, 'day')) 
DISTRIBUTED BY RANDOM BUCKETS 2 
PROPERTIES ('replication_num' = '1') 
AS select date_trunc(`k2`, 'day') as col1  from t6;  
```

should be 
```
partition by(date_trunc(`col1`, 'day')) 
```

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
Fix incorrect result of show create MTMV when partition by date_trunc
### Release note

Fix incorrect result of show create MTMV when partition by date_trunc

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

