### PR TITLE
[fix](function) fix some functions  make core problem by wrong parameters

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/AesCryptoFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/AesCryptoFunction.java
@@ -89,6 +89,11 @@ public abstract class AesCryptoFunction extends CryptoFunction {
     }
 
     @Override
+    public void checkLegalityBeforeTypeCoercion() {
+        checkLegalityAfterRewrite();
+    }
+
+    @Override
     public void checkLegalityAfterRewrite() {
         if (arity() >= 4 && child(3) instanceof StringLikeLiteral) {
             String mode = ((StringLikeLiteral) child(3)).getValue().toUpperCase();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Mask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Mask.java
@@ -36,8 +36,23 @@ import java.util.List;
  */
 public class Mask extends ScalarFunction implements ExplicitlyCastableSignature, PropagateNullable {
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
-            FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT).varArgs(VarcharType.SYSTEM_DEFAULT),
-            FunctionSignature.ret(StringType.INSTANCE).varArgs(StringType.INSTANCE)
+            FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT)
+                    .args(VarcharType.SYSTEM_DEFAULT),
+            FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT)
+                    .args(VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT),
+            FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT)
+                    .args(VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT),
+            FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT)
+                    .args(VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT,
+                            VarcharType.SYSTEM_DEFAULT),
+            FunctionSignature.ret(StringType.INSTANCE)
+                    .args(StringType.INSTANCE),
+            FunctionSignature.ret(StringType.INSTANCE)
+                    .args(StringType.INSTANCE, StringType.INSTANCE),
+            FunctionSignature.ret(StringType.INSTANCE)
+                    .args(StringType.INSTANCE, StringType.INSTANCE, StringType.INSTANCE),
+            FunctionSignature.ret(StringType.INSTANCE)
+                    .args(StringType.INSTANCE, StringType.INSTANCE, StringType.INSTANCE, StringType.INSTANCE)
     );
 
     /**
@@ -57,15 +72,10 @@ public class Mask extends ScalarFunction implements ExplicitlyCastableSignature,
      */
     @Override
     public Mask withChildren(List<Expression> children) {
-        Preconditions.checkArgument(!children.isEmpty());
+        Preconditions.checkArgument(!children.isEmpty()
+                && arity() >= 1
+                && arity() <= 4);
         return new Mask(getFunctionParams(children));
-    }
-
-    @Override
-    public void checkLegalityAfterRewrite() {
-        if (arity() > 4) {
-            throw new IllegalArgumentException("mask function only supports 1 to 4 arguments, but got: " + arity());
-        }
     }
 
     @Override

--- a/regression-test/suites/correctness_p0/test_mask_function.groovy
+++ b/regression-test/suites/correctness_p0/test_mask_function.groovy
@@ -113,4 +113,23 @@ suite("test_mask_function") {
         sql """ select mask_first_n("12345", id) from table_mask_test; """
         exception "mask_first_n must accept literal for 2nd argument"
     }
+
+    test {
+        sql """
+            SELECT mask('Ivy', 'G', 'g', '0', ')') AS result;
+        """
+        exception "Can not find the compatibility function signature: mask(VARCHAR(3), VARCHAR(1), VARCHAR(1), VARCHAR(1), VARCHAR(1))"
+    }
+
+    test {
+        sql """ SELECT mask() AS result;
+        """
+        exception "Can not found function 'mask' which has 0 arity. Candidate functions are: [mask(Expression, Expression...)]"
+    }
+
+    test {
+        sql """  SELECT mask('Ivy', 'G', 'g', '0', ')','ss','ada') AS result;
+        """
+        exception "Can not find the compatibility function signature: mask(VARCHAR(3), VARCHAR(1), VARCHAR(1), VARCHAR(1), VARCHAR(1), VARCHAR(2), VARCHAR(3))"
+    }
 }

--- a/regression-test/suites/correctness_p0/test_mask_function.groovy
+++ b/regression-test/suites/correctness_p0/test_mask_function.groovy
@@ -97,6 +97,10 @@ suite("test_mask_function") {
         exception "Argument at index 3 for function mask must be constant"
     }
 
