### PR TITLE
[fix](filecache) warm up download data less than actual

### DIFF
--- a/be/src/io/cache/block_file_cache_downloader.cpp
+++ b/be/src/io/cache/block_file_cache_downloader.cpp
@@ -265,10 +265,12 @@ void FileCacheBlockDownloader::download_segment_file(const DownloadFileMeta& met
 
     std::unique_ptr<char[]> buffer(new char[one_single_task_size]);
 
+    size_t task_offset = 0;
     for (size_t i = 0; i < task_num; i++) {
-        size_t offset = meta.offset + i * one_single_task_size;
-        size_t size =
-                std::min(one_single_task_size, static_cast<size_t>(meta.download_size - offset));
+        size_t offset = meta.offset + task_offset;
+
+        size_t size = std::min(one_single_task_size,
+                               static_cast<size_t>(meta.download_size - task_offset));
         size_t bytes_read;
         VLOG_DEBUG << "download_segment_file, path=" << meta.path << ", read_at offset=" << offset
                    << ", size=" << size;
@@ -285,6 +287,7 @@ void FileCacheBlockDownloader::download_segment_file(const DownloadFileMeta& met
             g_file_cache_download_failed_num << 1;
             return;
         }
+        task_offset += size;
         g_file_cache_download_finished_size << size;
     }
 


### PR DESCRIPTION
the offset calculation here is buggy. we should use task-level offset to calculate download size other than file-level offset. otherwise, when offset is not zero, file download size is incorrect, causing data download is less than actual.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

