### PR TITLE
[opt](oracle) support oracle synonym

### DIFF
--- a/docker/thirdparties/docker-compose/oracle/init/02-create-user.sql
+++ b/docker/thirdparties/docker-compose/oracle/init/02-create-user.sql
@@ -17,3 +17,6 @@
 
 create user doris_test identified by 123456;
 grant connect, resource to doris_test;
+
+create user synonym_test_user identified by 123456;
+grant connect, resource to synonym_test_user;

--- a/docker/thirdparties/docker-compose/oracle/init/03-create-table.sql
+++ b/docker/thirdparties/docker-compose/oracle/init/03-create-table.sql
@@ -22,6 +22,10 @@ age number(2),
 score number(3,1)
 );
 
+create SYNONYM DORIS_TEST.test_synonym_student for DORIS_TEST.STUDENT;
+create SYNONYM SYNONYM_TEST_USER.test_synonym_student for DORIS_TEST.STUDENT;
+create SYNONYM SYNONYM_TEST_USER.test_synonym_student2 for DORIS_TEST.STUDENT;
+
 create table doris_test.test_num (
 id int,
 n1 number,

--- a/docker/thirdparties/docker-compose/oracle/oracle-11.yaml.tpl
+++ b/docker/thirdparties/docker-compose/oracle/oracle-11.yaml.tpl
@@ -46,3 +46,7 @@ networks:
       driver: default
       config:
         - subnet: 168.40.0.0/24
+
+# login in container
+# sqlplus system/oracle@127.0.0.1:1521
+# sqlplus DORIS_TEST/123456@127.0.0.1:1521

--- a/regression-test/data/external_table_p0/jdbc/test_oracle_jdbc_catalog.out
+++ b/regression-test/data/external_table_p0/jdbc/test_oracle_jdbc_catalog.out
@@ -5,6 +5,7 @@ APEX_040000
 APEX_PUBLIC_USER
 DORIS_TEST
 HR
+SYNONYM_TEST_USER
 information_schema
 mysql
 
@@ -427,6 +428,36 @@ doris
 -- !null_operator9 --
 
 -- !null_operator10 --
+1	alice	20	99.5
+2	bob	21	90.5
+3	jerry	23	88.0
+4	andy	21	93.0
+
+-- !sql_syn01 --
+1	alice	20	99.5
+2	bob	21	90.5
+3	jerry	23	88.0
+4	andy	21	93.0
+
+-- !sql_syn02 --
+
+-- !sql_syn01 --
+1	alice	20	99.5
+2	bob	21	90.5
+3	jerry	23	88.0
+4	andy	21	93.0
+
+-- !sql_syn02 --
+TEST_SYNONYM_STUDENT
+TEST_SYNONYM_STUDENT2
+
+-- !sql_syn03 --
+1	alice	20	99.5
+2	bob	21	90.5
+3	jerry	23	88.0
+4	andy	21	93.0
+
+-- !sql_syn04 --
 1	alice	20	99.5
 2	bob	21	90.5
 3	jerry	23	88.0


### PR DESCRIPTION
### What problem does this PR solve?

This PR adds support for Oracle synonyms in the JDBC catalog integration. It enables Doris to recognize and query Oracle synonym objects as if they were regular tables.

- Adds logic to detect when a table is actually a synonym and resolve it to the underlying table
- Implements additional SQL queries to fetch synonym information from Oracle's system views
- Extends the base JdbcClient to support custom table discovery queries for database-specific features

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

