### PR TITLE
[opt](nereids) optimize normalize window

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/FillUpMissingSlotsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/FillUpMissingSlotsTest.java
@@ -647,8 +647,7 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
                     logicalProject(
                         logicalFilter(
                             logicalWindow(
-                                logicalProject(
-                                    logicalAggregate(logicalEmptyRelation())))
+                                    logicalAggregate(logicalEmptyRelation()))
                         ).when(filter -> filter.toString().contains("predicates=(rank() OVER(ORDER BY year asc null first)#5 > 1)"))
                     )
                 )
@@ -660,11 +659,9 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
                     logicalProject(
                         logicalFilter(
                             logicalWindow(
-                                logicalProject(
-                                    logicalFilter(
-                                        logicalAggregate(logicalEmptyRelation())
-                                    ).when(filter -> filter.toString().contains("predicates=(total#5 > 100)"))
-                                )
+                                logicalFilter(
+                                    logicalAggregate(logicalEmptyRelation())
+                                ).when(filter -> filter.toString().contains("predicates=(total#5 > 100)"))
                             )
                         ).when(filter -> filter.toString().contains("predicates=(row_number() OVER(ORDER BY year asc null first)#6 > 1)"))
                     )
@@ -692,7 +689,7 @@ public class FillUpMissingSlotsTest extends AnalyzeCheckTestBase implements Memo
                         logicalProject(
                             logicalFilter(
                                 logicalWindow(
-                                    logicalProject(logicalAggregate(logicalEmptyRelation())))
+                                    logicalAggregate(logicalEmptyRelation()))
                             ).when(filter -> filter.toString().contains("predicates=(row_number() OVER(ORDER BY year asc null first)#5 > 1)"))
                         )
                     )

--- a/regression-test/data/nereids_p0/cte/test_cte_filter_pushdown.out
+++ b/regression-test/data/nereids_p0/cte/test_cte_filter_pushdown.out
@@ -30,7 +30,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 -- !cte_filter_pushdown_3 --
 PhysicalResultSink
 --hashJoin[INNER_JOIN] hashCondition=((tmp2.k3 = dd.k3)) otherCondition=()
-----filter((tmp2.k3 = 0))
+----filter((tmp.k3 = 0))
 ------PhysicalWindow
 --------PhysicalQuickSort[LOCAL_SORT]
 ----------filter((tmp.k1 = 1))

--- a/regression-test/data/nereids_rules_p0/cte/test_cte_filter_pushdown.out
+++ b/regression-test/data/nereids_rules_p0/cte/test_cte_filter_pushdown.out
@@ -30,7 +30,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 -- !cte_filter_pushdown_3 --
 PhysicalResultSink
 --hashJoin[INNER_JOIN] hashCondition=((tmp2.k3 = dd.k3)) otherCondition=()
-----filter((tmp2.k3 = 0))
+----filter((tmp.k3 = 0))
 ------PhysicalWindow
 --------PhysicalQuickSort[LOCAL_SORT]
 ----------filter((tmp.k1 = 1))

--- a/regression-test/data/nereids_tpch_p0/tpch/push_filter_window_eqset.out
+++ b/regression-test/data/nereids_tpch_p0/tpch/push_filter_window_eqset.out
@@ -5,7 +5,7 @@ PhysicalResultSink
 ----PhysicalProject
 ------PhysicalWindow
 --------PhysicalQuickSort[LOCAL_SORT]
-----------PhysicalDistribute[DistributionSpecHash]
-------------PhysicalProject
---------------filter((region.r_regionkey = 1))
-----------------PhysicalOlapScan[region]
+----------PhysicalProject
+------------filter((region.r_regionkey = 1))
+--------------PhysicalOlapScan[region]
+

