### PR TITLE
[Improve](backup) add upload bytes metric

### DIFF
--- a/be/src/runtime/snapshot_loader.h
+++ b/be/src/runtime/snapshot_loader.h
@@ -63,6 +63,8 @@ public:
 
     std::shared_ptr<ResourceContext> resource_ctx() { return _resource_ctx; }
 
+    void update_upload_bytes(const int64_t bytes) { _upload_bytes += bytes; }
+
 protected:
     Status _get_tablet_id_from_remote_path(const std::string& remote_path, int64_t* tablet_id);
 
@@ -79,6 +81,8 @@ protected:
     const std::map<std::string, std::string> _prop;
     std::shared_ptr<io::RemoteFileSystem> _remote_fs;
     std::shared_ptr<ResourceContext> _resource_ctx;
+    // metric
+    int64_t _upload_bytes = 0;
 };
 
 /*

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -931,11 +931,14 @@ public class BackupHandler extends MasterDaemon implements Writable {
         addBackupOrRestoreJob(job.getDbId(), job);
     }
 
-    public boolean report(TTaskType type, long jobId, long taskId, int finishedNum, int totalNum) {
+    public boolean report(TTaskType type, long jobId, long taskId, int finishedNum, int totalNum, long uploadBytes) {
         for (AbstractJob job : getAllCurrentJobs()) {
             if (job.getType() == JobType.BACKUP) {
                 if (!job.isDone() && job.getJobId() == jobId && type == TTaskType.UPLOAD) {
                     job.taskProgress.put(taskId, Pair.of(finishedNum, totalNum));
+                    if (job instanceof BackupJob) {
+                        ((BackupJob) job).updateMetric(taskId, uploadBytes);
+                    }
                     return true;
                 }
             } else if (job.getType() == JobType.RESTORE) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowBackupCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowBackupCommand.java
@@ -60,7 +60,7 @@ public class ShowBackupCommand extends ShowCommand {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("JobId").add("SnapshotName").add("DbName").add("State").add("BackupObjs").add("CreateTime")
             .add("SnapshotFinishedTime").add("UploadFinishedTime").add("FinishedTime").add("UnfinishedTasks")
-            .add("Progress").add("TaskErrMsg").add("Status").add("Timeout")
+            .add("Progress").add("UploadBytes").add("TaskErrMsg").add("Status").add("Timeout")
             .build();
 
     private String dbName;

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -2285,7 +2285,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     @Override
     public TStatus snapshotLoaderReport(TSnapshotLoaderReportRequest request) throws TException {
         if (Env.getCurrentEnv().getBackupHandler().report(request.getTaskType(), request.getJobId(),
-                request.getTaskId(), request.getFinishedNum(), request.getTotalNum())) {
+                request.getTaskId(), request.getFinishedNum(), request.getTotalNum(), request.getUploadBytes())) {
             return new TStatus(TStatusCode.OK);
         }
         return new TStatus(TStatusCode.CANCELLED);

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -740,6 +740,7 @@ struct TSnapshotLoaderReportRequest {
     3: required Types.TTaskType task_type
     4: optional i32 finished_num
     5: optional i32 total_num
+    6: optional i64 upload_bytes
 }
 
 enum TFrontendPingFrontendStatusCode {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

When we need to settle accounts, we must accurately determine exactly how much data has been backed up to remote storage.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

