### PR TITLE
[fix](warmup) fix warm up jobs missing last batch (#53860)

### DIFF
--- a/be/src/cloud/cloud_warm_up_manager.cpp
+++ b/be/src/cloud/cloud_warm_up_manager.cpp
@@ -293,9 +293,9 @@ void CloudWarmUpManager::handle_jobs() {
             _finish_job.push_back(cur_job);
             // _pending_job_metas may be cleared by a CLEAR_JOB request
             // so we need to check it again.
-            // We can not call pop_front before the job is finished,
-            // because GET_CURRENT_JOB_STATE_AND_LEASE is relying on the pending job size.
             if (!_pending_job_metas.empty()) {
+                // We can not call pop_front before the job is finished,
+                // because GET_CURRENT_JOB_STATE_AND_LEASE is relying on the pending job size.
                 _pending_job_metas.pop_front();
             }
         }

--- a/be/src/cloud/cloud_warm_up_manager.cpp
+++ b/be/src/cloud/cloud_warm_up_manager.cpp
@@ -186,7 +186,6 @@ void CloudWarmUpManager::handle_jobs() {
             if (_closed) break;
             if (!_pending_job_metas.empty()) {
                 cur_job = _pending_job_metas.front();
-                _pending_job_metas.pop_front();
             }
         }
 
@@ -292,6 +291,13 @@ void CloudWarmUpManager::handle_jobs() {
         {
             std::unique_lock lock(_mtx);
             _finish_job.push_back(cur_job);
+            // _pending_job_metas may be cleared by a CLEAR_JOB request
+            // so we need to check it again.
+            // We can not call pop_front before the job is finished,
+            // because GET_CURRENT_JOB_STATE_AND_LEASE is relying on the pending job size.
+            if (!_pending_job_metas.empty()) {
+                _pending_job_metas.pop_front();
+            }
         }
     }
 #endif


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: DORIS-21591
Related PR: #53860 

Problem Summary:

1. `_pending_job_metas` may be cleared by a CLEAR_JOB request, so we need to check it again.
2. We can not call pop_front before the job is finished, because GET_CURRENT_JOB_STATE_AND_LEASE is relying on the pending job size.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

