### PR TITLE
[feat](cloud) change the type to optional in the alter storage vault command

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StorageVaultMgr.java
@@ -291,6 +291,27 @@ public class StorageVaultMgr {
         }
     }
 
+    public StorageVaultType getStorageVaultTypeByName(String vaultName) throws DdlException {
+        try {
+            Cloud.GetObjStoreInfoResponse resp = MetaServiceProxy.getInstance()
+                    .getObjStoreInfo(Cloud.GetObjStoreInfoRequest.newBuilder().build());
+
+            for (Cloud.StorageVaultPB vault : resp.getStorageVaultList()) {
+                if (vault.getName().equals(vaultName)) {
+                    if (vault.hasHdfsInfo()) {
+                        return StorageVaultType.HDFS;
+                    } else if (vault.hasObjInfo()) {
+                        return StorageVaultType.S3;
+                    }
+                }
+            }
+            return StorageVaultType.UNKNOWN;
+        } catch (RpcException e) {
+            LOG.warn("failed to get storage vault type due to RpcException: {}", e);
+            throw new DdlException(e.getMessage());
+        }
+    }
+
     @VisibleForTesting
     public void createHdfsVault(StorageVault vault) throws Exception {
         Cloud.StorageVaultPB.Builder alterHdfsInfoBuilder = buildAlterStorageVaultRequest(vault);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AlterStorageVaultCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AlterStorageVaultCommand.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.StorageVault;
 import org.apache.doris.catalog.StorageVault.StorageVaultType;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeNameFormat;
@@ -55,9 +56,24 @@ public class AlterStorageVaultCommand extends Command implements ForwardWithSync
         if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "ADMIN");
         }
-        StorageVault.StorageVaultType vaultType = StorageVaultType.fromString(properties.get(TYPE));
-        if (vaultType == StorageVault.StorageVaultType.UNKNOWN) {
-            throw new AnalysisException("Unsupported Storage Vault type: " + type);
+
+        StorageVault.StorageVaultType vaultType;
+        if (properties.containsKey(TYPE)) {
+            vaultType = StorageVaultType.fromString(properties.get(TYPE));
+            if (vaultType == StorageVaultType.UNKNOWN) {
+                throw new AnalysisException("Unsupported Storage Vault type: " + type);
+            }
+        } else {
+            // auto-detect
+            try {
+                vaultType = Env.getCurrentEnv().getStorageVaultMgr().getStorageVaultTypeByName(name);
+                if (vaultType == StorageVaultType.UNKNOWN) {
+                    throw new AnalysisException("Storage vault '" + name + "' does not exist or has unknown type. "
+                            + "You can use `SHOW STORAGE VAULT` to get all available vaults.");
+                }
+            } catch (DdlException e) {
+                throw new AnalysisException("Failed to get storage vault type: " + e.getMessage());
+            }
         }
 
         FeNameFormat.checkStorageVaultName(name);

--- a/regression-test/suites/vault_p0/alter/test_alter_vault_type.groovy
+++ b/regression-test/suites/vault_p0/alter/test_alter_vault_type.groovy
@@ -95,4 +95,28 @@ suite("test_alter_vault_type", "nonConcurrent") {
     } catch (Exception e) {
         assertTrue(e.getMessage().contains("Access denied for user"), e.getMessage())
     }
+
+    sql """
+        ALTER STORAGE VAULT ${s3VaultName}
+        PROPERTIES (
+            "s3.access_key" = "${getS3AK()}",
+            "s3.secret_key" = "${getS3SK()}"
+        );
+    """
+
+    sql """
+        ALTER STORAGE VAULT ${hdfsVaultName}
+        PROPERTIES (
+            "hadoop.username" = "${getHmsUser()}"
+        );
+    """
+
+    expectExceptionLike({
+        sql """
+            ALTER STORAGE VAULT non_existent_vault_${randomStr}
+            PROPERTIES (
+                "s3.access_key" = "test_ak"
+            );
+        """
+    }, "does not exist")
 }


### PR DESCRIPTION
### What problem does this PR solve?

change the type to optional in the alter storage vault command
before
```
ALTER STORAGE VAULT vault_name
PROPERTIES (
  "type"="S3",
  "s3.access_key" = "new_ak"
);
```
now
```
ALTER STORAGE VAULT vault_name
PROPERTIES (
  "s3.access_key" = "new_ak"
);
```

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

