### PR TITLE
[Fix](cast) process the invalid input from int to date to NULL

### DIFF
--- a/be/src/vec/functions/cast/cast_to_datev2_impl.hpp
+++ b/be/src/vec/functions/cast/cast_to_datev2_impl.hpp
@@ -200,6 +200,7 @@ inline bool CastToDateV2::from_integer(T input, DateV2Value<DateV2ValueType>& va
         if constexpr (IsStrict) {
             params.status = Status::InvalidArgument("invalid digits for datev2: {}", int_val);
         }
+        return false;
     }
     return true;
 }

--- a/be/test/vec/function/cast/cast_to_date_test.cpp
+++ b/be/test/vec/function/cast/cast_to_date_test.cpp
@@ -293,6 +293,35 @@ TEST_F(FunctionCastTest, test_from_numeric_to_date) {
     }
 }
 
+TEST_F(FunctionCastTest, test_from_numeric_to_date_invalid) {
+    // Test casting from Int64
+    {
+        InputTypeSet input_types = {PrimitiveType::TYPE_BIGINT};
+        DataSet data_set = {
+                {{int64_t(1)}, Null()},
+                {{int64_t(22)}, Null()},
+                {{int64_t(-222)}, Null()},
+                {{int64_t(7777777)}, Null()},
+                {{int64_t(2015010203040516)}, Null()},
+        };
+        check_function_for_cast<DataTypeDateV2>(input_types, data_set);
+        check_function_for_cast_strict_mode<DataTypeDateV2>(input_types, data_set, "date");
+    }
+    // Test casting from Double
+    {
+        InputTypeSet input_types = {PrimitiveType::TYPE_DOUBLE};
+        DataSet data_set = {
+                {{1.}, Null()},
+                {{22.223}, Null()},
+                {{-222.}, Null()},
+                {{7777777.}, Null()},
+                {{2015010203040516.}, Null()},
+        };
+        check_function_for_cast<DataTypeDateV2>(input_types, data_set);
+        check_function_for_cast_strict_mode<DataTypeDateV2>(input_types, data_set, "date");
+    }
+}
+
 TEST_F(FunctionCastTest, test_from_decimal_to_date) {
     // Test casting from Decimal(9,3)
     {

--- a/be/test/vec/function/cast/cast_to_datetime_test.cpp
+++ b/be/test/vec/function/cast/cast_to_datetime_test.cpp
@@ -307,6 +307,35 @@ TEST_F(FunctionCastTest, test_from_numeric_to_datetime) {
     }
 }
 
+TEST_F(FunctionCastTest, test_from_numeric_to_datetime_invalid) {
+    // Test casting from Int64
+    {
+        InputTypeSet input_types = {PrimitiveType::TYPE_BIGINT};
+        DataSet data_set = {
+                {{int64_t(1)}, Null()},
+                {{int64_t(22)}, Null()},
+                {{int64_t(-222)}, Null()},
+                {{int64_t(7777777)}, Null()},
+                {{int64_t(2015010203040516)}, Null()},
+        };
+        check_function_for_cast<DataTypeDateTimeV2>(input_types, data_set);
+        check_function_for_cast_strict_mode<DataTypeDateTimeV2>(input_types, data_set, "datetime");
+    }
+    // Test casting from Double
+    {
+        InputTypeSet input_types = {PrimitiveType::TYPE_DOUBLE};
+        DataSet data_set = {
+                {{1.}, Null()},
+                {{22.223}, Null()},
+                {{-222.}, Null()},
+                {{7777777.}, Null()},
+                {{2015010203040516.}, Null()},
+        };
+        check_function_for_cast<DataTypeDateTimeV2>(input_types, data_set);
+        check_function_for_cast_strict_mode<DataTypeDateTimeV2>(input_types, data_set, "datetime");
+    }
+}
+
 TEST_F(FunctionCastTest, test_from_decimal_to_datetime) {
     // Test casting from Decimal(9,3)
     {
@@ -328,6 +357,17 @@ TEST_F(FunctionCastTest, test_from_decimal_to_datetime) {
                 {{DECIMAL64(20151231, 999999, 6)}, std::string("2015-12-31 00:00:00.999999")},
                 {{Null()}, Null()}};
         check_function_for_cast<DataTypeDateTimeV2>(input_types, data_set, 6);
+    }
+}
+
+TEST_F(FunctionCastTest, test_from_decimal_to_datetime_invalid) {
+    {
+        InputTypeSet input_types = {{PrimitiveType::TYPE_DECIMAL64, 3, 17}};
+        DataSet data_set = {
+                {{DECIMAL64(99991231235959, 999, 3)}, Null()},
+        };
+        check_function_for_cast<DataTypeDateTimeV2>(input_types, data_set, 2);
+        check_function_for_cast_strict_mode<DataTypeDateTimeV2>(input_types, data_set, "datetime");
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

before we forget set the return value, so for invalid input when doing int -> datev2, we won't return null. that's wrong.

before:
```sql
mysql> set enable_strict_cast=false;
mysql> set debug_skip_fold_constant=true;
mysql> select cast(2 as date);
+-----------------+
| cast(2 as date) |
+-----------------+
|                 |
+-----------------+
```

now:
```sql
mysql> select cast(2 as date);
+-----------------+
| cast(2 as date) |
+-----------------+
| NULL            |
+-----------------+
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

