### PR TITLE
[bugfix](metrics) the uncompressed_bytes_read is different meaning when in pagecache and read from disk

### DIFF
--- a/be/src/olap/rowset/segment_v2/page_io.cpp
+++ b/be/src/olap/rowset/segment_v2/page_io.cpp
@@ -222,9 +222,6 @@ Status PageIO::read_and_decompress_page_(const PageReadOptions& opts, PageHandle
         // free memory of compressed page
         page = std::move(decompressed_page);
         page_slice = Slice(page->data(), footer->uncompressed_size() + footer_size + 4);
-        opts.stats->uncompressed_bytes_read += page_slice.size;
-    } else {
-        opts.stats->uncompressed_bytes_read += body_size;
     }
 
     if (opts.pre_decode && opts.encoding_info) {
@@ -238,6 +235,10 @@ Status PageIO::read_and_decompress_page_(const PageReadOptions& opts, PageHandle
 
     *body = Slice(page_slice.data, page_slice.size - 4 - footer_size);
     page->reset_size(page_slice.size);
+    // Uncompressed has 2 meanings: uncompress and decode. The buffer in pagecache maybe
+    // uncompressed or decoded. So that should update the uncompressed_bytes_read counter
+    // just before add it to pagecache, it will be consistency with reading data from page cache.
+    opts.stats->uncompressed_bytes_read += body->size;
     if (opts.use_page_cache && cache) {
         // insert this page into cache and return the cache handle
         cache->insert(cache_key, page.get(), &cache_handle, opts.type, opts.kept_in_memory);


### PR DESCRIPTION
### What problem does this PR solve?

Uncompressed has 2 meanings: uncompress and decode. The buffer in pagecache maybe
   uncompressed or decoded. So that should update the uncompressed_bytes_read counter
    just before add it to pagecache, it will be consistency with reading data from page cache.

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

