### PR TITLE
[Chore](memory) add jemalloc_hook to make jemalloc control malloc

### DIFF
--- a/be/src/runtime/CMakeLists.txt
+++ b/be/src/runtime/CMakeLists.txt
@@ -25,6 +25,10 @@ set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/runtime")
 
 file(GLOB_RECURSE RUNTIME_FILES CONFIGURE_DEPENDS *.cpp *.cc)
 
+if (NOT USE_JEMALLOC OR OS_MACOSX)
+    list(REMOVE_ITEM RUNTIME_FILES ${CMAKE_CURRENT_SOURCE_DIR}/memory/jemalloc_hook.cpp)
+endif()
+
 add_library(Runtime STATIC
     ${RUNTIME_FILES}
 )

--- a/be/src/runtime/memory/jemalloc_hook.cpp
+++ b/be/src/runtime/memory/jemalloc_hook.cpp
@@ -1,0 +1,85 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "jemalloc/jemalloc.h"
+
+#ifndef __THROW
+#if __cplusplus
+#define __THROW noexcept
+#else
+#define __THROW
+#endif
+#endif
+
+extern "C" {
+void* doris_malloc(size_t size) __THROW {
+    return jemalloc(size);
+}
+
+void doris_free(void* p) __THROW {
+    jefree(p);
+}
+
+void* doris_realloc(void* p, size_t size) __THROW {
+    return jerealloc(p, size);
+}
+
+void* doris_calloc(size_t n, size_t size) __THROW {
+    return jecalloc(n, size);
+}
+
+void doris_cfree(void* ptr) __THROW {
+    jefree(ptr);
+}
+
+void* doris_memalign(size_t align, size_t size) __THROW {
+    return jealigned_alloc(align, size);
+}
+
+void* doris_aligned_alloc(size_t align, size_t size) __THROW {
+    return jealigned_alloc(align, size);
+}
+
+void* doris_valloc(size_t size) __THROW {
+    return jevalloc(size);
+}
+
+void* doris_pvalloc(size_t size) __THROW {
+    return jevalloc(size);
+}
+
+int doris_posix_memalign(void** r, size_t align, size_t size) __THROW {
+    return jeposix_memalign(r, align, size);
+}
+
+size_t doris_malloc_usable_size(void* ptr) __THROW {
+    return jemalloc_usable_size(ptr);
+}
+
+#define ALIAS(doris_fn) __attribute__((alias(#doris_fn), used))
+void* malloc(size_t size) __THROW ALIAS(doris_malloc);
+void free(void* p) __THROW ALIAS(doris_free);
+void* realloc(void* p, size_t size) __THROW ALIAS(doris_realloc);
+void* calloc(size_t n, size_t size) __THROW ALIAS(doris_calloc);
+void cfree(void* ptr) __THROW ALIAS(doris_cfree);
+void* memalign(size_t align, size_t size) __THROW ALIAS(doris_memalign);
+void* aligned_alloc(size_t align, size_t size) __THROW ALIAS(doris_aligned_alloc);
+void* valloc(size_t size) __THROW ALIAS(doris_valloc);
+void* pvalloc(size_t size) __THROW ALIAS(doris_pvalloc);
+int posix_memalign(void** r, size_t a, size_t s) __THROW ALIAS(doris_posix_memalign);
+size_t malloc_usable_size(void* ptr) __THROW ALIAS(doris_malloc_usable_size);
+}

--- a/build.sh
+++ b/build.sh
@@ -400,20 +400,7 @@ elif [[ -z "${USE_JEMALLOC}" ]]; then
         USE_JEMALLOC='OFF'
     fi
 fi
-if [[ -f "${TP_INCLUDE_DIR}/jemalloc/jemalloc_doris_with_prefix.h" ]]; then
-    # compatible with old thirdparty
-    rm -rf "${TP_INCLUDE_DIR}/jemalloc/jemalloc.h"
-    rm -rf "${TP_LIB_DIR}/libjemalloc_doris.a"
-    rm -rf "${TP_LIB_DIR}/libjemalloc_doris_pic.a"
-    rm -rf "${TP_INCLUDE_DIR}/rocksdb"
-    rm -rf "${TP_LIB_DIR}/librocksdb.a"
 
-    mv "${TP_INCLUDE_DIR}/jemalloc/jemalloc_doris_with_prefix.h" "${TP_INCLUDE_DIR}/jemalloc/jemalloc.h"
-    mv "${TP_LIB_DIR}/libjemalloc_doris_with_prefix.a" "${TP_LIB_DIR}/libjemalloc_doris.a"
-    mv "${TP_LIB_DIR}/libjemalloc_doris_with_prefix_pic.a" "${TP_LIB_DIR}/libjemalloc_doris_pic.a"
-    mv "${TP_LIB_DIR}/librocksdb_jemalloc_with_prefix.a" "${TP_LIB_DIR}/librocksdb.a"
-    mv -f "${TP_INCLUDE_DIR}/rocksdb_jemalloc_with_prefix" "${TP_INCLUDE_DIR}/rocksdb"
-fi
 if [[ -z "${USE_BTHREAD_SCANNER}" ]]; then
     USE_BTHREAD_SCANNER='OFF'
 fi

--- a/cloud/src/common/CMakeLists.txt
+++ b/cloud/src/common/CMakeLists.txt
@@ -15,6 +15,12 @@ set(COMMON_FILES
     network_util.cpp
 )
 
+if (USE_JEMALLOC)
+    set(COMMON_FILES ${COMMON_FILES}
+        ${BUILD_DIR}/../../be/src/runtime/memory/jemalloc_hook.cpp
+    )
+endif()
+
 add_library(Common STATIC
     ${COMMON_FILES}
     )


### PR DESCRIPTION
### What problem does this PR solve?
In #53794 and #54028, we remove jemalloc_hook, but I found that without a jemalloc hook would cause doris to allocate memory not to apply jemalloc, but instead use glibc's malloc, so I added it back.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

