### PR TITLE
[refine](function) refine trim_in function

### DIFF
--- a/be/src/vec/functions/function_string.cpp
+++ b/be/src/vec/functions/function_string.cpp
@@ -721,8 +721,8 @@ struct TrimInUtil {
         const size_t offset_size = str_offsets.size();
         res_offsets.resize(offset_size);
         res_data.reserve(str_data.size());
-        // If remove_str contains only ASCII characters, there is no need to consider whether str contains UTF-8 characters,
-        // since UTF-8 bytes will not conflict with ASCII bytes.
+        // Since UTF-8 encoding ensures that ASCII bytes (0x00-0x7F) never appear within multi-byte sequences,
+        // if the string to remove contains only ASCII, byte-level removal is safe and will not corrupt any UTF-8 characters.
         bool all_ascii = simd::VStringFunctions::is_ascii(remove_str);
 
         if (all_ascii) {


### PR DESCRIPTION
### What problem does this PR solve?

For the ASCII check in trim_in, it is only necessary to consider whether remove_str contains UTF-8, because UTF-8 bytes do not conflict with ASCII bytes.

Remove the use of bitset, since set/test will check if the index is valid, and 256 bytes is not a significant amount of space.

Modify some incorrect uses of iterate_utf8_with_limit_length.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

