### PR TITLE
[fix](warmup): refresh BE list on every job execution

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/CloudWarmUpJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/CloudWarmUpJob.java
@@ -220,6 +220,7 @@ public class CloudWarmUpJob implements Writable {
         String clusterName = isEventDriven() ? srcClusterName : dstClusterName;
         List<Backend> backends = ((CloudSystemInfoService) Env.getCurrentSystemInfo())
                 .getBackendsByClusterName(clusterName);
+        this.beToThriftAddress = new HashMap<>();
         for (Backend backend : backends) {
             beToThriftAddress.put(backend.getId(), backend.getHost() + ":" + backend.getBePort());
         }
@@ -589,6 +590,10 @@ public class CloudWarmUpJob implements Writable {
         this.setJobDone = false;
         this.lastBatchId = -1;
         this.startTimeMs = System.currentTimeMillis();
+        // reset clients to ensure we have the latest BE info
+        this.beToThriftAddress = null;
+        this.beToClient = null;
+        this.beToAddr = null;
         MetricRepo.updateClusterWarmUpJobLatestStartTime(String.valueOf(jobId), srcClusterName,
                 dstClusterName, startTimeMs);
         this.fetchBeToTabletIdBatches();


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

This change refreshes the BE list at the start of every execution round,
ensuring that newly added BEs are included and removed BEs are skipped.
This keeps warmup jobs aligned with the current cluster info.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

