### PR TITLE
[feat](cloud): add file cache consistency check (#41280)

### DIFF
--- a/be/src/http/action/file_cache_action.cpp
+++ b/be/src/http/action/file_cache_action.cpp
@@ -50,6 +50,8 @@ constexpr static std::string_view CLEAR = "clear";
 constexpr static std::string_view RESET = "reset";
 constexpr static std::string_view HASH = "hash";
 constexpr static std::string_view LIST_CACHE = "list_cache";
+constexpr static std::string_view LIST_BASE_PATHS = "list_base_paths";
+constexpr static std::string_view CHECK_CONSISTENCY = "check_consistency";
 constexpr static std::string_view CAPACITY = "capacity";
 constexpr static std::string_view RELEASE = "release";
 constexpr static std::string_view BASE_PATH = "base_path";
@@ -130,6 +132,30 @@ Status FileCacheAction::_handle_header(HttpRequest* req, std::string* json_metri
         }
     } else if (operation == DUMP) {
         io::FileCacheFactory::instance()->dump_all_caches();
+    } else if (operation == LIST_BASE_PATHS) {
+        auto all_cache_base_path = io::FileCacheFactory::instance()->get_base_paths();
+        EasyJson json;
+        std::ranges::for_each(all_cache_base_path,
+                              [&json](auto& x) { json.PushBack(std::move(x)); });
+        *json_metrics = json.ToString();
+    } else if (operation == CHECK_CONSISTENCY) {
+        const std::string& cache_base_path = req->param(BASE_PATH.data());
+        if (cache_base_path.empty()) {
+            st = Status::InvalidArgument("missing parameter: {} is required", BASE_PATH.data());
+        } else {
+            auto* block_file_cache = io::FileCacheFactory::instance()->get_by_path(cache_base_path);
+            if (block_file_cache == nullptr) {
+                st = Status::InvalidArgument("file cache not found for base_path: {}",
+                                             cache_base_path);
+            } else {
+                std::vector<std::string> inconsistencies;
+                RETURN_IF_ERROR(block_file_cache->report_file_cache_inconsistency(inconsistencies));
+                EasyJson json;
+                std::ranges::for_each(inconsistencies,
+                                      [&json](auto& x) { json.PushBack(std::move(x)); });
+                *json_metrics = json.ToString();
+            }
+        }
     } else {
         st = Status::InternalError("invalid operation: {}", operation);
     }

--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -42,7 +42,6 @@
 #include "common/cast_set.h"
 #include "common/config.h"
 #include "common/logging.h"
-#include "cpp/sync_point.h"
 #include "io/cache/file_block.h"
 #include "io/cache/file_cache_common.h"
 #include "io/cache/fs_file_cache_storage.h"
