### PR TITLE
[fix](nereids)fix load command failed with bitmap column expr mapping

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsDataDescription.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsDataDescription.java
@@ -1167,10 +1167,15 @@ public class NereidsDataDescription {
         List<Expr> legacyColumnMappingList = new ArrayList<>();
         if (this.columnMappingList != null && !this.columnMappingList.isEmpty()) {
             for (Expression expression : this.columnMappingList) {
-                if (expression != null && expression instanceof EqualTo) {
-                    Expr left = PlanUtils.translateToLegacyExpr(((EqualTo) expression).left(), null, ctx);
-                    Expr right = PlanUtils.translateToLegacyExpr(((EqualTo) expression).right(), null, ctx);
-                    legacyColumnMappingList.add(new BinaryPredicate(BinaryPredicate.Operator.EQ, left, right));
+                if (expression != null) {
+                    if (expression instanceof EqualTo) {
+                        Expr left = PlanUtils.translateToLegacyExpr(((EqualTo) expression).left(), null, ctx);
+                        Expr right = PlanUtils.translateToLegacyExpr(((EqualTo) expression).right(), null, ctx);
+                        legacyColumnMappingList.add(new BinaryPredicate(BinaryPredicate.Operator.EQ, left, right));
+                    } else {
+                        throw new AnalysisException(String.format("column mapping expr must be EqualTo, but it's %s",
+                                expression));
+                    }
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsDataDescription.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsDataDescription.java
@@ -1169,7 +1169,7 @@ public class NereidsDataDescription {
             for (Expression expression : this.columnMappingList) {
                 if (expression != null) {
                     if (expression instanceof EqualTo) {
-                        // we should not cast right type to left type here, because we do the cast when 
+                        // we should not cast right type to left type here, because we do the cast when
                         // creating load plan later, see NereidsLoadUtils.createLoadPlan for more details
                         Expr left = PlanUtils.translateToLegacyExpr(((EqualTo) expression).left(), null, ctx);
                         Expr right = PlanUtils.translateToLegacyExpr(((EqualTo) expression).right(), null, ctx);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsDataDescription.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsDataDescription.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.load;
 
+import org.apache.doris.analysis.BinaryPredicate;
 import org.apache.doris.analysis.ColumnDef;
 import org.apache.doris.analysis.DataDescription;
 import org.apache.doris.analysis.Expr;
@@ -1166,8 +1167,10 @@ public class NereidsDataDescription {
         List<Expr> legacyColumnMappingList = new ArrayList<>();
         if (this.columnMappingList != null && !this.columnMappingList.isEmpty()) {
             for (Expression expression : this.columnMappingList) {
-                if (expression != null) {
-                    legacyColumnMappingList.add(PlanUtils.translateToLegacyExpr(expression, null, ctx));
+                if (expression != null && expression instanceof EqualTo) {
+                    Expr left = PlanUtils.translateToLegacyExpr(((EqualTo) expression).left(), null, ctx);
+                    Expr right = PlanUtils.translateToLegacyExpr(((EqualTo) expression).right(), null, ctx);
+                    legacyColumnMappingList.add(new BinaryPredicate(BinaryPredicate.Operator.EQ, left, right));
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsDataDescription.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsDataDescription.java
@@ -1169,6 +1169,8 @@ public class NereidsDataDescription {
             for (Expression expression : this.columnMappingList) {
                 if (expression != null) {
                     if (expression instanceof EqualTo) {
+                        // we should not cast right type to left type here, because we do the cast when 
+                        // creating load plan later, see NereidsLoadUtils.createLoadPlan for more details
                         Expr left = PlanUtils.translateToLegacyExpr(((EqualTo) expression).left(), null, ctx);
                         Expr right = PlanUtils.translateToLegacyExpr(((EqualTo) expression).right(), null, ctx);
                         legacyColumnMappingList.add(new BinaryPredicate(BinaryPredicate.Operator.EQ, left, right));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/LoadCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/LoadCommandTest.java
@@ -71,6 +71,48 @@ public class LoadCommandTest extends TestWithFeService {
                 + "\"storage_format\" = \"V2\"\n"
                 + ");";
         createTable(createTableSql);
+
+        String createTableBitmapSql = "CREATE TABLE `load_bitmap_table`\n"
+                + "        (\n"
+                + "            `dt_h`      datetime    NOT NULL,\n"
+                + "            `userid_bitmap` bitmap BITMAP_UNION NOT NULL\n"
+                + "        ) ENGINE = OLAP AGGREGATE KEY(`dt_h`)\n"
+                + "        DISTRIBUTED BY HASH(`dt_h`) BUCKETS 4\n"
+                + "        PROPERTIES (\"replication_num\" = \"1\");";
+        createTable(createTableBitmapSql);
+    }
+
+    @Test
+    public void testLoadCommandBitmap() {
+        String loadSql1 = "LOAD LABEL load_bitmap_table_test( "
+                + "     DATA INFILE(\"s3://bucket/load_bitmap_table\") "
+                + "     INTO TABLE load_bitmap_table "
+                + "     COLUMNS TERMINATED BY \"|\""
+                + "     LINES TERMINATED BY \"\n\""
+                + "     (raw_dt_h,raw_userid_bitmap) "
+                + "     SET (`dt_h` = raw_dt_h, `userid_bitmap` = bitmap_from_array(cast(raw_userid_bitmap as ARRAY<BIGINT(20)>)))"
+                + "  ) "
+                + "  WITH S3(  "
+                + "     \"s3.access_key\" = \"AK\", "
+                + "     \"s3.secret_key\" = \"SK\", "
+                + "     \"s3.endpoint\" = \"cos.ap-beijing.myqcloud.com\",   "
+                + "     \"s3.region\" = \"ap-beijing\") "
+                + "PROPERTIES( \"exec_mem_limit\" = \"8589934592\") COMMENT \"test\";";
+
+        List<Pair<LogicalPlan, StatementContext>> statements = new NereidsParser().parseMultiple(loadSql1);
+        Assertions.assertFalse(statements.isEmpty());
+
+        // columns
+        LoadCommand command = (LoadCommand) statements.get(0).first;
+        List<NereidsDataDescription> dataDescriptions = command.getDataDescriptions();
+        Assertions.assertFalse(dataDescriptions.isEmpty());
+        NereidsDataDescription dataDescription = dataDescriptions.get(0);
+        List<String> colNames = dataDescription.getFileFieldNames();
+        Assertions.assertEquals(2, colNames.size());
+        Assertions.assertTrue(colNames.contains("raw_dt_h"));
+        Assertions.assertTrue(colNames.contains("raw_userid_bitmap"));
+        Assertions.assertTrue(dataDescription.getColumnMappingList().size() == 2);
+        Assertions.assertTrue(dataDescription.getColumnMappingList().get(1).child(0).getExpressionName().contains("userid_bitmap"));
     }
 
     @Test


### PR DESCRIPTION
column mapping expr in form: 
`column = expr`, and the '=' should not be treat as equalTo but assign. So when analyze `column = expr,` we analyze the column and expr separately to work around the type mismatch issue with equalTo 

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

