### PR TITLE
[feat](variant) Support vertical compaction for subcolumns

### DIFF
--- a/be/src/cloud/cloud_rowset_writer.cpp
+++ b/be/src/cloud/cloud_rowset_writer.cpp
@@ -103,7 +103,12 @@ Status CloudRowsetWriter::build(RowsetSharedPtr& rowset) {
     // update rowset meta tablet schema if tablet schema updated
     auto rowset_schema = _context.merged_tablet_schema != nullptr ? _context.merged_tablet_schema
                                                                   : _context.tablet_schema;
-    _rowset_meta->set_tablet_schema(rowset_schema);
+    if (_context.strip_variant_extracted_columns_in_rowset_meta &&
+        rowset_schema->num_variant_columns() > 0) {
+        _rowset_meta->set_tablet_schema(rowset_schema->copy_without_variant_extracted_columns());
+    } else {
+        _rowset_meta->set_tablet_schema(rowset_schema);
+    }
 
     if (_rowset_meta->newest_write_timestamp() == -1) {
         _rowset_meta->set_newest_write_timestamp(UnixSeconds());

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1088,9 +1088,9 @@ DEFINE_mInt64(workload_group_scan_task_wait_timeout_ms, "10000");
 
 // Whether use schema dict in backend side instead of MetaService side(cloud mode)
 DEFINE_mBool(variant_use_cloud_schema_dict_cache, "true");
-DEFINE_mDouble(variant_ratio_of_defaults_as_sparse_column, "1");
 DEFINE_mInt64(variant_threshold_rows_to_estimate_sparse_column, "2048");
 DEFINE_mBool(variant_throw_exeception_on_invalid_json, "false");
+DEFINE_mBool(enable_vertical_compact_variant_subcolumns, "true");
 
 // block file cache
 DEFINE_Bool(enable_file_cache, "false");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1298,13 +1298,14 @@ DECLARE_mInt64(lookup_connection_cache_capacity);
 DECLARE_mInt64(LZ4_HC_compression_level);
 // Threshold of a column as sparse column
 // Notice: TEST ONLY
-DECLARE_mDouble(variant_ratio_of_defaults_as_sparse_column);
 DECLARE_mBool(variant_use_cloud_schema_dict_cache);
 // Threshold to estimate a column is sparsed
 // Notice: TEST ONLY
 DECLARE_mInt64(variant_threshold_rows_to_estimate_sparse_column);
 // Treat invalid json format str as string, instead of throwing exception if false
 DECLARE_mBool(variant_throw_exeception_on_invalid_json);
+// Enable vertical compact subcolumns of variant column
+DECLARE_mBool(enable_vertical_compact_variant_subcolumns);
 
 DECLARE_mBool(enable_merge_on_write_correctness_check);
 // USED FOR DEBUGING

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -79,6 +79,7 @@
 #include "util/doris_metrics.h"
 #include "util/time.h"
 #include "util/trace.h"
+#include "vec/common/schema_util.h"
 
 using std::vector;
 
@@ -129,7 +130,9 @@ Compaction::Compaction(BaseTabletSPtr tablet, const std::string& label)
                   MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::COMPACTION, label)),
           _tablet(std::move(tablet)),
           _is_vertical(config::enable_vertical_compaction),
