### PR TITLE
[workloadgroup](memory) flush memtable when memory is not enough

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1390,6 +1390,8 @@ DEFINE_Int32(spill_io_thread_pool_queue_size, "102400");
 // paused query in queue timeout(ms) will be resumed or canceled
 DEFINE_Int64(spill_in_paused_queue_timeout_ms, "60000");
 
+DEFINE_Int64(wait_cancel_release_memory_ms, "5000");
+
 DEFINE_mBool(check_segment_when_build_rowset_meta, "false");
 
 DEFINE_mBool(force_azure_blob_global_endpoint, "false");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1445,6 +1445,7 @@ DECLARE_mInt32(spill_gc_work_time_ms);
 DECLARE_Int32(spill_io_thread_pool_thread_num);
 DECLARE_Int32(spill_io_thread_pool_queue_size);
 DECLARE_Int64(spill_in_paused_queue_timeout_ms);
+DECLARE_Int64(wait_cancel_release_memory_ms);
 
 DECLARE_mBool(check_segment_when_build_rowset_meta);
 

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -348,7 +348,7 @@ void Daemon::memory_maintenance_thread() {
 
         // step 6. Refresh weighted memory ratio of workload groups.
         doris::ExecEnv::GetInstance()->workload_group_mgr()->do_sweep();
-        doris::ExecEnv::GetInstance()->workload_group_mgr()->refresh_wg_weighted_memory_limit();
+        doris::ExecEnv::GetInstance()->workload_group_mgr()->refresh_workload_group_memory_state();
 
         // step 7: handle paused queries(caused by memory insufficient)
         doris::ExecEnv::GetInstance()->workload_group_mgr()->handle_paused_queries();

--- a/be/src/exec/schema_scanner/schema_workload_group_resource_usage_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_workload_group_resource_usage_scanner.cpp
@@ -38,7 +38,6 @@ std::vector<SchemaScanner::ColumnDesc> SchemaBackendWorkloadGroupResourceUsage::
         {"CPU_USAGE_PERCENT", TYPE_DOUBLE, sizeof(double), false},
         {"LOCAL_SCAN_BYTES_PER_SECOND", TYPE_BIGINT, sizeof(int64_t), false},
         {"REMOTE_SCAN_BYTES_PER_SECOND", TYPE_BIGINT, sizeof(int64_t), false},
-        {"WRITE_BUFFER_USAGE_BYTES", TYPE_BIGINT, sizeof(int64_t), false},
 };
 
 SchemaBackendWorkloadGroupResourceUsage::SchemaBackendWorkloadGroupResourceUsage()

--- a/be/src/olap/memtable_memory_limiter.cpp
+++ b/be/src/olap/memtable_memory_limiter.cpp
@@ -119,7 +119,7 @@ int64_t MemTableMemoryLimiter::_need_flush() {
     return need_flush - _queue_mem_usage - _flush_mem_usage;
 }
 
