### PR TITLE
[fix](function) incorrect result of json_insert/json_replace

### DIFF
--- a/be/src/vec/functions/function_jsonb.cpp
+++ b/be/src/vec/functions/function_jsonb.cpp
@@ -2036,6 +2036,7 @@ public:
                     replace = true;
                     if (!build_parents_by_path(json_documents[row_idx]->getValue(),
                                                json_path[path_index], parents)) {
+                        DCHECK(false);
                         continue;
                     }
                 } else {
@@ -2051,6 +2052,7 @@ public:
 
                     if (!build_parents_by_path(json_documents[row_idx]->getValue(), new_path,
                                                parents)) {
+                        DCHECK(false);
                         continue;
                     }
                 }
@@ -2113,9 +2115,11 @@ public:
             std::string path_string;
             current.to_string(&path_string);
             return false;
+        } else if (find_result.value == root) {
+            return true;
+        } else {
+            parents.emplace_back(find_result.value);
         }
-
-        parents.emplace_back(find_result.value);
 
         return build_parents_by_path(find_result.value, path, parents);
     }
@@ -2225,8 +2229,7 @@ public:
                 writer.writeEndObject();
 
             } else {
-                writer.writeValue(root);
-                return Status::OK();
+                return Status::InvalidArgument("Cannot insert value into this type");
             }
         }
 
@@ -2256,60 +2259,39 @@ public:
             json_paths[index].resize(json_path_constant[index] ? 1 : input_rows_count);
             json_values[index].resize(json_value_constant[index] ? 1 : input_rows_count, nullptr);
 