--- a/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query51.out
+++ b/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query51.out
@@ -4,17 +4,17 @@ PhysicalResultSink
 --PhysicalTopN[MERGE_SORT]
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
---------filter((web_cumulative > store_cumulative))
-----------PhysicalWindow
-------------PhysicalQuickSort[LOCAL_SORT]
---------------PhysicalDistribute[DistributionSpecHash]
-----------------PhysicalProject
-------------------hashJoin[FULL_OUTER_JOIN colocated] hashCondition=((web.d_date = store.d_date) and (web.item_sk = store.item_sk)) otherCondition=()
---------------------PhysicalProject
-----------------------PhysicalWindow
-------------------------PhysicalQuickSort[LOCAL_SORT]
---------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------PhysicalProject
+--------PhysicalProject
+----------filter((web_cumulative > store_cumulative))
+------------PhysicalWindow
+--------------PhysicalQuickSort[LOCAL_SORT]
+----------------PhysicalDistribute[DistributionSpecHash]
+------------------PhysicalProject
+--------------------hashJoin[FULL_OUTER_JOIN colocated] hashCondition=((web.d_date = store.d_date) and (web.item_sk = store.item_sk)) otherCondition=()
+----------------------PhysicalProject
+------------------------PhysicalWindow
+--------------------------PhysicalQuickSort[LOCAL_SORT]
+----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------hashAgg[GLOBAL]
 --------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------hashAgg[LOCAL]
@@ -25,11 +25,10 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------filter((date_dim.d_month_seq <= 1227) and (date_dim.d_month_seq >= 1216))
 --------------------------------------------PhysicalOlapScan[date_dim]
---------------------PhysicalProject
-----------------------PhysicalWindow
-------------------------PhysicalQuickSort[LOCAL_SORT]
---------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------PhysicalProject
+----------------------PhysicalProject
+------------------------PhysicalWindow
+--------------------------PhysicalQuickSort[LOCAL_SORT]
+----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------hashAgg[GLOBAL]
 --------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------hashAgg[LOCAL]

--- a/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query51.out
+++ b/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query51.out
@@ -4,17 +4,17 @@ PhysicalResultSink
 --PhysicalTopN[MERGE_SORT]
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
---------filter((web_cumulative > store_cumulative))
-----------PhysicalWindow
-------------PhysicalQuickSort[LOCAL_SORT]
---------------PhysicalDistribute[DistributionSpecHash]
-----------------PhysicalProject
-------------------hashJoin[FULL_OUTER_JOIN colocated] hashCondition=((web.d_date = store.d_date) and (web.item_sk = store.item_sk)) otherCondition=()
---------------------PhysicalProject
-----------------------PhysicalWindow
-------------------------PhysicalQuickSort[LOCAL_SORT]
---------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------PhysicalProject
+--------PhysicalProject
+----------filter((web_cumulative > store_cumulative))
+------------PhysicalWindow
+--------------PhysicalQuickSort[LOCAL_SORT]
+----------------PhysicalDistribute[DistributionSpecHash]
+------------------PhysicalProject
+--------------------hashJoin[FULL_OUTER_JOIN colocated] hashCondition=((web.d_date = store.d_date) and (web.item_sk = store.item_sk)) otherCondition=()
+----------------------PhysicalProject
+------------------------PhysicalWindow
+--------------------------PhysicalQuickSort[LOCAL_SORT]
+----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------hashAgg[GLOBAL]
 --------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------hashAgg[LOCAL]
@@ -25,11 +25,10 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------filter((date_dim.d_month_seq <= 1227) and (date_dim.d_month_seq >= 1216))
 --------------------------------------------PhysicalOlapScan[date_dim]
