### PR TITLE
[fix](json) JSON_KEYS should return error with wildcard path parameter

### DIFF
--- a/be/src/vec/functions/function_jsonb.cpp
+++ b/be/src/vec/functions/function_jsonb.cpp
@@ -582,6 +582,12 @@ private:
                 return Status::InvalidArgument("Json path error: Invalid Json Path for value: {}",
                                                r_raw_ref.to_string());
             }
+
+            if (const_path.is_wildcard()) {
+                return Status::InvalidJsonPath(
+                        "In this situation, path expressions may not contain the * and ** tokens "
+                        "or an array range.");
+            }
         }
         const auto& ldata = col_from_string.get_chars();
         const auto& loffsets = col_from_string.get_offsets();
@@ -629,6 +635,13 @@ private:
                                 "Json path error: Invalid Json Path for value: {}",
                                 std::string_view(reinterpret_cast<const char*>(rdata.data()),
                                                  rdata.size()));
+                    }
+
+                    if (path.is_wildcard()) {
+                        return Status::InvalidJsonPath(
+                                "In this situation, path expressions may not contain the * and ** "
+                                "tokens "
+                                "or an array range.");
                     }
                     find_result = doc->getValue()->findValue(path);
                 } else {

--- a/regression-test/data/query_p0/sql_functions/json_functions/test_json_function.out
+++ b/regression-test/data/query_p0/sql_functions/json_functions/test_json_function.out
@@ -211,3 +211,15 @@ false
 -- !json_contains6 --
 \N
 
+-- !json_keys --
+["name", "age", "city"]
+
+-- !json_keys2 --
+\N
+
+-- !json_keys3 --
+\N
+["d"]
+["d"]
+["d"]
+

--- a/regression-test/suites/query_p0/sql_functions/json_functions/test_json_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/json_functions/test_json_function.groovy
@@ -130,4 +130,31 @@ suite("test_json_function", "arrow_flight_sql") {
     qt_json_contains6 """
       SELECT JSON_CONTAINS(NULL, '"music"', '{"age": 25}');
     """
+
+    qt_json_keys """
+      SELECT JSON_KEYS('{"name": "John", "age": 30, "city": "New York"}');
+    """
+    qt_json_keys2 """
+      SELECT JSON_KEYS('{"name": "John", "age": 30, "city": "New York", "hobbies": ["reading", "travelling"]}', '\$.hobbies');
+    """
+
+    qt_json_keys3 """
+      SELECT JSON_KEYS(k1, '\$.c') FROM d_table order by k1;
+    """
+
+    test {
+        sql """
+            SELECT JSON_KEYS('{"name": "John", "age": 30, "city": "New York", "hobbies": ["reading", "travelling"]}', '\$.*');
+        """
+
+        exception "In this situation, path expressions may not contain the * and ** tokens or an array range."
+    }
+    
+    test {
+        sql """
+            SELECT JSON_KEYS(k1, '\$.*.c') FROM d_table order by k1;
+        """
+
+        exception "In this situation, path expressions may not contain the * and ** tokens or an array range."
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

The parameter of `path` should not be wildcard.

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

