### PR TITLE
[env](ubsan) Avoid some errors reported by UBSan when compiling with O0 

### DIFF
--- a/be/src/olap/key_coder.h
+++ b/be/src/olap/key_coder.h
@@ -261,12 +261,13 @@ public:
 template <>
 class KeyCoderTraits<FieldType::OLAP_FIELD_TYPE_CHAR> {
 public:
-    static void full_encode_ascending(const void* value, std::string* buf) {
+    NO_SANITIZE_UNDEFINED static void full_encode_ascending(const void* value, std::string* buf) {
         auto slice = reinterpret_cast<const Slice*>(value);
         buf->append(slice->get_data(), slice->get_size());
     }
 
-    static void encode_ascending(const void* value, size_t index_size, std::string* buf) {
+    NO_SANITIZE_UNDEFINED static void encode_ascending(const void* value, size_t index_size,
+                                                       std::string* buf) {
         const Slice* slice = (const Slice*)value;
         CHECK(index_size <= slice->size)
                 << "index size is larger than char size, index=" << index_size
@@ -282,12 +283,13 @@ public:
 template <>
 class KeyCoderTraits<FieldType::OLAP_FIELD_TYPE_VARCHAR> {
 public:
-    static void full_encode_ascending(const void* value, std::string* buf) {
+    NO_SANITIZE_UNDEFINED static void full_encode_ascending(const void* value, std::string* buf) {
         auto slice = reinterpret_cast<const Slice*>(value);
         buf->append(slice->get_data(), slice->get_size());
     }
 
-    static void encode_ascending(const void* value, size_t index_size, std::string* buf) {
+    NO_SANITIZE_UNDEFINED static void encode_ascending(const void* value, size_t index_size,
+                                                       std::string* buf) {
         const Slice* slice = (const Slice*)value;
         size_t copy_size = std::min(index_size, slice->size);
         buf->append(slice->data, copy_size);
@@ -301,12 +303,13 @@ public:
 template <>
 class KeyCoderTraits<FieldType::OLAP_FIELD_TYPE_STRING> {
 public:
-    static void full_encode_ascending(const void* value, std::string* buf) {
+    NO_SANITIZE_UNDEFINED static void full_encode_ascending(const void* value, std::string* buf) {
         auto slice = reinterpret_cast<const Slice*>(value);
         buf->append(slice->get_data(), slice->get_size());
     }
 
-    static void encode_ascending(const void* value, size_t index_size, std::string* buf) {
+    NO_SANITIZE_UNDEFINED static void encode_ascending(const void* value, size_t index_size,
+                                                       std::string* buf) {
         const Slice* slice = (const Slice*)value;
         size_t copy_size = std::min(index_size, slice->size);
         buf->append(slice->data, copy_size);

--- a/conf/ubsan_ignorelist.txt
+++ b/conf/ubsan_ignorelist.txt
@@ -10,6 +10,7 @@ src:*/json/new_json_reader.cpp
 src:*/common/memcpy_small.h
 src:*/util/mysql_row_buffer.cpp
 src:*/util/bitmap_intersect.h
+src:*/util/slice.h
 fun:*BaseFieldTypeTraits*
 fun:*FieldTypeTraits*
 fun:*KeyCoderTraits*

--- a/conf/ubsan_suppr.conf
+++ b/conf/ubsan_suppr.conf
@@ -16,3 +16,4 @@
 # under the License.
 
 alignment:hash_util.hpp
+alignment:slice.h


### PR DESCRIPTION
### What problem does this PR solve?

Because on the pipeline we use O1 for compilation, but some UBSan errors only appear locally when compiling with O0, for example:
```
0x7ba502eb3a01: note: pointer points here
 02 00 00  00 30 52 8c 02 95 7b 00  00 03 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00
              ^ 
    #0 0x55cbe9f9acd2 in doris::Slice::compare(doris::Slice const&) const /mnt/disk8/yanxuecheng/tmp-doris/be/src/util/slice.h
    #1 0x55cbede3405c in doris::FieldTypeTraits<(doris::FieldType)13>::cmp(void const*, void const*) /mnt/disk8/yanxuecheng/tmp-doris/be/src/olap/types.h:1347:25
    #2 0x55cbe9e98dae in doris::ScalarTypeInfo::cmp(void const*, void const*) const /mnt/disk8/yanxuecheng/tmp-doris/be/src/olap/types.h:104:74
    #3 0x55cbeee73cf0 in int doris::Field::compare_cell<doris::RowCursorCell, doris::RowCursorCell>(doris::RowCursorCell const&, doris::RowCursorCell const&) const /mnt/disk8/yanxuecheng/tmp-doris/be/src/olap/field.h:120:41
    #4 0x55cbeee6a030 in doris::compare_row_key(doris::RowCursor const&, doris::RowCursor const&) /mnt/disk8/yanxuecheng/tmp-doris/be/src/olap/tablet_reader.h:75:47
    #5 0x55cbeee43237 in doris::TabletReader::_capture_rs_readers(doris::TabletReader::ReaderParams const&) /mnt/disk8/yanxuecheng/tmp-doris/be/src/olap/tablet_reader.cpp:188:17
    #6 0x55cc1d5f7985 in doris::vectorized::BlockReader::_init_collect_iter(doris::TabletReader::ReaderParams const&) /mnt/disk8/yanxuecheng/tmp-doris/be/src/vec/olap/block_reader.cpp:106:16
    #7 0x55cc1d5fd004 in doris::vectorized::BlockReader::init(doris::TabletReader::ReaderParams const&) /mnt/disk8/yanxuecheng/tmp-doris/be/src/vec/olap/block_reader.cpp:226:19
    #8 0x55cc15e09f53 in doris::vectorized::OlapScanner::open(doris::RuntimeState*) /mnt/disk8/yanxuecheng/tmp-doris/be/src/vec/exec/scan/olap_scanner.cpp:260:32
    #9 0x55cc15d7d89d in doris::vectorized::ScannerScheduler::_scanner_scan(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>) /mnt/disk8/yanxuecheng/tmp-doris/be/src/vec/exec/scan/scanner_scheduler.cpp:182:5
    #10 0x55cc15d88ce6 in doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::'lambda'()::operator()() const::'lambda'()::operator()() const /mnt/disk8/yanxuecheng/tmp-doris/be/src/vec/exec/scan/scanner_scheduler.cpp:96:17
    #11 0x55cc15d884b1 in doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::'lambda'()::operator()() const /mnt/disk8/yanxuecheng/tmp-doris/be/src/vec/exec/scan/scanner_scheduler.cpp:95:27
    #12 0x55cc15d8829c in bool std::__invoke_impl<bool, doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::'lambda'()&>(std::__invoke_other, doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::'lambda'()&) /mnt/disk6/common/ldb_toolchain_taipan/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:63:14
    #13 0x55cc15d8819c in std::enable_if<is_invocable_r_v<bool, doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::'lambda'()&>, bool>::type std::__invoke_r<bool, doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::'lambda'()&>(doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::'lambda'()&) /mnt/disk6/common/ldb_toolchain_taipan/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:116:9
    #14 0x55cc15d87c94 in std::_Function_handler<bool (), doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::'lambda'()>::_M_invoke(std::_Any_data const&) /mnt/disk6/common/ldb_toolchain_taipan/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:292:9
    #15 0x55cbe9632efd in std::function<bool ()>::operator()() const /mnt/disk6/common/ldb_toolchain_taipan/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:593:9
    #16 0x55cc15d87314 in doris::vectorized::ScannerSplitRunner::process_for(std::chrono::duration<long, std::ratio<1l, 1000000000l>>) /mnt/disk8/yanxuecheng/tmp-doris/be/src/vec/exec/scan/scanner_scheduler.cpp:407:25

```



### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

