### PR TITLE
[fix](nereids) fix execute err which throw eq function not exist exception when join reorder

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinCommute.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinCommute.java
@@ -74,15 +74,15 @@ public class JoinCommute extends OneExplorationRuleFactory {
                         && NestedLoopJoinNode.canParallelize(JoinType.toJoinOperator(join.getJoinType()))
                         && !NestedLoopJoinNode.canParallelize(JoinType.toJoinOperator(join.getJoinType().swap())))
                 .then(join -> {
-                    LogicalJoin<Plan, Plan> newJoin = join.withTypeChildren(join.getJoinType().swap(),
-                            join.right(), join.left(), null);
+                    LogicalJoin<? extends Plan, ? extends Plan> newJoin = join.withTypeChildren(
+                            join.getJoinType().swap(), join.right(), join.left(), null);
                     newJoin.getJoinReorderContext().copyFrom(join.getJoinReorderContext());
                     newJoin.getJoinReorderContext().setHasCommute(true);
                     if (swapType == SwapType.ZIG_ZAG && isNotBottomJoin(join)) {
                         newJoin.getJoinReorderContext().setHasCommuteZigZag(true);
                     }
                     if (newJoin.getJoinType().isOuterJoin()) {
-                        return JoinUtils.adjustJoinConjunctsNullable(newJoin);
+                        newJoin = JoinUtils.adjustJoinConjunctsNullable(newJoin);
                     }
                     return newJoin;
                 }).toRule(RuleType.LOGICAL_JOIN_COMMUTE);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinCommute.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinCommute.java
@@ -81,8 +81,10 @@ public class JoinCommute extends OneExplorationRuleFactory {
                     if (swapType == SwapType.ZIG_ZAG && isNotBottomJoin(join)) {
                         newJoin.getJoinReorderContext().setHasCommuteZigZag(true);
                     }
-
-                    return JoinUtils.adjustJoinConjunctsNullable(newJoin);
+                    if (newJoin.getJoinType().isOuterJoin()) {
+                        return JoinUtils.adjustJoinConjunctsNullable(newJoin);
+                    }
+                    return newJoin;
                 }).toRule(RuleType.LOGICAL_JOIN_COMMUTE);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinCommute.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinCommute.java
@@ -82,7 +82,7 @@ public class JoinCommute extends OneExplorationRuleFactory {
                         newJoin.getJoinReorderContext().setHasCommuteZigZag(true);
                     }
 
-                    return newJoin;
+                    return JoinUtils.adjustJoinConjunctsNullable(newJoin);
                 }).toRule(RuleType.LOGICAL_JOIN_COMMUTE);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinAssocProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinAssocProject.java
@@ -32,6 +32,7 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.util.ExpressionUtils;
+import org.apache.doris.nereids.util.JoinUtils;
 import org.apache.doris.nereids.util.Utils;
 
 import com.google.common.collect.ImmutableSet;
@@ -99,6 +100,7 @@ public class OuterJoinAssocProject extends OneExplorationRuleFactory {
                     /* ********** new Plan ********** */
                     LogicalJoin newBottomJoin = topJoin.withChildrenNoContext(b, c, null);
                     newBottomJoin.getJoinReorderContext().copyFrom(bottomJoin.getJoinReorderContext());
+                    newBottomJoin = JoinUtils.adjustJoinConjunctsNullable(newBottomJoin);
 
                     Set<ExprId> topUsedExprIds = new HashSet<>();
                     topProject.getProjects().forEach(expr -> topUsedExprIds.addAll(expr.getInputSlotExprIds()));
@@ -110,6 +112,7 @@ public class OuterJoinAssocProject extends OneExplorationRuleFactory {
                     LogicalJoin newTopJoin = bottomJoin.withChildrenNoContext(left, right, null);
                     newTopJoin.getJoinReorderContext().copyFrom(topJoin.getJoinReorderContext());
                     setReorderContext(newTopJoin, newBottomJoin);
+                    newTopJoin = JoinUtils.adjustJoinConjunctsNullable(newTopJoin);
 
                     return topProject.withChildren(newTopJoin);
                 }).toRule(RuleType.LOGICAL_OUTER_JOIN_ASSOC_PROJECT);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinLAsscomProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinLAsscomProject.java
