### PR TITLE
[fix](prepare statement)Fix date_trunc using prepare statement parameter type bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/DateTrunc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/DateTrunc.java
@@ -24,7 +24,6 @@ import org.apache.doris.nereids.trees.expressions.functions.AlwaysNullable;
 import org.apache.doris.nereids.trees.expressions.functions.CustomSignature;
 import org.apache.doris.nereids.trees.expressions.functions.Monotonic;
 import org.apache.doris.nereids.trees.expressions.literal.StringLikeLiteral;
-import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 import org.apache.doris.nereids.trees.expressions.shape.BinaryExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DateTimeV2Type;
@@ -65,14 +64,14 @@ public class DateTrunc extends ScalarFunction
             throw new AnalysisException("the time unit parameter of "
                     + getName() + " function must be a string constant: " + toSql());
         } else if (firstArgIsStringLiteral && secondArgIsStringLiteral) {
-            if (!LEGAL_TIME_UNIT.contains(((VarcharLiteral) getArgument(0)).getStringValue().toLowerCase())
-                    && !LEGAL_TIME_UNIT.contains(((VarcharLiteral) getArgument(1))
+            if (!LEGAL_TIME_UNIT.contains(((StringLikeLiteral) getArgument(0)).getStringValue().toLowerCase())
+                    && !LEGAL_TIME_UNIT.contains(((StringLikeLiteral) getArgument(1))
                     .getStringValue().toLowerCase())) {
                 throw new AnalysisException("date_trunc function time unit param only support argument is "
                         + String.join("|", LEGAL_TIME_UNIT));
             }
         } else {
-            final String constParam = ((VarcharLiteral) getArgument(firstArgIsStringLiteral ? 0 : 1))
+            final String constParam = ((StringLikeLiteral) getArgument(firstArgIsStringLiteral ? 0 : 1))
                     .getStringValue().toLowerCase();
             if (!LEGAL_TIME_UNIT.contains(constParam)) {
                 throw new AnalysisException("date_trunc function time unit param only support argument is "
@@ -100,9 +99,9 @@ public class DateTrunc extends ScalarFunction
                     .args(VarcharType.SYSTEM_DEFAULT, getArgument(1).getDataType());
         }
         boolean firstArgIsStringLiteral =
-                getArgument(0).isConstant() && getArgument(0) instanceof VarcharLiteral;
+                getArgument(0).isConstant() && getArgument(0) instanceof StringLikeLiteral;
         boolean secondArgIsStringLiteral =
-                getArgument(1).isConstant() && getArgument(1) instanceof VarcharLiteral;
+                getArgument(1).isConstant() && getArgument(1) instanceof StringLikeLiteral;
         if (firstArgIsStringLiteral && !secondArgIsStringLiteral) {
             return FunctionSignature.ret(DateTimeV2Type.SYSTEM_DEFAULT)
                     .args(VarcharType.SYSTEM_DEFAULT, DateTimeV2Type.SYSTEM_DEFAULT);
@@ -110,7 +109,7 @@ public class DateTrunc extends ScalarFunction
             return FunctionSignature.ret(DateTimeV2Type.SYSTEM_DEFAULT)
                     .args(DateTimeV2Type.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT);
         } else if (firstArgIsStringLiteral && secondArgIsStringLiteral) {
-            boolean timeUnitIsFirst = LEGAL_TIME_UNIT.contains(((VarcharLiteral) getArgument(0))
+            boolean timeUnitIsFirst = LEGAL_TIME_UNIT.contains(((StringLikeLiteral) getArgument(0))
                     .getStringValue().toLowerCase());
             return timeUnitIsFirst ? FunctionSignature.ret(DateTimeV2Type.SYSTEM_DEFAULT)
                     .args(VarcharType.SYSTEM_DEFAULT, DateTimeV2Type.SYSTEM_DEFAULT)

--- a/regression-test/data/prepared_stmt_p0/prepared_stmt.out
+++ b/regression-test/data/prepared_stmt_p0/prepared_stmt.out
@@ -135,6 +135,9 @@ a
 -- !select24 --
 1	\N	[{"id":"1", "name":"doris"}, {"id":"2", "name":"apache"}, null]	\N
 
+-- !select25 --
+2025-08-15T00:00
+
 -- !overflow_2 --
 2
 

--- a/regression-test/suites/prepared_stmt_p0/prepared_stmt.groovy
+++ b/regression-test/suites/prepared_stmt_p0/prepared_stmt.groovy
@@ -320,6 +320,12 @@ suite("test_prepared_stmt", "nonConcurrent") {
         stmt_read = prepareStatement("""SELECT 1, null, [{'id': 1, 'name' : 'doris'}, {'id': 2, 'name': 'apache'}, null], null""")
         assertEquals(com.mysql.cj.jdbc.ServerPreparedStatement, stmt_read.class)
         qe_select24 stmt_read
+
+        // test date_trunc
+        stmt_read = prepareStatement "select date_trunc (? , ?)"
+        stmt_read.setString(1, "2025-08-15 11:22:33")
+        stmt_read.setString(2, "DAY")
+        qe_select25 stmt_read
     }
 
     // test stmtId overflow


### PR DESCRIPTION
### What problem does this PR solve?

Fix date_trunc using prepare statement parameter type bug. JDBC will send date_trunc parameter as string type, not varchar type. Need to support this.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

