### PR TITLE
[bugfix](k8s) using stdout to output 

### DIFF
--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -60,31 +60,33 @@ struct StdoutLogSink : google::LogSink {
             severity_char = '?';
             break;
         }
+        // Set output formatting flags
+        std::cout << std::setfill('0');
 
-        // 2. Get timestamp components
-        time_t t = time.time();
-        struct tm tm;
-        localtime_r(&t, &tm); // Thread-safe local time conversion
+        // 1. Log severity (I/W/E/F)
+        std::cout << severity_char;
 
-        // Extract microseconds from the timestamp
-        int microseconds = static_cast<int>((time.usec() % 1000000));
+        // 2. Date (YYYYMMDD)
+        // Note: tm_year is years since 1900, tm_mon is 0-based (0-11)
+        std::cout << std::setw(4) << (time.year() + 1900) << std::setw(2) << std::setfill('0')
+                  << (time.month() + 1) << std::setw(2) << std::setfill('0') << time.day();
 
-        // 3. Get process ID
-        pid_t pid = getpid();
+        // 3. Time (HH:MM:SS.ffffff)
+        std::cout << " " << std::setw(2) << std::setfill('0') << time.hour() << ":" << std::setw(2)
+                  << std::setfill('0') << time.min() << ":" << std::setw(2) << std::setfill('0')
+                  << time.sec() << "." << std::setw(6) << std::setfill('0') << time.usec();
 
-        // 格式：级别 + 日期 + 时间 + 进程ID + 文件名:行号] 消息
-        std::cout << severity_char << std::setfill('0') << std::setw(4) << tm.tm_year + 1900 // 年份
-                  << std::setw(2) << tm.tm_mon + 1             // 月份
-                  << std::setw(2) << tm.tm_mday                // 日期
-                  << " " << std::setw(2) << tm.tm_hour         // 小时
-                  << ":" << std::setw(2) << tm.tm_min          // 分钟
-                  << ":" << std::setw(2) << tm.tm_sec          // 秒
-                  << "." << std::setw(6) << microseconds       // 微秒
-                  << " " << pid                                // 进程ID
-                  << " " << base_filename                      // 文件名
-                  << ":" << line                               // 行号
-                  << "] " << std::string(message, message_len) // 日志消息
-                  << std::endl;
+        // 4. Process ID
+        std::cout << " " << getpid();
+
+        // 5. Filename and line number
+        std::cout << " " << base_filename << ":" << line << "] ";
+
+        // 6. Log message
+        std::cout.write(message, message_len);
+
+        // Add newline and flush
+        std::cout << std::endl;
     }
 };
 

