### PR TITLE
[fix] cooldownTime in Partition Table not updated after the data cool down

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/DataProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/DataProperty.java
@@ -45,6 +45,8 @@ public class DataProperty implements Writable, GsonPostProcessable {
     private TStorageMedium storageMedium;
     @SerializedName(value = "cooldownTimeMs")
     private long cooldownTimeMs;
+    @SerializedName(value = "remoteDataSize")
+    private long remoteDataSize;
     @SerializedName(value = "storagePolicy")
     private String storagePolicy;
     @SerializedName(value = "isMutable")
@@ -59,6 +61,7 @@ public class DataProperty implements Writable, GsonPostProcessable {
         this.storageMedium = medium;
         this.cooldownTimeMs = MAX_COOLDOWN_TIME_MS;
         this.storagePolicy = "";
+        this.remoteDataSize = 0;
     }
 
     public DataProperty(DataProperty other) {
@@ -66,6 +69,7 @@ public class DataProperty implements Writable, GsonPostProcessable {
         this.cooldownTimeMs = other.cooldownTimeMs;
         this.storagePolicy = other.storagePolicy;
         this.isMutable = other.isMutable;
+        this.remoteDataSize = 0;
     }
 
     /**
@@ -84,6 +88,7 @@ public class DataProperty implements Writable, GsonPostProcessable {
         this.cooldownTimeMs = cooldown;
         this.storagePolicy = storagePolicy;
         this.isMutable = isMutable;
+        this.remoteDataSize = 0;
     }
 
     public TStorageMedium getStorageMedium() {
@@ -100,6 +105,14 @@ public class DataProperty implements Writable, GsonPostProcessable {
 
     public void setStoragePolicy(String storagePolicy) {
         this.storagePolicy = storagePolicy;
+    }
+
+    public long getRemoteDataSize() {
+        return remoteDataSize;
+    }
+
+    public void setRemoteDataSize(long remoteDataSize) {
+        this.remoteDataSize = remoteDataSize;
     }
 
     public boolean isStorageMediumSpecified() {


### PR DESCRIPTION
### What problem does this PR solve?
When if there is a tables data cooled by storage policy, its data property was not updating in show partitions command output.  
all partitions have shown as default to SSD storage medium cooling time of 9999-12-31 23:59:59.
Issue Number: close #53800 

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

