### PR TITLE
[fix](nereids) set wrong intput tuple ids for JoinNode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -1490,7 +1490,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         TupleDescriptor tupleDescriptor = generateTupleDesc(generate.getGeneratorOutput(), null, context);
         List<TupleId> childOutputTupleIds = currentFragment.getPlanRoot().getOutputTupleIds();
         if (childOutputTupleIds == null || childOutputTupleIds.isEmpty()) {
-            childOutputTupleIds = currentFragment.getPlanRoot().getTupleIds();
+            childOutputTupleIds = currentFragment.getPlanRoot().getOutputTupleIds();
         }
         List<SlotId> outputSlotIds = Stream.concat(childOutputTupleIds.stream(),
                         Stream.of(tupleDescriptor.getId()))

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/AnalyticEvalNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/AnalyticEvalNode.java
@@ -79,9 +79,7 @@ public class AnalyticEvalNode extends PlanNode {
             TupleDescriptor outputTupleDesc, Expr partitionByEq, Expr orderByEq,
             TupleDescriptor bufferedTupleDesc) {
         super(id,
-                (input.getOutputTupleDesc() != null
-                        ? Lists.newArrayList(input.getOutputTupleDesc().getId()) :
-                        input.getTupleIds()),
+                input.getOutputTupleIds(),
                 "ANALYTIC", StatisticalType.ANALYTIC_EVAL_NODE);
         Preconditions.checkState(!tupleIds.contains(outputTupleDesc.getId()));
         // we're materializing the input row augmented with the analytic output tuple

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/AssertNumRowsNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/AssertNumRowsNode.java
@@ -49,11 +49,7 @@ public class AssertNumRowsNode extends PlanNode {
         if (tupleDescriptor != null) {
             this.tupleIds.add(tupleDescriptor.getId());
         } else {
-            if (input.getOutputTupleDesc() != null) {
-                this.tupleIds.add(input.getOutputTupleDesc().getId());
-            } else {
-                this.tupleIds.addAll(input.getTupleIds());
-            }
+            this.tupleIds.addAll(input.getOutputTupleIds());
         }
 
         this.tblRefIds.addAll(input.getTblRefIds());

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ExchangeNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ExchangeNode.java
@@ -95,7 +95,7 @@ public class ExchangeNode extends PlanNode {
             nullableTupleIds.add(outputTupleDesc.getId());
         } else {
             clearTupleIds();
-            tupleIds.addAll(getChild(0).getTupleIds());
+            tupleIds.addAll(getChild(0).getOutputTupleIds());
             tblRefIds.addAll(getChild(0).getTblRefIds());
             nullableTupleIds.addAll(getChild(0).getNullableTupleIds());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -119,12 +119,12 @@ public class HashJoinNode extends JoinNodeBase {
 
         if (joinOp.equals(JoinOperator.LEFT_ANTI_JOIN) || joinOp.equals(JoinOperator.LEFT_SEMI_JOIN)
                 || joinOp.equals(JoinOperator.NULL_AWARE_LEFT_ANTI_JOIN)) {
-            tupleIds.addAll(outer.getTupleIds());
+            tupleIds.addAll(outer.getOutputTupleIds());
         } else if (joinOp.equals(JoinOperator.RIGHT_ANTI_JOIN) || joinOp.equals(JoinOperator.RIGHT_SEMI_JOIN)) {
-            tupleIds.addAll(inner.getTupleIds());
+            tupleIds.addAll(inner.getOutputTupleIds());
         } else {
-            tupleIds.addAll(outer.getTupleIds());
-            tupleIds.addAll(inner.getTupleIds());
+            tupleIds.addAll(outer.getOutputTupleIds());
+            tupleIds.addAll(inner.getOutputTupleIds());
         }
 
         for (Expr eqJoinPredicate : eqJoinConjuncts) {
@@ -143,12 +143,12 @@ public class HashJoinNode extends JoinNodeBase {
         nullableTupleIds.addAll(inner.getNullableTupleIds());
         nullableTupleIds.addAll(outer.getNullableTupleIds());
         if (joinOp.equals(JoinOperator.FULL_OUTER_JOIN)) {
-            nullableTupleIds.addAll(outer.getTupleIds());
-            nullableTupleIds.addAll(inner.getTupleIds());
+            nullableTupleIds.addAll(outer.getOutputTupleIds());
+            nullableTupleIds.addAll(inner.getOutputTupleIds());
         } else if (joinOp.equals(JoinOperator.LEFT_OUTER_JOIN)) {
-            nullableTupleIds.addAll(inner.getTupleIds());
+            nullableTupleIds.addAll(inner.getOutputTupleIds());
         } else if (joinOp.equals(JoinOperator.RIGHT_OUTER_JOIN)) {
-            nullableTupleIds.addAll(outer.getTupleIds());
+            nullableTupleIds.addAll(outer.getOutputTupleIds());
         }
         vIntermediateTupleDescList = Lists.newArrayList(intermediateTuple);
         this.outputTupleDesc = outputTuple;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/JoinCostEvaluation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/JoinCostEvaluation.java
@@ -52,7 +52,7 @@ public class JoinCostEvaluation {
         PlanNode rhsTree = rightChildFragment.getPlanRoot();
         rhsTreeCardinality = rhsTree.getCardinality();
         rhsTreeAvgRowSize = rhsTree.getAvgRowSize();
-        rhsTreeTupleIdNum = rhsTree.getTupleIds().size();
+        rhsTreeTupleIdNum = rhsTree.getOutputTupleIds().size();
         PlanNode lhsTree = leftChildFragment.getPlanRoot();
         lhsTreeCardinality = lhsTree.getCardinality();
         lhsTreeAvgRowSize = lhsTree.getAvgRowSize();

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/NestedLoopJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/NestedLoopJoinNode.java
@@ -95,12 +95,12 @@ public class NestedLoopJoinNode extends JoinNodeBase {
         nullableTupleIds.addAll(outer.getNullableTupleIds());
         nullableTupleIds.addAll(inner.getNullableTupleIds());
         if (joinOp.equals(JoinOperator.FULL_OUTER_JOIN)) {
-            nullableTupleIds.addAll(outer.getTupleIds());
-            nullableTupleIds.addAll(inner.getTupleIds());
+            nullableTupleIds.addAll(outer.getOutputTupleIds());
+            nullableTupleIds.addAll(inner.getOutputTupleIds());
         } else if (joinOp.equals(JoinOperator.LEFT_OUTER_JOIN)) {
-            nullableTupleIds.addAll(inner.getTupleIds());
+            nullableTupleIds.addAll(inner.getOutputTupleIds());
         } else if (joinOp.equals(JoinOperator.RIGHT_OUTER_JOIN)) {
-            nullableTupleIds.addAll(outer.getTupleIds());
+            nullableTupleIds.addAll(outer.getOutputTupleIds());
         }
         vIntermediateTupleDescList = Lists.newArrayList(intermediateTuple);
         outputTupleDesc = outputTuple;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -163,7 +163,7 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
     private List<TupleDescriptor> intermediateOutputTupleDescList = Lists.newArrayList();
     private List<List<Expr>> intermediateProjectListList = Lists.newArrayList();
 
-    protected PlanNode(PlanNodeId id, ArrayList<TupleId> tupleIds, String planNodeName,
+    protected PlanNode(PlanNodeId id, List<TupleId> tupleIds, String planNodeName,
             StatisticalType statisticalType) {
         this.id = id;
         this.limit = -1;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilter.java
@@ -116,7 +116,7 @@ public final class RuntimeFilter {
 
         public RuntimeFilterTarget(PlanNode targetNode, Expr targetExpr,
                                    boolean isBoundByKeyColumns, boolean isLocalTarget) {
-            Preconditions.checkState(targetExpr.isBoundByTupleIds(targetNode.getTupleIds())
+            Preconditions.checkState(targetExpr.isBoundByTupleIds(targetNode.getOutputTupleIds())
                     || targetNode instanceof CTEScanNode,
                     "RuntimeFilter target " + expr + " is not bounded: slotDesc"
                             + (targetExpr instanceof SlotRef ? ((SlotRef) targetExpr).getTupleId() : "null"));

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilter.java
@@ -116,7 +116,7 @@ public final class RuntimeFilter {
 
         public RuntimeFilterTarget(PlanNode targetNode, Expr targetExpr,
                                    boolean isBoundByKeyColumns, boolean isLocalTarget) {
-            Preconditions.checkState(targetExpr.isBoundByTupleIds(targetNode.getOutputTupleIds())
+            Preconditions.checkState(targetExpr.isBoundByTupleIds(targetNode.getTupleIds())
                     || targetNode instanceof CTEScanNode,
                     "RuntimeFilter target " + expr + " is not bounded: slotDesc"
                             + (targetExpr instanceof SlotRef ? ((SlotRef) targetExpr).getTupleId() : "null"));

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/TableFunctionNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/TableFunctionNode.java
@@ -51,7 +51,7 @@ public class TableFunctionNode extends PlanNode {
             if (childOutputTupleIds != null && !childOutputTupleIds.isEmpty()) {
                 tupleIds.addAll(childOutputTupleIds);
             } else {
-                tupleIds.addAll(inputNode.getTupleIds());
+                tupleIds.addAll(inputNode.getOutputTupleIds());
             }
         }
         tupleIds.add(lateralViewTupleId);

--- a/regression-test/suites/nereids_p0/join/translate_tuple_id/join_input_tuple_id.groovy
+++ b/regression-test/suites/nereids_p0/join/translate_tuple_id/join_input_tuple_id.groovy
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("join_input_tuple_id") {
+    sql """
+        drop table if exists t1;
+        create table t1(k int, v int) properties("replication_num"="1");
+        insert into t1 values (1, 1), (2, 2), (3,3);
+
+        drop table if exists t2;
+        create table t2(k int, v int) properties("replication_num"="1");
+        insert into t2 values (1, 1), (2, 2), (3,3);
+
+        drop table if exists t3;
+        create table t3(k int, v int) properties("replication_num"="1");
+        insert into t3 values (1, 1), (2, 2), (3,3);
+        set disable_join_reorder=true;
+    """
+
+    explain {
+        sql """
+            verbose select * 
+            from ((select k, v from t1) union all (select k, v from t2)) as u
+                join t3 on u.k+1 = t3.k
+        """
+        // verify that join's input tuple is union's output tuple id (5) not input tuple (4)
+        contains "tuple ids: 5 1N"
+
+//   7:VHASH JOIN(293)
+//   |  join op: INNER JOIN(BROADCAST)[]
+//   |  equal join conjunct: (expr_cast(k as BIGINT)[#13] = expr_(cast(k as BIGINT) - 1)[#4])
+//   |  cardinality=2
+//   |  vec output tuple id: 7
+//   |  output tuple id: 7
+//   |  vIntermediate tuple ids: 6 
+//   |  hash output slot ids: 2 3 11 12 
+//   |  isMarkJoin: false
+//   |  final projections: k[#14], v[#15], k[#17], v[#18]
+//   |  final project output tuple id: 7
+//   |  distribute expr lists: 
+//   |  distribute expr lists: 
+//   |  tuple ids: 5 1N 
+//   |  
+//   |----1:VEXCHANGE
+//   |       offset: 0
+//   |       distribute expr lists: 
+//   |       tuple ids: 1N 
+//   |    
+//   6:VUNION(276)
+//   |  child exprs: 
+//   |      k[#5] | v[#6]
+//   |      k[#7] | v[#8]
+//   |  final projections: k[#9], v[#10], CAST(k[#9] AS bigint)
+//   |  final project output tuple id: 5
+//   |  tuple ids: 4 
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?
In PlanNode, "tuple ids" describes input slots of a sql operator based on input tuples.
And "final project output tuple id" describes output slots.

So, all PlanNode should use child's  "final project output id“ as input tuple

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