+    sql """
+         set enable_fold_constant_by_be=true;
+    """
+
     test {
         sql """ select mask_last_n("12345", -100); """
         exception "function mask_last_n only accept non-negative input for 2nd argument but got -100"

--- a/regression-test/suites/nereids_p0/sql_functions/encryption_digest/test_encryption_function.groovy
+++ b/regression-test/suites/nereids_p0/sql_functions/encryption_digest/test_encryption_function.groovy
@@ -96,4 +96,16 @@ suite("test_encryption_function") {
     qt_sql_empty3 "select hex(aes_encrypt(rpad('', 17, ''), 'securekey456'));"
     qt_sql_empty4 "select hex(sm4_encrypt('', 'securekey456'));"
     qt_sql_empty5 "select sm4_decrypt(unhex('0D56319E329CDA9ABDF5870B9D5ACA57'), 'securekey456');"
+
+    test {
+      sql """set enable_fold_constant_by_be=true """
+      sql """select aes_encrypt('Constant', '0123456789abcdef0123456789abcdef', 'AES_128_ECB', '1234567890abcdef');"""
+      exception """mode 1234567890ABCDEF is not supported"""
+    }
+
+    test {
+      sql """set enable_fold_constant_by_be=true """
+      sql """select aes_decrypt('Constant', '0123456789abcdef0123456789abcdef', 'AES_128_ECB', '1234567890abcdef');"""
+      exception """mode 1234567890ABCDEF is not supported"""
+    }
 }

--- a/regression-test/suites/nereids_syntax_p0/mask_function.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mask_function.groovy
@@ -47,6 +47,10 @@ suite("test_mask_function") {
         ;
     """
 
+    qt_test_error_parameter_mask_function """
+        select mask(name, '*', '#', '!', 'a') from table_mask_test;
+    """
+    
     qt_select_all """
         select * from table_mask_test order by id;
     """

--- a/regression-test/suites/nereids_syntax_p0/mask_function.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mask_function.groovy
@@ -46,10 +46,6 @@ suite("test_mask_function") {
             (6, 'Meimei Han', '13556780000')
         ;
     """
-
-    qt_test_error_parameter_mask_function """
-        select mask(name, '*', '#', '!', 'a') from table_mask_test;
-    """
     
     qt_select_all """
         select * from table_mask_test order by id;


### PR DESCRIPTION
### What problem does this PR solve?
*** Query id: 159794e69f35488b-b9f10c347027c262 ***
*** is nereids: 0 ***
*** tablet id: 0 ***
*** Aborted at 1755220554 (unix time) try "date -d @1755220554" if you are using GNU date ***
*** Current BE git commitID: ee5ba3c9de ***
*** SIGABRT unknown detail explain (@0x24b354) received by PID 2405204 (TID 2405975 OR 0x7b389fb12640) from PID 2405204; stack trace: ***
    @              (nil)  (unknown)
    @     0x564d4d078cf0  execute_native_thread_routine
    @     0x564d2b08ad27  asan_thread_start()
    @     0x7f3cd533eac3  (unknown)
    @     0x564d2f43602f  doris::WorkThreadPool<>::work_thread()
    @     0x564d426de8df  doris::vectorized::VectorizedFnCall::open()
    @     0x7f3cd53d0850  (unknown)
    @     0x564d427891dc  doris::vectorized::VExprContext::open()
    @     0x564d2f4739ec  doris::FoldConstantExecutor::fold_constant_vexpr()
    @     0x564d2f3f8be8  std::_Function_handler<>::_M_invoke()
    @              (nil)  (unknown)
    @     0x564d426e1c24  doris::vectorized::VectorizedFnCall::execute()
    @     0x564d4d078cf0  execute_native_thread_routine
    @     0x564d2b08ad27  asan_thread_start()
    @     0x564d445f0267  doris::vectorized::PreparedFunctionImpl::execute()
    @     0x7f3cd533eac3  (unknown)
    @     0x564d4d078cf0  execute_native_thread_routine
    @     0x564d2b08ad27  asan_thread_start()
    @     0x7f3cd53d0850  (unknown)
    @     0x564d427891dc  doris::vectorized::VExprContext::open()
    @     0x564d2f47ffa2  doris::FoldConstantExecutor::_prepare_and_open<>()
    @     0x7f3cd533eac3  (unknown)
    @              (nil)  (unknown)
    @     0x564d2f43602f  doris::WorkThreadPool<>::work_thread()
    @     0x7f3cd53d0850  (unknown)
    @              (nil)  (unknown)
    @     0x564d426ff978  doris::vectorized::VExpr::get_const_col()
    @     0x564d2f4739ec  doris::FoldConstantExecutor::fold_constant_vexpr()
    @     0x564d2ea2a045  doris::vectorized::IFunctionBase::execute()
    @     0x564d2f3f8be8  std::_Function_handler<>::_M_invoke()
    @     0x564d2f47ffa2  doris::FoldConstantExecutor::_prepare_and_open<>()
    @     0x564d4d078cf0  execute_native_thread_routine
    @     0x564d2b08ad27  asan_thread_start()
    @     0x7f3cd533eac3  (unknown)
    @     0x7f3cd53d0850  (unknown)
    @     0x564d2f43602f  doris::WorkThreadPool<>::work_thread()
    @              (nil)  (unknown)
    @     0x564d2f4739ec  doris::FoldConstantExecutor::fold_constant_vexpr()
    @     0x564d2f3f8be8  std::_Function_handler<>::_M_invoke()
    @     0x564d426de8df  doris::vectorized::VectorizedFnCall::open()
    @     0x564d426e075e  doris::vectorized::VectorizedFnCall::_do_execute()
    @     0x564d4d078cf0  execute_native_thread_routine
    @     0x564d2b08ad27  asan_thread_start()
    @     0x7f3cd533eac3  (unknown)
    @     0x564d2f43602f  doris::WorkThreadPool<>::work_thread()
    @     0x7f3cd53d0850  (unknown)
    @              (nil)  (unknown)
    @     0x564d427891dc  doris::vectorized::VExprContext::open()
    @     0x564d4d078cf0  execute_native_thread_routine
    @     0x564d2b08ad27  asan_thread_start()
    @     0x7f3cd533eac3  (unknown)
    @     0x7f3cd53d0850  (unknown)                                               @              (nil)  (unknown)
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:420
 1# 0x00007F3CD52EC520 in /lib/x86_64-linux-gnu/libc.so.6
 2# pthread_kill at ./nptl/pthread_kill.c:89
 3# raise at ../sysdeps/posix/raise.c:27
 4# abort at ./stdlib/abort.c:81
 5# 0x0000564D49BBCBC5 in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 6# 0x0000564D49BAE47A in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 7# google::LogMessage::SendToLog() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 8# google::LogMessage::Flush() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
 9# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
10# doris::vectorized::FunctionMask::execute_impl(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned int, std::allocator<unsigned int> > const&, unsigned int, unsigned long) const at /home/zcp/repo_center/doris_master/doris/be/src/vec/functions/function_string.h:502
11# doris::vectorized::DefaultExecutable::execute_impl(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned int, std::allocator<unsigned int> > const&, unsigned int, unsigned long) const at /home/zcp/repo_center/doris_master/doris/be/src/vec/functions/function.h:438
12# doris::vectorized::PreparedFunctionImpl::_execute_skipped_constant_deal(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned int, std::allocator<unsigned int> > const&, unsigned int, unsigned long, bool) const in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
13# doris::vectorized::PreparedFunctionImpl::default_implementation_for_constant_arguments(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned int, std::allocator<unsigned int> > const&, unsigned int, unsigned long, bool, bool*) const at /home/zcp/repo_center/doris_master/doris/be/src/vec/functions/function.cpp:169
14# doris::vectorized::PreparedFunctionImpl::execute_without_low_cardinality_columns(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned int, std::allocator<unsigned int> > const&, unsigned int, unsigned long, bool) const at /home/zcp/repo_center/doris_master/doris/be/src/vec/functions/function.cpp:238
15# doris::vectorized::PreparedFunctionImpl::execute(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned int, std::allocator<unsigned int> > const&, unsigned int, unsigned long, bool) const at /home/zcp/repo_center/doris_master/doris/be/src/vec/functions/function.cpp:250
16# doris::vectorized::IFunctionBase::execute(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned int, std::allocator<unsigned int> > const&, unsigned int, unsigned long, bool) const at /home/zcp/repo_center/doris_master/doris/be/src/vec/functions/function.h:188
17# doris::vectorized::VectorizedFnCall::_do_execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*, std::vector<unsigned int, std::allocator<unsigned int> >&) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exprs/vectorized_fn_call.cpp:210
18# doris::vectorized::VectorizedFnCall::execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exprs/vectorized_fn_call.cpp:245
19# doris::vectorized::VExpr::get_const_col(doris::vectorized::VExprContext*, std::shared_ptr<doris::ColumnPtrWrapper>*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exprs/vexpr.cpp:563
20# doris::vectorized::VectorizedFnCall::open(doris::RuntimeState*, doris::vectorized::VExprContext*, doris::FunctionContext::FunctionStateScope) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exprs/vectorized_fn_call.cpp:143
21# doris::vectorized::VExprContext::open(doris::RuntimeState*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exprs/vexpr_context.cpp:92
22# doris::Status doris::FoldConstantExecutor::_prepare_and_open<doris::vectorized::VExprContext>(doris::vectorized::VExprContext*) in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
23# doris::FoldConstantExecutor::fold_constant_vexpr(doris::TFoldConstantParams const&, doris::PConstantExprResult*) at /home/zcp/repo_center/doris_master/doris/be/src/runtime/fold_constant_executor.cpp:95
24# std::_Function_handler<void (), doris::PInternalService::fold_constant_expr(google::protobuf::RpcController*, doris::PConstantExprRequest const*, doris::PConstantExprResult*, google::protobuf::Closure*)::$_0>::_M_invoke(std::_Any_data const&) at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:292
25# doris::WorkThreadPool<false>::work_thread(int) in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
26# execute_native_thread_routine in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
27# asan_thread_start(void*) in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
28# start_thread at ./nptl/pthread_create.c:442
29# 0x00007F3CD53D0850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83
 


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

the function will core by error parameter numbers ,Beacaue in debug_skip_fold_constant = false,enable_fold_constant = true,the be function will execute before rewrite done,so it will check checkLegalityAfterRewrite() after be function execute,the be will core at first,So We must use function signature check the parameters illegal

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

