### PR TITLE
[enhance](schema)When querying system tables, it supports pre-filtering data in the FE (Frontend).

### DIFF
--- a/be/src/exec/schema_scanner.h
+++ b/be/src/exec/schema_scanner.h
@@ -67,7 +67,7 @@ struct SchemaScannerCommonParam {
     const std::string* user = nullptr;                 // deprecated
     const std::string* user_ip = nullptr;              // deprecated
     const TUserIdentity* current_user_ident = nullptr; // to replace the user and user ip
-    const std::string* frontend_conjuncts = nullptr; // frontend_conjuncts
+    const std::string* frontend_conjuncts = nullptr;   // frontend_conjuncts
     const std::string* ip = nullptr;                   // frontend ip
     int32_t port;                                      // frontend thrift port
     int64_t thread_id;

--- a/be/src/exec/schema_scanner.h
+++ b/be/src/exec/schema_scanner.h
@@ -57,6 +57,7 @@ struct SchemaScannerCommonParam {
               user(nullptr),
               user_ip(nullptr),
               current_user_ident(nullptr),
+              frontend_conjuncts(nullptr),
               ip(nullptr),
               port(0),
               catalog(nullptr) {}
@@ -66,6 +67,7 @@ struct SchemaScannerCommonParam {
     const std::string* user = nullptr;                 // deprecated
     const std::string* user_ip = nullptr;              // deprecated
     const TUserIdentity* current_user_ident = nullptr; // to replace the user and user ip
+    const std::list<Exprs.TExpr>* frontend_conjuncts = nullptr;  // frontend_conjuncts
     const std::string* ip = nullptr;                   // frontend ip
     int32_t port;                                      // frontend thrift port
     int64_t thread_id;

--- a/be/src/exec/schema_scanner.h
+++ b/be/src/exec/schema_scanner.h
@@ -67,7 +67,7 @@ struct SchemaScannerCommonParam {
     const std::string* user = nullptr;                 // deprecated
     const std::string* user_ip = nullptr;              // deprecated
     const TUserIdentity* current_user_ident = nullptr; // to replace the user and user ip
-    const std::list<Exprs.TExpr>* frontend_conjuncts = nullptr;  // frontend_conjuncts
+    const std::vector<TExpr>* frontend_conjuncts = nullptr; // frontend_conjuncts
     const std::string* ip = nullptr;                   // frontend ip
     int32_t port;                                      // frontend thrift port
     int64_t thread_id;

--- a/be/src/exec/schema_scanner.h
+++ b/be/src/exec/schema_scanner.h
@@ -67,7 +67,7 @@ struct SchemaScannerCommonParam {
     const std::string* user = nullptr;                 // deprecated
     const std::string* user_ip = nullptr;              // deprecated
     const TUserIdentity* current_user_ident = nullptr; // to replace the user and user ip
-    const std::vector<TExpr>* frontend_conjuncts = nullptr; // frontend_conjuncts
+    const std::string* frontend_conjuncts = nullptr; // frontend_conjuncts
     const std::string* ip = nullptr;                   // frontend ip
     int32_t port;                                      // frontend thrift port
     int64_t thread_id;

--- a/be/src/exec/schema_scanner/schema_view_dependency_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_view_dependency_scanner.cpp
@@ -62,7 +62,7 @@ Status SchemaViewDependencyScanner::_get_view_dependency_block_from_fe() {
         schema_table_request_params.columns_name.emplace_back(_s_view_dependency_columns[i].name);
     }
     schema_table_request_params.__set_current_user_ident(*_param->common_param->current_user_ident);
-
+    schema_table_request_params.__set_frontend_conjuncts(*_param->common_param->frontend_conjuncts);
     TFetchSchemaTableDataRequest request;
     request.__set_schema_table_name(TSchemaTableName::VIEW_DEPENDENCY);
     request.__set_schema_table_params(schema_table_request_params);

--- a/be/src/pipeline/exec/schema_scan_operator.cpp
+++ b/be/src/pipeline/exec/schema_scan_operator.cpp
@@ -132,6 +132,11 @@ Status SchemaScanOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {
         fe_addr.port = tnode.schema_scan_node.port;
         _common_scanner_param->fe_addr_list.insert(fe_addr);
     }
+
+    if (tnode.schema_scan_node.__isset.frontend_conjuncts) {
+        _common_scanner_param->frontend_conjuncts = state->obj_pool()->add(
+                new std::list<Exprs.TExpr>(tnode.schema_scan_node.frontend_conjuncts));
+    }
     return Status::OK();
 }
 

--- a/be/src/pipeline/exec/schema_scan_operator.cpp
+++ b/be/src/pipeline/exec/schema_scan_operator.cpp
@@ -135,7 +135,7 @@ Status SchemaScanOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {
 
     if (tnode.schema_scan_node.__isset.frontend_conjuncts) {
         _common_scanner_param->frontend_conjuncts = state->obj_pool()->add(
-                new std::list<Exprs.TExpr>(tnode.schema_scan_node.frontend_conjuncts));
+                new std::vector<TExpr>(tnode.schema_scan_node.frontend_conjuncts));
     }
     return Status::OK();
 }

--- a/be/src/pipeline/exec/schema_scan_operator.cpp
+++ b/be/src/pipeline/exec/schema_scan_operator.cpp
@@ -134,8 +134,8 @@ Status SchemaScanOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {
     }
 
     if (tnode.schema_scan_node.__isset.frontend_conjuncts) {
-        _common_scanner_param->frontend_conjuncts = state->obj_pool()->add(
-                new std::vector<TExpr>(tnode.schema_scan_node.frontend_conjuncts));
+        _common_scanner_param->frontend_conjuncts =
+                state->obj_pool()->add(new std::string(tnode.schema_scan_node.frontend_conjuncts));
     }
     return Status::OK();
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -1039,11 +1039,13 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
                 table.getName())) {
             scanNode = new BackendPartitionedSchemaScanNode(context.nextPlanNodeId(), table, tupleDescriptor,
                     schemaScan.getSchemaCatalog().orElse(null), schemaScan.getSchemaDatabase().orElse(null),
-                    schemaScan.getSchemaTable().orElse(null), translateToExprs(schemaScan.getFrontendConjuncts()));
+                    schemaScan.getSchemaTable().orElse(null),
+                    translateToExprs(schemaScan.getFrontendConjuncts(), context));
         } else {
             scanNode = new SchemaScanNode(context.nextPlanNodeId(), tupleDescriptor,
                     schemaScan.getSchemaCatalog().orElse(null), schemaScan.getSchemaDatabase().orElse(null),
-                    schemaScan.getSchemaTable().orElse(null), translateToExprs(schemaScan.getFrontendConjuncts()));
+                    schemaScan.getSchemaTable().orElse(null), translateToExprs(schemaScan.getFrontendConjuncts(),
+                    context));
         }
         scanNode.setNereidsId(schemaScan.getId());
         context.getNereidsIdToPlanNodeIdMap().put(schemaScan.getId(), scanNode.getId());
