### PR TITLE
[chore](exception) add jni error flag for some BE JNI function

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -52,6 +52,7 @@ namespace ErrorCode {
     TStatusError(END_OF_FILE, false);                     \
     TStatusError(INTERNAL_ERROR, true);                   \
     TStatusError(RUNTIME_ERROR, true);                    \
+    TStatusError(JNI_ERROR, true);                        \
     TStatusError(CANCELLED, false);                       \
     TStatusError(ANALYSIS_ERROR, false);                  \
     TStatusError(MEM_LIMIT_EXCEEDED, false);              \
@@ -496,6 +497,7 @@ public:
     ERROR_CTOR_NOSTACK(EndOfFile, END_OF_FILE)
     ERROR_CTOR(InternalError, INTERNAL_ERROR)
     ERROR_CTOR(RuntimeError, RUNTIME_ERROR)
+    ERROR_CTOR(JniError, JNI_ERROR)
     ERROR_CTOR_NOSTACK(Cancelled, CANCELLED)
     ERROR_CTOR(MemoryLimitExceeded, MEM_LIMIT_EXCEEDED)
     ERROR_CTOR(RpcError, THRIFT_RPC_ERROR)

--- a/be/src/util/jni-util.h
+++ b/be/src/util/jni-util.h
@@ -24,7 +24,6 @@
 #include <stdint.h>
 
 #include <string>
-#include <unordered_map>
 
 #include "common/status.h"
 #include "jni_md.h"
@@ -74,7 +73,7 @@ public:
             }
         }
         if (*env == nullptr) {
-            return Status::RuntimeError("Failed to get JNIEnv: it is nullptr.");
+            return Status::JniError("Failed to get JNIEnv: it is nullptr.");
         }
         return Status::OK();
     }
