### PR TITLE
[fix](fe) fix unknown property error when have duplicate replicas properties

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
@@ -1081,4 +1081,76 @@ public class CreateTableTest extends TestWithFeService {
                         + "\"dynamic_partition.start\" = \"-3\"\n"
                         + ");", true));
     }
+
+    @Test
+    public void testCreateTablePropertyDuplicate() throws Exception {
+        String sql = "create table test.tbl_property_duplicate\n"
+                + "(`uuid` varchar(255) NULL,\n"
+                + "`action_datetime` date NULL\n"
+                + ")\n"
+                + "DUPLICATE KEY(uuid)\n"
+                + "PARTITION BY RANGE(action_datetime)()\n"
+                + "DISTRIBUTED BY HASH(uuid) BUCKETS 3\n"
+                + "PROPERTIES\n"
+                + "(\n"
+                + "\"replication_num\" = \"3\",\n"
+                + "\"replication_allocation\" = \"tag.location.default: 3\"\n"
+                + ");";
+        createTable(sql);
+        Database db =
+                Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+        OlapTable table = (OlapTable) db.getTableOrAnalysisException("tbl_property_duplicate");
+        Assert.assertEquals(3, table.getDefaultReplicaAllocation().getTotalReplicaNum());
+
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "duplicate properties: [replication_num] and [replication_allocation]",
+                () -> createTable("create table test.tbl_property_duplicate_invalid1\n"
+                        + "(`uuid` varchar(255) NULL,\n"
+                        + "`action_datetime` date NULL\n"
+                        + ")\n"
+                        + "DUPLICATE KEY(uuid)\n"
+                        + "PARTITION BY RANGE(action_datetime)()\n"
+                        + "DISTRIBUTED BY HASH(uuid) BUCKETS 3\n"
+                        + "PROPERTIES\n"
+                        + "(\n"
+                        + "\"replication_num\" = \"3\",\n"
+                        + "\"replication_allocation\" = \"tag.location.default: 2\"\n"
+                        + ");"));
+    }
+
+    @Test
+    public void testCreateTablePropertyDuplicateWithNereids() throws Exception {
+        String sql = "create table test.tbl_property_duplicate_with_nereids\n"
+                + "(`uuid` varchar(255) NULL,\n"
+                + "`action_datetime` date NULL\n"
+                + ")\n"
+                + "DUPLICATE KEY(uuid)\n"
+                + "PARTITION BY RANGE(action_datetime)()\n"
+                + "DISTRIBUTED BY HASH(uuid) BUCKETS 3\n"
+                + "PROPERTIES\n"
+                + "(\n"
+                + "\"replication_num\" = \"3\",\n"
+                + "\"replication_allocation\" = \"tag.location.default: 3\"\n"
+                + ");";
+        createTable(sql, true);
+        Database db =
+                Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+        OlapTable table = (OlapTable) db.getTableOrAnalysisException("tbl_property_duplicate_with_nereids");
+        Assert.assertEquals(3, table.getDefaultReplicaAllocation().getTotalReplicaNum());
+
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "duplicate properties: [replication_num] and [replication_allocation]",
+                () -> createTable("create table test.tbl_property_duplicate_invalid1\n"
+                        + "(`uuid` varchar(255) NULL,\n"
+                        + "`action_datetime` date NULL\n"
+                        + ")\n"
+                        + "DUPLICATE KEY(uuid)\n"
+                        + "PARTITION BY RANGE(action_datetime)()\n"
+                        + "DISTRIBUTED BY HASH(uuid) BUCKETS 3\n"
+                        + "PROPERTIES\n"
+                        + "(\n"
+                        + "\"replication_num\" = \"3\",\n"
+                        + "\"replication_allocation\" = \"tag.location.default: 2\"\n"
+                        + ");", true));
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
@@ -1102,7 +1102,7 @@ public class CreateTableTest extends TestWithFeService {
         OlapTable table = (OlapTable) db.getTableOrAnalysisException("tbl_property_duplicate");
         Assert.assertEquals(3, table.getDefaultReplicaAllocation().getTotalReplicaNum());
 
-        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+        ExceptionChecker.expectThrowsWithMsg(org.apache.doris.common.AnalysisException.class,
                 "duplicate properties: [replication_num] and [replication_allocation]",
                 () -> createTable("create table test.tbl_property_duplicate_invalid1\n"
                         + "(`uuid` varchar(255) NULL,\n"
@@ -1138,7 +1138,7 @@ public class CreateTableTest extends TestWithFeService {
         OlapTable table = (OlapTable) db.getTableOrAnalysisException("tbl_property_duplicate_with_nereids");
         Assert.assertEquals(3, table.getDefaultReplicaAllocation().getTotalReplicaNum());
 
-        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+        ExceptionChecker.expectThrowsWithMsg(org.apache.doris.common.AnalysisException.class,
                 "duplicate properties: [replication_num] and [replication_allocation]",
                 () -> createTable("create table test.tbl_property_duplicate_invalid1\n"
                         + "(`uuid` varchar(255) NULL,\n"


### PR DESCRIPTION
Issue Number: close #32577

### What problem does this PR solve?

Issue Number: close #32577

Problem Summary:
When we create a table in doris with two below properties, doris reports an unknown property error, however it should report a duplicated properties or if duplicated properties have same value, doris should just ignore it.
"replication_allocation" = "tag.location.default: 3",
"replication_num" = "3",

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

