### PR TITLE
[fix](asan) Fix ASAN error in ScalarColumnReader::_read_nested_column under O0 compilation.

### DIFF
--- a/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
@@ -392,7 +392,10 @@ Status ScalarColumnReader::_read_nested_column(ColumnPtr& doris_column, DataType
     size_t parsed_values = _chunk_reader->remaining_num_values() - remaining_values;
     _def_levels.resize(origin_size + parsed_values);
     if (has_def_level) {
-        _chunk_reader->def_level_decoder().get_levels(&_def_levels[origin_size], parsed_values);
+        // if parsed_values is 0, we don't need to decode levels
+        if (parsed_values != 0) {
+            _chunk_reader->def_level_decoder().get_levels(&_def_levels[origin_size], parsed_values);
+        }
     } else {
         std::fill(_def_levels.begin() + origin_size, _def_levels.end(), 0);
     }


### PR DESCRIPTION
### What problem does this PR solve?

There is a problem with the following code:

```cpp
size_t parsed_values = _chunk_reader->remaining_num_values() - remaining_values;
_def_levels.resize(origin_size + parsed_values);
if (has_def_level) {
    _chunk_reader->def_level_decoder().get_levels(&_def_levels[origin_size], parsed_values);
}
```

When `parsed_values` equals 0, the size of `_def_levels` is `origin_size`, but we attempt to access the element at index `origin_size`.  
With O0 compilation, ASAN will report an error in this case.  
In fact, if `parsed_values` is 0, nothing will actually happen inside `get_levels`.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