@@ -1069,7 +1071,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         return planFragment;
     }
 
-    private List<Expr> translateToExprs(List<Expression> expressions) {
+    private List<Expr> translateToExprs(List<Expression> expressions, PlanTranslatorContext context) {
         List<Expr> exprs = Lists.newArrayListWithCapacity(expressions.size());
         for (Expression expression : expressions) {
             exprs.add(ExpressionTranslator.translate(expression, context));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -1038,12 +1038,12 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         if (BackendPartitionedSchemaScanNode.isBackendPartitionedSchemaTable(
                 table.getName())) {
             scanNode = new BackendPartitionedSchemaScanNode(context.nextPlanNodeId(), table, tupleDescriptor,
-                schemaScan.getSchemaCatalog().orElse(null), schemaScan.getSchemaDatabase().orElse(null),
-                schemaScan.getSchemaTable().orElse(null));
+                    schemaScan.getSchemaCatalog().orElse(null), schemaScan.getSchemaDatabase().orElse(null),
+                    schemaScan.getSchemaTable().orElse(null), translateToExprs(schemaScan.getFrontendConjuncts()));
         } else {
             scanNode = new SchemaScanNode(context.nextPlanNodeId(), tupleDescriptor,
-                schemaScan.getSchemaCatalog().orElse(null), schemaScan.getSchemaDatabase().orElse(null),
-                schemaScan.getSchemaTable().orElse(null));
+                    schemaScan.getSchemaCatalog().orElse(null), schemaScan.getSchemaDatabase().orElse(null),
+                    schemaScan.getSchemaTable().orElse(null), translateToExprs(schemaScan.getFrontendConjuncts()));
         }
         scanNode.setNereidsId(schemaScan.getId());
         context.getNereidsIdToPlanNodeIdMap().put(schemaScan.getId(), scanNode.getId());
@@ -1067,6 +1067,14 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         context.addPlanFragment(planFragment);
         updateLegacyPlanIdToPhysicalPlan(planFragment.getPlanRoot(), schemaScan);
         return planFragment;
+    }
+
+    private List<Expr> translateToExprs(List<Expression> expressions) {
+        List<Expr> exprs = Lists.newArrayListWithCapacity(expressions.size());
+        for (Expression expression : expressions) {
+            exprs.add(ExpressionTranslator.translate(expression, context));
+        }
+        return exprs;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/LogicalSchemaScanToPhysicalSchemaScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/LogicalSchemaScanToPhysicalSchemaScan.java
@@ -37,7 +37,8 @@ public class LogicalSchemaScanToPhysicalSchemaScan extends OneImplementationRule
                         scan.getLogicalProperties(),
                         scan.getSchemaCatalog(),
                         scan.getSchemaDatabase(),
-                        scan.getSchemaTable())
+                        scan.getSchemaTable(),
+                        scan.getFrontendConjuncts())
         ).toRule(RuleType.LOGICAL_SCHEMA_SCAN_TO_PHYSICAL_SCHEMA_SCAN_RULE);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownFilterIntoSchemaScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownFilterIntoSchemaScan.java
@@ -28,6 +28,7 @@ import org.apache.doris.nereids.trees.expressions.InPredicate;
 import org.apache.doris.nereids.trees.expressions.LessThan;
 import org.apache.doris.nereids.trees.expressions.LessThanEqual;
 import org.apache.doris.nereids.trees.expressions.Not;
+import org.apache.doris.nereids.trees.expressions.NullSafeEqual;
 import org.apache.doris.nereids.trees.expressions.Or;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
