### PR TITLE
[feature](nereids) support explain command return empty string to test planner performance

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -741,6 +741,9 @@ public class NereidsPlanner extends Planner {
 
     @Override
     public String getExplainString(ExplainOptions explainOptions) {
+        if (getConnectContext().getSessionVariable().enableExplainNone) {
+            return "";
+        }
         ExplainLevel explainLevel = getExplainLevel(explainOptions);
         String plan = "";
         String mvSummary = "";
@@ -897,7 +900,7 @@ public class NereidsPlanner extends Planner {
     }
 
     public ConnectContext getConnectContext() {
-        return cascadesContext.getConnectContext();
+        return cascadesContext == null ? ConnectContext.get() : cascadesContext.getConnectContext();
     }
 
     public StatementContext getStatementContext() {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/Planner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/Planner.java
@@ -24,6 +24,7 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.common.profile.PlanTreeBuilder;
 import org.apache.doris.common.profile.PlanTreePrinter;
 import org.apache.doris.nereids.trees.plans.physical.TopnFilter;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ResultSet;
 import org.apache.doris.thrift.TQueryOptions;
 
@@ -53,6 +54,10 @@ public abstract class Planner {
 
     public String getExplainString(ExplainOptions explainOptions) {
         Preconditions.checkNotNull(explainOptions);
+        ConnectContext connectContext = ConnectContext.get();
+        if (connectContext != null && connectContext.getSessionVariable().enableExplainNone) {
+            return "";
+        }
         if (explainOptions.isGraph()) {
             // print the plan graph
             PlanTreeBuilder builder = new PlanTreeBuilder(fragments);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -2436,6 +2436,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String IGNORE_SHAPE_NODE = "ignore_shape_nodes";
 
+    public static final String ENABLE_EXPLAIN_NONE = "enable_explain_none";
+
     public static final String DETAIL_SHAPE_NODES = "detail_shape_nodes";
 
     public static final String ENABLE_SEGMENT_CACHE = "enable_segment_cache";
@@ -2457,6 +2459,12 @@ public class SessionVariable implements Serializable, Writable {
             description = {"'explain shape plan' 命令中显示详细信息的PlanNode 类型",
                     "the plan node type show detail in 'explain shape plan' command"})
     public String detailShapePlanNodes = "";
+
+    @VariableMgr.VarAttr(name = ENABLE_EXPLAIN_NONE, needForward = true, description = {
+            "执行explain命令，但不打印explain结果",
+            "execute explain command and return nothing"
+    })
+    public boolean enableExplainNone = false;
 
     private Set<String> detailShapePlanNodesSet = ImmutableSet.of();
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/ExplainInsertCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/ExplainInsertCommandTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.trees.plans;
 
+import org.apache.doris.analysis.ExplainOptions;
 import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.exceptions.AnalysisException;
@@ -26,10 +27,12 @@ import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.trees.plans.commands.ExplainCommand;
+import org.apache.doris.nereids.trees.plans.commands.ExplainCommand.ExplainLevel;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.util.MemoTestUtils;
 import org.apache.doris.planner.PlanFragment;
+import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.utframe.TestWithFeService;
 
 import org.junit.jupiter.api.Assertions;
@@ -132,6 +135,22 @@ public class ExplainInsertCommandTest extends TestWithFeService {
         Assertions.assertEquals(8, getOutputFragment(sql).getOutputExprs().size());
         sql = "explain insert into agg_have_dup_base select -4, k2, -4, 'd' from agg_have_dup_base";
         Assertions.assertEquals(8, getOutputFragment(sql).getOutputExprs().size());
+    }
+
+    @Test
+    public void explainNone() throws Exception {
+        String sql = "explain insert into agg_have_dup_base select -4, -4, -4, 'd'";
+        connectContext.getSessionVariable().enableExplainNone = false;
+        StmtExecutor sqlStmtExecutor = getSqlStmtExecutor(sql);
+        String explainString = sqlStmtExecutor.planner()
+                .getExplainString(new ExplainOptions(ExplainLevel.VERBOSE, false));
+        Assertions.assertNotEquals("", explainString);
+
+        connectContext.getSessionVariable().enableExplainNone = true;
+        sqlStmtExecutor = getSqlStmtExecutor(sql);
+        explainString = sqlStmtExecutor.planner()
+                .getExplainString(new ExplainOptions(ExplainLevel.VERBOSE, false));
+        Assertions.assertEquals("", explainString);
     }
 
     private PlanFragment getOutputFragment(String sql) throws Exception {


### PR DESCRIPTION
### What problem does this PR solve?

support explain command return empty string to test planner performance
```sql
MySQL root@127.0.0.1:test> set enable_explain_none=true;
Query OK, 0 rows affected
Time: 0.010s
MySQL root@127.0.0.1:test> explain insert into t1 values(1, 'a'), (2, 'b');
+---------------------------------+
| Explain String(Nereids Planner) |
+---------------------------------+
|                                 |
+---------------------------------+
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

