### PR TITLE
[fix](test) Force meta sync to avoid stale meta data on follower fe when mv rewrite

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -2133,6 +2133,7 @@ class Suite implements GroovyInterceptable {
         AS ${mv_sql}
         """
         waitingMVTaskFinishedByMvName(db, table_name, mv_name)
+        sql """sync;"""
     }
 
     def create_async_mv = { db, mv_name, mv_sql ->
@@ -2148,6 +2149,8 @@ class Suite implements GroovyInterceptable {
         def job_name = getJobName(db, mv_name);
         waitingMTMVTaskFinished(job_name)
         sql "analyze table ${db}.${mv_name} with sync;"
+        // force meta sync to avoid stale meta data on follower fe
+        sql """sync;"""
     }
 
     def create_async_partition_mv = { db, mv_name, mv_sql, partition_col ->
@@ -2164,6 +2167,8 @@ class Suite implements GroovyInterceptable {
         def job_name = getJobName(db, mv_name);
         waitingMTMVTaskFinished(job_name)
         sql "analyze table ${db}.${mv_name} with sync;"
+        // force meta sync to avoid stale meta data on follower fe
+        sql """sync;"""
     }
 
     // mv not part in rewrite process
@@ -2207,6 +2212,8 @@ class Suite implements GroovyInterceptable {
     void mv_rewrite_success(query_sql, mv_name, is_partition_statistics_ready = true) {
         logger.info("query_sql = " + query_sql + ", mv_name = " + mv_name
                 + ", is_partition_statistics_ready = " + is_partition_statistics_ready)
+        // force meta sync to avoid stale meta data on follower fe
+        sql """sync;"""
         if (!is_partition_statistics_ready) {
             // If partition statistics is no ready, degrade to without check cbo chosen
             mv_rewrite_success_without_check_chosen(query_sql, mv_name)
@@ -2224,6 +2231,8 @@ class Suite implements GroovyInterceptable {
     void mv_rewrite_all_success( query_sql, mv_names, is_partition_statistics_ready = true) {
         logger.info("query_sql = " + query_sql + ", mv_names = " + mv_names
                 + ", is_partition_statistics_ready = " + is_partition_statistics_ready)
+        // force meta sync to avoid stale meta data on follower fe
+        sql """sync;"""
         if (!is_partition_statistics_ready) {
             // If partition statistics is no ready, degrade to without check cbo chosen
             mv_rewrite_all_success_without_check_chosen(query_sql, mv_names)
@@ -2250,6 +2259,8 @@ class Suite implements GroovyInterceptable {
     void mv_rewrite_any_success(query_sql, mv_names, is_partition_statistics_ready = true) {
         logger.info("query_sql = " + query_sql + ", mv_names = " + mv_names
                 + ", is_partition_statistics_ready = " + is_partition_statistics_ready)
+        // force meta sync to avoid stale meta data on follower fe
+        sql """sync;"""
         if (!is_partition_statistics_ready) {
             // If partition statistics is no ready, degrade to without check cbo chosen
             mv_rewrite_any_success_without_check_chosen(query_sql, mv_names)
@@ -2273,6 +2284,8 @@ class Suite implements GroovyInterceptable {
     // multi mv part in rewrite process, all rewrte success without check if chosen by cbo
     void mv_rewrite_all_success_without_check_chosen(query_sql, mv_names) {
         logger.info("query_sql = " + query_sql + ", mv_names = " + mv_names)
+        // force meta sync to avoid stale meta data on follower fe
+        sql """sync;"""
         explain {
             sql(" memo plan ${query_sql}")
             check {result ->
@@ -2292,6 +2305,8 @@ class Suite implements GroovyInterceptable {
     // multi mv part in rewrite process, any of them rewrte success without check if chosen by cbo or not
     void mv_rewrite_any_success_without_check_chosen(query_sql, mv_names) {
         logger.info("query_sql = " + query_sql + ", mv_names = " + mv_names)
+        // force meta sync to avoid stale meta data on follower fe
+        sql """sync;"""
         explain {
             sql(" memo plan ${query_sql}")
             check { result ->
@@ -2310,6 +2325,8 @@ class Suite implements GroovyInterceptable {
     // multi mv part in rewrite process, rewrte success without check if chosen by cbo or not
     void mv_rewrite_success_without_check_chosen(query_sql, mv_name) {
         logger.info("query_sql = " + query_sql + ", mv_name = " + mv_name)
+        // force meta sync to avoid stale meta data on follower fe
+        sql """sync;"""
         explain {
             sql(" memo plan ${query_sql}")
             check { result ->
@@ -2321,6 +2338,8 @@ class Suite implements GroovyInterceptable {
     // single mv part in rewrite process, rewrte fail
     void mv_rewrite_fail(query_sql, mv_name) {
         logger.info("query_sql = " + query_sql + ", mv_name = " + mv_name)
+        // force meta sync to avoid stale meta data on follower fe
+        sql """sync;"""
         explain {
             sql(" memo plan ${query_sql}")
             contains(".${mv_name} fail")
@@ -2330,6 +2349,8 @@ class Suite implements GroovyInterceptable {
     // multi mv part in rewrite process, all rewrte fail
     void mv_rewrite_all_fail(query_sql, mv_names) {
         logger.info("query_sql = " + query_sql + ", mv_names = " + mv_names)
+        // force meta sync to avoid stale meta data on follower fe
+        sql """sync;"""
         explain {
             sql(" memo plan ${query_sql}")
             check {result ->
@@ -2349,6 +2370,8 @@ class Suite implements GroovyInterceptable {
     // multi mv part in rewrite process, any rewrte fail
     void mv_rewrite_any_fail (query_sql, mv_names) {
         logger.info("query_sql = " + query_sql + ", mv_names = " + mv_names)
+        // force meta sync to avoid stale meta data on follower fe
+        sql """sync;"""
         explain {
             sql(" memo plan ${query_sql}")
             check { result ->
@@ -2376,6 +2399,8 @@ class Suite implements GroovyInterceptable {
         """
         def job_name = getJobName(db, mv_name);
         waitingMTMVTaskFinished(job_name)
+        // force meta sync to avoid stale meta data on follower fe
+        sql """sync;"""
         mv_rewrite_success(query_sql, mv_name)
     }
 
