### PR TITLE
[fix](Nereids) should not produce date type for datev2 type when process string literal

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteral.java
@@ -276,7 +276,7 @@ public class DateLiteral extends Literal implements ComparableLiteral {
     }
 
     /** parseDateLiteral */
-    public static Result<DateLiteral, AnalysisException> parseDateLiteral(String s) {
+    public static Result<DateLiteral, AnalysisException> parseDateLiteral(String s, boolean isV2) {
         Result<TemporalAccessor, AnalysisException> parseResult = parseDateTime(s);
         if (parseResult.isError()) {
             return parseResult.cast();
@@ -289,7 +289,11 @@ public class DateLiteral extends Literal implements ComparableLiteral {
         if (checkDatetime(dateTime) || checkRange(year, month, day) || checkDate(year, month, day)) {
             return Result.err(() -> new AnalysisException("date/datetime literal [" + s + "] is out of range"));
         }
-        return Result.ok(new DateLiteral(year, month, day));
+        if (isV2) {
+            return Result.ok(new DateV2Literal(year, month, day));
+        } else {
+            return Result.ok(new DateLiteral(year, month, day));
+        }
     }
 
     /** parseDateTime */

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -619,7 +619,7 @@ public class TypeCoercionUtils {
             } else if (dataType.isDateTimeType() && DateTimeChecker.isValidDateTime(value)) {
                 ret = DateTimeLiteral.parseDateTimeLiteral(value, false).orElse(null);
             } else if (dataType.isDateV2Type() && DateTimeChecker.isValidDateTime(value)) {
-                Result<DateLiteral, AnalysisException> parseResult = DateV2Literal.parseDateLiteral(value);
+                Result<DateLiteral, AnalysisException> parseResult = DateV2Literal.parseDateLiteral(value, true);
                 if (parseResult.isOk()) {
                     ret = parseResult.get();
                 } else {
@@ -630,7 +630,7 @@ public class TypeCoercionUtils {
                     }
                 }
             } else if (dataType.isDateType() && DateTimeChecker.isValidDateTime(value)) {
-                ret = DateLiteral.parseDateLiteral(value).orElse(null);
+                ret = DateLiteral.parseDateLiteral(value, false).orElse(null);
             }
         } catch (Exception e) {
             if (LOG.isDebugEnabled()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
@@ -779,4 +779,20 @@ public class TypeCoercionUtilsTest {
         Assertions.assertEquals(DecimalV3Type.createDecimalV3Type(23, 3), smallIntString.getCompareExpr().getDataType());
         Assertions.assertEquals(DecimalV3Type.createDecimalV3Type(23, 3), smallIntString.getOptions().get(0).getDataType());
     }
+
+    @Test
+    public void testCharacterLiteralTypeCoercion() {
+        // datev2
+        Assertions.assertEquals(DateV2Type.INSTANCE,
+                TypeCoercionUtils.characterLiteralTypeCoercion("2020-02-02", DateV2Type.INSTANCE).get().getDataType());
+        // datetimev2
+        Assertions.assertEquals(DateTimeV2Type.of(0),
+                TypeCoercionUtils.characterLiteralTypeCoercion("2020-02-02", DateTimeV2Type.of(0)).get().getDataType());
+        // date
+        Assertions.assertEquals(DateType.INSTANCE,
+                TypeCoercionUtils.characterLiteralTypeCoercion("2020-02-02", DateType.INSTANCE).get().getDataType());
+        // datetime
+        Assertions.assertEquals(DateTimeType.INSTANCE,
+                TypeCoercionUtils.characterLiteralTypeCoercion("2020-02-02", DateTimeType.INSTANCE).get().getDataType());
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #42941

Problem Summary:

return wrong literal for datev2 type since it use DateLiteral#parseDateLiteral to process datev2 type.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

