### PR TITLE
[fix](constant propagation)  don't extract constant relation for null aware anti join

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CheckDataTypes.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CheckDataTypes.java
@@ -70,6 +70,10 @@ public class CheckDataTypes implements CustomRewriter {
             conjuncts = plan.getMarkJoinConjuncts();
         }
         for (Expression expr : conjuncts) {
+            // constant propagation may rewrite mark join conjuncts to literal,
+            if (expr.isLiteral()) {
+                continue;
+            }
             DataType leftType = expr.child(0).getDataType();
             DataType rightType = expr.child(1).getDataType();
             if (!leftType.acceptsType(rightType)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ConstantPropagation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ConstantPropagation.java
@@ -232,6 +232,13 @@ public class ConstantPropagation extends DefaultPlanRewriter<ExpressionRewriteCo
         // So we only combine the hash conjuncts and other conjuncts.
         join = visitChildren(this, join, context);
 
+        boolean userInnerInfer = false;
+        // for NULL_AWARE_LEFT_ANTI_JOIN, NULL can not be treated as FALSE, so don't extract their constant relations.
+        // for example: NULL_AWARE_LEFT_ANTI join on a < 1 and a > 10,  if a is null, the join conditions is null
+        // and don't output the row.
+        // The join type may change. For example PhysicalPlanTranslator may convert LEFT_ANTI_JOIN and LEFT_SEMI_JOIN
+        // to NULL_AWARE_XX_JOIN, for safety, we don't extract inner constant relations for Join.
+
         List<Expression> newHashJoinConjuncts = join.getHashJoinConjuncts();
         List<Expression> newOtherJoinConjuncts = join.getOtherJoinConjuncts();
         List<Expression> hashOtherConjuncts = Lists.newArrayListWithExpectedSize(
@@ -241,7 +248,7 @@ public class ConstantPropagation extends DefaultPlanRewriter<ExpressionRewriteCo
         if (!hashOtherConjuncts.isEmpty()) {
             Expression oldHashOtherPredicate = ExpressionUtils.and(hashOtherConjuncts);
             Expression newHashOtherPredicate
-                    = replaceConstantsAndRewriteExpr(join, oldHashOtherPredicate, true, context);
+                    = replaceConstantsAndRewriteExpr(join, oldHashOtherPredicate, userInnerInfer, context);
             if (!isExprEqualIgnoreOrder(oldHashOtherPredicate, newHashOtherPredicate)) {
                 // TODO: code from FindHashConditionForJoin
                 Pair<List<Expression>, List<Expression>> pair
@@ -263,7 +270,8 @@ public class ConstantPropagation extends DefaultPlanRewriter<ExpressionRewriteCo
             // TODO: we may extract more constant relations from hash conjuncts,
             //       then we may make mark join conjuncts more simplify.
             Expression oldMarkPredicate = ExpressionUtils.and(join.getMarkJoinConjuncts());
-            Expression newMarkPredicate = replaceConstantsAndRewriteExpr(join, oldMarkPredicate, true, context);
+            Expression newMarkPredicate = replaceConstantsAndRewriteExpr(join, oldMarkPredicate,
+                    userInnerInfer, context);
             newMarkJoinConjuncts = ExpressionUtils.extractConjunction(newMarkPredicate);
             if (Sets.newHashSet(newMarkJoinConjuncts).equals(Sets.newHashSet(join.getMarkJoinConjuncts()))) {
                 newMarkJoinConjuncts = join.getMarkJoinConjuncts();

--- a/regression-test/data/nereids_rules_p0/constant_propagation/constant_propagation.out
+++ b/regression-test/data/nereids_rules_p0/constant_propagation/constant_propagation.out
@@ -96,10 +96,11 @@ PhysicalResultSink
 
 -- !join_2_shape --
 PhysicalResultSink
---NestedLoopJoin[LEFT_OUTER_JOIN]
-----PhysicalProject[t1.a]
-------PhysicalOlapScan[t1]
-----PhysicalEmptyRelation
+--PhysicalProject[t1.a, t2.x]
+----NestedLoopJoin[LEFT_OUTER_JOIN]a IS NULL
+------PhysicalProject[a IS NULL AS `a IS NULL`, t1.a]
+--------PhysicalOlapScan[t1]
+------PhysicalEmptyRelation
 
 -- !join_2_result --
 1	\N
@@ -107,11 +108,12 @@ PhysicalResultSink
 
 -- !join_3_shape --
 PhysicalResultSink
---NestedLoopJoin[FULL_OUTER_JOIN]FALSE
-----PhysicalProject[t1.a]
-------PhysicalOlapScan[t1]
-----PhysicalProject[t2.x]
-------PhysicalOlapScan[t2]
+--PhysicalProject[t1.a, t2.x]
+----NestedLoopJoin[FULL_OUTER_JOIN](a = 1)(x = 2)(t1.a > t2.x)
+------PhysicalProject[(a = 1) AS `(a = 1)`, t1.a]
+--------PhysicalOlapScan[t1]
+------PhysicalProject[(x = 2) AS `(x = 2)`, t2.x]
+--------PhysicalOlapScan[t2]
 
 -- !join_3_result --
 \N	1
@@ -149,10 +151,10 @@ PhysicalResultSink
 -- !join_6_shape --
 PhysicalResultSink
 --PhysicalProject[t1.a, t2.x]
-----NestedLoopJoin[FULL_OUTER_JOIN](a = 10)(x = 1)
-------PhysicalProject[(a = 10) AS `(a = 10)`, t1.a]
+----hashJoin[FULL_OUTER_JOIN] hashCondition=((expr_cast(a as BIGINT) = expr_(cast(x as BIGINT) * 10))) otherCondition=((t2.x = 1))
+------PhysicalProject[cast(a as BIGINT) AS `expr_cast(a as BIGINT)`, t1.a]
 --------PhysicalOlapScan[t1]
-------PhysicalProject[(x = 1) AS `(x = 1)`, t2.x]
+------PhysicalProject[(cast(x as BIGINT) * 10) AS `expr_(cast(x as BIGINT) * 10)`, t2.x]
 --------PhysicalOlapScan[t2]
 
 -- !join_6_result --
@@ -202,6 +204,56 @@ PhysicalResultSink
 
 -- !join_9_result --
 10	1	1
+
+-- !join_10_shape --
+PhysicalResultSink
+--PhysicalProject[$c$1 AS `1  in (select null from t2)`]
+----NestedLoopJoin[LEFT_SEMI_JOIN] otherCondition=() markCondition=(NULL)
+------PhysicalProject[1 AS `1`]
+--------PhysicalStorageLayerAggregate[t1]
+------PhysicalProject[1 AS `1`]
+--------PhysicalStorageLayerAggregate[t2]
+
+-- !join_10_result --
+true
+true
+
+-- !join_11_shape --
+PhysicalResultSink
+--PhysicalProject[$c$1 AS `1 not in (select null from t2)`]
+----NestedLoopJoin[LEFT_ANTI_JOIN] otherCondition=() markCondition=(NULL)
+------PhysicalProject[1 AS `1`]
+--------PhysicalStorageLayerAggregate[t1]
+------PhysicalProject[1 AS `1`]
+--------PhysicalStorageLayerAggregate[t2]
+
+-- !join_11_result --
+false
+false
+
+-- !join_12_shape --
+PhysicalResultSink
+--hashJoin[LEFT_SEMI_JOIN] hashCondition=((t1.a = t3.a)) otherCondition=() build RFs:RF0 a->[a]
+----PhysicalProject[t1.a]
+------PhysicalOlapScan[t1] apply RFs: RF0
+----PhysicalProject[t3.a]
+------filter((t3.__DORIS_DELETE_SIGN__ = 0) and (t3.b = 10))
+--------PhysicalOlapScan[t3]
+
+-- !join_12_result --
+1
+
+-- !join_13_shape --
+PhysicalResultSink
+--hashJoin[NULL_AWARE_LEFT_ANTI_JOIN] hashCondition=((t1.a = t3.a)) otherCondition=()
+----PhysicalProject[t1.a]
+------PhysicalOlapScan[t1]
+----PhysicalProject[t3.a]
+------filter((t3.__DORIS_DELETE_SIGN__ = 0) and (t3.b = 10))
+--------PhysicalOlapScan[t3]
+
+-- !join_13_result --
+10
 
 -- !subquery_1_shape --
 PhysicalResultSink

--- a/regression-test/data/nereids_rules_p0/constant_propagation/constant_propagation.out
+++ b/regression-test/data/nereids_rules_p0/constant_propagation/constant_propagation.out
@@ -96,11 +96,10 @@ PhysicalResultSink
 
 -- !join_2_shape --
 PhysicalResultSink
---PhysicalProject[t1.a, t2.x]
-----NestedLoopJoin[LEFT_OUTER_JOIN]a IS NULL
-------PhysicalProject[a IS NULL AS `a IS NULL`, t1.a]
---------PhysicalOlapScan[t1]
-------PhysicalEmptyRelation
+--NestedLoopJoin[LEFT_OUTER_JOIN]
+----PhysicalProject[t1.a]
+------PhysicalOlapScan[t1]
+----PhysicalEmptyRelation
 
 -- !join_2_result --
 1	\N
@@ -108,12 +107,11 @@ PhysicalResultSink
 
 -- !join_3_shape --
 PhysicalResultSink
---PhysicalProject[t1.a, t2.x]
-----NestedLoopJoin[FULL_OUTER_JOIN](a = 1)(x = 2)(t1.a > t2.x)
-------PhysicalProject[(a = 1) AS `(a = 1)`, t1.a]
---------PhysicalOlapScan[t1]
-------PhysicalProject[(x = 2) AS `(x = 2)`, t2.x]
---------PhysicalOlapScan[t2]
+--NestedLoopJoin[FULL_OUTER_JOIN]FALSE
+----PhysicalProject[t1.a]
+------PhysicalOlapScan[t1]
+----PhysicalProject[t2.x]
+------PhysicalOlapScan[t2]
 
 -- !join_3_result --
 \N	1
@@ -151,10 +149,10 @@ PhysicalResultSink
 -- !join_6_shape --
 PhysicalResultSink
 --PhysicalProject[t1.a, t2.x]
-----hashJoin[FULL_OUTER_JOIN] hashCondition=((expr_cast(a as BIGINT) = expr_(cast(x as BIGINT) * 10))) otherCondition=((t2.x = 1))
-------PhysicalProject[cast(a as BIGINT) AS `expr_cast(a as BIGINT)`, t1.a]
+----NestedLoopJoin[FULL_OUTER_JOIN](a = 10)(x = 1)
+------PhysicalProject[(a = 10) AS `(a = 10)`, t1.a]
 --------PhysicalOlapScan[t1]
-------PhysicalProject[(cast(x as BIGINT) * 10) AS `expr_(cast(x as BIGINT) * 10)`, t2.x]
+------PhysicalProject[(x = 1) AS `(x = 1)`, t2.x]
 --------PhysicalOlapScan[t2]
 
 -- !join_6_result --
@@ -207,32 +205,6 @@ PhysicalResultSink
 
 -- !join_10_shape --
 PhysicalResultSink
---PhysicalProject[$c$1 AS `1  in (select null from t2)`]
-----NestedLoopJoin[LEFT_SEMI_JOIN] otherCondition=() markCondition=(NULL)
-------PhysicalProject[1 AS `1`]
---------PhysicalStorageLayerAggregate[t1]
-------PhysicalProject[1 AS `1`]
---------PhysicalStorageLayerAggregate[t2]
-
--- !join_10_result --
-true
-true
-
--- !join_11_shape --
-PhysicalResultSink
---PhysicalProject[$c$1 AS `1 not in (select null from t2)`]
-----NestedLoopJoin[LEFT_ANTI_JOIN] otherCondition=() markCondition=(NULL)
-------PhysicalProject[1 AS `1`]
---------PhysicalStorageLayerAggregate[t1]
-------PhysicalProject[1 AS `1`]
---------PhysicalStorageLayerAggregate[t2]
-
--- !join_11_result --
-false
-false
-
--- !join_12_shape --
-PhysicalResultSink
 --hashJoin[LEFT_SEMI_JOIN] hashCondition=((t1.a = t3.a)) otherCondition=() build RFs:RF0 a->[a]
 ----PhysicalProject[t1.a]
 ------PhysicalOlapScan[t1] apply RFs: RF0
@@ -240,10 +212,10 @@ PhysicalResultSink
 ------filter((t3.__DORIS_DELETE_SIGN__ = 0) and (t3.b = 10))
 --------PhysicalOlapScan[t3]
 
--- !join_12_result --
+-- !join_10_result --
 1
 
--- !join_13_shape --
+-- !join_11_shape --
 PhysicalResultSink
 --hashJoin[NULL_AWARE_LEFT_ANTI_JOIN] hashCondition=((t1.a = t3.a)) otherCondition=()
 ----PhysicalProject[t1.a]
@@ -252,7 +224,7 @@ PhysicalResultSink
 ------filter((t3.__DORIS_DELETE_SIGN__ = 0) and (t3.b = 10))
 --------PhysicalOlapScan[t3]
 
--- !join_13_result --
+-- !join_11_result --
 10
 
 -- !subquery_1_shape --

--- a/regression-test/data/nereids_rules_p0/predicate_infer/infer_predicate.out
+++ b/regression-test/data/nereids_rules_p0/predicate_infer/infer_predicate.out
@@ -318,7 +318,7 @@ PhysicalResultSink
 
 -- !infer3 --
 PhysicalResultSink
---hashJoin[FULL_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=((t1.id = 1) and (t2.id = 1))
+--hashJoin[FULL_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=((t1.id = 1))
 ----PhysicalOlapScan[t1]
 ----PhysicalOlapScan[t2]
 
@@ -345,7 +345,7 @@ PhysicalResultSink
 
 -- !infer6 --
 PhysicalResultSink
---hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.id = t2.id) and (t1.name = t2.name)) otherCondition=((t1.id = 1) and (t1.name = 'bob'))
+--hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.id = t2.id) and (t1.name = t2.name)) otherCondition=((t1.id = 1))
 ----PhysicalOlapScan[t1]
 ----filter((t2.id = 1) and (t2.name = 'bob'))
 ------PhysicalOlapScan[t2]

--- a/regression-test/data/nereids_rules_p0/predicate_infer/infer_predicate.out
+++ b/regression-test/data/nereids_rules_p0/predicate_infer/infer_predicate.out
@@ -318,7 +318,7 @@ PhysicalResultSink
 
 -- !infer3 --
 PhysicalResultSink
---hashJoin[FULL_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=((t1.id = 1))
+--hashJoin[FULL_OUTER_JOIN] hashCondition=((t1.id = t2.id)) otherCondition=((t1.id = 1) and (t2.id = 1))
 ----PhysicalOlapScan[t1]
 ----PhysicalOlapScan[t2]
 
@@ -345,7 +345,7 @@ PhysicalResultSink
 
 -- !infer6 --
 PhysicalResultSink
---hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.id = t2.id) and (t1.name = t2.name)) otherCondition=((t1.id = 1))
+--hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.id = t2.id) and (t1.name = t2.name)) otherCondition=((t1.id = 1) and (t1.name = 'bob'))
 ----PhysicalOlapScan[t1]
 ----filter((t2.id = 1) and (t2.name = 'bob'))
 ------PhysicalOlapScan[t2]

--- a/regression-test/suites/nereids_rules_p0/constant_propagation/constant_propagation.groovy
+++ b/regression-test/suites/nereids_rules_p0/constant_propagation/constant_propagation.groovy
@@ -35,9 +35,9 @@ suite('constant_propagation') {
         SET runtime_filter_type=2;
         """
 
-    sql 'drop table if exists t1'
-    sql 'drop table if exists t2'
-    sql 'drop table if exists t3'
+    sql 'drop table if exists t1 force'
+    sql 'drop table if exists t2 force'
+    sql 'drop table if exists t3 force'
 
     sql """
     create table t1(a int, b int, c int, d int, e int, f int,
@@ -95,6 +95,18 @@ suite('constant_propagation') {
 
     sql '''
     insert into t3 values(1, 10, 100, 1000), (2, 20, 200, 2000), (3, 30, 300, 3000)
+    '''
+
+    multi_sql'''
+        drop table if exists s1 force;
+        drop table if exists s2 force;
+        drop table if exists s3 force;
+        create table s1(c1 int, c2 int) properties ('replication_num' = '1');
+        create table s2(c1 int, c2 int) properties ('replication_num' = '1');
+        create table s3(c1 int, c2 int) properties ('replication_num' = '1');
+        insert into s1 values (1,2),(1,3), (2,4), (2,5), (3,3), (3,4), (20,2), (22,3), (24,4);
+        insert into s2 values (1,4), (1,2),  (2,4), (3,7), (3,9),(5,1);
+        insert into s3 values (1,9), (1,8),  (2,6), (3,7), (3,9),(5,1);
     '''
 
     explain_and_result 'string_1',  """
@@ -202,27 +214,49 @@ suite('constant_propagation') {
        from t1 join t2 on t1.a = t2.x * 10 join t3 on t2.x = t3.a where t1.a = 10
     '''
 
-    // NOTICE: the result should  '[[null], [null]]', but be return '[[true], [true]]'
-    explain_and_result  'join_10', '''
-        select 1  in (select null from t2)
-        from t1;
-    '''
-
-    // NOTICE: the result should  '[[null], [null]]', but be return '[[false], [false]]'
-    explain_and_result  'join_11', '''
-        select 1 not in (select null from t2)
-        from t1;
-    '''
-
-    explain_and_result 'join_12', '''
+    explain_and_result 'join_10', '''
         select t1.a
         from t1 where t1.a in (select t3.a from t3 where t3.b = 10);
     '''
 
-    explain_and_result 'join_13', '''
+    explain_and_result 'join_11', '''
         select t1.a
         from t1 where t1.a not in (select t3.a from t3 where t3.b = 10);
     '''
+
+    /* // BUG start
+    // BUG: the result should  '[[null], [null]]', but be return '[[true], [true]]'
+    explain_and_result  'join_12', '''
+         select 1  in (select null from t2)
+         from t1;
+    '''
+
+    // BUG: the result should  '[[null], [null]]', but be return '[[false], [false]]'
+    explain_and_result  'join_13', '''
+        select 1 not in (select null from t2)
+        from t1;
+    '''
+
+    // OK
+    explain_and_result 'join_14', '''
+        select null  in (select c1 from s2) from s1
+    '''
+
+    // BUG: the result expect multi rows with null, but be return multi rows with true
+    explain_and_result 'join_15', '''
+        select null  in (select 1 from s2) from s1
+    '''
+
+    // BUG: the result expect multi rows with null, but be return multi rows with true
+    explain_and_result 'join_16', '''
+        select 1  in (select null from s2) from s1
+    '''
+
+    // BUG: the result expect multi rows with null, but be return multi rows with false
+    explain_and_result 'join_17', '''
+        select 1 not in (select null from s2) from s1
+    '''
+    */ // BUG end
 
     explain_and_result 'subquery_1', '''
        select a, x

--- a/regression-test/suites/nereids_rules_p0/constant_propagation/constant_propagation.groovy
+++ b/regression-test/suites/nereids_rules_p0/constant_propagation/constant_propagation.groovy
@@ -202,6 +202,28 @@ suite('constant_propagation') {
        from t1 join t2 on t1.a = t2.x * 10 join t3 on t2.x = t3.a where t1.a = 10
     '''
 
+    // NOTICE: the result should  '[[null], [null]]', but be return '[[true], [true]]'
+    explain_and_result  'join_10', '''
+        select 1  in (select null from t2)
+        from t1;
+    '''
+
+    // NOTICE: the result should  '[[null], [null]]', but be return '[[false], [false]]'
+    explain_and_result  'join_11', '''
+        select 1 not in (select null from t2)
+        from t1;
+    '''
+
+    explain_and_result 'join_12', '''
+        select t1.a
+        from t1 where t1.a in (select t3.a from t3 where t3.b = 10);
+    '''
+
+    explain_and_result 'join_13', '''
+        select t1.a
+        from t1 where t1.a not in (select t3.a from t3 where t3.b = 10);
+    '''
+
     explain_and_result 'subquery_1', '''
        select a, x
        from (select a from t1 where a = 1) s1, (select x from t2 where x = 1) s2


### PR DESCRIPTION
### What problem does this PR solve?

for null aware anti join,  the null in join conditition can't treat as false,  so in constant propagation cann't extract constant relation from join conditions for null aware anti join.

for semi join or anti join,  the join may convert to null aware join and convert  the mark condition to hash condition, so we don't   extract constant relations from mark conditions too.


TODO:
1.  for sql `select 1 [not] in (select null from t)`  should return null,  but BE return true/false, the BE need to fix it;

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