-            for (size_t row_idx = 0; row_idx != input_rows_count; ++row_idx) {
-                if (json_path_constant[index] || row_idx == 0) {
-                    if ((json_path_null_maps[index]) && (*json_path_null_maps[index])[0]) {
-                        continue;
-                    }
-
-                    auto path_string = json_path_column->get_data_at(0);
-                    if (!json_paths[index][0].seek(path_string.data, path_string.size)) {
-                        return Status::InvalidArgument(
-                                "Json path error: Invalid Json Path for constant value: "
-                                "{}, "
-                                "argument "
-                                "index: {}",
-                                std::string_view(path_string.data, path_string.size), i);
-                    }
-                } else if (!json_path_constant[index]) {
-                    if (json_path_null_maps[index] && (*json_path_null_maps[index])[row_idx]) {
-                        continue;
-                    }
-
-                    auto path_string = json_path_column->get_data_at(row_idx);
-                    if (!json_paths[index][row_idx].seek(path_string.data, path_string.size)) {
-                        return Status::InvalidArgument(
-                                "Json path error: Invalid Json Path for value: {}, "
-                                "argument "
-                                "index: {}, row index: {}",
-                                std::string_view(path_string.data, path_string.size), i, row_idx);
-                    }
+            for (size_t row_idx = 0; row_idx != json_paths[index].size(); ++row_idx) {
+                if (json_path_null_maps[index] && (*json_path_null_maps[index])[row_idx]) {
+                    continue;
                 }
 
-                if (json_value_constant[index] || row_idx == 0) {
-                    if ((json_value_null_maps[index]) && (*json_value_null_maps[index])[0]) {
-                        continue;
-                    }
+                auto path_string = json_path_column->get_data_at(row_idx);
+                if (!json_paths[index][row_idx].seek(path_string.data, path_string.size)) {
+                    return Status::InvalidArgument(
+                            "Json path error: Invalid Json Path for value: {}, "
+                            "argument "
+                            "index: {}, row index: {}",
+                            std::string_view(path_string.data, path_string.size), i, row_idx);
+                }
 
-                    auto value_string = value_column->get_data_at(0);
-                    JsonbDocument* doc = nullptr;
-                    RETURN_IF_ERROR(JsonbDocument::checkAndCreateDocument(value_string.data,
-                                                                          value_string.size, &doc));
-                    if (doc) {
-                        json_values[index][0] = doc->getValue();
-                    }
-                } else if (!json_value_constant[index]) {
-                    if (json_value_null_maps[index] && (*json_value_null_maps[index])[row_idx]) {
-                        continue;
-                    }
+                if (json_paths[index][row_idx].is_wildcard()) {
+                    return Status::InvalidArgument(
+                            "In this situation, path expressions may not contain the * and ** "
+                            "tokens, argument index: {}, row index: {}",
+                            i, row_idx);
+                }
+            }
 
-                    auto value_string = value_column->get_data_at(row_idx);
-                    JsonbDocument* doc = nullptr;
-                    RETURN_IF_ERROR(JsonbDocument::checkAndCreateDocument(value_string.data,
-                                                                          value_string.size, &doc));
-                    if (doc) {
-                        json_values[index][row_idx] = doc->getValue();
-                    }
+            for (size_t row_idx = 0; row_idx != json_values[index].size(); ++row_idx) {
+                if (json_value_null_maps[index] && (*json_value_null_maps[index])[row_idx]) {
+                    continue;
+                }
+
+                auto value_string = value_column->get_data_at(row_idx);
+                JsonbDocument* doc = nullptr;
+                RETURN_IF_ERROR(JsonbDocument::checkAndCreateDocument(value_string.data,
+                                                                      value_string.size, &doc));
+                if (doc) {
+                    json_values[index][row_idx] = doc->getValue();
                 }
             }
         }

--- a/regression-test/data/query_p0/sql_functions/json_function/test_query_json_insert.out
+++ b/regression-test/data/query_p0/sql_functions/json_function/test_query_json_insert.out
@@ -53,4 +53,37 @@
 {"data":{"array":["\\"a\\"","\\"b\\""],"struct":{"name":"\\"a\\"","age":1},"json":{"c":"d"}}}
 {"data":{"array":["1","2"],"struct":{"name":"2","age":1},"json":{"a":"b"}}}
 {"data":{"array":["1","2","3","3"],"struct":{"name":"a","age":1},"json":{"a":"b"}}}
+{"data":{"array":["3","3","4","4"],"struct":{"name":"aa","age":11},"json":{"aa":"bb"}}}
+
+-- !sql3 --
+\N
+{"data":{}}
+{"data":{"key1":["1","2"]}}
+{"data":{"key2":["1","2","3","3"]}}
+
+-- !sql4 --
+1	\N	\N	\N	\N
+2	["a", "b"]	{"name":"a", "age":1}	{"a":"b"}	$[0]
+3	[""a"", ""b""]	{"name":""a"", "age":1}	{"c":"d"}	$.*.array
+4	["1", "2"]	{"name":"2", "age":1}	{"a":"b"}	$.data.key1
+5	["1", "2", "3", "3"]	{"name":"a", "age":1}	{"a":"b"}	$.data.key2
+6	["3", "3", "4", "4"]	{"name":"aa", "age":11}	{"aa":"bb"}	$.*.key2
+
+-- !insert1 --
+1
+
+-- !insert2 --
+[1,2]
+
+-- !insert3 --
+{"k":1}
+
+-- !insert4 --
+{"k":[1,2]}
+
+-- !insert5 --
+{"k":[1,null]}
+
+-- !insert6 --
+\N
 

--- a/regression-test/data/query_p0/sql_functions/json_function/test_query_json_replace.out
+++ b/regression-test/data/query_p0/sql_functions/json_function/test_query_json_replace.out
@@ -59,3 +59,21 @@ null
 {"data":{"array":["1","2"],"map":{"x":"y"},"struct":{"name":"2","age":1},"json":{"a":"b"}}}
 {"data":{"array":["1","2","3","3"],"map":{"x":"y"},"struct":{"name":"a","age":1},"json":{"a":"b"}}}
 
+-- !replace1 --
+2
+
+-- !replace2 --
+1
+
+-- !replace3 --
+{"k":2}
+
+-- !replace4 --
+{"k":1}
+
+-- !replace5 --
+{"k":null}
+
+-- !replace6 --
+\N
+

--- a/regression-test/data/query_p0/sql_functions/json_function/test_query_json_set.out
+++ b/regression-test/data/query_p0/sql_functions/json_function/test_query_json_set.out
@@ -54,3 +54,24 @@ null
 {"data":{"array":["1","2"],"map":null,"struct":{"name":"2","age":1},"json":{"a":"b"}}}
 {"data":{"array":["1","2","3","3"],"map":null,"struct":{"name":"a","age":1},"json":{"a":"b"}}}
 
+-- !set1 --
+2
+
+-- !set2 --
+[1,2]
+
+-- !set3 --
+{"k":2}
+
+-- !set4 --
+{"k":[1,2]}
+
+-- !set5 --
+{"k":null}
+
+-- !set6 --
+{"k":[1,null]}
+
+-- !set7 --
+\N
+

--- a/regression-test/suites/query_p0/sql_functions/json_function/test_query_json_replace.groovy
+++ b/regression-test/suites/query_p0/sql_functions/json_function/test_query_json_replace.groovy
@@ -102,14 +102,34 @@ suite("test_query_json_replace", "query") {
             "storage_format" = "V2"
             );
         """
-    sql "insert into ${tableName} values(1,null,null,null);"
-    sql "insert into ${tableName} values(2, array('a','b'), named_struct('name','a','age',1), '{\"a\":\"b\"}');"
-    sql """insert into ${tableName} values(3, array('"a"', '"b"'), named_struct('name','"a"','age', 1), '{\"c\":\"d\"}');"""
-    sql """insert into ${tableName} values(4, array(1,2), named_struct('name', 2, 'age',1), '{\"a\":\"b\"}');"""
-    sql """insert into ${tableName} values(5, array(1,2,3,3), named_struct('name',\"a\",'age',1), '{\"a\":\"b\"}');"""
+    sql """
+        insert into ${tableName} values
+            (1,null,null,null),
+            (2, array('a','b'), named_struct('name','a','age',1), '{\"a\":\"b\"}'),
+            (3, array('"a"', '"b"'), named_struct('name','"a"','age', 1), '{\"c\":\"d\"}'),
+            (4, array(1,2), named_struct('name', 2, 'age',1), '{\"a\":\"b\"}'),
+            (5, array(1,2,3,3), named_struct('name',\"a\",'age',1), '{\"a\":\"b\"}');
+    """
     qt_sql3 """select json_replace('{"data": {"array": [1], "map": {"x":"y"}, "struct": {"name":"x","age":0}, "json": {"x":"y"}}}', 
                               '\$.data.array', k1, 
                               '\$.data.struct', k3, 
                               '\$.data.json', k4) from ${tableName} order by k0;"""
     sql "DROP TABLE ${tableName};"
+
+    qt_replace1 """select json_replace('1', '\$[0]', 2);"""
+    qt_replace2 """select json_replace('1', '\$[1]', 2);"""
+    qt_replace3 """select json_replace('{"k": 1}', '\$.k[0]', 2);"""
+    qt_replace4 """select json_replace('{"k": 1}', '\$.k[1]', 2);"""
+    qt_replace5 """select json_replace('{"k": 1}', '\$.k[0]', NULL);"""
+    qt_replace6 """select json_replace('{"k": 1}', NULL, 2);"""
+
+    test {
+        sql """select json_replace('1', '\$.*', 4);"""
+        exception "In this situation, path expressions may not contain the * and ** tokens"
+    }
+
+    test {
+        sql "select json_replace('1', '\$.', 4);"
+        exception "Json path error: Invalid Json Path for value"
+    }
 }

--- a/regression-test/suites/query_p0/sql_functions/json_function/test_query_json_set.groovy
+++ b/regression-test/suites/query_p0/sql_functions/json_function/test_query_json_set.groovy
@@ -80,14 +80,36 @@ suite("test_query_json_set", "query") {
             "storage_format" = "V2"
             );
         """
-    sql "insert into ${tableName} values(1,null,null,null);"
-    sql "insert into ${tableName} values(2, array('a','b'), named_struct('name','a','age',1), '{\"a\":\"b\"}');"
-    sql """insert into ${tableName} values(3, array('"a"', '"b"'), named_struct('name','"a"','age', 1), '{\"c\":\"d\"}');"""
-    sql """insert into ${tableName} values(4, array(1,2), named_struct('name', 2, 'age',1), '{\"a\":\"b\"}');"""
-    sql """insert into ${tableName} values(5, array(1,2,3,3), named_struct('name',\"a\",'age',1), '{\"a\":\"b\"}');"""
+    sql """
+        insert into ${tableName} values
+            (1,null,null,null),
+            (2, array('a','b'), named_struct('name','a','age',1), '{\"a\":\"b\"}'),
+            (3, array('"a"', '"b"'), named_struct('name','"a"','age', 1), '{\"c\":\"d\"}'),
+            (4, array(1,2), named_struct('name', 2, 'age',1), '{\"a\":\"b\"}'),
+            (5, array(1,2,3,3), named_struct('name',\"a\",'age',1), '{\"a\":\"b\"}');
+    """
+
     qt_sql2 """select json_set('{"data": {"array": null, "map": null, "struct": null, "json": null}}', 
                               '\$.data.array', k1, 
                               '\$.data.struct', k3, 
                               '\$.data.json', k4) from ${tableName} order by k0;"""
     sql "DROP TABLE ${tableName};"
+
+    qt_set1 """select json_set('1', '\$[0]', 2);"""
+    qt_set2 """select json_set('1', '\$[1]', 2);"""
+    qt_set3 """select json_set('{"k": 1}', '\$.k[0]', 2);"""
+    qt_set4 """select json_set('{"k": 1}', '\$.k[1]', 2);"""
+    qt_set5 """select json_set('{"k": 1}', '\$.k[0]', NULL);"""
+    qt_set6 """select json_set('{"k": 1}', '\$.k[1]', NULL);"""
+    qt_set7 """select json_set('{"k": 1}', NULL, 2);"""
+
+    test {
+        sql """select json_set('1', '\$.*', 4);"""
+        exception "In this situation, path expressions may not contain the * and ** tokens"
+    }
+
+    test {
+        sql "select json_set('1', '\$.', 4);"
+        exception "Json path error: Invalid Json Path for value"
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

```sql
select json_replace('1', '$[0]', 4);
```
The result should be:
```text
+------------------------------+
| json_replace('1', '$[0]', 4) |
+------------------------------+
| 4                            |
+------------------------------+
```
But got:
```text
+------------------------------+
| json_replace('1', '$[0]', 4) |
+------------------------------+
| 1                            |
+------------------------------+
```

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

