### PR TITLE
[Fix](partition) Avoid duplicated partition creation due to parallel request

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3568,4 +3568,8 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, description = {"Prometheus 输出表维度指标的个数限制",
             "Prometheus output table dimension metric count limit"})
     public static int prom_output_table_metrics_limit = 10000;
+
+
+    @ConfField(mutable = true, masterOnly = true)
+    public static long create_partition_wait_seconds = 300;
 }

--- a/fe/fe-common/src/main/java/org/apache/doris/common/ResultOr.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/ResultOr.java
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+public class ResultOr<T, E> {
+    private final T value;
+
+    private final E error;
+
+    private final boolean isSuccess;
+
+    private ResultOr(T value, E error, boolean isSuccess) {
+        this.value = value;
+        this.error = error;
+        this.isSuccess = isSuccess;
+    }
+
+    public static <T, E> ResultOr<T, E> ok(T value) {
+        return new ResultOr<>(value, null, true);
+    }
+
+    public static <T, E> ResultOr<T, E> err(E error) {
+        return new ResultOr<>(null, error, false);
+    }
+
+    public boolean isOk() {
+        return isSuccess;
+    }
+
+    public boolean isErr() {
+        return !isSuccess;
+    }
+
+    public T unwrap() {
+        if (!isSuccess) {
+            throw new IllegalStateException("Tried to unwrap Err: " + error);
+        }
+        return value;
+    }
+
+    public E unwrapErr() {
+        if (isSuccess) {
+            throw new IllegalStateException("Tried to unwrapOk");
+        }
+        return error;
+    }
+
+    @Override
+    public String toString() {
+        return isSuccess ? "Ok(" + value + ")" : "Err(" + error + ")";
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -2001,11 +2001,6 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
         }
         tempPartitions.unsetPartitionInfo();
 
-        // Initialize transient state not present in persisted meta.
-        if (partitionCreationFutures == null) {
-            partitionCreationFutures = new ConcurrentHashMap<>();
-        }
-
         // In the present, the fullSchema could be rebuilt by schema change while the properties is changed by MV.
         // After that, some properties of fullSchema and nameToColumn may be not same as properties of base columns.
         // So, here we need to rebuild the fullSchema to ensure the correctness of the properties.

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -186,10 +186,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-
 
 /**
  * The Internal catalog will manage all self-managed meta object in a Doris cluster.
@@ -1646,7 +1646,69 @@ public class InternalCatalog implements CatalogIf<Database> {
         Preconditions.checkNotNull(olapTable);
         Preconditions.checkNotNull(indexIdToMeta);
 
+        // Guard to serialize concurrent creation of the same partition within the same table.
+        // We acquire or wait on a per-partition future to ensure only one creator proceeds to heavy work.
+        CompletableFuture<Void> ownerFuture = null;
+        while (true) {
+            Pair<CompletableFuture<Void>, Boolean> acquire = olapTable.acquirePartitionCreationFuture(partitionName);
+            if (acquire.second) {
+                // we have the ownership. do the creation work and share the result by completePartitionCreationFuture.
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("acquired owner for table[{}] partition[{}], tableId={}", tableName, partitionName,
+                            olapTable.getId());
+                }
+                ownerFuture = acquire.first;
+                break;
+            } else {
+                // Wait for ongoing creation to finish, then double-check existence.
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("waiting for ongoing creation of table[{}] partition[{}]", tableName, partitionName);
+                }
+                try {
+                    acquire.first.join();
+                } catch (RuntimeException ex) {
+                    // ignore the exception. we only care about it's created or not. will check below.
+                    if (LOG.isDebugEnabled()) {
+                        LOG.warn("previous creation future for table[{}] partition[{}] completed exceptionally: {}: {}",
+                                tableName, partitionName, ex.getClass().getSimpleName(), ex.getMessage());
+                    }
+                }
+                OlapTable t = db.getOlapTableOrDdlException(tableName);
+                t.readLock();
+                try {
+                    // if other succeed, always return.
+                    if (t.checkPartitionNameExist(partitionName)) {
+                        if (singlePartitionDesc.isSetIfNotExists()) {
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("partition[{}] already exists after waiting; IF NOT EXISTS no-op",
+                                        partitionName);
+                            }
+                            return null;
+                        } else {
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("partition[{}] already exists after waiting; raising duplicate error",
+                                        partitionName);
+                            }
+                            ErrorReport.reportDdlException(ErrorCode.ERR_SAME_NAME_PARTITION, partitionName);
+                        }
+                    }
+                    // If failed, continue this loop. Try acquire again before we decide to do by ourself in case
+                    // another task acquired the ownership between our wait and the check.
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("partition[{}] not present after wait on table[{}]; will retry acquire ownership",
+                                partitionName, tableName);
+                    }
+                } finally {
+                    t.readUnlock();
+                }
+            }
+        }
+
         // create partition outside db lock
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("start creating table[{}] partition[{}] (owner), temp={}", tableName, partitionName,
+                    isTempPartition);
+        }
         DataProperty dataProperty = singlePartitionDesc.getPartitionDataProperty();
         Preconditions.checkNotNull(dataProperty);
         // check replica quota if this operation done
@@ -1663,6 +1725,7 @@ public class InternalCatalog implements CatalogIf<Database> {
                 Env.getCurrentInvertedIndex().deleteTablet(tabletId);
             }
         };
+        Throwable creationThrowable = null;
         try {
             long partitionId = Config.isCloudMode() && !FeConstants.runningUnitTest && isCreateTable
                     ? generatedPartitionId : idGeneratorBuffer.getNextId();
@@ -1788,7 +1851,29 @@ public class InternalCatalog implements CatalogIf<Database> {
             }
         } catch (DdlException e) {
             failedCleanCallback.run();
+            creationThrowable = e;
             throw e;
+        } catch (Throwable t) {
+            // Ensure cleanup and propagate unexpected errors as well
+            failedCleanCallback.run();
+            creationThrowable = t;
+            throw t;
+        } finally {
+            if (ownerFuture != null) {
+                if (creationThrowable == null) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("complete owner future for table[{}] partition[{}]: success", tableName,
+                                partitionName);
+                    }
+                } else {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("complete owner future for table[{}] partition[{}]: failed: {}: {}", tableName,
+                                partitionName, creationThrowable.getClass().getSimpleName(),
+                                creationThrowable.getMessage());
+                    }
+                }
+                olapTable.completePartitionCreationFuture(partitionName, ownerFuture, creationThrowable);
+            }
         }
     }
 

--- a/regression-test/suites/partition_p0/auto_partition/test_auto_partition_behavior.groovy
+++ b/regression-test/suites/partition_p0/auto_partition/test_auto_partition_behavior.groovy
@@ -285,11 +285,11 @@ suite("test_auto_partition_behavior") {
 
     sql """ insert into test_change values ("20201212"); """
     def part_result = sql " show tablets from test_change "
-    assertEquals(part_result.size, 2 * replicaNum)
+    assertEquals(part_result.size(), 2 * replicaNum)
     sql """ ALTER TABLE test_change MODIFY DISTRIBUTION DISTRIBUTED BY HASH(k0) BUCKETS 50; """
     sql """ insert into test_change values ("20001212"); """
     part_result = sql " show tablets from test_change "
-    assertEquals(part_result.size, 52 * replicaNum)
+    assertEquals(part_result.size(), 52 * replicaNum)
 
 
 

--- a/regression-test/suites/partition_p1/auto_partition/sql/multi_thread_load.groovy
+++ b/regression-test/suites/partition_p1/auto_partition/sql/multi_thread_load.groovy
@@ -91,7 +91,7 @@ suite("multi_thread_load", "p1,nonConcurrent") { // stress case should use resou
         }
 
         def table_exist = sql """select * from information_schema.tables where  TABLE_SCHEMA = "${realDb}" and TABLE_NAME = "${tableName}";"""
-        assertTrue(table_exist.size == 1)
+        assertTrue(table_exist.size() == 1)
         dir_file_exist("""${dirPath}/${part_type}""")
 
         for (int i = 0; i < data_count; i++) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

data load instances which would request for creating partition for new data aren't aware of each other. so there would be duplicated create partition requests. before we create first and check existence after created. Although they would be recycled finally, but it will lead to partition expansion in BE because they were actually created.

now we add a future-wait mechanism to avoid duplicated partition creation.

**This patch is totally generated by GPT-5(high reasoning) and carefully checked by me.**

### Release note

Avoid creating a large number of unnecessary partitions caused by auto partition in specific cases

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

