### PR TITLE
[fix][paimon] Fix Paimon date partition conversion failure

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonUtil.java
@@ -59,6 +59,7 @@ import org.apache.paimon.types.DecimalType;
 import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.utils.DateTimeUtils;
 import org.apache.paimon.utils.InstantiationUtil;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.Projection;
@@ -116,12 +117,23 @@ public class PaimonUtil {
         Map<String, PartitionItem> nameToPartitionItem = Maps.newHashMap();
         Map<String, Partition> nameToPartition = Maps.newHashMap();
         PaimonPartitionInfo partitionInfo = new PaimonPartitionInfo(nameToPartitionItem, nameToPartition);
+        List<Type> types = partitionColumns.stream()
+                .map(Column::getType)
+                .collect(Collectors.toList());
 
         for (Partition partition : paimonPartitions) {
+            int index = 0;
             Map<String, String> spec = partition.spec();
             StringBuilder sb = new StringBuilder();
             for (Map.Entry<String, String> entry : spec.entrySet()) {
-                sb.append(entry.getKey()).append("=").append(entry.getValue()).append("/");
+                sb.append(entry.getKey()).append("=");
+                // Paimon stores DATE type as days since 1970-01-01 (epoch), so we convert the integer to a date string.
+                if (types.get(index).isDateV2()) {
+                    sb.append(DateTimeUtils.formatDate(Integer.parseInt(entry.getValue()))).append("/");
+                } else {
+                    sb.append(entry.getValue()).append("/");
+                }
+                index++;
             }
             if (sb.length() > 0) {
                 sb.deleteCharAt(sb.length() - 1);
@@ -131,7 +143,7 @@ public class PaimonUtil {
             try {
                 // partition values return by paimon api, may have problem,
                 // to avoid affecting the query, we catch exceptions here
-                nameToPartitionItem.put(partitionName, toListPartitionItem(partitionName, partitionColumns));
+                nameToPartitionItem.put(partitionName, toListPartitionItem(partitionName, types));
             } catch (Exception e) {
                 LOG.warn("toListPartitionItem failed, partitionColumns: {}, partitionValues: {}",
                         partitionColumns, partition.spec(), e);
@@ -140,11 +152,8 @@ public class PaimonUtil {
         return partitionInfo;
     }
 
-    public static ListPartitionItem toListPartitionItem(String partitionName, List<Column> partitionColumns)
+    public static ListPartitionItem toListPartitionItem(String partitionName, List<Type> types)
             throws AnalysisException {
-        List<Type> types = partitionColumns.stream()
-                .map(Column::getType)
-                .collect(Collectors.toList());
         // Partition name will be in format: nation=cn/city=beijing
         // parse it to get values "cn" and "beijing"
         List<String> partitionValues = HiveUtil.toPartitionValues(partitionName);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonUtil.java
@@ -120,20 +120,20 @@ public class PaimonUtil {
         List<Type> types = partitionColumns.stream()
                 .map(Column::getType)
                 .collect(Collectors.toList());
+        Map<String, Type> columnNameToType = partitionColumns.stream()
+                .collect(Collectors.toMap(Column::getName, Column::getType));
 
         for (Partition partition : paimonPartitions) {
-            int index = 0;
             Map<String, String> spec = partition.spec();
             StringBuilder sb = new StringBuilder();
             for (Map.Entry<String, String> entry : spec.entrySet()) {
                 sb.append(entry.getKey()).append("=");
                 // Paimon stores DATE type as days since 1970-01-01 (epoch), so we convert the integer to a date string.
-                if (types.get(index).isDateV2()) {
+                if (columnNameToType.getOrDefault(entry.getKey(), Type.NULL).isDateV2()) {
                     sb.append(DateTimeUtils.formatDate(Integer.parseInt(entry.getValue()))).append("/");
                 } else {
                     sb.append(entry.getValue()).append("/");
                 }
-                index++;
             }
             if (sb.length() > 0) {
                 sb.deleteCharAt(sb.length() - 1);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowPartitionsCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowPartitionsCommand.java
@@ -24,6 +24,7 @@ import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.PartitionItem;
 import org.apache.doris.catalog.PartitionKey;
+import org.apache.doris.catalog.PartitionType;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.TableIf;
@@ -46,6 +47,8 @@ import org.apache.doris.datasource.iceberg.IcebergExternalCatalog;
 import org.apache.doris.datasource.iceberg.IcebergExternalTable;
 import org.apache.doris.datasource.maxcompute.MaxComputeExternalCatalog;
 import org.apache.doris.datasource.maxcompute.MaxComputeExternalTable;
+import org.apache.doris.datasource.paimon.PaimonExternalCatalog;
+import org.apache.doris.datasource.paimon.PaimonExternalTable;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.analyzer.UnboundSlot;
 import org.apache.doris.nereids.properties.OrderKey;
@@ -211,7 +214,8 @@ public class ShowPartitionsCommand extends ShowCommand {
 
         // disallow unsupported catalog
         if (!(catalog.isInternalCatalog() || catalog instanceof HMSExternalCatalog
-                || catalog instanceof MaxComputeExternalCatalog || catalog instanceof IcebergExternalCatalog)) {
+                || catalog instanceof MaxComputeExternalCatalog || catalog instanceof IcebergExternalCatalog)
+                || catalog instanceof PaimonExternalCatalog) {
             throw new AnalysisException(String.format("Catalog of type '%s' is not allowed in ShowPartitionsCommand",
                     catalog.getType()));
         }
@@ -289,6 +293,13 @@ public class ShowPartitionsCommand extends ShowCommand {
             return;
         }
 
+        if (table instanceof PaimonExternalTable) {
+            if (((PaimonExternalTable) table).getPartitionType(Optional.empty()).equals(PartitionType.UNPARTITIONED)) {
+                throw new AnalysisException("Table " + tblName + " is not a partitioned table");
+            }
+            return;
+        }
+
         table.readLock();
         try {
             // build proc path
@@ -339,6 +350,34 @@ public class ShowPartitionsCommand extends ShowCommand {
         IcebergExternalTable icebergTable = (IcebergExternalTable) icebergCatalog.getDb(db).get().getTable(tbl).get();
 
         Map<String, PartitionItem> partitions = icebergTable.getAndCopyPartitionItems(Optional.empty());
+        List<List<String>> rows = new ArrayList<>();
+        for (Map.Entry<String, PartitionItem> entry : partitions.entrySet()) {
+            List<String> row = new ArrayList<>();
+            Range<PartitionKey> items = entry.getValue().getItems();
+            row.add(entry.getKey());
+            row.add(items.lowerEndpoint().toString());
+            row.add(items.upperEndpoint().toString());
+            rows.add(row);
+        }
+        // sort by partition name
+        if (orderByPairs != null && orderByPairs.get(0).isDesc()) {
+            rows.sort(Comparator.comparing(x -> x.get(0), Comparator.reverseOrder()));
+        } else {
+            rows.sort(Comparator.comparing(x -> x.get(0)));
+        }
+
+        rows = applyLimit(limit, offset, rows);
+
+        return new ShowResultSet(getMetaData(), rows);
+    }
+
+    private ShowResultSet handleShowPaimonTablePartitions() {
+        PaimonExternalCatalog paimonCatalog = (PaimonExternalCatalog) catalog;
+        String db = ClusterNamespace.getNameFromFullName(tableName.getDb());
+        String tbl = tableName.getTbl();
+        PaimonExternalTable paimonTable = (PaimonExternalTable) paimonCatalog.getDb(db).get().getTable(tbl).get();
+
+        Map<String, PartitionItem> partitions = paimonTable.getAndCopyPartitionItems(Optional.empty());
         List<List<String>> rows = new ArrayList<>();
         for (Map.Entry<String, PartitionItem> entry : partitions.entrySet()) {
             List<String> row = new ArrayList<>();
@@ -446,7 +485,7 @@ public class ShowPartitionsCommand extends ShowCommand {
             for (String col : result.getColumnNames()) {
                 builder.addColumn(new Column(col, ScalarType.createVarchar(30)));
             }
-        } else if (catalog instanceof IcebergExternalCatalog) {
+        } else if (catalog instanceof IcebergExternalCatalog || catalog instanceof PaimonExternalCatalog) {
             builder.addColumn(new Column("Partition", ScalarType.createVarchar(60)));
             builder.addColumn(new Column("Lower Bound", ScalarType.createVarchar(100)));
             builder.addColumn(new Column("Upper Bound", ScalarType.createVarchar(100)));

--- a/regression-test/data/mtmv_p0/test_paimon_mtmv.out
+++ b/regression-test/data/mtmv_p0/test_paimon_mtmv.out
@@ -143,6 +143,9 @@ true
 -- !date_partition_base_table --
 1	2020-01-01
 
+-- !date_type_partition --
+1	2020-01-01
+
 -- !date_partition --
 1	2020-01-01
 


### PR DESCRIPTION
### What problem does this PR solve?

**Background**: PR [#46641](https://github.com/apache/doris/pull/46641) worked around Paimon date partition failures by treating date partitions as unpartitioned tables.

**Root Cause**: Paimon stores date partition values as integers (e.g., `20231225` for `2023-12-25`), but the previous implementation failed to convert these to Doris-compatible date formats, resulting in:
```
org.apache.doris.common.AnalysisException: errCode = 2, detailMessage = date literal [19737] is invalid: null
```


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

