### PR TITLE
[fix](init-catalog) use equals instead of ==

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
@@ -209,7 +209,7 @@ public class MysqlProto {
         // try to change catalog, if default_init_catalog inside user property is not 'internal'
         try {
             String userInitCatalog = Env.getCurrentEnv().getAuth().getInitCatalog(context.getQualifiedUser());
-            if (userInitCatalog != null && userInitCatalog != InternalCatalog.INTERNAL_CATALOG_NAME) {
+            if (userInitCatalog != null && !userInitCatalog.equals(InternalCatalog.INTERNAL_CATALOG_NAME)) {
                 CatalogIf catalogIf = context.getEnv().getCatalogMgr().getCatalog(userInitCatalog);
                 if (catalogIf != null) {
                     context.getEnv().changeCatalog(context, userInitCatalog);


### PR DESCRIPTION
Followup #49658
Should use `equals` instead of `==`