### PR TITLE
[Enhancement](stack) print stacktrace for doris Exception

### DIFF
--- a/be/src/common/exception.cpp
+++ b/be/src/common/exception.cpp
@@ -19,8 +19,9 @@
 
 #include "common/config.h"
 #include "util/stack_util.h"
-namespace doris {
 
+namespace doris {
+// private concrete constructor
 Exception::Exception(int code, const std::string_view& msg, bool from_status) {
     _code = code;
     _err_msg = std::make_unique<ErrMsg>();

--- a/be/src/common/exception.h
+++ b/be/src/common/exception.h
@@ -35,7 +35,7 @@ inline thread_local int enable_thread_catch_bad_alloc = 0;
 class Exception : public std::exception {
 public:
     Exception() : _code(ErrorCode::OK) {}
-    Exception(int code, const std::string_view& msg, bool from_status = false);
+    Exception(int code, const std::string_view& msg) : Exception(code, std::string(msg), false) {}
     Exception(const Status& status) : Exception(status.code(), status.msg(), true) {}
 
     // Format message with fmt::format, like the logging functions.
@@ -53,6 +53,8 @@ public:
     Status to_status() const { return {code(), _err_msg->_msg, _err_msg->_stack}; }
 
 private:
+    Exception(int code, const std::string_view& msg, bool from_status);
+
     int _code;
     struct ErrMsg {
         std::string _msg;

--- a/be/src/common/exception.h
+++ b/be/src/common/exception.h
@@ -27,7 +27,7 @@
 #include <utility>
 
 #include "common/status.h"
-#include "util/defer_op.h"
+#include "util/defer_op.h" // IWYU pragma: keep
 
 namespace doris {
 
@@ -35,8 +35,8 @@ inline thread_local int enable_thread_catch_bad_alloc = 0;
 class Exception : public std::exception {
 public:
     Exception() : _code(ErrorCode::OK) {}
-    Exception(int code, const std::string_view& msg);
-    Exception(const Status& status) : Exception(status.code(), status.msg()) {}
+    Exception(int code, const std::string_view& msg, bool from_status = false);
+    Exception(const Status& status) : Exception(status.code(), status.msg(), true) {}
 
     // Format message with fmt::format, like the logging functions.
     template <typename... Args>


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

before if we construct a `doris::Exception` with error_code which should print stacktrace, **it wouldn't**. now fixed.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

