### PR TITLE
[enhance](auth)support ldap user show grants

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowGrantsCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowGrantsCommand.java
@@ -70,7 +70,6 @@ public class ShowGrantsCommand extends ShowCommand {
 
     @Override
     public ShowResultSet doRun(ConnectContext ctx, StmtExecutor executor) throws Exception {
-        boolean isSelf = false;
         if (userIdent != null) {
             if (isAll) {
                 throw new AnalysisException("Can not specified keyword ALL when specified user");
@@ -80,9 +79,9 @@ public class ShowGrantsCommand extends ShowCommand {
             if (!isAll) {
                 // self
                 userIdent = ConnectContext.get().getCurrentUserIdentity();
-                isSelf = true;
             }
         }
+        boolean isSelf = userIdent!= null && ConnectContext.get().getCurrentUserIdentity().equals(userIdent);
         Preconditions.checkState(isAll || userIdent != null);
         // if show all grants, or show other user's grants, need global GRANT priv.
         if (isAll || !isSelf) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowGrantsCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowGrantsCommand.java
@@ -81,7 +81,7 @@ public class ShowGrantsCommand extends ShowCommand {
                 userIdent = ConnectContext.get().getCurrentUserIdentity();
             }
         }
-        boolean isSelf = userIdent!= null && ConnectContext.get().getCurrentUserIdentity().equals(userIdent);
+        boolean isSelf = userIdent != null && ConnectContext.get().getCurrentUserIdentity().equals(userIdent);
         Preconditions.checkState(isAll || userIdent != null);
         // if show all grants, or show other user's grants, need global GRANT priv.
         if (isAll || !isSelf) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowGrantsCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowGrantsCommand.java
@@ -70,6 +70,7 @@ public class ShowGrantsCommand extends ShowCommand {
 
     @Override
     public ShowResultSet doRun(ConnectContext ctx, StmtExecutor executor) throws Exception {
+        boolean isSelf = false;
         if (userIdent != null) {
             if (isAll) {
                 throw new AnalysisException("Can not specified keyword ALL when specified user");
@@ -79,18 +80,19 @@ public class ShowGrantsCommand extends ShowCommand {
             if (!isAll) {
                 // self
                 userIdent = ConnectContext.get().getCurrentUserIdentity();
+                isSelf = true;
             }
         }
         Preconditions.checkState(isAll || userIdent != null);
-        UserIdentity self = ConnectContext.get().getCurrentUserIdentity();
-
         // if show all grants, or show other user's grants, need global GRANT priv.
-        if (isAll || !self.equals(userIdent)) {
+        if (isAll || !isSelf) {
             if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(), PrivPredicate.GRANT)) {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "GRANT");
             }
         }
-        if (userIdent != null && !Env.getCurrentEnv().getAccessManager().getAuth().doesUserExist(userIdent)) {
+        // ldap user not exist in userManager, so should not check
+        if (userIdent != null && !isSelf && !Env.getCurrentEnv().getAccessManager().getAuth()
+                .doesUserExist(userIdent)) {
             throw new AnalysisException(String.format("User: %s does not exist", userIdent));
         }
         List<List<String>> infos = Env.getCurrentEnv().getAuth().getAuthInfo(userIdent);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowGrantsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowGrantsCommandTest.java
@@ -86,4 +86,21 @@ public class ShowGrantsCommandTest extends TestWithFeService {
         int size = results.size();
         Assertions.assertEquals("'zzz'@'%'", results.get(size - 1).get(0));
     }
+
+    @Test
+    void testNonExistUser() {
+        ConnectContext ctx = ConnectContext.get();
+        UserIdentity nonExistUser = UserIdentity.createAnalyzedUserIdentWithIp("non_exist_user", "%");
+        Assertions.assertThrows(AnalysisException.class, () -> {
+            ShowGrantsCommand sg = new ShowGrantsCommand(nonExistUser, false);
+            sg.doRun(ctx, null);
+        });
+
+        ctx.setIsTempUser(true);
+        ctx.setCurrentUserIdentity(nonExistUser);
+        Assertions.assertDoesNotThrow(() -> {
+            ShowGrantsCommand sg = new ShowGrantsCommand(null, false);
+            sg.doRun(ctx, null);
+        });
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

The LDAP user does not exist in Doris, so a "user does not exist" prompt will appear when executing the "show grants" command.

It is a reasonable requirement for users to check their own permissions after logging in. Therefore, this PR enables LDAP users to view their own permissions when executing `show grants` themselves. However, others are still unable to do so, whether by specifying a particular username or checking all users.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
support ldap user show grants
### Release note

support ldap user show grants

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