---------------------PhysicalProject
-----------------------PhysicalWindow
-------------------------PhysicalQuickSort[LOCAL_SORT]
---------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------PhysicalProject
+----------------------PhysicalProject
+------------------------PhysicalWindow
+--------------------------PhysicalQuickSort[LOCAL_SORT]
+----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------hashAgg[GLOBAL]
 --------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------hashAgg[LOCAL]

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query51.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query51.out
@@ -4,17 +4,17 @@ PhysicalResultSink
 --PhysicalTopN[MERGE_SORT]
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
---------filter((web_cumulative > store_cumulative))
-----------PhysicalWindow
-------------PhysicalQuickSort[LOCAL_SORT]
---------------PhysicalDistribute[DistributionSpecHash]
-----------------PhysicalProject
-------------------hashJoin[FULL_OUTER_JOIN colocated] hashCondition=((web.d_date = store.d_date) and (web.item_sk = store.item_sk)) otherCondition=()
---------------------PhysicalProject
-----------------------PhysicalWindow
-------------------------PhysicalQuickSort[LOCAL_SORT]
---------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------PhysicalProject
+--------PhysicalProject
+----------filter((web_cumulative > store_cumulative))
+------------PhysicalWindow
+--------------PhysicalQuickSort[LOCAL_SORT]
+----------------PhysicalDistribute[DistributionSpecHash]
+------------------PhysicalProject
+--------------------hashJoin[FULL_OUTER_JOIN colocated] hashCondition=((web.d_date = store.d_date) and (web.item_sk = store.item_sk)) otherCondition=()
+----------------------PhysicalProject
+------------------------PhysicalWindow
+--------------------------PhysicalQuickSort[LOCAL_SORT]
+----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------hashAgg[GLOBAL]
 --------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------hashAgg[LOCAL]
@@ -25,11 +25,10 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------filter((date_dim.d_month_seq <= 1227) and (date_dim.d_month_seq >= 1216))
 --------------------------------------------PhysicalOlapScan[date_dim]
---------------------PhysicalProject
-----------------------PhysicalWindow
-------------------------PhysicalQuickSort[LOCAL_SORT]
---------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------PhysicalProject
+----------------------PhysicalProject
+------------------------PhysicalWindow
+--------------------------PhysicalQuickSort[LOCAL_SORT]
+----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------hashAgg[GLOBAL]
 --------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------hashAgg[LOCAL]

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query51.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query51.out
@@ -4,17 +4,17 @@ PhysicalResultSink
 --PhysicalTopN[MERGE_SORT]
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
---------filter((web_cumulative > store_cumulative))
-----------PhysicalWindow
-------------PhysicalQuickSort[LOCAL_SORT]
---------------PhysicalDistribute[DistributionSpecHash]
-----------------PhysicalProject
-------------------hashJoin[FULL_OUTER_JOIN colocated] hashCondition=((web.d_date = store.d_date) and (web.item_sk = store.item_sk)) otherCondition=()
---------------------PhysicalProject
-----------------------PhysicalWindow
-------------------------PhysicalQuickSort[LOCAL_SORT]
---------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------PhysicalProject
+--------PhysicalProject
+----------filter((web_cumulative > store_cumulative))
+------------PhysicalWindow
+--------------PhysicalQuickSort[LOCAL_SORT]
+----------------PhysicalDistribute[DistributionSpecHash]
+------------------PhysicalProject
+--------------------hashJoin[FULL_OUTER_JOIN colocated] hashCondition=((web.d_date = store.d_date) and (web.item_sk = store.item_sk)) otherCondition=()
+----------------------PhysicalProject
+------------------------PhysicalWindow
+--------------------------PhysicalQuickSort[LOCAL_SORT]
+----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------hashAgg[GLOBAL]
 --------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------hashAgg[LOCAL]
@@ -25,11 +25,10 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------filter((date_dim.d_month_seq <= 1227) and (date_dim.d_month_seq >= 1216))
 --------------------------------------------PhysicalOlapScan[date_dim]
---------------------PhysicalProject
-----------------------PhysicalWindow
-------------------------PhysicalQuickSort[LOCAL_SORT]
---------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------PhysicalProject
+----------------------PhysicalProject
+------------------------PhysicalWindow
+--------------------------PhysicalQuickSort[LOCAL_SORT]
+----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------hashAgg[GLOBAL]
 --------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------hashAgg[LOCAL]

