### PR TITLE
[refine](Agg)Reduce the binary size by providing more information to agg

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function.h
+++ b/be/src/vec/aggregate_functions/aggregate_function.h
@@ -48,6 +48,7 @@ class IDataType;
 struct AggregateFunctionAttr {
     bool enable_decimal256 {false};
     bool is_window_function {false};
+    bool is_foreach {false};
     std::vector<std::string> column_names;
 };
 

--- a/be/src/vec/aggregate_functions/aggregate_function.h
+++ b/be/src/vec/aggregate_functions/aggregate_function.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <type_traits>
 #include <utility>
 
 #include "common/exception.h"
@@ -663,6 +664,15 @@ private:
     const IAggregateFunction* _function;
     std::unique_ptr<AggregateData[]> _data;
 };
+
+//Hint information of AggregateFunction signature
+
+struct NullableAggregateFunction {};    // Function's return value can be nullable
+struct NotNullableAggregateFunction {}; // Function's return value cannot be nullable
+
+struct UnaryExpression {};   // Can only have one parameter
+struct MultiExpression {};   // Must have multiple parameters (more than 1)
+struct VarargsExpression {}; // Uncertain number of parameters
 
 } // namespace doris::vectorized
 

--- a/be/src/vec/aggregate_functions/aggregate_function_approx_count_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_approx_count_distinct.h
@@ -81,7 +81,9 @@ struct AggregateFunctionApproxCountDistinctData {
 template <PrimitiveType type>
 class AggregateFunctionApproxCountDistinct final
         : public IAggregateFunctionDataHelper<AggregateFunctionApproxCountDistinctData,
-                                              AggregateFunctionApproxCountDistinct<type>> {
+                                              AggregateFunctionApproxCountDistinct<type>>,
+          UnaryExpression,
+          NotNullableAggregateFunction {
 public:
     using ColumnDataType = typename PrimitiveTypeTraits<type>::ColumnType;
     String get_name() const override { return "approx_count_distinct"; }

--- a/be/src/vec/aggregate_functions/aggregate_function_approx_top_k.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_approx_top_k.h
@@ -53,7 +53,9 @@ struct AggregateFunctionTopKGenericData {
 class AggregateFunctionApproxTopK final
         : public IAggregateFunctionDataHelper<AggregateFunctionTopKGenericData,
                                               AggregateFunctionApproxTopK>,
-          AggregateFunctionApproxTop {
+          AggregateFunctionApproxTop,
+          VarargsExpression,
+          NullableAggregateFunction {
 private:
     using State = AggregateFunctionTopKGenericData;
 

--- a/be/src/vec/aggregate_functions/aggregate_function_approx_top_sum.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_approx_top_sum.h
@@ -52,7 +52,9 @@ template <PrimitiveType T, typename TResult, typename Data>
 class AggregateFunctionApproxTopSum final
         : public IAggregateFunctionDataHelper<Data,
                                               AggregateFunctionApproxTopSum<T, TResult, Data>>,
-          AggregateFunctionApproxTop {
+          AggregateFunctionApproxTop,
+          VarargsExpression,
+          NullableAggregateFunction {
 private:
     using State = AggregateFunctionTopKGenericData;
 

--- a/be/src/vec/aggregate_functions/aggregate_function_array_agg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_array_agg.h
@@ -296,7 +296,9 @@ struct AggregateFunctionArrayAggData<T> {
 //todo: Supports order by sorting for array_agg
 template <typename Data>
 class AggregateFunctionArrayAgg
-        : public IAggregateFunctionDataHelper<Data, AggregateFunctionArrayAgg<Data>, true> {
+        : public IAggregateFunctionDataHelper<Data, AggregateFunctionArrayAgg<Data>, true>,
+          UnaryExpression,
+          NotNullableAggregateFunction {
 public:
     AggregateFunctionArrayAgg(const DataTypes& argument_types_)
             : IAggregateFunctionDataHelper<Data, AggregateFunctionArrayAgg<Data>, true>(

--- a/be/src/vec/aggregate_functions/aggregate_function_avg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_avg.h
@@ -108,7 +108,9 @@ struct AggregateFunctionAvgData {
 /// Calculates arithmetic mean of numbers.
 template <PrimitiveType T, typename Data>
 class AggregateFunctionAvg final
-        : public IAggregateFunctionDataHelper<Data, AggregateFunctionAvg<T, Data>> {
+        : public IAggregateFunctionDataHelper<Data, AggregateFunctionAvg<T, Data>>,
+          UnaryExpression,
+          NullableAggregateFunction {
 public:
     using ResultType = std::conditional_t<
             T == TYPE_DECIMALV2, Decimal128V2,

--- a/be/src/vec/aggregate_functions/aggregate_function_avg_weighted.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_avg_weighted.h
@@ -87,7 +87,9 @@ struct AggregateFunctionAvgWeightedData {
 template <PrimitiveType type>
 class AggregateFunctionAvgWeight final
         : public IAggregateFunctionDataHelper<AggregateFunctionAvgWeightedData<type>,
-                                              AggregateFunctionAvgWeight<type>> {
+                                              AggregateFunctionAvgWeight<type>>,
+          MultiExpression,
+          NullableAggregateFunction {
 public:
     using T = typename PrimitiveTypeTraits<type>::CppType;
     using ColVecType = typename PrimitiveTypeTraits<type>::ColumnType;

--- a/be/src/vec/aggregate_functions/aggregate_function_binary.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_binary.h
@@ -44,7 +44,9 @@ struct StatFunc {
 template <typename StatFunc>
 struct AggregateFunctionBinary
         : public IAggregateFunctionDataHelper<typename StatFunc::Data,
-                                              AggregateFunctionBinary<StatFunc>> {
+                                              AggregateFunctionBinary<StatFunc>>,
+          MultiExpression,
+          NullableAggregateFunction {
     static constexpr PrimitiveType ResultType = StatFunc::ResultPrimitiveType;
 
     using ColVecT1 = typename StatFunc::ColVecT1;

--- a/be/src/vec/aggregate_functions/aggregate_function_bit.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bit.h
@@ -107,7 +107,9 @@ struct AggregateFunctionGroupBitXorData : public AggregateFunctionBaseData<T> {
 /// Counts bitwise operation on numbers.
 template <PrimitiveType T, typename Data>
 class AggregateFunctionBitwise final
-        : public IAggregateFunctionDataHelper<Data, AggregateFunctionBitwise<T, Data>> {
+        : public IAggregateFunctionDataHelper<Data, AggregateFunctionBitwise<T, Data>>,
+          UnaryExpression,
+          NullableAggregateFunction {
 public:
     AggregateFunctionBitwise(const DataTypes& argument_types_)
             : IAggregateFunctionDataHelper<Data, AggregateFunctionBitwise<T, Data>>(

--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
@@ -253,7 +253,9 @@ protected:
 template <typename Op>
 class AggregateFunctionBitmapOp final
         : public AggregateFunctionBitmapSerializationHelper<AggregateFunctionBitmapData<Op>,
-                                                            AggregateFunctionBitmapOp<Op>> {
+                                                            AggregateFunctionBitmapOp<Op>>,
+          UnaryExpression,
+          NullableAggregateFunction {
 public:
     using ResultDataType = BitmapValue;
     using ColVecType = ColumnBitmap;
@@ -333,7 +335,9 @@ template <bool arg_is_nullable, typename ColVecType>
 class AggregateFunctionBitmapCount final
         : public AggregateFunctionBitmapSerializationHelper<
                   AggregateFunctionBitmapData<AggregateFunctionBitmapUnionOp>,
-                  AggregateFunctionBitmapCount<arg_is_nullable, ColVecType>> {
+                  AggregateFunctionBitmapCount<arg_is_nullable, ColVecType>>,
+          UnaryExpression,
+          NotNullableAggregateFunction {
 public:
     // using ColVecType = ColumnBitmap;
     using ColVecResult = ColumnInt64;

--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap_agg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap_agg.h
@@ -60,7 +60,9 @@ struct AggregateFunctionBitmapAggData {
 template <bool arg_nullable, PrimitiveType T>
 class AggregateFunctionBitmapAgg final
         : public IAggregateFunctionDataHelper<AggregateFunctionBitmapAggData<T>,
-                                              AggregateFunctionBitmapAgg<arg_nullable, T>> {
+                                              AggregateFunctionBitmapAgg<arg_nullable, T>>,
+          UnaryExpression,
+          NotNullableAggregateFunction {
 public:
     using ColVecType = typename PrimitiveTypeTraits<T>::ColumnType;
     using Data = AggregateFunctionBitmapAggData<T>;

--- a/be/src/vec/aggregate_functions/aggregate_function_collect.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_collect.h
@@ -395,8 +395,9 @@ struct AggregateFunctionCollectListData<T, HasLimit> {
 
 template <typename Data, bool HasLimit>
 class AggregateFunctionCollect
-        : public IAggregateFunctionDataHelper<Data, AggregateFunctionCollect<Data, HasLimit>,
-                                              true> {
+        : public IAggregateFunctionDataHelper<Data, AggregateFunctionCollect<Data, HasLimit>, true>,
+          VarargsExpression,
+          NotNullableAggregateFunction {
     static constexpr bool ENABLE_ARENA =
             std::is_same_v<Data, AggregateFunctionCollectSetData<TYPE_STRING, HasLimit>> ||
             std::is_same_v<Data, AggregateFunctionCollectSetData<TYPE_CHAR, HasLimit>> ||

--- a/be/src/vec/aggregate_functions/aggregate_function_count.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_count.h
@@ -50,7 +50,9 @@ struct AggregateFunctionCountData {
 
 /// Simply count number of calls.
 class AggregateFunctionCount final
-        : public IAggregateFunctionDataHelper<AggregateFunctionCountData, AggregateFunctionCount> {
+        : public IAggregateFunctionDataHelper<AggregateFunctionCountData, AggregateFunctionCount>,
+          VarargsExpression,
+          NotNullableAggregateFunction {
 public:
     AggregateFunctionCount(const DataTypes& argument_types_)
             : IAggregateFunctionDataHelper(argument_types_) {}

--- a/be/src/vec/aggregate_functions/aggregate_function_count_by_enum.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_count_by_enum.h
@@ -179,7 +179,9 @@ private:
 
 template <typename Data>
 class AggregateFunctionCountByEnum final
-        : public IAggregateFunctionDataHelper<Data, AggregateFunctionCountByEnum<Data>> {
+        : public IAggregateFunctionDataHelper<Data, AggregateFunctionCountByEnum<Data>>,
+          VarargsExpression,
+          NotNullableAggregateFunction {
 public:
     AggregateFunctionCountByEnum() = default;
     AggregateFunctionCountByEnum(const DataTypes& argument_types_)

--- a/be/src/vec/aggregate_functions/aggregate_function_covar.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_covar.h
@@ -139,7 +139,9 @@ struct SampData : BaseData<T> {
 
 template <typename Data>
 class AggregateFunctionSampCovariance
-        : public IAggregateFunctionDataHelper<Data, AggregateFunctionSampCovariance<Data>> {
+        : public IAggregateFunctionDataHelper<Data, AggregateFunctionSampCovariance<Data>>,
+          MultiExpression,
+          NullableAggregateFunction {
 public:
     AggregateFunctionSampCovariance(const DataTypes& argument_types_)
             : IAggregateFunctionDataHelper<Data, AggregateFunctionSampCovariance<Data>>(

--- a/be/src/vec/aggregate_functions/aggregate_function_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_distinct.h
@@ -263,7 +263,9 @@ struct AggregateFunctionDistinctMultipleGenericData
 template <template <bool stable> typename Data, bool stable = false>
 class AggregateFunctionDistinct
         : public IAggregateFunctionDataHelper<Data<stable>,
-                                              AggregateFunctionDistinct<Data, stable>> {
+                                              AggregateFunctionDistinct<Data, stable>>,
+          VarargsExpression,
+          NullableAggregateFunction {
 private:
     size_t prefix_size;
     AggregateFunctionPtr nested_func;

--- a/be/src/vec/aggregate_functions/aggregate_function_foreach.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_foreach.h
@@ -53,7 +53,9 @@ struct AggregateFunctionForEachData {
   * TODO Allow variable number of arguments.
   */
 class AggregateFunctionForEach : public IAggregateFunctionDataHelper<AggregateFunctionForEachData,
-                                                                     AggregateFunctionForEach> {
+                                                                     AggregateFunctionForEach>,
+                                 VarargsExpression,
+                                 NullableAggregateFunction {
 protected:
     using Base =
             IAggregateFunctionDataHelper<AggregateFunctionForEachData, AggregateFunctionForEach>;

--- a/be/src/vec/aggregate_functions/aggregate_function_group_array_intersect.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_group_array_intersect.h
@@ -121,7 +121,9 @@ struct AggregateFunctionGroupArrayIntersectData {
 template <PrimitiveType T>
 class AggregateFunctionGroupArrayIntersect
         : public IAggregateFunctionDataHelper<AggregateFunctionGroupArrayIntersectData<T>,
-                                              AggregateFunctionGroupArrayIntersect<T>> {
+                                              AggregateFunctionGroupArrayIntersect<T>>,
+          UnaryExpression,
+          NotNullableAggregateFunction {
 private:
     using State = AggregateFunctionGroupArrayIntersectData<T>;
     DataTypePtr argument_type;

--- a/be/src/vec/aggregate_functions/aggregate_function_group_concat.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_group_concat.h
@@ -131,7 +131,9 @@ struct AggregateFunctionGroupConcatImplStrStr {
 template <typename Impl>
 class AggregateFunctionGroupConcat final
         : public IAggregateFunctionDataHelper<AggregateFunctionGroupConcatData,
-                                              AggregateFunctionGroupConcat<Impl>> {
+                                              AggregateFunctionGroupConcat<Impl>>,
+          VarargsExpression,
+          NullableAggregateFunction {
 public:
     AggregateFunctionGroupConcat(const DataTypes& argument_types_)
             : IAggregateFunctionDataHelper<AggregateFunctionGroupConcatData,

--- a/be/src/vec/aggregate_functions/aggregate_function_histogram.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_histogram.h
@@ -166,7 +166,9 @@ private:
 template <typename Data, bool has_input_param>
 class AggregateFunctionHistogram final
         : public IAggregateFunctionDataHelper<Data,
-                                              AggregateFunctionHistogram<Data, has_input_param>> {
+                                              AggregateFunctionHistogram<Data, has_input_param>>,
+          VarargsExpression,
+          NotNullableAggregateFunction {
 public:
     AggregateFunctionHistogram() = default;
     AggregateFunctionHistogram(const DataTypes& argument_types_)

--- a/be/src/vec/aggregate_functions/aggregate_function_hll_union_agg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_hll_union_agg.h
@@ -104,7 +104,9 @@ struct AggregateFunctionHLLUnionAggImpl : Data {
 
 template <typename Data>
 class AggregateFunctionHLLUnion
-        : public IAggregateFunctionDataHelper<Data, AggregateFunctionHLLUnion<Data>> {
+        : public IAggregateFunctionDataHelper<Data, AggregateFunctionHLLUnion<Data>>,
+          UnaryExpression,
+          NullableAggregateFunction {
 public:
     AggregateFunctionHLLUnion(const DataTypes& argument_types_)
             : IAggregateFunctionDataHelper<Data, AggregateFunctionHLLUnion<Data>>(argument_types_) {

--- a/be/src/vec/aggregate_functions/aggregate_function_java_udaf.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_java_udaf.h
@@ -263,7 +263,9 @@ private:
 };
 
 class AggregateJavaUdaf final
-        : public IAggregateFunctionDataHelper<AggregateJavaUdafData, AggregateJavaUdaf> {
+        : public IAggregateFunctionDataHelper<AggregateJavaUdafData, AggregateJavaUdaf>,
+          VarargsExpression,
+          NullableAggregateFunction {
 public:
     ENABLE_FACTORY_CREATOR(AggregateJavaUdaf);
     AggregateJavaUdaf(const TFunction& fn, const DataTypes& argument_types_,

--- a/be/src/vec/aggregate_functions/aggregate_function_linear_histogram.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_linear_histogram.h
@@ -185,7 +185,9 @@ public:
 template <PrimitiveType T, typename Data, bool has_offset>
 class AggregateFunctionLinearHistogram final
         : public IAggregateFunctionDataHelper<
-                  Data, AggregateFunctionLinearHistogram<T, Data, has_offset>> {
+                  Data, AggregateFunctionLinearHistogram<T, Data, has_offset>>,
+          MultiExpression,
+          NotNullableAggregateFunction {
 public:
     using ColVecType = typename PrimitiveTypeTraits<T>::ColumnType;
 

--- a/be/src/vec/aggregate_functions/aggregate_function_map.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_map.h
@@ -178,7 +178,9 @@ private:
 
 template <typename Data, PrimitiveType K>
 class AggregateFunctionMapAgg final
-        : public IAggregateFunctionDataHelper<Data, AggregateFunctionMapAgg<Data, K>> {
+        : public IAggregateFunctionDataHelper<Data, AggregateFunctionMapAgg<Data, K>>,
+          MultiExpression,
+          NotNullableAggregateFunction {
 public:
     using KeyColumnType = typename PrimitiveTypeTraits<K>::ColumnType;
     AggregateFunctionMapAgg() = default;

--- a/be/src/vec/aggregate_functions/aggregate_function_map_v2.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_map_v2.h
@@ -175,7 +175,9 @@ private:
 
 template <typename Data>
 class AggregateFunctionMapAggV2 final
-        : public IAggregateFunctionDataHelper<Data, AggregateFunctionMapAggV2<Data>> {
+        : public IAggregateFunctionDataHelper<Data, AggregateFunctionMapAggV2<Data>>,
+          MultiExpression,
+          NotNullableAggregateFunction {
 public:
     AggregateFunctionMapAggV2() = default;
     AggregateFunctionMapAggV2(const DataTypes& argument_types_)

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max_by.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max_by.h
@@ -147,7 +147,9 @@ struct AggregateFunctionMinByData : public AggregateFunctionMinMaxByBaseData<VT,
 
 template <typename Data>
 class AggregateFunctionsMinMaxBy final
-        : public IAggregateFunctionDataHelper<Data, AggregateFunctionsMinMaxBy<Data>> {
+        : public IAggregateFunctionDataHelper<Data, AggregateFunctionsMinMaxBy<Data>>,
+          MultiExpression,
+          NullableAggregateFunction {
 private:
     DataTypePtr& value_type;
     DataTypePtr& key_type;

--- a/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.h
@@ -378,7 +378,9 @@ private:
 
 template <typename Impl>
 class AggFunctionOrthBitmapFunc final
-        : public IAggregateFunctionDataHelper<Impl, AggFunctionOrthBitmapFunc<Impl>> {
+        : public IAggregateFunctionDataHelper<Impl, AggFunctionOrthBitmapFunc<Impl>>,
+          VarargsExpression,
+          NullableAggregateFunction {
 public:
     String get_name() const override { return Impl::name; }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile.h
@@ -183,7 +183,9 @@ public:
     }
 };
 
-class AggregateFunctionPercentileApproxTwoParams : public AggregateFunctionPercentileApprox {
+class AggregateFunctionPercentileApproxTwoParams final : public AggregateFunctionPercentileApprox,
+                                                         public MultiExpression,
+                                                         public NullableAggregateFunction {
 public:
     AggregateFunctionPercentileApproxTwoParams(const DataTypes& argument_types_)
             : AggregateFunctionPercentileApprox(argument_types_) {}
@@ -211,7 +213,9 @@ public:
     }
 };
 
-class AggregateFunctionPercentileApproxThreeParams : public AggregateFunctionPercentileApprox {
+class AggregateFunctionPercentileApproxThreeParams final : public AggregateFunctionPercentileApprox,
+                                                           public MultiExpression,
+                                                           public NullableAggregateFunction {
 public:
     AggregateFunctionPercentileApproxThreeParams(const DataTypes& argument_types_)
             : AggregateFunctionPercentileApprox(argument_types_) {}
@@ -242,8 +246,10 @@ public:
     }
 };
 
-class AggregateFunctionPercentileApproxWeightedThreeParams
-        : public AggregateFunctionPercentileApprox {
+class AggregateFunctionPercentileApproxWeightedThreeParams final
+        : public AggregateFunctionPercentileApprox,
+          MultiExpression,
+          NullableAggregateFunction {
 public:
     AggregateFunctionPercentileApproxWeightedThreeParams(const DataTypes& argument_types_)
             : AggregateFunctionPercentileApprox(argument_types_) {}
@@ -276,8 +282,10 @@ public:
     }
 };
 
-class AggregateFunctionPercentileApproxWeightedFourParams
-        : public AggregateFunctionPercentileApprox {
+class AggregateFunctionPercentileApproxWeightedFourParams final
+        : public AggregateFunctionPercentileApprox,
+          MultiExpression,
+          NullableAggregateFunction {
 public:
     AggregateFunctionPercentileApproxWeightedFourParams(const DataTypes& argument_types_)
             : AggregateFunctionPercentileApprox(argument_types_) {}
@@ -424,7 +432,9 @@ struct PercentileState {
 
 template <PrimitiveType T>
 class AggregateFunctionPercentile final
-        : public IAggregateFunctionDataHelper<PercentileState<T>, AggregateFunctionPercentile<T>> {
+        : public IAggregateFunctionDataHelper<PercentileState<T>, AggregateFunctionPercentile<T>>,
+          MultiExpression,
+          NullableAggregateFunction {
 public:
     using ColVecType = typename PrimitiveTypeTraits<T>::ColumnType;
     using Base = IAggregateFunctionDataHelper<PercentileState<T>, AggregateFunctionPercentile<T>>;
@@ -482,7 +492,9 @@ public:
 template <PrimitiveType T>
 class AggregateFunctionPercentileArray final
         : public IAggregateFunctionDataHelper<PercentileState<T>,
-                                              AggregateFunctionPercentileArray<T>> {
+                                              AggregateFunctionPercentileArray<T>>,
+          MultiExpression,
+          NotNullableAggregateFunction {
 public:
     using ColVecType = typename PrimitiveTypeTraits<T>::ColumnType;
     using Base =

--- a/be/src/vec/aggregate_functions/aggregate_function_product.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_product.h
@@ -117,7 +117,9 @@ struct AggregateFunctionProductData<T> {
 
 template <PrimitiveType T, PrimitiveType TResult, typename Data>
 class AggregateFunctionProduct final
-        : public IAggregateFunctionDataHelper<Data, AggregateFunctionProduct<T, TResult, Data>> {
+        : public IAggregateFunctionDataHelper<Data, AggregateFunctionProduct<T, TResult, Data>>,
+          UnaryExpression,
+          NullableAggregateFunction {
 public:
     using ResultDataType = typename PrimitiveTypeTraits<TResult>::DataType;
     using ColVecType = typename PrimitiveTypeTraits<T>::ColumnType;

--- a/be/src/vec/aggregate_functions/aggregate_function_retention.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_retention.h
@@ -109,7 +109,9 @@ struct RetentionState {
 };
 
 class AggregateFunctionRetention
-        : public IAggregateFunctionDataHelper<RetentionState, AggregateFunctionRetention> {
+        : public IAggregateFunctionDataHelper<RetentionState, AggregateFunctionRetention>,
+          VarargsExpression,
+          NullableAggregateFunction {
 public:
     AggregateFunctionRetention(const DataTypes& argument_types_)
             : IAggregateFunctionDataHelper<RetentionState, AggregateFunctionRetention>(

--- a/be/src/vec/aggregate_functions/aggregate_function_sequence_match.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sequence_match.h
@@ -649,7 +649,9 @@ private:
 
 template <PrimitiveType T>
 class AggregateFunctionSequenceMatch final
-        : public AggregateFunctionSequenceBase<T, AggregateFunctionSequenceMatch<T>> {
+        : public AggregateFunctionSequenceBase<T, AggregateFunctionSequenceMatch<T>>,
+          VarargsExpression,
+          NullableAggregateFunction {
 public:
     AggregateFunctionSequenceMatch(const DataTypes& arguments, const String& pattern_)
             : AggregateFunctionSequenceBase<T, AggregateFunctionSequenceMatch<T>>(arguments,
@@ -693,7 +695,9 @@ public:
 
 template <PrimitiveType T>
 class AggregateFunctionSequenceCount final
-        : public AggregateFunctionSequenceBase<T, AggregateFunctionSequenceCount<T>> {
+        : public AggregateFunctionSequenceBase<T, AggregateFunctionSequenceCount<T>>,
+          VarargsExpression,
+          NotNullableAggregateFunction {
 public:
     AggregateFunctionSequenceCount(const DataTypes& arguments, const String& pattern_)
             : AggregateFunctionSequenceBase<T, AggregateFunctionSequenceCount<T>>(arguments,

--- a/be/src/vec/aggregate_functions/aggregate_function_stddev.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_stddev.h
@@ -177,7 +177,9 @@ struct StddevSampName {
 
 template <typename Data>
 class AggregateFunctionSampVariance
-        : public IAggregateFunctionDataHelper<Data, AggregateFunctionSampVariance<Data>> {
+        : public IAggregateFunctionDataHelper<Data, AggregateFunctionSampVariance<Data>>,
+          UnaryExpression,
+          NullableAggregateFunction {
 public:
     AggregateFunctionSampVariance(const DataTypes& argument_types_)
             : IAggregateFunctionDataHelper<Data, AggregateFunctionSampVariance<Data>>(

--- a/be/src/vec/aggregate_functions/aggregate_function_sum.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sum.h
@@ -69,7 +69,9 @@ struct AggregateFunctionSumData {
 /// Counts the sum of the numbers.
 template <PrimitiveType T, PrimitiveType TResult, typename Data>
 class AggregateFunctionSum final
-        : public IAggregateFunctionDataHelper<Data, AggregateFunctionSum<T, TResult, Data>> {
+        : public IAggregateFunctionDataHelper<Data, AggregateFunctionSum<T, TResult, Data>>,
+          UnaryExpression,
+          NullableAggregateFunction {
 public:
     using ResultDataType = typename PrimitiveTypeTraits<TResult>::DataType;
     using ColVecType = typename PrimitiveTypeTraits<T>::ColumnType;

--- a/be/src/vec/aggregate_functions/aggregate_function_topn.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_topn.h
@@ -332,7 +332,9 @@ public:
 
 //topn function return string
 template <typename Impl>
-class AggregateFunctionTopN final : public AggregateFunctionTopNBase<Impl> {
+class AggregateFunctionTopN final : public AggregateFunctionTopNBase<Impl>,
+                                    MultiExpression,
+                                    NullableAggregateFunction {
 public:
     AggregateFunctionTopN(const DataTypes& argument_types_)
             : AggregateFunctionTopNBase<Impl>(argument_types_) {}
@@ -349,7 +351,9 @@ public:
 
 //topn function return array
 template <typename Impl>
-class AggregateFunctionTopNArray final : public AggregateFunctionTopNBase<Impl> {
+class AggregateFunctionTopNArray final : public AggregateFunctionTopNBase<Impl>,
+                                         MultiExpression,
+                                         NullableAggregateFunction {
 public:
     AggregateFunctionTopNArray(const DataTypes& argument_types_)
             : AggregateFunctionTopNBase<Impl>(argument_types_),

--- a/be/src/vec/aggregate_functions/aggregate_function_uniq.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_uniq.h
@@ -114,7 +114,9 @@ struct OneAdder {
 /// Calculates the number of different values approximately or exactly.
 template <PrimitiveType T, typename Data>
 class AggregateFunctionUniq final
-        : public IAggregateFunctionDataHelper<Data, AggregateFunctionUniq<T, Data>> {
+        : public IAggregateFunctionDataHelper<Data, AggregateFunctionUniq<T, Data>>,
+          VarargsExpression,
+          NotNullableAggregateFunction {
 public:
     using KeyType =
             std::conditional_t<is_string_type(T), UInt128,

--- a/be/src/vec/aggregate_functions/aggregate_function_uniq_distribute_key.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_uniq_distribute_key.h
@@ -75,7 +75,9 @@ struct AggregateFunctionUniqDistributeKeyData {
 
 template <PrimitiveType T, typename Data>
 class AggregateFunctionUniqDistributeKey final
-        : public IAggregateFunctionDataHelper<Data, AggregateFunctionUniqDistributeKey<T, Data>> {
+        : public IAggregateFunctionDataHelper<Data, AggregateFunctionUniqDistributeKey<T, Data>>,
+          VarargsExpression,
+          NullableAggregateFunction {
 public:
     using KeyType = std::conditional_t<is_string_type(T), UInt128,
                                        typename PrimitiveTypeTraits<T>::ColumnItemType>;

--- a/be/src/vec/aggregate_functions/aggregate_function_window.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window.h
@@ -339,7 +339,9 @@ struct NTileData {
 };
 
 class WindowFunctionNTile final
-        : public IAggregateFunctionDataHelper<NTileData, WindowFunctionNTile> {
+        : public IAggregateFunctionDataHelper<NTileData, WindowFunctionNTile>,
+          UnaryExpression,
+          NullableAggregateFunction {
 public:
     WindowFunctionNTile(const DataTypes& argument_types_)
             : IAggregateFunctionDataHelper(argument_types_) {}

--- a/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
@@ -346,7 +346,9 @@ template <PrimitiveType PrimitiveType, typename NativeType>
 class AggregateFunctionWindowFunnel
         : public IAggregateFunctionDataHelper<
                   WindowFunnelState<PrimitiveType, NativeType>,
-                  AggregateFunctionWindowFunnel<PrimitiveType, NativeType>> {
+                  AggregateFunctionWindowFunnel<PrimitiveType, NativeType>>,
+          MultiExpression,
+          NullableAggregateFunction {
 public:
     AggregateFunctionWindowFunnel(const DataTypes& argument_types_)
             : IAggregateFunctionDataHelper<

--- a/be/src/vec/aggregate_functions/helpers.h
+++ b/be/src/vec/aggregate_functions/helpers.h
@@ -121,8 +121,10 @@ struct creator_without_type {
                         argument_types_, result_is_nullable, attr, std::forward<TArgs>(args)...);
             }
         } else {
-            return create_varargs<AggregateFunctionTemplate>(argument_types_, result_is_nullable,
-                                                             attr, std::forward<TArgs>(args)...);
+            static_assert(std::is_same_v<AggregateFunctionTemplate, void>,
+                          "AggregateFunctionTemplate must have tag (UnaryExpression, "
+                          "MultiExpression or VarargsExpression) , (NullableAggregateFunction , "
+                          "NonNullableAggregateFunction)");
         }
         return nullptr;
     }

--- a/be/src/vec/aggregate_functions/helpers.h
+++ b/be/src/vec/aggregate_functions/helpers.h
@@ -153,7 +153,7 @@ struct creator_without_type {
     static AggregateFunctionPtr create_varargs_return_not_nullable(
             const DataTypes& argument_types_, const bool result_is_nullable,
             const AggregateFunctionAttr& attr, TArgs&&... args) {
-        if (result_is_nullable) {
+        if (!attr.is_foreach && result_is_nullable) {
             throw doris::Exception(Status::InternalError(
                     "create_varargs_return_not_nullable: result_is_nullable must be false"));
         }
@@ -207,7 +207,7 @@ struct creator_without_type {
                     Status::InternalError("create_multi_arguments_return_not_nullable: "
                                           "argument_types_ size must be > 1"));
         }
-        if (result_is_nullable) {
+        if (!attr.is_foreach && result_is_nullable) {
             throw doris::Exception(
                     Status::InternalError("create_multi_arguments_return_not_nullable: "
                                           "result_is_nullable must be false"));
@@ -255,7 +255,7 @@ struct creator_without_type {
             throw doris::Exception(Status::InternalError(
                     "create_unary_arguments_return_not_nullable: argument_types_ size must be 1"));
         }
-        if (result_is_nullable) {
+        if (!attr.is_foreach && result_is_nullable) {
             throw doris::Exception(
                     Status::InternalError("create_unary_arguments_return_not_nullable: "
                                           "result_is_nullable must be false"));

--- a/be/src/vec/exprs/vectorized_agg_fn.cpp
+++ b/be/src/vec/exprs/vectorized_agg_fn.cpp
@@ -205,6 +205,9 @@ Status AggFnEvaluator::prepare(RuntimeState* state, const RowDescriptor& desc,
                                          _fn.name.function_name);
         }
     } else {
+        const bool is_foreach =
+                AggregateFunctionSimpleFactory::is_foreach(_fn.name.function_name) ||
+                AggregateFunctionSimpleFactory::is_foreachv2(_fn.name.function_name);
         // Here, only foreachv1 needs special treatment, and v2 can follow the normal code logic.
         if (AggregateFunctionSimpleFactory::is_foreach(_fn.name.function_name)) {
             _function = AggregateFunctionSimpleFactory::instance().get(
@@ -213,6 +216,7 @@ Status AggFnEvaluator::prepare(RuntimeState* state, const RowDescriptor& desc,
                     state->be_exec_version(),
                     {.enable_decimal256 = state->enable_decimal256(),
                      .is_window_function = _is_window_function,
+                     .is_foreach = is_foreach,
                      .column_names = std::move(column_names)});
         } else {
             _function = AggregateFunctionSimpleFactory::instance().get(
@@ -220,6 +224,7 @@ Status AggFnEvaluator::prepare(RuntimeState* state, const RowDescriptor& desc,
                     state->be_exec_version(),
                     {.enable_decimal256 = state->enable_decimal256(),
                      .is_window_function = _is_window_function,
+                     .is_foreach = is_foreach,
                      .column_names = std::move(column_names)});
         }
     }


### PR DESCRIPTION
### What problem does this PR solve?

Here is the English translation:

By tagging the agg function, we can reduce some instantiations during creation.  
For example, in the file `aggregate_function_approx_count_distinct.cpp`.  
Its registration in the FE is as follows:
```java
public class Ndv extends NotNullableAggregateFunction
        implements UnaryExpression, ExplicitlyCastableSignature, RollUpTrait {
```
This way, when creating, we don't need to consider the cases of nullable and multiple parameters.

Binary size:  
Before:  
```
34.34 MB   ./vec/CMakeFiles/Vec.dir/aggregate_functions/aggregate_function_approx_count_distinct.cpp.o  
```
Now:  
```
16.43 MB   ./vec/CMakeFiles/Vec.dir/aggregate_functions/aggregate_function_approx_count_distinct.cpp.o
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

