### PR TITLE
[NoMergeLatest](exit) call stop before brpc server stop to stop queries and allow brpc exist gracefully

### DIFF
--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -74,13 +74,31 @@ PipelineTask::PipelineTask(
           _task_idx(task_idx),
           _pipeline_name(_pipeline->name()) {
     _pipeline_task_watcher.start();
+#ifndef BE_TEST
+    _query_mem_tracker = fragment_context->get_query_ctx()->query_mem_tracker();
+#endif
     _execution_dependencies.push_back(state->get_query_ctx()->get_execution_dependency());
     auto shared_state = _sink->create_shared_state();
     if (shared_state) {
         _sink_shared_state = shared_state;
     }
 }
-
+PipelineTask::~PipelineTask() {
+// PipelineTask is also hold by task queue( https://github.com/apache/doris/pull/49753),
+// so that it maybe the last one to be destructed.
+// But pipeline task hold some objects, like operators, shared state, etc. So that should release
+// memory manually.
+#ifndef BE_TEST
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_query_mem_tracker);
+#endif
+    _sink_shared_state.reset();
+    _op_shared_states.clear();
+    _sink.reset();
+    _operators.clear();
+    _spill_context.reset();
+    _block.reset();
+    _pipeline.reset();
+}
 Status PipelineTask::prepare(const TPipelineInstanceParams& local_params, const TDataSink& tsink,
                              QueryContext* query_ctx) {
     DCHECK(_sink);

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -54,6 +54,7 @@ public:
                                          std::shared_ptr<Dependency>>>
                          le_state_map,
                  int task_idx);
+    ~PipelineTask();
 
     Status prepare(const TPipelineInstanceParams& local_params, const TDataSink& tsink,
                    QueryContext* query_ctx);
@@ -316,6 +317,8 @@ private:
     std::atomic<bool> _eos = false;
     std::atomic<bool> _wake_up_early = false;
     const std::string _pipeline_name;
+    // PipelineTask maybe hold by TaskQueue
+    std::shared_ptr<MemTrackerLimiter> _query_mem_tracker;
 };
 
 using PipelineTaskSPtr = std::shared_ptr<PipelineTask>;


### PR DESCRIPTION
### What problem does this PR solve?

Thread 1 (Thread 0x7f2a03130040 (LWP 3064597) "doris_be"):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x612000433780) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x612000433730, cond=0x612000433758) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x612000433758, mutex=0x612000433730) at pthread_cond_wait.c:647
#3  0x000055e4848e6a68 in brpc::Acceptor::Join() ()
#4  0x000055e4848d2cdd in brpc::Server::Join() ()
#5  0x000055e44aeec3d8 in doris::BRpcService::join (this=<optimized out>) at /root/doris/be/src/service/brpc_service.cpp:107
#6  0x000055e44aeec155 in doris::BRpcService::~BRpcService (this=0x612000433780) at /root/doris/be/src/service/brpc_service.cpp:59
#7  0x000055e446772f04 in std::default_delete<doris::BRpcService>::operator() (this=<optimized out>, __ptr=0x6020005e64d0) at /var/local/ldb-toolchain-018/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85
#8  std::__uniq_ptr_impl<doris::BRpcService, std::default_delete<doris::BRpcService> >::reset (this=this@entry=0x7f2a0120f0c0, __p=0x80, __p@entry=0x0) at /var/local/ldb-toolchain-018/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:182
#9  0x000055e446747225 in std::unique_ptr<doris::BRpcService, std::default_delete<doris::BRpcService> >::reset (__p=0x0, this=<optimized out>) at /var/local/ldb-toolchain-018/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:456
#10 main (argc=<optimized out>, argv=<optimized out>) at /root/doris/be/src/service/doris_main.cpp:631
Detaching from program: /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be, process 3064597
[Inferior 1 (process 3064597) detached]

When call doris be to exit gracefully, doris main function will blocked at brpc server's join method. It will try to wait all brpc  closures to stop. But after wait, we did not stop task schedulers and fragments, and some query will continue to run. 

In this PR, I try to stop 3 core thread pools, it will stop all queries.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