@@ -191,7 +190,7 @@ Status SerializeThriftMsg(JNIEnv* env, T* msg, jbyteArray* serialized_msg) {
     // Make sure that 'size' is within the limit of INT_MAX as the use of
     // 'size' below takes int.
     if (size > INT_MAX) {
-        return Status::InternalError(
+        return Status::JniError(
                 "The length of the serialization buffer ({} bytes) exceeds the limit of {} bytes",
                 size, INT_MAX);
     }
@@ -199,7 +198,9 @@ Status SerializeThriftMsg(JNIEnv* env, T* msg, jbyteArray* serialized_msg) {
     /// create jbyteArray given buffer
     *serialized_msg = env->NewByteArray(size);
     RETURN_ERROR_IF_EXC(env);
-    if (*serialized_msg == NULL) return Status::InternalError("couldn't construct jbyteArray");
+    if (*serialized_msg == nullptr) {
+        return Status::JniError("couldn't construct jbyteArray");
+    }
     env->SetByteArrayRegion(*serialized_msg, 0, size, reinterpret_cast<jbyte*>(buffer));
     RETURN_ERROR_IF_EXC(env);
     return Status::OK();

--- a/be/src/vec/functions/function_java_udf.h
+++ b/be/src/vec/functions/function_java_udf.h
@@ -24,8 +24,6 @@
 
 #include <functional>
 #include <memory>
-#include <mutex>
-#include <ostream>
 
 #include "common/logging.h"
 #include "common/status.h"
@@ -33,7 +31,6 @@
 #include "util/jni-util.h"
 #include "vec/core/block.h"
 #include "vec/core/column_numbers.h"
-#include "vec/core/column_with_type_and_name.h"
 #include "vec/core/columns_with_type_and_name.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
@@ -143,9 +140,7 @@ private:
                 return status;
             }
             env->CallNonvirtualVoidMethodA(executor, executor_cl, executor_close_id, nullptr);
-            RETURN_ERROR_IF_EXC(env);
             env->DeleteGlobalRef(executor);
-            RETURN_ERROR_IF_EXC(env);
             env->DeleteGlobalRef(executor_cl);
             RETURN_IF_ERROR(JniUtil::GetJniExceptionMsg(env));
             is_closed = true;

--- a/fe/be-java-extensions/java-udf/src/main/java/org/apache/doris/udf/BaseExecutor.java
+++ b/fe/be-java-extensions/java-udf/src/main/java/org/apache/doris/udf/BaseExecutor.java
@@ -191,7 +191,8 @@ public abstract class BaseExecutor {
         objCache.methodAccess = null;
     }
 
-    protected ColumnValueConverter getInputConverter(TPrimitiveType primitiveType, Class clz) {
+    protected ColumnValueConverter getInputConverter(TPrimitiveType primitiveType, Class clz)
+            throws UdfRuntimeException {
         switch (primitiveType) {
             case DATE:
             case DATEV2: {
@@ -220,7 +221,7 @@ public abstract class BaseExecutor {
                         return result;
                     };
                 } else if (!LocalDate.class.equals(clz)) {
-                    throw new RuntimeException("Unsupported date type: " + clz.getCanonicalName());
+                    throw new UdfRuntimeException("Unsupported date type: " + clz.getCanonicalName());
                 }
                 break;
             }
@@ -253,7 +254,7 @@ public abstract class BaseExecutor {
                         return result;
                     };
                 } else if (!LocalDateTime.class.equals(clz)) {
-                    throw new RuntimeException("Unsupported date type: " + clz.getCanonicalName());
+                    throw new UdfRuntimeException("Unsupported date type: " + clz.getCanonicalName());
                 }
                 break;
             }
@@ -279,7 +280,8 @@ public abstract class BaseExecutor {
         return null;
     }
 
-    protected ColumnValueConverter getOutputConverter(JavaUdfDataType returnType, Class clz) {
+    protected ColumnValueConverter getOutputConverter(JavaUdfDataType returnType, Class clz)
+            throws UdfRuntimeException {
         switch (returnType.getPrimitiveType()) {
             case DATE:
             case DATEV2: {
@@ -306,7 +308,7 @@ public abstract class BaseExecutor {
                         return result;
                     };
                 } else if (!LocalDate.class.equals(clz)) {
-                    throw new RuntimeException("Unsupported date type: " + clz.getCanonicalName());
+                    throw new UdfRuntimeException("Unsupported date type: " + clz.getCanonicalName());
                 }
                 break;
             }
@@ -367,7 +369,8 @@ public abstract class BaseExecutor {
     }
 
     // Add unified converter methods
-    protected Map<Integer, ColumnValueConverter> getInputConverters(int numColumns, boolean isUdaf) {
+    protected Map<Integer, ColumnValueConverter> getInputConverters(int numColumns, boolean isUdaf)
+            throws UdfRuntimeException {
         Map<Integer, ColumnValueConverter> converters = new HashMap<>();
         for (int j = 0; j < numColumns; ++j) {
             // For UDAF, we need to offset by 1 since first arg is state
@@ -381,7 +384,7 @@ public abstract class BaseExecutor {
         return converters;
     }
 
-    protected ColumnValueConverter getOutputConverter() {
+    protected ColumnValueConverter getOutputConverter() throws UdfRuntimeException {
         return getOutputConverter(objCache.retType, objCache.retClass);
     }
 }

--- a/gensrc/thrift/Status.thrift
+++ b/gensrc/thrift/Status.thrift
@@ -78,6 +78,7 @@ enum TStatusCode {
     OLAP_ERR_VERSION_ALREADY_MERGED = 45,
     DATA_QUALITY_ERROR  = 46,
     INVALID_JSON_PATH   = 47,
+    JNI_ERROR           = 48,
 
     //VEC_EXCEPTION = 50,
     //VEC_LOGIC_ERROR = 51,


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:

```
mysql> select java_udf_int_test_nullable2(1) from test_query_qa.baseall;
ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[JNI_ERROR]UdfRuntimeException: UDF failed to evaluate | CAUSED BY: IllegalArgumentException: Input value cannot be
```
In some error reports, when an InternalError is returned, users may not immediately understand the issue and must check the logs in detail. To improve this, we've introduced a JNI_ERROR error code. When users see this error code, they can quickly recognize its meaning, especially in the context of UDF calls.

Additionally, this error will be followed by a UdfRuntimeException message, making it clear to users that the error occurred within a UDF.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

