### PR TITLE
[fix](mv) ut case selectBitmapMvWithProjectMultiMv is unstable

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/mv/BaseMaterializedIndexSelectTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/mv/BaseMaterializedIndexSelectTest.java
@@ -25,6 +25,7 @@ import org.apache.doris.utframe.TestWithFeService;
 import org.junit.jupiter.api.Assertions;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 
 /**
@@ -35,6 +36,14 @@ public abstract class BaseMaterializedIndexSelectTest extends TestWithFeService 
         singleTableTest(sql, scan -> {
             Assertions.assertEquals(preAgg, scan.isPreAggregation());
             Assertions.assertEquals(indexName, scan.getSelectedIndexName());
+        });
+    }
+
+    // any index in indexNameSet is ok
+    protected void singleTableTest(String sql, Set<String> indexNameSet, boolean preAgg) {
+        singleTableTest(sql, scan -> {
+            Assertions.assertEquals(preAgg, scan.isPreAggregation());
+            Assertions.assertTrue(indexNameSet.contains(scan.getSelectedIndexName()));
         });
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMvIndexTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMvIndexTest.java
@@ -40,6 +40,7 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.DorisAssert;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -1145,7 +1146,8 @@ class SelectMvIndexTest extends BaseMaterializedIndexSelectTest implements MemoP
         createMv("create materialized view mv2 as"
                 + "  select a, c, bitmap_union(to_bitmap(b)) from selectBitmapMvWithProjectMultiMv group by a, c;");
 
-        testMv("select a, bitmap_union_count(to_bitmap(b)) as cnt from selectBitmapMvWithProjectMultiMv group by a", "mv");
+        testMv("select a, bitmap_union_count(to_bitmap(b)) as cnt from selectBitmapMvWithProjectMultiMv group by a",
+                ImmutableSet.of("mv", "mv2"));
         dropTable("selectBitmapMvWithProjectMultiMv", true);
     }
 
@@ -1211,6 +1213,10 @@ class SelectMvIndexTest extends BaseMaterializedIndexSelectTest implements MemoP
 
     private void testMv(String sql, String indexName) {
         singleTableTest(sql, indexName, true);
+    }
+
+    private void testMv(String sql, Set<String> indexNameSet) {
+        singleTableTest(sql, indexNameSet, true);
     }
 
     private void assertOneAggFuncType(LogicalAggregate<? extends Plan> agg, Class<?> aggFuncType) {


### PR DESCRIPTION
### What problem does this PR solve?

 Fix ut test unstable, the ut test case is org.apache.doris.nereids.rules.rewrite.mv.SelectMvIndexTest#selectBitmapMvWithProjectMultiMv

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

