### PR TITLE
[fix](config) fix admin set all frontends config

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -6577,7 +6577,7 @@ public class Env {
         }
     }
 
-    public void setConfig(AdminSetFrontendConfigCommand command) throws Exception {
+    public void setConfig(AdminSetFrontendConfigCommand command, boolean isProxy) throws Exception {
         Map<String, String> configs = command.getConfigs();
         Preconditions.checkState(configs.size() == 1);
 
@@ -6589,7 +6589,8 @@ public class Env {
             }
         }
 
-        if (command.isApplyToAll()) {
+        // if this request already come from other Frontend, do not forward it again
+        if (!isProxy && command.isApplyToAll()) {
             for (Frontend fe : Env.getCurrentEnv().getFrontends(null /* all */)) {
                 if (!fe.isAlive() || fe.getHost().equals(Env.getCurrentEnv().getSelfNode().getHost())) {
                     continue;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminSetFrontendConfigCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminSetFrontendConfigCommand.java
@@ -74,7 +74,7 @@ public class AdminSetFrontendConfigCommand extends Command implements Redirect {
     public void run(ConnectContext ctx, StmtExecutor executor) throws Exception {
         validate();
         originStmt = ctx.getStatementContext().getOriginStatement();
-        Env.getCurrentEnv().setConfig(this);
+        Env.getCurrentEnv().setConfig(this, executor.isProxy());
     }
 
     /**
@@ -116,7 +116,7 @@ public class AdminSetFrontendConfigCommand extends Command implements Redirect {
      */
     public OriginStatement getLocalSetStmt() {
         Object[] keyArr = configs.keySet().toArray();
-        String sql = String.format("ADMIN SET FRONTEND CONFIG (\"%s\" = \"%s\");",
+        String sql = String.format("ADMIN SET %s CONFIG (\"%s\" = \"%s\");", applyToAll ? "ALL FRONTENDS" : "FRONTEND",
                 keyArr[0].toString(), configs.get(keyArr[0].toString()));
 
         return new OriginStatement(sql, originStmt.idx);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminSetFrontendConfigCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminSetFrontendConfigCommand.java
@@ -119,7 +119,7 @@ public class AdminSetFrontendConfigCommand extends Command implements Redirect {
         String sql = String.format("ADMIN SET %s CONFIG (\"%s\" = \"%s\");", applyToAll ? "ALL FRONTENDS" : "FRONTEND",
                 keyArr[0].toString(), configs.get(keyArr[0].toString()));
 
-        return new OriginStatement(sql, originStmt.idx);
+        return new OriginStatement(sql, originStmt == null ? 0 : originStmt.idx);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminSetFrontendConfigCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminSetFrontendConfigCommandTest.java
@@ -80,7 +80,7 @@ public class AdminSetFrontendConfigCommandTest extends TestWithFeService {
         LogicalPlan plan = new NereidsParser().parseSingle(sql);
 
         Assertions.assertTrue(plan instanceof AdminSetFrontendConfigCommand);
-        Env.getCurrentEnv().setConfig((AdminSetFrontendConfigCommand) plan);
+        Env.getCurrentEnv().setConfig((AdminSetFrontendConfigCommand) plan, false);
         Assertions.assertNotEquals(enableMtmv, Config.enable_mtmv);
 
         // 2. set with experimental
@@ -89,7 +89,7 @@ public class AdminSetFrontendConfigCommandTest extends TestWithFeService {
         plan = new NereidsParser().parseSingle(sql);
 
         Assertions.assertTrue(plan instanceof AdminSetFrontendConfigCommand);
-        Env.getCurrentEnv().setConfig((AdminSetFrontendConfigCommand) plan);
+        Env.getCurrentEnv().setConfig((AdminSetFrontendConfigCommand) plan, false);
         Assertions.assertNotEquals(enableMtmv, Config.enable_mtmv);
 
         // 3. show config

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminSetFrontendConfigCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminSetFrontendConfigCommandTest.java
@@ -42,6 +42,8 @@ public class AdminSetFrontendConfigCommandTest extends TestWithFeService {
         LogicalPlan plan = new NereidsParser().parseSingle(sql);
         Assertions.assertTrue(plan instanceof AdminSetFrontendConfigCommand);
         Assertions.assertDoesNotThrow(() -> ((AdminSetFrontendConfigCommand) plan).validate());
+        Assertions.assertTrue(((AdminSetFrontendConfigCommand) plan).getLocalSetStmt().originStmt
+                .startsWith("ADMIN SET FRONTEND CONFIG"));
     }
 
     @Test
@@ -113,5 +115,20 @@ public class AdminSetFrontendConfigCommandTest extends TestWithFeService {
 
         Assertions.assertTrue(plan instanceof AdminSetFrontendConfigCommand);
         Assertions.assertEquals("60", ((AdminSetFrontendConfigCommand) plan).getConfigs().get("alter_table_timeout_second"));
+    }
+
+    @Test
+    public void testSetAllFrontendsConfig() throws Exception {
+        String sql = "admin set all frontends config(\" alter_table_timeout_second \" = \"77\");";
+        LogicalPlan plan = new NereidsParser().parseSingle(sql);
+
+        Assertions.assertInstanceOf(AdminSetFrontendConfigCommand.class, plan);
+        AdminSetFrontendConfigCommand command = (AdminSetFrontendConfigCommand) plan;
+        Assertions.assertTrue(command.isApplyToAll());
+        Assertions.assertEquals(command.toRedirectStatus(), RedirectStatus.NO_FORWARD);
+        Assertions.assertTrue(command.getLocalSetStmt().originStmt.startsWith("ADMIN SET ALL FRONTENDS CONFIG"));
+
+        Env.getCurrentEnv().setConfig(command, true);
+        Assertions.assertEquals(77, Config.alter_table_timeout_second);
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

related pr: https://github.com/apache/doris/pull/54409

**What's the problem:**
1. `ADMIN SET ALL FRONTENDS CONFIG` command will forward to other FEs use new commnad `ADMIN SET FRONTEND CONFIG`
2. Then other FE if found `MasterOnly` config, will forward to this request to MASTER again

**How to fix:**
1. `SET ALL FRONTENDS` forward to other FEs, still use the same command: `SET ALL FRONTENDS`;
2. while Env.setConfig for `SET ALL FRONTENDS` , do not forward again while is proxy;

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