@@ -29,6 +29,7 @@ import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
+import org.apache.doris.nereids.util.JoinUtils;
 import org.apache.doris.nereids.util.Utils;
 
 import com.google.common.collect.ImmutableSet;
@@ -84,6 +85,7 @@ public class OuterJoinLAsscomProject extends OneExplorationRuleFactory {
                     newBottomJoin.getJoinReorderContext().copyFrom(bottomJoin.getJoinReorderContext());
                     newBottomJoin.getJoinReorderContext().setHasLAsscom(false);
                     newBottomJoin.getJoinReorderContext().setHasCommute(false);
+                    newBottomJoin = JoinUtils.adjustJoinConjunctsNullable(newBottomJoin);
 
                     Set<ExprId> topUsedExprIds = new HashSet<>();
                     topProject.getProjects().forEach(expr -> topUsedExprIds.addAll(expr.getInputSlotExprIds()));
@@ -95,6 +97,7 @@ public class OuterJoinLAsscomProject extends OneExplorationRuleFactory {
                     LogicalJoin newTopJoin = bottomJoin.withChildrenNoContext(left, right, null);
                     newTopJoin.getJoinReorderContext().copyFrom(topJoin.getJoinReorderContext());
                     newTopJoin.getJoinReorderContext().setHasLAsscom(true);
+                    newTopJoin = JoinUtils.adjustJoinConjunctsNullable(newTopJoin);
 
                     return topProject.withChildren(newTopJoin);
                 }).toRule(RuleType.LOGICAL_OUTER_JOIN_LASSCOM_PROJECT);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AdjustNullable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AdjustNullable.java
