### PR TITLE
[opt](s3) change default s3 schema to https

### DIFF
--- a/be/src/util/s3_util.cpp
+++ b/be/src/util/s3_util.cpp
@@ -331,7 +331,12 @@ std::shared_ptr<io::ObjStorageClient> S3ClientFactory::_create_s3_client(
         aws_config.connectTimeoutMs = s3_conf.connect_timeout_ms;
     }
 
-    if (config::s3_client_http_scheme == "http") {
+    // If `s3_conf.need_override_endpoint` is true, it usually means we're accessing a non-AWS,
+    // S3-compatible object storage. In such cases, we retain the HTTP scheme for broader compatibility.
+    //
+    // However, if `s3_client_http_scheme` is explicitly set to HTTPS, or if we are indeed
+    // accessing AWS S3 despite `need_override_endpoint` being true, we stick with the default HTTPS scheme.
+    if (config::s3_client_http_scheme == "http" && s3_conf.need_override_endpoint) {
         aws_config.scheme = Aws::Http::Scheme::HTTP;
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
When accessing s3 table bucket, the schema must be "https".
But I remained the default config `s3_client_http_scheme` unchanged, which is still "http",
and only use `https` when `need_override_endpoint` is false.
Because `need_override_endpoint` is false only when we access s3 table bucket.
This is minimal change that will not affect other situation.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