--- a/regression-test/data/shape_check/tpcds_sf1000/hint/query51.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/hint/query51.out
@@ -4,17 +4,17 @@ PhysicalResultSink
 --PhysicalTopN[MERGE_SORT]
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
---------filter((web_cumulative > store_cumulative))
-----------PhysicalWindow
-------------PhysicalQuickSort[LOCAL_SORT]
---------------PhysicalDistribute[DistributionSpecHash]
-----------------PhysicalProject
-------------------hashJoin[FULL_OUTER_JOIN colocated] hashCondition=((web.d_date = store.d_date) and (web.item_sk = store.item_sk)) otherCondition=()
---------------------PhysicalProject
-----------------------PhysicalWindow
-------------------------PhysicalQuickSort[LOCAL_SORT]
---------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------PhysicalProject
+--------PhysicalProject
+----------filter((web_cumulative > store_cumulative))
+------------PhysicalWindow
+--------------PhysicalQuickSort[LOCAL_SORT]
+----------------PhysicalDistribute[DistributionSpecHash]
+------------------PhysicalProject
+--------------------hashJoin[FULL_OUTER_JOIN colocated] hashCondition=((web.d_date = store.d_date) and (web.item_sk = store.item_sk)) otherCondition=()
+----------------------PhysicalProject
+------------------------PhysicalWindow
+--------------------------PhysicalQuickSort[LOCAL_SORT]
+----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------hashAgg[GLOBAL]
 --------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------hashAgg[LOCAL]
@@ -25,11 +25,10 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------filter((date_dim.d_month_seq <= 1223) and (date_dim.d_month_seq >= 1212))
 --------------------------------------------PhysicalOlapScan[date_dim]
---------------------PhysicalProject
-----------------------PhysicalWindow
-------------------------PhysicalQuickSort[LOCAL_SORT]
---------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------PhysicalProject
+----------------------PhysicalProject
+------------------------PhysicalWindow
+--------------------------PhysicalQuickSort[LOCAL_SORT]
+----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------hashAgg[GLOBAL]
 --------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------hashAgg[LOCAL]

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query51.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query51.out
@@ -4,17 +4,17 @@ PhysicalResultSink
 --PhysicalTopN[MERGE_SORT]
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
---------filter((web_cumulative > store_cumulative))
-----------PhysicalWindow
-------------PhysicalQuickSort[LOCAL_SORT]
---------------PhysicalDistribute[DistributionSpecHash]
-----------------PhysicalProject
-------------------hashJoin[FULL_OUTER_JOIN colocated] hashCondition=((web.d_date = store.d_date) and (web.item_sk = store.item_sk)) otherCondition=()
---------------------PhysicalProject
-----------------------PhysicalWindow
-------------------------PhysicalQuickSort[LOCAL_SORT]
---------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------PhysicalProject
+--------PhysicalProject
+----------filter((web_cumulative > store_cumulative))
+------------PhysicalWindow
+--------------PhysicalQuickSort[LOCAL_SORT]
+----------------PhysicalDistribute[DistributionSpecHash]
+------------------PhysicalProject
+--------------------hashJoin[FULL_OUTER_JOIN colocated] hashCondition=((web.d_date = store.d_date) and (web.item_sk = store.item_sk)) otherCondition=()
+----------------------PhysicalProject
+------------------------PhysicalWindow
+--------------------------PhysicalQuickSort[LOCAL_SORT]
+----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------hashAgg[GLOBAL]
 --------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------hashAgg[LOCAL]
@@ -25,11 +25,10 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------filter((date_dim.d_month_seq <= 1223) and (date_dim.d_month_seq >= 1212))
 --------------------------------------------PhysicalOlapScan[date_dim]
---------------------PhysicalProject
-----------------------PhysicalWindow
-------------------------PhysicalQuickSort[LOCAL_SORT]
---------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------PhysicalProject
+----------------------PhysicalProject
+------------------------PhysicalWindow
+--------------------------PhysicalQuickSort[LOCAL_SORT]
+----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------hashAgg[GLOBAL]
 --------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------hashAgg[LOCAL]

