### PR TITLE
[fix](compile) Link error when build debug on arm

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -389,7 +389,7 @@ if (USE_DWARF)
 endif()
 
 # For CMAKE_BUILD_TYPE=Debug
-if (OS_MACOSX AND ARCH_ARM)
+if (ARCH_ARM)
     # Using -O0 may meet ARM64 branch out of range errors when linking with tcmalloc.
     set(CXX_FLAGS_DEBUG "-Og")
 else()


### PR DESCRIPTION
### What problem does this PR solve?

Link error when using `BUILD_TYPE=Debug` on arm
```
ld.lld: error: undefined symbol: __muloti4
>>> referenced by numeric:196 (/opt/ldb_toolchain/bin/../lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/numeric:196)
>>>               math.cpp.o:(std::common_type<__int128, __int128>::type std::lcm<__int128, __int128>(__int128, __int128)) in archive src/vec/libVec.a
clang++-17: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

