### PR TITLE
[fix](nereids) when ColumnStatistics.avgSizeByte is NaN, use default size 1.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
@@ -186,7 +186,11 @@ public class Statistics {
             for (Slot slot : slots) {
                 ColumnStatistic s = expressionToColumnStats.get(slot);
                 if (s != null) {
-                    tempSize += Math.max(1, Math.min(CharacterType.DEFAULT_WIDTH, s.avgSizeByte));
+                    double avgSize = s.avgSizeByte;
+                    if (!Double.isFinite(avgSize)) {
+                        avgSize = 1;
+                    }
+                    tempSize += Math.max(1, Math.min(CharacterType.DEFAULT_WIDTH, avgSize));
                 }
             }
             tupleSize = Math.max(1, tempSize);

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsTest.java
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.types.IntegerType;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class StatisticsTest {
+    @Test
+    public void testAvgSizeAbnormal() {
+        SlotReference slot = SlotReference.of("a", IntegerType.INSTANCE);
+        ColumnStatisticBuilder colBuilder = new ColumnStatisticBuilder();
+        colBuilder.setAvgSizeByte(Double.NaN);
+        Statistics stats = new Statistics(1, 1, ImmutableMap.of(slot, colBuilder.build()));
+        double tupleSize = stats.computeTupleSize(ImmutableList.of(slot));
+        Assertions.assertEquals(1, tupleSize);
+
+        colBuilder.setAvgSizeByte(Double.POSITIVE_INFINITY);
+        stats = new Statistics(1, 1, ImmutableMap.of(slot, colBuilder.build()));
+        tupleSize = stats.computeTupleSize(ImmutableList.of(slot));
+        Assertions.assertEquals(1, tupleSize);
+
+        colBuilder.setAvgSizeByte(Double.NEGATIVE_INFINITY);
+        stats = new Statistics(1, 1, ImmutableMap.of(slot, colBuilder.build()));
+        tupleSize = stats.computeTupleSize(ImmutableList.of(slot));
+        Assertions.assertEquals(1, tupleSize);
+
+        colBuilder.setAvgSizeByte(-1.0);
+        stats = new Statistics(1, 1, ImmutableMap.of(slot, colBuilder.build()));
+        tupleSize = stats.computeTupleSize(ImmutableList.of(slot));
+        Assertions.assertEquals(1, tupleSize);
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?
when deriving column statistics, sometimes the avgSizeByte is NaN (after applying some functions). This NaN size blocks the computation of cost of distribution.
So when  avgSizeByte is NaN, set it to 1.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

