### PR TITLE
[opt][editlog] Added the ability to skip certain editlog exceptions when fe is abnormal

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1285,6 +1285,13 @@ public class Config extends ConfigBase {
     @ConfField(mutable = false, masterOnly = false)
     public static String[] force_skip_journal_ids = {};
 
+    @ConfField(description = {"当回放 editlog 时遇到特定操作类型的异常导致 FE 无法启动时，可以配置需要忽略的 editlog 操作类型枚举值，"
+            + "从而跳过这些异常，让 replay 线程可以继续回放其他日志",
+        "When replaying editlog encounters exceptions with specific operation types that prevent FE from starting, "
+            + "you can configure the editlog operation type enum values to be ignored, "
+            + "thereby skipping these exceptions and allowing the replay thread to continue replaying other logs"})
+    public static short[] skip_operation_types_on_replay_exception =  {-1, -1};
+
     /**
      * Decide how often to check dynamic partition
      */
@@ -2539,7 +2546,7 @@ public class Config extends ConfigBase {
     /**
      * To prevent different types (V1, V2, V3) of behavioral inconsistencies,
      * we may delete the DecimalV2 and DateV1 types in the future.
-     * At this stage, we use ‘disable_decimalv2’ and ‘disable_datev1’
+     * At this stage, we use 'disable_decimalv2' and 'disable_datev1'
      * to determine whether these two types take effect.
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -1438,8 +1438,8 @@ public class EditLog {
         } catch (Exception e) {
             short[] ignoreExceptionLogIds = Config.skip_operation_types_on_replay_exception;
             boolean skip = false;
-            for (short id : ignoreExceptionLogIds) {
-                if (id == opCode) {
+            for (short ignoreLogId : ignoreExceptionLogIds) {
+                if (ignoreLogId == opCode) {
                     skip = true;
                     break;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -1436,8 +1436,20 @@ public class EditLog {
              */
             LOG.warn("[INCONSISTENT META] replay log {} failed, journal {}: {}", logId, journal, e.getMessage(), e);
         } catch (Exception e) {
-            LOG.error("replay Operation Type {}, log id: {}", opCode, logId, e);
-            System.exit(-1);
+            short[] ignoreExceptionLogIds = Config.skip_operation_types_on_replay_exception;
+            boolean skip = false;
+            for (short id : ignoreExceptionLogIds) {
+                if (id == opCode) {
+                    skip = true;
+                    break;
+                }
+            }
+            if (!skip) {
+                LOG.error("replay Operation Type {}, log id: {}", opCode, logId, e);
+                System.exit(-1);
+            } else {
+                LOG.warn("Skip replay Operation Type {} due to exception, log id: {}", opCode, logId, e);
+            }
         }
     }
 


### PR DESCRIPTION
…hen fe is abnormal



The previous operation and maintenance method force_skip_journal_ids can only skip a specific logid. If there are many abnormal logids, it is difficult to configure


### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->
https://github.com/apache/doris-website/pull/2731/files

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

