### PR TITLE
[bug](group commit) Fix group commit blocked after schema change throw exception

### DIFF
--- a/regression-test/suites/insert_p0/insert_group_commit_into.groovy
+++ b/regression-test/suites/insert_p0/insert_group_commit_into.groovy
@@ -234,6 +234,23 @@ suite("insert_group_commit_into") {
             logger.info("row count: " + rowCount)
             assertEquals(23, rowCount[0][0])
 
+            // 8. Test create rollup throw exception and group commit behavior
+            try {
+                sql """ alter table ${table} ADD ROLLUP r1(name, score); """
+                assertTrue(false, "create rollup with duplicate name should fail.")
+            } catch (Exception e) {
+                logger.info("Expected create rollup error: " + e.getMessage())
+                assertTrue(e.getMessage().contains("already exists"))
+            }
+
+            group_commit_insert_with_retry """ insert into ${table}(id, name) values(2, 'b');  """, 1
+            group_commit_insert_with_retry """ insert into ${table}(id) values(6); """, 1
+            getRowCount(25)
+
+            // Verify group commit works after add rollup throw exception
+            group_commit_insert """ insert into ${table}(id, name) values(2, 'b'); """, 1
+            getRowCount(26)
+
             // txn insert
             sql """ set enable_nereids_dml = true; """
             sql """ set enable_nereids_planner=true; """
@@ -247,7 +264,7 @@ suite("insert_group_commit_into") {
 
             rowCount = sql "select count(*) from ${table}"
             logger.info("row count: " + rowCount)
-            assertEquals(rowCount[0][0], 25)
+            assertEquals(rowCount[0][0], 28)
         }
     } finally {
         // try_sql("DROP TABLE ${table}")


### PR DESCRIPTION
### What problem does this PR solve?

Fix group commit blocked after schema change throw exception

Problem Summary:

Reproduce step:

1、create table

```
CREATE TABLE `test_table_uniq` (
  `company_id` varchar(32) NOT NULL,
  `date` datetime NOT NULL,
  `discount` decimal(19,10) NULL,
) ENGINE=OLAP
UNIQUE KEY(`company_id`, `date`)
DISTRIBUTED BY HASH(`company_id`) BUCKETS 8
```

2、group commit insert  SUCCESS

```
SET group_commit = async_mode;
INSERT INTO test_table_uniq (company_id, date, discount) VALUES(1, '2025-07-25', 10);
```

3、create rollup and wait job SUCCESS

```
CREATE MATERIALIZED VIEW mv_company_day
AS 
SELECT   company_id,   date
FROM test_table_uniq;
```

4、group commit insert  SUCCESS

```
SET group_commit = async_mode;
INSERT INTO test_table_uniq (company_id, date, discount) VALUES(2, '2025-07-25', 11);
```

5、create rollup with same name and throw exception

```
CREATE MATERIALIZED VIEW mv_company_day
AS 
SELECT   company_id,   date
FROM test_table_uniq;
ERROR 1105 (HY000): errCode = 2, detailMessage = Materialized view[mv_company_day] already exists
```

6、group commit insert  FAIL

```
SET group_commit = async_mode;
INSERT INTO test_table_uniq (company_id, date, discount) VALUES(3, '2025-07-25', 12);
```


JDBC ERROR LOG:
```
java.sql.BatchUpdateException: errCode = 2, detailMessage = insert table 1753872336812 is blocked on schema change
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at com.mysql.cj.util.Util.handleNewInstance(Util.java:192)
        at com.mysql.cj.util.Util.getInstance(Util.java:167)
        at com.mysql.cj.util.Util.getInstance(Util.java:174)
        at com.mysql.cj.jdbc.exceptions.SQLError.createBatchUpdateException(SQLError.java:224)
        at com.mysql.cj.jdbc.ClientPreparedStatement.executeBatchedInserts(ClientPreparedStatement.java:755)
        at com.mysql.cj.jdbc.ClientPreparedStatement.executeBatchInternal(ClientPreparedStatement.java:426)
        at com.mysql.cj.jdbc.StatementImpl.executeBatch(StatementImpl.java:795)
        at DorisStressTest.main(DorisStressTest.java:78)
Caused by: java.sql.SQLException: errCode = 2, detailMessage = insert table 1753872336812 is blocked on schema change
        at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:129)
        at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
        at com.mysql.cj.jdbc.ServerPreparedStatement.serverExecute(ServerPreparedStatement.java:633)
        at com.mysql.cj.jdbc.ServerPreparedStatement.executeInternal(ServerPreparedStatement.java:417)
        at com.mysql.cj.jdbc.ClientPreparedStatement.executeUpdateInternal(ClientPreparedStatement.java:1098)
        at com.mysql.cj.jdbc.ClientPreparedStatement.executeUpdateInternal(ClientPreparedStatement.java:1046)
        at com.mysql.cj.jdbc.ClientPreparedStatement.executeLargeUpdate(ClientPreparedStatement.java:1371)
        at com.mysql.cj.jdbc.ClientPreparedStatement.executeBatchedInserts(ClientPreparedStatement.java:716)
```

### Release note

master/3.0/2.1

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

