### PR TITLE
[fix](config) dynamic set FE masterOnly config will lost after change MASTER

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminSetFrontendConfigCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminSetFrontendConfigCommand.java
@@ -59,11 +59,13 @@ public class AdminSetFrontendConfigCommand extends Command implements ForwardWit
         }
         this.applyToAll = applyToAll;
 
-        // we have to analyze configs here to determine whether to forward it to master
-        for (String key : this.configs.keySet()) {
-            if (ConfigBase.checkIsMasterOnly(key)) {
-                redirectStatus = RedirectStatus.FORWARD_NO_SYNC;
-                this.applyToAll = false;
+        if (!this.applyToAll) {
+            // we have to analyze configs here to determine whether to forward it to master
+            for (String key : this.configs.keySet()) {
+                if (ConfigBase.checkIsMasterOnly(key)) {
+                    redirectStatus = RedirectStatus.FORWARD_NO_SYNC;
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
### What problem does this PR solve?

**Problem:**
After `SET ALL FRONTENDS CONFIG` for masterOnly  config, and then stop MASTER FE, new MASTER will lost the change.

Reproduce Steps:
1、try to set masterOnly  config for all FEs, but it will only forward to FE MASTER, will not change config on other FEs.
```ADMIN SET ALL FRONTENDS CONFIG ("disable_balance" = "true");```

2、stop MASTER FE, then a follower FE will become the new MASTER, the new MASTER will lost the SET in step1.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

