### PR TITLE
[fix](column reader) fix memory leak

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -113,6 +113,14 @@ struct ColumnIteratorOptions {
     }
 };
 
+class ColumnIterator;
+class OffsetFileColumnIterator;
+class FileColumnIterator;
+
+using ColumnIteratorUPtr = std::unique_ptr<ColumnIterator>;
+using OffsetFileColumnIteratorUPtr = std::unique_ptr<OffsetFileColumnIterator>;
+using FileColumnIteratorUPtr = std::unique_ptr<FileColumnIterator>;
+
 // There will be concurrent users to read the same column. So
 // we should do our best to reduce resource usage through share
 // same information, such as OrdinalPageIndex and Page data.
@@ -152,13 +160,13 @@ public:
     ~ColumnReader() override;
 
     // create a new column iterator. Client should delete returned iterator
-    virtual Status new_iterator(ColumnIterator** iterator, const TabletColumn* col,
+    virtual Status new_iterator(ColumnIteratorUPtr* iterator, const TabletColumn* col,
                                 const StorageReadOptions*);
-    Status new_iterator(ColumnIterator** iterator, const TabletColumn* tablet_column);
-    Status new_array_iterator(ColumnIterator** iterator, const TabletColumn* tablet_column);
-    Status new_struct_iterator(ColumnIterator** iterator, const TabletColumn* tablet_column);
-    Status new_map_iterator(ColumnIterator** iterator, const TabletColumn* tablet_column);
-    Status new_agg_state_iterator(ColumnIterator** iterator);
+    Status new_iterator(ColumnIteratorUPtr* iterator, const TabletColumn* tablet_column);
+    Status new_array_iterator(ColumnIteratorUPtr* iterator, const TabletColumn* tablet_column);
+    Status new_struct_iterator(ColumnIteratorUPtr* iterator, const TabletColumn* tablet_column);
+    Status new_map_iterator(ColumnIteratorUPtr* iterator, const TabletColumn* tablet_column);
+    Status new_agg_state_iterator(ColumnIteratorUPtr* iterator);
     // Client should delete returned iterator
     Status new_bitmap_index_iterator(BitmapIndexIterator** iterator);
 
@@ -443,8 +451,8 @@ public:
 // This iterator make offset operation write once for
 class OffsetFileColumnIterator final : public ColumnIterator {
 public:
-    explicit OffsetFileColumnIterator(FileColumnIterator* offset_reader) {
-        _offset_iterator.reset(offset_reader);
+    explicit OffsetFileColumnIterator(FileColumnIteratorUPtr offset_reader) {
+        _offset_iterator = std::move(offset_reader);
     }
 
     ~OffsetFileColumnIterator() override = default;
@@ -472,9 +480,10 @@ private:
 // This iterator is used to read map value column
 class MapFileColumnIterator final : public ColumnIterator {
 public:
-    explicit MapFileColumnIterator(ColumnReader* reader, ColumnIterator* null_iterator,
-                                   OffsetFileColumnIterator* offsets_iterator,
-                                   ColumnIterator* key_iterator, ColumnIterator* val_iterator);
+    explicit MapFileColumnIterator(ColumnReader* reader, ColumnIteratorUPtr null_iterator,
+                                   OffsetFileColumnIteratorUPtr offsets_iterator,
+                                   ColumnIteratorUPtr key_iterator,
+                                   ColumnIteratorUPtr val_iterator);
 
     ~MapFileColumnIterator() override = default;
 
@@ -493,16 +502,16 @@ public:
 
 private:
     ColumnReader* _map_reader = nullptr;
-    std::unique_ptr<ColumnIterator> _null_iterator;
-    std::unique_ptr<OffsetFileColumnIterator> _offsets_iterator; //OffsetFileIterator
-    std::unique_ptr<ColumnIterator> _key_iterator;
-    std::unique_ptr<ColumnIterator> _val_iterator;
+    ColumnIteratorUPtr _null_iterator;
+    OffsetFileColumnIteratorUPtr _offsets_iterator; //OffsetFileIterator
+    ColumnIteratorUPtr _key_iterator;
+    ColumnIteratorUPtr _val_iterator;
 };
 
 class StructFileColumnIterator final : public ColumnIterator {
 public:
-    explicit StructFileColumnIterator(ColumnReader* reader, ColumnIterator* null_iterator,
-                                      std::vector<ColumnIterator*>& sub_column_iterators);
+    explicit StructFileColumnIterator(ColumnReader* reader, ColumnIteratorUPtr null_iterator,
+                                      std::vector<ColumnIteratorUPtr>&& sub_column_iterators);
 
     ~StructFileColumnIterator() override = default;
 
@@ -521,14 +530,16 @@ public:
 
 private:
     ColumnReader* _struct_reader = nullptr;
-    std::unique_ptr<ColumnIterator> _null_iterator;
-    std::vector<std::unique_ptr<ColumnIterator>> _sub_column_iterators;
+    ColumnIteratorUPtr _null_iterator;
+    std::vector<ColumnIteratorUPtr> _sub_column_iterators;
 };
 
 class ArrayFileColumnIterator final : public ColumnIterator {
 public:
-    explicit ArrayFileColumnIterator(ColumnReader* reader, OffsetFileColumnIterator* offset_reader,
-                                     ColumnIterator* item_iterator, ColumnIterator* null_iterator);
+    explicit ArrayFileColumnIterator(ColumnReader* reader,
+                                     OffsetFileColumnIteratorUPtr offset_reader,
+                                     ColumnIteratorUPtr item_iterator,
+                                     ColumnIteratorUPtr null_iterator);
 
     ~ArrayFileColumnIterator() override = default;
 

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -728,9 +728,7 @@ Status Segment::new_column_iterator(const TabletColumn& tablet_column,
         return Status::OK();
     }
     // init iterator by unique id
-    ColumnIterator* it;
-    RETURN_IF_ERROR(_column_readers.at(unique_id)->new_iterator(&it, &tablet_column, opt));
-    iter->reset(it);
+    RETURN_IF_ERROR(_column_readers.at(unique_id)->new_iterator(iter, &tablet_column, opt));
 
     if (config::enable_column_type_check && !tablet_column.has_path_info() &&
         !tablet_column.is_agg_state_type() &&
@@ -759,10 +757,8 @@ Status Segment::get_column_reader(int32_t col_unique_id, ColumnReader** reader) 
 Status Segment::new_column_iterator(int32_t unique_id, const StorageReadOptions* opt,
                                     std::unique_ptr<ColumnIterator>* iter) {
     RETURN_IF_ERROR(_create_column_readers_once(opt->stats));
-    ColumnIterator* it;
     TabletColumn tablet_column = _tablet_schema->column_by_uid(unique_id);
-    RETURN_IF_ERROR(_column_readers.at(unique_id)->new_iterator(&it, &tablet_column));
-    iter->reset(it);
+    RETURN_IF_ERROR(_column_readers.at(unique_id)->new_iterator(iter, &tablet_column));
     return Status::OK();
 }
 

--- a/be/src/olap/rowset/segment_v2/variant/hierarchical_data_iterator.h
+++ b/be/src/olap/rowset/segment_v2/variant/hierarchical_data_iterator.h
@@ -69,7 +69,7 @@ public:
 
     HierarchicalDataIterator(const vectorized::PathInData& path) : _path(path) {}
 
-    static Status create(ColumnIterator** reader, vectorized::PathInData path,
+    static Status create(ColumnIteratorUPtr* reader, vectorized::PathInData path,
                          const SubcolumnColumnReaders::Node* target_node,
                          const SubcolumnColumnReaders::Node* root, ReadType read_type,
                          std::unique_ptr<ColumnIterator>&& sparse_reader);

--- a/be/test/olap/rowset/segment_v2/column_reader_writer_test.cpp
+++ b/be/test/olap/rowset/segment_v2/column_reader_writer_test.cpp
@@ -134,7 +134,7 @@ void test_nullable_data(uint8_t* src_data, uint8_t* src_is_null, int num_rows,
             auto st = ColumnReader::create(reader_opts, meta, num_rows, file_reader, &reader);
             EXPECT_TRUE(st.ok());
 
-            ColumnIterator* iter = nullptr;
+            ColumnIteratorUPtr iter;
             st = reader->new_iterator(&iter);
             EXPECT_TRUE(st.ok());
 
@@ -185,7 +185,7 @@ void test_nullable_data(uint8_t* src_data, uint8_t* src_is_null, int num_rows,
             auto st = ColumnReader::create(reader_opts, meta, num_rows, file_reader, &reader);
             EXPECT_TRUE(st.ok());
 
-            ColumnIterator* iter = nullptr;
+            ColumnIteratorUPtr iter;
             st = reader->new_iterator(&iter);
             EXPECT_TRUE(st.ok());
 
@@ -308,7 +308,7 @@ void test_array_nullable_data(CollectionValue* src_data, uint8_t* src_is_null, i
         auto st = ColumnReader::create(reader_opts, meta, num_rows, file_reader, &reader);
         EXPECT_TRUE(st.ok());
 
-        ColumnIterator* iter = nullptr;
+        ColumnIteratorUPtr iter;
         st = reader->new_iterator(&iter);
         EXPECT_TRUE(st.ok());
 

--- a/be/test/olap/rowset/segment_v2/variant_column_writer_reader_test.cpp
+++ b/be/test/olap/rowset/segment_v2/variant_column_writer_reader_test.cpp
@@ -269,13 +269,13 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_normal) {
     }
 
     // 9. check hier reader
-    ColumnIterator* it;
+    ColumnIteratorUPtr it;
     TabletColumn parent_column = _tablet_schema->column(0);
     StorageReadOptions storage_read_opts;
     storage_read_opts.io_ctx.reader_type = ReaderType::READER_QUERY;
     st = variant_column_reader->new_iterator(&it, &parent_column, &storage_read_opts);
     EXPECT_TRUE(st.ok()) << st.msg();
-    EXPECT_TRUE(assert_cast<HierarchicalDataIterator*>(it) != nullptr);
+    EXPECT_TRUE(assert_cast<HierarchicalDataIterator*>(it.get()) != nullptr);
     ColumnIteratorOptions column_iter_opts;
     OlapReaderStatistics stats;
     column_iter_opts.stats = &stats;
@@ -293,7 +293,7 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_normal) {
 
     // seek_to_first for HierarchicalDataIterator no need to implement
     {
-        auto iter = assert_cast<HierarchicalDataIterator*>(it);
+        auto iter = assert_cast<HierarchicalDataIterator*>(it.get());
         std::unique_ptr<ColumnReader> column_reader1;
         st = ColumnReader::create(read_opts, footer, 0, 1000, file_reader, &column_reader1);
         EXPECT_TRUE(st.ok()) << st.msg();
@@ -340,7 +340,7 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_normal) {
         EXPECT_EQ(value, inserted_jsonstr[row_ids[i]]);
     }
 
-    auto read_to_column_object = [&](ColumnIterator* it) {
+    auto read_to_column_object = [&](ColumnIteratorUPtr& it) {
         new_column_object = ColumnVariant::create(3);
         nrows = 1000;
         st = it->seek_to_ordinal(0);
@@ -350,7 +350,6 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_normal) {
         EXPECT_TRUE(stats.bytes_read > 0);
         EXPECT_EQ(nrows, 1000);
     };
-    delete (it);
 
     // 10. check sparse extract reader
     for (int i = 3; i < 10; ++i) {
@@ -364,17 +363,17 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_normal) {
                 parent_column.variant_max_subcolumns_count());
         subcolumn_in_sparse.set_is_nullable(true);
 
-        ColumnIterator* it;
+        ColumnIteratorUPtr it;
         st = variant_column_reader->new_iterator(&it, &subcolumn_in_sparse, &storage_read_opts);
         EXPECT_TRUE(st.ok()) << st.msg();
-        EXPECT_TRUE(assert_cast<SparseColumnExtractIterator*>(it) != nullptr);
+        EXPECT_TRUE(assert_cast<SparseColumnExtractIterator*>(it.get()) != nullptr);
         st = it->init(column_iter_opts);
         EXPECT_TRUE(st.ok()) << st.msg();
 
         read_to_column_object(it);
         {
             // read with opt
-            auto iter = assert_cast<SparseColumnExtractIterator*>(it);
+            auto* iter = assert_cast<SparseColumnExtractIterator*>(it.get());
             StorageReadOptions storage_read_opts1;
             storage_read_opts1.io_ctx.reader_type = ReaderType::READER_QUERY;
             iter->_read_opts = &storage_read_opts1;
@@ -398,7 +397,6 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_normal) {
                 }
             }
         }
-        delete (it);
     }
 
     // 11. check leaf reader
@@ -414,11 +412,11 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_normal) {
                     parent_column.variant_max_subcolumns_count());
             subcolumn.set_is_nullable(true);
 
-            ColumnIterator* it;
+            ColumnIteratorUPtr it;
             st = variant_column_reader->new_iterator(&it, &subcolumn, &storage_read_opts);
             EXPECT_TRUE(st.ok()) << st.msg();
             std::cout << "key " << key << std::endl;
-            EXPECT_TRUE(dynamic_cast<FileColumnIterator*>(it) != nullptr);
+            EXPECT_TRUE(dynamic_cast<FileColumnIterator*>(it.get()) != nullptr);
             st = it->init(column_iter_opts);
             EXPECT_TRUE(st.ok()) << st.msg();
 
@@ -441,7 +439,6 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_normal) {
                     }
                 }
             }
-            delete (it);
         }
     };
     check_leaf_reader();
