### PR TITLE
[Fix](profile) profile error master

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
@@ -206,6 +206,7 @@ public class InsertIntoTableCommand extends Command implements NeedAuditEncrypti
      */
     public AbstractInsertExecutor initPlan(ConnectContext ctx, StmtExecutor stmtExecutor,
                                            boolean needBeginTransaction) throws Exception {
+        stmtExecutor.setProfileType(ProfileType.LOAD);
         List<String> qualifiedTargetTableName = InsertUtils.getTargetTableQualified(originLogicalQuery, ctx);
 
         AbstractInsertExecutor insertExecutor;
@@ -271,7 +272,6 @@ public class InsertIntoTableCommand extends Command implements NeedAuditEncrypti
                 Throwables.throwIfInstanceOf(e, RuntimeException.class);
                 throw new IllegalStateException(e.getMessage(), e);
             }
-            stmtExecutor.setProfileType(ProfileType.LOAD);
             // We exposed @StmtExecutor#cancel as a unified entry point for statement interruption,
             // so we need to set this here
             insertExecutor.getCoordinator().setTxnId(insertExecutor.getTxnId());

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -310,7 +310,11 @@ public class StmtExecutor {
             if (coord != null) {
                 taskState = coord.getExecStatus().getErrorCode().name();
             } else {
-                taskState = context.getState().toString();
+                if (isForwardToMaster()) {
+                    taskState = getProxyStatus();
+                } else {
+                    taskState = context.getState().toString();
+                }
             }
         }
         builder.taskState(taskState);

--- a/regression-test/suites/query_profile/test_profile.groovy
+++ b/regression-test/suites/query_profile/test_profile.groovy
@@ -96,6 +96,17 @@ suite('test_profile') {
         }
     }
 
+    profile("test_profile_load") {
+        run {
+            sql "/* test_profile_load */ insert into test_profile select id1, name from test_profile"
+        }
+
+        check { profileString, exception ->
+            log.info(profileString)
+            assertTrue(profileString.contains("Task  Type:  LOAD"))
+        }
+    }
+
     sql """ SET enable_profile = false """
     sql """ DROP TABLE IF EXISTS test_profile """
 }


### PR DESCRIPTION
### What problem does this PR solve?
case 1: Forward an insert stmt to master.
In non master fe node.
`set enable_profile = true;`
Exeute an insert query and fail.
in `/rest/v1/query_profile` result, the `Task State` is `OK`.

case 2: When plan fail, the insert stmt's `Task Type` is `QUERY`.
In master fe node.
`set enable_profile = true;`
Exeute an insert query and plan fail.
in `/rest/v1/query_profile` result, the `Task Type` is `QUERY`.

I will add a rt later.
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

