### PR TITLE
[fix](columns) ensure data independence in ColumnConst::clone_resized

### DIFF
--- a/be/src/vec/columns/column_const.h
+++ b/be/src/vec/columns/column_const.h
@@ -123,7 +123,7 @@ public:
     void resize(size_t new_size) override { s = new_size; }
 
     MutableColumnPtr clone_resized(size_t new_size) const override {
-        return ColumnConst::create(data, new_size);
+        return ColumnConst::create(data->clone_resized(1), new_size);
     }
 
     size_t size() const override { return s; }


### PR DESCRIPTION
### What problem does this PR solve?

Previously, `ColumnConst::clone_resized` directly reused the original data column, 
which could lead to unintended data sharing between the original and cloned columns. 

This fix ensures each cloned ColumnConst has its own independent data copy by calling `data->clone_resized(1)`, 
maintaining the invariant that ColumnConst's internal data column always has exactly one element while providing proper data isolation.

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

