### PR TITLE
[fix](warmup) fix integer type in warm up WHERE clause

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CancelWarmUpJobCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CancelWarmUpJobCommand.java
@@ -28,7 +28,7 @@ import org.apache.doris.nereids.glue.translator.PlanTranslatorContext;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
-import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.IntegerLikeLiteral;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.logical.LogicalEmptyRelation;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -100,8 +100,8 @@ public class CancelWarmUpJobCommand extends Command implements ForwardWithSync {
         }
 
         String leftKey = ((UnboundSlot) whereClause.child(0)).getName();
-        if (leftKey.equalsIgnoreCase("id") && (whereClause.child(1) instanceof IntegerLiteral)) {
-            jobId = ((IntegerLiteral) whereClause.child(1)).getLongValue();
+        if (leftKey.equalsIgnoreCase("id") && (whereClause.child(1) instanceof IntegerLikeLiteral)) {
+            jobId = ((IntegerLikeLiteral) whereClause.child(1)).getLongValue();
         } else {
             return false;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowWarmUpCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowWarmUpCommand.java
@@ -26,7 +26,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.nereids.analyzer.UnboundSlot;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
-import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.IntegerLikeLiteral;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.qe.ConnectContext;
@@ -106,8 +106,8 @@ public class ShowWarmUpCommand extends ShowCommand {
         }
 
         String leftKey = ((UnboundSlot) expr.child(0)).getName();
-        if (leftKey.equalsIgnoreCase("id") && (expr.child(1) instanceof IntegerLiteral)) {
-            jobId = ((IntegerLiteral) expr.child(1)).getLongValue();
+        if (leftKey.equalsIgnoreCase("id") && (expr.child(1) instanceof IntegerLikeLiteral)) {
+            jobId = ((IntegerLikeLiteral) expr.child(1)).getLongValue();
             return true;
         } else {
             return false;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowWarmUpCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowWarmUpCommandTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.nereids.analyzer.UnboundSlot;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.literal.BigIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 
@@ -35,17 +36,32 @@ public class ShowWarmUpCommandTest {
         //test whereClause ia null
         ShowWarmUpCommand command = new ShowWarmUpCommand(null);
         Assertions.assertDoesNotThrow(() -> command.validate());
+    }
 
+    @Test
+    public void testValidate2() {
         //test whereClause is equalTo
         Expression where = new EqualTo(new UnboundSlot(Lists.newArrayList("test")),
                 new StringLiteral("test"));
-        ShowWarmUpCommand command2 = new ShowWarmUpCommand(where);
-        Assertions.assertThrows(AnalysisException.class, () -> command2.validate());
+        ShowWarmUpCommand command = new ShowWarmUpCommand(where);
+        Assertions.assertThrows(AnalysisException.class, () -> command.validate());
+    }
 
+    @Test
+    public void testValidate3() {
         //test whereClause is equalTo
-        Expression where2 = new EqualTo(new UnboundSlot(Lists.newArrayList("id")),
+        Expression where = new EqualTo(new UnboundSlot(Lists.newArrayList("id")),
                 new IntegerLiteral(111));
-        ShowWarmUpCommand command3 = new ShowWarmUpCommand(where2);
-        Assertions.assertDoesNotThrow(() -> command3.validate());
+        ShowWarmUpCommand command = new ShowWarmUpCommand(where);
+        Assertions.assertDoesNotThrow(() -> command.validate());
+    }
+
+    @Test
+    public void testValidate4() {
+        //test whereClause is equalTo BigIntLiteral
+        Expression where = new EqualTo(new UnboundSlot(Lists.newArrayList("id")),
+                new BigIntLiteral(1754626195722L));
+        ShowWarmUpCommand command = new ShowWarmUpCommand(where);
+        Assertions.assertDoesNotThrow(() -> command.validate());
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: 

Related PR: #51081

Problem Summary:

Large ID values are parsed as BigIntLiteral instead of IntegerLiteral. 
This change uses IntegerLikeLiteral to handle both cases correctly.

```
[ShowWarmUpCommand.isWhereClauseValid():118] Left key ID is not 'id' or right child 1754626195722 (org.apache.doris.nereids.trees.expressions.literal.BigIntLiteral) is not IntegerLiteral: ('ID = 1754626195722)
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

