### PR TITLE
[fix](constant propagation)  don't rewrite mark join condition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CheckDataTypes.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CheckDataTypes.java
@@ -70,10 +70,6 @@ public class CheckDataTypes implements CustomRewriter {
             conjuncts = plan.getMarkJoinConjuncts();
         }
         for (Expression expr : conjuncts) {
-            // constant propagation may rewrite mark join conjuncts to literal,
-            if (expr.isLiteral()) {
-                continue;
-            }
             DataType leftType = expr.child(0).getDataType();
             DataType rightType = expr.child(1).getDataType();
             if (!leftType.acceptsType(rightType)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ConstantPropagation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ConstantPropagation.java
@@ -230,6 +230,8 @@ public class ConstantPropagation extends DefaultPlanRewriter<ExpressionRewriteCo
         // Then after rewrite the combine conjuncts, we need split the rewritten expression into hash/other/mark
         // join conjuncts. But we can not extract the mark join conjuncts from the rewritten expression.
         // So we only combine the hash conjuncts and other conjuncts.
+        // update: BE not support nested loop mark join, so mark join condition need to be an equation,
+        // but constant propagation may rewrite an equal to TRUE/FALSE/NULL, so we don't rewrite mark join condition.
         join = visitChildren(this, join, context);
 
         List<Expression> newHashJoinConjuncts = join.getHashJoinConjuncts();
@@ -266,23 +268,8 @@ public class ConstantPropagation extends DefaultPlanRewriter<ExpressionRewriteCo
             }
         }
 
-        List<Expression> newMarkJoinConjuncts = join.getMarkJoinConjuncts();
-        if (!join.getMarkJoinConjuncts().isEmpty()) {
-            // TODO: we may extract more constant relations from hash conjuncts,
-            //       then we may make mark join conjuncts more simplify.
-            // mark join conjuncts may rewrite to hash join conjuncts and join convert to null aware anti join.
-            // we don't replaced NULL with FALSE in mark join conjuncts, so let useInnerInfer = false.
-            Expression oldMarkPredicate = ExpressionUtils.and(join.getMarkJoinConjuncts());
-            Expression newMarkPredicate = replaceConstantsAndRewriteExpr(join, oldMarkPredicate, false, context);
-            newMarkJoinConjuncts = ExpressionUtils.extractConjunction(newMarkPredicate);
-            if (Sets.newHashSet(newMarkJoinConjuncts).equals(Sets.newHashSet(join.getMarkJoinConjuncts()))) {
-                newMarkJoinConjuncts = join.getMarkJoinConjuncts();
-            }
-        }
-
         if (newHashJoinConjuncts.equals(join.getHashJoinConjuncts())
-                && newOtherJoinConjuncts.equals(join.getOtherJoinConjuncts())
-                && newMarkJoinConjuncts.equals(join.getMarkJoinConjuncts())) {
+                && newOtherJoinConjuncts.equals(join.getOtherJoinConjuncts())) {
             return join;
         }
 
@@ -294,7 +281,7 @@ public class ConstantPropagation extends DefaultPlanRewriter<ExpressionRewriteCo
         return new LogicalJoin<>(joinType,
                 newHashJoinConjuncts,
                 newOtherJoinConjuncts,
-                newMarkJoinConjuncts,
+                join.getMarkJoinConjuncts(),
                 join.getDistributeHint(),
                 join.getMarkJoinSlotReference(),
                 join.children(), join.getJoinReorderContext());

--- a/regression-test/data/nereids_rules_p0/constant_propagation/constant_propagation.out
+++ b/regression-test/data/nereids_rules_p0/constant_propagation/constant_propagation.out
@@ -227,6 +227,112 @@ PhysicalResultSink
 -- !join_11_result --
 10
 
