### PR TITLE
[bugfix](be) should set is inited = true only when init successfully and not update counters if init == false

### DIFF
--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -127,7 +127,6 @@ static std::string read_columns_to_string(TabletSchemaSPtr tablet_schema,
 }
 
 Status NewOlapScanner::init() {
-    _is_init = true;
     auto* local_state = static_cast<pipeline::OlapScanLocalState*>(_local_state);
     auto& tablet = _tablet_reader_params.tablet;
     auto& tablet_schema = _tablet_reader_params.tablet_schema;
@@ -237,6 +236,7 @@ Status NewOlapScanner::init() {
         SchemaCache::instance()->insert_schema(schema_key, tablet_schema);
     }
 
+    _is_init = true;
     return Status::OK();
 }
 

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -315,8 +315,10 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
     }
     // WorkloadGroup Policy will check cputime realtime, so that should update the counter
     // as soon as possible, could not update it on close.
-    scanner->update_scan_cpu_timer();
-    scanner->update_realtime_counters();
+    if (scanner->is_init()) {
+        scanner->update_scan_cpu_timer();
+        scanner->update_realtime_counters();
+    }
 
     if (eos) {
         scanner->mark_to_need_to_close();


### PR DESCRIPTION
### What problem does this PR solve?

If init = false, some variables is not inited, for example, the _tablet_reader is not inited. And when update counters, it will core.
This problem only exist in master and 3.1.
And in master branch, I refactor these code because the init flag is modified very confused.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

