### PR TITLE
[enhance](auth)Add a configuration to prohibit accessing LDAP with an empty password

### DIFF
--- a/conf/ldap.conf
+++ b/conf/ldap.conf
@@ -55,3 +55,4 @@ ldap_group_basedn = ou=group,dc=domain,dc=com
 # ldap_pool_test_on_borrow = false
 # ldap_pool_test_on_return = false
 # ldap_pool_test_while_idle = false
+# ldap_allow_empty_password = true

--- a/fe/fe-common/src/main/java/org/apache/doris/common/LdapConfig.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/LdapConfig.java
@@ -157,4 +157,10 @@ public class LdapConfig extends ConfigBase {
      */
     @ConfigBase.ConfField
     public static boolean ldap_pool_test_while_idle = false;
+
+    /**
+     * Whether to allow LDAP users to log in with an empty password
+     */
+    @ConfigBase.ConfField
+    public static boolean ldap_allow_empty_password = true;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
@@ -1233,7 +1233,10 @@ public enum ErrorCode {
     ERR_NO_CLUSTER_ERROR(5099, new byte[]{'4', '2', '0', '0', '0'}, "No compute group (cloud cluster) selected"),
 
     ERR_NOT_CLOUD_MODE(6000, new byte[]{'4', '2', '0', '0', '0'},
-            "Command only support in cloud mode.");
+            "Command only support in cloud mode."),
+
+    ERR_EMPTY_PASSWORD(6001, new byte[]{'4', '2', '0', '0', '0'},
+            "not allow empty password.");
 
     // This is error code
     private final int code;

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticator.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.LdapConfig;
 import org.apache.doris.mysql.authenticate.AuthenticateRequest;
 import org.apache.doris.mysql.authenticate.AuthenticateResponse;
 import org.apache.doris.mysql.authenticate.Authenticator;
@@ -32,6 +33,7 @@ import org.apache.doris.mysql.authenticate.password.PasswordResolver;
 import org.apache.doris.mysql.privilege.Auth;
 
 import com.google.common.base.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -94,6 +96,11 @@ public class LdapAuthenticator implements Authenticator {
         String userName = ClusterNamespace.getNameFromFullName(qualifiedUser);
         if (LOG.isDebugEnabled()) {
             LOG.debug("user:{}", userName);
+        }
+
+        if (StringUtils.isEmpty(password) && !LdapConfig.ldap_allow_empty_password) {
+            ErrorReport.report(ErrorCode.ERR_EMPTY_PASSWORD);
+            return AuthenticateResponse.failedResponse;
         }
 
         // check user password by ldap server.

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticatorTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.mysql.authenticate.ldap;
 
 import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.common.LdapConfig;
 import org.apache.doris.mysql.authenticate.AuthenticateRequest;
 import org.apache.doris.mysql.authenticate.AuthenticateResponse;
 import org.apache.doris.mysql.authenticate.password.ClearPassword;
@@ -142,5 +143,19 @@ public class LdapAuthenticatorTest {
     @Test
     public void testGetPasswordResolver() {
         Assert.assertTrue(ldapAuthenticator.getPasswordResolver() instanceof ClearPasswordResolver);
+    }
+
+    @Test
+    public void testEmptyPassword() throws IOException {
+        setCheckPassword(true);
+        setGetUserInDoris(true);
+        AuthenticateRequest request = new AuthenticateRequest(USER_NAME, new ClearPassword(""), IP);
+        LdapConfig.ldap_allow_empty_password = true;
+        AuthenticateResponse response = ldapAuthenticator.authenticate(request);
+        Assert.assertTrue(response.isSuccess());
+        LdapConfig.ldap_allow_empty_password = false;
+        response = ldapAuthenticator.authenticate(request);
+        Assert.assertFalse(response.isSuccess());
+        LdapConfig.ldap_allow_empty_password = true;
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

When LDAP is enabled with null bind, an empty password will automatically convert to an anonymous user login. This scenario is judged as a correct password, and since the username used actually exists, the corresponding user can also be correctly found through the LDAP account. As a result, it becomes possible to log in to any LDAP account with an empty password.

resolve:

add ldap config: ldap_allow_empty_password,default is true,

when set it to false,use empty password login will failed

```
mysql -h127.0.0.1 -P 3030 -u zd -p --enable-cleartext-plugin
Enter password: 
ERROR 6001 (42000): not allow empty password.
```

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
Add a configuration to prohibit accessing LDAP with an empty password
### Release note

Add a configuration to prohibit accessing LDAP with an empty password

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

