### PR TITLE
[fix](iceberg) Remove duplicated warehouse propert

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/IcebergRestProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/IcebergRestProperties.java
@@ -58,11 +58,6 @@ public class IcebergRestProperties extends AbstractIcebergProperties {
             description = "The prefix of the iceberg rest catalog service.")
     private String icebergRestPrefix = "";
 
-    @ConnectorProperty(names = {"iceberg.rest.warehouse", "warehouse"},
-            required = false,
-            description = "The warehouse of the iceberg rest catalog service.")
-    private String icebergRestWarehouse = "";
-
     @ConnectorProperty(names = {"iceberg.rest.security.type"},
             required = false,
             description = "The security type of the iceberg rest catalog service,"
@@ -221,8 +216,8 @@ public class IcebergRestProperties extends AbstractIcebergProperties {
             icebergRestCatalogProperties.put(PREFIX_PROPERTY, icebergRestPrefix);
         }
 
-        if (Strings.isNotBlank(icebergRestWarehouse)) {
-            icebergRestCatalogProperties.put(CatalogProperties.WAREHOUSE_LOCATION, icebergRestWarehouse);
+        if (Strings.isNotBlank(warehouse)) {
+            icebergRestCatalogProperties.put(CatalogProperties.WAREHOUSE_LOCATION, warehouse);
         }
 
         if (isIcebergRestVendedCredentialsEnabled()) {
@@ -266,7 +261,7 @@ public class IcebergRestProperties extends AbstractIcebergProperties {
      * This method handles all storage types (HDFS, S3, MinIO, etc.) and populates
      * the fileIOProperties map and Configuration object accordingly.
      *
-     * @param storagePropertiesMap Map of storage properties
+     * @param storagePropertiesList Map of storage properties
      * @param fileIOProperties Options map to be populated
      * @param conf Configuration object to be populated (for HDFS), will be created if null and HDFS is used
      */

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/IcebergRestPropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/IcebergRestPropertiesTest.java
@@ -32,8 +32,8 @@ public class IcebergRestPropertiesTest {
     public void testBasicRestProperties() {
         Map<String, String> props = new HashMap<>();
         props.put("iceberg.rest.uri", "http://localhost:8080");
-        props.put("iceberg.rest.warehouse", "s3://warehouse/path");
         props.put("iceberg.rest.prefix", "prefix");
+        props.put("warehouse", "s3://warehouse/path");
 
         IcebergRestProperties restProps = new IcebergRestProperties(props);
         restProps.initNormalizeAndCheckProps();
@@ -209,7 +209,7 @@ public class IcebergRestPropertiesTest {
 
         Map<String, String> props2 = new HashMap<>();
         props2.put("iceberg.rest.uri", "http://localhost:8080");
-        props2.put("iceberg.rest.warehouse", "s3://warehouse/path");
+        props2.put("warehouse", "s3://warehouse/path");
         IcebergRestProperties restProps2 = new IcebergRestProperties(props2);
         restProps2.initNormalizeAndCheckProps();
         Assertions.assertEquals("s3://warehouse/path",


### PR DESCRIPTION
`AbstractIcebergProperties` already defines the warehouse property, so there is no need to redefine it in `IcebergRestProperties`. Also, `iceberg.rest.warehouse` is not a standard Iceberg API name and should be unified as `warehouse`.