### PR TITLE
branch-3.1: [fix](variant) Prohibit older versions of variant from using the schema templates feature

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TypeDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TypeDef.java
@@ -360,6 +360,11 @@ public class TypeDef implements ParseNode {
                             + PropertyAnalyzer.PROPERTIES_VARIANT_ENABLE_TYPED_PATHS_TO_SPARSE
                             + " and " + PropertyAnalyzer.PROPERTIES_VARIANT_MAX_SUBCOLUMNS_COUNT);
                 }
+
+                if (variantMaxSubcolumnsCount == 0 && !variantType.getPredefinedFields().isEmpty()) {
+                    throw new AnalysisException("variant_max_subcolumns_count must be greater than 0 "
+                            + "when variant has fields, but got " + variantMaxSubcolumnsCount);
+                }
                 break;
             }
             case INVALID_TYPE:

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -3610,6 +3610,11 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
                     + " and " + PropertyAnalyzer.PROPERTIES_VARIANT_MAX_SUBCOLUMNS_COUNT);
         }
 
+        if (variantMaxSubcolumnsCount == 0 && !fields.isEmpty()) {
+            throw new NotSupportedException("variant_max_subcolumns_count must be greater than 0 "
+                    + "when variant has fields, but got " + variantMaxSubcolumnsCount);
+        }
+
         return new VariantType(fields, variantMaxSubcolumnsCount, enableTypedPathsToSparse);
     }
 

--- a/regression-test/suites/variant_p0/delete_update.groovy
+++ b/regression-test/suites/variant_p0/delete_update.groovy
@@ -22,10 +22,11 @@ suite("regression_test_variant_delete_and_update", "variant_type"){
     def table_name = "var_delete_update"
     sql "DROP TABLE IF EXISTS ${table_name}"
     sql """ set enable_variant_flatten_nested = true """
+    def max_subcolumns_count = new Random().nextInt(10) + 1
     sql """
         CREATE TABLE IF NOT EXISTS ${table_name} (
             k bigint,
-            v variant<'a' : int, 'b' : array<int>, 'c' : double>
+            v variant<'a' : int, 'b' : array<int>, 'c' : double, properties("variant_max_subcolumns_count" = "${max_subcolumns_count}")>
         )
         UNIQUE KEY(`k`)
         DISTRIBUTED BY HASH(k) BUCKETS 3
@@ -51,7 +52,7 @@ suite("regression_test_variant_delete_and_update", "variant_type"){
     sql """
         CREATE TABLE IF NOT EXISTS ${table_name} (
             k bigint,
-            v  variant<'a' : int, 'b' : array<int>, 'c' : double>,
+            v  variant<'a' : int, 'b' : array<int>, 'c' : double, properties("variant_max_subcolumns_count" = "${max_subcolumns_count}")>,
             vs string 
         )
         UNIQUE KEY(`k`)

--- a/regression-test/suites/variant_p0/predefine/delete_update.groovy
+++ b/regression-test/suites/variant_p0/predefine/delete_update.groovy
@@ -111,7 +111,7 @@ suite("regression_test_variant_predefine_delete_and_update", "variant_type"){
                 `score` int(11) NOT NULL COMMENT "用户得分",
                 `test` int(11) NULL COMMENT "null test",
                 `dft` int(11) DEFAULT "4321",
-                `var` variant<'id' : int, 'name' : string, 'score' : int, 'test' : int, 'dft' : int> NULL)
+                `var` variant<'id' : int, 'name' : string, 'score' : int, 'test' : int, 'dft' : int, properties("variant_max_subcolumns_count" = "${max_subcolumns_count}")> NULL)
                 UNIQUE KEY(`id`) DISTRIBUTED BY HASH(`id`) BUCKETS 1
                 PROPERTIES("replication_num" = "1", "enable_unique_key_merge_on_write" = "true", "disable_auto_compaction" = "true", "store_row_column" = "true")
     """

--- a/regression-test/suites/variant_p0/predefine/element_function.groovy
+++ b/regression-test/suites/variant_p0/predefine/element_function.groovy
@@ -17,11 +17,12 @@
 
 suite("regression_test_variant_predefine_element_at", "p0")  {
     sql """ DROP TABLE IF EXISTS element_fn_test """
+    def max_subcolumns_count = new Random().nextInt(10) + 1
     sql """
         CREATE TABLE IF NOT EXISTS element_fn_test(
             k bigint,
-            v variant<'arr1' : array<int>, 'arr2' : array<int>>,
-            v1 variant<'arr1' : array<int>, 'arr2' : array<int>> not null,
+            v variant<'arr1' : array<int>, 'arr2' : array<int>, properties("variant_max_subcolumns_count" = "${max_subcolumns_count}")>,
+            v1 variant<'arr1' : array<int>, 'arr2' : array<int>, properties("variant_max_subcolumns_count" = "${max_subcolumns_count}")> not null,
         )
         UNIQUE KEY(`k`)
         DISTRIBUTED BY HASH(k) BUCKETS 4

--- a/regression-test/suites/variant_p0/tpch/load.groovy
+++ b/regression-test/suites/variant_p0/tpch/load.groovy
@@ -37,9 +37,9 @@ suite("load") {
 
     tables.forEach { tableName ->
         sql "DROP TABLE IF EXISTS ${tableName}"
-        int max_subcolumns_count = Math.floor(Math.random() * 7) 
+        int max_subcolumns_count = Math.floor(Math.random() * 7)
         def var_def = "variant"
-        if (max_subcolumns_count % 2 == 0) {
+        if (max_subcolumns_count % 2 == 0 && max_subcolumns_count > 0) {
             var_def = "variant<'O_CLERK' : string, 'C_COMMENT' : string, 'L_RETURNFLAG' : string, 'S_COMMENT' : string, 'S_ACCTBAL' : double, properties(\"variant_max_subcolumns_count\" = \"${max_subcolumns_count}\", \"variant_enable_typed_paths_to_sparse\" = \"false\")>"
         }
         sql """

--- a/regression-test/suites/variant_p0/with_index/var_index.groovy
+++ b/regression-test/suites/variant_p0/with_index/var_index.groovy
@@ -18,11 +18,13 @@
 suite("regression_test_variant_var_index", "p0, nonConcurrent"){
     def table_name = "var_index"
     sql """ set default_variant_enable_typed_paths_to_sparse = false """
+
+    def max_subcolumns_count = new Random().nextInt(10) + 1
     sql "DROP TABLE IF EXISTS var_index"
     sql """
         CREATE TABLE IF NOT EXISTS var_index (
             k bigint,
-            v variant<'timestamp' : double, 'a' : int, 'b' : string, 'c' : int>,
+            v variant<'timestamp' : double, 'a' : int, 'b' : string, 'c' : int, properties("variant_max_subcolumns_count" = "${max_subcolumns_count}")>,
             INDEX idx_var(v) USING INVERTED  PROPERTIES("parser" = "english") COMMENT ''
         )
         DUPLICATE KEY(`k`)


### PR DESCRIPTION

### What problem does this PR solve?
In the master branch, we removed the write code for the old version of variant。
In the branch-3.1, we prohibited the old version of variant from using the new schema templates feature.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

