### PR TITLE
branch-3.1: [fix](warmup) refresh tablet location cache and retry on error #53852

### DIFF
--- a/be/src/cloud/cloud_internal_service.cpp
+++ b/be/src/cloud/cloud_internal_service.cpp
@@ -187,6 +187,9 @@ void CloudInternalServiceImpl::warm_up_rowset(google::protobuf::RpcController* c
                                                    /* local_only = */ local_only);
         if (!res.has_value()) {
             LOG_WARNING("Warm up error ").tag("tablet_id", tablet_id).error(res.error());
+            if (res.error().msg().find("local_only=true") != std::string::npos) {
+                res.error().set_code(ErrorCode::TABLE_NOT_FOUND);
+            }
             res.error().to_protobuf(response->mutable_status());
             continue;
         }

--- a/be/src/cloud/cloud_internal_service.cpp
+++ b/be/src/cloud/cloud_internal_service.cpp
@@ -180,12 +180,14 @@ void CloudInternalServiceImpl::warm_up_rowset(google::protobuf::RpcController* c
             continue;
         }
         int64_t tablet_id = rs_meta.tablet_id();
+        bool local_only = !(request->has_skip_existence_check() && request->skip_existence_check());
         auto res = _engine.tablet_mgr().get_tablet(tablet_id, /* warmup_data = */ false,
                                                    /* sync_delete_bitmap = */ true,
                                                    /* sync_stats = */ nullptr,
-                                                   /* local_only = */ true);
+                                                   /* local_only = */ local_only);
         if (!res.has_value()) {
             LOG_WARNING("Warm up error ").tag("tablet_id", tablet_id).error(res.error());
+            res.error().to_protobuf(response->mutable_status());
             continue;
         }
         auto tablet = res.value();

--- a/be/src/cloud/cloud_warm_up_manager.cpp
+++ b/be/src/cloud/cloud_warm_up_manager.cpp
@@ -509,7 +509,7 @@ void CloudWarmUpManager::warm_up_rowset(RowsetMeta& rs_meta, int64_t sync_wait_t
         return;
     }
     Status st = _do_warm_up_rowset(rs_meta, replicas, sync_wait_timeout_ms, refresh);
-    if (!refresh && !st.ok() && st.msg().find("local_only=true") != std::string::npos) {
+    if (!refresh && !st.ok() && st.is<ErrorCode::TABLE_NOT_FOUND>()) {
         refresh = true;
         replicas = get_replica_info(rs_meta.tablet_id(), refresh);
         st = _do_warm_up_rowset(rs_meta, replicas, sync_wait_timeout_ms, refresh);

--- a/be/src/cloud/cloud_warm_up_manager.h
+++ b/be/src/cloud/cloud_warm_up_manager.h
@@ -90,7 +90,8 @@ private:
     Status _do_warm_up_rowset(RowsetMeta& rs_meta, std::vector<TReplicaInfo>& replicas,
                               int64_t sync_wait_timeout_ms, bool skip_existence_check);
 
-    std::vector<TReplicaInfo> get_replica_info(int64_t tablet_id, bool& refresh);
+    std::vector<TReplicaInfo> get_replica_info(int64_t tablet_id, bool bypass_cache,
+                                               bool& cache_hit);
 
     void submit_download_tasks(io::Path path, int64_t file_size, io::FileSystemSPtr file_system,
                                int64_t expiration_time,

--- a/be/src/cloud/cloud_warm_up_manager.h
+++ b/be/src/cloud/cloud_warm_up_manager.h
@@ -86,7 +86,11 @@ public:
 
 private:
     void handle_jobs();
-    std::vector<TReplicaInfo> get_replica_info(int64_t tablet_id);
+
+    Status _do_warm_up_rowset(RowsetMeta& rs_meta, std::vector<TReplicaInfo>& replicas,
+                              int64_t sync_wait_timeout_ms, bool skip_existence_check);
+
+    std::vector<TReplicaInfo> get_replica_info(int64_t tablet_id, bool& refresh);
 
     void submit_download_tasks(io::Path path, int64_t file_size, io::FileSystemSPtr file_system,
                                int64_t expiration_time,

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -841,9 +841,11 @@ message PWarmUpRowsetRequest {
     repeated RowsetMetaPB rowset_metas = 1;
     optional int64 unix_ts_us = 2;
     optional int64 sync_wait_timeout_ms = 3;
+    optional bool skip_existence_check = 4;
 }
 
 message PWarmUpRowsetResponse {
+    optional PStatus status = 1;
 }
 
 message RecycleCacheMeta {


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #53852

When warm up rowset on event, if the tablet is not found on the target BE, it will now return an error to the source BE.
The source BE will try to refresh the tablet location cache, and retry the warmup with `force` flag.
When the `force` flag is set, the target BE will do the warm up regardless of the tablet existence.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

