### PR TITLE
[opt](inverted index) create non analyzer when parser is none for inverted index

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
@@ -218,7 +218,9 @@ Status InvertedIndexColumnWriter<field_type>::init_fulltext_index() {
     RETURN_IF_ERROR(open_index_directory());
     _char_string_reader =
             DORIS_TRY(create_char_string_reader(_inverted_index_ctx->char_filter_map));
-    _analyzer = DORIS_TRY(create_analyzer(_inverted_index_ctx));
+    if (_should_analyzer) {
+        _analyzer = DORIS_TRY(create_analyzer(_inverted_index_ctx));
+    }
     _similarity = std::make_unique<lucene::search::LengthSimilarity>();
     _index_writer = create_index_writer();
     _doc = std::make_unique<lucene::document::Document>();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #54619

Problem Summary:
When no parser is specified, the inverted index writer currently creates a default analyzer (simple analyzer), which can cause unnecessary performance overhead. This PR addresses this by setting the analyzer to nullptr to avoid the overhead.
Note: This PR should be merged together with or after #54619.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

