### PR TITLE
[fix](load) fix missing error url return for stream load

### DIFF
--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -222,6 +222,10 @@ void PipelineFragmentContext::cancel(const Status reason) {
     auto stream_load_ctx = _exec_env->new_load_stream_mgr()->get(_query_id);
     if (stream_load_ctx != nullptr) {
         stream_load_ctx->pipe->cancel(reason.to_string());
+        // Set error URL here because after pipe is cancelled, stream load execution may return early.
+        // We need to set the error URL at this point to ensure error information is properly
+        // propagated to the client.
+        stream_load_ctx->error_url = get_load_error_url();
     }
 
     for (auto& tasks : _tasks) {

--- a/regression-test/suites/load_p0/stream_load/test_stream_load_with_filtered_rows.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_stream_load_with_filtered_rows.groovy
@@ -21,7 +21,7 @@ import org.apache.http.util.EntityUtils
 
 import java.text.SimpleDateFormat
 
-suite("test_stream_load_with_filtered_rows", "p2") {
+suite("test_stream_load_with_filtered_rows", "p0") {
     sql "show tables"
 
     // test length of input is too long than schema.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
when pipe is cancelled, stream load execution may return early without error url.
(test_stream_load_with_filtered_rows.groovy:64) - Stream load result: {
    "TxnId": 11,
    "Label": "2bbde37b-0589-4cce-8497-58e25af46590",
    "Comment": "",
    "TwoPhaseCommit": "false",
    "Status": "Fail",
    "Message": "[CANCELLED]cancelled: [DATA_QUALITY_ERROR]Encountered unqualified data, stop processing. Please check if the source data matches the schema, and consider disabling strict mode or increasing max_filter_ratio.. cur path: ",
    "NumberTotalRows": 32512,
    "NumberLoadedRows": 32460,
    "NumberFilteredRows": 52,
    "NumberUnselectedRows": 0,
    "LoadBytes": 29494781,
    "LoadTimeMs": 2138,
    "BeginTxnTimeMs": 1,
    "StreamLoadPutTimeMs": 7,
    "ReadDataTimeMs": 24,
    "WriteDataTimeMs": 0,
    "ReceiveDataTimeMs": 1836,
    "CommitAndPublishTimeMs": 0
}

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