@@ -2475,7 +2474,6 @@ template void BlockFileCache::remove(FileBlockSPtr file_block,
 
 #include "common/compile_check_end.h"
 
-
 Status BlockFileCache::report_file_cache_inconsistency(std::vector<std::string>& results) {
     InconsistencyContext inconsistency_context;
     RETURN_IF_ERROR(check_file_cache_consistency(inconsistency_context));
@@ -2483,9 +2481,9 @@ Status BlockFileCache::report_file_cache_inconsistency(std::vector<std::string>&
     results.reserve(n);
     for (size_t i = 0; i < n; i++) {
         std::string result;
-        result += "File cahce info in manager:\n";
+        result += "File cache info in manager:\n";
         result += inconsistency_context.infos_in_manager[i].to_string();
-        result += "File cahce info in storage:\n";
+        result += "File cache info in storage:\n";
         result += inconsistency_context.infos_in_storage[i].to_string();
         result += inconsistency_context.types[i].to_string();
         result += "\n";

--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -22,6 +22,7 @@
 
 #include <cstdio>
 #include <fstream>
+#include <unordered_set>
 
 #include "common/status.h"
 #include "cpp/sync_point.h"
@@ -2473,5 +2474,85 @@ template void BlockFileCache::remove(FileBlockSPtr file_block,
                                      std::lock_guard<std::mutex>& block_lock, bool sync);
 
 #include "common/compile_check_end.h"
+
+
+Status BlockFileCache::report_file_cache_inconsistency(std::vector<std::string>& results) {
+    InconsistencyContext inconsistency_context;
+    RETURN_IF_ERROR(check_file_cache_consistency(inconsistency_context));
+    auto n = inconsistency_context.types.size();
+    results.reserve(n);
+    for (size_t i = 0; i < n; i++) {
+        std::string result;
+        result += "File cahce info in manager:\n";
+        result += inconsistency_context.infos_in_manager[i].to_string();
+        result += "File cahce info in storage:\n";
+        result += inconsistency_context.infos_in_storage[i].to_string();
+        result += inconsistency_context.types[i].to_string();
+        result += "\n";
+        results.push_back(std::move(result));
+    }
+    return Status::OK();
+}
+
+Status BlockFileCache::check_file_cache_consistency(InconsistencyContext& inconsistency_context) {
+    std::lock_guard<std::mutex> cache_lock(_mutex);
+    std::vector<FileCacheInfo> infos_in_storage;
+    RETURN_IF_ERROR(_storage->get_file_cache_infos(infos_in_storage, cache_lock));
+    std::unordered_set<AccessKeyAndOffset, KeyAndOffsetHash> confirmed_blocks;
+    for (const auto& info_in_storage : infos_in_storage) {
+        confirmed_blocks.insert({info_in_storage.hash, info_in_storage.offset});
+        auto* cell = get_cell(info_in_storage.hash, info_in_storage.offset, cache_lock);
+        if (cell == nullptr || cell->file_block == nullptr) {
+            inconsistency_context.infos_in_manager.emplace_back();
+            inconsistency_context.infos_in_storage.push_back(info_in_storage);
+            inconsistency_context.types.emplace_back(InconsistencyType::NOT_LOADED);
+            continue;
+        }
+        FileCacheInfo info_in_manager {
+                .hash = info_in_storage.hash,
+                .expiration_time = cell->file_block->expiration_time(),
+                .size = cell->size(),
+                .offset = info_in_storage.offset,
+                .is_tmp = cell->file_block->state() == FileBlock::State::DOWNLOADING,
+                .cache_type = cell->file_block->cache_type()};
+        InconsistencyType inconsistent_type;
+        if (info_in_storage.is_tmp != info_in_manager.is_tmp) {
+            inconsistent_type |= InconsistencyType::TMP_FILE_EXPECT_DOWNLOADING_STATE;
+        }
+        size_t expected_size =
+                info_in_manager.is_tmp ? cell->dowloading_size() : info_in_manager.size;
+        if (info_in_storage.size != expected_size) {
+            inconsistent_type |= InconsistencyType::SIZE_INCONSISTENT;
+        }
+        // Only if it is not a tmp file need we check the cache type.
+        if ((inconsistent_type & InconsistencyType::TMP_FILE_EXPECT_DOWNLOADING_STATE) == 0 &&
+            info_in_storage.cache_type != info_in_manager.cache_type) {
+            inconsistent_type |= InconsistencyType::CACHE_TYPE_INCONSISTENT;
+        }
+        if (info_in_storage.expiration_time != info_in_manager.expiration_time) {
+            inconsistent_type |= InconsistencyType::EXPIRATION_TIME_INCONSISTENT;
+        }
+        if (inconsistent_type != InconsistencyType::NONE) {
+            inconsistency_context.infos_in_manager.push_back(info_in_manager);
+            inconsistency_context.infos_in_storage.push_back(info_in_storage);
+            inconsistency_context.types.push_back(inconsistent_type);
+        }
+    }
+
+    for (const auto& [hash, offset_to_cell] : _files) {
+        for (const auto& [offset, cell] : offset_to_cell) {
+            if (confirmed_blocks.contains({hash, offset})) {
+                continue;
+            }
+            const auto& block = cell.file_block;
+            inconsistency_context.infos_in_manager.emplace_back(
+                    hash, block->expiration_time(), cell.size(), offset,
+                    cell.file_block->state() == FileBlock::State::DOWNLOADING, block->cache_type());
+            inconsistency_context.infos_in_storage.emplace_back();
+            inconsistency_context.types.emplace_back(InconsistencyType::MISSING_IN_STORAGE);
+        }
+    }
+    return Status::OK();
+}
 
 } // namespace doris::io

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -114,6 +114,8 @@ struct FileBlockCell {
 
     FileBlockCell& operator=(const FileBlockCell&) = delete;
     FileBlockCell(const FileBlockCell&) = delete;
+
+    size_t dowloading_size() const { return file_block->_downloaded_size; }
 };
 
 class BlockFileCache {
@@ -341,36 +343,6 @@ public:
     Status check_file_cache_consistency(InconsistencyContext& inconsistency_context);
 
 private:
-    struct FileBlockCell {
-        FileBlockSPtr file_block;
-        /// Iterator is put here on first reservation attempt, if successful.
-        std::optional<LRUQueue::Iterator> queue_iterator;
-
-        mutable int64_t atime {0};
-        void update_atime() const {
-            atime = std::chrono::duration_cast<std::chrono::seconds>(
-                            std::chrono::steady_clock::now().time_since_epoch())
-                            .count();
-        }
-
-        /// Pointer to file block is always hold by the cache itself.
-        /// Apart from pointer in cache, it can be hold by cache users, when they call
-        /// getorSet(), but cache users always hold it via FileBlocksHolder.
-        bool releasable() const { return file_block.use_count() == 1; }
-
-        size_t size() const { return file_block->_block_range.size(); }
-        size_t dowloading_size() const { return file_block->_downloaded_size; }
-
-        FileBlockCell(FileBlockSPtr file_block, std::lock_guard<std::mutex>& cache_lock);
-        FileBlockCell(FileBlockCell&& other) noexcept
-                : file_block(std::move(other.file_block)),
-                  queue_iterator(other.queue_iterator),
-                  atime(other.atime) {}
-
-        FileBlockCell& operator=(const FileBlockCell&) = delete;
-        FileBlockCell(const FileBlockCell&) = delete;
-    };
-
     LRUQueue& get_queue(FileCacheType type);
     const LRUQueue& get_queue(FileCacheType type) const;
 

--- a/be/src/io/cache/file_cache_common.cpp
+++ b/be/src/io/cache/file_cache_common.cpp
@@ -99,7 +99,9 @@ FileCacheSettings get_file_cache_settings(size_t capacity, size_t max_query_cach
                                           size_t index_percent, size_t ttl_percent,
                                           const std::string& storage) {
     io::FileCacheSettings settings;
-    if (capacity == 0) return settings;
+    if (capacity == 0) {
+        return settings;
+    }
     settings.capacity = capacity;
     settings.max_file_block_size = config::file_cache_each_block_size;
     settings.max_query_cache_size = max_query_cache_size;
@@ -145,5 +147,42 @@ FileBlocksHolderPtr FileCacheAllocatorBuilder::allocate_cache_holder(size_t offs
 
 template size_t LRUQueue::get_capacity(std::lock_guard<std::mutex>& cache_lock) const;
 template void LRUQueue::remove(Iterator queue_it, std::lock_guard<std::mutex>& cache_lock);
+
+std::string FileCacheInfo::to_string() const {
+    std::stringstream ss;
+    ss << "Hash: " << hash.to_string() << "\n"
+       << "Expiration Time: " << expiration_time << "\n"
+       << "Offset: " << offset << "\n"
+       << "Cache Type: " << cache_type_to_string(cache_type) << "\n";
+    return ss.str();
+}
+
+std::string InconsistencyType::to_string() const {
+    std::string result = "Inconsistency Reason: ";
+    if (type == NONE) {
+        result += "NONE";
+    } else {
+        if (type & NOT_LOADED) {
+            result += "NOT_LOADED ";
+        }
+        if (type & MISSING_IN_STORAGE) {
+            result += "MISSING_IN_STORAGE ";
+        }
+        if (type & SIZE_INCONSISTENT) {
+            result += "SIZE_INCONSISTENT ";
+        }
+        if (type & CACHE_TYPE_INCONSISTENT) {
+            result += "CACHE_TYPE_INCONSISTENT ";
+        }
+        if (type & EXPIRATION_TIME_INCONSISTENT) {
+            result += "EXPIRATION_TIME_INCONSISTENT ";
+        }
+        if (type & TMP_FILE_EXPECT_DOWNLOADING_STATE) {
+            result += "TMP_FILE_EXPECT_DOWNLOADING_STATE";
+        }
+    }
+    result += "\n";
+    return result;
+}
 
 } // namespace doris::io

--- a/be/src/io/cache/file_cache_common.h
+++ b/be/src/io/cache/file_cache_common.h
@@ -19,6 +19,9 @@
 // and modified by Doris
 
 #pragma once
+#include <cstdint>
+#include <vector>
+
 #include "io/io_common.h"
 #include "vec/common/uint128.h"
 
@@ -39,7 +42,6 @@ enum FileCacheType {
     DISPOSABLE = 0,
     TTL = 3,
 };
-
 std::string cache_type_to_surfix(FileCacheType type);
 FileCacheType surfix_to_cache_type(const std::string& str);
 
@@ -251,6 +253,49 @@ public:
     std::unordered_map<std::pair<UInt128Wrapper, size_t>, Iterator, HashFileKeyAndOffset> map;
     size_t cache_size = 0;
     int64_t hot_data_interval {0};
+};
+struct FileCacheInfo {
+    UInt128Wrapper hash {0};
+    uint64_t expiration_time {0};
+    uint64_t size {0};
+    size_t offset {0};
+    bool is_tmp {false};
+    FileCacheType cache_type {NORMAL};
+
+    std::string to_string() const;
+};
+
+class InconsistencyType {
+    uint32_t type;
+
+public:
+    enum : uint32_t {
+        // No anomaly
+        NONE = 0,
+        // Missing a block cache metadata in _files
+        NOT_LOADED = 1 << 0,
+        // A block cache is missing in storage
+        MISSING_IN_STORAGE = 1 << 1,
+        // Size of a block cache recorded in _files is inconsistent with the storage
+        SIZE_INCONSISTENT = 1 << 2,
+        // Cache type of a block cache recorded in _files is inconsistent with the storage
+        CACHE_TYPE_INCONSISTENT = 1 << 3,
+        // Expiration time of a block cache recorded in _files is inconsistent with the storage
+        EXPIRATION_TIME_INCONSISTENT = 1 << 4,
+        // File in storage has a _tmp suffix, but the state of block cache in _files is not set to downloading
+        TMP_FILE_EXPECT_DOWNLOADING_STATE = 1 << 5
+    };
+    InconsistencyType(uint32_t t = 0) : type(t) {}
+    operator uint32_t&() { return type; }
+
+    std::string to_string() const;
+};
+
+struct InconsistencyContext {
+    // The infos in _files of BlockFileCache.
+    std::vector<FileCacheInfo> infos_in_manager;
+    std::vector<FileCacheInfo> infos_in_storage;
+    std::vector<InconsistencyType> types;
 };
 
 } // namespace doris::io

--- a/be/src/io/cache/file_cache_storage.h
+++ b/be/src/io/cache/file_cache_storage.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#include <mutex>
+
+#include "common/status.h"
 #include "io/cache/file_cache_common.h"
 #include "util/slice.h"
 
@@ -67,6 +70,10 @@ public:
     virtual FileCacheStorageType get_type() = 0;
     // get local cached file
     virtual std::string get_local_file(const FileCacheKey& key) = 0;
+    virtual Status get_file_cache_infos(std::vector<FileCacheInfo>& infos,
+                                        std::lock_guard<std::mutex>& cache_lock) const {
+        return Status::OK();
+    };
 };
 
 } // namespace doris::io

--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -17,15 +17,19 @@
 
 #include "io/cache/fs_file_cache_storage.h"
 
+#include <fmt/core.h>
+
 #include <filesystem>
 #include <mutex>
 #include <system_error>
 
 #include "common/logging.h"
+#include "common/status.h"
 #include "cpp/sync_point.h"
 #include "io/cache/block_file_cache.h"
 #include "io/cache/file_block.h"
 #include "io/cache/file_cache_common.h"
+#include "io/cache/file_cache_storage.h"
 #include "io/fs/file_reader_writer_fwd.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_reader.h"
@@ -694,7 +698,7 @@ void FSFileCacheStorage::load_cache_info_into_memory(BlockFileCache* _mgr) const
             std::error_code ec;
             std::filesystem::directory_iterator offset_it(key_it->path(), ec);
             if (ec) [[unlikely]] {
-                LOG(WARNING) << "filesystem error, failed to remove file, file=" << key_it->path()
+                LOG(WARNING) << "filesystem error, failed to list dir, dir=" << key_it->path()
                              << " error=" << ec.message();
                 continue;
             }
@@ -774,6 +778,69 @@ void FSFileCacheStorage::load_cache_info_into_memory(BlockFileCache* _mgr) const
         add_cell_batch_func();
     }
     TEST_SYNC_POINT_CALLBACK("BlockFileCache::TmpFile2");
