### PR TITLE
[fix](schema-change) Fix null new tablet when cleaning up sc job on failure

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -297,7 +297,7 @@ void alter_cloud_tablet(CloudStorageEngine& engine, const TAgentTaskRequest& age
                 job.process_alter_tablet(agent_task_req.alter_tablet_req_v2),
                 [&](const doris::Exception& ex) {
                     DorisMetrics::instance()->create_rollup_requests_failed->increment(1);
-                    job.clean_up_on_failed();
+                    job.clean_up_on_failure();
                 });
         return Status::OK();
     }();

--- a/be/src/cloud/cloud_schema_change_job.cpp
+++ b/be/src/cloud/cloud_schema_change_job.cpp
@@ -557,6 +557,9 @@ Status CloudSchemaChangeJob::_process_delete_bitmap(int64_t alter_version,
 }
 
 void CloudSchemaChangeJob::clean_up_on_failed() {
+    if (_new_tablet == nullptr) {
+        return;
+    }
     if (_new_tablet->keys_type() == KeysType::UNIQUE_KEYS &&
         _new_tablet->enable_unique_key_merge_on_write()) {
         _cloud_storage_engine.meta_mgr().remove_delete_bitmap_update_lock(

--- a/be/src/cloud/cloud_schema_change_job.cpp
+++ b/be/src/cloud/cloud_schema_change_job.cpp
@@ -556,7 +556,7 @@ Status CloudSchemaChangeJob::_process_delete_bitmap(int64_t alter_version,
     return Status::OK();
 }
 
-void CloudSchemaChangeJob::clean_up_on_failed() {
+void CloudSchemaChangeJob::clean_up_on_failure() {
     if (_new_tablet == nullptr) {
         return;
     }

--- a/be/src/cloud/cloud_schema_change_job.h
+++ b/be/src/cloud/cloud_schema_change_job.h
@@ -36,7 +36,7 @@ public:
     // This method is idempotent for a same request.
     Status process_alter_tablet(const TAlterTabletReqV2& request);
 
-    void clean_up_on_failed();
+    void clean_up_on_failure();
 
 private:
     Status _convert_historical_rowsets(const SchemaChangeParams& sc_params,


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

1. New tablet cloud be nullptr when get tablet action failed, take it into account.
2. Fix grammer error of the method signature.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

