### PR TITLE
[feat](sve) Add SVE instruction check

### DIFF
--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -143,7 +143,8 @@ enum class InstructionFail {
     AVX = 6,
     AVX2 = 7,
     AVX512 = 8,
-    ARM_NEON = 9
+    ARM_NEON = 9,
+    ARM_SVE = 10
 };
 
 auto instruction_fail_to_string(InstructionFail fail) {
@@ -169,6 +170,8 @@ auto instruction_fail_to_string(InstructionFail fail) {
         ret("AVX512");
     case InstructionFail::ARM_NEON:
         ret("ARM_NEON");
+    case InstructionFail::ARM_SVE:
+        ret("ARM_SVE");
     }
 
     LOG(ERROR) << "Unrecognized instruction fail value." << std::endl;
@@ -233,7 +236,14 @@ void check_required_instructions_impl(volatile InstructionFail& fail) {
 #if defined(__ARM_NEON__)
     fail = InstructionFail::ARM_NEON;
 #ifndef __APPLE__
-    __asm__ volatile("vadd.i32  q8, q8, q8" : : : "q8");
+    __asm__ volatile("add v0.4s, v0.4s, v0.4s" : : : "v0");
+#endif
+#endif
+
+#if defined(__ARM_FEATURE_SVE)
+    fail = InstructionFail::ARM_SVE;
+#ifndef __APPLE__
+    __asm__ volatile("add z0.d, z0.d, z0.d" : : : "z0");
 #endif
 #endif
 


### PR DESCRIPTION
### What problem does this PR solve?

Since now we can build ARM SVE via `ARM_MARCH=armv8-a+sve`, we should check SVE instructions before start.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

