### PR TITLE
[Refactor](VExpr) Change the member val to constexpr static val to reduce the mem cost

### DIFF
--- a/be/src/vec/exprs/vbitmap_predicate.cpp
+++ b/be/src/vec/exprs/vbitmap_predicate.cpp
@@ -45,7 +45,7 @@ namespace doris::vectorized {
 class VExprContext;
 
 vectorized::VBitmapPredicate::VBitmapPredicate(const TExprNode& node)
-        : VExpr(node), _filter(nullptr), _expr_name("bitmap_predicate") {}
+        : VExpr(node), _filter(nullptr) {}
 
 doris::Status vectorized::VBitmapPredicate::prepare(doris::RuntimeState* state,
                                                     const RowDescriptor& desc,
@@ -106,13 +106,7 @@ doris::Status vectorized::VBitmapPredicate::execute(vectorized::VExprContext* co
         _filter->find_batch(argument_column->get_raw_data().data, nullptr, sz, ptr);
     }
 
-    if (_data_type->is_nullable()) {
-        auto null_map = ColumnUInt8::create(block->rows(), 0);
-        block->insert({ColumnNullable::create(std::move(res_data_column), std::move(null_map)),
-                       _data_type, _expr_name});
-    } else {
-        block->insert({std::move(res_data_column), _data_type, _expr_name});
-    }
+    block->insert({std::move(res_data_column), _data_type, EXPR_NAME});
     *result_column_id = num_columns_without_result;
     return Status::OK();
 }
@@ -123,7 +117,7 @@ void vectorized::VBitmapPredicate::close(vectorized::VExprContext* context,
 }
 
 const std::string& vectorized::VBitmapPredicate::expr_name() const {
-    return _expr_name;
+    return EXPR_NAME;
 }
 
 void vectorized::VBitmapPredicate::set_filter(std::shared_ptr<BitmapFilterFuncBase> filter) {

--- a/be/src/vec/exprs/vbitmap_predicate.h
+++ b/be/src/vec/exprs/vbitmap_predicate.h
@@ -72,6 +72,6 @@ public:
 
 private:
     std::shared_ptr<BitmapFilterFuncBase> _filter;
-    std::string _expr_name;
+    inline static const std::string EXPR_NAME = "bitmap_predicate";
 };
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/vbloom_predicate.cpp
+++ b/be/src/vec/exprs/vbloom_predicate.cpp
@@ -44,8 +44,7 @@ namespace doris::vectorized {
 
 class VExprContext;
 
-VBloomPredicate::VBloomPredicate(const TExprNode& node)
-        : VExpr(node), _filter(nullptr), _expr_name("bloom_predicate") {}
+VBloomPredicate::VBloomPredicate(const TExprNode& node) : VExpr(node), _filter(nullptr) {}
 
 Status VBloomPredicate::prepare(RuntimeState* state, const RowDescriptor& desc,
                                 VExprContext* context) {
@@ -89,20 +88,13 @@ Status VBloomPredicate::execute(VExprContext* context, Block* block, int* result
     res_data_column->resize(sz);
     auto* ptr = ((ColumnUInt8*)res_data_column.get())->get_data().data();
     _filter->find_fixed_len(argument_column, ptr);
-
-    if (_data_type->is_nullable()) {
-        auto null_map = ColumnUInt8::create(block->rows(), 0);
-        block->insert({ColumnNullable::create(std::move(res_data_column), std::move(null_map)),
-                       _data_type, _expr_name});
-    } else {
-        block->insert({std::move(res_data_column), _data_type, _expr_name});
-    }
+    block->insert({std::move(res_data_column), _data_type, EXPR_NAME});
     *result_column_id = num_columns_without_result;
     return Status::OK();
 }
 
 const std::string& VBloomPredicate::expr_name() const {
-    return _expr_name;
+    return EXPR_NAME;
 }
 
 void VBloomPredicate::set_filter(std::shared_ptr<BloomFilterFuncBase> filter) {

--- a/be/src/vec/exprs/vbloom_predicate.h
+++ b/be/src/vec/exprs/vbloom_predicate.h
@@ -55,6 +55,6 @@ public:
 
 private:
     std::shared_ptr<BloomFilterFuncBase> _filter;
-    std::string _expr_name;
+    inline static const std::string EXPR_NAME = "bloom_predicate";
 };
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/vcase_expr.h
+++ b/be/src/vec/exprs/vcase_expr.h
@@ -52,11 +52,22 @@ public:
     std::string debug_string() const override;
 
 private:
+    std::string get_function_name() const {
+        std::string res = FUNCTION_NAME;
+        if (_has_case_expr) {
+            res += "_has_case";
+        }
+        if (_has_else_expr) {
+            res += "_has_else";
+        }
+        return res;
+    }
+
     bool _has_case_expr;
     bool _has_else_expr;
 
     FunctionBasePtr _function;
-    std::string _function_name = "case";
-    const std::string _expr_name = "vcase expr";
+    inline static const std::string FUNCTION_NAME = "case";
+    inline static const std::string EXPR_NAME = "vcase expr";
 };
 } // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?

Change the member val to constexpr static val to reduce the mem cost
Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