@@ -2392,6 +2417,8 @@ class Suite implements GroovyInterceptable {
 
         def job_name = getJobName(db, mv_name);
         waitingMTMVTaskFinished(job_name)
+        // force meta sync to avoid stale meta data on follower fe
+        sql """sync;"""
         mv_rewrite_success_without_check_chosen(query_sql, mv_name)
     }
 
@@ -2409,6 +2436,8 @@ class Suite implements GroovyInterceptable {
 
         def job_name = getJobName(db, mv_name);
         waitingMTMVTaskFinished(job_name)
+        // force meta sync to avoid stale meta data on follower fe
+        sql """sync;"""
         mv_rewrite_fail(query_sql, mv_name)
     }
 
@@ -2424,6 +2453,8 @@ class Suite implements GroovyInterceptable {
 
         def job_name = getJobName(db, mv_name);
         waitingMTMVTaskFinished(job_name)
+        // force meta sync to avoid stale meta data on follower fe
+        sql """sync;"""
     }
 
     def token = context.config.metaServiceToken


### PR DESCRIPTION
### What problem does this PR solve?

Force meta sync to avoid stale meta data on follower fe when mv rewrite

Such as the regression test code as fllowing, if the test code run on follower fe, `mv_rewrite_fail` method check would fail sometimes, because the meta data on follower fe is not consistant from master fe and the `SHOW ALTER TABLE MATERIALIZED VIEW` statement is always forwarded to master fe to run.
```sql
        create table table1(
            k1 int null,
            k2 int not null,
            k3 bigint null,
            k4 bigint null,
            k5 varchar(100) null
        )
        duplicate key (k1, k2, k3)
        distributed by hash(k1) buckets 3
        properties("replication_num" = "1");

    insert into table1 select e1, -4, -4, -4, 'd' from (select 1 k1) as t lateral view explode_numbers(100) tmp1 as e1;
    create materialized view common_mv as select k1, k3, sum(k2), count(k4) from ${tblName} group by k1, k3;

    SHOW ALTER TABLE MATERIALIZED VIEW from table1 where TableName='common_mv' ORDER BY CreateTime DESC;
     
     -- if the mv status is finished by above show statement, then check the mv should rewrite fail, but sometimes the common_mv is not part in the 
     -- mv rewrite which cause the test case fail.

    mv_rewrite_fail("""select count(k1) from agg_use_key_direct""", "common_mv")

```


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