-          _allow_delete_in_cumu_compaction(config::enable_delete_when_cumu_compaction) {
+          _allow_delete_in_cumu_compaction(config::enable_delete_when_cumu_compaction),
+          _enable_vertical_compact_variant_subcolumns(
+                  config::enable_vertical_compact_variant_subcolumns) {
     init_profile(label);
     SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
     _rowid_conversion = std::make_unique<RowIdConversion>();
@@ -306,7 +309,7 @@ Tablet* CompactionMixin::tablet() {
 }
 
 Status CompactionMixin::do_compact_ordered_rowsets() {
-    build_basic_info();
+    RETURN_IF_ERROR(build_basic_info(true));
     RowsetWriterContext ctx;
     RETURN_IF_ERROR(construct_output_rowset_writer(ctx));
 
@@ -337,11 +340,12 @@ Status CompactionMixin::do_compact_ordered_rowsets() {
     rowset_meta->set_rowset_state(VISIBLE);
     rowset_meta->set_segments_key_bounds_truncated(segments_key_bounds_truncated);
     rowset_meta->set_segments_key_bounds(segment_key_bounds);
+
     _output_rowset = _output_rs_writer->manual_build(rowset_meta);
     return Status::OK();
 }
 
-void CompactionMixin::build_basic_info() {
+Status CompactionMixin::build_basic_info(bool is_ordered_compaction) {
     for (auto& rowset : _input_rowsets) {
         const auto& rowset_meta = rowset->rowset_meta();
         auto index_size = rowset_meta->index_disk_size();
@@ -369,7 +373,8 @@ void CompactionMixin::build_basic_info() {
     COUNTER_UPDATE(_input_row_num_counter, _input_row_num);
     COUNTER_UPDATE(_input_segments_num_counter, _input_num_segments);
 
-    TEST_SYNC_POINT_RETURN_WITH_VOID("compaction::CompactionMixin::build_basic_info");
+    TEST_SYNC_POINT_RETURN_WITH_VALUE("compaction::CompactionMixin::build_basic_info",
+                                      Status::OK());
 
     _output_version =
             Version(_input_rowsets.front()->start_version(), _input_rowsets.back()->end_version());
@@ -380,6 +385,16 @@ void CompactionMixin::build_basic_info() {
     std::transform(_input_rowsets.begin(), _input_rowsets.end(), rowset_metas.begin(),
                    [](const RowsetSharedPtr& rowset) { return rowset->rowset_meta(); });
     _cur_tablet_schema = _tablet->tablet_schema_with_merged_max_schema_version(rowset_metas);
+
+    // if enable_vertical_compact_variant_subcolumns is true, we need to compact the variant subcolumns in seperate column groups
+    // so get_extended_compaction_schema will extended the schema for variant columns
+    // for ordered compaction, we don't need to extend the schema for variant columns
+    if (_enable_vertical_compact_variant_subcolumns && !is_ordered_compaction) {
+        RETURN_IF_ERROR(
+                vectorized::schema_util::VariantCompactionUtil::get_extended_compaction_schema(
+                        _input_rowsets, _cur_tablet_schema));
+    }
+    return Status::OK();
 }
 
 bool CompactionMixin::handle_ordered_data_compaction() {
@@ -509,7 +524,7 @@ Status CompactionMixin::execute_compact_impl(int64_t permits) {
         _state = CompactionState::SUCCESS;
         return Status::OK();
     }
-    build_basic_info();
+    RETURN_IF_ERROR(build_basic_info());
 
     TEST_SYNC_POINT_RETURN_WITH_VALUE("compaction::CompactionMixin::execute_compact_impl",
                                       Status::OK());
@@ -1099,6 +1114,11 @@ Status CompactionMixin::construct_output_rowset_writer(RowsetWriterContext& ctx)
     ctx.rowset_state = VISIBLE;
     ctx.segments_overlap = NONOVERLAPPING;
     ctx.tablet_schema = _cur_tablet_schema;
+    // If we extended variant subcolumns for vertical compaction, make sure rowset meta
+    // does not persist those extracted subcolumns.
+    ctx.strip_variant_extracted_columns_in_rowset_meta =
+            _enable_vertical_compact_variant_subcolumns &&
+            (_cur_tablet_schema->num_variant_columns() > 0);
     ctx.newest_write_timestamp = _newest_write_timestamp;
     ctx.write_type = DataWriteType::TYPE_COMPACTION;
     ctx.compaction_type = compaction_type();
@@ -1340,6 +1360,9 @@ Status Compaction::check_correctness() {
                 _tablet->tablet_id(), _input_row_num, _stats.merged_rows, _stats.filtered_rows,
                 _output_rowset->num_rows());
     }
+    // 2. check variant column path stats
+    RETURN_IF_ERROR(vectorized::schema_util::VariantCompactionUtil::check_path_stats(
+            _input_rowsets, _output_rowset, _tablet));
     return Status::OK();
 }
 
@@ -1383,7 +1406,7 @@ void Compaction::_load_segment_to_cache() {
     }
 }
 
-void CloudCompactionMixin::build_basic_info() {
+Status CloudCompactionMixin::build_basic_info() {
     _output_version =
             Version(_input_rowsets.front()->start_version(), _input_rowsets.back()->end_version());
 
@@ -1393,6 +1416,14 @@ void CloudCompactionMixin::build_basic_info() {
     std::transform(_input_rowsets.begin(), _input_rowsets.end(), rowset_metas.begin(),
                    [](const RowsetSharedPtr& rowset) { return rowset->rowset_meta(); });
     _cur_tablet_schema = _tablet->tablet_schema_with_merged_max_schema_version(rowset_metas);
+    // if enable_vertical_compact_variant_subcolumns is true, we need to compact the variant subcolumns in seperate column groups
+    // so get_extended_compaction_schema will extended the schema for variant columns
+    if (_enable_vertical_compact_variant_subcolumns) {
+        RETURN_IF_ERROR(
+                vectorized::schema_util::VariantCompactionUtil::get_extended_compaction_schema(
+                        _input_rowsets, _cur_tablet_schema));
+    }
+    return Status::OK();
 }
 
 int64_t CloudCompactionMixin::get_compaction_permits() {
@@ -1415,7 +1446,7 @@ CloudCompactionMixin::CloudCompactionMixin(CloudStorageEngine& engine, CloudTabl
 Status CloudCompactionMixin::execute_compact_impl(int64_t permits) {
     OlapStopWatch watch;
 
-    build_basic_info();
+    RETURN_IF_ERROR(build_basic_info());
 
     LOG(INFO) << "start " << compaction_name() << ". tablet=" << _tablet->tablet_id()
               << ", output_version=" << _output_version << ", permits: " << permits;
@@ -1511,6 +1542,11 @@ Status CloudCompactionMixin::construct_output_rowset_writer(RowsetWriterContext&
     ctx.newest_write_timestamp = _newest_write_timestamp;
     ctx.write_type = DataWriteType::TYPE_COMPACTION;
     ctx.compaction_type = compaction_type();
+    // If we extended variant subcolumns for vertical compaction, make sure rowset meta
+    // does not persist those extracted subcolumns.
+    ctx.strip_variant_extracted_columns_in_rowset_meta =
+            _enable_vertical_compact_variant_subcolumns &&
+            (_cur_tablet_schema->num_variant_columns() > 0);
 
     // We presume that the data involved in cumulative compaction is sufficiently 'hot'
     // and should always be retained in the cache.

--- a/be/src/olap/compaction.h
+++ b/be/src/olap/compaction.h
@@ -126,6 +126,7 @@ protected:
 
     bool _is_vertical;
     bool _allow_delete_in_cumu_compaction;
+    bool _enable_vertical_compact_variant_subcolumns;
 
     Version _output_version;
 
@@ -179,7 +180,7 @@ protected:
 private:
     Status execute_compact_impl(int64_t permits);
 
-    void build_basic_info();
+    Status build_basic_info(bool is_ordered_compaction = false);
 
     // Return true if do ordered data compaction successfully
     bool handle_ordered_data_compaction();
@@ -222,7 +223,7 @@ private:
 
     Status execute_compact_impl(int64_t permits);
 
-    void build_basic_info();
+    Status build_basic_info();
 
     virtual Status modify_rowsets();
 

--- a/be/src/olap/rowset/rowset.h
+++ b/be/src/olap/rowset/rowset.h
@@ -142,7 +142,9 @@ public:
     // publish rowset to make it visible to read
     void make_visible(Version version);
     void set_version(Version version);
-    const TabletSchemaSPtr& tablet_schema() const { return _schema; }
+    const TabletSchemaSPtr& tablet_schema() const {
+        return _rowset_meta->tablet_schema() ? _rowset_meta->tablet_schema() : _schema;
+    }
 
     // helper class to access RowsetMeta
     int64_t start_version() const { return rowset_meta()->version().first; }

--- a/be/src/olap/rowset/rowset_writer_context.h
+++ b/be/src/olap/rowset/rowset_writer_context.h
@@ -106,6 +106,12 @@ struct RowsetWriterContext {
 
     bool is_transient_rowset_writer = false;
 
+    // When true, writers should remove variant extracted subcolumns from the
+    // schema stored in RowsetMeta. This is used when compaction temporarily
+    // extends schema to split variant subcolumns for vertical compaction but
+    // the final rowset meta must not persist those extracted subcolumns.
+    bool strip_variant_extracted_columns_in_rowset_meta = false;
+
     // For collect segment statistics for compaction
     std::vector<RowsetReaderSharedPtr> input_rs_readers;
 

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -1520,7 +1520,6 @@ Status DefaultValueColumnIterator::init(const ColumnIteratorOptions& opts) {
     // "NULL" is a special default value which means the default value is null.
     if (_has_default_value) {
         if (_default_value == "NULL") {
-            DCHECK(_is_nullable);
             _is_default_value_null = true;
         } else {
             _type_size = _type_info->size();

--- a/be/src/olap/rowset/segment_v2/column_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/column_writer.cpp
@@ -297,12 +297,12 @@ Status ColumnWriter::create_variant_writer(const ColumnWriterOptions& opts,
                                            std::unique_ptr<ColumnWriter>* writer) {
     if (column->is_extracted_column()) {
         VLOG_DEBUG << "gen subwriter for " << column->path_info_ptr()->get_path();
-        *writer = std::unique_ptr<ColumnWriter>(new VariantSubcolumnWriter(
-                opts, column, std::unique_ptr<Field>(FieldFactory::create(*column))));
+        *writer = std::make_unique<VariantSubcolumnWriter>(
+                opts, column, std::unique_ptr<Field>(FieldFactory::create(*column)));
         return Status::OK();
     }
-    *writer = std::unique_ptr<ColumnWriter>(new VariantColumnWriter(
-            opts, column, std::unique_ptr<Field>(FieldFactory::create(*column))));
+    *writer = std::make_unique<VariantColumnWriter>(
+            opts, column, std::unique_ptr<Field>(FieldFactory::create(*column)));
     return Status::OK();
 }
 

--- a/be/src/olap/rowset/segment_v2/variant/sparse_column_merge_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/variant/sparse_column_merge_iterator.cpp
@@ -1,0 +1,169 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "olap/rowset/segment_v2/variant/sparse_column_merge_iterator.h"
+
+#include <memory>
+#include <string_view>
+#include <unordered_map>
+
+#include "common/status.h"
+#include "olap/rowset/segment_v2/column_reader.h"
+#include "olap/rowset/segment_v2/stream_reader.h"
+#include "vec/columns/column.h"
+#include "vec/columns/column_nullable.h"
+#include "vec/columns/column_variant.h"
+#include "vec/columns/subcolumn_tree.h"
+#include "vec/common/assert_cast.h"
+#include "vec/data_types/data_type.h"
+#include "vec/data_types/data_type_nullable.h"
+
+namespace doris::segment_v2 {
+
+Status SparseColumnMergeIterator::seek_to_ordinal(ordinal_t ord) {
+    RETURN_IF_ERROR(_sparse_column_reader->seek_to_ordinal(ord));
+    for (auto& entry : _src_subcolumns_for_sparse) {
+        RETURN_IF_ERROR(entry->data.iterator->seek_to_ordinal(ord));
+    }
+    return Status::OK();
+}
+
+Status SparseColumnMergeIterator::init(const ColumnIteratorOptions& opts) {
+    RETURN_IF_ERROR(_sparse_column_reader->init(opts));
+    for (auto& entry : _src_subcolumns_for_sparse) {
+        entry->data.serde = entry->data.type->get_serde();
+        RETURN_IF_ERROR(entry->data.iterator->init(opts));
+        const auto& path = entry->path.get_path();
+        _sorted_src_subcolumn_for_sparse.emplace_back(StringRef(path.data(), path.size()), entry);
+    }
+
+    // sort src subcolumns by path
+    std::sort(
+            _sorted_src_subcolumn_for_sparse.begin(), _sorted_src_subcolumn_for_sparse.end(),
+            [](const auto& lhsItem, const auto& rhsItem) { return lhsItem.first < rhsItem.first; });
+    return Status::OK();
+}
+
+void SparseColumnMergeIterator::_serialize_nullable_column_to_sparse(
+        const SubstreamReaderTree::Node* src_subcolumn,
+        vectorized::ColumnString& dst_sparse_column_paths,
+        vectorized::ColumnString& dst_sparse_column_values, const StringRef& src_path, size_t row) {
+    // every subcolumn is always Nullable
+    const auto& nullable_serde =
+            assert_cast<vectorized::DataTypeNullableSerDe&>(*src_subcolumn->data.serde);
+    const auto& nullable_col =
+            assert_cast<const vectorized::ColumnNullable&, TypeCheckOnRelease::DISABLE>(
+                    *src_subcolumn->data.column);
+    if (nullable_col.is_null_at(row)) {
+        return;
+    }
+    // insert key
+    dst_sparse_column_paths.insert_data(src_path.data, src_path.size);
+    // insert value
+    vectorized::ColumnString::Chars& chars = dst_sparse_column_values.get_chars();
+    nullable_serde.get_nested_serde()->write_one_cell_to_binary(nullable_col.get_nested_column(),
+                                                                chars, row);
+    dst_sparse_column_values.get_offsets().push_back(chars.size());
+}
+
+void SparseColumnMergeIterator::_process_data_without_sparse_column(
+        vectorized::MutableColumnPtr& dst, size_t num_rows) {
+    if (_src_subcolumns_for_sparse.empty()) {
+        dst->insert_many_defaults(num_rows);
+    } else {
+        // merge subcolumns to sparse column
+        // Otherwise insert required src dense columns into sparse column.
+        auto& map_column = assert_cast<vectorized::ColumnMap&>(*dst);
+        auto& sparse_column_keys = assert_cast<vectorized::ColumnString&>(map_column.get_keys());
+        auto& sparse_column_values =
+                assert_cast<vectorized::ColumnString&>(map_column.get_values());
+        auto& sparse_column_offsets = map_column.get_offsets();
+        for (size_t i = 0; i != num_rows; ++i) {
+            // Paths in sorted_src_subcolumn_for_sparse_column are already sorted.
+            for (const auto& entry : _sorted_src_subcolumn_for_sparse) {
+                const auto& path = entry.first;
+                _serialize_nullable_column_to_sparse(entry.second.get(), sparse_column_keys,
+                                                     sparse_column_values, path, i);
+            }
+            sparse_column_offsets.push_back(sparse_column_keys.size());
+        }
+    }
+}
+
+void SparseColumnMergeIterator::_merge_to(vectorized::MutableColumnPtr& dst) {
+    auto& column_map = assert_cast<vectorized::ColumnMap&>(*dst);
+    auto& dst_sparse_column_paths = assert_cast<vectorized::ColumnString&>(column_map.get_keys());
+    auto& dst_sparse_column_values =
+            assert_cast<vectorized::ColumnString&>(column_map.get_values());
+    auto& dst_sparse_column_offsets = column_map.get_offsets();
+
+    const auto& src_column_map = assert_cast<const vectorized::ColumnMap&>(*_sparse_column);
+    const auto& src_sparse_column_paths =
+            assert_cast<const vectorized::ColumnString&>(*src_column_map.get_keys_ptr());
+    const auto& src_sparse_column_values =
+            assert_cast<const vectorized::ColumnString&>(*src_column_map.get_values_ptr());
+    const auto& src_serialized_sparse_column_offsets = src_column_map.get_offsets();
+    DCHECK_EQ(src_sparse_column_paths.size(), src_sparse_column_values.size());
+    // Src object column contains some paths in serialized sparse column in specified range.
+    // Iterate over this range and insert all required paths into serialized sparse column or subcolumns.
+    for (size_t row = 0; row != _sparse_column->size(); ++row) {
+        // Use separate index to iterate over sorted sorted_src_subcolumn_for_sparse_column.
+        size_t sorted_src_subcolumn_for_sparse_column_idx = 0;
+        size_t sorted_src_subcolumn_for_sparse_column_size = _src_subcolumns_for_sparse.size();
+
+        size_t offset = src_serialized_sparse_column_offsets[row - 1];
+        size_t end = src_serialized_sparse_column_offsets[row];
+        // Iterator over [path, binary value]
+        for (size_t i = offset; i != end; ++i) {
+            const StringRef src_sparse_path_string = src_sparse_column_paths.get_data_at(i);
+            // Check if we have this path in subcolumns. This path already materialized in subcolumns.
+            // So we don't need to insert it into sparse column.
+            if (!_src_subcolumn_map.contains(src_sparse_path_string)) {
+                // Before inserting this path into sparse column check if we need to
+                // insert subcolumns from sorted_src_subcolumn_for_sparse_column before.
+                while (sorted_src_subcolumn_for_sparse_column_idx <
+                               sorted_src_subcolumn_for_sparse_column_size &&
+                       _sorted_src_subcolumn_for_sparse[sorted_src_subcolumn_for_sparse_column_idx]
+                                       .first < src_sparse_path_string) {
+                    auto& [src_path, src_subcolumn] = _sorted_src_subcolumn_for_sparse
+                            [sorted_src_subcolumn_for_sparse_column_idx++];
+                    _serialize_nullable_column_to_sparse(src_subcolumn.get(),
+                                                         dst_sparse_column_paths,
+                                                         dst_sparse_column_values, src_path, row);
+                }
+
+                /// Insert path and value from src sparse column to our sparse column.
+                dst_sparse_column_paths.insert_from(src_sparse_column_paths, i);
+                dst_sparse_column_values.insert_from(src_sparse_column_values, i);
+            }
+        }
+
+        // Insert remaining dynamic paths from src_dynamic_paths_for_sparse_data.
+        while (sorted_src_subcolumn_for_sparse_column_idx <
+               sorted_src_subcolumn_for_sparse_column_size) {
+            auto& [src_path, src_subcolumn] =
+                    _sorted_src_subcolumn_for_sparse[sorted_src_subcolumn_for_sparse_column_idx++];
+            _serialize_nullable_column_to_sparse(src_subcolumn.get(), dst_sparse_column_paths,
+                                                 dst_sparse_column_values, src_path, row);
+        }
+
+        // All the sparse columns in this row are null.
+        dst_sparse_column_offsets.push_back(dst_sparse_column_paths.size());
+    }
+}
+
+} // namespace doris::segment_v2

--- a/be/src/olap/rowset/segment_v2/variant/sparse_column_merge_iterator.h
+++ b/be/src/olap/rowset/segment_v2/variant/sparse_column_merge_iterator.h
@@ -1,0 +1,135 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <parallel_hashmap/phmap.h>
+
+#include <memory>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+
+#include "common/exception.h"
+#include "common/status.h"
+#include "io/io_common.h"
+#include "olap/field.h"
+#include "olap/iterators.h"
+#include "olap/rowset/segment_v2/column_reader.h"
+#include "olap/rowset/segment_v2/stream_reader.h"
+#include "olap/rowset/segment_v2/variant/sparse_column_extract_iterator.h"
+#include "olap/schema.h"
+#include "olap/tablet_schema.h"
+#include "vec/columns/column.h"
+#include "vec/columns/column_nullable.h"
+#include "vec/columns/column_variant.h"
+#include "vec/columns/subcolumn_tree.h"
+#include "vec/common/assert_cast.h"
+#include "vec/core/column_with_type_and_name.h"
+#include "vec/core/columns_with_type_and_name.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type.h"
+#include "vec/data_types/data_type_array.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_string.h"
+#include "vec/data_types/data_type_variant.h"
+#include "vec/functions/function_helpers.h"
+#include "vec/json/path_in_data.h"
+
+namespace doris::segment_v2 {
+
+// Implementation for merge processor
+class SparseColumnMergeIterator : public BaseSparseColumnProcessor {
+public:
+    SparseColumnMergeIterator(const TabletSchema::PathsSetInfo& path_set_info,
+                              std::unique_ptr<ColumnIterator>&& sparse_column_reader,
+                              SubstreamReaderTree&& src_subcolumns_for_sparse,
+                              StorageReadOptions* opts, const TabletColumn& col)
+            : BaseSparseColumnProcessor(std::move(sparse_column_reader), opts, col),
+              _src_subcolumn_map(path_set_info.sub_path_set),
+              _src_subcolumns_for_sparse(src_subcolumns_for_sparse) {}
+    Status init(const ColumnIteratorOptions& opts) override;
+
+    // Batch processing using template method
+    Status next_batch(size_t* n, vectorized::MutableColumnPtr& dst, bool* has_null) override {
+        // read subcolumns first
+        RETURN_IF_ERROR(_read_subcolumns([&](SubstreamReaderTree::Node* entry) {
+            bool has_null = false;
+            return entry->data.iterator->next_batch(n, entry->data.column, &has_null);
+        }));
+        // then read sparse column
+        return _process_batch(
+                [&]() { return _sparse_column_reader->next_batch(n, _sparse_column, has_null); },
+                *n, dst);
+    }
+
+    // RowID-based read using template method
+    Status read_by_rowids(const rowid_t* rowids, const size_t count,
+                          vectorized::MutableColumnPtr& dst) override {
+        // read subcolumns first
+        RETURN_IF_ERROR(_read_subcolumns([&](SubstreamReaderTree::Node* entry) {
+            return entry->data.iterator->read_by_rowids(rowids, count, entry->data.column);
+        }));
+        // then read sparse column
+        return _process_batch(
+                [&]() {
+                    return _sparse_column_reader->read_by_rowids(rowids, count, _sparse_column);
+                },
+                count, dst);
+    }
+
+    Status seek_to_ordinal(ordinal_t ord) override;
+
+private:
+    template <typename ReadFunction>
+    Status _read_subcolumns(ReadFunction&& read_func) {
+        // clear previous data
+        for (auto& entry : _src_subcolumns_for_sparse) {
+            entry->data.column->clear();
+        }
+        // read subcolumns
+        for (auto& entry : _src_subcolumns_for_sparse) {
+            RETURN_IF_ERROR(read_func(entry.get()));
+        }
+        return Status::OK();
+    }
+
+    // subcolumns in src tablet schema, which will be filtered
+    PathSet _src_subcolumn_map;
+    // subcolumns to merge to sparse column
+    SubstreamReaderTree _src_subcolumns_for_sparse;
+    std::vector<std::pair<StringRef, std::shared_ptr<SubstreamReaderTree::Node>>>
+            _sorted_src_subcolumn_for_sparse;
+
+    // Path filtering implementation
+    void _process_data_with_existing_sparse_column(vectorized::MutableColumnPtr& dst,
+                                                   size_t num_rows) override {
+        _merge_to(dst);
+    }
+
+    void _merge_to(vectorized::MutableColumnPtr& dst);
+
+    void _process_data_without_sparse_column(vectorized::MutableColumnPtr& dst,
+                                             size_t num_rows) override;
+
+    void _serialize_nullable_column_to_sparse(const SubstreamReaderTree::Node* src_subcolumn,
+                                              vectorized::ColumnString& dst_sparse_column_paths,
+                                              vectorized::ColumnString& dst_sparse_column_values,
+                                              const StringRef& src_path, size_t row);
+};
+
+} // namespace doris::segment_v2

--- a/be/src/olap/rowset/segment_v2/variant/variant_column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/variant/variant_column_reader.cpp
@@ -31,7 +31,7 @@
 #include "olap/rowset/segment_v2/segment.h"
 #include "olap/rowset/segment_v2/variant/hierarchical_data_iterator.h"
 #include "olap/rowset/segment_v2/variant/sparse_column_extract_iterator.h"
-//#include "olap/rowset/segment_v2/variant/sparse_column_merge_iterator.h"
+#include "olap/rowset/segment_v2/variant/sparse_column_merge_iterator.h"
 #include "olap/tablet_schema.h"
 #include "vec/columns/column_array.h"
 #include "vec/columns/column_nullable.h"
@@ -120,43 +120,42 @@ Status VariantColumnReader::_create_hierarchical_reader(ColumnIterator** reader,
     return Status::OK();
 }
 
-// Status VariantColumnReader::_create_sparse_merge_reader(ColumnIterator** iterator,
-//                                                         const StorageReadOptions* opts,
-//                                                         const TabletColumn& target_col,
-//                                                         ColumnIterator* inner_iter) {
-//     // Get subcolumns path set from tablet schema
-//     const auto& path_set_info = opts->tablet_schema->path_set_info(target_col.parent_unique_id());
-//
-//     // Build substream reader tree for merging subcolumns into sparse column
-//     SubstreamReaderTree src_subcolumns_for_sparse;
-//     for (const auto& subcolumn_reader : *_subcolumn_readers) {
-//         const auto& path = subcolumn_reader->path.get_path();
-//         if (path_set_info.sparse_path_set.find(StringRef(path)) ==
-//             path_set_info.sparse_path_set.end()) {
-//             // The subcolumn is not a sparse column, skip it
-//             continue;
-//         }
-//         // Create subcolumn iterator
-//         ColumnIterator* it;
-//         RETURN_IF_ERROR(subcolumn_reader->data.reader->new_iterator(&it, nullptr));
-//         std::unique_ptr<ColumnIterator> it_ptr(it);
-//
-//         // Create substream reader and add to tree
-//         SubstreamIterator reader(subcolumn_reader->data.file_column_type->create_column(),
-//                                  std::move(it_ptr), subcolumn_reader->data.file_column_type);
-//         if (!src_subcolumns_for_sparse.add(subcolumn_reader->path, std::move(reader))) {
-//             return Status::InternalError("Failed to add node path {}", path);
-//         }
-//     }
-//     VLOG_DEBUG << "subcolumns to merge " << src_subcolumns_for_sparse.size();
-//     // Create sparse column merge reader
-//     TODO(lihangyu): uncomment
-//     *iterator = new SparseColumnMergeIterator(path_set_info,
-//                                               std::unique_ptr<ColumnIterator>(inner_iter),
-//                                               std::move(src_subcolumns_for_sparse),
-//                                               const_cast<StorageReadOptions*>(opts), target_col);
-//     return Status::OK();
-// }
+Status VariantColumnReader::_create_sparse_merge_reader(ColumnIterator** iterator,
+                                                        const StorageReadOptions* opts,
+                                                        const TabletColumn& target_col,
+                                                        ColumnIterator* inner_iter) {
+    // Get subcolumns path set from tablet schema
+    const auto& path_set_info = opts->tablet_schema->path_set_info(target_col.parent_unique_id());
+
+    // Build substream reader tree for merging subcolumns into sparse column
+    SubstreamReaderTree src_subcolumns_for_sparse;
+    for (const auto& subcolumn_reader : *_subcolumn_readers) {
+        const auto& path = subcolumn_reader->path.get_path();
+        if (path_set_info.sparse_path_set.find(StringRef(path)) ==
+            path_set_info.sparse_path_set.end()) {
+            // The subcolumn is not a sparse column, skip it
+            continue;
+        }
+        // Create subcolumn iterator
+        ColumnIterator* it;
+        RETURN_IF_ERROR(subcolumn_reader->data.reader->new_iterator(&it, nullptr));
+        std::unique_ptr<ColumnIterator> it_ptr(it);
+
+        // Create substream reader and add to tree
+        SubstreamIterator reader(subcolumn_reader->data.file_column_type->create_column(),
+                                 std::move(it_ptr), subcolumn_reader->data.file_column_type);
+        if (!src_subcolumns_for_sparse.add(subcolumn_reader->path, std::move(reader))) {
+            return Status::InternalError("Failed to add node path {}", path);
+        }
+    }
+    VLOG_DEBUG << "subcolumns to merge " << src_subcolumns_for_sparse.size();
+    // Create sparse column merge reader
+    *iterator = new SparseColumnMergeIterator(path_set_info,
+                                              std::unique_ptr<ColumnIterator>(inner_iter),
+                                              std::move(src_subcolumns_for_sparse),
+                                              const_cast<StorageReadOptions*>(opts), target_col);
+    return Status::OK();
+}
 
 Status VariantColumnReader::_new_default_iter_with_same_nested(ColumnIterator** iterator,
                                                                const TabletColumn& tablet_column) {
@@ -206,15 +205,14 @@ Status VariantColumnReader::_new_iterator_with_flat_leaves(ColumnIterator** iter
     const auto* node =
             target_col.has_path_info() ? _subcolumn_readers->find_leaf(relative_path) : nullptr;
     if (!node) {
-        // TODO(lihangyu): uncomment
-        // if (relative_path.get_path() == SPARSE_COLUMN_PATH) {
-        //     // read sparse column and filter extracted columns in subcolumn_path_map
-        //     ColumnIterator* inner_iter;
-        //     RETURN_IF_ERROR(_sparse_column_reader->new_iterator(&inner_iter, nullptr));
-        //     // get subcolumns in sparse path set which will be merged into sparse column
-        //     RETURN_IF_ERROR(_create_sparse_merge_reader(iterator, opts, target_col, inner_iter));
-        //     return Status::OK();
-        // }
+        if (relative_path.get_path() == SPARSE_COLUMN_PATH) {
+            // read sparse column and filter extracted columns in subcolumn_path_map
+            ColumnIterator* inner_iter;
+            RETURN_IF_ERROR(_sparse_column_reader->new_iterator(&inner_iter, nullptr));
+            // get subcolumns in sparse path set which will be merged into sparse column
+            RETURN_IF_ERROR(_create_sparse_merge_reader(iterator, opts, target_col, inner_iter));
+            return Status::OK();
+        }
 
         if (target_col.is_nested_subcolumn()) {
             // using the sibling of the nested column to fill the target nested column
@@ -280,7 +278,8 @@ Status VariantColumnReader::new_iterator(ColumnIterator** iterator, const Tablet
                                                 config::variant_max_sparse_column_statistics_size;
 
     // If the variant column has extracted columns and is a compaction reader, then read flat leaves
-    // Otherwise read hierarchical data, since the variant subcolumns are flattened in schema_util::get_extended_compaction_schema
+    // Otherwise read hierarchical data, since the variant subcolumns are flattened in schema_util::VariantCompactionUtil::get_extended_compaction_schema
+    // when config::enable_vertical_compact_variant_subcolumns is true
     auto has_extracted_columns_in_compaction = [](const StorageReadOptions* opts) {
         return opts != nullptr && opts->tablet_schema != nullptr &&
                std::ranges::any_of(
@@ -416,20 +415,19 @@ Status VariantColumnReader::init(const ColumnReaderOptions& opts, const SegmentF
             }
             _subcolumn_readers->add(relative_path,
                                     SubcolumnReader {std::move(reader), get_data_type_fn()});
-            // TODO(lihangyu): uncomment
-            // TabletSchema::SubColumnInfo sub_column_info;
-            // // if subcolumn has index, add index to _variant_subcolumns_indexes
-            // if (vectorized::schema_util::generate_sub_column_info(
-            //             *opts.tablet_schema, self_column_pb.unique_id(), relative_path.get_path(),
-            //             &sub_column_info) &&
-            //     !sub_column_info.indexes.empty()) {
-            //     _variant_subcolumns_indexes[path.get_path()] = std::move(sub_column_info.indexes);
-            // }
+            TabletSchema::SubColumnInfo sub_column_info;
+            // if subcolumn has index, add index to _variant_subcolumns_indexes
+            if (vectorized::schema_util::generate_sub_column_info(
+                        *opts.tablet_schema, self_column_pb.unique_id(), relative_path.get_path(),
+                        &sub_column_info) &&
+                !sub_column_info.indexes.empty()) {
+                _variant_subcolumns_indexes[path.get_path()] = std::move(sub_column_info.indexes);
+            }
             // if parent column has index, add index to _variant_subcolumns_indexes
-            // else if (!parent_index.empty()) {
-            vectorized::schema_util::inherit_index(
-                    parent_index, _variant_subcolumns_indexes[path.get_path()], column_pb);
-            //}
+            else if (!parent_index.empty()) {
+                vectorized::schema_util::inherit_index(
+                        parent_index, _variant_subcolumns_indexes[path.get_path()], column_pb);
+            }
         }
     }
 

--- a/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
@@ -178,6 +178,7 @@ Status VerticalBetaRowsetWriter<T>::_create_segment_writer(
     writer_options.enable_unique_key_merge_on_write = context.enable_unique_key_merge_on_write;
     writer_options.rowset_ctx = &context;
     writer_options.max_rows_per_segment = context.max_rows_per_segment;
+    writer_options.write_type = DataWriteType::TYPE_COMPACTION;
     // TODO if support VerticalSegmentWriter, also need to handle cluster key primary key index
     *writer = std::make_unique<segment_v2::SegmentWriter>(
             segment_file_writer.get(), seg_id, context.tablet_schema, context.tablet,

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -959,6 +959,7 @@ void TabletMeta::modify_rs_metas(const std::vector<RowsetMetaSharedPtr>& to_add,
         // put to_delete rowsets in _stale_rs_metas.
         _stale_rs_metas.insert(_stale_rs_metas.end(), to_delete.begin(), to_delete.end());
     }
+
     // put to_add rowsets in _rs_metas.
     _rs_metas.insert(_rs_metas.end(), to_add.begin(), to_add.end());
     _check_mow_rowset_cache_version_size(rowset_cache_version_size);

--- a/be/src/vec/data_types/get_least_supertype.cpp
+++ b/be/src/vec/data_types/get_least_supertype.cpp
@@ -243,6 +243,10 @@ void get_least_supertype_jsonb(const DataTypes& types, DataTypePtr* type) {
     for (const auto& type : types) {
         type_ids.insert(type->get_primitive_type());
     }
+    if (type_ids.size() == 1) {
+        *type = types[0];
+        return;
+    }
     get_least_supertype_jsonb(type_ids, type);
 }
 

--- a/be/test/olap/compaction_metrics_test.cpp
+++ b/be/test/olap/compaction_metrics_test.cpp
@@ -198,8 +198,8 @@ TEST_F(CompactionMetricsTest, TestCompactionReadWriteThroughput) {
     auto* sp = SyncPoint::get_instance();
     sp->enable_processing();
     sp->set_call_back("compaction::CompactionMixin::build_basic_info", [](auto&& values) {
-        bool* pred = try_any_cast<bool*>(values.back());
-        *pred = true;
+        auto* pairs = try_any_cast<std::pair<Status, bool>*>(values.back());
+        pairs->second = true;
     });
     sp->set_call_back("compaction::CompactionMixin::execute_compact_impl", [&](auto&& values) {
         auto* pairs = try_any_cast<std::pair<Status, bool>*>(values.back());

--- a/be/test/olap/rowset/segment_v2/inverted_index/compaction/util/index_compaction_utils.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index/compaction/util/index_compaction_utils.cpp
@@ -437,7 +437,7 @@ class IndexCompactionUtils {
         // only base compaction can handle delete predicate
         BaseCompaction compaction(*engine_ref, tablet);
         compaction._input_rowsets = std::move(rowsets);
-        compaction.build_basic_info();
+        RETURN_IF_ERROR(compaction.build_basic_info());
 
         std::vector<RowsetReaderSharedPtr> input_rs_readers;
         create_input_rowsets_readers(compaction, input_rs_readers);

--- a/be/test/vec/columns/column_variant_test.cpp
+++ b/be/test/vec/columns/column_variant_test.cpp
@@ -1408,7 +1408,7 @@ TEST_F(ColumnVariantTest, clear) {
 }
 
 TEST_F(ColumnVariantTest, convert_column_if_overflow) {
-    // convert_column_if_overflow may need impl in ColumnObject, like ColumnArray?
+    // convert_column_if_overflow may need impl in ColumnVariant, like ColumnArray?
     auto ret = column_variant->convert_column_if_overflow();
     EXPECT_EQ(ret.get(), column_variant.get());
 }
@@ -2509,7 +2509,7 @@ TEST_F(ColumnVariantTest, unnest) {
 }
 
 TEST_F(ColumnVariantTest, path_in_data_builder_test) {
-    // Create a ColumnObject with nested subcolumns
+    // Create a ColumnVariant with nested subcolumns
     auto variant = ColumnVariant::create(5);
 
     // Test case 1: Build a nested path with PathInDataBuilder

--- a/be/test/vec/columns/common_column_test.h
+++ b/be/test/vec/columns/common_column_test.h
@@ -1207,7 +1207,7 @@ public:
         ASSERT_EQ(expect_name, column.get_name());
     }
 
-    // use in ColumnObject for check_if_sparse_column
+    // use in ColumnVariant for check_if_sparse_column
     static void assert_get_ratio_of_default_rows(MutableColumns& load_cols,
                                                  DataTypeSerDeSPtrs serders) {
         // just check cols get_ratio_of_default_rows is the same as assert_res

--- a/be/test/vec/common/schema_util_rowset_test.cpp
+++ b/be/test/vec/common/schema_util_rowset_test.cpp
@@ -392,6 +392,11 @@ TEST_F(SchemaUtilRowsetTest, collect_path_stats_and_get_extended_compaction_sche
     EXPECT_EQ(Status::OK(), output_rs_writer->build(out_rowset));
     ASSERT_TRUE(out_rowset);
 
+    // check no variant subcolumns in output rowset
+    for (const auto& column : out_rowset->tablet_schema()->columns()) {
+        EXPECT_FALSE(column->is_extracted_column());
+    }
+
     // 7. check output rowset
     EXPECT_TRUE(schema_util::VariantCompactionUtil::check_path_stats(rowsets, out_rowset, _tablet)
                         .ok());
@@ -628,6 +633,11 @@ TEST_F(SchemaUtilRowsetTest, typed_path_to_sparse_column) {
     RowsetSharedPtr out_rowset;
     EXPECT_EQ(Status::OK(), output_rs_writer->build(out_rowset));
     ASSERT_TRUE(out_rowset);
+
+    // check no variant subcolumns in output rowset
+    for (const auto& column : out_rowset->tablet_schema()->columns()) {
+        EXPECT_FALSE(column->is_extracted_column());
+    }
 
     // 7. check output rowset
     EXPECT_TRUE(schema_util::VariantCompactionUtil::check_path_stats(rowsets, out_rowset, _tablet)

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -2826,6 +2826,7 @@ public class SessionVariable implements Serializable, Writable {
         // 10MB = 10 * 1024 * 1024 bytes
         int maxBytes = 10 * 1024 * 1024;
         this.exchangeMultiBlocksByteSize = minBytes + (int) (random.nextDouble() * (maxBytes - minBytes));
+        this.defaultVariantMaxSubcolumnsCount = random.nextInt(10);
         int randomInt = random.nextInt(4);
         if (randomInt % 2 == 0) {
             this.rewriteOrToInPredicateThreshold = 100000;

--- a/regression-test/data/variant_p0/with_index/var_index.out
+++ b/regression-test/data/variant_p0/with_index/var_index.out
@@ -6,6 +6,11 @@
 
 -- !sql --
 2	{"a":18811,"b":"hello world","c":1181111}
+3	{"a":18811,"b":"hello wworld","c":11111}
+4	{"a":1234,"b":"hello xxx world","c":8181111}
+
+-- !sql --
+2	{"a":18811,"b":"hello world","c":1181111}
 4	{"a":1234,"b":"hello xxx world","c":8181111}
 
 -- !sql --
@@ -13,12 +18,12 @@
 2	{"a":18811,"b":"hello world","c":1181111}
 3	{"a":18811,"b":"hello wworld","c":11111}
 4	{"a":1234,"b":"hello xxx world","c":8181111}
-5	{"a":123456789,"b":123456,"c":8181111}
-6	{"timestamp":1713283200.06036}
+5	{"a":123456789,"b":"123456","c":8181111}
+6	{"timestamp":1713283200.060359}
 7	{"timestamp":17}
-8	{"timestamp":[123]}
+8	{"arr":[123]}
 9	{"timestamp":17}
-10	{"timestamp":"17.0"}
+10	{"timestamp":17}
 11	{"nested":[{"a":1}]}
 11	{"nested":[{"b":"1024"}]}
 

--- a/regression-test/suites/variant_p0/compaction/test_compaction.groovy
+++ b/regression-test/suites/variant_p0/compaction/test_compaction.groovy
@@ -53,7 +53,7 @@ suite("test_compaction_variant") {
                 )
                 ${key_type} KEY(`k`)
                 DISTRIBUTED BY HASH(k) BUCKETS ${buckets}
-                properties("replication_num" = "1", "disable_auto_compaction" = "false");
+                properties("replication_num" = "1", "disable_auto_compaction" = "true");
             """
         }
 

--- a/regression-test/suites/variant_p0/test_variant_is_null_expr.groovy
+++ b/regression-test/suites/variant_p0/test_variant_is_null_expr.groovy
@@ -19,7 +19,7 @@
 suite("test_variant_is_null_expr", "p0, nonConcurrent") {
     // define a sql table
     def testTable = "test_variant_is_null_expr"
-
+    sql "set default_variant_max_subcolumns_count = 10"
     sql """ DROP TABLE IF EXISTS ${testTable} """ 
     sql """
         CREATE TABLE ${testTable} (


### PR DESCRIPTION
This commit introduces a new mechanism to improve compaction
  performance for tables with VARIANT columns by enabling vertical
  compaction for frequently accessed subcolumns.

Key Changes:

 1. Vertical Compaction of Subcolumns: During compaction, the table schema is temporarily extended to treat "hot" subcolumns (frequently accessed paths) within the VARIANT column as separate, top-level columns. This allows them to
 be compacted more efficiently in their own column groups,
improving overall performance. This behavior is controlled by the new configuration parameter
`enable_vertical_compact_variant_subcolumns`, which is enabled by default.

 2. Schema Handling in Rowsets: * To prevent these temporary extracted subcolumns from being persisted permanently, a new flag, strip_variant_extracted_columns_in_rowset_meta, has been added to RowsetWriterContext. When enabled, the RowsetWriter removes these temporary columns from the schema before saving the rowset metadata. * This change ensures that the in-memory Rowset object uses the same schema as the one persisted in its RowsetMeta, preventing potential data inconsistencies.

 3. Sparse Column Merging on Read:
     * A new SparseColumnMergeIterator has been implemented. This iterator is responsible for merging data from the base sparse representation of the VARIANT with data from any extracted subcolumns during reads. This provides a complete and unified view of the VARIANT data to the upper-level query engine.

 4. Other Fixes and Improvements: * The DataTypeVariant constructor now correctly accepts the max_subcolumns_count parameter. * A new correctness check (check_path_stats) has been added to ensure that the final output rowset does not contain any temporary, extracted subcolumns after compaction. * Previously commented-out code related to subcolumn indexing and sparse column merging has been re-enabled. * The build_basic_info method in the compaction process has been refactored to return a Status for more robust error handling.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