-void MemTableMemoryLimiter::handle_memtable_flush() {
+void MemTableMemoryLimiter::handle_memtable_flush(std::function<bool()> cancel_check) {
     // Check the soft limit.
     DCHECK(_load_soft_mem_limit > 0);
     do {

--- a/be/src/olap/memtable_memory_limiter.cpp
+++ b/be/src/olap/memtable_memory_limiter.cpp
@@ -119,43 +119,11 @@ int64_t MemTableMemoryLimiter::_need_flush() {
     return need_flush - _queue_mem_usage - _flush_mem_usage;
 }
 
-void MemTableMemoryLimiter::handle_workload_group_memtable_flush(
-        WorkloadGroupPtr wg, std::function<bool()> cancel_check) {
-    // It means some query is pending on here to flush memtable and to continue running.
-    // So that should wait here.
-    // Wait at most 3s, because this code is not aware cancel flag. If the load task is cancelled
-    // Should releae memory quickly.
-    using namespace std::chrono_literals;
-    int32_t max_sleep_times = 30;
-    int32_t sleep_times = max_sleep_times;
-    MonotonicStopWatch timer;
-    timer.start();
-    while (wg != nullptr && wg->enable_write_buffer_limit() && wg->exceed_write_buffer_limit() &&
-           sleep_times > 0) {
-        if (cancel_check && cancel_check()) {
-            LOG(INFO) << "cancelled when waiting for memtable flush, wg: "
-                      << (wg == nullptr ? "null" : wg->debug_string());
-            return;
-        }
-        std::this_thread::sleep_for(100ms);
-        --sleep_times;
-    }
-    if (sleep_times < max_sleep_times) {
-        timer.stop();
-        VLOG_DEBUG << "handle_workload_group_memtable_flush waited "
-                   << PrettyPrinter::print(timer.elapsed_time(), TUnit::TIME_NS)
-                   << ", wg: " << wg->debug_string();
-    }
-    // Check process memory again.
-    _handle_memtable_flush(wg, cancel_check);
-}
-
-void MemTableMemoryLimiter::_handle_memtable_flush(WorkloadGroupPtr wg,
-                                                   std::function<bool()> cancel_check) {
+void MemTableMemoryLimiter::handle_memtable_flush() {
     // Check the soft limit.
     DCHECK(_load_soft_mem_limit > 0);
     do {
-        DBUG_EXECUTE_IF("MemTableMemoryLimiter._handle_memtable_flush.limit_reached", {
+        DBUG_EXECUTE_IF("MemTableMemoryLimiter.handle_memtable_flush.limit_reached", {
             LOG(INFO) << "debug memtable limit reached";
             break;
         });
@@ -192,8 +160,7 @@ void MemTableMemoryLimiter::_handle_memtable_flush(WorkloadGroupPtr wg,
                       << ", active: " << PrettyPrinter::print_bytes(_active_mem_usage)
                       << ", queue: " << PrettyPrinter::print_bytes(_queue_mem_usage)
                       << ", flush: " << PrettyPrinter::print_bytes(_flush_mem_usage)
-                      << ", need flush: " << PrettyPrinter::print_bytes(need_flush)
-                      << ", wg: " << (wg ? wg->debug_string() : "null");
+                      << ", need flush: " << PrettyPrinter::print_bytes(need_flush);
             if (VLOG_DEBUG_IS_ON) {
                 auto log_str = doris::ProcessProfile::instance()
                                        ->memory_profile()
@@ -216,33 +183,7 @@ void MemTableMemoryLimiter::_handle_memtable_flush(WorkloadGroupPtr wg,
                   << ", memtable writers num: " << _writers.size()
                   << ", active: " << PrettyPrinter::print_bytes(_active_mem_usage)
                   << ", queue: " << PrettyPrinter::print_bytes(_queue_mem_usage)
-                  << ", flush: " << PrettyPrinter::print_bytes(_flush_mem_usage)
-                  << ", wg: " << (wg ? wg->debug_string() : "null.");
-    }
-}
-
-int64_t MemTableMemoryLimiter::flush_workload_group_memtables(uint64_t wg_id, int64_t need_flush) {
-    std::unique_lock<std::mutex> l(_lock);
-    return _flush_active_memtables(wg_id, need_flush);
-}
-
-void MemTableMemoryLimiter::get_workload_group_memtable_usage(uint64_t wg_id, int64_t* active_bytes,
-                                                              int64_t* queue_bytes,
-                                                              int64_t* flush_bytes) {
-    std::unique_lock<std::mutex> l(_lock);
-    *active_bytes = 0;
-    *queue_bytes = 0;
-    *flush_bytes = 0;
-    for (auto it = _writers.begin(); it != _writers.end(); ++it) {
-        if (auto writer = it->lock()) {
-            // If wg id is specified, but wg id not match, then not need flush
-            if (writer->workload_group_id() != wg_id) {
-                continue;
-            }
-            *active_bytes += writer->active_memtable_mem_consumption();
-            *queue_bytes += writer->mem_consumption(MemType::WRITE_FINISHED);
-            *flush_bytes += writer->mem_consumption(MemType::FLUSH);
-        }
+                  << ", flush: " << PrettyPrinter::print_bytes(_flush_mem_usage);
     }
 }
 

--- a/be/src/olap/memtable_memory_limiter.cpp
+++ b/be/src/olap/memtable_memory_limiter.cpp
@@ -144,8 +144,7 @@ void MemTableMemoryLimiter::handle_memtable_flush(std::function<bool()> cancel_c
             }
         }
         if (cancel_check && cancel_check()) {
-            LOG(INFO) << "cancelled when waiting for memtable flush, wg: "
-                      << (wg == nullptr ? "null" : wg->debug_string());
+            LOG(INFO) << "cancelled when waiting for memtable flush";
             return;
         }
         first = false;
@@ -167,7 +166,7 @@ void MemTableMemoryLimiter::handle_memtable_flush(std::function<bool()> cancel_c
                                        ->process_memory_detail_str();
                 LOG_LONG_STRING(INFO, log_str);
             }
-            _flush_active_memtables(0, need_flush);
+            _flush_active_memtables(need_flush);
         }
     } while (_hard_limit_reached() && !_load_usage_low());
     g_memtable_memory_limit_waiting_threads << -1;
@@ -187,7 +186,7 @@ void MemTableMemoryLimiter::handle_memtable_flush(std::function<bool()> cancel_c
     }
 }
 
-int64_t MemTableMemoryLimiter::_flush_active_memtables(uint64_t wg_id, int64_t need_flush) {
+int64_t MemTableMemoryLimiter::_flush_active_memtables(int64_t need_flush) {
     if (need_flush <= 0) {
         return 0;
     }
@@ -219,10 +218,7 @@ int64_t MemTableMemoryLimiter::_flush_active_memtables(uint64_t wg_id, int64_t n
         if (w == nullptr) {
             continue;
         }
-        // If wg id is specified, but wg id not match, then not need flush
-        if (wg_id != 0 && w->workload_group_id() != wg_id) {
-            continue;
-        }
+
         int64_t mem = w->active_memtable_mem_consumption();
         if (mem < sort_mem * 0.9) {
             // if the memtable writer just got flushed, don't flush it again

--- a/be/src/olap/memtable_memory_limiter.h
+++ b/be/src/olap/memtable_memory_limiter.h
@@ -44,7 +44,7 @@ public:
     // If yes, it will flush memtable to try to reduce memory consumption.
     // Every write operation will call this API to check if need flush memtable OR hang
     // when memory is not available.
-    void handle_memtable_flush();
+    void handle_memtable_flush(std::function<bool()> cancel_check);
 
     void register_writer(std::weak_ptr<MemTableWriter> writer);
 

--- a/be/src/olap/memtable_memory_limiter.h
+++ b/be/src/olap/memtable_memory_limiter.h
@@ -40,13 +40,11 @@ public:
 
     Status init(int64_t process_mem_limit);
 
-    void handle_workload_group_memtable_flush(WorkloadGroupPtr wg,
-                                              std::function<bool()> cancel_check);
-
-    int64_t flush_workload_group_memtables(uint64_t wg_id, int64_t need_flush_bytes);
-
-    void get_workload_group_memtable_usage(uint64_t wg_id, int64_t* active_bytes,
-                                           int64_t* queue_bytes, int64_t* flush_bytes);
+    // check if the total mem consumption exceeds limit.
+    // If yes, it will flush memtable to try to reduce memory consumption.
+    // Every write operation will call this API to check if need flush memtable OR hang
+    // when memory is not available.
+    void handle_memtable_flush();
 
     void register_writer(std::weak_ptr<MemTableWriter> writer);
 
@@ -57,22 +55,7 @@ public:
     int64_t mem_usage() const { return _mem_usage; }
 
 private:
-    // check if the total mem consumption exceeds limit.
-    // If yes, it will flush memtable to try to reduce memory consumption.
-    // Every write operation will call this API to check if need flush memtable OR hang
-    // when memory is not available.
-    void _handle_memtable_flush(WorkloadGroupPtr wg, std::function<bool()> cancel_check);
-
     static inline int64_t _sys_avail_mem_less_than_warning_water_mark();
-    static inline int64_t _process_used_mem_more_than_soft_mem_limit();
-
-    bool _soft_limit_reached();
-    bool _hard_limit_reached();
-    bool _load_usage_low();
-    int64_t _need_flush();
-    int64_t _flush_active_memtables(uint64_t wg_id, int64_t need_flush);
-    void _refresh_mem_tracker();
-
     std::mutex _lock;
     std::condition_variable _hard_limit_end_cond;
     int64_t _mem_usage = 0;

--- a/be/src/olap/memtable_memory_limiter.h
+++ b/be/src/olap/memtable_memory_limiter.h
@@ -56,6 +56,14 @@ public:
 
 private:
     static inline int64_t _sys_avail_mem_less_than_warning_water_mark();
+    static inline int64_t _process_used_mem_more_than_soft_mem_limit();
+
+    bool _soft_limit_reached();
+    bool _hard_limit_reached();
+    bool _load_usage_low();
+    int64_t _need_flush();
+    int64_t _flush_active_memtables(uint64_t wg_id, int64_t need_flush);
+    void _refresh_mem_tracker();
     std::mutex _lock;
     std::condition_variable _hard_limit_end_cond;
     int64_t _mem_usage = 0;

--- a/be/src/olap/memtable_memory_limiter.h
+++ b/be/src/olap/memtable_memory_limiter.h
@@ -62,7 +62,7 @@ private:
     bool _hard_limit_reached();
     bool _load_usage_low();
     int64_t _need_flush();
-    int64_t _flush_active_memtables(uint64_t wg_id, int64_t need_flush);
+    int64_t _flush_active_memtables(int64_t need_flush);
     void _refresh_mem_tracker();
     std::mutex _lock;
     std::condition_variable _hard_limit_end_cond;

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -152,11 +152,7 @@ Status LoadChannelMgr::add_batch(const PTabletWriterAddBlockRequest& request,
         // If this is a high priority load task, do not handle this.
         // because this may block for a while, which may lead to rpc timeout.
         SCOPED_TIMER(channel->get_handle_mem_limit_timer());
-        ExecEnv::GetInstance()->memtable_memory_limiter()->handle_workload_group_memtable_flush(
-                channel->workload_group(), [channel]() { return channel->is_cancelled(); });
-        if (channel->is_cancelled()) {
-            return Status::Cancelled("LoadChannel has been cancelled: {}.", load_id.to_string());
-        }
+        ExecEnv::GetInstance()->memtable_memory_limiter()->handle_memtable_flush();
     }
 
     // 3. add batch to load channel

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -152,7 +152,11 @@ Status LoadChannelMgr::add_batch(const PTabletWriterAddBlockRequest& request,
         // If this is a high priority load task, do not handle this.
         // because this may block for a while, which may lead to rpc timeout.
         SCOPED_TIMER(channel->get_handle_mem_limit_timer());
-        ExecEnv::GetInstance()->memtable_memory_limiter()->handle_memtable_flush();
+        ExecEnv::GetInstance()->memtable_memory_limiter()->handle_memtable_flush(
+                [channel]() { return channel->is_cancelled(); });
+        if (channel->is_cancelled()) {
+            return Status::Cancelled("LoadChannel has been cancelled: {}.", load_id.to_string());
+        }
     }
 
     // 3. add batch to load channel

--- a/be/src/runtime/memory/global_memory_arbitrator.cpp
+++ b/be/src/runtime/memory/global_memory_arbitrator.cpp
@@ -62,7 +62,6 @@ std::atomic<double> GlobalMemoryArbitrator::last_periodic_refreshed_cache_capaci
 std::atomic<double> GlobalMemoryArbitrator::last_memory_exceeded_cache_capacity_adjust_weighted {1};
 // The value that take affect
 std::atomic<double> GlobalMemoryArbitrator::last_affected_cache_capacity_adjust_weighted {1};
-std::atomic<bool> GlobalMemoryArbitrator::any_workload_group_exceed_limit {false};
 std::mutex GlobalMemoryArbitrator::memtable_memory_refresh_lock;
 std::condition_variable GlobalMemoryArbitrator::memtable_memory_refresh_cv;
 std::atomic<bool> GlobalMemoryArbitrator::memtable_memory_refresh_notify {false};

--- a/be/src/runtime/memory/global_memory_arbitrator.h
+++ b/be/src/runtime/memory/global_memory_arbitrator.h
@@ -166,7 +166,6 @@ public:
     static std::atomic<double> last_memory_exceeded_cache_capacity_adjust_weighted;
     // The value that take affect
     static std::atomic<double> last_affected_cache_capacity_adjust_weighted;
-    static std::atomic<bool> any_workload_group_exceed_limit;
 
     static void notify_cache_adjust_capacity() {
         cache_adjust_capacity_notify.store(true, std::memory_order_relaxed);

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -220,8 +220,6 @@ public:
     static void make_top_consumption_tasks_tracker_profile(RuntimeProfile* profile, int top_num);
     static void make_all_tasks_tracker_profile(RuntimeProfile* profile);
 
-    int64_t write_buffer_size() const { return _write_tracker->consumption(); }
-
     std::shared_ptr<MemTrackerLimiter> write_tracker() { return _write_tracker; }
 
     void print_log_usage(const std::string& msg);

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -181,7 +181,7 @@ void QueryContext::_init_resource_context() {
 }
 
 void QueryContext::init_query_task_controller() {
-    _resource_ctx->set_task_controller(QueryTaskController::create(this));
+    _resource_ctx->set_task_controller(QueryTaskController::create(shared_from_this()));
     _resource_ctx->task_controller()->set_task_id(_query_id);
     _resource_ctx->task_controller()->set_fe_addr(current_connect_fe);
     _resource_ctx->task_controller()->set_query_type(_query_options.query_type);

--- a/be/src/runtime/workload_group/workload_group.cpp
+++ b/be/src/runtime/workload_group/workload_group.cpp
@@ -81,11 +81,8 @@ WorkloadGroup::WorkloadGroup(const WorkloadGroupInfo& wg_info)
     }
     _remote_scan_io_throttle = std::make_shared<IOThrottle>();
     if (_max_memory_percent > 0) {
-        std::cout << _max_memory_percent << std::endl;
-        std::cout << _min_memory_percent << std::endl;
         _min_memory_limit = static_cast<int64_t>(
                 static_cast<double>(_memory_limit * _min_memory_percent) / _max_memory_percent);
-        std::cout << _min_memory_limit << std::endl;
     }
 
     _wg_metrics = std::make_shared<WorkloadGroupMetrics>(this);

--- a/be/src/runtime/workload_management/memory_context.h
+++ b/be/src/runtime/workload_management/memory_context.h
@@ -89,13 +89,14 @@ public:
     void set_mem_limit(int64_t new_mem_limit) const { mem_tracker_->set_limit(new_mem_limit); }
     int64_t mem_limit() const { return mem_tracker_->limit(); }
 
+    int64_t user_set_mem_limit() const { return user_set_mem_limit_; }
+
     // The new memlimit should be less than user set memlimit.
     void set_adjusted_mem_limit(int64_t new_mem_limit) {
         adjusted_mem_limit_ = std::min<int64_t>(new_mem_limit, user_set_mem_limit_);
     }
     // Expected mem limit is the limit when workload group reached limit.
     int64_t adjusted_mem_limit() { return adjusted_mem_limit_; }
-    void effect_adjusted_mem_limit() { set_mem_limit(adjusted_mem_limit_); }
 
     int64_t current_memory_bytes() const { return mem_tracker_->consumption(); }
     int64_t peak_memory_bytes() const { return mem_tracker_->peak_consumption(); }

--- a/be/src/runtime/workload_management/query_task_controller.cpp
+++ b/be/src/runtime/workload_management/query_task_controller.cpp
@@ -24,8 +24,9 @@
 namespace doris {
 #include "common/compile_check_begin.h"
 
-std::unique_ptr<TaskController> QueryTaskController::create(QueryContext* query_ctx) {
-    return QueryTaskController::create_unique(query_ctx->shared_from_this());
+std::unique_ptr<TaskController> QueryTaskController::create(
+        std::shared_ptr<QueryContext> query_ctx) {
+    return QueryTaskController::create_unique(query_ctx);
 }
 
 bool QueryTaskController::is_cancelled() const {

--- a/be/src/runtime/workload_management/query_task_controller.h
+++ b/be/src/runtime/workload_management/query_task_controller.h
@@ -29,7 +29,7 @@ class QueryTaskController : public TaskController {
     ENABLE_FACTORY_CREATOR(QueryTaskController);
 
 public:
-    static std::unique_ptr<TaskController> create(QueryContext* query_ctx);
+    static std::unique_ptr<TaskController> create(std::shared_ptr<QueryContext> query_ctx);
     ~QueryTaskController() override = default;
 
     bool is_cancelled() const override;

--- a/be/src/runtime/workload_management/task_controller.h
+++ b/be/src/runtime/workload_management/task_controller.h
@@ -77,6 +77,8 @@ public:
         return cancel_impl(reason);
     }
 
+    int64_t cancel_elapsed_millis() const { return MonotonicMillis() - cancelled_time_; }
+
     virtual bool cancel_impl(const Status& reason) { return false; }
 
     int64_t cancelled_time() const { return cancelled_time_; }

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -564,11 +564,7 @@ Status VTabletWriterV2::_write_memtable(std::shared_ptr<vectorized::Block> block
     }
     {
         SCOPED_TIMER(_wait_mem_limit_timer);
-        ExecEnv::GetInstance()->memtable_memory_limiter()->handle_workload_group_memtable_flush(
-                _state->workload_group(), [state = _state]() { return state->is_cancelled(); });
-        if (_state->is_cancelled()) {
-            return _state->cancel_reason();
-        }
+        ExecEnv::GetInstance()->memtable_memory_limiter()->handle_memtable_flush();
     }
     SCOPED_TIMER(_write_memtable_timer);
     st = delta_writer->write(block.get(), rows.row_idxes);

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -564,7 +564,11 @@ Status VTabletWriterV2::_write_memtable(std::shared_ptr<vectorized::Block> block
     }
     {
         SCOPED_TIMER(_wait_mem_limit_timer);
-        ExecEnv::GetInstance()->memtable_memory_limiter()->handle_memtable_flush();
+        ExecEnv::GetInstance()->memtable_memory_limiter()->handle_memtable_flush(
+                [state = _state]() { return state->is_cancelled(); });
+        if (_state->is_cancelled()) {
+            return _state->cancel_reason();
+        }
     }
     SCOPED_TIMER(_write_memtable_timer);
     st = delta_writer->write(block.get(), rows.row_idxes);

--- a/be/test/olap/memtable_memory_limiter_test.cpp
+++ b/be/test/olap/memtable_memory_limiter_test.cpp
@@ -169,7 +169,7 @@ TEST_F(MemTableMemoryLimiterTest, handle_memtable_flush_test) {
         ASSERT_TRUE(res.ok());
     }
     static_cast<void>(mem_limiter->init(100));
-    mem_limiter->handle_memtable_flush();
+    mem_limiter->handle_memtable_flush(nullptr);
     CHECK_EQ(0, mem_limiter->mem_usage());
 
     res = delta_writer->close();

--- a/be/test/olap/memtable_memory_limiter_test.cpp
+++ b/be/test/olap/memtable_memory_limiter_test.cpp
@@ -169,7 +169,7 @@ TEST_F(MemTableMemoryLimiterTest, handle_memtable_flush_test) {
         ASSERT_TRUE(res.ok());
     }
     static_cast<void>(mem_limiter->init(100));
-    mem_limiter->_handle_memtable_flush(nullptr, nullptr);
+    mem_limiter->handle_memtable_flush();
     CHECK_EQ(0, mem_limiter->mem_usage());
 
     res = delta_writer->close();

--- a/be/test/runtime/workload_group/workload_group_manager_test.cpp
+++ b/be/test/runtime/workload_group/workload_group_manager_test.cpp
@@ -72,8 +72,6 @@ protected:
 
         config::spill_in_paused_queue_timeout_ms = 2000;
         doris::ExecEnv::GetInstance()->set_memtable_memory_limiter(new MemTableMemoryLimiter());
-
-        std::cout << "ss1" << std::endl;
     }
     void TearDown() override {
         _wg_manager.reset();
@@ -83,7 +81,6 @@ protected:
         EXPECT_EQ(system("rm -rf ./wg_test_run"), 0);
         config::spill_in_paused_queue_timeout_ms = _spill_in_paused_queue_timeout_ms;
         doris::ExecEnv::GetInstance()->set_memtable_memory_limiter(nullptr);
-        std::cout << "tearDown" << std::endl;
     }
 
 private:

--- a/be/test/runtime/workload_group/workload_group_manager_test.cpp
+++ b/be/test/runtime/workload_group/workload_group_manager_test.cpp
@@ -72,6 +72,8 @@ protected:
 
         config::spill_in_paused_queue_timeout_ms = 2000;
         doris::ExecEnv::GetInstance()->set_memtable_memory_limiter(new MemTableMemoryLimiter());
+
+        std::cout << "ss1" << std::endl;
     }
     void TearDown() override {
         _wg_manager.reset();
@@ -81,6 +83,7 @@ protected:
         EXPECT_EQ(system("rm -rf ./wg_test_run"), 0);
         config::spill_in_paused_queue_timeout_ms = _spill_in_paused_queue_timeout_ms;
         doris::ExecEnv::GetInstance()->set_memtable_memory_limiter(nullptr);
+        std::cout << "tearDown" << std::endl;
     }
 
 private:
@@ -125,6 +128,8 @@ TEST_F(WorkloadGroupManagerTest, get_or_create_workload_group) {
     ASSERT_EQ(wg->id(), 0);
 }
 
+// Query is paused due to query memlimit exceed, after waiting in queue for  spill_in_paused_queue_timeout_ms
+// it should be resumed
 TEST_F(WorkloadGroupManagerTest, query_exceed) {
     auto wg = _wg_manager->get_or_create_workload_group({});
     auto query_context = _generate_on_query(wg);
@@ -132,19 +137,21 @@ TEST_F(WorkloadGroupManagerTest, query_exceed) {
     query_context->resource_ctx()->memory_context()->set_mem_limit(1024 * 1024);
     query_context->query_mem_tracker()->consume(1024 * 4);
 
+    std::cout << config::spill_in_paused_queue_timeout_ms << std::endl;
+
     _wg_manager->add_paused_query(query_context->resource_ctx(), 1024L * 1024 * 1024,
                                   Status::Error(ErrorCode::QUERY_MEMORY_EXCEEDED, "test"));
     {
         std::unique_lock<std::mutex> lock(_wg_manager->_paused_queries_lock);
         ASSERT_EQ(_wg_manager->_paused_queries_list[wg].size(), 1)
-                << "pasued queue should not be empty";
+                << "paused queue should not be empty";
     }
 
     query_context->query_mem_tracker()->consume(-1024 * 4);
     _run_checking_loop(wg);
 
     std::unique_lock<std::mutex> lock(_wg_manager->_paused_queries_lock);
-    ASSERT_TRUE(_wg_manager->_paused_queries_list[wg].empty()) << "pasued queue should be empty";
+    ASSERT_TRUE(_wg_manager->_paused_queries_list[wg].empty()) << "paused queue should be empty";
     ASSERT_EQ(query_context->is_cancelled(), false) << "query should be not canceled";
     ASSERT_EQ(query_context->resource_ctx()->task_controller()->is_enable_reserve_memory(), false)
             << "query should disable reserve memory";
@@ -172,7 +179,7 @@ TEST_F(WorkloadGroupManagerTest, wg_exceed1) {
 
     std::unique_lock<std::mutex> lock(_wg_manager->_paused_queries_lock);
     ASSERT_TRUE(_wg_manager->_paused_queries_list[wg].empty()) << "pasued queue should be empty";
-    ASSERT_EQ(query_context->is_cancelled(), false) << "query should be canceled";
+    ASSERT_EQ(query_context->is_cancelled(), false) << "query should not be canceled";
 }
 
 // TWgSlotMemoryPolicy::NONE
@@ -251,7 +258,7 @@ TEST_F(WorkloadGroupManagerTest, wg_exceed4) {
                 << "pasued queue should not be empty";
     }
 
-    _wg_manager->refresh_wg_weighted_memory_limit();
+    _wg_manager->refresh_workload_group_memory_state();
     LOG(INFO) << "***** wg usage " << wg->refresh_memory_usage();
     _run_checking_loop(wg);
 
@@ -260,7 +267,7 @@ TEST_F(WorkloadGroupManagerTest, wg_exceed4) {
     LOG(INFO) << "***** query_context->get_mem_limit(): "
               << query_context->resource_ctx()->memory_context()->mem_limit();
     const auto delta = std::abs(query_context->resource_ctx()->memory_context()->mem_limit() -
-                                ((1024L * 1024 * 100 * 95) / 100 - 10 * 1024 * 1024) / 5);
+                                (1024L * 1024 * 100 * 95) / 100 / 5);
     ASSERT_LE(delta, 1);
 
     std::unique_lock<std::mutex> lock(_wg_manager->_paused_queries_lock);
@@ -271,6 +278,8 @@ TEST_F(WorkloadGroupManagerTest, wg_exceed4) {
 TEST_F(WorkloadGroupManagerTest, wg_exceed5) {
     WorkloadGroupInfo wg_info {.id = 1,
                                .memory_limit = 1024L * 1024 * 100,
+                               .min_memory_percent = 10,
+                               .max_memory_percent = 100,
                                .memory_low_watermark = 80,
                                .memory_high_watermark = 95,
                                .total_query_slot_count = 5,
@@ -285,10 +294,10 @@ TEST_F(WorkloadGroupManagerTest, wg_exceed5) {
     {
         std::unique_lock<std::mutex> lock(_wg_manager->_paused_queries_lock);
         ASSERT_EQ(_wg_manager->_paused_queries_list[wg].size(), 1)
-                << "pasued queue should not be empty";
+                << "paused queue should not be empty";
     }
 
-    _wg_manager->refresh_wg_weighted_memory_limit();
+    _wg_manager->refresh_workload_group_memory_state();
     LOG(INFO) << "***** wg usage " << wg->refresh_memory_usage();
     _run_checking_loop(wg);
 
@@ -296,8 +305,10 @@ TEST_F(WorkloadGroupManagerTest, wg_exceed5) {
     ASSERT_TRUE(query_context->resource_ctx()->task_controller()->paused_reason().ok());
     LOG(INFO) << "***** query_context->get_mem_limit(): "
               << query_context->resource_ctx()->memory_context()->mem_limit();
+
+    // + slot count, because in query memlimit it + slot count
     ASSERT_LE(query_context->resource_ctx()->memory_context()->mem_limit(),
-              (1024L * 1024 * 100 * 95) / 100);
+              ((1024L * 1024 * 100 * 95) / 100 + 5));
 
     std::unique_lock<std::mutex> lock(_wg_manager->_paused_queries_lock);
     ASSERT_TRUE(_wg_manager->_paused_queries_list[wg].empty()) << "pasued queue should be empty";
@@ -383,90 +394,119 @@ TEST_F(WorkloadGroupManagerTest, query_released) {
     ASSERT_TRUE(_wg_manager->_paused_queries_list[wg].empty()) << "pasued queue should be empty";
 }
 
-TEST_F(WorkloadGroupManagerTest, overcommit1) {
-    WorkloadGroupInfo wg1_info {.id = 1, .memory_limit = 1024L * 1024 * 100};
-    WorkloadGroupInfo wg2_info {.id = 2, .memory_limit = 1024L * 1024 * 100};
-    WorkloadGroupInfo wg3_info {.id = 3, .memory_limit = 1024L * 1024 * 100};
-    WorkloadGroupInfo wg4_info {.id = 4, .memory_limit = 1024L * 1024 * 1024 * 10};
-    WorkloadGroupInfo wg5_info {.id = 5, .memory_limit = 1024L * 1024 * 1024 * 100};
+TEST_F(WorkloadGroupManagerTest, ProcessMemoryNotEnough) {
+    WorkloadGroupInfo wg1_info {.id = 1,
+                                .memory_limit = 1024L * 1024 * 1000,
+                                .min_memory_percent = 10,
+                                .max_memory_percent = 100};
+    WorkloadGroupInfo wg2_info {.id = 2,
+                                .memory_limit = 1024L * 1024 * 1000,
+                                .min_memory_percent = 10,
+                                .max_memory_percent = 100};
+    WorkloadGroupInfo wg3_info {.id = 3,
+                                .memory_limit = 1024L * 1024 * 1000,
+                                .min_memory_percent = 10,
+                                .max_memory_percent = 100};
+
     auto wg1 = _wg_manager->get_or_create_workload_group(wg1_info);
     auto wg2 = _wg_manager->get_or_create_workload_group(wg2_info);
     auto wg3 = _wg_manager->get_or_create_workload_group(wg3_info);
-    auto wg4 = _wg_manager->get_or_create_workload_group(wg4_info);
-    auto wg5 = _wg_manager->get_or_create_workload_group(wg5_info);
+
     EXPECT_EQ(wg1->id(), wg1_info.id);
     EXPECT_EQ(wg2->id(), wg2_info.id);
     EXPECT_EQ(wg3->id(), wg3_info.id);
-    EXPECT_EQ(wg5->id(), wg5_info.id);
+
+    EXPECT_EQ(1024L * 1024 * 100, wg1->min_memory_limit());
 
     auto query_context11 = _generate_on_query(wg1);
-
-    // wg2 is overcommited, some query is overcommited
-    auto query_context21 = _generate_on_query(wg2);
-    auto query_context22 = _generate_on_query(wg2);
-    auto query_context23 = _generate_on_query(wg2);
-    auto query_context24 = _generate_on_query(wg2);
-    auto query_context25 = _generate_on_query(wg2);
-    auto query_context26 = _generate_on_query(wg2);
-    query_context21->resource_ctx()->memory_context()->set_mem_limit(1024 * 1024);
-    query_context21->query_mem_tracker()->consume(1024 * 1024 * 1024);
-    query_context22->resource_ctx()->memory_context()->set_mem_limit(1024 * 1024 * 1024);
-    query_context22->query_mem_tracker()->consume(1024 * 1024 * 64);
-    query_context23->resource_ctx()->memory_context()->set_mem_limit(1024 * 1024);
-    query_context23->query_mem_tracker()->consume(1024 * 1024 * 10);
-    query_context24->resource_ctx()->memory_context()->set_mem_limit(1024 * 1024);
-    query_context24->query_mem_tracker()->consume(1024);
-    query_context25->resource_ctx()->memory_context()->set_mem_limit(1024 * 1024 * 512);
-    query_context25->query_mem_tracker()->consume(1024 * 1024 * 1024);
-    query_context26->resource_ctx()->memory_context()->set_mem_limit(1024L * 1024 * 1024 * 100);
-    query_context26->query_mem_tracker()->consume(1024 * 1024 * 1024);
-
-    // wg3 is overcommited, some query is overcommited
-    auto query_context31 = _generate_on_query(wg3);
-    auto query_context32 = _generate_on_query(wg3);
-    auto query_context33 = _generate_on_query(wg3);
-    query_context31->resource_ctx()->memory_context()->set_mem_limit(1024 * 1024);
-    query_context31->query_mem_tracker()->consume(1024 * 1024 * 1024);
-    query_context32->resource_ctx()->memory_context()->set_mem_limit(1024 * 1024 * 1024);
-    query_context32->query_mem_tracker()->consume(1024 * 1024 * 512);
-    query_context33->resource_ctx()->memory_context()->set_mem_limit(1024 * 1024 * 512);
-    query_context33->query_mem_tracker()->consume(1024 * 1024 * 1024);
-
-    // wg4 not overcommited, query is overcommited
-    auto query_context41 = _generate_on_query(wg4);
-    query_context41->resource_ctx()->memory_context()->set_mem_limit(1024L * 1024);
-    query_context41->query_mem_tracker()->consume(1024L * 1024 * 1024 * 9);
-
-    // wg5 disable overcommited, query is overcommited
-    auto query_context51 = _generate_on_query(wg5);
-    query_context51->resource_ctx()->memory_context()->set_mem_limit(1024L * 1024);
-    query_context51->query_mem_tracker()->consume(1024L * 1024 * 1024 * 99);
+    query_context11->resource_ctx()->memory_context()->set_mem_limit(1024 * 1024 * 1024);
+    query_context11->query_mem_tracker()->consume(1024 * 1024 * 10);
 
     wg1->refresh_memory_usage();
     wg2->refresh_memory_usage();
     wg3->refresh_memory_usage();
-    wg4->refresh_memory_usage();
-    wg5->refresh_memory_usage();
 
-    // step1, wg2 is overcommited largest, cancel some overcommited query, freed memory less than need_free_mem.
-    // step2, wg3 is less overcommited than wg2, cancel some overcommited query, terminate after freed memory is greater than need_free_mem.
-    // query41 in wg4 has largest overcommited, but wg4 not overcommited, so not cancel query41.
-    EXPECT_EQ(_wg_manager->revoke_memory_from_other_overcommited_groups_(
-                      query_context11->resource_ctx(), 1024L * 1024 * 1024 * 3 + 1),
-              1024L * 1024 * 1024 * 4);
+    // There is no query in workload groups, so that revoke memory will return 0
+    EXPECT_EQ(0, _wg_manager->revoke_memory_from_other_groups_());
 
-    ASSERT_FALSE(query_context11->is_cancelled());
-    ASSERT_TRUE(query_context21->is_cancelled());
+    // If exceed memory less than 128MB, then not revoke
+    auto query_context21 = _generate_on_query(wg2);
+    query_context21->resource_ctx()->memory_context()->set_mem_limit(1024 * 1024 * 1024);
+    query_context21->query_mem_tracker()->consume(1024 * 1024 * 50);
+    wg2->refresh_memory_usage();
+    EXPECT_EQ(wg2->total_mem_used(), 1024 * 1024 * 50);
+    EXPECT_EQ(wg2->min_memory_limit(), 1024 * 1024 * 100);
+    // There is not workload group's memory usage > it's min memory limit.
+    EXPECT_EQ(0, _wg_manager->revoke_memory_from_other_groups_());
+    ASSERT_FALSE(query_context21->is_cancelled());
+
+    // Add another query that use a lot of memory
+    auto query_context22 = _generate_on_query(wg2);
+    query_context22->resource_ctx()->memory_context()->set_mem_limit(1024 * 1024 * 1024);
+    query_context22->query_mem_tracker()->consume(1024 * 1024 * 60);
+    wg2->refresh_memory_usage();
+    EXPECT_EQ(wg2->total_mem_used(), 1024 * 1024 * 110);
+    EXPECT_EQ(wg2->min_memory_limit(), 1024 * 1024 * 100);
+    // Could not revoke larger than 128MB, not revoke.
+    EXPECT_EQ(0, _wg_manager->revoke_memory_from_other_groups_());
+    ASSERT_FALSE(query_context21->is_cancelled());
     ASSERT_FALSE(query_context22->is_cancelled());
-    ASSERT_FALSE(query_context23->is_cancelled());
-    ASSERT_FALSE(query_context24->is_cancelled());
-    ASSERT_TRUE(query_context25->is_cancelled());
-    ASSERT_TRUE(query_context26->is_cancelled());
+
+    // Add another query that use a lot of memory
+    auto query_context23 = _generate_on_query(wg2);
+    query_context23->resource_ctx()->memory_context()->set_mem_limit(1024 * 1024 * 1024);
+    query_context23->query_mem_tracker()->consume(1024 * 1024 * 300);
+    wg2->refresh_memory_usage();
+    EXPECT_EQ(wg2->total_mem_used(), 1024 * 1024 * 410);
+    EXPECT_EQ(wg2->min_memory_limit(), 1024 * 1024 * 100);
+    EXPECT_EQ(31 * 1024 * 1024, _wg_manager->revoke_memory_from_other_groups_());
+    ASSERT_FALSE(query_context21->is_cancelled());
+    ASSERT_FALSE(query_context22->is_cancelled());
+    ASSERT_TRUE(query_context23->is_cancelled());
+    // Although query23 is cancelled, but it is not removed from workload group2, so that it still occupy memory usage.
+    wg2->refresh_memory_usage();
+    EXPECT_EQ(wg2->total_mem_used(), 1024 * 1024 * 410);
+    // clear cancelled query from workload group.
+    wg2->clear_cancelled_resource_ctx();
+    wg2->refresh_memory_usage();
+    EXPECT_EQ(wg2->total_mem_used(), 1024 * 1024 * 110);
+    // todo 应该是cancel 最大的query
+
+    auto query_context24 = _generate_on_query(wg2);
+    query_context24->resource_ctx()->memory_context()->set_mem_limit(1024 * 1024 * 1024);
+    query_context24->query_mem_tracker()->consume(1024 * 1024 * 300);
+    wg2->refresh_memory_usage();
+    EXPECT_EQ(wg2->total_mem_used(), 1024 * 1024 * 410); // WG2 exceed 310MB
+
+    // wg3 is overcommited, some query is overcommited
+    auto query_context31 = _generate_on_query(wg3);
+    query_context31->resource_ctx()->memory_context()->set_mem_limit(1024 * 1024 * 1024);
+    query_context31->query_mem_tracker()->consume(1024 * 1024 * 500);
+    wg3->refresh_memory_usage();
+    EXPECT_EQ(wg3->total_mem_used(), 1024 * 1024 * 500); // WG3 exceed 400MB
+
+    EXPECT_EQ(40 * 1024 * 1024, _wg_manager->revoke_memory_from_other_groups_());
+
+    wg1->refresh_memory_usage();
+    wg2->refresh_memory_usage();
+    wg3->refresh_memory_usage();
+
     ASSERT_TRUE(query_context31->is_cancelled());
-    ASSERT_FALSE(query_context32->is_cancelled());
-    ASSERT_FALSE(query_context33->is_cancelled());
-    ASSERT_FALSE(query_context41->is_cancelled());
-    ASSERT_FALSE(query_context51->is_cancelled());
+    // query31 is still in wg3, so that it is not cancel again.
+    EXPECT_EQ(40 * 1024 * 1024, _wg_manager->revoke_memory_from_other_groups_());
+    ASSERT_FALSE(query_context11->is_cancelled());
+    ASSERT_FALSE(query_context21->is_cancelled());
+    ASSERT_FALSE(query_context22->is_cancelled());
+    ASSERT_FALSE(query_context24->is_cancelled());
+    ASSERT_TRUE(query_context31->is_cancelled());
+
+    // remove query31 from wg
+    wg3->clear_cancelled_resource_ctx();
+
+    wg1->refresh_memory_usage();
+    wg2->refresh_memory_usage();
+    wg3->refresh_memory_usage();
+    EXPECT_EQ(wg3->total_mem_used(), 0); // WG3 exceed 400MB
 }
 
 } // namespace doris

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/SchemaTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/SchemaTable.java
@@ -587,7 +587,6 @@ public class SchemaTable extends Table {
                                     .column("CPU_USAGE_PERCENT", ScalarType.createType(PrimitiveType.DOUBLE))
                                     .column("LOCAL_SCAN_BYTES_PER_SECOND", ScalarType.createType(PrimitiveType.BIGINT))
                                     .column("REMOTE_SCAN_BYTES_PER_SECOND", ScalarType.createType(PrimitiveType.BIGINT))
-                                    .column("WRITE_BUFFER_USAGE_BYTES", ScalarType.createType(PrimitiveType.BIGINT))
                                     .build())
             )
             .put("file_cache_statistics",

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
@@ -85,7 +85,6 @@ public class WorkloadGroupMgr implements Writable, GsonPostProcessable {
             .add(WorkloadGroup.COMPUTE_GROUP)
             .add(WorkloadGroup.READ_BYTES_PER_SECOND)
             .add(WorkloadGroup.REMOTE_READ_BYTES_PER_SECOND)
-            .add(WorkloadGroup.WRITE_BUFFER_RATIO)
             .add(WorkloadGroup.SLOT_MEMORY_POLICY)
             .add(QueryQueue.RUNNING_QUERY_NUM)
             .add(QueryQueue.WAITING_QUERY_NUM)


### PR DESCRIPTION
### What problem does this PR solve?
1. flush memtable when memory is not enough
2. cancel the query that use more memory than min_memory_percent

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

