### PR TITLE
[fix] cooldownTime in Partition Table not updated after the data cooldown

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/DataProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/DataProperty.java
@@ -39,6 +39,8 @@ public class DataProperty implements GsonPostProcessable {
     private TStorageMedium storageMedium;
     @SerializedName(value = "cooldownTimeMs")
     private long cooldownTimeMs;
+    @SerializedName(value = "remoteDataSize")
+    private long remoteDataSize;
     @SerializedName(value = "storagePolicy")
     private String storagePolicy;
     @SerializedName(value = "isMutable")
@@ -53,6 +55,7 @@ public class DataProperty implements GsonPostProcessable {
         this.storageMedium = medium;
         this.cooldownTimeMs = MAX_COOLDOWN_TIME_MS;
         this.storagePolicy = "";
+        this.remoteDataSize = 0;
     }
 
     public DataProperty(DataProperty other) {
@@ -60,6 +63,7 @@ public class DataProperty implements GsonPostProcessable {
         this.cooldownTimeMs = other.cooldownTimeMs;
         this.storagePolicy = other.storagePolicy;
         this.isMutable = other.isMutable;
+        this.remoteDataSize = 0;
     }
 
     /**
@@ -78,6 +82,7 @@ public class DataProperty implements GsonPostProcessable {
         this.cooldownTimeMs = cooldown;
         this.storagePolicy = storagePolicy;
         this.isMutable = isMutable;
+        this.remoteDataSize = 0;
     }
 
     public TStorageMedium getStorageMedium() {
@@ -94,6 +99,14 @@ public class DataProperty implements GsonPostProcessable {
 
     public void setStoragePolicy(String storagePolicy) {
         this.storagePolicy = storagePolicy;
+    }
+
+    public long getRemoteDataSize() {
+        return remoteDataSize;
+    }
+
+    public void setRemoteDataSize(long remoteDataSize) {
+        this.remoteDataSize = remoteDataSize;
     }
 
     public boolean isStorageMediumSpecified() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -325,6 +325,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -4562,6 +4563,8 @@ public class Env {
         // dbId -> (tableId -> partitionId)
         HashMap<Long, Multimap<Long, Long>> changedPartitionsMap = new HashMap<Long, Multimap<Long, Long>>();
         long currentTimeMs = System.currentTimeMillis();
+        long zonedTimeMillis
+                = Instant.ofEpochMilli(currentTimeMs).atZone(TimeUtils.getDorisZoneId()).toInstant().toEpochMilli();
         List<Long> dbIds = getInternalCatalog().getDbIds();
 
         for (long dbId : dbIds) {
@@ -4596,6 +4599,26 @@ public class Env {
                                 changedPartitionsMap.put(dbId, multimap);
                             }
                             multimap.put(tableId, partitionId);
+                        } else if (!Strings.isNullOrEmpty(dataProperty.getStoragePolicy())
+                                && partition.getRemoteDataSize() > 0) {
+                            if (partition.getRemoteDataSize() > dataProperty.getRemoteDataSize()) {
+                                // if the remote data size increased, that means a bunch of new data is cooled
+                                // and we update the cooldownTimeMs
+                                DataProperty newDataProperty = new DataProperty(dataProperty.getStorageMedium(),
+                                        zonedTimeMillis, dataProperty.getStoragePolicy());
+                                newDataProperty.setRemoteDataSize(partition.getRemoteDataSize());
+                                partitionInfo.setDataProperty(partition.getId(), newDataProperty);
+                                // log
+                                ModifyPartitionInfo info = new ModifyPartitionInfo(db.getId(), olapTable.getId(),
+                                        partition.getId(), newDataProperty, ReplicaAllocation.NOT_SET,
+                                        partitionInfo.getIsInMemory(partition.getId()),
+                                        partitionInfo.getStoragePolicy(partitionId), Maps.newHashMap());
+                                editLog.logModifyPartition(info);
+                            } else if (partition.getRemoteDataSize() < dataProperty.getRemoteDataSize()) {
+                                // if the remote data is removed, set up-to-date remote data information.
+                                dataProperty.setRemoteDataSize(partition.getRemoteDataSize());
+                                partitionInfo.setDataProperty(partition.getId(), dataProperty);
+                            }
                         } else {
                             storageMediumMap.put(partitionId, dataProperty.getStorageMedium());
                         }


### PR DESCRIPTION
### What problem does this PR solve?
When if there is a tables data cooled by storage policy, its data property was not updating in show partitions command output.
all partitions have shown as default to SSD storage medium cooling time of 9999-12-31 23:59:59.
Issue Number: close #53800

Related PR: #53874 

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