+}
+
+Status FSFileCacheStorage::get_file_cache_infos(std::vector<FileCacheInfo>& infos,
+                                                std::lock_guard<std::mutex>& cache_lock) const {
+    std::error_code ec;
+    std::filesystem::directory_iterator key_prefix_it {_cache_base_path, ec};
+    if (ec) [[unlikely]] {
+        LOG(ERROR) << fmt::format("Failed to list dir {}, err={}", _cache_base_path, ec.message());
+        return Status::InternalError("Failed to list dir {}, err={}", _cache_base_path,
+                                     ec.message());
+    }
+    // Only supports version 2. For more details, refer to 'USE_CACHE_VERSION2'.
+    for (; key_prefix_it != std::filesystem::directory_iterator(); ++key_prefix_it) {
+        if (!key_prefix_it->is_directory()) {
+            // skip version file
+            continue;
+        }
+        if (key_prefix_it->path().filename().native().size() != KEY_PREFIX_LENGTH) {
+            LOG(WARNING) << "Unknown directory " << key_prefix_it->path().native();
+            continue;
+        }
+        std::filesystem::directory_iterator key_it {key_prefix_it->path(), ec};
+        if (ec) [[unlikely]] {
+            LOG(ERROR) << fmt::format("Failed to list dir {}, err={}",
+                                      key_prefix_it->path().filename().native(), ec.message());
+            return Status::InternalError("Failed to list dir {}, err={}",
+                                         key_prefix_it->path().filename().native(), ec.message());
+        }
+        for (; key_it != std::filesystem::directory_iterator(); ++key_it) {
+            auto key_with_suffix = key_it->path().filename().native();
+            auto delim_pos = key_with_suffix.find('_');
+            DCHECK(delim_pos != std::string::npos);
+            std::string key_str = key_with_suffix.substr(0, delim_pos);
+            std::string expiration_time_str = key_with_suffix.substr(delim_pos + 1);
+            long expiration_time = std::stoul(expiration_time_str);
+            auto hash = UInt128Wrapper(vectorized::unhex_uint<uint128_t>(key_str.c_str()));
+            std::error_code ec;
+            std::filesystem::directory_iterator offset_it(key_it->path(), ec);
+            if (ec) [[unlikely]] {
+                LOG(ERROR) << fmt::format("Failed to list dir {}, err={}",
+                                          key_it->path().filename().native(), ec.message());
+                return Status::InternalError("Failed to list dir {}, err={}",
+                                             key_it->path().filename().native(), ec.message());
+            }
+            for (; offset_it != std::filesystem::directory_iterator(); ++offset_it) {
+                size_t size = offset_it->file_size(ec);
+                if (ec) [[unlikely]] {
+                    LOG(ERROR) << fmt::format("Failed to get file size, file name {}, err={}",
+                                              key_it->path().filename().native(), ec.message());
+                    return Status::InternalError("Failed to get file size, file name {}, err={}",
+                                                 key_it->path().filename().native(), ec.message());
+                }
+                size_t offset = 0;
+                bool is_tmp = false;
+                FileCacheType cache_type = FileCacheType::NORMAL;
+                RETURN_IF_ERROR(this->parse_filename_suffix_to_cache_type(
+                        fs, offset_it->path().filename().native(), expiration_time, size, &offset,
+                        &is_tmp, &cache_type));
+                infos.emplace_back(hash, expiration_time, size, offset, is_tmp, cache_type);
+            }
+        }
+    }
+    return Status::OK();
 }
 
 void FSFileCacheStorage::load_blocks_directly_unlocked(BlockFileCache* mgr, const FileCacheKey& key,

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -112,6 +112,9 @@ private:
     [[nodiscard]] std::vector<std::string> get_path_in_local_cache_all_candidates(
             const std::string& dir, size_t offset);
 
+    Status get_file_cache_infos(std::vector<FileCacheInfo>& infos,
+                                std::lock_guard<std::mutex>& cache_lock) const override;
+
     std::string _cache_base_path;
     std::thread _cache_background_load_thread;
     const std::shared_ptr<LocalFileSystem>& fs = global_local_filesystem();

--- a/be/test/http/file_cache_action_test.cpp
+++ b/be/test/http/file_cache_action_test.cpp
@@ -143,7 +143,8 @@ TEST_F(FileCacheActionTest, check_consistency_not_found) {
 
     EXPECT_FALSE(status.ok());
     EXPECT_EQ(status.to_string(),
-              "[INVALID_ARGUMENT]file cache not found for base_path: /tmp/file_cache_action_ut_not_exist");
+              "[INVALID_ARGUMENT]file cache not found for base_path: "
+              "/tmp/file_cache_action_ut_not_exist");
 }
 
 TEST_F(FileCacheActionTest, check_consistency_ok) {

--- a/be/test/http/file_cache_action_test.cpp
+++ b/be/test/http/file_cache_action_test.cpp
@@ -1,0 +1,162 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "http/action/file_cache_action.h"
+
+#include <event2/event.h>
+#include <event2/http.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <memory>
+#include <thread>
+
+#include "common/config.h"
+#include "http/http_request.h"
+#include "io/cache/block_file_cache.h"
+#include "io/cache/block_file_cache_factory.h"
+#include "io/cache/file_cache_common.h"
+#include "runtime/exec_env.h"
+
+namespace doris {
+
+class FileCacheActionTest : public testing::Test {
+public:
+    FileCacheActionTest() : _action(nullptr) {}
+    ~FileCacheActionTest() override = default;
+
+    static void SetUpTestSuite() {
+        if (doris::ExecEnv::GetInstance()->file_cache_factory() == nullptr) {
+            _suite_factory = std::make_unique<doris::io::FileCacheFactory>();
+            doris::ExecEnv::GetInstance()->_file_cache_factory = _suite_factory.get();
+        }
+
+        if (!doris::ExecEnv::GetInstance()->_file_cache_open_fd_cache) {
+            doris::ExecEnv::GetInstance()->_file_cache_open_fd_cache =
+                    std::make_unique<doris::io::FDCache>();
+        }
+    }
+    static void TearDownTestSuite() {
+        if (doris::ExecEnv::GetInstance()->file_cache_factory() != nullptr) {
+            doris::io::FileCacheFactory::instance()->clear_file_caches(true);
+        }
+        _suite_factory.reset(nullptr);
+        doris::ExecEnv::GetInstance()->_file_cache_open_fd_cache.reset(nullptr);
+    }
+
+    void SetUp() override {
+        _event_base = event_base_new();
+        _evhttp_req = evhttp_request_new(nullptr, nullptr);
+        _action = std::make_unique<FileCacheAction>(nullptr);
+
+        ASSERT_NE(doris::ExecEnv::GetInstance()->file_cache_factory(), nullptr);
+
+        _base_path = "/tmp/file_cache_action_ut_" + std::to_string(getpid());
+        (void)std::filesystem::create_directories(_base_path);
+        doris::io::FileCacheSettings settings;
+        settings.storage = "memory";
+        settings.capacity = 1024 * 1024;          // 1MB
+        settings.max_file_block_size = 64 * 1024; // 64KB
+        auto cache = std::make_unique<doris::io::BlockFileCache>(_base_path, settings);
+        ASSERT_TRUE(cache->initialize());
+        for (int i = 0; i < 1000; ++i) {
+            if (cache->get_async_open_success()) break;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        auto* raw = cache.get();
+        auto* factory = doris::io::FileCacheFactory::instance();
+        factory->_caches.emplace_back(std::move(cache));
+        factory->_path_to_cache[_base_path] = raw;
+    }
+
+    void TearDown() override {
+        if (_evhttp_req != nullptr) {
+            evhttp_request_free(_evhttp_req);
+        }
+
+        if (_event_base != nullptr) {
+            event_base_free(_event_base);
+        }
+
+        if (doris::ExecEnv::GetInstance()->file_cache_factory() != nullptr) {
+            doris::io::FileCacheFactory::instance()->clear_file_caches(true);
+        }
+    }
+
+protected:
+    evhttp_request* _evhttp_req = nullptr;
+    event_base* _event_base = nullptr;
+    std::unique_ptr<FileCacheAction> _action;
+    std::string _base_path;
+
+    inline static std::unique_ptr<doris::io::FileCacheFactory> _suite_factory;
+};
+
+TEST_F(FileCacheActionTest, list_base_paths) {
+    HttpRequest req(_evhttp_req);
+    std::string json_metrics;
+
+    req._params["op"] = "list_base_paths";
+
+    Status status = _action->_handle_header(&req, &json_metrics);
+    EXPECT_TRUE(status.ok());
+
+    std::string expected = "[\"" + _base_path + "\"]";
+    EXPECT_EQ(json_metrics, expected);
+}
+
+TEST_F(FileCacheActionTest, check_consistency_missing_param) {
+    HttpRequest req(_evhttp_req);
+    std::string json_metrics;
+
+    req._params["op"] = "check_consistency";
+
+    Status status = _action->_handle_header(&req, &json_metrics);
+
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.to_string(), "missing parameter: base_path is required");
+}
+
+TEST_F(FileCacheActionTest, check_consistency_not_found) {
+    HttpRequest req(_evhttp_req);
+    std::string json_metrics;
+
+    req._params["op"] = "check_consistency";
+    req._params["base_path"] = "/tmp/file_cache_action_ut_not_exist";
+
+    Status status = _action->_handle_header(&req, &json_metrics);
+
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.to_string(),
+              "file cache not found for base_path: /tmp/file_cache_action_ut_not_exist");
+}
+
+TEST_F(FileCacheActionTest, check_consistency_ok) {
+    HttpRequest req(_evhttp_req);
+    std::string json_metrics;
+
+    req._params["op"] = "check_consistency";
+    req._params["base_path"] = _base_path;
+
+    Status status = _action->_handle_header(&req, &json_metrics);
+
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(json_metrics, "null");
+}
+
+} // namespace doris

