### PR TITLE
[Feat](params-refactor): Refactor Paimon Metastore parameter integration

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Resource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Resource.java
@@ -24,7 +24,6 @@ import org.apache.doris.common.io.DeepCopy;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.proc.BaseProcResult;
-import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.nereids.trees.plans.commands.CreateResourceCommand;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateResourceInfo;
 import org.apache.doris.persist.gson.GsonPostProcessable;
@@ -288,20 +287,7 @@ public abstract class Resource implements Writable, GsonPostProcessable {
     private void notifyUpdate(Map<String, String> properties) {
         references.entrySet().stream().collect(Collectors.groupingBy(Entry::getValue)).forEach((type, refs) -> {
             if (type == ReferenceType.CATALOG) {
-                for (Map.Entry<String, ReferenceType> ref : refs) {
-                    String catalogName = ref.getKey().split(REFERENCE_SPLIT)[0];
-                    CatalogIf catalog = Env.getCurrentEnv().getCatalogMgr().getCatalog(catalogName);
-                    if (catalog == null) {
-                        LOG.warn("Can't find the reference catalog {} for resource {}", catalogName, name);
-                        continue;
-                    }
-                    if (!name.equals(catalog.getResource())) {
-                        LOG.warn("Failed to update catalog {} for different resource "
-                                + "names(resource={}, catalog.resource={})", catalogName, name, catalog.getResource());
-                        continue;
-                    }
-                    catalog.notifyPropertiesUpdated(properties);
-                }
+                // No longer support resource in Catalog.
             }
         });
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogIf.java
@@ -36,7 +36,6 @@ import org.apache.doris.nereids.trees.plans.commands.info.CreateOrReplaceTagInfo
 import org.apache.doris.nereids.trees.plans.commands.info.DropBranchInfo;
 import org.apache.doris.nereids.trees.plans.commands.info.DropTagInfo;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -88,10 +87,6 @@ public interface CatalogIf<T extends DatabaseIf> {
     T getDbNullable(long dbId);
 
     Map<String, String> getProperties();
-
-    default String getResource() {
-        return null;
-    }
 
     default void notifyPropertiesUpdated(Map<String, String> updatedProps) {
         if (this instanceof ExternalCatalog) {
@@ -175,7 +170,7 @@ public interface CatalogIf<T extends DatabaseIf> {
         CatalogLog log = new CatalogLog();
         log.setCatalogId(getId());
         log.setCatalogName(getName());
-        log.setResource(Strings.nullToEmpty(getResource()));
+        log.setResource("");
         log.setComment(getComment());
         log.setProps(getProperties());
         return log;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogLog.java
@@ -56,6 +56,7 @@ public class CatalogLog implements Writable {
     @SerializedName(value = "invalidCache")
     private boolean invalidCache;
 
+    @Deprecated
     @SerializedName(value = "resource")
     private String resource;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -23,8 +23,6 @@ import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.EnvFactory;
-import org.apache.doris.catalog.Resource;
-import org.apache.doris.catalog.Resource.ReferenceType;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.AnalysisException;
@@ -121,12 +119,6 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         if (!catalogName.equals(InternalCatalog.INTERNAL_CATALOG_NAME)) {
             ((ExternalCatalog) catalog).resetToUninitialized(false);
         }
-        if (!Strings.isNullOrEmpty(catalog.getResource())) {
-            Resource resource = Env.getCurrentEnv().getResourceMgr().getResource(catalog.getResource());
-            if (resource != null) {
-                resource.addReference(catalog.getName(), ReferenceType.CATALOG);
-            }
-        }
     }
 
     private CatalogIf removeCatalog(long catalogId) {
@@ -139,12 +131,6 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
                 ConnectContext.get().removeLastDBOfCatalog(catalog.getName());
             }
             Env.getCurrentEnv().getExtMetaCacheMgr().removeCache(catalog.getId());
-            if (!Strings.isNullOrEmpty(catalog.getResource())) {
-                Resource catalogResource = Env.getCurrentEnv().getResourceMgr().getResource(catalog.getResource());
-                if (catalogResource != null) {
-                    catalogResource.removeReference(catalog.getName(), ReferenceType.CATALOG);
-                }
-            }
             Env.getCurrentEnv().getQueryStats().clear(catalog.getId());
         }
         return catalog;
@@ -435,9 +421,6 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
                             ErrorCode.ERR_CATALOG_ACCESS_DENIED,
                             ConnectContext.get().getQualifiedUser(),
                             catalog.getName());
-                }
-                if (!Strings.isNullOrEmpty(catalog.getResource())) {
-                    rows.add(Arrays.asList("resource", catalog.getResource()));
                 }
                 Map<String, String> sortedMap = getCatalogPropertiesWithPrintable(catalog);
                 sortedMap.forEach((k, v) -> rows.add(Arrays.asList(k, v)));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogProperty.java
@@ -31,7 +31,6 @@ import org.apache.logging.log4j.Logger;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -45,16 +44,24 @@ public class CatalogProperty {
     @Deprecated
     @SerializedName(value = "resource")
     private String resource;
+
     @SerializedName(value = "properties")
     private Map<String, String> properties;
 
+    // Lazy-loaded storage properties map, using volatile to ensure visibility
     private volatile Map<StorageProperties.Type, StorageProperties> storagePropertiesMap;
 
-    private final AtomicReference<Map<String, String>> backendStoragePropertiesRef = new AtomicReference<>();
+    // Lazy-loaded metastore properties, using volatile to ensure visibility
+    private volatile MetastoreProperties metastoreProperties;
 
-    private MetastoreProperties metastoreProperties;
+    // Lazy-loaded backend storage properties, using volatile to ensure visibility
+    private volatile Map<String, String> backendStorageProperties;
+
+    // Lazy-loaded Hadoop properties, using volatile to ensure visibility
+    private volatile Map<String, String> hadoopProperties;
 
     public CatalogProperty(String resource, Map<String, String> properties) {
+        this.resource = resource; // Keep but not used
         this.properties = properties;
         if (this.properties == null) {
             this.properties = Maps.newConcurrentMap();
@@ -66,93 +73,128 @@ public class CatalogProperty {
     }
 
     public Map<String, String> getProperties() {
-        Map<String, String> mergedProperties = Maps.newHashMap(properties);
-        return mergedProperties;
+        return Maps.newHashMap(properties);
     }
 
     public void modifyCatalogProps(Map<String, String> props) {
-        properties.putAll(PropertyConverter.convertToMetaProperties(props));
-        this.storagePropertiesMap = null;
-    }
-
-    private void reInitCatalogStorageProperties() {
-        List<StorageProperties> storageProperties;
-        try {
-            storageProperties = StorageProperties.createAll(getProperties());
-            this.storagePropertiesMap = (storageProperties.stream()
-                    .collect(java.util.stream.Collectors.toMap(StorageProperties::getType, Function.identity())));
-        } catch (UserException e) {
-            throw new RuntimeException(e);
+        synchronized (this) {
+            properties.putAll(PropertyConverter.convertToMetaProperties(props));
+            resetAllCaches();
         }
-
     }
 
     public void rollBackCatalogProps(Map<String, String> props) {
-        properties.clear();
-        properties = new HashMap<>(props);
-        this.storagePropertiesMap = null;
-    }
-
-
-    public Map<String, String> getHadoopProperties() {
-        Map<String, String> hadoopProperties = getProperties();
-        hadoopProperties.putAll(PropertyConverter.convertToHadoopFSProperties(getProperties()));
-        return hadoopProperties;
+        synchronized (this) {
+            properties = new HashMap<>(props);
+            resetAllCaches();
+        }
     }
 
     public void addProperty(String key, String val) {
-        this.properties.put(key, val);
-        this.storagePropertiesMap = null; // reset storage properties map
+        synchronized (this) {
+            this.properties.put(key, val);
+            resetAllCaches();
+        }
     }
 
     public void deleteProperty(String key) {
-        this.properties.remove(key);
-        this.storagePropertiesMap = null;
+        synchronized (this) {
+            this.properties.remove(key);
+            resetAllCaches();
+        }
     }
 
+    /**
+     * Unified cache reset method to ensure all caches are properly cleared
+     */
+    private void resetAllCaches() {
+        this.storagePropertiesMap = null;
+        this.metastoreProperties = null;
+        this.backendStorageProperties = null;
+        this.hadoopProperties = null;
+    }
+
+    /**
+     * Get storage properties map with lazy loading, using double-check locking to ensure thread safety
+     */
     public Map<StorageProperties.Type, StorageProperties> getStoragePropertiesMap() {
         if (storagePropertiesMap == null) {
             synchronized (this) {
                 if (storagePropertiesMap == null) {
-                    reInitCatalogStorageProperties();
+                    try {
+                        List<StorageProperties> storageProperties = StorageProperties.createAll(getProperties());
+                        this.storagePropertiesMap = storageProperties.stream()
+                                .collect(Collectors.toMap(StorageProperties::getType, Function.identity()));
+                    } catch (UserException e) {
+                        LOG.warn("Failed to initialize catalog storage properties", e);
+                        throw new RuntimeException("Failed to initialize storage properties for catalog", e);
+                    }
                 }
             }
         }
         return storagePropertiesMap;
     }
 
+    /**
+     * Get metastore properties with lazy loading, using double-check locking to ensure thread safety
+     */
     public MetastoreProperties getMetastoreProperties() {
         if (MapUtils.isEmpty(getProperties())) {
             return null;
         }
+
         if (metastoreProperties == null) {
-            try {
-                metastoreProperties = MetastoreProperties.create(getProperties());
-            } catch (UserException e) {
-                throw new RuntimeException(e);
+            synchronized (this) {
+                if (metastoreProperties == null) {
+                    try {
+                        metastoreProperties = MetastoreProperties.create(getProperties());
+                    } catch (UserException e) {
+                        LOG.warn("Failed to create metastore properties", e);
+                        throw new RuntimeException("Failed to create metastore properties", e);
+                    }
+                }
             }
         }
         return metastoreProperties;
     }
 
+    /**
+     * Get backend storage properties with lazy loading, using double-check locking to ensure thread safety
+     */
     public Map<String, String> getBackendStorageProperties() {
-        Map<String, String> existing = backendStoragePropertiesRef.get();
-        if (existing != null) {
-            return existing;
-        }
+        if (backendStorageProperties == null) {
+            synchronized (this) {
+                if (backendStorageProperties == null) {
+                    Map<String, String> result = new HashMap<>();
+                    Map<StorageProperties.Type, StorageProperties> storageMap = getStoragePropertiesMap();
 
-        Map<String, String> computed = getStoragePropertiesMap().values().stream()
-                .flatMap(m -> m.getBackendConfigProperties().entrySet().stream())
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        Map.Entry::getValue,
-                        (v1, v2) -> v2));
+                    for (StorageProperties sp : storageMap.values()) {
+                        Map<String, String> backendProps = sp.getBackendConfigProperties();
+                        if (backendProps != null) {
+                            result.putAll(backendProps);
+                        }
+                    }
 
-        // only one thread will succeed in setting this
-        if (backendStoragePropertiesRef.compareAndSet(null, computed)) {
-            return computed;
-        } else {
-            return backendStoragePropertiesRef.get();
+                    this.backendStorageProperties = result;
+                }
+            }
         }
+        return backendStorageProperties;
+    }
+
+    /**
+     * Get Hadoop properties with lazy loading, using double-check locking to ensure thread safety
+     */
+    public Map<String, String> getHadoopProperties() {
+        if (hadoopProperties == null) {
+            synchronized (this) {
+                if (hadoopProperties == null) {
+                    Map<String, String> result = getProperties();
+                    result.putAll(PropertyConverter.convertToHadoopFSProperties(getProperties()));
+                    this.hadoopProperties = result;
+                }
+            }
+        }
+        return hadoopProperties;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -675,11 +675,6 @@ public abstract class ExternalCatalog
                 + ", table id: " + tableId);
     }
 
-    @Override
-    public String getResource() {
-        return catalogProperty.getResource();
-    }
-
     @Nullable
     @Override
     public ExternalDatabase<? extends ExternalTable> getDbNullable(String dbName) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
@@ -601,13 +601,8 @@ public class HMSExternalTable extends ExternalTable implements MTMVRelatedTableI
         return catalog.getCatalogProperty().getStoragePropertiesMap();
     }
 
-    public Map<String, String> getHadoopProperties() {
-        return getStoragePropertiesMap().values().stream()
-                .flatMap(m -> m.getBackendConfigProperties().entrySet().stream())
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        Map.Entry::getValue,
-                        (v1, v2) -> v2));
+    public Map<String, String> getBackendStorageProperties() {
+        return catalog.getCatalogProperty().getBackendStorageProperties();
 
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
@@ -603,7 +603,6 @@ public class HMSExternalTable extends ExternalTable implements MTMVRelatedTableI
 
     public Map<String, String> getBackendStorageProperties() {
         return catalog.getCatalogProperty().getBackendStorageProperties();
-
     }
 
     public List<ColumnStatisticsObj> getHiveTableColumnStats(List<String> columns) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/source/HiveScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/source/HiveScanNode.java
@@ -477,8 +477,8 @@ public class HiveScanNode extends FileQueryScanNode {
     }
 
     @Override
-    protected Map<String, String> getLocationProperties() throws UserException  {
-        return hmsTable.getHadoopProperties();
+    protected Map<String, String> getLocationProperties() {
+        return hmsTable.getBackendStorageProperties();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiScanNode.java
@@ -231,12 +231,12 @@ public class HudiScanNode extends HiveScanNode {
     }
 
     @Override
-    protected Map<String, String> getLocationProperties() throws UserException {
+    protected Map<String, String> getLocationProperties() {
         if (incrementalRead) {
             return incrementalRelation.getHoodieParams();
         } else {
             // HudiJniScanner uses hadoop client to read data.
-            return hmsTable.getHadoopProperties();
+            return hmsTable.getBackendStorageProperties();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalCatalog.java
@@ -23,18 +23,14 @@ import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.InitCatalogLog;
 import org.apache.doris.datasource.SessionContext;
 import org.apache.doris.datasource.operations.ExternalMetadataOperations;
-import org.apache.doris.datasource.property.PropertyConverter;
 import org.apache.doris.datasource.property.metastore.AbstractIcebergProperties;
 import org.apache.doris.datasource.property.metastore.MetastoreProperties;
 import org.apache.doris.transaction.TransactionManagerFactory;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.s3a.Constants;
 import org.apache.iceberg.catalog.Catalog;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 public abstract class IcebergExternalCatalog extends ExternalCatalog {
 
@@ -140,11 +136,6 @@ public abstract class IcebergExternalCatalog extends ExternalCatalog {
         if (null != catalog) {
             catalog = null;
         }
-    }
-
-    protected void initS3Param(Configuration conf) {
-        Map<String, String> properties = catalogProperty.getHadoopProperties();
-        conf.set(Constants.AWS_CREDENTIALS_PROVIDER, PropertyConverter.getAWSCredentialsProviders(properties));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
@@ -361,7 +361,7 @@ public class JdbcExternalCatalog extends ExternalCatalog {
         jdbcTable.setDriverClass(this.getDriverClass());
         jdbcTable.setDriverUrl(this.getDriverUrl());
         jdbcTable.setCheckSum(this.getCheckSum());
-        jdbcTable.setResourceName(this.getResource());
+        jdbcTable.setResourceName("");
         jdbcTable.setConnectionPoolMinSize(this.getConnectionPoolMinSize());
         jdbcTable.setConnectionPoolMaxSize(this.getConnectionPoolMaxSize());
         jdbcTable.setConnectionPoolMaxLifeTime(this.getConnectionPoolMaxLifeTime());

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonDLFExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonDLFExternalCatalog.java
@@ -17,23 +17,12 @@
 
 package org.apache.doris.datasource.paimon;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.util.Map;
 
 public class PaimonDLFExternalCatalog extends PaimonExternalCatalog {
-    private static final Logger LOG = LogManager.getLogger(PaimonDLFExternalCatalog.class);
 
     public PaimonDLFExternalCatalog(long catalogId, String name, String resource,
                                     Map<String, String> props, String comment) {
         super(catalogId, name, resource, props, comment);
-    }
-
-    @Override
-    protected void initLocalObjectsImpl() {
-        super.initLocalObjectsImpl();
-        catalogType = PAIMON_DLF;
-        catalog = createCatalog();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalog.java
@@ -18,30 +18,21 @@
 package org.apache.doris.datasource.paimon;
 
 import org.apache.doris.common.DdlException;
-import org.apache.doris.common.security.authentication.AuthenticationConfig;
-import org.apache.doris.common.security.authentication.HadoopAuthenticator;
-import org.apache.doris.common.security.authentication.HadoopExecutionAuthenticator;
+import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.CatalogProperty;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.InitCatalogLog;
 import org.apache.doris.datasource.NameMapping;
 import org.apache.doris.datasource.SessionContext;
-import org.apache.doris.datasource.property.PropertyConverter;
-import org.apache.doris.datasource.property.constants.HMSProperties;
-import org.apache.doris.datasource.property.constants.PaimonProperties;
-import org.apache.doris.fs.remote.dfs.DFSFileSystem;
+import org.apache.doris.datasource.property.metastore.AbstractPaimonProperties;
+import org.apache.doris.datasource.property.metastore.MetastoreProperties;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Catalog.TableNotExistException;
-import org.apache.paimon.catalog.CatalogContext;
-import org.apache.paimon.catalog.CatalogFactory;
 import org.apache.paimon.catalog.Identifier;
-import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
 
 import java.io.IOException;
@@ -49,7 +40,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public abstract class PaimonExternalCatalog extends ExternalCatalog {
+public class PaimonExternalCatalog extends ExternalCatalog {
     private static final Logger LOG = LogManager.getLogger(PaimonExternalCatalog.class);
     public static final String PAIMON_CATALOG_TYPE = "paimon.catalog.type";
     public static final String PAIMON_FILESYSTEM = "filesystem";
@@ -57,35 +48,33 @@ public abstract class PaimonExternalCatalog extends ExternalCatalog {
     public static final String PAIMON_DLF = "dlf";
     protected String catalogType;
     protected Catalog catalog;
-    protected AuthenticationConfig authConf;
-    protected HadoopAuthenticator hadoopAuthenticator;
 
-    private static final List<String> REQUIRED_PROPERTIES = ImmutableList.of(
-            PaimonProperties.WAREHOUSE
-    );
+    private AbstractPaimonProperties paimonProperties;
 
-    public PaimonExternalCatalog(long catalogId, String name, String resource,
-                                 Map<String, String> props, String comment) {
+    public PaimonExternalCatalog(long catalogId, String name, String resource, Map<String, String> props,
+                                 String comment) {
         super(catalogId, name, InitCatalogLog.Type.PAIMON, comment);
-        props = PropertyConverter.convertToMetaProperties(props);
         catalogProperty = new CatalogProperty(resource, props);
+
     }
 
     @Override
     protected void initLocalObjectsImpl() {
-        Configuration conf = DFSFileSystem.getHdfsConf(ifNotSetFallbackToSimpleAuth());
-        for (Map.Entry<String, String> propEntry : this.catalogProperty.getHadoopProperties().entrySet()) {
-            conf.set(propEntry.getKey(), propEntry.getValue());
+        try {
+            paimonProperties = (AbstractPaimonProperties) MetastoreProperties.create(catalogProperty.getProperties());
+        } catch (UserException e) {
+            throw new IllegalArgumentException("Failed to create Paimon properties from catalog properties,exception: "
+                    + e.getMessage(), e);
         }
-        authConf = AuthenticationConfig.getKerberosConfig(conf);
-        hadoopAuthenticator = HadoopAuthenticator.getHadoopAuthenticator(authConf);
+        catalogType = paimonProperties.getPaimonCatalogType();
+        catalog = createCatalog();
         initPreExecutionAuthenticator();
     }
 
     @Override
     protected synchronized void initPreExecutionAuthenticator() {
         if (executionAuthenticator == null) {
-            executionAuthenticator = new HadoopExecutionAuthenticator(hadoopAuthenticator);
+            executionAuthenticator = paimonProperties.getExecutionAuthenticator();
         }
     }
 
@@ -96,8 +85,8 @@ public abstract class PaimonExternalCatalog extends ExternalCatalog {
 
     protected List<String> listDatabaseNames() {
         try {
-            return hadoopAuthenticator.doAs(() -> new ArrayList<>(catalog.listDatabases()));
-        } catch (IOException e) {
+            return executionAuthenticator.execute(() -> new ArrayList<>(catalog.listDatabases()));
+        } catch (Exception e) {
             throw new RuntimeException("Failed to list databases names, catalog name: " + getName(), e);
         }
     }
@@ -106,7 +95,7 @@ public abstract class PaimonExternalCatalog extends ExternalCatalog {
     public boolean tableExist(SessionContext ctx, String dbName, String tblName) {
         makeSureInitialized();
         try {
-            return hadoopAuthenticator.doAs(() -> {
+            return executionAuthenticator.execute(() -> {
                 try {
                     catalog.getTable(Identifier.create(dbName, tblName));
                     return true;
@@ -117,6 +106,8 @@ public abstract class PaimonExternalCatalog extends ExternalCatalog {
 
         } catch (IOException e) {
             throw new RuntimeException("Failed to check table existence, catalog name: " + getName(), e);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -124,7 +115,7 @@ public abstract class PaimonExternalCatalog extends ExternalCatalog {
     public List<String> listTableNames(SessionContext ctx, String dbName) {
         makeSureInitialized();
         try {
-            return hadoopAuthenticator.doAs(() -> {
+            return executionAuthenticator.execute(() -> {
                 List<String> tableNames = null;
                 try {
                     tableNames = catalog.listTables(dbName);
@@ -133,7 +124,7 @@ public abstract class PaimonExternalCatalog extends ExternalCatalog {
                 }
                 return tableNames;
             });
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new RuntimeException("Failed to list table names, catalog name: " + getName(), e);
         }
     }
@@ -141,32 +132,31 @@ public abstract class PaimonExternalCatalog extends ExternalCatalog {
     public org.apache.paimon.table.Table getPaimonTable(NameMapping nameMapping) {
         makeSureInitialized();
         try {
-            return hadoopAuthenticator.doAs(() -> catalog.getTable(
-                    Identifier.create(nameMapping.getRemoteDbName(), nameMapping.getRemoteTblName())));
+            return executionAuthenticator.execute(() -> catalog.getTable(Identifier.create(nameMapping
+                    .getRemoteDbName(), nameMapping.getRemoteTblName())));
         } catch (Exception e) {
-            throw new RuntimeException("Failed to get Paimon table:" + getName() + "."
-                    + nameMapping.getLocalDbName() + "." + nameMapping.getLocalTblName() + ", because "
-                    + e.getMessage(), e);
+            throw new RuntimeException("Failed to get Paimon table:" + getName() + "." + nameMapping.getLocalDbName()
+                    + "." + nameMapping.getLocalTblName() + ", because " + e.getMessage(), e);
         }
     }
 
     public List<Partition> getPaimonPartitions(NameMapping nameMapping) {
         makeSureInitialized();
         try {
-            return hadoopAuthenticator.doAs(() -> {
+            return executionAuthenticator.execute(() -> {
                 List<Partition> partitions = new ArrayList<>();
                 try {
-                    partitions = catalog.listPartitions(
-                            Identifier.create(nameMapping.getRemoteDbName(), nameMapping.getRemoteTblName()));
+                    partitions = catalog.listPartitions(Identifier.create(nameMapping.getRemoteDbName(),
+                            nameMapping.getRemoteTblName()));
                 } catch (Catalog.TableNotExistException e) {
                     LOG.warn("TableNotExistException", e);
                 }
                 return partitions;
             });
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new RuntimeException("Failed to get Paimon table partitions:" + getName() + "."
-                    + nameMapping.getRemoteDbName() + "." + nameMapping.getRemoteTblName()
-                    + ", because " + e.getMessage(), e);
+                    + nameMapping.getRemoteDbName() + "." + nameMapping.getRemoteTblName() + ", because "
+                    + e.getMessage(), e);
         }
     }
 
@@ -174,11 +164,11 @@ public abstract class PaimonExternalCatalog extends ExternalCatalog {
         return getPaimonSystemTable(nameMapping, null, queryType);
     }
 
-    public org.apache.paimon.table.Table getPaimonSystemTable(NameMapping nameMapping, String branch,
-            String queryType) {
+    public org.apache.paimon.table.Table getPaimonSystemTable(NameMapping nameMapping,
+                                                              String branch, String queryType) {
         makeSureInitialized();
         try {
-            return hadoopAuthenticator.doAs(() -> catalog.getTable(new Identifier(nameMapping.getRemoteDbName(),
+            return executionAuthenticator.execute(() -> catalog.getTable(new Identifier(nameMapping.getRemoteDbName(),
                     nameMapping.getRemoteTblName(), branch, queryType)));
         } catch (Exception e) {
             throw new RuntimeException("Failed to get Paimon system table:" + getName() + "."
@@ -187,66 +177,33 @@ public abstract class PaimonExternalCatalog extends ExternalCatalog {
         }
     }
 
-    protected String getPaimonCatalogType(String catalogType) {
-        if (PAIMON_HMS.equalsIgnoreCase(catalogType)) {
-            return PaimonProperties.PAIMON_HMS_CATALOG;
-        } else {
-            return PaimonProperties.PAIMON_FILESYSTEM_CATALOG;
-        }
-    }
 
     protected Catalog createCatalog() {
         try {
-            return hadoopAuthenticator.doAs(() -> {
-                Options options = new Options();
-                Map<String, String> paimonOptionsMap = getPaimonOptionsMap();
-                for (Map.Entry<String, String> kv : paimonOptionsMap.entrySet()) {
-                    options.set(kv.getKey(), kv.getValue());
-                }
-                CatalogContext context = CatalogContext.create(options, getConfiguration());
-                return createCatalogImpl(context);
-            });
-        } catch (IOException e) {
+            return paimonProperties.initializeCatalog(getName(), new ArrayList<>(catalogProperty
+                    .getStoragePropertiesMap().values()));
+        } catch (Exception e) {
             throw new RuntimeException("Failed to create catalog, catalog name: " + getName(), e);
         }
     }
 
-    protected Catalog createCatalogImpl(CatalogContext context) {
-        return CatalogFactory.createCatalog(context);
-    }
-
     public Map<String, String> getPaimonOptionsMap() {
-        Map<String, String> properties = catalogProperty.getHadoopProperties();
-        Map<String, String> options = Maps.newHashMap();
-        options.put(PaimonProperties.WAREHOUSE, properties.get(PaimonProperties.WAREHOUSE));
-        setPaimonCatalogOptions(properties, options);
-        setPaimonExtraOptions(properties, options);
-        return options;
-    }
-
-    protected abstract void setPaimonCatalogOptions(Map<String, String> properties, Map<String, String> options);
-
-    protected void setPaimonExtraOptions(Map<String, String> properties, Map<String, String> options) {
-        for (Map.Entry<String, String> kv : properties.entrySet()) {
-            if (kv.getKey().startsWith(PaimonProperties.PAIMON_PREFIX)) {
-                options.put(kv.getKey().substring(PaimonProperties.PAIMON_PREFIX.length()), kv.getValue());
-            }
-        }
-
-        // hive version.
-        // This property is used for both FE and BE, so it has no "paimon." prefix.
-        // We need to handle it separately.
-        if (properties.containsKey(HMSProperties.HIVE_VERSION)) {
-            options.put(HMSProperties.HIVE_VERSION, properties.get(HMSProperties.HIVE_VERSION));
-        }
+        makeSureInitialized();
+        Map<String, String> optionsMap = Maps.newHashMap();
+        paimonProperties.getCatalogOptions().keySet().forEach(key -> optionsMap.put(key, paimonProperties
+                .getCatalogOptions().get(key)));
+        return optionsMap;
     }
 
     @Override
     public void checkProperties() throws DdlException {
-        super.checkProperties();
-        for (String requiredProperty : REQUIRED_PROPERTIES) {
-            if (!catalogProperty.getProperties().containsKey(requiredProperty)) {
-                throw new DdlException("Required property '" + requiredProperty + "' is missing");
+        if (null != paimonProperties) {
+            try {
+                this.paimonProperties = (AbstractPaimonProperties) MetastoreProperties
+                        .create(catalogProperty.getProperties());
+            } catch (UserException e) {
+                throw new DdlException("Failed to create Paimon properties from catalog properties, exception: "
+                        + e.getMessage(), e);
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalog.java
@@ -27,7 +27,6 @@ import org.apache.doris.datasource.SessionContext;
 import org.apache.doris.datasource.property.metastore.AbstractPaimonProperties;
 import org.apache.doris.datasource.property.metastore.MetastoreProperties;
 
-import com.google.common.collect.Maps;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -36,7 +35,6 @@ import org.apache.paimon.catalog.Catalog.TableNotExistException;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.partition.Partition;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -56,7 +54,6 @@ public class PaimonExternalCatalog extends ExternalCatalog {
                                  String comment) {
         super(catalogId, name, InitCatalogLog.Type.PAIMON, comment);
         catalogProperty = new CatalogProperty(resource, props);
-
     }
 
     @Override
@@ -105,10 +102,9 @@ public class PaimonExternalCatalog extends ExternalCatalog {
                 }
             });
 
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to check table existence, catalog name: " + getName(), e);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Failed to check table existence, catalog name: " + getName()
+                    + "error message is:" + ExceptionUtils.getRootCauseMessage(e), e);
         }
     }
 
@@ -191,10 +187,7 @@ public class PaimonExternalCatalog extends ExternalCatalog {
 
     public Map<String, String> getPaimonOptionsMap() {
         makeSureInitialized();
-        Map<String, String> optionsMap = Maps.newHashMap();
-        paimonProperties.getCatalogOptions().keySet().forEach(key -> optionsMap.put(key, paimonProperties
-                .getCatalogOptions().get(key)));
-        return optionsMap;
+        return paimonProperties.getCatalogOptionsMap();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalog.java
@@ -28,6 +28,7 @@ import org.apache.doris.datasource.property.metastore.AbstractPaimonProperties;
 import org.apache.doris.datasource.property.metastore.MetastoreProperties;
 
 import com.google.common.collect.Maps;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.paimon.catalog.Catalog;
@@ -64,7 +65,7 @@ public class PaimonExternalCatalog extends ExternalCatalog {
             paimonProperties = (AbstractPaimonProperties) MetastoreProperties.create(catalogProperty.getProperties());
         } catch (UserException e) {
             throw new IllegalArgumentException("Failed to create Paimon properties from catalog properties,exception: "
-                    + e.getMessage(), e);
+                    + ExceptionUtils.getRootCauseMessage(e), e);
         }
         catalogType = paimonProperties.getPaimonCatalogType();
         catalog = createCatalog();
@@ -136,7 +137,7 @@ public class PaimonExternalCatalog extends ExternalCatalog {
                     .getRemoteDbName(), nameMapping.getRemoteTblName())));
         } catch (Exception e) {
             throw new RuntimeException("Failed to get Paimon table:" + getName() + "." + nameMapping.getLocalDbName()
-                    + "." + nameMapping.getLocalTblName() + ", because " + e.getMessage(), e);
+                    + "." + nameMapping.getLocalTblName() + ", because " + ExceptionUtils.getRootCauseMessage(e), e);
         }
     }
 
@@ -156,7 +157,7 @@ public class PaimonExternalCatalog extends ExternalCatalog {
         } catch (Exception e) {
             throw new RuntimeException("Failed to get Paimon table partitions:" + getName() + "."
                     + nameMapping.getRemoteDbName() + "." + nameMapping.getRemoteTblName() + ", because "
-                    + e.getMessage(), e);
+                    + ExceptionUtils.getRootCauseMessage(e), e);
         }
     }
 
@@ -173,7 +174,7 @@ public class PaimonExternalCatalog extends ExternalCatalog {
         } catch (Exception e) {
             throw new RuntimeException("Failed to get Paimon system table:" + getName() + "."
                     + nameMapping.getRemoteDbName() + "." + nameMapping.getRemoteTblName() + "$" + queryType
-                    + ", because " + e.getMessage(), e);
+                    + ", because " + ExceptionUtils.getRootCauseMessage(e), e);
         }
     }
 
@@ -183,7 +184,8 @@ public class PaimonExternalCatalog extends ExternalCatalog {
             return paimonProperties.initializeCatalog(getName(), new ArrayList<>(catalogProperty
                     .getStoragePropertiesMap().values()));
         } catch (Exception e) {
-            throw new RuntimeException("Failed to create catalog, catalog name: " + getName(), e);
+            throw new RuntimeException("Failed to create catalog, catalog name: " + getName() + ", exception: "
+                    + ExceptionUtils.getRootCauseMessage(e), e);
         }
     }
 
@@ -203,7 +205,7 @@ public class PaimonExternalCatalog extends ExternalCatalog {
                         .create(catalogProperty.getProperties());
             } catch (UserException e) {
                 throw new DdlException("Failed to create Paimon properties from catalog properties, exception: "
-                        + e.getMessage(), e);
+                        + ExceptionUtils.getRootCauseMessage(e), e);
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalogFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalogFactory.java
@@ -37,7 +37,7 @@ public class PaimonExternalCatalogFactory {
             case PaimonExternalCatalog.PAIMON_HMS:
             case PaimonExternalCatalog.PAIMON_FILESYSTEM:
             case PaimonExternalCatalog.PAIMON_DLF:
-                return  new PaimonExternalCatalog(catalogId, name, resource, props, comment);
+                return new PaimonExternalCatalog(catalogId, name, resource, props, comment);
             default:
                 throw new DdlException("Unknown " + PaimonExternalCatalog.PAIMON_CATALOG_TYPE
                         + " value: " + metastoreType);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalogFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalogFactory.java
@@ -19,7 +19,6 @@ package org.apache.doris.datasource.paimon;
 
 import org.apache.doris.common.DdlException;
 import org.apache.doris.datasource.ExternalCatalog;
-import org.apache.doris.datasource.property.constants.HMSProperties;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -36,12 +35,9 @@ public class PaimonExternalCatalogFactory {
         metastoreType = metastoreType.toLowerCase();
         switch (metastoreType) {
             case PaimonExternalCatalog.PAIMON_HMS:
-                return new PaimonHMSExternalCatalog(catalogId, name, resource, props, comment);
             case PaimonExternalCatalog.PAIMON_FILESYSTEM:
-                return new PaimonFileExternalCatalog(catalogId, name, resource, props, comment);
             case PaimonExternalCatalog.PAIMON_DLF:
-                props.put(HMSProperties.HIVE_METASTORE_TYPE, HMSProperties.DLF_TYPE);
-                return new PaimonDLFExternalCatalog(catalogId, name, resource, props, comment);
+                return  new PaimonExternalCatalog(catalogId, name, resource, props, comment);
             default:
                 throw new DdlException("Unknown " + PaimonExternalCatalog.PAIMON_CATALOG_TYPE
                         + " value: " + metastoreType);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonFileExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonFileExternalCatalog.java
@@ -17,26 +17,12 @@
 
 package org.apache.doris.datasource.paimon;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.util.Map;
 
-
 public class PaimonFileExternalCatalog extends PaimonExternalCatalog {
-    private static final Logger LOG = LogManager.getLogger(PaimonFileExternalCatalog.class);
 
     public PaimonFileExternalCatalog(long catalogId, String name, String resource,
             Map<String, String> props, String comment) {
         super(catalogId, name, resource, props, comment);
     }
-
-    @Override
-    protected void initLocalObjectsImpl() {
-        super.initLocalObjectsImpl();
-        catalogType = PAIMON_FILESYSTEM;
-        catalog = createCatalog();
-        initPreExecutionAuthenticator();
-    }
-
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonFileExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonFileExternalCatalog.java
@@ -17,13 +17,6 @@
 
 package org.apache.doris.datasource.paimon;
 
-import org.apache.doris.common.util.LocationPath;
-import org.apache.doris.datasource.property.PropertyConverter;
-import org.apache.doris.datasource.property.constants.CosProperties;
-import org.apache.doris.datasource.property.constants.ObsProperties;
-import org.apache.doris.datasource.property.constants.OssProperties;
-import org.apache.doris.datasource.property.constants.PaimonProperties;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -43,51 +36,7 @@ public class PaimonFileExternalCatalog extends PaimonExternalCatalog {
         super.initLocalObjectsImpl();
         catalogType = PAIMON_FILESYSTEM;
         catalog = createCatalog();
+        initPreExecutionAuthenticator();
     }
 
-    @Override
-    protected void setPaimonCatalogOptions(Map<String, String> properties, Map<String, String> options) {
-        if (properties.containsKey(PaimonProperties.PAIMON_S3_ENDPOINT)) {
-            options.put(PaimonProperties.PAIMON_S3_ENDPOINT,
-                    properties.get(PaimonProperties.PAIMON_S3_ENDPOINT));
-            options.put(PaimonProperties.PAIMON_S3_ACCESS_KEY,
-                    properties.get(PaimonProperties.PAIMON_S3_ACCESS_KEY));
-            options.put(PaimonProperties.PAIMON_S3_SECRET_KEY,
-                    properties.get(PaimonProperties.PAIMON_S3_SECRET_KEY));
-        } else if (properties.containsKey(PaimonProperties.PAIMON_OSS_ENDPOINT)) {
-            boolean hdfsEnabled = Boolean.parseBoolean(properties.getOrDefault(
-                    OssProperties.OSS_HDFS_ENABLED, "false"));
-            if (!LocationPath.isHdfsOnOssEndpoint(properties.get(PaimonProperties.PAIMON_OSS_ENDPOINT))
-                    && !hdfsEnabled) {
-                options.put(PaimonProperties.PAIMON_OSS_ENDPOINT,
-                        properties.get(PaimonProperties.PAIMON_OSS_ENDPOINT));
-                options.put(PaimonProperties.PAIMON_OSS_ACCESS_KEY,
-                        properties.get(PaimonProperties.PAIMON_OSS_ACCESS_KEY));
-                options.put(PaimonProperties.PAIMON_OSS_SECRET_KEY,
-                        properties.get(PaimonProperties.PAIMON_OSS_SECRET_KEY));
-            }
-        } else if (properties.containsKey(CosProperties.ENDPOINT)) {
-            options.put(PaimonProperties.PAIMON_S3_ENDPOINT,
-                    properties.get(CosProperties.ENDPOINT));
-            options.put(PaimonProperties.PAIMON_S3_ACCESS_KEY,
-                    properties.get(CosProperties.ACCESS_KEY));
-            options.put(PaimonProperties.PAIMON_S3_SECRET_KEY,
-                    properties.get(CosProperties.SECRET_KEY));
-            options.put(PaimonProperties.WAREHOUSE,
-                    options.get(PaimonProperties.WAREHOUSE).replace("cosn://", "s3://"));
-        } else if (properties.containsKey(ObsProperties.ENDPOINT)) {
-            options.put(PaimonProperties.PAIMON_S3_ENDPOINT,
-                    properties.get(ObsProperties.ENDPOINT));
-            options.put(PaimonProperties.PAIMON_S3_ACCESS_KEY,
-                    properties.get(ObsProperties.ACCESS_KEY));
-            options.put(PaimonProperties.PAIMON_S3_SECRET_KEY,
-                    properties.get(ObsProperties.SECRET_KEY));
-            options.put(PaimonProperties.WAREHOUSE,
-                    options.get(PaimonProperties.WAREHOUSE).replace("obs://", "s3://"));
-        }
-
-        if (properties.containsKey(PropertyConverter.USE_PATH_STYLE)) {
-            options.put(PaimonProperties.S3_PATH_STYLE, properties.get(PropertyConverter.USE_PATH_STYLE));
-        }
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonHMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonHMSExternalCatalog.java
@@ -17,44 +17,12 @@
 
 package org.apache.doris.datasource.paimon;
 
-import org.apache.doris.common.DdlException;
-import org.apache.doris.datasource.property.constants.HMSProperties;
-
-import com.google.common.collect.ImmutableList;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.util.List;
 import java.util.Map;
 
 public class PaimonHMSExternalCatalog extends PaimonExternalCatalog {
-    private static final Logger LOG = LogManager.getLogger(PaimonHMSExternalCatalog.class);
-    private static final List<String> REQUIRED_PROPERTIES = ImmutableList.of(
-            HMSProperties.HIVE_METASTORE_URIS
-    );
 
     public PaimonHMSExternalCatalog(long catalogId, String name, String resource,
             Map<String, String> props, String comment) {
         super(catalogId, name, resource, props, comment);
-    }
-
-    @Override
-    protected void initLocalObjectsImpl() {
-        super.initLocalObjectsImpl();
-        catalogType = PAIMON_HMS;
-        catalog = createCatalog();
-        initPreExecutionAuthenticator();
-    }
-
-
-
-    @Override
-    public void checkProperties() throws DdlException {
-        super.checkProperties();
-        for (String requiredProperty : REQUIRED_PROPERTIES) {
-            if (!catalogProperty.getProperties().containsKey(requiredProperty)) {
-                throw new DdlException("Required property '" + requiredProperty + "' is missing");
-            }
-        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonHMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonHMSExternalCatalog.java
@@ -19,7 +19,6 @@ package org.apache.doris.datasource.paimon;
 
 import org.apache.doris.common.DdlException;
 import org.apache.doris.datasource.property.constants.HMSProperties;
-import org.apache.doris.datasource.property.constants.PaimonProperties;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.logging.log4j.LogManager;
@@ -44,13 +43,10 @@ public class PaimonHMSExternalCatalog extends PaimonExternalCatalog {
         super.initLocalObjectsImpl();
         catalogType = PAIMON_HMS;
         catalog = createCatalog();
+        initPreExecutionAuthenticator();
     }
 
-    @Override
-    protected void setPaimonCatalogOptions(Map<String, String> properties, Map<String, String> options) {
-        options.put(PaimonProperties.PAIMON_CATALOG_TYPE, getPaimonCatalogType(catalogType));
-        options.put(PaimonProperties.HIVE_METASTORE_URIS, properties.get(HMSProperties.HIVE_METASTORE_URIS));
-    }
+
 
     @Override
     public void checkProperties() throws DdlException {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
@@ -139,9 +139,9 @@ public class PaimonScanNode extends FileQueryScanNode {
     protected ConcurrentHashMap<Long, Boolean> currentQuerySchema = new ConcurrentHashMap<>();
 
     public PaimonScanNode(PlanNodeId id,
-            TupleDescriptor desc,
-            boolean needCheckColumnPriv,
-            SessionVariable sv) {
+                          TupleDescriptor desc,
+                          boolean needCheckColumnPriv,
+                          SessionVariable sv) {
         super(id, desc, "PAIMON_SCAN_NODE", StatisticalType.PAIMON_SCAN_NODE, needCheckColumnPriv, sv);
     }
 
@@ -422,13 +422,13 @@ public class PaimonScanNode extends FileQueryScanNode {
 
     @Override
     public Map<String, String> getLocationProperties() throws MetaNotFoundException, DdlException {
-        HashMap<String, String> map = new HashMap<>(source.getCatalog().getProperties());
-        source.getCatalog().getCatalogProperty().getHadoopProperties().forEach((k, v) -> {
-            if (!map.containsKey(k)) {
-                map.put(k, v);
-            }
-        });
-        return map;
+        return source.getCatalog().getCatalogProperty()
+                .getStoragePropertiesMap().values().stream()
+                .flatMap(m -> m.getBackendConfigProperties().entrySet().stream())
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue,
+                        (v1, v2) -> v2));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
@@ -421,14 +421,8 @@ public class PaimonScanNode extends FileQueryScanNode {
     }
 
     @Override
-    public Map<String, String> getLocationProperties() throws MetaNotFoundException, DdlException {
-        return source.getCatalog().getCatalogProperty()
-                .getStoragePropertiesMap().values().stream()
-                .flatMap(m -> m.getBackendConfigProperties().entrySet().stream())
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        Map.Entry::getValue,
-                        (v1, v2) -> v2));
+    protected Map<String, String> getLocationProperties() {
+        return source.getCatalog().getCatalogProperty().getBackendStorageProperties();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/AbstractPaimonProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/AbstractPaimonProperties.java
@@ -1,25 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package org.apache.doris.datasource.property.metastore;
+
+import org.apache.doris.common.security.authentication.ExecutionAuthenticator;
+import org.apache.doris.datasource.property.ConnectorProperty;
+import org.apache.doris.datasource.property.storage.S3Properties;
+import org.apache.doris.datasource.property.storage.StorageProperties;
 
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.doris.common.security.authentication.ExecutionAuthenticator;
-import org.apache.doris.datasource.property.ConnectorProperty;
-import org.apache.doris.datasource.property.storage.StorageProperties;
 import org.apache.paimon.catalog.Catalog;
-import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 
-
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public abstract class AbstractPaimonProperties extends MetastoreProperties {
     @ConnectorProperty(
             names = {"warehouse"},
-            required = false,
-            description = "The location of the Iceberg warehouse. This is where the tables will be stored."
+            description = "The location of the Paimon warehouse. This is where the tables will be stored."
     )
     protected String warehouse;
 
@@ -27,6 +42,11 @@ public abstract class AbstractPaimonProperties extends MetastoreProperties {
     @Getter
     protected ExecutionAuthenticator executionAuthenticator = new ExecutionAuthenticator() {
     };
+
+    @Getter
+    protected Options catalogOptions;
+
+    public abstract String getPaimonCatalogType();
 
     private static final String USER_PROPERTY_PREFIX = "paimon.";
 
@@ -37,7 +57,37 @@ public abstract class AbstractPaimonProperties extends MetastoreProperties {
     public abstract Catalog initializeCatalog(String catalogName, List<StorageProperties> storagePropertiesList);
 
 
-    private void appendCatalogOptions(Options catalogOptions) {
+    /**
+     * Adapt S3 storage properties for Apache Paimon's S3 file system.
+     *
+     * <p>Paimon's S3 file system does not follow the standard Hadoop-compatible
+     * configuration keys (like fs.s3a.access.key). Instead, it expects specific
+     * keys such as "s3.access.key", "s3.secret.key", etc.
+     *
+     * <p>Therefore, we explicitly map our internal S3 configuration (usually designed
+     * for HDFS-compatible systems) to Paimon's expected format.
+     *
+     * <p>See: org.apache.paimon.s3.S3Loader
+     *
+     * @param storagePropertiesList the list of configured storage backends
+     */
+    protected void appendS3PropertiesIsNeeded(List<StorageProperties> storagePropertiesList) {
+
+        S3Properties s3Properties = (S3Properties) storagePropertiesList.stream()
+                .filter(storageProperties -> storageProperties.getType() == StorageProperties.Type.S3)
+                .findFirst()
+                .orElse(null);
+        if (s3Properties != null) {
+            catalogOptions.set("s3.access.key", s3Properties.getSecretKey());
+            catalogOptions.set("s3.secret.key", s3Properties.getAccessKey());
+            catalogOptions.set("s3.endpoint", s3Properties.getEndpoint());
+            catalogOptions.set("s3.region", s3Properties.getRegion());
+        }
+
+    }
+
+
+    protected void appendCatalogOptions(List<StorageProperties> storagePropertiesList) {
         if (StringUtils.isNotBlank(warehouse)) {
             catalogOptions.set(CatalogOptions.WAREHOUSE.key(), warehouse);
         }
@@ -50,22 +100,61 @@ public abstract class AbstractPaimonProperties extends MetastoreProperties {
                 }
             }
         });
+        appendS3PropertiesIsNeeded(storagePropertiesList);
     }
 
 
     /**
      * Build catalog options including common and subclass-specific ones.
      */
-    public  Options buildCatalogOptions() {
-        Options catalogOptions = new Options();
-        appendCatalogOptions(catalogOptions);
-        appendCustomCatalogOptions(catalogOptions);
-        return catalogOptions;
+    public void buildCatalogOptions(List<StorageProperties> storagePropertiesList) {
+        catalogOptions = new Options();
+        appendCatalogOptions(storagePropertiesList);
+        appendCustomCatalogOptions();
     }
-    
 
 
-    protected abstract void appendCustomCatalogOptions(Options catalogOptions);
+    /**
+     * Hook method for subclasses to append metastore-specific or custom catalog options.
+     *
+     * <p>This method is invoked after common catalog options (e.g., warehouse path,
+     * metastore type, user-defined keys, and S3 compatibility mappings) have been
+     * added to the {@link org.apache.paimon.options.Options} instance.
+     *
+     * <p>Subclasses should override this method to inject additional configuration
+     * required for their specific metastore or environment. For example:
+     *
+     * <ul>
+     *   <li>DLF-based catalog may require a custom metastore client class.</li>
+     *   <li>HMS-based catalog may include URI and client pool parameters.</li>
+     *   <li>Other environments may inject authentication, endpoint, or caching options.</li>
+     * </ul>
+     *
+     * <p>If the subclass does not require any special options beyond the common ones,
+     * it can safely leave this method empty.
+     */
+    protected abstract void appendCustomCatalogOptions();
 
+    /**
+     * Returns the metastore type identifier used by the Paimon catalog factory.
+     *
+     * <p>This identifier must match one of the known metastore types supported by
+     * Apache Paimon. Internally, the value returned here is used to configure the
+     * `metastore` option in {@code Options}, which determines the specific
+     * {@link org.apache.paimon.catalog.CatalogFactory} implementation to be used
+     * when instantiating the catalog.
+     *
+     * <p>You can find valid identifiers by reviewing implementations of the
+     * {@link org.apache.paimon.catalog.CatalogFactory} interface. Each implementation
+     * declares its identifier via a static {@code IDENTIFIER} field or equivalent constant.
+     *
+     * <p>Examples:
+     * <ul>
+     *   <li>{@code "filesystem"} - for {@link org.apache.paimon.catalog.FileSystemCatalogFactory}</li>
+     *   <li>{@code "hive"} - for {@link org.apache.paimon.hive.HiveCatalogFactory}</li>
+     * </ul>
+     *
+     * @return the metastore type identifier string
+     */
     protected abstract String getMetastoreType();
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/AbstractPaimonProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/AbstractPaimonProperties.java
@@ -1,0 +1,71 @@
+package org.apache.doris.datasource.property.metastore;
+
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.doris.common.security.authentication.ExecutionAuthenticator;
+import org.apache.doris.datasource.property.ConnectorProperty;
+import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.options.CatalogOptions;
+import org.apache.paimon.options.Options;
+
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class AbstractPaimonProperties extends MetastoreProperties {
+    @ConnectorProperty(
+            names = {"warehouse"},
+            required = false,
+            description = "The location of the Iceberg warehouse. This is where the tables will be stored."
+    )
+    protected String warehouse;
+
+
+    @Getter
+    protected ExecutionAuthenticator executionAuthenticator = new ExecutionAuthenticator() {
+    };
+
+    private static final String USER_PROPERTY_PREFIX = "paimon.";
+
+    protected AbstractPaimonProperties(Map<String, String> props) {
+        super(props);
+    }
+
+    public abstract Catalog initializeCatalog(String catalogName, List<StorageProperties> storagePropertiesList);
+
+
+    private void appendCatalogOptions(Options catalogOptions) {
+        if (StringUtils.isNotBlank(warehouse)) {
+            catalogOptions.set(CatalogOptions.WAREHOUSE.key(), warehouse);
+        }
+        catalogOptions.set(CatalogOptions.METASTORE.key(), getMetastoreType());
+        origProps.forEach((k, v) -> {
+            if (k.toLowerCase().startsWith(USER_PROPERTY_PREFIX)) {
+                String newKey = k.substring(USER_PROPERTY_PREFIX.length());
+                if (StringUtils.isNotBlank(newKey)) {
+                    catalogOptions.set(newKey, v);
+                }
+            }
+        });
+    }
+
+
+    /**
+     * Build catalog options including common and subclass-specific ones.
+     */
+    public  Options buildCatalogOptions() {
+        Options catalogOptions = new Options();
+        appendCatalogOptions(catalogOptions);
+        appendCustomCatalogOptions(catalogOptions);
+        return catalogOptions;
+    }
+    
+
+
+    protected abstract void appendCustomCatalogOptions(Options catalogOptions);
+
+    protected abstract String getMetastoreType();
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/MetastoreProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/MetastoreProperties.java
@@ -46,6 +46,7 @@ public class MetastoreProperties extends ConnectionProperties {
     public enum Type {
         HMS("hms"),
         ICEBERG("iceberg"),
+        PAIMON("paimon"),
         GLUE("glue"),
         DLF("dlf"),
         DATAPROC("dataproc"),
@@ -83,6 +84,7 @@ public class MetastoreProperties extends ConnectionProperties {
         //subclasses should be registered here
         register(Type.HMS, new HMSPropertiesFactory());
         register(Type.ICEBERG, new IcebergPropertiesFactory());
+        register(Type.PAIMON, new PaimonPropertiesFactory());
     }
 
     public static void register(Type type, MetastorePropertiesFactory factory) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonAliyunDLFMetaStoreProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonAliyunDLFMetaStoreProperties.java
@@ -1,24 +1,68 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package org.apache.doris.datasource.property.metastore;
+
+import org.apache.doris.datasource.paimon.PaimonExternalCatalog;
+import org.apache.doris.datasource.property.storage.OSSProperties;
+import org.apache.doris.datasource.property.storage.StorageProperties;
 
 import com.aliyun.datalake.metastore.common.DataLakeConfig;
 import com.aliyun.datalake.metastore.hive2.ProxyMetaStoreClient;
-import org.apache.doris.datasource.property.constants.PaimonProperties;
-import org.apache.doris.datasource.property.storage.StorageProperties;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
 import org.apache.paimon.hive.HiveCatalogOptions;
-import org.apache.paimon.options.Options;
 
 import java.util.List;
 import java.util.Map;
 
+/**
+ * PaimonAliyunDLFMetaStoreProperties
+ *
+ * <p>This class provides configuration support for using Apache Paimon with
+ * Aliyun Data Lake Formation (DLF) as the metastore. Although DLF is not an
+ * officially supported metastore type in Paimon, this implementation adapts
+ * DLF by treating it as a Hive Metastore (HMS) underneath, enabling
+ * interoperability with Paimon's HiveCatalog.
+ *
+ * <p>Key Characteristics:
+ * <ul>
+ *   <li>Internally uses HiveCatalog with custom HiveConf configured for Aliyun DLF.</li>
+ *   <li>Relies on {@link ProxyMetaStoreClient} to bridge DLF compatibility.</li>
+ *   <li>Requires Aliyun OSS as the storage backend. Other storage types are not
+ *       currently verified for compatibility.</li>
+ * </ul>
+ *
+ * <p>Note: This is an internal extension and not an officially supported Paimon
+ * metastore type. Future compatibility should be validated when upgrading Paimon
+ * or changing storage backends.
+ *
+ * @see org.apache.paimon.hive.HiveCatalog
+ * @see org.apache.paimon.catalog.CatalogFactory
+ * @see ProxyMetaStoreClient
+ */
 public class PaimonAliyunDLFMetaStoreProperties extends AbstractPaimonProperties {
 
-
     private AliyunDLFBaseProperties baseProperties;
+
     protected PaimonAliyunDLFMetaStoreProperties(Map<String, String> props) {
         super(props);
-        
     }
 
     @Override
@@ -43,24 +87,37 @@ public class PaimonAliyunDLFMetaStoreProperties extends AbstractPaimonProperties
     @Override
     public Catalog initializeCatalog(String catalogName, List<StorageProperties> storagePropertiesList) {
         HiveConf hiveConf = buildHiveConf();
-        buildCatalogOptions();
-        
-        return null;
+        buildCatalogOptions(storagePropertiesList);
+        StorageProperties ossProps = storagePropertiesList.stream()
+                .filter(sp -> sp.getType() == StorageProperties.Type.OSS)
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Paimon DLF metastore requires OSS storage properties."));
+
+        if (!(ossProps instanceof OSSProperties)) {
+            throw new IllegalStateException("Expected OSSProperties type.");
+        }
+        OSSProperties ossProperties = (OSSProperties) ossProps;
+        for (Map.Entry<String, String> entry : ossProperties.getHadoopStorageConfig()) {
+            catalogOptions.set(entry.getKey(), entry.getValue());
+        }
+        hiveConf.addResource(ossProperties.getHadoopStorageConfig());
+        CatalogContext catalogContext = CatalogContext.create(catalogOptions, hiveConf);
+        return CatalogFactory.createCatalog(catalogContext);
     }
 
+
     @Override
-    protected void appendCustomCatalogOptions(Options catalogOptions) {
-        catalogOptions.put(PaimonProperties.PAIMON_METASTORE_CLIENT, ProxyMetaStoreClient.class.getName());
-        catalogOptions.put(PaimonProperties.PAIMON_OSS_ENDPOINT,
-                properties.get(PaimonProperties.PAIMON_OSS_ENDPOINT));
-        catalogOptions.put(PaimonProperties.PAIMON_OSS_ACCESS_KEY,
-                properties.get(PaimonProperties.PAIMON_OSS_ACCESS_KEY));
-        catalogOptions.put(PaimonProperties.PAIMON_OSS_SECRET_KEY,
-                properties.get(PaimonProperties.PAIMON_OSS_SECRET_KEY));
+    protected void appendCustomCatalogOptions() {
+        catalogOptions.set("metastore.client.class", ProxyMetaStoreClient.class.getName());
     }
 
     @Override
     protected String getMetastoreType() {
         return HiveCatalogOptions.IDENTIFIER;
+    }
+
+    @Override
+    public String getPaimonCatalogType() {
+        return PaimonExternalCatalog.PAIMON_DLF;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonAliyunDLFMetaStoreProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonAliyunDLFMetaStoreProperties.java
@@ -1,0 +1,66 @@
+package org.apache.doris.datasource.property.metastore;
+
+import com.aliyun.datalake.metastore.common.DataLakeConfig;
+import com.aliyun.datalake.metastore.hive2.ProxyMetaStoreClient;
+import org.apache.doris.datasource.property.constants.PaimonProperties;
+import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.hive.HiveCatalogOptions;
+import org.apache.paimon.options.Options;
+
+import java.util.List;
+import java.util.Map;
+
+public class PaimonAliyunDLFMetaStoreProperties extends AbstractPaimonProperties {
+
+
+    private AliyunDLFBaseProperties baseProperties;
+    protected PaimonAliyunDLFMetaStoreProperties(Map<String, String> props) {
+        super(props);
+        
+    }
+
+    @Override
+    public void initNormalizeAndCheckProps() {
+        super.initNormalizeAndCheckProps();
+        baseProperties = AliyunDLFBaseProperties.of(origProps);
+    }
+
+    private HiveConf buildHiveConf() {
+        HiveConf hiveConf = new HiveConf();
+        hiveConf.set(DataLakeConfig.CATALOG_ACCESS_KEY_ID, baseProperties.dlfAccessKey);
+        hiveConf.set(DataLakeConfig.CATALOG_ACCESS_KEY_SECRET, baseProperties.dlfSecretKey);
+        hiveConf.set(DataLakeConfig.CATALOG_ENDPOINT, baseProperties.dlfEndpoint);
+        hiveConf.set(DataLakeConfig.CATALOG_REGION_ID, baseProperties.dlfRegion);
+        hiveConf.set(DataLakeConfig.CATALOG_SECURITY_TOKEN, baseProperties.dlfSessionToken);
+        hiveConf.set(DataLakeConfig.CATALOG_USER_ID, baseProperties.dlfUid);
+        hiveConf.set(DataLakeConfig.CATALOG_ID, baseProperties.dlfCatalogId);
+        hiveConf.set(DataLakeConfig.CATALOG_PROXY_MODE, baseProperties.dlfProxyMode);
+        return hiveConf;
+    }
+
+    @Override
+    public Catalog initializeCatalog(String catalogName, List<StorageProperties> storagePropertiesList) {
+        HiveConf hiveConf = buildHiveConf();
+        buildCatalogOptions();
+        
+        return null;
+    }
+
+    @Override
+    protected void appendCustomCatalogOptions(Options catalogOptions) {
+        catalogOptions.put(PaimonProperties.PAIMON_METASTORE_CLIENT, ProxyMetaStoreClient.class.getName());
+        catalogOptions.put(PaimonProperties.PAIMON_OSS_ENDPOINT,
+                properties.get(PaimonProperties.PAIMON_OSS_ENDPOINT));
+        catalogOptions.put(PaimonProperties.PAIMON_OSS_ACCESS_KEY,
+                properties.get(PaimonProperties.PAIMON_OSS_ACCESS_KEY));
+        catalogOptions.put(PaimonProperties.PAIMON_OSS_SECRET_KEY,
+                properties.get(PaimonProperties.PAIMON_OSS_SECRET_KEY));
+    }
+
+    @Override
+    protected String getMetastoreType() {
+        return HiveCatalogOptions.IDENTIFIER;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonFileSystemMetaStoreProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonFileSystemMetaStoreProperties.java
@@ -1,0 +1,29 @@
+package org.apache.doris.datasource.property.metastore;
+
+import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.options.Options;
+
+import java.util.List;
+import java.util.Map;
+
+public class PaimonFileSystemMetaStoreProperties extends AbstractPaimonProperties{
+    protected PaimonFileSystemMetaStoreProperties(Map<String, String> props) {
+        super(props);
+    }
+
+    @Override
+    public Catalog initializeCatalog(String catalogName, List<StorageProperties> storagePropertiesList) {
+        return null;
+    }
+
+    @Override
+    protected void appendCustomCatalogOptions(Options catalogOptions) {
+
+    }
+
+    @Override
+    protected String getMetastoreType() {
+        return "";
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonFileSystemMetaStoreProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonFileSystemMetaStoreProperties.java
@@ -1,29 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package org.apache.doris.datasource.property.metastore;
 
+import org.apache.doris.common.security.authentication.HadoopExecutionAuthenticator;
+import org.apache.doris.datasource.paimon.PaimonExternalCatalog;
+import org.apache.doris.datasource.property.storage.HdfsProperties;
 import org.apache.doris.datasource.property.storage.StorageProperties;
+
+import org.apache.hadoop.conf.Configuration;
 import org.apache.paimon.catalog.Catalog;
-import org.apache.paimon.options.Options;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.FileSystemCatalogFactory;
 
 import java.util.List;
 import java.util.Map;
 
-public class PaimonFileSystemMetaStoreProperties extends AbstractPaimonProperties{
+public class PaimonFileSystemMetaStoreProperties extends AbstractPaimonProperties {
     protected PaimonFileSystemMetaStoreProperties(Map<String, String> props) {
         super(props);
     }
 
     @Override
     public Catalog initializeCatalog(String catalogName, List<StorageProperties> storagePropertiesList) {
-        return null;
+        buildCatalogOptions(storagePropertiesList);
+        Configuration conf = new Configuration(false);
+        storagePropertiesList.forEach(storageProperties -> {
+            for (Map.Entry<String, String> entry : storageProperties.getHadoopStorageConfig()) {
+                catalogOptions.set(entry.getKey(), entry.getValue());
+            }
+            conf.addResource(storageProperties.getHadoopStorageConfig());
+            if (storageProperties.getType().equals(StorageProperties.Type.HDFS)) {
+                this.executionAuthenticator = new HadoopExecutionAuthenticator(((HdfsProperties) storageProperties)
+                        .getHadoopAuthenticator());
+            }
+        });
+
+        CatalogContext catalogContext = CatalogContext.create(catalogOptions, conf);
+        try {
+            return this.executionAuthenticator.execute(() -> CatalogFactory.createCatalog(catalogContext));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
-    protected void appendCustomCatalogOptions(Options catalogOptions) {
-
+    protected void appendCustomCatalogOptions() {
+        //nothing need to do
     }
 
     @Override
     protected String getMetastoreType() {
-        return "";
+        return FileSystemCatalogFactory.IDENTIFIER;
+    }
+
+    @Override
+    public String getPaimonCatalogType() {
+        return PaimonExternalCatalog.PAIMON_FILESYSTEM;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonHMSMetaStoreProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonHMSMetaStoreProperties.java
@@ -1,26 +1,33 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package org.apache.doris.datasource.property.metastore;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.doris.common.security.authentication.HadoopExecutionAuthenticator;
+import org.apache.doris.datasource.paimon.PaimonExternalCatalog;
 import org.apache.doris.datasource.property.ConnectorProperty;
-import org.apache.doris.datasource.property.constants.HMSProperties;
-import org.apache.doris.datasource.property.constants.PaimonProperties;
 import org.apache.doris.datasource.property.storage.StorageProperties;
+
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.CatalogProperties;
-import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
 import org.apache.paimon.hive.HiveCatalogOptions;
-import org.apache.paimon.options.CatalogOptions;
-import org.apache.paimon.options.ConfigOptions;
-import org.apache.paimon.options.Options;
-import org.apache.paimon.options.description.Description;
-import org.apache.paimon.options.description.InlineElement;
-import org.apache.paimon.options.description.TextElement;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -46,6 +53,11 @@ public class PaimonHMSMetaStoreProperties extends AbstractPaimonProperties {
     private boolean locationInProperties = false;
 
 
+    @Override
+    public String getPaimonCatalogType() {
+        return PaimonExternalCatalog.PAIMON_DLF;
+    }
+
     protected PaimonHMSMetaStoreProperties(Map<String, String> props) {
         super(props);
     }
@@ -63,8 +75,8 @@ public class PaimonHMSMetaStoreProperties extends AbstractPaimonProperties {
      * Builds the Hadoop Configuration by adding hive-site.xml and storage-specific configs.
      */
     private Configuration buildHiveConfiguration(List<StorageProperties> storagePropertiesList) {
-        Configuration conf = new Configuration();
-        conf.addResource(hmsBaseProperties.getHiveConf());
+        Configuration conf = hmsBaseProperties.getHiveConf();
+
         for (StorageProperties sp : storagePropertiesList) {
             if (sp.getHadoopStorageConfig() != null) {
                 conf.addResource(sp.getHadoopStorageConfig());
@@ -76,9 +88,17 @@ public class PaimonHMSMetaStoreProperties extends AbstractPaimonProperties {
     @Override
     public Catalog initializeCatalog(String catalogName, List<StorageProperties> storagePropertiesList) {
         Configuration conf = buildHiveConfiguration(storagePropertiesList);
-        Options catalogOptions = buildCatalogOptions();
+        buildCatalogOptions(storagePropertiesList);
+        for (Map.Entry<String, String> entry : conf) {
+            catalogOptions.set(entry.getKey(), entry.getValue());
+        }
         CatalogContext catalogContext = CatalogContext.create(catalogOptions, conf);
-        return CatalogFactory.createCatalog(catalogContext);
+        try {
+            return executionAuthenticator.execute(() -> CatalogFactory.createCatalog(catalogContext));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create Paimon catalog with HMS metastore", e);
+        }
+
     }
 
     @Override
@@ -88,8 +108,10 @@ public class PaimonHMSMetaStoreProperties extends AbstractPaimonProperties {
     }
 
     @Override
-    protected void appendCustomCatalogOptions(Options catalogOptions) {
-        catalogOptions.set(CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS_KEY, String.valueOf(clientPoolCacheEvictionIntervalMs));
+    protected void appendCustomCatalogOptions() {
+        catalogOptions.set(CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS_KEY,
+                String.valueOf(clientPoolCacheEvictionIntervalMs));
         catalogOptions.set(LOCATION_IN_PROPERTIES_KEY, String.valueOf(locationInProperties));
+        catalogOptions.set("uri", hmsBaseProperties.getHiveMetastoreUri());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonHMSMetaStoreProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonHMSMetaStoreProperties.java
@@ -1,0 +1,95 @@
+package org.apache.doris.datasource.property.metastore;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.doris.common.security.authentication.HadoopExecutionAuthenticator;
+import org.apache.doris.datasource.property.ConnectorProperty;
+import org.apache.doris.datasource.property.constants.HMSProperties;
+import org.apache.doris.datasource.property.constants.PaimonProperties;
+import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.hive.HiveCatalog;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.hive.HiveCatalogOptions;
+import org.apache.paimon.options.CatalogOptions;
+import org.apache.paimon.options.ConfigOptions;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.options.description.Description;
+import org.apache.paimon.options.description.InlineElement;
+import org.apache.paimon.options.description.TextElement;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class PaimonHMSMetaStoreProperties extends AbstractPaimonProperties {
+
+    private HMSBaseProperties hmsBaseProperties;
+
+    private static final String CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS_KEY = "client-pool-cache.eviction-interval-ms";
+
+    private static final String LOCATION_IN_PROPERTIES_KEY = "location-in-properties";
+
+    @ConnectorProperty(
+            names = {CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS_KEY},
+            required = false,
+            description = "Setting the client's pool cache eviction interval(ms).")
+    private long clientPoolCacheEvictionIntervalMs = TimeUnit.MINUTES.toMillis(5L);
+
+    @ConnectorProperty(
+            names = {LOCATION_IN_PROPERTIES_KEY},
+            required = false,
+            description = "Setting whether to use the location in the properties.")
+    private boolean locationInProperties = false;
+
+
+    protected PaimonHMSMetaStoreProperties(Map<String, String> props) {
+        super(props);
+    }
+
+    @Override
+    public void initNormalizeAndCheckProps() {
+        super.initNormalizeAndCheckProps();
+        hmsBaseProperties = HMSBaseProperties.of(origProps);
+        hmsBaseProperties.initAndCheckParams();
+        this.executionAuthenticator = new HadoopExecutionAuthenticator(hmsBaseProperties.getHmsAuthenticator());
+    }
+
+
+    /**
+     * Builds the Hadoop Configuration by adding hive-site.xml and storage-specific configs.
+     */
+    private Configuration buildHiveConfiguration(List<StorageProperties> storagePropertiesList) {
+        Configuration conf = new Configuration();
+        conf.addResource(hmsBaseProperties.getHiveConf());
+        for (StorageProperties sp : storagePropertiesList) {
+            if (sp.getHadoopStorageConfig() != null) {
+                conf.addResource(sp.getHadoopStorageConfig());
+            }
+        }
+        return conf;
+    }
+
+    @Override
+    public Catalog initializeCatalog(String catalogName, List<StorageProperties> storagePropertiesList) {
+        Configuration conf = buildHiveConfiguration(storagePropertiesList);
+        Options catalogOptions = buildCatalogOptions();
+        CatalogContext catalogContext = CatalogContext.create(catalogOptions, conf);
+        return CatalogFactory.createCatalog(catalogContext);
+    }
+
+    @Override
+    protected String getMetastoreType() {
+        //See org.apache.paimon.hive.HiveCatalogFactory
+        return HiveCatalogOptions.IDENTIFIER;
+    }
+
+    @Override
+    protected void appendCustomCatalogOptions(Options catalogOptions) {
+        catalogOptions.set(CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS_KEY, String.valueOf(clientPoolCacheEvictionIntervalMs));
+        catalogOptions.set(LOCATION_IN_PROPERTIES_KEY, String.valueOf(locationInProperties));
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonPropertiesFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonPropertiesFactory.java
@@ -15,25 +15,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.datasource.paimon;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+package org.apache.doris.datasource.property.metastore;
 
 import java.util.Map;
 
-public class PaimonDLFExternalCatalog extends PaimonExternalCatalog {
-    private static final Logger LOG = LogManager.getLogger(PaimonDLFExternalCatalog.class);
+public class PaimonPropertiesFactory extends AbstractMetastorePropertiesFactory {
 
-    public PaimonDLFExternalCatalog(long catalogId, String name, String resource,
-                                    Map<String, String> props, String comment) {
-        super(catalogId, name, resource, props, comment);
+    private static final String KEY = "paimon.catalog.type";
+    private static final String DEFAULT_TYPE = "filesystem";
+
+    public PaimonPropertiesFactory() {
+        register("dlf", PaimonAliyunDLFMetaStoreProperties::new);
+        register("filesystem", PaimonFileSystemMetaStoreProperties::new);
+        register("hms", PaimonHMSMetaStoreProperties::new);
     }
 
     @Override
-    protected void initLocalObjectsImpl() {
-        super.initLocalObjectsImpl();
-        catalogType = PAIMON_DLF;
-        catalog = createCatalog();
+    public MetastoreProperties create(Map<String, String> props) {
+        return createInternal(props, KEY, DEFAULT_TYPE);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/COSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/COSProperties.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableSet;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.conf.Configuration;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
@@ -130,7 +129,7 @@ public class COSProperties extends AbstractS3CompatibleProperties {
 
     @Override
     public void initializeHadoopStorageConfig() {
-        hadoopStorageConfig = new Configuration();
+        super.initializeHadoopStorageConfig();
         hadoopStorageConfig.set("fs.cos.impl", "org.apache.hadoop.fs.CosFileSystem");
         hadoopStorageConfig.set("fs.cosn.impl", "org.apache.hadoop.fs.CosFileSystem");
         hadoopStorageConfig.set("fs.AbstractFileSystem.cos.impl", "org.apache.hadoop.fs.Cos");

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/COSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/COSProperties.java
@@ -130,19 +130,7 @@ public class COSProperties extends AbstractS3CompatibleProperties {
     @Override
     public void initializeHadoopStorageConfig() {
         super.initializeHadoopStorageConfig();
-        hadoopStorageConfig.set("fs.cos.impl", "org.apache.hadoop.fs.CosFileSystem");
-        hadoopStorageConfig.set("fs.cosn.impl", "org.apache.hadoop.fs.CosFileSystem");
-        hadoopStorageConfig.set("fs.AbstractFileSystem.cos.impl", "org.apache.hadoop.fs.Cos");
-        hadoopStorageConfig.set("fs.cos.secretId", accessKey);
-        hadoopStorageConfig.set("fs.cos.secretKey", secretKey);
-        hadoopStorageConfig.set("fs.cosn.userinfo.secretId", accessKey);
-        hadoopStorageConfig.set("fs.cosn.userinfo.secretKey", secretKey);
-        hadoopStorageConfig.set("fs.cos.region", region);
-        hadoopStorageConfig.set("fs.cos.endpoint", endpoint);
-        hadoopStorageConfig.set("fs.cosn.bucket.region", region);
-        hadoopStorageConfig.set("fs.cos.connection.timeout", connectionTimeoutS);
-        hadoopStorageConfig.set("fs.cos.connection.request.timeout", requestTimeoutS);
-        hadoopStorageConfig.set("fs.cos.connection.maximum", maxConnections);
-        hadoopStorageConfig.set("fs.cos.use.path.style", usePathStyle);
+        hadoopStorageConfig.set("fs.cos.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
+        hadoopStorageConfig.set("fs.cosn.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/COSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/COSProperties.java
@@ -136,8 +136,11 @@ public class COSProperties extends AbstractS3CompatibleProperties {
         hadoopStorageConfig.set("fs.AbstractFileSystem.cos.impl", "org.apache.hadoop.fs.Cos");
         hadoopStorageConfig.set("fs.cos.secretId", accessKey);
         hadoopStorageConfig.set("fs.cos.secretKey", secretKey);
+        hadoopStorageConfig.set("fs.cosn.userinfo.secretId", accessKey);
+        hadoopStorageConfig.set("fs.cosn.userinfo.secretKey", secretKey);
         hadoopStorageConfig.set("fs.cos.region", region);
         hadoopStorageConfig.set("fs.cos.endpoint", endpoint);
+        hadoopStorageConfig.set("fs.cosn.bucket.region", region);
         hadoopStorageConfig.set("fs.cos.connection.timeout", connectionTimeoutS);
         hadoopStorageConfig.set("fs.cos.connection.request.timeout", requestTimeoutS);
         hadoopStorageConfig.set("fs.cos.connection.maximum", maxConnections);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/MinioProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/MinioProperties.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableSet;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.conf.Configuration;
 
 import java.util.Map;
 import java.util.Set;
@@ -94,19 +93,5 @@ public class MinioProperties extends AbstractS3CompatibleProperties {
     @Override
     protected Set<Pattern> endpointPatterns() {
         return ImmutableSet.of(Pattern.compile("^(?:https?://)?[a-zA-Z0-9.-]+(?::\\d+)?$"));
-    }
-
-    @Override
-    public void initializeHadoopStorageConfig() {
-        hadoopStorageConfig = new Configuration();
-        hadoopStorageConfig.set("fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
-        hadoopStorageConfig.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
-        hadoopStorageConfig.set("fs.s3a.endpoint", endpoint);
-        hadoopStorageConfig.set("fs.s3a.access.key", accessKey);
-        hadoopStorageConfig.set("fs.s3a.secret.key", secretKey);
-        hadoopStorageConfig.set("fs.s3a.connection.maximum", maxConnections);
-        hadoopStorageConfig.set("fs.s3a.connection.request.timeout", requestTimeoutS);
-        hadoopStorageConfig.set("fs.s3a.connection.timeout", connectionTimeoutS);
-        hadoopStorageConfig.set("fs.s3a.path.style.access", usePathStyle);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OBSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OBSProperties.java
@@ -135,12 +135,6 @@ public class OBSProperties extends AbstractS3CompatibleProperties {
     @Override
     public void initializeHadoopStorageConfig() {
         super.initializeHadoopStorageConfig();
-        hadoopStorageConfig.set("fs.obs.impl", "org.apache.hadoop.fs.obs.OBSFileSystem");
-        hadoopStorageConfig.set("fs.obs.access.key", accessKey);
-        hadoopStorageConfig.set("fs.obs.secret.key", secretKey);
-        hadoopStorageConfig.set("fs.obs.endpoint", endpoint);
-        hadoopStorageConfig.set("fs.obs.connection.timeout", connectionTimeoutS);
-        hadoopStorageConfig.set("fs.obs.request.timeout", requestTimeoutS);
-        hadoopStorageConfig.set("fs.obs.connection.max", maxConnections);
+        hadoopStorageConfig.set("fs.obs.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OBSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OBSProperties.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableSet;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.conf.Configuration;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
@@ -135,7 +134,7 @@ public class OBSProperties extends AbstractS3CompatibleProperties {
 
     @Override
     public void initializeHadoopStorageConfig() {
-        hadoopStorageConfig = new Configuration();
+        super.initializeHadoopStorageConfig();
         hadoopStorageConfig.set("fs.obs.impl", "org.apache.hadoop.fs.obs.OBSFileSystem");
         hadoopStorageConfig.set("fs.obs.access.key", accessKey);
         hadoopStorageConfig.set("fs.obs.secret.key", secretKey);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OBSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OBSProperties.java
@@ -136,7 +136,7 @@ public class OBSProperties extends AbstractS3CompatibleProperties {
     @Override
     public void initializeHadoopStorageConfig() {
         hadoopStorageConfig = new Configuration();
-        hadoopStorageConfig.set("fs.obs.impl", "com.obs.services.hadoop.fs.OBSFileSystem");
+        hadoopStorageConfig.set("fs.obs.impl", "org.apache.hadoop.fs.obs.OBSFileSystem");
         hadoopStorageConfig.set("fs.obs.access.key", accessKey);
         hadoopStorageConfig.set("fs.obs.secret.key", secretKey);
         hadoopStorageConfig.set("fs.obs.endpoint", endpoint);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableSet;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.conf.Configuration;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
@@ -172,7 +171,7 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
 
     @Override
     public void initializeHadoopStorageConfig() {
-        hadoopStorageConfig = new Configuration();
+        super.initializeHadoopStorageConfig();
         hadoopStorageConfig.set("fs.oss.impl", "org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystem");
         hadoopStorageConfig.set("fs.oss.endpoint", endpoint);
         hadoopStorageConfig.set("fs.oss.region", region);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
@@ -172,14 +172,6 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
     @Override
     public void initializeHadoopStorageConfig() {
         super.initializeHadoopStorageConfig();
-        hadoopStorageConfig.set("fs.oss.impl", "org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystem");
-        hadoopStorageConfig.set("fs.oss.endpoint", endpoint);
-        hadoopStorageConfig.set("fs.oss.region", region);
-        hadoopStorageConfig.set("fs.oss.accessKeyId", accessKey);
-        hadoopStorageConfig.set("fs.oss.accessKeySecret", secretKey);
-        hadoopStorageConfig.set("fs.oss.connection.timeout", connectionTimeoutS);
-        hadoopStorageConfig.set("fs.oss.connection.max", maxConnections);
-        hadoopStorageConfig.set("fs.oss.connection.request.timeout", requestTimeoutS);
-        hadoopStorageConfig.set("fs.oss.use.path.style.access", usePathStyle);
+        hadoopStorageConfig.set("fs.oss.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/S3Properties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/S3Properties.java
@@ -27,7 +27,6 @@ import com.google.common.collect.Lists;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.conf.Configuration;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
@@ -295,20 +294,5 @@ public class S3Properties extends AbstractS3CompatibleProperties {
                 WebIdentityTokenFileCredentialsProvider.create(),
                 ProfileCredentialsProvider.create(),
                 InstanceProfileCredentialsProvider.create());
-    }
-
-
-    @Override
-    public void initializeHadoopStorageConfig() {
-        hadoopStorageConfig = new Configuration();
-        hadoopStorageConfig.set("fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
-        hadoopStorageConfig.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
-        hadoopStorageConfig.set("fs.s3a.endpoint", endpoint);
-        hadoopStorageConfig.set("fs.s3a.access.key", accessKey);
-        hadoopStorageConfig.set("fs.s3a.secret.key", secretKey);
-        hadoopStorageConfig.set("fs.s3a.connection.maximum", s3ConnectionMaximum);
-        hadoopStorageConfig.set("fs.s3a.connection.request.timeout", s3ConnectionRequestTimeoutS);
-        hadoopStorageConfig.set("fs.s3a.connection.timeout", s3ConnectionTimeoutS);
-        hadoopStorageConfig.set("fs.s3a.path.style.access", usePathStyle);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHudiScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHudiScan.java
@@ -187,7 +187,7 @@ public class LogicalHudiScan extends LogicalFileScan {
         Optional<IncrementalRelation> newIncrementalRelation = Optional.empty();
         if (optScanParams.isPresent() && optScanParams.get().incrementalRead()) {
             TableScanParams scanParams = optScanParams.get();
-            Map<String, String> optParams = table.getHadoopProperties();
+            Map<String, String> optParams = table.getBackendStorageProperties();
             if (scanParams.getMapParams().containsKey("beginTime")) {
                 optParams.put("hoodie.datasource.read.begin.instanttime", scanParams.getMapParams().get("beginTime"));
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HiveTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HiveTableSink.java
@@ -162,7 +162,7 @@ public class HiveTableSink extends BaseExternalTableDataSink {
             tSink.setBrokerAddresses(getBrokerAddresses(targetTable.getCatalog().bindBrokerName()));
         }
 
-        tSink.setHadoopConfig(targetTable.getHadoopProperties());
+        tSink.setHadoopConfig(targetTable.getBackendStorageProperties());
 
         tDataSink = new TDataSink(getDataSinkType());
         tDataSink.setHiveTableSink(tSink);


### PR DESCRIPTION
### What problem does this PR solve?

#50238 
[](https://github.com/apache/doris/commit/cba9b29bd0f9e3e18b90f18f6bab9e435ea90d50) 

This PR introduces a refactored parameter integration framework for Apache Paimon metastore catalogs. The goal is to standardize parameter injection, improving configuration consistency and ease of use.

Key Changes
Introduced an abstract class AbstractPaimonProperties to provide a unified parameter injection workflow and extension point.

The new parameter system supports multiple metastore types, including:

HMS (Hive Metastore)

Aliyun DLF (an HMS-based adaptation)

FileSystem (local or HDFS)

All configuration parameters are constructed through a standardized Options object, eliminating the need for ad-hoc parameter mapping or conversions.

Subclasses inject metastore-specific parameters (e.g., hive.metastore.uris, DLF credentials) by implementing the ↳appendCustomCatalogOptions method.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

