### PR TITLE
[fix](fe)show config command use readline instead of  ready

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowConfigCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowConfigCommand.java
@@ -133,12 +133,11 @@ public class ShowConfigCommand extends Command implements NoForward {
                 urlConnection.setRequestProperty("Auth-Token", Env.getCurrentEnv().getTokenManager().acquireToken());
                 InputStream inputStream = urlConnection.getInputStream();
                 BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
-                while (reader.ready()) {
+                String line;
+                while ((line = reader.readLine()) != null) {
                     // line's format like [["k1","v1"], ["k2","v2"]]
-                    String line = reader.readLine();
                     JSONArray outer = new JSONArray(line);
                     for (int i = 0; i < outer.length(); ++i) {
-                        // [key, type, value, isMutable]
                         JSONArray inner = outer.getJSONArray(i);
                         if (matcher == null || matcher.match(inner.getString(0))) {
                             List<String> rows = Lists.newArrayList();
@@ -154,7 +153,7 @@ public class ShowConfigCommand extends Command implements NoForward {
                 }
             } catch (Exception e) {
                 throw new AnalysisException(
-                        String.format("Can’t get backend config, backendId: %d, host: %s. error: %s",
+                        String.format("Can't get backend config, backendId: %d, host: %s. error: %s",
                                 beId, host, e.getMessage()), e);
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowConfigCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowConfigCommand.java
@@ -138,6 +138,7 @@ public class ShowConfigCommand extends Command implements NoForward {
                     // line's format like [["k1","v1"], ["k2","v2"]]
                     JSONArray outer = new JSONArray(line);
                     for (int i = 0; i < outer.length(); ++i) {
+                        // [key, type, value, isMutable]
                         JSONArray inner = outer.getJSONArray(i);
                         if (matcher == null || matcher.match(inner.getString(0))) {
                             List<String> rows = Lists.newArrayList();


### PR DESCRIPTION
ready() in Java does not mean “more data is available to read”; it only means that reading will not block.
For network streams, ready() may immediately return false because the data is still being decrypted by TLS or has not yet been passed from the TCP buffer to the BufferedReader.
This can cause miss subsequent response data.