+-- !join_12_shape --
+PhysicalResultSink
+--PhysicalProject[$c$1 AS `1  in (select null from t2)`]
+----hashJoin[LEFT_SEMI_JOIN] hashCondition=() otherCondition=() markCondition=((cast(null as TINYINT) = 1))
+------PhysicalProject[1 AS `1`]
+--------PhysicalStorageLayerAggregate[t1]
+------PhysicalProject[NULL AS `null`]
+--------PhysicalStorageLayerAggregate[t2]
+
+-- !join_12_result --
+\N
+\N
+
+-- !join_13_shape --
+PhysicalResultSink
+--PhysicalProject[$c$1 AS `1 not in (select null from t2)`]
+----hashJoin[LEFT_ANTI_JOIN] hashCondition=() otherCondition=() markCondition=((cast(null as TINYINT) = 1))
+------PhysicalProject[1 AS `1`]
+--------PhysicalStorageLayerAggregate[t1]
+------PhysicalProject[NULL AS `null`]
+--------PhysicalStorageLayerAggregate[t2]
+
+-- !join_13_result --
+\N
+\N
+
+-- !join_14_shape --
+PhysicalResultSink
+--PhysicalProject[$c$1 AS `null  in (select c1 from s2)`]
+----hashJoin[LEFT_SEMI_JOIN] hashCondition=() otherCondition=() markCondition=((NULL = s2.c1))
+------PhysicalProject[1 AS `1`]
+--------PhysicalStorageLayerAggregate[s1]
+------PhysicalProject[s2.c1]
+--------PhysicalOlapScan[s2]
+
+-- !join_14_result --
+\N
+\N
+\N
+\N
+\N
+\N
+\N
+\N
+\N
+
+-- !join_15_shape --
+PhysicalResultSink
+--PhysicalProject[$c$1 AS `null  in (select 1 from s2)`]
+----hashJoin[LEFT_SEMI_JOIN] hashCondition=() otherCondition=() markCondition=((NULL = 1))
+------PhysicalProject[1 AS `1`]
+--------PhysicalStorageLayerAggregate[s1]
+------PhysicalProject[1 AS `1`]
+--------PhysicalStorageLayerAggregate[s2]
+
+-- !join_15_result --
+\N
+\N
+\N
+\N
+\N
+\N
+\N
+\N
+\N
+
+-- !join_16_shape --
+PhysicalResultSink
+--PhysicalProject[$c$1 AS `1  in (select null from s2)`]
+----hashJoin[LEFT_SEMI_JOIN] hashCondition=() otherCondition=() markCondition=((cast(null as TINYINT) = 1))
+------PhysicalProject[1 AS `1`]
+--------PhysicalStorageLayerAggregate[s1]
+------PhysicalProject[NULL AS `null`]
+--------PhysicalStorageLayerAggregate[s2]
+
+-- !join_16_result --
+\N
+\N
+\N
+\N
+\N
+\N
+\N
+\N
+\N
+
+-- !join_17_shape --
+PhysicalResultSink
+--PhysicalProject[$c$1 AS `1 not in (select null from s2)`]
+----hashJoin[LEFT_ANTI_JOIN] hashCondition=() otherCondition=() markCondition=((cast(null as TINYINT) = 1))
+------PhysicalProject[1 AS `1`]
+--------PhysicalStorageLayerAggregate[s1]
+------PhysicalProject[NULL AS `null`]
+--------PhysicalStorageLayerAggregate[s2]
+
+-- !join_17_result --
+\N
+\N
+\N
+\N
+\N
+\N
+\N
+\N
+\N
+
 -- !subquery_1_shape --
 PhysicalResultSink
 --PhysicalEmptyRelation

--- a/regression-test/suites/nereids_rules_p0/constant_propagation/constant_propagation.groovy
+++ b/regression-test/suites/nereids_rules_p0/constant_propagation/constant_propagation.groovy
@@ -224,39 +224,31 @@ suite('constant_propagation') {
         from t1 where t1.a not in (select t3.a from t3 where t3.b = 10);
     '''
 
-    /* // BUG start
-    // BUG: the result should  '[[null], [null]]', but be return '[[true], [true]]'
     explain_and_result  'join_12', '''
          select 1  in (select null from t2)
          from t1;
     '''
 
-    // BUG: the result should  '[[null], [null]]', but be return '[[false], [false]]'
     explain_and_result  'join_13', '''
         select 1 not in (select null from t2)
         from t1;
     '''
 
-    // OK
     explain_and_result 'join_14', '''
         select null  in (select c1 from s2) from s1
     '''
 
-    // BUG: the result expect multi rows with null, but be return multi rows with true
     explain_and_result 'join_15', '''
         select null  in (select 1 from s2) from s1
     '''
 
-    // BUG: the result expect multi rows with null, but be return multi rows with true
     explain_and_result 'join_16', '''
         select 1  in (select null from s2) from s1
     '''
 
-    // BUG: the result expect multi rows with null, but be return multi rows with false
     explain_and_result 'join_17', '''
         select 1 not in (select null from s2) from s1
     '''
-    */ // BUG end
 
     explain_and_result 'subquery_1', '''
        select a, x


### PR DESCRIPTION
### What problem does this PR solve?

BE not support nested loop mark join,  so the mark join condition need to be an equation,  but constant propagation may rewrite an equation to TRUE/FALSE/NULL,

so constant propagation don't rewrite the mark join condition.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

