### PR TITLE
[fix](deadlock) avoid deadlock on tabletInvertedIndex

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -122,10 +122,10 @@ public class DatabaseTransactionMgr {
     private final MonitoredReentrantReadWriteLock transactionLock = new MonitoredReentrantReadWriteLock(true);
 
     // transactionId -> running TransactionState
-    private final Map<Long, TransactionState> idToRunningTransactionState = Maps.newHashMap();
+    private final Map<Long, TransactionState> idToRunningTransactionState = Maps.newConcurrentMap();
 
     // transactionId -> final status TransactionState
-    private final Map<Long, TransactionState> idToFinalStatusTransactionState = Maps.newHashMap();
+    private final Map<Long, TransactionState> idToFinalStatusTransactionState = Maps.newConcurrentMap();
     private final Map<Long, Long> subTxnIdToTxnId = new ConcurrentHashMap<>();
 
     // The following 2 queues are to store transactionStates with final status
@@ -193,12 +193,8 @@ public class DatabaseTransactionMgr {
     }
 
     protected TransactionState getTransactionState(Long transactionId) {
-        readLock();
-        try {
-            return unprotectedGetTransactionState(transactionId);
-        } finally {
-            readUnlock();
-        }
+        return unprotectedGetTransactionState(transactionId);
+
     }
 
     private TransactionState unprotectedGetTransactionState(Long transactionId) {


### PR DESCRIPTION
StampLock used by tabletInvertedIndex is a fair lock.

Comments from StampLock:
In particular, we use the phase-fair anti-barging rule: If an incoming reader arrives while read lock is held but there is a queued writer, this incoming reader is queued.

A dead lock happens like below:

ReportThread: hold TabletInvertedIndex.readLock and try to acquire DatabaseTransactionMgr.readLock.

CommitThread: try to acquire TabletInvertedIndex.readLock.

TabletOperatorThread: try to acquire TabletInvertedIndex.writeLock.

CommitThread: hold DatabaseTransactionMgr.writeLock and waiting for editlog's lock.

The DatabaseTransactionMgr.writeLock is held when writing editlog, so sometimes it is time consuming and results in time  consuming tablet report.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

