### PR TITLE
[Bug](join) do not set _should_keep_column_flags when key column belong to intermediate tuple

### DIFF
--- a/be/src/pipeline/exec/hashjoin_build_sink.cpp
+++ b/be/src/pipeline/exec/hashjoin_build_sink.cpp
@@ -212,7 +212,12 @@ Status HashJoinBuildSinkLocalState::close(RuntimeState* state, Status exec_statu
         // because it is used to compare with probe side hash key column
 
         if (p._should_keep_hash_key_column && _build_col_ids.size() == 1) {
-            p._should_keep_column_flags[_build_col_ids[0]] = true;
+            // when key column from build side tuple, we should keep it
+            // if key column belong to intermediate tuple, it means _build_col_ids[0] >= _should_keep_column_flags.size(),
+            // key column still kept too.
+            if (_build_col_ids[0] < p._should_keep_column_flags.size()) {
+                p._should_keep_column_flags[_build_col_ids[0]] = true;
+            }
         }
 
         if (_shared_state->build_block) {


### PR DESCRIPTION
### What problem does this PR solve?
```cpp
./run-regression-test.sh --run constant_propagation 

   4# 0x000056492C02C9C5 in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
   5# 0x000056492C01E27A in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
   6# google::LogMessage::SendToLog() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
   7# google::LogMessage::Flush() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
   8# google::LogMessageFatal::~LogMessageFatal() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
   9# doris::pipeline::HashJoinBuildSinkLocalState::close(doris::RuntimeState*, doris::Status)::$_0::operator()() const at /root/doris/be/src/pipeline/exec/hashjoin_build_sink.cpp:215
  10# doris::Defer<doris::pipeline::HashJoinBuildSinkLocalState::close(doris::RuntimeState*, doris::Status)::$_0>::~Defer() at /root/doris/be/src/util/defer_op.h:37
  11# doris::pipeline::HashJoinBuildSinkLocalState::close(doris::RuntimeState*, doris::Status) at /root/doris/be/src/pipeline/exec/hashjoin_build_sink.cpp:261
  12# doris::pipeline::DataSinkOperatorXBase::close(doris::RuntimeState*, doris::Status) at /root/doris/be/src/pipeline/exec/operator.h:669
  13# doris::pipeline::PipelineTask::close(doris::Status, bool) at /root/doris/be/src/pipeline/pipeline_task.cpp:678
```