--- a/be/test/http/file_cache_action_test.cpp
+++ b/be/test/http/file_cache_action_test.cpp
@@ -129,7 +129,7 @@ TEST_F(FileCacheActionTest, check_consistency_missing_param) {
     Status status = _action->_handle_header(&req, &json_metrics);
 
     EXPECT_FALSE(status.ok());
-    EXPECT_EQ(status.to_string(), "missing parameter: base_path is required");
+    EXPECT_EQ(status.to_string(), "[INVALID_ARGUMENT]missing parameter: base_path is required");
 }
 
 TEST_F(FileCacheActionTest, check_consistency_not_found) {
@@ -143,7 +143,7 @@ TEST_F(FileCacheActionTest, check_consistency_not_found) {
 
     EXPECT_FALSE(status.ok());
     EXPECT_EQ(status.to_string(),
-              "file cache not found for base_path: /tmp/file_cache_action_ut_not_exist");
+              "[INVALID_ARGUMENT]file cache not found for base_path: /tmp/file_cache_action_ut_not_exist");
 }
 
 TEST_F(FileCacheActionTest, check_consistency_ok) {

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -1924,7 +1924,8 @@ TEST_F(BlockFileCacheTest, fix_tmp_file) {
             },
             &guard1);
     SyncPoint::CallbackGuard guard2;