@@ -453,10 +450,10 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_normal) {
     subcolumn.set_parent_unique_id(parent_column.unique_id());
     subcolumn.set_path_info(PathInData(parent_column.name_lower_case() + ".key10"));
     subcolumn.set_is_nullable(true);
-    ColumnIterator* it1;
+    ColumnIteratorUPtr it1;
     st = variant_column_reader->new_iterator(&it1, &subcolumn, &storage_read_opts);
     EXPECT_TRUE(st.ok()) << st.msg();
-    EXPECT_TRUE(assert_cast<DefaultValueColumnIterator*>(it1) != nullptr);
+    EXPECT_TRUE(assert_cast<DefaultValueColumnIterator*>(it1.get()) != nullptr);
 
     // 13. check statistics size == limit
     auto& variant_stats = variant_column_reader->_statistics;
@@ -471,12 +468,11 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_normal) {
     EXPECT_TRUE(variant_stats->sparse_column_non_null_size.size() ==
                 config::variant_max_sparse_column_statistics_size);
     EXPECT_TRUE(variant_column_reader->is_exceeded_sparse_column_limit());
-    delete (it1);
 
-    ColumnIterator* it2;
+    ColumnIteratorUPtr it2;
     st = variant_column_reader->new_iterator(&it2, &subcolumn, &storage_read_opts);
     EXPECT_TRUE(st.ok()) << st.msg();
-    EXPECT_TRUE(assert_cast<HierarchicalDataIterator*>(it2) != nullptr);
+    EXPECT_TRUE(assert_cast<HierarchicalDataIterator*>(it2.get()) != nullptr);
     st = it2->init(column_iter_opts);
     EXPECT_TRUE(st.ok()) << st.msg();
 
@@ -522,17 +518,16 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_normal) {
 
     // 14. check compaction subcolumn reader
     check_leaf_reader();
-    delete (it2);
     // 15. check compaction root reader
-    ColumnIterator* it3;
+    ColumnIteratorUPtr it3;
     st = variant_column_reader->new_iterator(&it3, &parent_column, &storage_read_opts);
     EXPECT_TRUE(st.ok()) << st.msg();
-    EXPECT_TRUE(assert_cast<VariantRootColumnIterator*>(it3) != nullptr);
+    EXPECT_TRUE(assert_cast<VariantRootColumnIterator*>(it3.get()) != nullptr);
     st = it3->init(column_iter_opts);
     EXPECT_TRUE(st.ok()) << st.msg();
     // test VariantRootColumnIterator for next_batch and read_by_rowids
     {
-        auto iter = assert_cast<VariantRootColumnIterator*>(it3);
+        auto iter = assert_cast<VariantRootColumnIterator*>(it3.get());
         auto nullable_dt = std::make_shared<vectorized::DataTypeNullable>(
                 std::make_shared<vectorized::DataTypeVariant>(3));
         MutableColumnPtr root_column_object = nullable_dt->create_column();
@@ -551,13 +546,13 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_normal) {
         auto row_id = iter->get_current_ordinal();
         std::cout << "current row id: " << row_id << std::endl;
     }
-    delete (it3);
+
     // 16. check compacton sparse column
     TabletColumn sparse_column = schema_util::create_sparse_column(parent_column);
-    ColumnIterator* it4;
+    ColumnIteratorUPtr it4;
     st = variant_column_reader->new_iterator(&it4, &sparse_column, &storage_read_opts);
     EXPECT_TRUE(st.ok()) << st.msg();
-    EXPECT_TRUE(assert_cast<SparseColumnMergeIterator*>(it4) != nullptr);
+    EXPECT_TRUE(assert_cast<SparseColumnMergeIterator*>(it4.get()) != nullptr);
     st = it4->init(column_iter_opts);
     EXPECT_TRUE(st.ok()) << st.msg();
     auto column_type = DataTypeFactory::instance().create_data_type(sparse_column, false);
@@ -571,7 +566,7 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_normal) {
 
     {
         // test SparseColumnMergeIterator seek_to_first
-        auto iter = assert_cast<SparseColumnMergeIterator*>(it4);
+        auto iter = assert_cast<SparseColumnMergeIterator*>(it4.get());
         EXPECT_ANY_THROW(iter->get_current_ordinal());
         // and test read_by_rowids for 0 -> 1000
         std::vector<rowid_t> row_ids1;
@@ -620,18 +615,17 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_normal) {
                 << "row: " << row << ", value: " << value;
     }
 
-    delete (it4);
     // 17. check limit = 10000
     subcolumn.set_name(parent_column.name_lower_case() + ".key10");
     subcolumn.set_path_info(PathInData(parent_column.name_lower_case() + ".key10"));
-    ColumnIterator* it5;
+    ColumnIteratorUPtr it5;
     st = variant_column_reader->new_iterator(&it5, &subcolumn, &storage_read_opts);
     EXPECT_TRUE(st.ok()) << st.msg();
-    EXPECT_TRUE(assert_cast<SparseColumnExtractIterator*>(it5) != nullptr);
+    EXPECT_TRUE(assert_cast<SparseColumnExtractIterator*>(it5.get()) != nullptr);
 
     {
         // test SparseColumnExtractIterator seek_to_first
-        auto iter = assert_cast<SparseColumnExtractIterator*>(it5);
+        auto iter = assert_cast<SparseColumnExtractIterator*>(it5.get());
         EXPECT_TRUE(st.ok()) << st.msg();
         // and test read_by_rowids
         std::vector<rowid_t> row_ids1;
@@ -669,26 +663,23 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_normal) {
         std::string key = parent_column.name_lower_case() + ".key10" + std::to_string(i);
         variant_stats->sparse_column_non_null_size.erase(key);
     }
-    delete (it5);
 
     // 18. check compacton sparse extract column
-    ColumnIterator* it6;
+    ColumnIteratorUPtr it6;
     subcolumn.set_name(parent_column.name_lower_case() + ".key3");
     subcolumn.set_path_info(PathInData(parent_column.name_lower_case() + ".key3"));
     st = variant_column_reader->new_iterator(&it6, &subcolumn, &storage_read_opts);
     EXPECT_TRUE(st.ok()) << st.msg();
-    EXPECT_TRUE(assert_cast<SparseColumnExtractIterator*>(it6) != nullptr);
-    delete (it6);
+    EXPECT_TRUE(assert_cast<SparseColumnExtractIterator*>(it6.get()) != nullptr);
 
     // 19. check compaction default column
     subcolumn.set_name(parent_column.name_lower_case() + ".key10");
     subcolumn.set_path_info(PathInData(parent_column.name_lower_case() + ".key10"));
-    ColumnIterator* it7;
+    ColumnIteratorUPtr it7;
     st = variant_column_reader->new_iterator(&it7, &subcolumn, &storage_read_opts);
     EXPECT_TRUE(st.ok()) << st.msg();
-    EXPECT_TRUE(assert_cast<DefaultValueColumnIterator*>(it7) != nullptr);
+    EXPECT_TRUE(assert_cast<DefaultValueColumnIterator*>(it7.get()) != nullptr);
     EXPECT_TRUE(io::global_local_filesystem()->delete_directory(_tablet->tablet_path()).ok());
-    delete (it7);
 }
 
 TEST_F(VariantColumnWriterReaderTest, test_write_data_advanced) {
@@ -790,13 +781,13 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_advanced) {
     }
 
     // 9. check root
