### PR TITLE
[chore](build) Fix macOS compilation without PCH enabled

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -340,6 +340,11 @@ add_definitions(-D__STDC_FORMAT_MACROS
 # Thrift requires these two definitions for some types that we use
 add_definitions(-DHAVE_INTTYPES_H -DHAVE_NETINET_IN_H)
 
+# Mac specific definitions - needed for system headers and third-party libs
+if (OS_MACOSX)
+    add_definitions(-D_DARWIN_C_SOURCE)
+endif()
+
 if (RECORD_COMPILER_SWITCHES)
     add_compile_options(-frecord-gcc-switches)
 endif()

--- a/be/src/pipeline/dependency.h
+++ b/be/src/pipeline/dependency.h
@@ -17,6 +17,11 @@
 
 #pragma once
 
+#ifdef __APPLE__
+#include <netinet/in.h>
+#include <sys/_types/_u_int.h>
+#endif
+
 #include <concurrentqueue.h>
 #include <sqltypes.h>
 

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -47,11 +47,6 @@
 #define ALLOCATOR_ASLR 1
 #endif
 
-#if !defined(__APPLE__) && !defined(__FreeBSD__)
-#else
-#define _DARWIN_C_SOURCE
-#endif
-
 #include <sys/mman.h>
 
 #include <algorithm>

--- a/be/src/vec/core/wide_integer.h
+++ b/be/src/vec/core/wide_integer.h
@@ -45,6 +45,7 @@
 #include <iomanip>
 #include <iostream>
 #include <limits>
+#include <sstream>
 #include <string>
 #include <type_traits>
 

--- a/be/src/vec/core/wide_integer_impl.h
+++ b/be/src/vec/core/wide_integer_impl.h
@@ -1212,7 +1212,7 @@ constexpr integer<Bits, Signed>::operator long double() const noexcept {
         long double t = res;
         res *= static_cast<long double>(std::numeric_limits<base_type>::max());
         res += t;
-        res += tmp.items[_impl::big(i)];
+        res += static_cast<long double>(tmp.items[_impl::big(i)]);
     }
 
     if (_impl::is_negative(*this)) {


### PR DESCRIPTION
  This PR fixes compilation issues on macOS when Precompiled Headers (PCH) are disabled. The changes include:

  Key fixes:
  - Add _DARWIN_C_SOURCE macro definition for macOS to enable system headers like INADDR_NONE
  - Include necessary system headers (netinet/in.h, sys/_types/_u_int.h) for macOS compatibility
  - Add missing <sstream> header for std::ostringstream usage
  - Fix implicit type conversion warnings in wide integer implementation

  Changes:
  - Updated CMakeLists.txt with macOS-specific definitions
  - Added system header includes in dependency.h for macOS
  - Fixed missing header includes in wide_integer.h
  - Added explicit type casting to resolve precision warnings

  This ensures the codebase compiles correctly on macOS regardless of PCH settings.