### PR TITLE
[improve](statistics)Improve drop expired stats function.

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsCleanerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsCleanerTest.java
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.common.Config;
+import org.apache.doris.statistics.StatisticsCleaner.ExpiredStats;
+
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+class StatisticsCleanerTest {
+
+    @Test
+    void testFindExpiredStats() {
+        StatisticsCleaner cleaner = new StatisticsCleaner();
+        ExpiredStats stat = new ExpiredStats();
+        OlapTable olapTable = new OlapTable();
+        for (int i = 0; i <= Config.max_allowed_in_element_num_of_delete; i++) {
+            stat.expiredCatalog.add((long) i);
+        }
+        long expiredStats = cleaner.findExpiredStats(null, stat, 1, true);
+        Assertions.assertEquals(expiredStats, 1);
+
+        try (MockedStatic<StatisticsRepository> mockedRep = Mockito.mockStatic(StatisticsRepository.class)) {
+            mockedRep.when(() -> StatisticsRepository.fetchStatsFullName(
+                    ArgumentMatchers.anyLong(), ArgumentMatchers.anyLong(), ArgumentMatchers.anyBoolean()))
+                    .thenReturn(Lists.newArrayList());
+            stat.expiredCatalog.clear();
+            expiredStats = cleaner.findExpiredStats(olapTable, stat, 0, true);
+            Assertions.assertEquals(expiredStats, StatisticConstants.FETCH_LIMIT);
+        }
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Improve drop expired stats function. When drop expired stats records, don't judge whether the entire table has been traversed by the table row count, because the reported table row count is not accurate.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