--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -272,7 +272,7 @@ bool init_glog(const char* basename) {
 
 void shutdown_logging() {
     std::lock_guard<std::mutex> logging_lock(logging_mutex);
-    google::RemoveLogSink(&stdcout_sink);
+    google::RemoveLogSink(&stdout_log_sink);
     google::ShutdownGoogleLogging();
 }
 

--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -97,15 +97,6 @@ bool init_glog(const char* basename) {
         return true;
     }
 
-    bool log_to_console = (getenv("DORIS_LOG_TO_STDERR") != nullptr);
-    if (log_to_console) {
-        if (config::enable_file_logger) {
-            FLAGS_alsologtostderr = true;
-        } else {
-            FLAGS_logtostderr = true;
-        }
-    }
-
     // don't log to stderr except fatal level
     // so fatal log can output to be.out .
     FLAGS_stderrthreshold = google::FATAL;

--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -97,6 +97,7 @@ bool init_glog(const char* basename) {
         return true;
     }
 
+    bool log_to_console = (getenv("DORIS_LOG_TO_STDERR") != nullptr);
     // don't log to stderr except fatal level
     // so fatal log can output to be.out .
     FLAGS_stderrthreshold = google::FATAL;

--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -36,8 +36,6 @@ static bool logging_initialized = false;
 
 static std::mutex logging_mutex;
 
-static StdoutLogSink stdout_log_sink;
-
 // Implement the custom log format: I20250118 10:53:06.239614 1318521 timezone_utils.cpp:115] Preloaded653 timezones.
 struct StdoutLogSink : google::LogSink {
     void send(google::LogSeverity severity, const char* /*full_filename*/,
@@ -89,6 +87,8 @@ struct StdoutLogSink : google::LogSink {
                   << std::endl;
     }
 };
+
+static StdoutLogSink stdout_log_sink;
 
 static bool iequals(const std::string& a, const std::string& b) {
     unsigned int sz = a.size();

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -400,9 +400,18 @@ int main(int argc, char** argv) {
     google::ParseCommandLineFlags(&argc, &argv, true);
     // ATTN: MUST init before LOG
     doris::init_glog("be");
-
+    bool log_to_console = (getenv("DORIS_LOG_TO_STDERR") != nullptr);
     StdoutLogSink sink;
-    google::AddLogSink(&sink);
+    if (log_to_console) {
+        if (config::enable_file_logger) {
+            // will output log to be.info and output log to stdout
+            google::AddLogSink(&sink);
+        } else {
+            // enable_file_logger is false, will only output log to stdout
+            // Not output to stderr because be.out will output log to stderr
+            FLAGS_logtostdout = true;
+        }
+    }
 
     LOG(INFO) << doris::get_version_string(false);
 

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -403,7 +403,7 @@ int main(int argc, char** argv) {
     bool log_to_console = (getenv("DORIS_LOG_TO_STDERR") != nullptr);
     StdoutLogSink sink;
     if (log_to_console) {
-        if (config::enable_file_logger) {
+        if (doris::config::enable_file_logger) {
             // will output log to be.info and output log to stdout
             google::AddLogSink(&sink);
         } else {

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -311,7 +311,7 @@ struct Checker {
         ;
 
 // This method is in logging.cc in glog.
-extern void ColoredWriteToStdout(LogSeverity severity, const char* message, size_t len);
+extern void ColoredWriteToStdout(google::LogSeverity severity, const char* message, size_t len);
 // GLog has flags FLAGS_logtostderr, FLAGS_logtostdout, FLAGS_alsologtostderr. But not
 // has flags like FLAGS_alsologtostdout. We need to log BE.INFO into stdout for k8s usage.
 // Because log stack trace need to use stderr to output the log to be.out.

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -459,8 +459,10 @@ elif [[ "${RUN_DAEMON}" -eq 1 ]]; then
         nohup ${LIMIT:+${LIMIT}} "${DORIS_HOME}/lib/doris_be" "$@" >>"${LOG_DIR}/be.out" 2>&1 </dev/null &
     fi
 elif [[ "${RUN_CONSOLE}" -eq 1 ]]; then
+    # stdout outputs console
+    # stderr outputs be.out
     export DORIS_LOG_TO_STDERR=1
-    ${LIMIT:+${LIMIT}} "${DORIS_HOME}/lib/doris_be" "$@" 2>&1 </dev/null
+    ${LIMIT:+${LIMIT}} "${DORIS_HOME}/lib/doris_be" "$@" 2>>"${LOG_DIR}/be.out" </dev/null
 else
     ${LIMIT:+${LIMIT}} "${DORIS_HOME}/lib/doris_be" "$@" >>"${LOG_DIR}/be.out" 2>&1 </dev/null
 fi

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -107,9 +107,9 @@ log() {
     cur_date=$(date +"%Y-%m-%d %H:%M:%S,$(date +%3N)")
     if [[ "${RUN_CONSOLE}" -eq 1 ]]; then
         echo "StdoutLogger ${cur_date} $1"
-    else
-        echo "StdoutLogger ${cur_date} $1" >>"${STDOUT_LOGGER}"
     fi
+    # always output start time info into be.out file
+    echo "StdoutLogger ${cur_date} $1" >>"${STDOUT_LOGGER}"
 }
 
 jdk_version() {


### PR DESCRIPTION
### What problem does this PR solve?

K8S using stdout to capture BE INFO logs. But when BE crash be will try to output crash stack to be.out file. In the past, it could not output to be.out file. In this feature, I format the behaviors of be log:
1. -- daemon, output log to be.info file and output crash stack to be.out file.
2. --console,
     2.1 enable_file_logger = true, output all logs to console (stdout) and output all logs to be.info and crash stack to be.out
     2.2 enable_file_logger = false, output all logs to console(stdout) and crash stack to be.out

we will always output crash stack to logs/be.out file.

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

