### PR TITLE
branch-3.0: [fix](binlog)default partition dont append version_info

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/AddPartitionRecord.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/AddPartitionRecord.java
@@ -95,10 +95,10 @@ public class AddPartitionRecord {
             if (!partitionSql.isEmpty()) {
                 sb.append("VALUES IN ");
                 sb.append(partitionSql);
+                sb.append(" (\"version_info\" = \"");
+                sb.append(partition.getVisibleVersion());
+                sb.append("\");");
             }
-            sb.append(" (\"version_info\" = \"");
-            sb.append(partition.getVisibleVersion());
-            sb.append("\");");
         } else {
             // unpartitioned.
         }


### PR DESCRIPTION
3.0 dont support syntax default partition with properties, it think ("values_info"="x") is a values in (xx), the ccr would get the wrong result(tosql), the sql cant execute