### PR TITLE
[improve](udf) let create udf function error msg more clear

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateFunctionCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateFunctionCommand.java
@@ -700,7 +700,9 @@ public class CreateFunctionCommand extends Command implements ForwardWithSync {
                 m -> m.getParameters().length == argsDef.getArgTypes().length).collect(Collectors.toList());
         if (evalArgLengthMatchList.size() == 0) {
             throw new AnalysisException(
-                    String.format("The arguments number udf provided and create function command is not equal, the parameters of '%s' method in class '%s' maybe should %d.",
+                    String.format(
+                            "The arguments number udf provided and create function command is not equal,"
+                                    + " the parameters of '%s' method in class '%s' maybe should %d.",
                             EVAL_METHOD_KEY, udfClass.getCanonicalName(), argsDef.getArgTypes().length));
         } else if (evalArgLengthMatchList.size() == 1) {
             Method method = evalArgLengthMatchList.get(0);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateFunctionCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateFunctionCommand.java
@@ -700,7 +700,7 @@ public class CreateFunctionCommand extends Command implements ForwardWithSync {
                 m -> m.getParameters().length == argsDef.getArgTypes().length).collect(Collectors.toList());
         if (evalArgLengthMatchList.size() == 0) {
             throw new AnalysisException(
-                    String.format("The number of parameters for method '%s' in class '%s' should be %d",
+                    String.format("The arguments number udf provided and create function command is not equal, the parameters of '%s' method in class '%s' maybe should %d.",
                             EVAL_METHOD_KEY, udfClass.getCanonicalName(), argsDef.getArgTypes().length));
         } else if (evalArgLengthMatchList.size() == 1) {
             Method method = evalArgLengthMatchList.get(0);
@@ -751,19 +751,21 @@ public class CreateFunctionCommand extends Command implements ForwardWithSync {
             javaTypes = Type.PrimitiveTypeToJavaClassType.get(structType.getPrimitiveType());
         } else {
             throw new AnalysisException(
-                    String.format("Method '%s' in class '%s' does not support type '%s'",
+                    String.format("Method '%s' in class '%s' does not support type '%s'.",
                             method.getName(), clazz.getCanonicalName(), expType));
         }
 
         if (javaTypes == null) {
             throw new AnalysisException(
-                    String.format("Method '%s' in class '%s' does not support type '%s'",
-                            method.getName(), clazz.getCanonicalName(), expType.toString()));
+                    String.format("Method '%s' in class '%s' does not support type '%s'.",
+                            method.getName(), clazz.getCanonicalName(), expType.getPrimitiveType().toString()));
         }
         if (!javaTypes.contains(pType)) {
             throw new AnalysisException(
-                    String.format("UDF class '%s' method '%s' %s[%s] type is not supported!",
-                            clazz.getCanonicalName(), method.getName(), pname, pType.getCanonicalName()));
+                    String.format(
+                            "UDF class '%s' of method '%s' %s is [%s] type, but create function command type is %s.",
+                            clazz.getCanonicalName(), method.getName(), pname, pType.getCanonicalName(),
+                            expType.getPrimitiveType().toString()));
         }
     }
 

--- a/regression-test/suites/javaudf_p0/test_javaudf_int.groovy
+++ b/regression-test/suites/javaudf_p0/test_javaudf_int.groovy
@@ -147,6 +147,16 @@ suite("test_javaudf_int") {
             exception "but the return type is not nullable"
         }
 
+        test {
+            sql """ CREATE FUNCTION java_udf_largeint_test_not_nullable(largeint) RETURNS string PROPERTIES (
+                "file"="file://${jarPath}",
+                "symbol"="org.apache.doris.udf.LargeintTest",
+                "always_nullable"="false",
+                "type"="JAVA_UDF"
+            ); """
+            exception "but create function command type is STRING"
+        }
+
     } finally {
         try_sql("DROP GLOBAL FUNCTION IF EXISTS java_udf_int_test_global(int);")
         try_sql("DROP FUNCTION IF EXISTS java_udf_tinyint_test(tinyint);")


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
sometimes user create function maybe have mistake of parameter
so need more clear error msg to know what happend.

```
 ERROR 1105 (HY000): errCode = 2, detailMessage = UDF class 'org.apache.doris.udf.AddOne' method 'evaluate' return[java.lang.Integer] type is not supported!

before and after of error msg

ERROR 1105 (HY000): errCode = 2, detailMessage = UDF class 'org.apache.doris.udf.AddOne' of method 'evaluate' return is [java.lang.Integer] type, but create function command type is STRING


```


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

