### PR TITLE
branch-3.1: [fix](load) allow memtable to detect cancellation while blocked by memory limiter #53070

### DIFF
--- a/be/src/olap/memtable_memory_limiter.h
+++ b/be/src/olap/memtable_memory_limiter.h
@@ -19,6 +19,8 @@
 
 #include <stdint.h>
 
+#include <functional>
+
 #include "common/status.h"
 #include "runtime/memory/mem_tracker.h"
 #include "util/countdown_latch.h"
@@ -39,7 +41,7 @@ public:
 
     // check if the total mem consumption exceeds limit.
     // If yes, it will flush memtable to try to reduce memory consumption.
-    void handle_memtable_flush();
+    void handle_memtable_flush(std::function<bool()> cancel_check);
 
     void register_writer(std::weak_ptr<MemTableWriter> writer);
 

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -292,6 +292,7 @@ bool LoadChannel::is_finished() {
 }
 
 Status LoadChannel::cancel() {
+    _cancelled.store(true);
     std::lock_guard<std::mutex> l(_lock);
     for (auto& it : _tablets_channels) {
         static_cast<void>(it.second->cancel());

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -68,6 +68,8 @@ public:
 
     bool is_high_priority() const { return _is_high_priority; }
 
+    bool is_cancelled() const { return _cancelled.load(); }
+
     RuntimeProfile::Counter* get_mgr_add_batch_timer() { return _mgr_add_batch_timer; }
     RuntimeProfile::Counter* get_handle_mem_limit_timer() { return _handle_mem_limit_timer; }
 
@@ -107,6 +109,7 @@ private:
     std::unordered_set<int64_t> _finished_channel_ids;
     // set to true if at least one tablets channel has been opened
     bool _opened = false;
+    std::atomic<bool> _cancelled {false};
 
     QueryThreadContext _query_thread_context;
 

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -152,7 +152,11 @@ Status LoadChannelMgr::add_batch(const PTabletWriterAddBlockRequest& request,
         // If this is a high priority load task, do not handle this.
         // because this may block for a while, which may lead to rpc timeout.
         SCOPED_TIMER(channel->get_handle_mem_limit_timer());
-        ExecEnv::GetInstance()->memtable_memory_limiter()->handle_memtable_flush();
+        ExecEnv::GetInstance()->memtable_memory_limiter()->handle_memtable_flush(
+                [channel]() { return channel->is_cancelled(); });
+        if (channel->is_cancelled()) {
+            return Status::Cancelled("LoadChannel has been cancelled: {}.", load_id.to_string());
+        }
     }
 
     // 3. add batch to load channel

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -555,7 +555,11 @@ Status VTabletWriterV2::_write_memtable(std::shared_ptr<vectorized::Block> block
     }
     {
         SCOPED_TIMER(_wait_mem_limit_timer);
-        ExecEnv::GetInstance()->memtable_memory_limiter()->handle_memtable_flush();
+        ExecEnv::GetInstance()->memtable_memory_limiter()->handle_memtable_flush(
+                [state = _state]() { return state->is_cancelled(); });
+        if (_state->is_cancelled()) {
+            return _state->cancel_reason();
+        }
     }
     SCOPED_TIMER(_write_memtable_timer);
     st = delta_writer->write(block.get(), rows.row_idxes);

--- a/be/test/olap/memtable_memory_limiter_test.cpp
+++ b/be/test/olap/memtable_memory_limiter_test.cpp
@@ -170,7 +170,7 @@ TEST_F(MemTableMemoryLimiterTest, handle_memtable_flush_test) {
         ASSERT_TRUE(res.ok());
     }
     static_cast<void>(mem_limiter->init(100));
-    mem_limiter->handle_memtable_flush();
+    mem_limiter->_handle_memtable_flush(nullptr);
     CHECK_EQ(0, mem_limiter->mem_usage());
 
     res = delta_writer->close();

--- a/be/test/olap/memtable_memory_limiter_test.cpp
+++ b/be/test/olap/memtable_memory_limiter_test.cpp
@@ -170,7 +170,7 @@ TEST_F(MemTableMemoryLimiterTest, handle_memtable_flush_test) {
         ASSERT_TRUE(res.ok());
     }
     static_cast<void>(mem_limiter->init(100));
-    mem_limiter->_handle_memtable_flush(nullptr);
+    mem_limiter->handle_memtable_flush(nullptr);
     CHECK_EQ(0, mem_limiter->mem_usage());
 
     res = delta_writer->close();


### PR DESCRIPTION
Backport #53070

### What problem does this PR solve?

Problem Summary:

When a memtable write is blocked by the memory limiter, it should be able to detect if the context has been cancelled and return early. This prevents the system from hanging indefinitely in blocked state during shutdown or timeout scenarios.