@@ -117,6 +118,7 @@ public class PushDownFilterIntoSchemaScan extends OneRewriteRuleFactory {
                 || expression instanceof LessThanEqual
                 || expression instanceof GreaterThan
                 || expression instanceof GreaterThanEqual
+                || expression instanceof NullSafeEqual
                 || expression instanceof Not;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownFilterIntoSchemaScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownFilterIntoSchemaScan.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.GreaterThan;
 import org.apache.doris.nereids.trees.expressions.GreaterThanEqual;
+import org.apache.doris.nereids.trees.expressions.InPredicate;
 import org.apache.doris.nereids.trees.expressions.LessThan;
 import org.apache.doris.nereids.trees.expressions.LessThanEqual;
 import org.apache.doris.nereids.trees.expressions.Not;
@@ -111,6 +112,7 @@ public class PushDownFilterIntoSchemaScan extends OneRewriteRuleFactory {
     private boolean supportOnFe(Expression expression) {
         return expression instanceof EqualTo
                 || expression instanceof Or
+                || expression instanceof InPredicate
                 || expression instanceof LessThan
                 || expression instanceof LessThanEqual
                 || expression instanceof GreaterThan

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSchemaScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSchemaScan.java
@@ -154,11 +154,13 @@ public class LogicalSchemaScan extends LogicalCatalogRelation {
         return Objects.equals(schemaCatalog, that.schemaCatalog)
                 && Objects.equals(schemaDatabase, that.schemaDatabase)
                 && Objects.equals(schemaTable, that.schemaTable)
+                && Objects.equals(frontendConjuncts, that.frontendConjuncts)
                 && filterPushed == that.filterPushed;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), schemaCatalog, schemaDatabase, schemaTable, filterPushed);
+        return Objects.hash(super.hashCode(), schemaCatalog, schemaDatabase, schemaTable, filterPushed,
+                frontendConjuncts);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSchemaScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSchemaScan.java
@@ -30,7 +30,6 @@ import org.apache.doris.nereids.util.Utils;
 
 import com.google.common.collect.ImmutableList;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -48,8 +47,8 @@ public class LogicalSchemaScan extends LogicalCatalogRelation {
 
     public LogicalSchemaScan(RelationId id, TableIf table, List<String> qualifier) {
         this(id, table, qualifier, false,
-                Optional.empty(), Optional.empty(), Optional.empty(), ImmutableList.of(),
-                Optional.empty(), Optional.empty(), Collections.emptyList());
+                Optional.empty(), Optional.empty(), Optional.empty(), ImmutableList.of(), ImmutableList.of(),
+                Optional.empty(), Optional.empty());
     }
 
     /**
@@ -63,15 +62,14 @@ public class LogicalSchemaScan extends LogicalCatalogRelation {
      * @param schemaDatabase Optional database name in the schema
      * @param schemaTable Optional table name in the schema
      * @param virtualColumns List of virtual columns to be included in the scan
+     * @param frontendConjuncts conjuncts needed by FrontendService
      * @param groupExpression Optional group expression for memo representation
      * @param logicalProperties Optional logical properties for this plan node
-     * @param frontendConjuncts conjuncts needed by FrontendService
      */
     public LogicalSchemaScan(RelationId id, TableIf table, List<String> qualifier, boolean filterPushed,
             Optional<String> schemaCatalog, Optional<String> schemaDatabase, Optional<String> schemaTable,
-            List<NamedExpression> virtualColumns,
-            Optional<GroupExpression> groupExpression, Optional<LogicalProperties> logicalProperties,
-            List<Expression> frontendConjuncts) {
+            List<NamedExpression> virtualColumns, List<Expression> frontendConjuncts,
+            Optional<GroupExpression> groupExpression, Optional<LogicalProperties> logicalProperties) {
         super(id, PlanType.LOGICAL_SCHEMA_SCAN, table, qualifier, ImmutableList.of(), virtualColumns,
                 groupExpression, logicalProperties);
         this.filterPushed = filterPushed;
@@ -110,28 +108,28 @@ public class LogicalSchemaScan extends LogicalCatalogRelation {
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
         return new LogicalSchemaScan(relationId, table, qualifier, filterPushed,
                 schemaCatalog, schemaDatabase, schemaTable, virtualColumns,
-                groupExpression, Optional.of(getLogicalProperties()), frontendConjuncts);
+                frontendConjuncts, groupExpression, Optional.of(getLogicalProperties()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         return new LogicalSchemaScan(relationId, table, qualifier, filterPushed,
-                schemaCatalog, schemaDatabase, schemaTable, virtualColumns, groupExpression, logicalProperties,
-                frontendConjuncts);
+                schemaCatalog, schemaDatabase, schemaTable, virtualColumns, frontendConjuncts, groupExpression,
+                logicalProperties);
     }
 
     @Override
     public LogicalSchemaScan withRelationId(RelationId relationId) {
         return new LogicalSchemaScan(relationId, table, qualifier, filterPushed,
-                schemaCatalog, schemaDatabase, schemaTable, virtualColumns, Optional.empty(), Optional.empty(),
-                frontendConjuncts);
+                schemaCatalog, schemaDatabase, schemaTable, virtualColumns, frontendConjuncts, Optional.empty(),
+                Optional.empty());
     }
 
     public LogicalSchemaScan withFrontendConjuncts(Optional<String> schemaCatalog, Optional<String> schemaDatabase,
             Optional<String> schemaTable, List<Expression> frontendConjuncts) {
         return new LogicalSchemaScan(relationId, table, qualifier, true, schemaCatalog, schemaDatabase, schemaTable,
-                virtualColumns, Optional.empty(), Optional.of(getLogicalProperties()), frontendConjuncts);
+                virtualColumns, frontendConjuncts, Optional.empty(), Optional.of(getLogicalProperties()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalSchemaScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalSchemaScan.java
@@ -140,12 +140,13 @@ public class PhysicalSchemaScan extends PhysicalCatalogRelation {
         PhysicalSchemaScan that = (PhysicalSchemaScan) o;
         return Objects.equals(schemaCatalog, that.schemaCatalog)
                 && Objects.equals(schemaDatabase, that.schemaDatabase)
+                && Objects.equals(frontendConjuncts, that.frontendConjuncts)
                 && Objects.equals(schemaTable, that.schemaTable);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), schemaCatalog, schemaDatabase, schemaTable);
+        return Objects.hash(super.hashCode(), schemaCatalog, schemaDatabase, schemaTable, frontendConjuncts);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalSchemaScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalSchemaScan.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.TableIf;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
+import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.RelationId;
@@ -42,26 +43,33 @@ public class PhysicalSchemaScan extends PhysicalCatalogRelation {
     private final Optional<String> schemaCatalog;
     private final Optional<String> schemaDatabase;
     private final Optional<String> schemaTable;
+    private final List<Expression> frontendConjuncts;
 
+    /**PhysicalSchemaScan*/
     public PhysicalSchemaScan(RelationId id, TableIf table, List<String> qualifier,
             Optional<GroupExpression> groupExpression, LogicalProperties logicalProperties,
-            Optional<String> schemaCatalog, Optional<String> schemaDatabase, Optional<String> schemaTable) {
+            Optional<String> schemaCatalog, Optional<String> schemaDatabase, Optional<String> schemaTable,
+            List<Expression> frontendConjuncts) {
         super(id, PlanType.PHYSICAL_SCHEMA_SCAN, table, qualifier, groupExpression, logicalProperties,
                 ImmutableList.of());
         this.schemaCatalog = schemaCatalog;
         this.schemaDatabase = schemaDatabase;
         this.schemaTable = schemaTable;
+        this.frontendConjuncts = frontendConjuncts;
     }
 
+    /**PhysicalSchemaScan*/
     public PhysicalSchemaScan(RelationId id, TableIf table, List<String> qualifier,
             Optional<GroupExpression> groupExpression, LogicalProperties logicalProperties,
             PhysicalProperties physicalProperties, Statistics statistics,
-            Optional<String> schemaCatalog, Optional<String> schemaDatabase, Optional<String> schemaTable) {
+            Optional<String> schemaCatalog, Optional<String> schemaDatabase, Optional<String> schemaTable,
+            List<Expression> frontendConjuncts) {
         super(id, PlanType.PHYSICAL_SCHEMA_SCAN, table, qualifier, groupExpression,
                 logicalProperties, physicalProperties, statistics, ImmutableList.of());
         this.schemaCatalog = schemaCatalog;
         this.schemaDatabase = schemaDatabase;
         this.schemaTable = schemaTable;
+        this.frontendConjuncts = frontendConjuncts;
     }
 
     public Optional<String> getSchemaCatalog() {
@@ -74,6 +82,10 @@ public class PhysicalSchemaScan extends PhysicalCatalogRelation {
 
     public Optional<String> getSchemaTable() {
         return schemaTable;
+    }
+
+    public List<Expression> getFrontendConjuncts() {
+        return frontendConjuncts;
     }
 
     @Override
@@ -90,7 +102,7 @@ public class PhysicalSchemaScan extends PhysicalCatalogRelation {
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
         return new PhysicalSchemaScan(relationId, getTable(), qualifier,
                 groupExpression, getLogicalProperties(), physicalProperties, statistics,
-                schemaCatalog, schemaDatabase, schemaTable);
+                schemaCatalog, schemaDatabase, schemaTable, frontendConjuncts);
     }
 
     @Override
@@ -98,7 +110,7 @@ public class PhysicalSchemaScan extends PhysicalCatalogRelation {
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         return new PhysicalSchemaScan(relationId, getTable(), qualifier,
                 groupExpression, logicalProperties.get(), physicalProperties, statistics,
-                schemaCatalog, schemaDatabase, schemaTable);
+                schemaCatalog, schemaDatabase, schemaTable, frontendConjuncts);
     }
 
     @Override
@@ -106,7 +118,7 @@ public class PhysicalSchemaScan extends PhysicalCatalogRelation {
             Statistics statistics) {
         return new PhysicalSchemaScan(relationId, getTable(), qualifier,
                 groupExpression, getLogicalProperties(), physicalProperties, statistics,
-                schemaCatalog, schemaDatabase, schemaTable);
+                schemaCatalog, schemaDatabase, schemaTable, frontendConjuncts);
     }
 
     @Override
@@ -127,8 +139,8 @@ public class PhysicalSchemaScan extends PhysicalCatalogRelation {
         }
         PhysicalSchemaScan that = (PhysicalSchemaScan) o;
         return Objects.equals(schemaCatalog, that.schemaCatalog)
-            && Objects.equals(schemaDatabase, that.schemaDatabase)
-            && Objects.equals(schemaTable, that.schemaTable);
+                && Objects.equals(schemaDatabase, that.schemaDatabase)
+                && Objects.equals(schemaTable, that.schemaTable);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/FrontendConjunctsUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/FrontendConjunctsUtils.java
@@ -125,8 +125,9 @@ public class FrontendConjunctsUtils {
                     List<String> nameParts = ((UnboundSlot) expr).getNameParts();
                     if (!CollectionUtils.isEmpty(nameParts)) {
                         String name = nameParts.get(nameParts.size() - 1).toLowerCase();
-                        if (values.containsKey(name)) {
-                            return Literal.of(values.get(name));
+                        Object value = values.get(name);
+                        if (value != null) {
+                            return Literal.of(value);
                         } else {
                             containsAllColumn.set(false);
                         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/FrontendConjunctsUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/FrontendConjunctsUtils.java
@@ -18,22 +18,21 @@
 package org.apache.doris.nereids.util;
 
 import org.apache.doris.analysis.Expr;
-import org.apache.doris.catalog.Column;
+import org.apache.doris.nereids.analyzer.UnboundSlot;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.rules.expression.rules.FoldConstantRuleOnFE;
 import org.apache.doris.nereids.trees.expressions.Expression;
-import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.persist.gson.GsonUtils;
 
 import com.google.common.collect.Maps;
 import com.google.gson.reflect.TypeToken;
+import org.apache.commons.collections.CollectionUtils;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -84,10 +83,10 @@ public class FrontendConjunctsUtils {
      */
     public static boolean isFiltered(Expression expression, Map<String, Object> values) {
         Expression rewrittenExpr = expression.rewriteUp(expr -> {
-            if (expr instanceof SlotReference) {
-                Optional<Column> originalColumn = ((SlotReference) expr).getOriginalColumn();
-                if (originalColumn.isPresent()) {
-                    String name = originalColumn.get().getName().toLowerCase();
+            if (expr instanceof UnboundSlot) {
+                List<String> nameParts = ((UnboundSlot) expr).getNameParts();
+                if (!CollectionUtils.isEmpty(nameParts) && nameParts.size() == 1) {
+                    String name = nameParts.get(0).toLowerCase();
                     if (values.containsKey(name)) {
                         return Literal.of(values.get(name));
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/FrontendConjunctsUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/FrontendConjunctsUtils.java
@@ -19,10 +19,7 @@ package org.apache.doris.nereids.util;
 
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.catalog.Column;
-import org.apache.doris.nereids.CascadesContext;
-import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.parser.NereidsParser;
-import org.apache.doris.nereids.rules.expression.ExpressionRewriteContext;
 import org.apache.doris.nereids.rules.expression.rules.FoldConstantRuleOnFE;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
@@ -99,8 +96,7 @@ public class FrontendConjunctsUtils {
             return expr;
         });
 
-        Expression evaluate = FoldConstantRuleOnFE.evaluate(rewrittenExpr,
-                new ExpressionRewriteContext(CascadesContext.initContext(new StatementContext(), null, null)));
+        Expression evaluate = FoldConstantRuleOnFE.evaluate(rewrittenExpr, null);
         if (evaluate instanceof BooleanLiteral && !((BooleanLiteral) evaluate).getValue()) {
             return true;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/FrontendConjunctsUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/FrontendConjunctsUtils.java
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.util;
+
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.nereids.parser.NereidsParser;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.persist.gson.GsonUtils;
+
+import com.google.gson.reflect.TypeToken;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * FrontendConjunctsUtils
+ */
+public class FrontendConjunctsUtils {
+    public static List<Expression> convertToExpression(String conjuncts) {
+        List<Expr> exprs = GsonUtils.GSON.fromJson(conjuncts, new TypeToken<List<Expr>>() {
+        }.getType());
+        return exprs.stream()
+                .map(expr -> exprToExpression(expr))
+                .collect(Collectors.toList());
+    }
+
+    public static Expression exprToExpression(Expr expr) {
+        NereidsParser nereidsParser = new NereidsParser();
+        return nereidsParser.parseExpression(expr.toSql());
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/BackendPartitionedSchemaScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/BackendPartitionedSchemaScanNode.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.planner;
 
+import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.catalog.Column;
@@ -94,8 +95,8 @@ public class BackendPartitionedSchemaScanNode extends SchemaScanNode {
     private Collection<Long> selectedPartitionIds = Lists.newArrayList();
 
     public BackendPartitionedSchemaScanNode(PlanNodeId id, TableIf table, TupleDescriptor desc,
-                                            String schemaCatalog, String schemaDatabase, String schemaTable) {
-        super(id, desc, schemaCatalog, schemaDatabase, schemaTable);
+            String schemaCatalog, String schemaDatabase, String schemaTable, List<Expr> frontendConjuncts) {
+        super(id, desc, schemaCatalog, schemaDatabase, schemaTable, frontendConjuncts);
         this.tableIf = table;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SchemaScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SchemaScanNode.java
@@ -185,6 +185,10 @@ public class SchemaScanNode extends ScanNode {
             Expr expr = convertConjunctsToAndCompoundPredicate(conjuncts);
             output.append(prefix).append("PREDICATES: ").append(expr.toSql()).append("\n");
         }
+        if (!frontendConjuncts.isEmpty()) {
+            Expr expr = convertConjunctsToAndCompoundPredicate(frontendConjuncts);
+            output.append(prefix).append("FRONTEND PREDICATES: ").append(expr.toSql()).append("\n");
+        }
         if (!runtimeFilters.isEmpty()) {
             output.append(prefix).append("runtime filters: ");
             output.append(getRuntimeFilterExplainString());

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SchemaScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SchemaScanNode.java
@@ -30,6 +30,7 @@ import org.apache.doris.service.FrontendOptions;
 import org.apache.doris.statistics.StatisticalType;
 import org.apache.doris.system.Frontend;
 import org.apache.doris.thrift.TExplainLevel;
+import org.apache.doris.thrift.TExpr;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TPlanNode;
 import org.apache.doris.thrift.TPlanNodeType;
@@ -58,17 +59,19 @@ public class SchemaScanNode extends ScanNode {
     private String frontendIP;
     private int frontendPort;
     private String schemaCatalog;
+    private List<Expr> frontendConjuncts;
 
     /**
      * Constructs node to scan given data files of table 'tbl'.
      */
     public SchemaScanNode(PlanNodeId id, TupleDescriptor desc,
-                          String schemaCatalog, String schemaDb, String schemaTable) {
+            String schemaCatalog, String schemaDb, String schemaTable, List<Expr> frontendConjuncts) {
         super(id, desc, "SCAN SCHEMA", StatisticalType.SCHEMA_SCAN_NODE);
         this.tableName = desc.getTable().getName();
         this.schemaCatalog = schemaCatalog;
         this.schemaDb = schemaDb;
         this.schemaTable = schemaTable;
+        this.frontendConjuncts = frontendConjuncts;
     }
 
     public String getTableName() {
@@ -81,6 +84,10 @@ public class SchemaScanNode extends ScanNode {
 
     public String getSchemaCatalog() {
         return desc.getTable().getDatabase().getCatalog().getName();
+    }
+
+    public List<Expr> getFrontendConjuncts() {
+        return frontendConjuncts;
     }
 
     @Override
@@ -148,6 +155,11 @@ public class SchemaScanNode extends ScanNode {
 
         TUserIdentity tCurrentUser = ConnectContext.get().getCurrentUserIdentity().toThrift();
         msg.schema_scan_node.setCurrentUserIdent(tCurrentUser);
+        List<TExpr> tExprs = Lists.newArrayListWithCapacity(frontendConjuncts.size());
+        for (Expr expr : frontendConjuncts) {
+            tExprs.add(expr.treeToThrift());
+        }
+        msg.schema_scan_node.setFrontendConjuncts(tExprs);
         setFeAddrList(msg);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SchemaScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SchemaScanNode.java
@@ -25,12 +25,12 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.FederationBackendPolicy;
+import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.service.FrontendOptions;
 import org.apache.doris.statistics.StatisticalType;
 import org.apache.doris.system.Frontend;
 import org.apache.doris.thrift.TExplainLevel;
-import org.apache.doris.thrift.TExpr;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TPlanNode;
 import org.apache.doris.thrift.TPlanNodeType;
@@ -155,11 +155,7 @@ public class SchemaScanNode extends ScanNode {
 
         TUserIdentity tCurrentUser = ConnectContext.get().getCurrentUserIdentity().toThrift();
         msg.schema_scan_node.setCurrentUserIdent(tCurrentUser);
-        List<TExpr> tExprs = Lists.newArrayListWithCapacity(frontendConjuncts.size());
-        for (Expr expr : frontendConjuncts) {
-            tExprs.add(expr.treeToThrift());
-        }
-        msg.schema_scan_node.setFrontendConjuncts(tExprs);
+        msg.schema_scan_node.setFrontendConjuncts(GsonUtils.GSON.toJson(frontendConjuncts));
         setFeAddrList(msg);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
@@ -631,6 +631,9 @@ public class MetadataGenerator {
         if (params.isSetFrontendConjuncts()) {
             conjuncts = FrontendConjunctsUtils.convertToExpression(params.getFrontendConjuncts());
         }
+        List<Expression> viewSchemaConjuncts = FrontendConjunctsUtils.filterBySlotName(conjuncts, "VIEW_SCHEMA");
+        List<Expression> viewTypeConjuncts = FrontendConjunctsUtils.filterBySlotName(conjuncts, "VIEW_TYPE");
+        List<Expression> viewNameConjuncts = FrontendConjunctsUtils.filterBySlotName(conjuncts, "VIEW_NAME");
         Collection<DatabaseIf<? extends TableIf>> allDbs = Env.getCurrentEnv().getInternalCatalog().getAllDbs();
         TFetchSchemaTableDataResult result = new TFetchSchemaTableDataResult();
         List<TRow> dataBatch = Lists.newArrayList();
@@ -638,17 +641,17 @@ public class MetadataGenerator {
         ctx.setEnv(Env.getCurrentEnv());
         for (DatabaseIf<? extends TableIf> db : allDbs) {
             String dbName = db.getFullName();
-            if (FrontendConjunctsUtils.isFiltered(conjuncts, "VIEW_SCHEMA", dbName)) {
+            if (FrontendConjunctsUtils.isFiltered(viewSchemaConjuncts, "VIEW_SCHEMA", dbName)) {
                 continue;
             }
             List<? extends TableIf> tables = db.getTables();
             for (TableIf table : tables) {
-                if (FrontendConjunctsUtils.isFiltered(conjuncts, "VIEW_TYPE", table.getType().name())) {
+                if (FrontendConjunctsUtils.isFiltered(viewTypeConjuncts, "VIEW_TYPE", table.getType().name())) {
                     continue;
                 }
                 if (table instanceof MTMV) {
                     String tableName = table.getName();
-                    if (FrontendConjunctsUtils.isFiltered(conjuncts, "VIEW_NAME", tableName)) {
+                    if (FrontendConjunctsUtils.isFiltered(viewNameConjuncts, "VIEW_NAME", tableName)) {
                         continue;
                     }
                     MTMVRelation relation = ((MTMV) table).getRelation();
@@ -667,7 +670,7 @@ public class MetadataGenerator {
                     }
                 } else if (table instanceof View) {
                     String tableName = table.getName();
-                    if (FrontendConjunctsUtils.isFiltered(conjuncts, "VIEW_NAME", tableName)) {
+                    if (FrontendConjunctsUtils.isFiltered(viewNameConjuncts, "VIEW_NAME", tableName)) {
                         continue;
                     }
                     String inlineViewDef = ((View) table).getInlineViewDef();

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
@@ -73,6 +73,7 @@ import org.apache.doris.mtmv.MTMVPartitionUtil;
 import org.apache.doris.mtmv.MTMVRelation;
 import org.apache.doris.mtmv.MTMVStatus;
 import org.apache.doris.mysql.privilege.PrivPredicate;
+import org.apache.doris.nereids.util.FrontendConjunctsUtils;
 import org.apache.doris.nereids.util.PlanUtils;
 import org.apache.doris.plsql.metastore.PlsqlManager;
 import org.apache.doris.plsql.metastore.PlsqlProcedureKey;
@@ -622,7 +623,7 @@ public class MetadataGenerator {
 
     private static TFetchSchemaTableDataResult viewDependencyMetadataResult(TSchemaTableRequestParams params) {
         if (params.isSetFrontendConjuncts()) {
-            System.out.println(params.getFrontendConjuncts());
+            System.out.println(FrontendConjunctsUtils.convertToExpression(params.getFrontendConjuncts()));
         }
         if (!params.isSetCurrentUserIdent()) {
             return errorResult("current user ident is not set.");

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
@@ -621,6 +621,9 @@ public class MetadataGenerator {
     }
 
     private static TFetchSchemaTableDataResult viewDependencyMetadataResult(TSchemaTableRequestParams params) {
+        if (params.isSetFrontendConjuncts()) {
+            System.out.println(params.getFrontendConjuncts());
+        }
         if (!params.isSetCurrentUserIdent()) {
             return errorResult("current user ident is not set.");
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/FrontendConjunctsUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/FrontendConjunctsUtilsTest.java
@@ -1,0 +1,198 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.util;
+
+import org.apache.doris.nereids.analyzer.UnboundSlot;
+import org.apache.doris.nereids.trees.expressions.EqualTo;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.GreaterThan;
+import org.apache.doris.nereids.trees.expressions.GreaterThanEqual;
+import org.apache.doris.nereids.trees.expressions.InPredicate;
+import org.apache.doris.nereids.trees.expressions.LessThan;
+import org.apache.doris.nereids.trees.expressions.LessThanEqual;
+import org.apache.doris.nereids.trees.expressions.Like;
+import org.apache.doris.nereids.trees.expressions.Not;
+import org.apache.doris.nereids.trees.expressions.Or;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FrontendConjunctsUtilsTest {
+    @Test
+    public void testEqString() {
+        EqualTo equalTo = generateEqualTo("c1", "v1");
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(equalTo), "c1", "v1"));
+        // Return true only when the columnName matches but the value differs.
+        Assertions.assertTrue(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(equalTo), "c1", "v2"));
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(equalTo), "c2", "v2"));
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(equalTo), "c2", "v1"));
+    }
+
+    @Test
+    public void testEqDigit() {
+        EqualTo equalTo = generateEqualTo("c1", 2L);
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(equalTo), "c1", 2));
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(equalTo), "c1", 2L));
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(equalTo), "c1", 2.0));
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(equalTo), "c1", 2.0d));
+        Assertions.assertTrue(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(equalTo), "c1", 3));
+    }
+
+    @Test
+    public void testOr() {
+        Or or = new Or(generateEqualTo("c1", "v1"), generateEqualTo("c2", "v2"));
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(or), "c1", "v1"));
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(or), "c2", "v2"));
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(or), "c3", "v3"));
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(or), "c1", "v2"));
+        Assertions.assertFalse(
+                FrontendConjunctsUtils.isFiltered(Lists.newArrayList(or), ImmutableMap.of("c1", "v1", "c2", "v2")));
+        Assertions.assertFalse(
+                FrontendConjunctsUtils.isFiltered(Lists.newArrayList(or), ImmutableMap.of("c1", "v1", "c2", "v3")));
+        Assertions.assertFalse(
+                FrontendConjunctsUtils.isFiltered(Lists.newArrayList(or), ImmutableMap.of("c1", "v3", "c2", "v2")));
+        Assertions.assertTrue(
+                FrontendConjunctsUtils.isFiltered(Lists.newArrayList(or), ImmutableMap.of("c1", "v3", "c2", "v3")));
+    }
+
+    @Test
+    public void testMultiConjuncts() {
+        EqualTo c1 = generateEqualTo("c1", 1);
+        EqualTo c2 = generateEqualTo("c2", 2);
+        Assertions.assertTrue(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(c1, c2), "c1", 2));
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(c1, c2), "c1", 1));
+        Assertions.assertFalse(
+                FrontendConjunctsUtils.isFiltered(Lists.newArrayList(c1, c2), ImmutableMap.of("c1", 1, "c2", 2)));
+        Assertions.assertTrue(
+                FrontendConjunctsUtils.isFiltered(Lists.newArrayList(c1, c2), ImmutableMap.of("c1", 2, "c2", 2)));
+    }
+
+    @Test
+    public void testException() {
+        EqualTo c1 = generateEqualTo("c1", 1);
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(c1), "c1", "v1"));
+    }
+
+    @Test
+    public void testIn() {
+        InPredicate in = generateIn("c1", Lists.newArrayList("v1", "v2"));
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(in), "c1", "v1"));
+        Assertions.assertTrue(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(in), "c1", "v3"));
+    }
+
+    @Test
+    public void testLike() {
+        Like like = generateLike("c1", "%value%");
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(like), "c1", "value1"));
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(like), "c1", "1value"));
+        // FoldConstant not support like, so return false
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(like), "c1", "xxx"));
+    }
+
+    @Test
+    public void testNotIn() {
+        Not notIn = generateNotIn("c1", Lists.newArrayList("v1", "v2"));
+        Assertions.assertTrue(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(notIn), "c1", "v1"));
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(notIn), "c1", "v3"));
+    }
+
+    @Test
+    public void testLessThan() {
+        LessThan lessThan = generateLessThan("c1", 2L);
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(lessThan), "c1", 1L));
+        Assertions.assertTrue(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(lessThan), "c1", 2L));
+    }
+
+    @Test
+    public void testLessThanEqual() {
+        LessThanEqual lessThanEqual = generateLessThanEqual("c1", 2L);
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(lessThanEqual), "c1", 1L));
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(lessThanEqual), "c1", 2L));
+        Assertions.assertTrue(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(lessThanEqual), "c1", 3L));
+    }
+
+    @Test
+    public void testGreaterThan() {
+        GreaterThan greaterThan = generateGreaterThan("c1", 2L);
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(greaterThan), "c1", 3L));
+        Assertions.assertTrue(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(greaterThan), "c1", 2L));
+    }
+
+    @Test
+    public void testGreaterThanEqual() {
+        GreaterThanEqual greaterThanEqual = generateGreaterThanEqual("c1", 2L);
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(greaterThanEqual), "c1", 3L));
+        Assertions.assertFalse(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(greaterThanEqual), "c1", 2L));
+        Assertions.assertTrue(FrontendConjunctsUtils.isFiltered(Lists.newArrayList(greaterThanEqual), "c1", 1L));
+    }
+
+    private EqualTo generateEqualTo(String columnName, Object value) {
+        UnboundSlot c1 = new UnboundSlot(columnName);
+        Literal v1 = Literal.of(value);
+        return new EqualTo(c1, v1);
+    }
+
+    private InPredicate generateIn(String columnName, List<Object> values) {
+        UnboundSlot c1 = new UnboundSlot(columnName);
+        List<Expression> literals = values.stream().map(Literal::of).collect(Collectors.toList());
+        return new InPredicate(c1, literals);
+    }
+
+    private Not generateNotIn(String columnName, List<Object> values) {
+        UnboundSlot c1 = new UnboundSlot(columnName);
+        List<Expression> literals = values.stream().map(Literal::of).collect(Collectors.toList());
+        InPredicate inPredicate = new InPredicate(c1, literals);
+        return new Not(inPredicate);
+    }
+
+    private Like generateLike(String columnName, Object value) {
+        UnboundSlot c1 = new UnboundSlot(columnName);
+        Literal v1 = Literal.of(value);
+        return new Like(c1, v1);
+    }
+
+    private LessThan generateLessThan(String columnName, Object value) {
+        UnboundSlot c1 = new UnboundSlot(columnName);
+        Literal v1 = Literal.of(value);
+        return new LessThan(c1, v1);
+    }
+
+    private LessThanEqual generateLessThanEqual(String columnName, Object value) {
+        UnboundSlot c1 = new UnboundSlot(columnName);
+        Literal v1 = Literal.of(value);
+        return new LessThanEqual(c1, v1);
+    }
+
+    private GreaterThan generateGreaterThan(String columnName, Object value) {
+        UnboundSlot c1 = new UnboundSlot(columnName);
+        Literal v1 = Literal.of(value);
+        return new GreaterThan(c1, v1);
+    }
+
+    private GreaterThanEqual generateGreaterThanEqual(String columnName, Object value) {
+        UnboundSlot c1 = new UnboundSlot(columnName);
+        Literal v1 = Literal.of(value);
+        return new GreaterThanEqual(c1, v1);
+    }
+}

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -850,6 +850,7 @@ struct TSchemaTableRequestParams {
     4: optional string catalog  // use for table specific queries
     5: optional i64 dbId         // used for table specific queries
     6: optional string time_zone // used for DATETIME field
+    7: optional list<Exprs.TExpr> frontend_conjuncts
 }
 
 struct TFetchSchemaTableDataRequest {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -850,7 +850,7 @@ struct TSchemaTableRequestParams {
     4: optional string catalog  // use for table specific queries
     5: optional i64 dbId         // used for table specific queries
     6: optional string time_zone // used for DATETIME field
-    7: optional list<Exprs.TExpr> frontend_conjuncts
+    7: optional string frontend_conjuncts
 }
 
 struct TFetchSchemaTableDataRequest {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -758,7 +758,7 @@ struct TSchemaScanNode {
   // 13: optional list<TSchemaTableStructure> table_structure // deprecated
   14: optional string catalog
   15: optional list<Types.TNetworkAddress> fe_addr_list
-  16: optional list<Exprs.TExpr> frontend_conjuncts
+  16: optional string frontend_conjuncts
 }
 
 struct TMetaScanNode {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -758,6 +758,7 @@ struct TSchemaScanNode {
   // 13: optional list<TSchemaTableStructure> table_structure // deprecated
   14: optional string catalog
   15: optional list<Types.TNetworkAddress> fe_addr_list
+  16: optional list<Exprs.TExpr> frontend_conjuncts
 }
 
 struct TMetaScanNode {

--- a/regression-test/data/query_p0/schema_table/test_view_dependency.out
+++ b/regression-test/data/query_p0/schema_table/test_view_dependency.out
@@ -15,3 +15,34 @@ internal	test_view_dependency_db	stu_view_5	VIEW	internal	test_view_dependency_d
 internal	test_view_dependency_db	stu_view_5	VIEW	internal	test_view_dependency_db	mv_b	MATERIALIZED_VIEW
 internal	test_view_dependency_db	stu_view_cte	VIEW	internal	test_view_dependency_db	stu	OLAP
 
+-- !filter_1 --
+internal	test_view_dependency_db	mv_c	MATERIALIZED_VIEW	internal	test_view_dependency_db	grade	OLAP
+internal	test_view_dependency_db	mv_c	MATERIALIZED_VIEW	internal	test_view_dependency_db	stu	OLAP
+
+-- !filter_2 --
+internal	test_view_dependency_db	mv_a	MATERIALIZED_VIEW	internal	test_view_dependency_db	stu	OLAP
+internal	test_view_dependency_db	mv_b	MATERIALIZED_VIEW	internal	test_view_dependency_db	mv_a	MATERIALIZED_VIEW
+internal	test_view_dependency_db	mv_c	MATERIALIZED_VIEW	internal	test_view_dependency_db	grade	OLAP
+internal	test_view_dependency_db	mv_c	MATERIALIZED_VIEW	internal	test_view_dependency_db	stu	OLAP
+
+-- !filter_3 --
+internal	test_view_dependency_db	mv_a	MATERIALIZED_VIEW	internal	test_view_dependency_db	stu	OLAP
+internal	test_view_dependency_db	mv_c	MATERIALIZED_VIEW	internal	test_view_dependency_db	grade	OLAP
+internal	test_view_dependency_db	mv_c	MATERIALIZED_VIEW	internal	test_view_dependency_db	stu	OLAP
+
+-- !filter_4 --
+internal	test_view_dependency_db	mv_a	MATERIALIZED_VIEW	internal	test_view_dependency_db	stu	OLAP
+internal	test_view_dependency_db	mv_b	MATERIALIZED_VIEW	internal	test_view_dependency_db	mv_a	MATERIALIZED_VIEW
+internal	test_view_dependency_db	mv_c	MATERIALIZED_VIEW	internal	test_view_dependency_db	grade	OLAP
+internal	test_view_dependency_db	mv_c	MATERIALIZED_VIEW	internal	test_view_dependency_db	stu	OLAP
+
+-- !filter_5 --
+internal	test_view_dependency_db	mv_b	MATERIALIZED_VIEW	internal	test_view_dependency_db	mv_a	MATERIALIZED_VIEW
+
+-- !filter_6 --
+internal	test_view_dependency_db	mv_a	MATERIALIZED_VIEW	internal	test_view_dependency_db	stu	OLAP
+internal	test_view_dependency_db	mv_b	MATERIALIZED_VIEW	internal	test_view_dependency_db	mv_a	MATERIALIZED_VIEW
+internal	test_view_dependency_db	mv_c	MATERIALIZED_VIEW	internal	test_view_dependency_db	grade	OLAP
+internal	test_view_dependency_db	mv_c	MATERIALIZED_VIEW	internal	test_view_dependency_db	stu	OLAP
+internal	test_view_dependency_db	stu_view_1	VIEW	internal	test_view_dependency_db	stu_view	VIEW
+

--- a/regression-test/suites/query_p0/schema_table/test_view_dependency.groovy
+++ b/regression-test/suites/query_p0/schema_table/test_view_dependency.groovy
@@ -98,6 +98,13 @@ suite("test_view_dependency") {
 
     qt_sql "select * from information_schema.view_dependency where view_schema = 'test_view_dependency_db' order by view_catalog,view_schema,view_name"
 
+    order_qt_filter_1 "select * from information_schema.view_dependency where view_schema = 'test_view_dependency_db' and VIEW_NAME = 'mv_c'"
+    order_qt_filter_2 "select * from information_schema.view_dependency where view_schema = 'test_view_dependency_db' and VIEW_NAME like 'mv_%'"
+    order_qt_filter_3 "select * from information_schema.view_dependency where view_schema = 'test_view_dependency_db' and VIEW_NAME in('mv_c','mv_a')"
+    order_qt_filter_4 "select * from information_schema.view_dependency where view_schema = 'test_view_dependency_db' and VIEW_TYPE = 'MATERIALIZED_VIEW'"
+    order_qt_filter_5 "select * from information_schema.view_dependency where view_schema = 'test_view_dependency_db' and VIEW_TYPE = 'MATERIALIZED_VIEW' and VIEW_NAME not in('mv_c','mv_a')"
+    order_qt_filter_6 "select * from information_schema.view_dependency where view_schema = 'test_view_dependency_db' and VIEW_TYPE = 'MATERIALIZED_VIEW' or VIEW_NAME = 'stu_view_1'"
+
     // support eq
     def explain = sql """explain select * from information_schema.view_dependency where view_schema = 'test_view_dependency_db'"""
     assertTrue(explain.toString().contains("FRONTEND PREDICATES"))

--- a/regression-test/suites/query_p0/schema_table/test_view_dependency.groovy
+++ b/regression-test/suites/query_p0/schema_table/test_view_dependency.groovy
@@ -97,5 +97,33 @@ suite("test_view_dependency") {
     sql "create view stu_view_5 as select * from (select sid from mv_b) a join grade using(sid);"
 
     qt_sql "select * from information_schema.view_dependency where view_schema = 'test_view_dependency_db' order by view_catalog,view_schema,view_name"
+
+    // support eq
+    def explain = sql """explain select * from information_schema.view_dependency where view_schema = 'test_view_dependency_db'"""
+    assertTrue(explain.toString().contains("FRONTEND PREDICATES"))
+    // support in
+    explain = sql """explain select * from information_schema.view_dependency where view_schema in ('test_view_dependency_db','test_view_dependency_db1')"""
+    assertTrue(explain.toString().contains("FRONTEND PREDICATES"))
+    // support not in
+    explain = sql """explain select * from information_schema.view_dependency where view_schema not in ('test_view_dependency_db','test_view_dependency_db1')"""
+    assertTrue(explain.toString().contains("FRONTEND PREDICATES"))
+    // support or
+    explain = sql """explain select * from information_schema.view_dependency where view_schema = 'test_view_dependency_db' or VIEW_NAME='stu_view_5'"""
+    assertTrue(explain.toString().contains("FRONTEND PREDICATES"))
+    // support >
+    explain = sql """explain select * from information_schema.view_dependency where view_schema > 'test_view_dependency_db'"""
+    assertTrue(explain.toString().contains("FRONTEND PREDICATES"))
+    // support >=
+    explain = sql """explain select * from information_schema.view_dependency where view_schema >= 'test_view_dependency_db'"""
+    assertTrue(explain.toString().contains("FRONTEND PREDICATES"))
+    // support <
+    explain = sql """explain select * from information_schema.view_dependency where view_schema < 'test_view_dependency_db'"""
+    assertTrue(explain.toString().contains("FRONTEND PREDICATES"))
+    // support <=
+    explain = sql """explain select * from information_schema.view_dependency where view_schema <= 'test_view_dependency_db'"""
+    assertTrue(explain.toString().contains("FRONTEND PREDICATES"))
+    // not support like
+    explain = sql """explain select * from information_schema.view_dependency where view_schema like '%test_view_dependency_db%'"""
+    assertFalse(explain.toString().contains("FRONTEND PREDICATES"))
 }
 

--- a/regression-test/suites/query_p0/schema_table/test_view_dependency.groovy
+++ b/regression-test/suites/query_p0/schema_table/test_view_dependency.groovy
@@ -132,5 +132,8 @@ suite("test_view_dependency") {
     // not support like
     explain = sql """explain select * from information_schema.view_dependency where view_schema like '%test_view_dependency_db%'"""
     assertFalse(explain.toString().contains("FRONTEND PREDICATES"))
+    // support catalog.db.table.column
+    explain = sql """explain select * from information_schema.view_dependency where internal.information_schema.view_dependency.view_schema = 'test_view_dependency_db';"""
+    assertTrue(explain.toString().contains("FRONTEND PREDICATES"))
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

The current implementation of system tables involves the BE (Backend) requesting data from the FE (Frontend). The FE sends all the data to the BE, and then the BE filters the data based on the conditions.

This approach leads to slow queries and wastes computational resources.

This PR enables pre-filtering of data on the FE side.

The implementation involves serializing the filter conditions that the FE can process using Gson and passing them to the BE. The BE then returns these conditions unchanged to the FE, where they are deserialized and used to filter the data.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

When querying system tables, it supports pre-filtering data in the FE (Frontend).

### Release note

When querying system tables, it supports pre-filtering data in the FE (Frontend).

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

