### PR TITLE
[fix](balance) prevent BeLoadRebalancer schedule fail due to inconsis…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/BeLoadRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/BeLoadRebalancer.java
@@ -337,6 +337,16 @@ public class BeLoadRebalancer extends Rebalancer {
         // select a replica as source
         boolean setSource = false;
         for (Replica replica : replicas) {
+            Backend be = infoService.getBackend(replica.getBackendIdWithoutException());
+            if (be == null) {
+                throw new SchedException(Status.UNRECOVERABLE, SubCode.DIAGNOSE_IGNORE,
+                        "backend is dropped: " + replica.getBackendIdWithoutException());
+            }
+            if (!be.getLocationTag().equals(tabletCtx.getTag())) {
+                // prevent selected src replica has different tag with tabletCtx's tag
+                // otherwise it could lead to schedule fail
+                continue;
+            }
             PathSlot slot = backendsWorkingSlots.get(replica.getBackendIdWithoutException());
             if (slot == null) {
                 continue;

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/LoadStatisticForTag.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/LoadStatisticForTag.java
@@ -362,6 +362,10 @@ public class LoadStatisticForTag {
         if (optSrcBeStat.isPresent()) {
             srcBeStat = optSrcBeStat.get();
         } else {
+            if (LOG.isDebugEnabled()) {
+                LOG.info("migrate {}(size: {}) from {} to {} failed, tag: {}, medium: {}, src BE stat does not exist.",
+                        tabletId, tabletSize, srcBeId, destBeId, tag, medium);
+            }
             return false;
         }
 
@@ -371,10 +375,19 @@ public class LoadStatisticForTag {
         if (optDestBeStat.isPresent()) {
             destBeStat = optDestBeStat.get();
         } else {
+            if (LOG.isDebugEnabled()) {
+                LOG.info("migrate {}(size: {}) from {} to {} failed, tag: {}, medium: {}, dest BE stat does not exist.",
+                        tabletId, tabletSize, srcBeId, destBeId, tag, medium);
+            }
             return false;
         }
 
         if (!srcBeStat.hasMedium(medium) || !destBeStat.hasMedium(medium)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.info("migrate {}(size: {}) from {} to {} failed, tag: {}, medium: {}, "
+                        + "src or dest BE does not have medium.",
+                        tabletId, tabletSize, srcBeId, destBeId, tag, medium);
+            }
             return false;
         }
 


### PR DESCRIPTION
…tent resource tag

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
in BeLoadRebalancer the resource tag of tabletCtx is set during `selectAlternativeTabletsForCluster`. However there is no filter in selecting src replica in `completeSchedCtx`. Such conflict could lead to a lots of check fail in `clusterStat.isMoreBalanced` and cause balance schedule very slow.
Also add some log to help further problem investigation. 

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

