### PR TITLE
[chore](cast) Avoid multiple prepares for cast.

### DIFF
--- a/be/src/vec/functions/cast/function_cast.cpp
+++ b/be/src/vec/functions/cast/function_cast.cpp
@@ -364,7 +364,9 @@ public:
         }
         auto* cast_state = reinterpret_cast<CastState*>(
                 context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
-        DCHECK(cast_state != nullptr) << "Function context for function '" << get_name();
+        if (cast_state == nullptr) {
+            return create_cast_function(context);
+        }
         return cast_state->cast_function;
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

In the past, prepare_unpack_dictionaries was called every time during cast execution.
In fact, we can save the specific cast function during the open phase.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

