### PR TITLE
[fix](test) make test_writer_fault_injection do not affected by other cases

### DIFF
--- a/regression-test/suites/fault_injection_p0/test_writer_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_writer_fault_injection.groovy
@@ -22,7 +22,7 @@ suite("test_writer_fault_injection", "nonConcurrent") {
     sql """ set enable_memtable_on_sink_node=false """
     try {
         sql """
-            CREATE TABLE IF NOT EXISTS `baseall` (
+            CREATE TABLE IF NOT EXISTS `test_writer_fault_injection_source` (
                 `k0` boolean null comment "",
                 `k1` tinyint(4) null comment "",
                 `k2` smallint(6) null comment "",
@@ -41,7 +41,7 @@ suite("test_writer_fault_injection", "nonConcurrent") {
             DISTRIBUTED BY HASH(`k1`) BUCKETS 5 properties("replication_num" = "1")
             """
         sql """
-            CREATE TABLE IF NOT EXISTS `test` (
+            CREATE TABLE IF NOT EXISTS `test_writer_fault_injection_dest` (
                 `k0` boolean null comment "",
                 `k1` tinyint(4) null comment "",
                 `k2` smallint(6) null comment "",
@@ -62,7 +62,7 @@ suite("test_writer_fault_injection", "nonConcurrent") {
 
         GetDebugPoint().clearDebugPointsForAllBEs()
         streamLoad {
-            table "baseall"
+            table "test_writer_fault_injection_source"
             db "regression_test_fault_injection_p0"
             set 'column_separator', ','
             file "baseall.txt"
@@ -71,7 +71,7 @@ suite("test_writer_fault_injection", "nonConcurrent") {
         def load_with_injection = { injection, error_msg="", success=false->
             try {
                 GetDebugPoint().enableDebugPointForAllBEs(injection)
-                sql "insert into test select * from baseall where k1 <= 3"
+                sql "insert into test_writer_fault_injection_dest select * from test_writer_fault_injection_source where k1 <= 3"
                 assertTrue(success, String.format("expected Exception '%s', actual success", error_msg))
             } catch(Exception e) {
                 logger.info(e.getMessage())


### PR DESCRIPTION
### What problem does this PR solve?

thread1 (execute other cases): 
```
if (item[11].toString() == "insert into test select * from baseall where k1 <= 3".toString()){
                        def res = sql "kill ${item[1]}"
}
```

thread 2(execute test_writer_fault_injection):
```
insert into test select * from baseall where k1 <= 3
```

Therefore, `java.nio.channels.ClosedChannelException` happened and case failed.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

