### PR TITLE
[fix](thirdparty) resolve build error when downloading aws_sdk

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1364,7 +1364,7 @@ build_aws_sdk() {
         -DCMAKE_PREFIX_PATH="${TP_INSTALL_DIR}" -DBUILD_SHARED_LIBS=OFF -DENABLE_TESTING=OFF \
         -DCURL_LIBRARY_RELEASE="${TP_INSTALL_DIR}/lib/libcurl.a" -DZLIB_LIBRARY_RELEASE="${TP_INSTALL_DIR}/lib/libz.a" \
         -DBUILD_ONLY="core;s3;s3-crt;transfer;identity-management;sts" \
-        -DCMAKE_CXX_FLAGS="-Wno-nonnull -Wno-deprecated-literal-operator ${warning_deprecated_literal_operator} -Wno-deprecated-declarations ${warning_dangling_reference}" -DCPP_STANDARD=17
+        -DCMAKE_CXX_FLAGS="-Wno-nonnull ${warning_deprecated_literal_operator} -Wno-deprecated-declarations ${warning_dangling_reference}" -DCPP_STANDARD=17
 
     cd "${BUILD_DIR}"
 


### PR DESCRIPTION
### What problem does this PR solve?

1. An error occurred while downloading aws_sdk.
```text
[230/523] Building CXX object src/aws-cpp-sdk-core/CMakeFiles/aws-cpp-sdk-core.dir/source/utils/ARN.cpp.o
FAILED: src/aws-cpp-sdk-core/CMakeFiles/aws-cpp-sdk-core.dir/source/utils/ARN.cpp.o
/usr/bin/clang++ -DAWS_SDK_VERSION_MAJOR=1 -DAWS_SDK_VERSION_MINOR=11 -DAWS_SDK_VERSION_PATCH=119 -DAWS_TEST_REGION=US_EAST_1 -DAWS_USE_EPOLL -DENABLED_REQUEST_COMPRESSION -DENABLED_ZLIB_REQUEST_COMPRESSION -DENABLE_CURL_CLIENT -DENABLE_CURL_LOGGING -DENABLE_OPENSSL_ENCRYPTION -DHAS_PATHCONF -DHAS_UMASK -DPLATFORM_LINUX -I/home/ljh/doris/thirdparty/src/aws-sdk-cpp-1.11.119/src/aws-cpp-sdk-core/include/aws/core/platform/refs -I/home/ljh/doris/thirdparty/src/aws-sdk-cpp-1.11.119/src/aws-cpp-sdk-core/include -I/home/ljh/doris/thirdparty/src/aws-sdk-cpp-1.11.119/crt/aws-crt-cpp/include -I/home/ljh/doris/thirdparty/src/aws-sdk-cpp-1.11.119/crt/aws-crt-cpp/crt/aws-c-http/include -I/home/ljh/doris/thirdparty/src/aws-sdk-cpp-1.11.119/crt/aws-crt-cpp/crt/aws-c-io/include -I/home/ljh/doris/thirdparty/src/aws-sdk-cpp-1.11.119/crt/aws-crt-cpp/crt/s2n -I/home/ljh/doris/thirdparty/src/aws-sdk-cpp-1.11.119/crt/aws-crt-cpp/crt/s2n/api -I/home/ljh/doris/thirdparty/src/aws-sdk-cpp-1.11.119/crt/aws-crt-cpp/crt/aws-c-common/include -I/home/ljh/doris/thirdparty/src/aws-sdk-cpp-1.11.119/doris_build/crt/aws-crt-cpp/crt/aws-c-common/generated/include -I/home/ljh/doris/thirdparty/src/aws-sdk-cpp-1.11.119/crt/aws-crt-cpp/crt/aws-c-cal/include -I/home/ljh/doris/thirdparty/src/aws-sdk-cpp-1.11.119/crt/aws-crt-cpp/crt/aws-c-compression/include -I/home/ljh/doris/thirdparty/src/aws-sdk-cpp-1.11.119/crt/aws-crt-cpp/crt/aws-c-mqtt/include -I/home/ljh/doris/thirdparty/src/aws-sdk-cpp-1.11.119/crt/aws-crt-cpp/crt/aws-c-auth/include -I/home/ljh/doris/thirdparty/src/aws-sdk-cpp-1.11.119/crt/aws-crt-cpp/crt/aws-c-sdkutils/include -I/home/ljh/doris/thirdparty/src/aws-sdk-cpp-1.11.119/crt/aws-crt-cpp/crt/aws-checksums/include -I/home/ljh/doris/thirdparty/src/aws-sdk-cpp-1.11.119/crt/aws-crt-cpp/crt/aws-c-event-stream/include -I/home/ljh/doris/thirdparty/src/aws-sdk-cpp-1.11.119/crt/aws-crt-cpp/crt/aws-c-s3/include -isystem /home/ljh/doris/thirdparty/installed/include -Wno-nonnull -Wno-deprecated-literal-operator  -Wno-deprecated-declarations -O2 -g -DNDEBUG -fno-exceptions -std=c++17 -fPIC -Wall -Werror -pedantic -Wextra -pthread -MD -MT src/aws-cpp-sdk-core/CMakeFiles/aws-cpp-sdk-core.dir/source/utils/ARN.cpp.o -MF src/aws-cpp-sdk-core/CMakeFiles/aws-cpp-sdk-core.dir/source/utils/ARN.cpp.o.d -o src/aws-cpp-sdk-core/CMakeFiles/aws-cpp-sdk-core.dir/source/utils/ARN.cpp.o -c /home/ljh/doris/thirdparty/src/aws-sdk-cpp-1.11.119/src/aws-cpp-sdk-core/source/utils/ARN.cpp
error: unknown warning option '-Wno-deprecated-literal-operator'; did you mean '-Wno-deprecated-copy-dtor'? [-Werror,-Wunknown-warning-option]
```
2. `${warning_deprecated_literal_operator}` is the same as `-Wno-deprecated-literal-operator`.
```shell
if [[ "${CC}" == *gcc ]]; then
    warning_uninitialized='-Wno-maybe-uninitialized'
    warning_stringop_truncation='-Wno-stringop-truncation'
    warning_class_memaccess='-Wno-class-memaccess'
    warning_array_parameter='-Wno-array-parameter'
    warning_narrowing='-Wno-narrowing'
    warning_dangling_reference='-Wno-dangling-reference'

    gcc_major_version=$("${CC}" -dumpversion | cut -d. -f1)
    if [[ "${gcc_major_version}" -ge 15 ]]; then
        warning_deprecated_literal_operator='-Wno-deprecated-literal-operator'
    fi
```
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [x] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

