### PR TITLE
[opt](bitmap) Optimize the performance of bitmap_union_count function

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
@@ -342,6 +342,7 @@ public:
     // using ColVecType = ColumnBitmap;
     using ColVecResult = ColumnInt64;
     using AggFunctionData = AggregateFunctionBitmapData<AggregateFunctionBitmapUnionOp>;
+    static int constexpr BATCH_HALF_ROWS = 4064 / 2;
 
     AggregateFunctionBitmapCount(const DataTypes& argument_types_)
             : AggregateFunctionBitmapSerializationHelper<
@@ -400,9 +401,20 @@ public:
 
     void add_batch_single_place(size_t batch_size, AggregateDataPtr place, const IColumn** columns,
                                 Arena& arena) const override {
+        auto normal_add_lambda = [&]() {
+            for (size_t i = 0; i < batch_size; ++i) {
+                this->add(place, columns, i, arena);
+            }
+        };
+
         // now this only for bitmap_union_count function
         if constexpr (std::is_same_v<ColVecType, ColumnBitmap>) {
-            auto lambda_function = [&](const IColumn& data_column, const NullMap* null_map) {
+            // if batch_size is small, the add_batch of fast union seems to be slower than normal add
+            if (batch_size < BATCH_HALF_ROWS) {
+                normal_add_lambda();
+                return;
+            }
+            auto add_batch_lambda = [&](const IColumn& data_column, const NullMap* null_map) {
                 const auto& column = assert_cast<const ColVecType&>(data_column);
                 std::vector<const BitmapValue*> values;
                 for (size_t i = 0; i < batch_size; ++i) {
@@ -418,15 +430,13 @@ public:
 
             if constexpr (arg_is_nullable) {
                 const auto& nullable_column = assert_cast<const ColumnNullable&>(*columns[0]);
-                lambda_function(nullable_column.get_nested_column(),
-                                &(nullable_column.get_null_map_data()));
+                add_batch_lambda(nullable_column.get_nested_column(),
+                                 &(nullable_column.get_null_map_data()));
             } else {
-                lambda_function(*columns[0], nullptr);
+                add_batch_lambda(*columns[0], nullptr);
             }
         } else {
-            for (size_t i = 0; i < batch_size; ++i) {
-                this->add(place, columns, i, arena);
-            }
+            normal_add_lambda();
         }
     }
 

--- a/regression-test/data/correctness_p0/test_bitmap_count.out
+++ b/regression-test/data/correctness_p0/test_bitmap_count.out
@@ -11,3 +11,9 @@ aa	bb	2019-04-26	1	time_zone1	pid1	gid2	3
 aa	bb	2019-04-26	2	time_zone1	pid1	gid1	2
 aa	bb	2019-04-26	2	time_zone1	pid1	gid2	3
 
+-- !select_default --
+40960
+
+-- !select_default --
+40960
+


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

the exectue bitmap_union_count agg function will call Op::add_batch function
but this case only input 2 bitmap rows, and in smaller rows, 
found the bitmap_value **fast_union** is lower than **|=** function

```
mysql> SELECT bitmap_union_count(user_bitmap) AS user_count FROM user_tags_bitmap WHERE tag_code IN ('tag_1', 'tag_2')   AND update_time = '2025-08-18';
+------------+
| user_count |
+------------+
|     510000 |
+------------+
1 row in set (0.78 sec)

mysql>
mysql> SELECT bitmap_union_count(user_bitmap) AS user_count FROM user_tags_bitmap WHERE tag_code IN ('tag_1', 'tag_2')   AND update_time = '2025-08-18';
+------------+
| user_count |
+------------+
|     510000 |
+------------+
1 row in set (0.48 sec)
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