-    ColumnIterator* it;
+    ColumnIteratorUPtr it;
     TabletColumn parent_column = _tablet_schema->column(0);
     StorageReadOptions storage_read_opts;
     storage_read_opts.io_ctx.reader_type = ReaderType::READER_QUERY;
     st = variant_column_reader->new_iterator(&it, &parent_column, &storage_read_opts);
     EXPECT_TRUE(st.ok()) << st.msg();
-    EXPECT_TRUE(assert_cast<HierarchicalDataIterator*>(it) != nullptr);
+    EXPECT_TRUE(assert_cast<HierarchicalDataIterator*>(it.get()) != nullptr);
     ColumnIteratorOptions column_iter_opts;
     OlapReaderStatistics stats;
     column_iter_opts.stats = &stats;
@@ -819,7 +810,7 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_advanced) {
         EXPECT_EQ(value, inserted_jsonstr[i]);
     }
 
-    auto read_to_column_object = [&](ColumnIterator* it) {
+    auto read_to_column_object = [&](ColumnIteratorUPtr& it) {
         new_column_object = ColumnVariant::create(10);
         nrows = 1000;
         st = it->seek_to_ordinal(0);
@@ -829,7 +820,6 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_advanced) {
         EXPECT_TRUE(stats.bytes_read > 0);
         EXPECT_EQ(nrows, 1000);
     };
-    delete (it);
 
     auto check_key_stats = [&](const std::string& key_num) {
         std::string key = ".key" + key_num;
@@ -842,10 +832,10 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_advanced) {
                 parent_column.variant_max_subcolumns_count());
         subcolumn_in_nested.set_is_nullable(true);
 
-        ColumnIterator* it1;
+        ColumnIteratorUPtr it1;
         st = variant_column_reader->new_iterator(&it1, &subcolumn_in_nested, &storage_read_opts);
         EXPECT_TRUE(st.ok()) << st.msg();
-        EXPECT_TRUE(assert_cast<HierarchicalDataIterator*>(it1) != nullptr);
+        EXPECT_TRUE(assert_cast<HierarchicalDataIterator*>(it1.get()) != nullptr);
         st = it1->init(column_iter_opts);
         EXPECT_TRUE(st.ok()) << st.msg();
         read_to_column_object(it1);
@@ -864,7 +854,6 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_advanced) {
         }
         EXPECT_EQ(key_count, path_with_size["key" + key_num]);
         EXPECT_EQ(key_nested_count, path_with_size["key" + key_num + ".nested" + key_num]);
