### PR TITLE
[refine](cast) Remove the rollback logic from parsing complex types.

### DIFF
--- a/be/src/vec/data_types/serde/data_type_nullable_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_nullable_serde.cpp
@@ -436,6 +436,7 @@ Status DataTypeNullableSerDe::read_one_cell_from_json(IColumn& column,
     return Status::OK();
 }
 
+// In non-strict mode, from string will handle errors by inserting a null value.
 Status DataTypeNullableSerDe::from_string(StringRef& str, IColumn& column,
                                           const FormatOptions& options) const {
     auto& null_column = assert_cast<ColumnNullable&>(column);
@@ -450,10 +451,7 @@ Status DataTypeNullableSerDe::from_string(StringRef& str, IColumn& column,
     return Status::OK();
 }
 
-// Note that the difference between the strict mode and the non-strict mode here is that in the non-strict mode,
-// if an error occurs, a null value will be inserted.
-// But the problem is that in fact, only some nested complex types need to "inject an error and insert a null value".
-// Maybe it's better to leave this processing to the complex type's own from string processing?
+// In strict mode, from string will directly return an error.
 Status DataTypeNullableSerDe::from_string_strict_mode(StringRef& str, IColumn& column,
                                                       const FormatOptions& options) const {
     auto& null_column = assert_cast<ColumnNullable&>(column);


### PR DESCRIPTION
### What problem does this PR solve?

Previously, the approach for parsing complex types was to read part of the string and then parse the internal types. 

If an error occurred later, it was necessary to roll back the parts that had already been parsed. 

But now, we first split the string into the required parts and then parse them.

If it is non-strict mode, the internal type is Nullable, and Nullable will handle errors itself.
If it is strict mode, errors will be returned directly.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

