### PR TITLE
[opt](table_function) Refine JSON-related table functions

### DIFF
--- a/be/src/vec/exprs/table_function/vexplode_json_array.h
+++ b/be/src/vec/exprs/table_function/vexplode_json_array.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <glog/logging.h>
-#include <rapidjson/document.h>
 
 #include "common/status.h"
 #include "vec/data_types/data_type.h"
@@ -37,7 +36,6 @@ struct ParsedData {
         _backup_data.clear();
         _values_null_flag.clear();
     }
-    virtual int set_output(rapidjson::Document& document, int value_size) = 0;
     virtual int set_output(const ArrayVal& array_doc, int value_size) = 0;
     virtual void insert_result_from_parsed_data(MutableColumnPtr& column, int64_t cur_offset,
                                                 int max_step) = 0;
@@ -53,7 +51,6 @@ struct ParsedData {
 struct ParsedDataInt : public ParsedData<int64_t> {
     static constexpr auto MAX_VALUE = std::numeric_limits<int64_t>::max(); //9223372036854775807
     static constexpr auto MIN_VALUE = std::numeric_limits<int64_t>::min(); //-9223372036854775808
-    int set_output(rapidjson::Document& document, int value_size) override;
     int set_output(const ArrayVal& array_doc, int value_size) override;
     void insert_result_from_parsed_data(MutableColumnPtr& column, int64_t cur_offset,
                                         int max_step) override;
@@ -61,8 +58,6 @@ struct ParsedDataInt : public ParsedData<int64_t> {
                                                  int length) override;
 };
 struct ParsedDataDouble : public ParsedData<double> {
-    int set_output(rapidjson::Document& document, int value_size) override;
-
     int set_output(const ArrayVal& array_doc, int value_size) override;
 
     void insert_result_from_parsed_data(MutableColumnPtr& column, int64_t cur_offset,
@@ -85,14 +80,10 @@ struct ParsedDataStringBase : public ParsedData<std::string> {
     char tmp_buf[128] = {0};
 };
 struct ParsedDataString : public ParsedDataStringBase {
-    int set_output(rapidjson::Document& document, int value_size) override;
-
     int set_output(const ArrayVal& array_doc, int value_size) override;
 };
 
 struct ParsedDataJSON : public ParsedDataStringBase {
-    int set_output(rapidjson::Document& document, int value_size) override;
-
     int set_output(const ArrayVal& array_doc, int value_size) override;
 };
 

--- a/be/test/vec/table_function/vexplode_json_array_test.cpp
+++ b/be/test/vec/table_function/vexplode_json_array_test.cpp
@@ -1,0 +1,70 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/exprs/table_function/vexplode_json_array.h"
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "util/jsonb_document.h"
+#include "util/jsonb_writer.h"
+
+namespace doris::vectorized {
+TEST(VExplodeJsonArrayTest, test_double) {
+    ParsedDataDouble parsed_data_double;
+
+    JsonbWriter jsonb_writer;
+
+    jsonb_writer.writeStartArray();
+
+    jsonb_writer.writeDouble(1.23);
+    jsonb_writer.writeDouble(4.56);
+    jsonb_writer.writeDouble(7.89);
+    jsonb_writer.writeInt(100);
+
+    Decimal32 decimal_value32(int32_t(99999999));
+    jsonb_writer.writeDecimal(decimal_value32, 9, 4);
+
+    Decimal64 decimal_value64(int64_t(999999999999999999ULL));
+    jsonb_writer.writeDecimal(decimal_value64, 18, 4);
+
+    Decimal128V3 decimal_value((__int128_t(std::numeric_limits<uint64_t>::max())));
+    jsonb_writer.writeDecimal(decimal_value, 30, 8);
+
+    wide::Int256 int256_value(wide::Int256(std::numeric_limits<__int128_t>::max()) * 2);
+    vectorized::Decimal256 decimal256_value(int256_value);
+    jsonb_writer.writeDecimal(decimal256_value, 40, 8);
+
+    jsonb_writer.writeEndArray();
+
+    auto* jsonb_doc = jsonb_writer.getDocument();
+
+    parsed_data_double.set_output(*jsonb_doc->getValue()->unpack<ArrayVal>(),
+                                  jsonb_doc->getValue()->unpack<ArrayVal>()->numElem());
+
+    ASSERT_EQ(parsed_data_double._backup_data.size(),
+              jsonb_doc->getValue()->unpack<ArrayVal>()->numElem());
+    ASSERT_DOUBLE_EQ(parsed_data_double._backup_data[0], 1.23);
+    ASSERT_DOUBLE_EQ(parsed_data_double._backup_data[1], 4.56);
+    ASSERT_DOUBLE_EQ(parsed_data_double._backup_data[2], 7.89);
+    ASSERT_DOUBLE_EQ(parsed_data_double._backup_data[3], 100);
+    ASSERT_DOUBLE_EQ(parsed_data_double._backup_data[4], 9999.9999);
+    ASSERT_DOUBLE_EQ(parsed_data_double._backup_data[5], 99999999999999.9999);
+    ASSERT_DOUBLE_EQ(parsed_data_double._backup_data[6], 184467440737.09551615);
+    ASSERT_DOUBLE_EQ(parsed_data_double._backup_data[7], 3.4028236692093847e+30);
+}
+} // namespace doris::vectorized

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeJsonArrayDouble.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeJsonArrayDouble.java
@@ -24,7 +24,6 @@ import org.apache.doris.nereids.trees.expressions.shape.UnaryExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DoubleType;
 import org.apache.doris.nereids.types.JsonType;
-import org.apache.doris.nereids.types.VarcharType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -37,8 +36,7 @@ import java.util.List;
 public class ExplodeJsonArrayDouble extends TableGeneratingFunction implements UnaryExpression, PropagateNullable {
 
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
-            FunctionSignature.ret(DoubleType.INSTANCE).args(JsonType.INSTANCE),
-            FunctionSignature.ret(DoubleType.INSTANCE).args(VarcharType.SYSTEM_DEFAULT)
+            FunctionSignature.ret(DoubleType.INSTANCE).args(JsonType.INSTANCE)
     );
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeJsonArrayDoubleOuter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeJsonArrayDoubleOuter.java
@@ -24,7 +24,6 @@ import org.apache.doris.nereids.trees.expressions.shape.UnaryExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DoubleType;
 import org.apache.doris.nereids.types.JsonType;
-import org.apache.doris.nereids.types.VarcharType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -37,8 +36,7 @@ import java.util.List;
 public class ExplodeJsonArrayDoubleOuter extends TableGeneratingFunction implements UnaryExpression, AlwaysNullable {
 
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
-            FunctionSignature.ret(DoubleType.INSTANCE).args(JsonType.INSTANCE),
-            FunctionSignature.ret(DoubleType.INSTANCE).args(VarcharType.SYSTEM_DEFAULT)
+            FunctionSignature.ret(DoubleType.INSTANCE).args(JsonType.INSTANCE)
     );
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeJsonArrayInt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeJsonArrayInt.java
@@ -24,7 +24,6 @@ import org.apache.doris.nereids.trees.expressions.shape.UnaryExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.JsonType;
-import org.apache.doris.nereids.types.VarcharType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -37,8 +36,7 @@ import java.util.List;
 public class ExplodeJsonArrayInt extends TableGeneratingFunction implements UnaryExpression, PropagateNullable {
 
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
-            FunctionSignature.ret(BigIntType.INSTANCE).args(JsonType.INSTANCE),
-            FunctionSignature.ret(BigIntType.INSTANCE).args(VarcharType.SYSTEM_DEFAULT)
+            FunctionSignature.ret(BigIntType.INSTANCE).args(JsonType.INSTANCE)
     );
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeJsonArrayIntOuter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeJsonArrayIntOuter.java
@@ -24,7 +24,6 @@ import org.apache.doris.nereids.trees.expressions.shape.UnaryExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.JsonType;
-import org.apache.doris.nereids.types.VarcharType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -37,8 +36,7 @@ import java.util.List;
 public class ExplodeJsonArrayIntOuter extends TableGeneratingFunction implements UnaryExpression, AlwaysNullable {
 
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
-            FunctionSignature.ret(BigIntType.INSTANCE).args(JsonType.INSTANCE),
-            FunctionSignature.ret(BigIntType.INSTANCE).args(VarcharType.SYSTEM_DEFAULT)
+            FunctionSignature.ret(BigIntType.INSTANCE).args(JsonType.INSTANCE)
     );
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeJsonArrayJson.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeJsonArrayJson.java
@@ -23,7 +23,6 @@ import org.apache.doris.nereids.trees.expressions.functions.PropagateNullable;
 import org.apache.doris.nereids.trees.expressions.shape.UnaryExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.JsonType;
-import org.apache.doris.nereids.types.VarcharType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -36,8 +35,7 @@ import java.util.List;
  */
 public class ExplodeJsonArrayJson extends TableGeneratingFunction implements UnaryExpression, PropagateNullable {
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
-            FunctionSignature.ret(JsonType.INSTANCE).args(JsonType.INSTANCE),
-            FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT).args(VarcharType.SYSTEM_DEFAULT)
+            FunctionSignature.ret(JsonType.INSTANCE).args(JsonType.INSTANCE)
     );
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeJsonArrayJsonOuter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeJsonArrayJsonOuter.java
@@ -23,7 +23,6 @@ import org.apache.doris.nereids.trees.expressions.functions.AlwaysNullable;
 import org.apache.doris.nereids.trees.expressions.shape.UnaryExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.JsonType;
-import org.apache.doris.nereids.types.VarcharType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -36,8 +35,7 @@ import java.util.List;
  */
 public class ExplodeJsonArrayJsonOuter extends TableGeneratingFunction implements UnaryExpression, AlwaysNullable {
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
-            FunctionSignature.ret(JsonType.INSTANCE).args(JsonType.INSTANCE),
-            FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT).args(VarcharType.SYSTEM_DEFAULT)
+            FunctionSignature.ret(JsonType.INSTANCE).args(JsonType.INSTANCE)
     );
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeJsonArrayString.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeJsonArrayString.java
@@ -36,8 +36,7 @@ import java.util.List;
 public class ExplodeJsonArrayString extends TableGeneratingFunction implements UnaryExpression, PropagateNullable {
 
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
-            FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT).args(JsonType.INSTANCE),
-            FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT).args(VarcharType.SYSTEM_DEFAULT)
+            FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT).args(JsonType.INSTANCE)
     );
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeJsonArrayStringOuter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/generator/ExplodeJsonArrayStringOuter.java
@@ -36,8 +36,7 @@ import java.util.List;
 public class ExplodeJsonArrayStringOuter extends TableGeneratingFunction implements UnaryExpression, AlwaysNullable {
 
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
-            FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT).args(JsonType.INSTANCE),
-            FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT).args(VarcharType.SYSTEM_DEFAULT)
+            FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT).args(JsonType.INSTANCE)
     );
 
     /**


### PR DESCRIPTION
### What problem does this PR solve?

1.	Removed function overloads that accept String parameters; retained only versions that take JSON arguments.
2.	Added support for implicit conversion from other numeric types to double.

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