-        delete (it1);
     };
 
     for (int i = 3; i < 10; ++i) {
@@ -1085,20 +1074,19 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_nullable) {
     }
 
     // 9. check root
-    ColumnIterator* it;
+    ColumnIteratorUPtr it;
     TabletColumn parent_column = _tablet_schema->column(0);
     StorageReadOptions storage_read_opts;
     storage_read_opts.io_ctx.reader_type = ReaderType::READER_QUERY;
     st = variant_column_reader->new_iterator(&it, &parent_column, &storage_read_opts);
     EXPECT_TRUE(st.ok()) << st.msg();
-    EXPECT_TRUE(assert_cast<HierarchicalDataIterator*>(it) != nullptr);
+    EXPECT_TRUE(assert_cast<HierarchicalDataIterator*>(it.get()) != nullptr);
     ColumnIteratorOptions column_iter_opts;
     OlapReaderStatistics stats;
     column_iter_opts.stats = &stats;
     column_iter_opts.file_reader = file_reader.get();
     st = it->init(column_iter_opts);
     EXPECT_TRUE(st.ok()) << st.msg();
-    delete (it);
 
     EXPECT_TRUE(io::global_local_filesystem()->delete_directory(_tablet->tablet_path()).ok());
 }
@@ -1686,12 +1674,11 @@ TEST_F(VariantColumnWriterReaderTest, test_no_sub_in_sparse_column) {
     EXPECT_GT(variant_reader->get_metadata_size(), 0);
 
     // 10. test hierarchical reader with empty statistics
-    ColumnIterator* iterator = nullptr;
+    ColumnIteratorUPtr iterator;
     StorageReadOptions read_opts;
     st = variant_reader->new_iterator(&iterator, &column, &read_opts);
     EXPECT_TRUE(st.ok()) << st.msg();
     EXPECT_TRUE(iterator != nullptr);
-    delete iterator;
 }
 
 TEST_F(VariantColumnWriterReaderTest, test_prefix_in_sub_and_sparse) {
@@ -1826,12 +1813,11 @@ TEST_F(VariantColumnWriterReaderTest, test_prefix_in_sub_and_sparse) {
     EXPECT_GT(variant_reader->get_metadata_size(), 0);
 
     // 10. test hierarchical reader with empty statistics
-    ColumnIterator* iterator = nullptr;
+    ColumnIteratorUPtr iterator;
     StorageReadOptions read_opts;
     st = variant_reader->new_iterator(&iterator, &column, &read_opts);
     EXPECT_TRUE(st.ok()) << st.msg();
     EXPECT_TRUE(iterator != nullptr);
-    delete iterator;
 }
 
 void test_write_variant_column(StorageEngine* _engine_ref, std::string _absolute_dir,
@@ -1998,12 +1984,12 @@ TEST_F(VariantColumnWriterReaderTest, test_nested_subcolumn) {
     StorageReadOptions storageReadOptions;
     storageReadOptions.io_ctx.reader_type = ReaderType::READER_CUMULATIVE_COMPACTION;
 
-    ColumnIterator* nested_column_iter;
+    ColumnIteratorUPtr nested_column_iter;
     st = variant_column_reader->_new_iterator_with_flat_leaves(&nested_column_iter, target_column,
                                                                &storageReadOptions, false, false);
     EXPECT_TRUE(st.ok()) << st.msg();
     // check iter for read_by_rowids, next_batch
-    auto nested_iter = assert_cast<DefaultNestedColumnIterator*>(nested_column_iter);
+    auto nested_iter = assert_cast<DefaultNestedColumnIterator*>(nested_column_iter.get());
     std::vector<rowid_t> row_ids = {1, 10, 100};
     // dst is always nullable(array<nullable(string)>)
     DataTypePtr array_string_ptr = std::make_shared<vectorized::DataTypeNullable>(
@@ -2026,13 +2012,13 @@ TEST_F(VariantColumnWriterReaderTest, test_nested_subcolumn) {
     std::cout << "row_id: " << row_id << std::endl;
     // make some error senior
     {
-        ColumnIterator* nested_column_iter11;
+        ColumnIteratorUPtr nested_column_iter11;
         st = variant_column_reader->_new_iterator_with_flat_leaves(
                 &nested_column_iter11, target_column, &storageReadOptions, false, false);
         EXPECT_TRUE(st.ok()) << st.msg();
         st = nested_column_iter11->init(nested_column_iter_opts);
         EXPECT_TRUE(st.ok()) << st.msg();
-        auto nested_iter11 = assert_cast<DefaultNestedColumnIterator*>(nested_column_iter11);
+        auto* nested_iter11 = assert_cast<DefaultNestedColumnIterator*>(nested_column_iter11.get());
         assert(nested_iter11);
         st = nested_iter11->seek_to_ordinal(0);
         EXPECT_TRUE(st.ok()) << st.msg();
@@ -2042,9 +2028,8 @@ TEST_F(VariantColumnWriterReaderTest, test_nested_subcolumn) {
         st = nested_iter11->next_batch_of_zone_map(&nrows, wrong_arr);
         EXPECT_FALSE(st.ok());
         EXPECT_ANY_THROW(Status sta = nested_iter11->next_batch(&nrows, wrong_arr));
-        delete (nested_column_iter11);
     }
-    auto read_to_column_arr = [&](ColumnIterator* it) {
+    auto read_to_column_arr = [&](ColumnIteratorUPtr& it) {
         MutableColumnPtr arr = array_string_ptr->create_column();
         size_t nrows = 1000;
         st = it->seek_to_ordinal(0);
@@ -2052,7 +2037,6 @@ TEST_F(VariantColumnWriterReaderTest, test_nested_subcolumn) {
         st = it->next_batch(&nrows, arr);
         EXPECT_TRUE(st.ok()) << st.msg();
         EXPECT_EQ(arr->size(), 1000);
-        delete (it);
     };
 
     read_to_column_arr(nested_column_iter);
@@ -2072,14 +2056,14 @@ TEST_F(VariantColumnWriterReaderTest, test_nested_subcolumn) {
     EXPECT_TRUE(target_column.is_nested_subcolumn())
             << target_column._column_path->has_nested_part();
 
-    ColumnIterator* nested_column_iter1;
+    ColumnIteratorUPtr nested_column_iter1;
     st = variant_column_reader->_new_iterator_with_flat_leaves(&nested_column_iter1, target_column,
                                                                &storageReadOptions, false, false);
     EXPECT_TRUE(st.ok()) << st.msg();
     // check iter for read_by_rowids, next_batch
     // dst is array<nullable(string)>
     MutableColumnPtr dst_object2 = array_string_ptr->create_column();
-    auto nested_iter1 = assert_cast<DefaultNestedColumnIterator*>(nested_column_iter1);
+    auto nested_iter1 = assert_cast<DefaultNestedColumnIterator*>(nested_column_iter1.get());
     st = nested_column_iter1->init(nested_column_iter_opts);
     EXPECT_TRUE(st.ok()) << st.msg();
     st = nested_iter1->seek_to_ordinal(0);
@@ -2090,13 +2074,13 @@ TEST_F(VariantColumnWriterReaderTest, test_nested_subcolumn) {
 
     {
         // make read by nested_iter1 directly
-        ColumnIterator* nested_column_iter11;
+        ColumnIteratorUPtr nested_column_iter11;
         st = variant_column_reader->_new_iterator_with_flat_leaves(
                 &nested_column_iter11, target_column, &storageReadOptions, false, false);
         EXPECT_TRUE(st.ok()) << st.msg();
         st = nested_column_iter11->init(nested_column_iter_opts);
         EXPECT_TRUE(st.ok()) << st.msg();
-        auto nested_iter11 = assert_cast<DefaultNestedColumnIterator*>(nested_column_iter11);
+        auto* nested_iter11 = assert_cast<DefaultNestedColumnIterator*>(nested_column_iter11.get());
         MutableColumnPtr arr = array_string_ptr->create_column();
         size_t nrows = 1000;
         st = nested_iter11->seek_to_ordinal(0);
@@ -2104,7 +2088,6 @@ TEST_F(VariantColumnWriterReaderTest, test_nested_subcolumn) {
         st = nested_iter11->next_batch(&nrows, arr);
         EXPECT_TRUE(st.ok()) << st.msg();
         EXPECT_EQ(arr->size(), 1000);
-        delete (nested_column_iter11);
     }
     read_to_column_arr(nested_column_iter1);
 }
@@ -2137,12 +2120,12 @@ TEST_F(VariantColumnWriterReaderTest, test_nested_iter) {
     StorageReadOptions storageReadOptions;
     storageReadOptions.io_ctx.reader_type = ReaderType::READER_QUERY;
 
-    ColumnIterator* nested_column_iter;
+    ColumnIteratorUPtr nested_column_iter;
     st = variant_column_reader->new_iterator(&nested_column_iter, &_tablet_schema->column(0),
                                              &storageReadOptions);
     EXPECT_TRUE(st.ok()) << st.msg();
     // this is nested column root
-    auto nested_iter = assert_cast<HierarchicalDataIterator*>(nested_column_iter);
+    auto* nested_iter = assert_cast<HierarchicalDataIterator*>(nested_column_iter.get());
     EXPECT_TRUE(nested_iter != nullptr);
     ColumnIteratorOptions column_iter_opts;
     OlapReaderStatistics stats;
@@ -2172,10 +2155,9 @@ TEST_F(VariantColumnWriterReaderTest, test_nested_iter) {
         EXPECT_TRUE(st.ok()) << st.msg();
         EXPECT_TRUE(stats.bytes_read > 0);
     }
-    delete (nested_column_iter);
     // read dst is nullable column object
     {
-        ColumnIterator* nested_column_iter1;
+        ColumnIteratorUPtr nested_column_iter1;
         TabletColumn target_column;
         target_column.set_name("a");
         target_column.set_type(FieldType::OLAP_FIELD_TYPE_ARRAY);
@@ -2191,7 +2173,7 @@ TEST_F(VariantColumnWriterReaderTest, test_nested_iter) {
                                                  &storageReadOptions);
         EXPECT_TRUE(st.ok()) << st.msg();
         // this is nested column root
-        auto nested_iter2 = assert_cast<HierarchicalDataIterator*>(nested_column_iter1);
+        auto* nested_iter2 = assert_cast<HierarchicalDataIterator*>(nested_column_iter1.get());
         EXPECT_TRUE(nested_iter2 != nullptr);
         st = nested_iter2->init(column_iter_opts);
         EXPECT_TRUE(st.ok()) << st.msg();
@@ -2204,11 +2186,10 @@ TEST_F(VariantColumnWriterReaderTest, test_nested_iter) {
         EXPECT_TRUE(st.ok()) << st.msg();
         st = nested_iter2->next_batch(&nrows, null_object2, &has_null);
         EXPECT_TRUE(st.ok()) << st.msg();
-        delete (nested_column_iter1);
     }
     // test _process_with_nested_column for offsets not equals
     {
-        ColumnIterator* nested_column_iter1;
+        ColumnIteratorUPtr nested_column_iter1;
         TabletColumn target_column;
         target_column.set_name("a");
         target_column.set_type(FieldType::OLAP_FIELD_TYPE_ARRAY);
@@ -2224,7 +2205,7 @@ TEST_F(VariantColumnWriterReaderTest, test_nested_iter) {
                                                  &storageReadOptions);
         EXPECT_TRUE(st.ok()) << st.msg();
         // this is nested column root
-        auto nested_iter2 = assert_cast<HierarchicalDataIterator*>(nested_column_iter1);
+        auto* nested_iter2 = assert_cast<HierarchicalDataIterator*>(nested_column_iter1.get());
         EXPECT_TRUE(nested_iter2 != nullptr);
         st = nested_iter2->init(column_iter_opts);
         EXPECT_TRUE(st.ok()) << st.msg();
@@ -2262,7 +2243,6 @@ TEST_F(VariantColumnWriterReaderTest, test_nested_iter) {
         st = nested_iter2->_process_nested_columns(container_variant, nested_subcolumns, n);
         std::cout << st.msg() << std::endl;
         EXPECT_FALSE(st.ok()) << st.msg();
-        delete (nested_column_iter1);
     }
 }
 
@@ -2294,12 +2274,12 @@ TEST_F(VariantColumnWriterReaderTest, test_nested_iter_nullable) {
     StorageReadOptions storageReadOptions;
     storageReadOptions.io_ctx.reader_type = ReaderType::READER_QUERY;
 
-    ColumnIterator* nested_column_iter;
+    ColumnIteratorUPtr nested_column_iter;
     st = variant_column_reader->new_iterator(&nested_column_iter, &_tablet_schema->column(0),
                                              &storageReadOptions);
     EXPECT_TRUE(st.ok()) << st.msg();
     // this is nested column root
-    auto nested_iter = assert_cast<HierarchicalDataIterator*>(nested_column_iter);
+    auto* nested_iter = assert_cast<HierarchicalDataIterator*>(nested_column_iter.get());
     EXPECT_TRUE(nested_iter != nullptr);
     ColumnIteratorOptions column_iter_opts;
     OlapReaderStatistics stats;
@@ -2318,7 +2298,6 @@ TEST_F(VariantColumnWriterReaderTest, test_nested_iter_nullable) {
     st = nested_iter->next_batch(&nrows, null_object, &has_null);
     EXPECT_TRUE(st.ok()) << st.msg();
     EXPECT_TRUE(stats.bytes_read > 0);
-    delete (nested_column_iter);
 }
 
 } // namespace doris


### PR DESCRIPTION
Use unique_ptr instead of raw pointers to avoid memory leaks.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