--- a/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query51.out
+++ b/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query51.out
@@ -4,17 +4,17 @@ PhysicalResultSink
 --PhysicalTopN[MERGE_SORT]
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
---------filter((web_cumulative > store_cumulative))
-----------PhysicalWindow
-------------PhysicalQuickSort[LOCAL_SORT]
---------------PhysicalDistribute[DistributionSpecHash]
-----------------PhysicalProject
-------------------hashJoin[FULL_OUTER_JOIN colocated] hashCondition=((web.d_date = store.d_date) and (web.item_sk = store.item_sk)) otherCondition=()
---------------------PhysicalProject
-----------------------PhysicalWindow
-------------------------PhysicalQuickSort[LOCAL_SORT]
---------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------PhysicalProject
+--------PhysicalProject
+----------filter((web_cumulative > store_cumulative))
+------------PhysicalWindow
+--------------PhysicalQuickSort[LOCAL_SORT]
+----------------PhysicalDistribute[DistributionSpecHash]
+------------------PhysicalProject
+--------------------hashJoin[FULL_OUTER_JOIN colocated] hashCondition=((web.d_date = store.d_date) and (web.item_sk = store.item_sk)) otherCondition=()
+----------------------PhysicalProject
+------------------------PhysicalWindow
+--------------------------PhysicalQuickSort[LOCAL_SORT]
+----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------hashAgg[GLOBAL]
 --------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------hashAgg[LOCAL]
@@ -25,11 +25,10 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------filter((date_dim.d_month_seq <= 1225) and (date_dim.d_month_seq >= 1214))
 --------------------------------------------PhysicalOlapScan[date_dim]
---------------------PhysicalProject
-----------------------PhysicalWindow
-------------------------PhysicalQuickSort[LOCAL_SORT]
---------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------PhysicalProject
+----------------------PhysicalProject
+------------------------PhysicalWindow
+--------------------------PhysicalQuickSort[LOCAL_SORT]
+----------------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------------hashAgg[GLOBAL]
 --------------------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------------------hashAgg[LOCAL]


### PR DESCRIPTION
### What problem does this PR solve?

close #54577

optimize normalize window, only push down the expression's used slots to bottom projects, which the expression not contains WindowFunction, so we can push down more filter through window.

for this sql:
```sql
  select
    SUBSTR(orderdate,1,10) AS dt,
    ROW_NUMBER() OVER(PARTITION BY orderdate ORDER BY orderid DESC) AS rn
  from lineorders
  having dt = '2025-01-01'
```
we not push down the `dt` slot under LogicalWindow, but push down [orderdate, orderid]
to the bottom projects, because if we push down `dt`, the plan tree will be:
```
            LogicalFilter(substr(dt#3, 1, 10) = '2025-01-01')
                                    |
     LogicalWindow(rowNumber(partition by orderdate#2, order by orderid#1))
                                    |
  LogicalProject(orderid#1, orderdate#2, substr(orderdate#1, 1, 10) as dt#3)
```

and can not push down filter by `PushDownFilterThroughWindow`, causing inefficiency,
because dt#3 in LogicalFilter not contains in the partition key in LogicalWindow: [orderdate#2].


so we only push down orderdate in the LogicalFilter, not push down `dt`:

```
     LogicalFilter(substr(orderdate#2, 1, 10) = '2025-01-01')
                              |
     LogicalWindow(rowNumber(partition by orderdate#2, order by orderid#1))
                              |
            LogicalProject(orderid#1, orderdate#2)
```

and then, `PushDownFilterThroughWindow` found the LogicalFilter's `orderdate#2` contains
in the LogicalWindow's partition key: [orderdate#2], and can push down filter to:

```
  LogicalWindow(rowNumber(partition by orderdate#2, order by orderid#1))
                              |
            LogicalProject(orderid#1, orderdate#2)
                             |
    LogicalFilter(substr(orderdate#2, 1, 10) = '2025-01-01')
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

