### PR TITLE
[Bug](profile) fix wrong 'Total Instances Num' in profile

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
@@ -392,7 +392,7 @@ public class NereidsCoordinator extends Coordinator {
             for (MultiFragmentsPipelineTask beTasks : executionTask.getChildrenTasks().values()) {
                 TNetworkAddress brpcAddress = beTasks.getBackend().getBrpcAddress();
                 String brpcAddrString = brpcAddress.hostname.concat(":").concat("" + brpcAddress.port);
-                result.put(brpcAddrString, beTasks.getChildrenTasks().size());
+                result.put(brpcAddrString, beTasks.getInstanceNum());
             }
         }
         return result;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/AbstractRuntimeTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/AbstractRuntimeTask.java
@@ -33,6 +33,12 @@ public abstract class AbstractRuntimeTask<ChildId, Child extends AbstractRuntime
         }
     }
 
+    public Integer getInstanceNum() {
+        return childrenTasks.allTasks().stream()
+                .mapToInt(Child::getInstanceNum)
+                .sum();
+    }
+
     public Map<ChildId, Child> getChildrenTasks() {
         return childrenTasks.allTaskMap();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/MultiFragmentsPipelineTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/MultiFragmentsPipelineTask.java
@@ -86,10 +86,6 @@ public class MultiFragmentsPipelineTask extends AbstractRuntimeTask<Integer, Sin
         );
     }
 
-    public Integer getInstanceNum() {
-        return coordinatorContext.instanceNum.get();
-    }
-
     public Future<PExecPlanFragmentResult> sendPhaseTwoRpc() {
         return execPlanFragmentStartAsync(backendClientProxy, backend.getBrpcAddress());
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/MultiFragmentsPipelineTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/MultiFragmentsPipelineTask.java
@@ -86,6 +86,10 @@ public class MultiFragmentsPipelineTask extends AbstractRuntimeTask<Integer, Sin
         );
     }
 
+    public Integer getInstanceNum() {
+        return coordinatorContext.instanceNum.get();
+    }
+
     public Future<PExecPlanFragmentResult> sendPhaseTwoRpc() {
         return execPlanFragmentStartAsync(backendClientProxy, backend.getBrpcAddress());
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/SingleFragmentPipelineTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/SingleFragmentPipelineTask.java
@@ -82,6 +82,10 @@ public class SingleFragmentPipelineTask extends LeafRuntimeTask {
         return fragmentId;
     }
 
+    public Integer getInstanceNum() {
+        return instanceIds.size();
+    }
+
     public List<FragmentInstanceInfo> buildFragmentInstanceInfo() {
         TNetworkAddress address = new TNetworkAddress(backend.getHost(), backend.getBePort());
         List<FragmentInstanceInfo> infos = Lists.newArrayListWithCapacity(instanceIds.size());


### PR DESCRIPTION
### What problem does this PR solve?
```sql
select ndv(k1) from t1;
```

before:
   - Total Instances Num: 2
   - Parallel Fragment Exec Instance Num: 64

after:
   - Total Instances Num: 65
   - Parallel Fragment Exec Instance Num: 64

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason (hard to check profile text)

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

