### PR TITLE
[DO NOT Merge] just for test

### DIFF
--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -423,8 +423,6 @@ using ColumnId = uint32_t;
 using UniqueIdSet = std::set<uint32_t>;
 // Column unique Id -> column id map
 using UniqueIdToColumnIdMap = std::map<ColumnId, ColumnId>;
-struct RowsetId;
-RowsetId next_rowset_id();
 
 // 8 bit rowset id version
 // 56 bit, inc number from 1
@@ -445,7 +443,7 @@ struct RowsetId {
             if (ec != std::errc {}) [[unlikely]] {
                 if (config::force_regenerate_rowsetid_on_start_error) {
                     LOG(WARNING) << "failed to init rowset id: " << rowset_id_str;
-                    high = next_rowset_id().hi;
+                    high = MAX_ROWSET_ID - 1;
                 } else {
                     LOG(FATAL) << "failed to init rowset id: " << rowset_id_str;
                 }

--- a/be/src/olap/rowset/unique_rowset_id_generator.cpp
+++ b/be/src/olap/rowset/unique_rowset_id_generator.cpp
@@ -17,16 +17,7 @@
 
 #include "olap/rowset/unique_rowset_id_generator.h"
 
-#include <atomic>
-
-#include "olap/storage_engine.h"
-#include "runtime/exec_env.h"
-
 namespace doris {
-
-RowsetId next_rowset_id() {
-    return ExecEnv::GetInstance()->get_storage_engine()->next_rowset_id();
-}
 
 UniqueRowsetIdGenerator::UniqueRowsetIdGenerator(const UniqueId& backend_uid)
         : _backend_uid(backend_uid), _inc_id(1) {}

--- a/be/test/olap/rowset/rowset_meta_test.cpp
+++ b/be/test/olap/rowset/rowset_meta_test.cpp
@@ -21,6 +21,7 @@
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest-message.h>
 #include <gtest/gtest-test-part.h>
+#include <gtest/gtest.h>
 
 #include <filesystem>
 #include <fstream>
@@ -111,6 +112,15 @@ TEST_F(RowsetMetaTest, TestInitWithInvalidData) {
     RowsetMeta rowset_meta;
     EXPECT_FALSE(rowset_meta.init_from_json("invalid json meta data"));
     EXPECT_FALSE(rowset_meta.init("invalid pb meta data"));
+}
+
+TEST_F(RowsetMetaTest, TestRowsetIdInit) {
+    RowsetId id {};
+    config::force_regenerate_rowsetid_on_start_error = true;
+    std::string_view rowset_id_str = "test";
+    id.init(rowset_id_str);
+    // 0x100000000000000 - 0x01
+    EXPECT_EQ(id.to_string(), "72057594037927935");
 }
 
 } // namespace doris

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,11 +34,13 @@
     "classnames": "^2.2.6",
     "i18next": "^19.7.0",
     "i18next-browser-languagedetector": "^6.0.1",
+    "json-bigint": "^1.0.0",
     "lodash-decorators": "^6.0.1",
     "path-to-regexp": "^2.2.0",
     "react": "^16.13.1",
     "react-codemirror2": "^7.1.0",
     "react-dom": "^16.13.1",
+    "react-draggable": "4.4.6",
     "react-i18next": "^11.7.2",
     "react-resizable": "^1.10.1",
     "react-router": "^5.2.0",
@@ -77,5 +79,8 @@
     "webpack-cli": "^3.3.3",
     "webpack-dev-server": "^3.7.1",
     "webpack-merge": "^4.2.1"
+  },
+  "resolutions": {
+    "react-draggable": "4.4.6"
   }
 }


### PR DESCRIPTION
In PR #42949, during the rowset ID initialization process, we used a random ID to replace the rowset ID that failed during serialization. However, the generation of random IDs depends on the storage engine, which hasn't been initialized during the rowset ID initialization process, leading to a core dump. This PR fixes this issue by uniformly using MAX_ROWSET_ID-1 to replace the failed rowset ID. This approach is safe because the rowset ID generator won't generate such a large ID, and we can consider all rowsets with rowset ID equal to MAX_ROWSET_ID-1 as failed initialization rowsets that should rely on multiple replicas for automatic recovery.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

