### PR TITLE
[Improvement](runtime-filter) fixed_len_to_uint32_v2 change hash method to crc32

### DIFF
--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -111,7 +111,6 @@
 #include "runtime/thread_context.h"
 #include "runtime_filter/runtime_filter_mgr.h"
 #include "service/backend_options.h"
-#include "util/container_util.hpp"
 #include "util/countdown_latch.h"
 #include "util/debug_util.h"
 #include "util/uid_util.h"
@@ -488,7 +487,7 @@ Status PipelineFragmentContext::_build_pipeline_tasks(const doris::TPipelineFrag
                 DCHECK(task != nullptr);
 
                 // If this task has upstream dependency, then inject it into this task.
-                if (_dag.find(_pipeline->id()) != _dag.end()) {
+                if (_dag.contains(_pipeline->id())) {
                     auto& deps = _dag[_pipeline->id()];
                     for (auto& dep : deps) {
                         if (pipeline_id_to_task.contains(dep)) {
@@ -509,9 +508,10 @@ Status PipelineFragmentContext::_build_pipeline_tasks(const doris::TPipelineFrag
                 auto* task = pipeline_id_to_task[_pipelines[pip_idx]->id()];
                 DCHECK(pipeline_id_to_profile[pip_idx]);
                 std::vector<TScanRangeParams> scan_ranges;
-                scan_ranges = find_with_default(local_params.per_node_scan_ranges,
-                                                _pipelines[pip_idx]->operators().front()->node_id(),
-                                                scan_ranges);
+                auto node_id = _pipelines[pip_idx]->operators().front()->node_id();
+                if (local_params.per_node_scan_ranges.contains(node_id)) {
+                    scan_ranges = local_params.per_node_scan_ranges.find(node_id)->second;
+                }
                 RETURN_IF_ERROR_OR_CATCH_EXCEPTION(task->prepare(
                         scan_ranges, local_params.sender_id, request.fragment.output_sink));
             }
@@ -1237,7 +1237,9 @@ Status PipelineFragmentContext::_create_operator(ObjectPool* pool, const TPlanNo
         break;
     }
     case TPlanNodeType::EXCHANGE_NODE: {
-        int num_senders = find_with_default(request.per_exch_num_senders, tnode.node_id, 0);
+        int num_senders = request.per_exch_num_senders.contains(tnode.node_id)
+                                  ? request.per_exch_num_senders.find(tnode.node_id)->second
+                                  : 0;
         DCHECK_GT(num_senders, 0);
         op.reset(new ExchangeSourceOperatorX(pool, tnode, next_operator_id(), descs, num_senders));
         RETURN_IF_ERROR(cur_pipe->add_operator(

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -39,7 +39,6 @@
 #include "runtime/query_context.h"
 #include "runtime/thread_context.h"
 #include "runtime/workload_group/workload_group_manager.h"
-#include "util/container_util.hpp"
 #include "util/defer_op.h"
 #include "util/mem_info.h"
 #include "util/runtime_profile.h"

--- a/be/src/runtime_filter/runtime_filter.cpp
+++ b/be/src/runtime_filter/runtime_filter.cpp
@@ -98,8 +98,6 @@ Status RuntimeFilter::_init_with_desc(const TRuntimeFilterDesc* desc,
         params.bloom_filter_size = desc->bloom_filter_size_bytes;
     }
     params.null_aware = desc->__isset.null_aware && desc->null_aware;
-    params.enable_fixed_len_to_uint32_v2 = options->__isset.enable_fixed_len_to_uint32_v2 &&
-                                           options->enable_fixed_len_to_uint32_v2;
     if (_runtime_filter_type == RuntimeFilterType::BITMAP_FILTER) {
         if (_has_remote_target) {
             return Status::InternalError("bitmap filter do not support remote target");

--- a/be/src/runtime_filter/runtime_filter_definitions.h
+++ b/be/src/runtime_filter/runtime_filter_definitions.h
@@ -57,8 +57,6 @@ struct RuntimeFilterParams {
     bool build_bf_by_runtime_size {};
     // Whether an estimated size by NDV is used to build bloom filter
     bool bloom_filter_size_calculated_by_ndv {};
-    // Whether an optimized way to build BF using fixed-length values
-    bool enable_fixed_len_to_uint32_v2 {};
 
     // Bitmap filter
     // Whether a join expression is `not in`

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -42,7 +42,6 @@
 #include "common/compiler_util.h" // IWYU pragma: keep
 #include "common/logging.h"
 #include "util/binary_cast.hpp"
-#include "util/container_util.hpp"
 #include "util/pretty_printer.h"
 #include "util/stopwatch.hpp"
 

--- a/be/src/vec/common/hash_table/hash.h
+++ b/be/src/vec/common/hash_table/hash.h
@@ -118,6 +118,11 @@ inline size_t hash_crc32(doris::vectorized::UInt128 u) {
 }
 
 template <>
+inline size_t hash_crc32(unsigned __int128 u) {
+    return doris::vectorized::UInt128HashCRC32()(u);
+}
+
+template <>
 inline size_t hash_crc32(doris::vectorized::Int128 u) {
     return doris::vectorized::UInt128HashCRC32()({(u >> 64) & int64_t(-1), u & int64_t(-1)});
 }
@@ -142,6 +147,7 @@ DEFINE_HASH(doris::vectorized::Int64)
 DEFINE_HASH(doris::vectorized::Int128)
 DEFINE_HASH(doris::vectorized::Float32)
 DEFINE_HASH(doris::vectorized::Float64)
+DEFINE_HASH(unsigned __int128)
 
 #undef DEFINE_HASH
 

--- a/be/test/exprs/bloom_filter_func_test.cpp
+++ b/be/test/exprs/bloom_filter_func_test.cpp
@@ -62,7 +62,6 @@ TEST_F(BloomFilterFuncTest, Init) {
                                 256,
                                 0,
                                 0,
-                                false,
                                 false};
     bloom_filter_func.init_params(&params);
 
@@ -88,74 +87,18 @@ TEST_F(BloomFilterFuncTest, Init) {
     bloom_filter_func2.light_copy(&bloom_filter_func);
 }
 
-#define TEST_NUMERIC_VALUES32(type)              \
-    do {                                         \
-        type a {};                               \
-        type b = type_limit<type>::min();        \
-        type c = type_limit<type>::max();        \
-                                                 \
-        ASSERT_EQ(fixed_len(a), fixed_lenv2(a)); \
-        ASSERT_EQ(fixed_len(b), fixed_lenv2(b)); \
-        ASSERT_EQ(fixed_len(c), fixed_lenv2(c)); \
-        ASSERT_EQ(fixed_len(a), (uint32_t)(a));  \
-        ASSERT_EQ(fixed_len(b), (uint32_t)(b));  \
-        ASSERT_EQ(fixed_len(c), (uint32_t)(c));  \
-    } while (0)
-
-#define TEST_NUMERIC_VALUES_BIG(type)                            \
-    do {                                                         \
-        type a {};                                               \
-        type b = type_limit<type>::min();                        \
-        type c = type_limit<type>::max();                        \
-        ASSERT_EQ(fixed_len(a), fixed_lenv2(a));                 \
-        ASSERT_EQ(fixed_len(b), fixed_lenv2(b));                 \
-        ASSERT_EQ(fixed_len(c), fixed_lenv2(c));                 \
-        ASSERT_EQ(fixed_len(a), (uint32_t)std::hash<type>()(a)); \
-        ASSERT_EQ(fixed_len(b), (uint32_t)std::hash<type>()(b)); \
-        ASSERT_EQ(fixed_len(c), (uint32_t)std::hash<type>()(c)); \
-    } while (0)
-
 TEST_F(BloomFilterFuncTest, FixedLenToUInt32) {
-    fixed_len_to_uint32 fixed_len;
     fixed_len_to_uint32_v2 fixed_lenv2;
-
-    TEST_NUMERIC_VALUES32(int8_t);
-    TEST_NUMERIC_VALUES32(int16_t);
-    TEST_NUMERIC_VALUES32(int32_t);
-    TEST_NUMERIC_VALUES32(uint8_t);
-    TEST_NUMERIC_VALUES32(uint16_t);
-    TEST_NUMERIC_VALUES32(uint32_t);
-    TEST_NUMERIC_VALUES32(float);
-    TEST_NUMERIC_VALUES32(vectorized::Decimal32);
-
-    TEST_NUMERIC_VALUES_BIG(int64_t);
-    TEST_NUMERIC_VALUES_BIG(uint64_t);
-    TEST_NUMERIC_VALUES_BIG(double);
-    TEST_NUMERIC_VALUES_BIG(int128_t);
-    TEST_NUMERIC_VALUES_BIG(uint128_t);
-    TEST_NUMERIC_VALUES_BIG(wide::UInt128);
-    TEST_NUMERIC_VALUES_BIG(wide::UInt256);
-    TEST_NUMERIC_VALUES_BIG(wide::Int256);
-    TEST_NUMERIC_VALUES_BIG(vectorized::Decimal64);
-    TEST_NUMERIC_VALUES_BIG(vectorized::Decimal128V2);
-    TEST_NUMERIC_VALUES_BIG(vectorized::Decimal128V3);
-    TEST_NUMERIC_VALUES_BIG(vectorized::Decimal256);
-    TEST_NUMERIC_VALUES_BIG(VecDateTimeValue);
-    TEST_NUMERIC_VALUES_BIG(DateV2Value<DateTimeV2ValueType>);
-
     {
         DateV2Value<DateV2ValueType> date;
         date.from_date_str("2021-01-01", strlen("2021-01-01"));
         auto min = binary_cast<uint32_t, DateV2Value<DateV2ValueType>>(MIN_DATE_V2);
         auto max = binary_cast<uint32_t, DateV2Value<DateV2ValueType>>(MAX_DATE_V2);
 
-        ASSERT_EQ(fixed_len(date), (uint32_t)date.to_int64());
         ASSERT_EQ(fixed_lenv2(date), (uint32_t)date.to_date_int_val());
 
-        ASSERT_EQ(fixed_len(min), (uint32_t)min.to_int64());
         ASSERT_EQ(fixed_lenv2(min), (uint32_t)min.to_date_int_val());
 
-        ASSERT_EQ(fixed_len(max), (uint32_t)max.to_int64());
         ASSERT_EQ(fixed_lenv2(max), (uint32_t)max.to_date_int_val());
     }
 }
@@ -173,7 +116,6 @@ TEST_F(BloomFilterFuncTest, InsertSet) {
                                 256,
                                 0,
                                 0,
-                                false,
                                 false};
     bloom_filter_func.init_params(&params);
     auto st = bloom_filter_func.init_with_fixed_length(runtime_length);
@@ -228,7 +170,6 @@ TEST_F(BloomFilterFuncTest, InsertFixedLen) {
                                 256,
                                 0,
                                 0,
-                                false,
                                 false};
     bloom_filter_func.init_params(&params);
     auto st = bloom_filter_func.init_with_fixed_length(runtime_length);
@@ -303,7 +244,6 @@ TEST_F(BloomFilterFuncTest, Merge) {
                                 256,
                                 0,
                                 0,
-                                false,
                                 false};
     bloom_filter_func.init_params(&params);
     auto st = bloom_filter_func.init_with_fixed_length(runtime_length);
@@ -399,7 +339,6 @@ TEST_F(BloomFilterFuncTest, HashAlgorithm) {
                                 256,
                                 0,
                                 0,
-                                false,
                                 false};
     bloom_filter_func.init_params(&params);
 
@@ -448,7 +387,6 @@ TEST_F(BloomFilterFuncTest, MergeLargeData) {
                                 256,
                                 0,
                                 0,
-                                false,
                                 false};
     bloom_filter_func.init_params(&params);
     auto st = bloom_filter_func.init_with_fixed_length(runtime_length);
@@ -552,7 +490,6 @@ TEST_F(BloomFilterFuncTest, FindDictOlapEngine) {
                                 256,
                                 0,
                                 0,
-                                false,
                                 false};
     bloom_filter_func.init_params(&params);
     auto st = bloom_filter_func.init_with_fixed_length(0);
@@ -594,7 +531,6 @@ TEST_F(BloomFilterFuncTest, FindFixedLenOlapEngine) {
                                 256,
                                 0,
                                 0,
-                                false,
                                 false};
     bloom_filter_func.init_params(&params);
     auto st = bloom_filter_func.init_with_fixed_length(0);

--- a/be/test/exprs/bloom_filter_func_test.cpp
+++ b/be/test/exprs/bloom_filter_func_test.cpp
@@ -203,7 +203,6 @@ TEST_F(BloomFilterFuncTest, InsertSet) {
     }
 
     BloomFilterFunc<PrimitiveType::TYPE_INT> bloom_filter_func2(false);
-    params.enable_fixed_len_to_uint32_v2 = true;
     bloom_filter_func2.init_params(&params);
     st = bloom_filter_func2.init_with_fixed_length(runtime_length);
     ASSERT_TRUE(st.ok()) << "Failed to init bloom filter with fixed length: " << st.to_string();
@@ -421,8 +420,6 @@ TEST_F(BloomFilterFuncTest, HashAlgorithm) {
     ASSERT_EQ(memcmp(BloomFilterBinary.data(), encode_string.data(),
                      strlen(BloomFilterBinary.c_str())),
               0);
-
-    params.enable_fixed_len_to_uint32_v2 = true;
 
     BloomFilterFunc<PrimitiveType::TYPE_INT> bloom_filter_func2(false);
     bloom_filter_func2.init_params(&params);

--- a/be/test/runtime_filter/runtime_filter_wrapper_test.cpp
+++ b/be/test/runtime_filter/runtime_filter_wrapper_test.cpp
@@ -52,7 +52,6 @@ TEST_F(RuntimeFilterWrapperTest, TestIn) {
     bool build_bf_by_runtime_size = true;
     int64_t bloom_filter_size = 0;
     bool bloom_filter_size_calculated_by_ndv = true;
-    bool enable_fixed_len_to_uint32_v2 = true;
 
     bool bitmap_filter_not_in = false;
 
@@ -68,7 +67,6 @@ TEST_F(RuntimeFilterWrapperTest, TestIn) {
             .bloom_filter_size = bloom_filter_size,
             .build_bf_by_runtime_size = build_bf_by_runtime_size,
             .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-            .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
             .bitmap_filter_not_in = bitmap_filter_not_in};
 
     auto wrapper = std::make_shared<RuntimeFilterWrapper>(&params);
@@ -195,7 +193,6 @@ TEST_F(RuntimeFilterWrapperTest, TestInAssign) {
     bool build_bf_by_runtime_size = true;
     int64_t bloom_filter_size = 0;
     bool bloom_filter_size_calculated_by_ndv = true;
-    bool enable_fixed_len_to_uint32_v2 = true;
 
     bool bitmap_filter_not_in = false;
 
@@ -213,7 +210,7 @@ TEST_F(RuntimeFilterWrapperTest, TestInAssign) {
                 .bloom_filter_size = bloom_filter_size,                                            \
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,                              \
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,        \
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,                    \
+                                                                                                   \
                 .bitmap_filter_not_in = bitmap_filter_not_in};                                     \
         auto wrapper = std::make_shared<RuntimeFilterWrapper>(&params);                            \
         PMergeFilterRequest valid_request;                                                         \
@@ -274,7 +271,6 @@ TEST_F(RuntimeFilterWrapperTest, TestMinMaxAssign) {
     bool build_bf_by_runtime_size = true;
     int64_t bloom_filter_size = 0;
     bool bloom_filter_size_calculated_by_ndv = true;
-    bool enable_fixed_len_to_uint32_v2 = true;
 
     bool bitmap_filter_not_in = false;
 
@@ -292,7 +288,7 @@ TEST_F(RuntimeFilterWrapperTest, TestMinMaxAssign) {
                 .bloom_filter_size = bloom_filter_size,                                      \
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,                        \
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,  \
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,              \
+                                                                                             \
                 .bitmap_filter_not_in = bitmap_filter_not_in};                               \
         auto wrapper = std::make_shared<RuntimeFilterWrapper>(&params);                      \
         PMergeFilterRequest valid_request;                                                   \
@@ -363,7 +359,6 @@ TEST_F(RuntimeFilterWrapperTest, TestBloom) {
     bool build_bf_by_runtime_size = false;
     int64_t bloom_filter_size = 0;
     bool bloom_filter_size_calculated_by_ndv = true;
-    bool enable_fixed_len_to_uint32_v2 = true;
 
     bool bitmap_filter_not_in = false;
 
@@ -381,7 +376,7 @@ TEST_F(RuntimeFilterWrapperTest, TestBloom) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
+
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         wrapper = std::make_shared<RuntimeFilterWrapper>(&params);
         EXPECT_FALSE(wrapper->build_bf_by_runtime_size());
@@ -401,7 +396,7 @@ TEST_F(RuntimeFilterWrapperTest, TestBloom) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
+
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         wrapper = std::make_shared<RuntimeFilterWrapper>(&params);
         EXPECT_EQ(wrapper->bloom_filter_func()->_bloom_filter_length,
@@ -427,7 +422,7 @@ TEST_F(RuntimeFilterWrapperTest, TestBloom) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
+
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         wrapper = std::make_shared<RuntimeFilterWrapper>(&params);
         EXPECT_TRUE(wrapper->build_bf_by_runtime_size());
@@ -457,7 +452,7 @@ TEST_F(RuntimeFilterWrapperTest, TestBloom) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
+
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         wrapper = std::make_shared<RuntimeFilterWrapper>(&params);
         EXPECT_EQ(wrapper->bloom_filter_func()->_bloom_filter_length,
@@ -509,7 +504,7 @@ TEST_F(RuntimeFilterWrapperTest, TestBloom) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
+
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         auto new_wrapper = std::make_shared<RuntimeFilterWrapper>(&new_params);
         EXPECT_TRUE(new_wrapper->assign(valid_request, &stream).ok());
@@ -531,7 +526,7 @@ TEST_F(RuntimeFilterWrapperTest, TestBloom) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
+
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         auto new_wrapper = std::make_shared<RuntimeFilterWrapper>(&new_params);
         EXPECT_TRUE(new_wrapper->init(runtime_size).ok());
@@ -579,7 +574,6 @@ TEST_F(RuntimeFilterWrapperTest, TestMinMax) {
     bool build_bf_by_runtime_size = false;
     int64_t bloom_filter_size = 0;
     bool bloom_filter_size_calculated_by_ndv = true;
-    bool enable_fixed_len_to_uint32_v2 = true;
 
     bool bitmap_filter_not_in = false;
 
@@ -597,7 +591,7 @@ TEST_F(RuntimeFilterWrapperTest, TestMinMax) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
+
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         {
             wrapper = std::make_shared<RuntimeFilterWrapper>(&params);
@@ -666,7 +660,7 @@ TEST_F(RuntimeFilterWrapperTest, TestMinMax) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
+
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         {
             wrapper = std::make_shared<RuntimeFilterWrapper>(&params);
@@ -735,7 +729,7 @@ TEST_F(RuntimeFilterWrapperTest, TestMinMax) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
+
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         {
             wrapper = std::make_shared<RuntimeFilterWrapper>(&params);
@@ -805,7 +799,6 @@ TEST_F(RuntimeFilterWrapperTest, TestBitMap) {
     bool build_bf_by_runtime_size = false;
     int64_t bloom_filter_size = 0;
     bool bloom_filter_size_calculated_by_ndv = true;
-    bool enable_fixed_len_to_uint32_v2 = true;
 
     bool bitmap_filter_not_in = false;
 
@@ -820,7 +813,7 @@ TEST_F(RuntimeFilterWrapperTest, TestBitMap) {
             .bloom_filter_size = bloom_filter_size,
             .build_bf_by_runtime_size = build_bf_by_runtime_size,
             .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-            .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
+
             .bitmap_filter_not_in = bitmap_filter_not_in};
 
     std::shared_ptr<RuntimeFilterWrapper> wrapper;
@@ -924,7 +917,6 @@ TEST_F(RuntimeFilterWrapperTest, TestInOrBloom) {
     bool build_bf_by_runtime_size = false;
     int64_t bloom_filter_size = 64;
     bool bloom_filter_size_calculated_by_ndv = false;
-    bool enable_fixed_len_to_uint32_v2 = true;
 
     bool bitmap_filter_not_in = false;
 
@@ -941,7 +933,7 @@ TEST_F(RuntimeFilterWrapperTest, TestInOrBloom) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
+
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         wrapper = std::make_shared<RuntimeFilterWrapper>(&params);
         EXPECT_EQ(wrapper->bloom_filter_func()->_bloom_filter_length, bloom_filter_size);
@@ -974,7 +966,7 @@ TEST_F(RuntimeFilterWrapperTest, TestInOrBloom) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
+
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         wrapper = std::make_shared<RuntimeFilterWrapper>(&params);
         EXPECT_EQ(wrapper->bloom_filter_func()->_bloom_filter_length, bloom_filter_size);
@@ -1004,7 +996,7 @@ TEST_F(RuntimeFilterWrapperTest, TestInOrBloom) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
+
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         wrapper = std::make_shared<RuntimeFilterWrapper>(&params);
         EXPECT_EQ(wrapper->get_real_type(), RuntimeFilterType::IN_FILTER);
@@ -1021,7 +1013,7 @@ TEST_F(RuntimeFilterWrapperTest, TestInOrBloom) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
+
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         auto new_wrapper = std::make_shared<RuntimeFilterWrapper>(&new_params);
         EXPECT_EQ(new_wrapper->get_real_type(), RuntimeFilterType::IN_FILTER);
@@ -1060,7 +1052,6 @@ TEST_F(RuntimeFilterWrapperTest, TestInOrBloom) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         wrapper = std::make_shared<RuntimeFilterWrapper>(&params);
         EXPECT_EQ(wrapper->get_real_type(), RuntimeFilterType::IN_FILTER);
@@ -1077,7 +1068,6 @@ TEST_F(RuntimeFilterWrapperTest, TestInOrBloom) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         auto new_wrapper = std::make_shared<RuntimeFilterWrapper>(&new_params);
         EXPECT_EQ(new_wrapper->get_real_type(), RuntimeFilterType::IN_FILTER);
@@ -1123,7 +1113,6 @@ TEST_F(RuntimeFilterWrapperTest, TestInOrBloom) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         wrapper = std::make_shared<RuntimeFilterWrapper>(&params);
         EXPECT_EQ(wrapper->get_real_type(), RuntimeFilterType::IN_FILTER);
@@ -1143,7 +1132,6 @@ TEST_F(RuntimeFilterWrapperTest, TestInOrBloom) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         auto new_wrapper = std::make_shared<RuntimeFilterWrapper>(&new_params);
         EXPECT_EQ(new_wrapper->get_real_type(), RuntimeFilterType::IN_FILTER);
@@ -1191,7 +1179,6 @@ TEST_F(RuntimeFilterWrapperTest, TestInOrBloom) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         wrapper = std::make_shared<RuntimeFilterWrapper>(&params);
         EXPECT_EQ(wrapper->get_real_type(), RuntimeFilterType::IN_FILTER);
@@ -1211,7 +1198,6 @@ TEST_F(RuntimeFilterWrapperTest, TestInOrBloom) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         auto new_wrapper = std::make_shared<RuntimeFilterWrapper>(&new_params);
         EXPECT_EQ(new_wrapper->get_real_type(), RuntimeFilterType::IN_FILTER);
@@ -1260,7 +1246,6 @@ TEST_F(RuntimeFilterWrapperTest, TestInOrBloom) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         wrapper = std::make_shared<RuntimeFilterWrapper>(&params);
         EXPECT_EQ(wrapper->get_real_type(), RuntimeFilterType::IN_FILTER);
@@ -1278,7 +1263,6 @@ TEST_F(RuntimeFilterWrapperTest, TestInOrBloom) {
                 .bloom_filter_size = bloom_filter_size,
                 .build_bf_by_runtime_size = build_bf_by_runtime_size,
                 .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-                .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
                 .bitmap_filter_not_in = bitmap_filter_not_in};
         auto new_wrapper = std::make_shared<RuntimeFilterWrapper>(&new_params);
         EXPECT_EQ(new_wrapper->get_real_type(), RuntimeFilterType::IN_FILTER);
@@ -1334,7 +1318,6 @@ TEST_F(RuntimeFilterWrapperTest, TestErrorPath) {
     bool build_bf_by_runtime_size = false;
     int64_t bloom_filter_size = 64;
     bool bloom_filter_size_calculated_by_ndv = false;
-    bool enable_fixed_len_to_uint32_v2 = true;
 
     bool bitmap_filter_not_in = false;
     RuntimeFilterParams params {
@@ -1348,7 +1331,6 @@ TEST_F(RuntimeFilterWrapperTest, TestErrorPath) {
             .bloom_filter_size = bloom_filter_size,
             .build_bf_by_runtime_size = build_bf_by_runtime_size,
             .bloom_filter_size_calculated_by_ndv = bloom_filter_size_calculated_by_ndv,
-            .enable_fixed_len_to_uint32_v2 = enable_fixed_len_to_uint32_v2,
             .bitmap_filter_not_in = bitmap_filter_not_in};
     std::shared_ptr<RuntimeFilterWrapper> wrapper = std::make_shared<RuntimeFilterWrapper>(&params);
     auto col = vectorized::ColumnHelper::create_column<DataType>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1323,10 +1323,6 @@ public class SessionVariable implements Serializable, Writable {
             "Ignore the rf when it encounters an error" })
     public boolean ignoreRuntimeFilterError = false;
 
-    @VariableMgr.VarAttr(name = "enable_fixed_len_to_uint32_v2", needForward = true, description = {
-            "使用新版本fixed_len_to_uint32_v2,对datetimev2类型bloom filter做了优化",
-            "Using the new version fixed_len_to_uint32_v2, the datetimev2 type bloom filter has been optimized" })
-    public boolean enableFixedLenToUint32V2 = true;
 
     @VariableMgr.VarAttr(name = RUNTIME_FILTER_MODE, needForward = true)
     private String runtimeFilterMode = "GLOBAL";
@@ -4391,7 +4387,6 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setOrcMaxMergeDistanceBytes(orcMaxMergeDistanceBytes);
         tResult.setOrcOnceMaxReadBytes(orcOnceMaxReadBytes);
         tResult.setIgnoreRuntimeFilterError(ignoreRuntimeFilterError);
-        tResult.setEnableFixedLenToUint32V2(enableFixedLenToUint32V2);
         tResult.setProfileLevel(getProfileLevel());
         tResult.setEnableRuntimeFilterPartitionPrune(enableRuntimeFilterPartitionPrune);
 


### PR DESCRIPTION
### What problem does this PR solve?
1. fixed_len_to_uint32_v2 change hash method to crc32
2. remove some compatibility code
3. remove container_util

```sql
drop table if exists t1;
create table t1(
        k1 largeint,
        k2 largeint
) distributed by hash (k1) buckets 1
properties ("replication_num"="1");
set parallel_pipeline_task_num=1;
set enable_runtime_filter_prune=false;
insert into t1 select e1,-e1 from (select 1 k1) as t lateral view explode_numbers(100000000) tmp1 as e1;

select count(*) from t1 as a ,t1 as b where a.k1=b.k2;

11.19 sec -> 10.25 sec
```
### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