-    sp->set_call_back("BlockFileCache::TmpFile2", [&](auto&&) { flag2 = true; }, &guard2);
+    sp->set_call_back(
+            "BlockFileCache::TmpFile2", [&](auto&&) { flag2 = true; }, &guard2);
     io::BlockFileCache cache(cache_base_path, settings);
     ASSERT_TRUE(cache.initialize());
     auto holder = cache.get_or_set(key, 100, 1, context); /// Add range [9, 9]

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -19,6 +19,7 @@
 // and modified by Doris
 
 #include "block_file_cache_test_common.h"
+
 namespace doris::io {
 
 fs::path caches_dir = fs::current_path() / "lru_cache_test";
@@ -5326,6 +5327,155 @@ TEST_F(BlockFileCacheTest, file_cache_path_storage_parse) {
         ASSERT_TRUE(cache_paths[0].path == "memory");
         ASSERT_TRUE(cache_paths[0].total_bytes == 102400);
         ASSERT_TRUE(cache_paths[0].storage == "disk");
+    }
+}
+
+TEST_F(BlockFileCacheTest, check_file_cache_consistency) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.index_queue_size = 30;
+    settings.index_queue_elements = 5;
+    settings.disposable_queue_size = 30;
+    settings.disposable_queue_elements = 5;
+    settings.capacity = 90;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+    auto key1 = io::BlockFileCache::hash("key1");
+    auto key2 = io::BlockFileCache::hash("key2");
+
+    io::BlockFileCache mgr(cache_base_path, settings);
+    ASSERT_TRUE(mgr.initialize());
+    for (int i = 0; i < 100; i++) {
+        if (mgr.get_async_open_success()) {
+            break;
+        };
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    io::CacheContext cache_context;
+    cache_context.cache_type = io::FileCacheType::TTL;
+    cache_context.query_id = query_id;
+    cache_context.expiration_time = 0;
+    {
+        cache_context.cache_type = io::FileCacheType::NORMAL;
+        auto holder = mgr.get_or_set(key1, 0, 9, cache_context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        assert_range(1, blocks[0], io::FileBlock::Range(0, 8), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        assert_range(2, blocks[0], io::FileBlock::Range(0, 8), io::FileBlock::State::DOWNLOADING);
+        download(blocks[0]);
+        std::vector<std::string> result;
+        Status status = mgr.report_file_cache_inconsistency(result);
+        ASSERT_TRUE(result.empty());
+    }
+
+    {
+        auto holder = mgr.get_or_set(key1, 10, 9, cache_context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        assert_range(1, blocks[0], io::FileBlock::Range(10, 18), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        assert_range(2, blocks[0], io::FileBlock::Range(10, 18), io::FileBlock::State::DOWNLOADING);
+        download(blocks[0]);
+        mgr._files[key1].erase(10);
+    }
+
+    {
+        auto holder = mgr.get_or_set(key1, 20, 9, cache_context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        assert_range(1, blocks[0], io::FileBlock::Range(20, 28), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        assert_range(2, blocks[0], io::FileBlock::Range(20, 28), io::FileBlock::State::DOWNLOADING);
+        download(blocks[0]);
+        auto* fs_file_cache_storage = dynamic_cast<FSFileCacheStorage*>(mgr._storage.get());
+        std::string dir_path = fs_file_cache_storage->get_path_in_local_cache(key1, 0);
+        fs::path block_file_path = std::filesystem::path(dir_path) / "20";
+        fs::remove(block_file_path);
+    }
+
+    {
+        auto holder = mgr.get_or_set(key1, 30, 9, cache_context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        assert_range(1, blocks[0], io::FileBlock::Range(30, 38), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        assert_range(2, blocks[0], io::FileBlock::Range(30, 38), io::FileBlock::State::DOWNLOADING);
+        download(blocks[0]);
+        auto* fs_file_cache_storage = dynamic_cast<FSFileCacheStorage*>(mgr._storage.get());
+        std::string dir_path = fs_file_cache_storage->get_path_in_local_cache(key1, 0);
+        fs::path block_file_path = std::filesystem::path(dir_path) / "30";
+        std::string data = "This is a test message.";
+        std::ofstream out_file(block_file_path, std::ios::out | std::ios::app);
+        out_file << data;
+        out_file.close();
+    }
+
+    {
+        auto holder = mgr.get_or_set(key1, 40, 9, cache_context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        assert_range(1, blocks[0], io::FileBlock::Range(40, 48), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        assert_range(2, blocks[0], io::FileBlock::Range(40, 48), io::FileBlock::State::DOWNLOADING);
+        download(blocks[0]);
+        blocks[0]->_key.meta.type = io::FileCacheType::INDEX;
+    }
+
+    int64_t expiration_time = UnixSeconds() + 120;
+    {
+        cache_context.cache_type = FileCacheType::TTL;
+        cache_context.expiration_time = expiration_time;
+        auto holder = mgr.get_or_set(key2, 0, 9, cache_context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        assert_range(1, blocks[0], io::FileBlock::Range(0, 8), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        assert_range(2, blocks[0], io::FileBlock::Range(0, 8), io::FileBlock::State::DOWNLOADING);
+        download(blocks[0]);
+        blocks[0]->_key.meta.expiration_time = 0;
+    }
+    std::vector<std::string> results;
+    Status status = mgr.report_file_cache_inconsistency(results);
+    std::unordered_set<std::string> expected_results = {
+            "File cahce info in manager:\nHash: "
+            "62434304659ae12df53386481113dfe1\nExpiration Time: 0\nOffset: 0\nCache Type: "
+            "TTL\nFile cahce info in storage:\nHash: "
+            "62434304659ae12df53386481113dfe1\nExpiration Time: " +
+                    std::to_string(expiration_time) +
+                    "\nOffset: 0\nCache Type: "
+                    "TTL\nInconsistency Reason: EXPIRATION_TIME_INCONSISTENT \n\n",
+            "File cahce info in manager:\nHash: "
+            "00000000000000000000000000000000\nExpiration Time: 0\nOffset: 0\nCache Type: "
+            "NORMAL\nFile cahce info in storage:\nHash: "
+            "f36131fb4ba563c17e727cd0cdd63689\nExpiration Time: 0\nOffset: 10\nCache Type: "
+            "NORMAL\nInconsistency Reason: NOT_LOADED \n\n",
+            "File cahce info in manager:\nHash: "
+            "f36131fb4ba563c17e727cd0cdd63689\nExpiration Time: 0\nOffset: 30\nCache Type: "
+            "NORMAL\nFile cahce info in storage:\nHash: "
+            "f36131fb4ba563c17e727cd0cdd63689\nExpiration Time: 0\nOffset: 30\nCache Type: "
+            "NORMAL\nInconsistency Reason: SIZE_INCONSISTENT \n\n",
+            "File cahce info in manager:\nHash: "
+            "f36131fb4ba563c17e727cd0cdd63689\nExpiration Time: 0\nOffset: 40\nCache Type: "
+            "INDEX\nFile cahce info in storage:\nHash: "
+            "f36131fb4ba563c17e727cd0cdd63689\nExpiration Time: 0\nOffset: 40\nCache Type: "
+            "NORMAL\nInconsistency Reason: CACHE_TYPE_INCONSISTENT \n\n",
+            "File cahce info in manager:\nHash: "
+            "f36131fb4ba563c17e727cd0cdd63689\nExpiration Time: 0\nOffset: 20\nCache Type: "
+            "NORMAL\nFile cahce info in storage:\nHash: "
+            "00000000000000000000000000000000\nExpiration Time: 0\nOffset: 0\nCache Type: "
+            "NORMAL\nInconsistency Reason: MISSING_IN_STORAGE \n\n"};
+    ASSERT_EQ(results.size(), expected_results.size());
+    for (const auto& result : results) {
+        ASSERT_TRUE(expected_results.contains(result));
     }
 }
 

--- a/regression-test/suites/cloud_p2/cache/http/test_check_file_cache_consistency.groovy
+++ b/regression-test/suites/cloud_p2/cache/http/test_check_file_cache_consistency.groovy
@@ -1,0 +1,141 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite("test_check_file_cache_consistency", "docker") {
+    def options = new ClusterOptions()
+    options.setFeNum(1)
+    options.setBeNum(1)
+    options.beConfigs.add("enable_file_cache=true")
+    options.beConfigs.add('file_cache_path=[{"path":"/data/doris_cloud/file_cache","total_size":104857600,"query_limit":104857600}]')
+    
+    docker(options) {
+        def backendId_to_backendIP = [:]
+        def backendId_to_backendHttpPort = [:]
+        getBackendIpHttpPort(backendId_to_backendIP, backendId_to_backendHttpPort)
+        
+        def beId = backendId_to_backendIP.keySet()[0]
+        def beIp = backendId_to_backendIP.get(beId)
+        def beHttpPort = backendId_to_backendHttpPort.get(beId)
+        def socket = "${beIp}:${beHttpPort}"
+        
+        // wait for be start
+        Thread.sleep(5000)
+        
+        sql """
+            CREATE DATABASE IF NOT EXISTS test_file_cache_db
+        """
+        
+        sql """
+            CREATE TABLE IF NOT EXISTS test_file_cache_db.test_table (
+                id INT,
+                name STRING,
+                value DOUBLE
+            ) DUPLICATE KEY(id)
+            DISTRIBUTED BY HASH(id) BUCKETS 3
+            PROPERTIES (
+                "replication_num" = "1"
+            )
+        """
+        
+        sql """
+            INSERT INTO test_file_cache_db.test_table VALUES
+            (1, 'test1', 1.1),
+            (2, 'test2', 2.2),
+            (3, 'test3', 3.3),
+            (4, 'test4', 4.4),
+            (5, 'test5', 5.5)
+        """
+        
+        // query to trigger cache
+        sql """
+            SELECT * FROM test_file_cache_db.test_table WHERE id > 0
+        """
+        
+        sql """
+            SELECT COUNT(*) FROM test_file_cache_db.test_table
+        """
+        
+        sql """
+            SELECT AVG(value) FROM test_file_cache_db.test_table WHERE id > 2
+        """
+        
+        // wait for cache to be created
+        Thread.sleep(5000)
+        
+        // Test 1: list_base_paths operation
+        httpTest {
+            endpoint ""
+            uri "${socket}/api/file_cache?op=list_base_paths"
+            op "post"
+            body ""
+            check {respCode, body ->
+                assertEquals(respCode, 200)
+                println("List base paths response: ${body}")
+                
+                assertNotNull(body, "Response body should not be null")
+                assertNotEquals(body, "null", "Response body should not be 'null'")
+                
+                def respJson = parseJson(body)
+                assertTrue(respJson instanceof List, "Response should be a JSON array")
+                assertEquals(1, respJson.size(), "Should return exactly one base path")
+                
+                def basePath = respJson[0]
+                assertEquals("/data/doris_cloud/file_cache", basePath, "Base path should match configured path")
+                
+                println("Verified base path: ${basePath}")
+            }
+        }
+
+        // Test 2: check_consistency operation
+        httpTest {
+            endpoint ""
+            uri "${socket}/api/file_cache?op=check_consistency&base_path=/data/doris_cloud/file_cache"
+            op "post"
+            body ""
+            check {respCode, body ->
+                assertEquals(respCode, 200)
+                
+                if (body == null || body == "null") {
+                    println("No inconsistencies found in file cache - this is expected for a clean cache")
+                } else {
+                    // should't be any inconsistency
+                    try {
+                        def respJson = parseJson(body)
+                        
+                        if (respJson instanceof List) {
+                            println("Found ${respJson.size()} inconsistencies in file cache")
+                            respJson.each { inconsistency ->
+                                assertTrue(inconsistency instanceof String, "Each inconsistency should be a string")
+                                assertTrue(inconsistency.contains("Hash:") || 
+                                         inconsistency.contains("Inconsistency Reason") ||
+                                         inconsistency.contains("File cache info") ||
+                                         inconsistency.contains("File cahce info"), 
+                                         "Inconsistency should contain expected format")
+                            }
+                        } else {
+                            fail("If not null, response should be a JSON array")
+                        }
+                    } catch (Exception e) {
+                        throw e
+                    }
+                }
+            }
+        }
+    }
+} 


### PR DESCRIPTION
add a tool api to verify the consistency of the file cache, checking whether the disk cache is under the control of the file cache management system

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #41280 

Problem Summary:
Occasionally, we found that there have been cases of disk cache data escaping from the management of Doris file cache, causing disk space leaks. To make it easier for debugging, we need a checking tool that compares the contents in the Doris file cache memory management structure with the current disk contents to identify the differences between the two (which are potential problematic data).

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

