### PR TITLE
[fix](docker case) disable `PluginQueryTimeoutDebugger` in docker case

### DIFF
--- a/regression-test/plugins/plugin_query_timeout_debugger.groovy
+++ b/regression-test/plugins/plugin_query_timeout_debugger.groovy
@@ -37,6 +37,7 @@ class PluginQueryTimeoutDebuggerHolder {
 PluginQueryTimeoutDebugger.jdbcUrl = context.config.jdbcUrl
 PluginQueryTimeoutDebugger.jdbcUser = context.config.jdbcUser
 PluginQueryTimeoutDebugger.jdbcPassword = context.config.jdbcPassword
+PluginQueryTimeoutDebugger.skip = !context.config.excludeDockerTest
 PluginQueryTimeoutDebugger.logger = logger
 PluginQueryTimeoutDebuggerHolder.staticResource.startWorker()
 
@@ -54,6 +55,7 @@ class PluginQueryTimeoutDebugger {
     static public String jdbcUser
     static public String jdbcPassword
     static public Logger logger
+    static public Boolean skip
 
     private ScheduledExecutorService scheduler
     private List<String> backendUrls = []
@@ -61,6 +63,10 @@ class PluginQueryTimeoutDebugger {
 
     // catch all exceptions in timer function.
     private void startWorker() {
+        if (skip) {
+            logger.info("docker case skip this plugin")
+            return
+        }
         if (scheduler?.isShutdown() == false) {
             logger.warn("worker already started")
             return


### PR DESCRIPTION
### What problem does this PR solve?

Fix docker case log
```
Caused by: com.mysql.cj.exceptions.CJCommunicationsException: Communications link failure

The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server.
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
        at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:61)
        at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:105)
        at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:151)
        at com.mysql.cj.exceptions.ExceptionFactory.createCommunicationsException(ExceptionFactory.java:167)
        at com.mysql.cj.protocol.a.NativeSocketConnection.connect(NativeSocketConnection.java:89)
        at com.mysql.cj.NativeSession.connect(NativeSession.java:120)
        at com.mysql.cj.jdbc.ConnectionImpl.connectOneTryOnly(ConnectionImpl.java:949)
        at com.mysql.cj.jdbc.ConnectionImpl.createNewIO(ConnectionImpl.java:819)
        ... 37 common frames omitted
Caused by: java.net.ConnectException: 拒绝连接
        at java.base/sun.nio.ch.Net.pollConnect(Native Method)
        at java.base/sun.nio.ch.Net.pollConnectNow(Net.java:672)
        at java.base/sun.nio.ch.NioSocketImpl.timedFinishConnect(NioSocketImpl.java:542)
        at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:597)
        at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327)
        at java.base/java.net.Socket.connect(Socket.java:633)
        at com.mysql.cj.protocol.StandardSocketFactory.connect(StandardSocketFactory.java:156)
        at com.mysql.cj.protocol.a.NativeSocketConnection.connect(NativeSocketConnection.java:63)
        ... 40 common frames omitted
```

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [x] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

