### PR TITLE
[enhance](csv reader) limit csv line reader output buffer size

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1572,6 +1572,9 @@ DEFINE_mBool(enable_auto_clone_on_compaction_missing_version, "false");
 
 DEFINE_mBool(enable_auto_clone_on_mow_publish_missing_version, "false");
 
+// The maximum csv line reader output buffer size
+DEFINE_mInt64(max_csv_line_reader_output_buffer_size, "4294967296");
+
 // The maximum number of threads supported when executing LLMFunction
 DEFINE_mInt32(llm_max_concurrent_requests, "1");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1628,6 +1628,9 @@ DECLARE_mBool(enable_auto_clone_on_mow_publish_missing_version);
 // p0, daily, rqg, external
 DECLARE_String(fuzzy_test_type);
 
+// The maximum csv line reader output buffer size
+DECLARE_mInt64(max_csv_line_reader_output_buffer_size);
+
 // The maximum number of threads supported when executing LLMFunction
 DECLARE_mInt32(llm_max_concurrent_requests);
 

--- a/be/src/vec/exec/format/file_reader/new_plain_text_line_reader.cpp
+++ b/be/src/vec/exec/format/file_reader/new_plain_text_line_reader.cpp
@@ -19,6 +19,8 @@
 
 #include <gen_cpp/Metrics_types.h>
 #include <glog/logging.h>
+
+#include "util/debug_points.h"
 #ifdef __AVX2__
 #include <immintrin.h>
 #endif
@@ -287,7 +289,19 @@ void NewPlainTextLineReader::extend_input_buf() {
     } while (false);
 }
 
-void NewPlainTextLineReader::extend_output_buf() {
+Status NewPlainTextLineReader::extend_output_buf() {
+    DBUG_EXECUTE_IF("NewPlainTextLineReader.read_line.limit_output_buf_size",
+                    { _output_buf_size = 4294967296; });
+
+    if (_output_buf_size >= config::max_csv_line_reader_output_buffer_size) [[unlikely]] {
+        return Status::InternalError(
+                "Output buffer size exceeds configured limit of " +
+                std::to_string(config::max_csv_line_reader_output_buffer_size /
+                               (1024 * 1024 * 1024)) +
+                "GB. "
+                "It may be due to a configuration error or a very large row of data.");
+    }
+
     // left capacity
     size_t capacity = _output_buf_size - _output_buf_limit;
     // we want at least 1024 bytes capacity left
@@ -322,6 +336,8 @@ void NewPlainTextLineReader::extend_output_buf() {
         _output_buf_limit -= _output_buf_pos;
         _output_buf_pos = 0;
     } while (false);
+
+    return Status::OK();
 }
 
 Status NewPlainTextLineReader::read_line(const uint8_t** ptr, size_t* size, bool* eof,
@@ -340,13 +356,16 @@ Status NewPlainTextLineReader::read_line(const uint8_t** ptr, size_t* size, bool
         uint8_t* cur_ptr = _output_buf + _output_buf_pos;
         const uint8_t* pos = _line_reader_ctx->read_line(cur_ptr, output_buf_read_remaining());
 
+        DBUG_EXECUTE_IF("NewPlainTextLineReader.read_line.limit_output_buf_size",
+                        { pos = nullptr; });
+
         if (pos == nullptr) {
             // didn't find line delimiter, read more data from decompressor
             // for multi bytes delimiter we cannot set offset to avoid incomplete
             // delimiter
             // read from file reader
             offset = output_buf_read_remaining();
-            extend_output_buf();
+            RETURN_IF_ERROR(extend_output_buf());
             if ((_input_buf_limit > _input_buf_pos) && _more_input_bytes == 0) {
                 // we still have data in input which is not decompressed.
                 // and no more data is required for input

--- a/be/src/vec/exec/format/file_reader/new_plain_text_line_reader.h
+++ b/be/src/vec/exec/format/file_reader/new_plain_text_line_reader.h
@@ -299,7 +299,7 @@ private:
     bool done() { return _file_eof && output_buf_read_remaining() == 0; }
 
     void extend_input_buf();
-    void extend_output_buf();
+    Status extend_output_buf();
 
     RuntimeProfile* _profile = nullptr;
     io::FileReaderSPtr _file_reader;

--- a/regression-test/suites/load_p0/stream_load/test_csv_buffer_size_limit.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_csv_buffer_size_limit.groovy
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_csv_buffer_size_limit", "nonConcurrent") {
+
+    def tableName = "test_csv_buffer_size_limit"
+
+    sql """ DROP TABLE IF EXISTS ${tableName} """
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tableName} (
+            `k1` int(20) NULL,
+            `k2` string NULL,
+            `v1` date  NULL,
+            `v2` string  NULL,
+            `v3` datetime  NULL,
+            `v4` string  NULL
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`k1`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+        PROPERTIES ("replication_allocation" = "tag.location.default: 1");
+    """
+
+    def debugPoint = "NewPlainTextLineReader.read_line.limit_output_buf_size"
+    try {
+        GetDebugPoint().enableDebugPointForAllBEs(debugPoint)
+        streamLoad {
+            table "${tableName}"
+            set 'column_separator', '@@'
+            set 'line_delimiter', '$$$'
+            set 'trim_double_quotes', 'true'
+            set 'enclose', "\""
+            set 'escape', '\\'
+
+            file "enclose_multi_char_delimiter.csv"
+
+            check { result, exception, startTime, endTime ->
+                if (exception != null) {
+                    throw exception
+                }
+                log.info("Stream load result: ${result}".toString())
+                def json = parseJson(result)
+                assertEquals("fail", json.Status.toLowerCase())
+                assertTrue(json.Message.toLowerCase().contains("output buffer size exceeds configured limit"))
+            }
+        }
+    } finally {
+       GetDebugPoint().disableDebugPointForAllBEs(debugPoint)
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Limit CSV line reader output buffer size to avoid output buffer keeps expanding when the user makes a configuration error.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