@@ -419,7 +419,16 @@ public class AdjustNullable extends DefaultPlanRewriter<Map<ExprId, Slot>> imple
     private <T extends Expression> Optional<T> updateExpression(T input,
             Map<ExprId, Slot> replaceMap, boolean debugCheck) {
         AtomicBoolean changed = new AtomicBoolean(false);
-        Expression replaced = input.rewriteDownShortCircuit(e -> {
+        Expression replaced = doUpdateExpression(changed, input, replaceMap, debugCheck, isAnalyzedPhase);
+        return changed.get() ? Optional.of((T) replaced) : Optional.empty();
+    }
+
+    /**
+     * Adjust nullable attribute of slot reference in expression.
+     */
+    public static Expression doUpdateExpression(AtomicBoolean changed, Expression input,
+            Map<ExprId, Slot> replaceMap, boolean debugCheck, boolean isAnalyzedPhase) {
+        return input.rewriteDownShortCircuit(e -> {
             if (e instanceof SlotReference) {
                 SlotReference slotReference = (SlotReference) e;
                 Slot newSlotReference = slotReference;
@@ -463,7 +472,6 @@ public class AdjustNullable extends DefaultPlanRewriter<Map<ExprId, Slot>> imple
                 return e;
             }
         });
-        return changed.get() ? Optional.of((T) replaced) : Optional.empty();
     }
 
     private <T extends Expression> Optional<List<T>> updateExpressions(List<T> inputs,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
@@ -495,15 +495,21 @@ public class JoinUtils {
      * the nullable property of b.condition should be false
      */
     public static LogicalJoin<Plan, Plan> adjustJoinConjunctsNullable(LogicalJoin<Plan, Plan> join) {
-        Map<ExprId, Slot> childSlotMap = new HashMap<>();
+        Map<ExprId, Slot> equalConjunctsSlotMap = new HashMap<>();
         for (Plan child : join.children()) {
             for (Slot slot : child.getOutput()) {
-                childSlotMap.put(slot.getExprId(), slot);
+                equalConjunctsSlotMap.put(slot.getExprId(), slot);
             }
         }
+        Map<ExprId, Slot> otherConjunctsSlotMap = new HashMap<>();
+        for (Slot slot : join.getOutput()) {
+            otherConjunctsSlotMap.put(slot.getExprId(), slot);
+        }
         return join.withJoinConjuncts(
-                updateExpressions(join.getHashJoinConjuncts(), childSlotMap, true, false),
-                updateExpressions(join.getOtherJoinConjuncts(), childSlotMap, true, false),
+                updateExpressions(join.getHashJoinConjuncts(), equalConjunctsSlotMap, false,
+                        false),
+                updateExpressions(join.getOtherJoinConjuncts(), otherConjunctsSlotMap, false,
+                        false),
                 join.getJoinReorderContext());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
@@ -501,6 +501,7 @@ public class JoinUtils {
                 equalConjunctsSlotMap.put(slot.getExprId(), slot);
             }
         }
+        // other conjuncts should use join output slot
         Map<ExprId, Slot> otherConjunctsSlotMap = new HashMap<>();
         for (Slot slot : join.getOutput()) {
             otherConjunctsSlotMap.put(slot.getExprId(), slot);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/join/JoinCommuteTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/join/JoinCommuteTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.rules.exploration.join;
 import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.trees.expressions.GreaterThan;
 import org.apache.doris.nereids.trees.plans.JoinType;
+import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
@@ -32,6 +33,8 @@ import org.apache.doris.nereids.util.PlanConstructor;
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 public class JoinCommuteTest implements MemoPatternMatchSupported {
     @Test
@@ -72,5 +75,26 @@ public class JoinCommuteTest implements MemoPatternMatchSupported {
         Assertions.assertEquals(1, PlanChecker.from(MemoTestUtils.createConnectContext(), join)
                 .applyExploration(JoinCommute.BUSHY.build())
                 .getAllPlan().size());
+    }
+
+
+    @Test
+    void testJoinConjunctNullableWhenCommute() {
+        LogicalOlapScan scan1 = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
+        LogicalOlapScan scan2 = PlanConstructor.newLogicalOlapScan(1, "t2", 0);
+
+        LogicalJoin<?, ?> join = (LogicalJoin<?, ?>) new LogicalPlanBuilder(scan1)
+                .join(scan2, JoinType.LEFT_OUTER_JOIN, Pair.of(0, 0))
+                .build();
+        join = join.withJoinConjuncts(
+                ImmutableList.of(),
+                ImmutableList.of(new GreaterThan(scan1.getOutput().get(0).withNullable(true),
+                        scan2.getOutput().get(0))),
+                join.getJoinReorderContext());
+
+        List<Plan> allPlan = PlanChecker.from(MemoTestUtils.createConnectContext(), join)
+                .applyExploration(JoinCommute.BUSHY.build())
+                .getAllPlan();
+        Assertions.assertEquals(1, allPlan.size());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/join/JoinCommuteTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/join/JoinCommuteTest.java
@@ -112,7 +112,15 @@ public class JoinCommuteTest implements MemoPatternMatchSupported {
         }
         for (Expression expr : newJoin.getOtherJoinConjuncts()) {
             expr.collectToSet(SlotReference.class::isInstance)
-                    .forEach(slot -> Assertions.assertFalse(((SlotReference) slot).nullable()));
+                    .forEach(slot -> {
+                        if (slot.equals(scan1.getOutput().get(0))) {
+                            // the slot from scan1 should be nullable true
+                            Assertions.assertFalse(((SlotReference) slot).nullable());
+                        } else {
+                            // the slot from scan2 should be nullable false
+                            Assertions.assertTrue(((SlotReference) slot).nullable());
+                        }
+                    });
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinAsscomProjectTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinAsscomProjectTest.java
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.exploration.join;
+
+import org.apache.doris.nereids.trees.expressions.EqualTo;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.GreaterThan;
+import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.JoinType;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
+import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
+import org.apache.doris.nereids.util.LogicalPlanBuilder;
+import org.apache.doris.nereids.util.MemoTestUtils;
+import org.apache.doris.nereids.util.PlanChecker;
+import org.apache.doris.nereids.util.PlanConstructor;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class OuterJoinAsscomProjectTest {
+
+    private final LogicalOlapScan scan1 = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
+    private final LogicalOlapScan scan2 = PlanConstructor.newLogicalOlapScan(1, "t2", 0);
+    private final LogicalOlapScan scan3 = PlanConstructor.newLogicalOlapScan(2, "t3", 0);
+
+    @Test
+    public void testJoinConjunctNullableWhenAssociate() {
+        List<Expression> bottomHashJoinConjunct = ImmutableList.of(
+                new EqualTo(scan1.getOutput().get(0), scan2.getOutput().get(0)));
+        List<Expression> bottomOtherJoinConjunct = ImmutableList.of(
+                new GreaterThan(scan1.getOutput().get(1), scan2.getOutput().get(1)));
+        LogicalPlan bottomJoin = new LogicalPlanBuilder(scan1)
+                .join(scan2, JoinType.LEFT_OUTER_JOIN, bottomHashJoinConjunct, bottomOtherJoinConjunct)
+                .build();
+        LogicalPlan bottomProject = new LogicalProject<>(
+                bottomJoin.getOutput().stream().map(NamedExpression.class::cast).collect(Collectors.toList()),
+                bottomJoin);
+
+        List<Expression> topHashJoinConjunct = ImmutableList.of(
+                new EqualTo(bottomProject.getOutput().get(2).withNullable(true), scan3.getOutput().get(0)));
+        List<Expression> topOtherJoinConjunct = ImmutableList.of(
+                new GreaterThan(bottomProject.getOutput().get(3).withNullable(true), scan3.getOutput().get(1)));
+        LogicalPlan topJoin = new LogicalPlanBuilder(bottomProject)
+                .join(scan3, JoinType.LEFT_OUTER_JOIN, topHashJoinConjunct, topOtherJoinConjunct)
+                .build();
+        LogicalPlan plan = new LogicalProject<>(
+                topJoin.getOutput().stream().map(NamedExpression.class::cast).collect(
+                Collectors.toList()), topJoin);
+
+        List<Plan> allPlan = PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+                .printlnOrigin()
+                .applyExploration(OuterJoinAssocProject.INSTANCE.build())
+                .getAllPlan();
+        Assertions.assertEquals(2, allPlan.size());
+
+        // check optimized join plan conjuncts null property, should be false
+        Set<LogicalJoin<Plan, Plan>> joinSet = allPlan.get(1).collect(LogicalJoin.class::isInstance);
+        for (LogicalJoin<Plan, Plan> newJoin : joinSet) {
+            Plan child0 = newJoin.child(0);
+            Plan child1 = newJoin.child(1);
+            if ((child0 instanceof LogicalOlapScan && ((LogicalOlapScan) child0).getTable().getName().equals("t3"))
+                    || (child1 instanceof LogicalOlapScan
+                    && ((LogicalOlapScan) child1).getTable().getName().equals("t3"))) {
+                for (Expression expr : newJoin.getHashJoinConjuncts()) {
+                    expr.collectToSet(SlotReference.class::isInstance)
+                            .forEach(slot -> Assertions.assertFalse(((SlotReference) slot).nullable()));
+                }
+                for (Expression expr : newJoin.getOtherJoinConjuncts()) {
+                    expr.collectToSet(SlotReference.class::isInstance)
+                            .forEach(slot -> Assertions.assertFalse(((SlotReference) slot).nullable()));
+                }
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinLAsscomProjectTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinLAsscomProjectTest.java
@@ -22,9 +22,14 @@ import org.apache.doris.nereids.rules.rewrite.PushDownAliasThroughJoin;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.GreaterThan;
+import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.plans.JoinType;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.util.LogicalPlanBuilder;
 import org.apache.doris.nereids.util.MemoPatternMatchSupported;
 import org.apache.doris.nereids.util.MemoTestUtils;
@@ -36,6 +41,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 class OuterJoinLAsscomProjectTest implements MemoPatternMatchSupported {
 
@@ -159,5 +166,55 @@ class OuterJoinLAsscomProjectTest implements MemoPatternMatchSupported {
                 .checkMemo(memo -> {
                     Assertions.assertEquals(1, memo.getRoot().getLogicalExpressions().size());
                 });
+    }
+
+    @Test
+    public void testJoinConjunctNullableWhenLAssociate() {
+        List<Expression> bottomHashJoinConjunct = ImmutableList.of(
+                new EqualTo(scan1.getOutput().get(0), scan2.getOutput().get(0)));
+        List<Expression> bottomOtherJoinConjunct = ImmutableList.of(
+                new GreaterThan(scan1.getOutput().get(1), scan2.getOutput().get(1)));
+        LogicalPlan bottomJoin = new LogicalPlanBuilder(scan1)
+                .join(scan2, JoinType.LEFT_OUTER_JOIN, bottomHashJoinConjunct, bottomOtherJoinConjunct)
+                .build();
+        LogicalPlan bottomProject = new LogicalProject<>(
+                bottomJoin.getOutput().stream().map(NamedExpression.class::cast).collect(Collectors.toList()),
+                bottomJoin);
+
+        List<Expression> topHashJoinConjunct = ImmutableList.of(
+                new EqualTo(bottomProject.getOutput().get(0), scan3.getOutput().get(0).withNullable(true)));
+        List<Expression> topOtherJoinConjunct = ImmutableList.of(
+                new GreaterThan(bottomProject.getOutput().get(1), scan3.getOutput().get(1).withNullable(true)));
+        LogicalPlan topJoin = new LogicalPlanBuilder(bottomProject)
+                .join(scan3, JoinType.LEFT_OUTER_JOIN, topHashJoinConjunct, topOtherJoinConjunct)
+                .build();
+
+        LogicalPlan plan = new LogicalProject<>(
+                topJoin.getOutput().stream().map(NamedExpression.class::cast).collect(
+                        Collectors.toList()), topJoin);
+
+        List<Plan> allPlan = PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+                .printlnOrigin()
+                .applyExploration(OuterJoinLAsscomProject.INSTANCE.build())
+                .getAllPlan();
+
+        Assertions.assertEquals(2, allPlan.size());
+        Set<LogicalJoin<Plan, Plan>> joinSet = allPlan.get(1).collect(LogicalJoin.class::isInstance);
+        for (LogicalJoin<Plan, Plan> newJoin : joinSet) {
+            Plan child0 = newJoin.child(0);
+            Plan child1 = newJoin.child(1);
+            if ((child0 instanceof LogicalOlapScan && ((LogicalOlapScan) child0).getTable().getName().equals("t3"))
+                    || (child1 instanceof LogicalOlapScan
+                    && ((LogicalOlapScan) child1).getTable().getName().equals("t3"))) {
+                for (Expression expr : newJoin.getHashJoinConjuncts()) {
+                    expr.collectToSet(SlotReference.class::isInstance)
+                            .forEach(slot -> Assertions.assertFalse(((SlotReference) slot).nullable()));
+                }
+                for (Expression expr : newJoin.getOtherJoinConjuncts()) {
+                    expr.collectToSet(SlotReference.class::isInstance)
+                            .forEach(slot -> Assertions.assertFalse(((SlotReference) slot).nullable()));
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

if query as following:
```sql
select xx
from a 
left join b on a.id = b.id
left join c on b.id = c.id
```

the column in table a, b, c are all non nullable.
after join reorder the query is as following:
```sql
select xx
from 
b 
left join c on b.id = c.id
right join a on on a.id = b.id
```

the the nullable condition  in join conjuncts maybe nullable wrongly.
this would cause be exec fail with err msg `[INTERNAL_ERROR]Could not find function eq, arg String return Nullable(BOOL) `
the pr fix this



Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

