### PR TITLE
[Fix](Broker)Adapt Broker as load storage

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BrokerDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BrokerDesc.java
@@ -112,6 +112,10 @@ public class BrokerDesc extends StorageDesc implements Writable {
         if (properties != null) {
             this.properties.putAll(properties);
         }
+        if (StorageType.BROKER.equals(storageType)) {
+            this.storageProperties = BrokerProperties.of(name, properties);
+            return;
+        }
         if (MapUtils.isNotEmpty(this.properties) && StorageType.REFACTOR_STORAGE_TYPES.contains(storageType)) {
             this.storageProperties = StorageProperties.createPrimary(properties);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BrokerDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BrokerDesc.java
@@ -22,6 +22,7 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.PrintableMap;
+import org.apache.doris.datasource.property.storage.BrokerProperties;
 import org.apache.doris.datasource.property.storage.StorageProperties;
 import org.apache.doris.datasource.property.storage.exception.StoragePropertiesException;
 import org.apache.doris.persist.gson.GsonUtils;
@@ -93,8 +94,9 @@ public class BrokerDesc extends StorageDesc implements Writable {
                 this.storageType = StorageBackend.StorageType.valueOf(storageProperties.getStorageName());
             } catch (StoragePropertiesException e) {
                 // Currently ignored: these properties might be broker-specific.
-                // Support for broker properties will be added in the future.
-                LOG.info("Failed to create storage properties for broker: {}, properties: {}", name, properties, e);
+                // Just keep the storage type as BROKER, and try to create BrokerProperties
+                this.storageProperties = BrokerProperties.of(name, properties);
+                this.storageType = StorageBackend.StorageType.BROKER;
             }
         }
         //only storage type is broker

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -1889,7 +1889,8 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
         } else if (ctx.LOCAL() != null) {
             brokerDesc = new BrokerDesc("HDFS", StorageBackend.StorageType.LOCAL, brokerPropertiesMap);
         } else if (ctx.BROKER() != null) {
-            brokerDesc = new BrokerDesc(visitIdentifierOrText(ctx.brokerName), brokerPropertiesMap);
+            brokerDesc = new BrokerDesc(visitIdentifierOrText(ctx.brokerName),
+                    StorageBackend.StorageType.BROKER, brokerPropertiesMap);
         }
         return brokerDesc;
     }

--- a/regression-test/suites/load_p0/broker_load/test_broker_load_with_properties.groovy
+++ b/regression-test/suites/load_p0/broker_load/test_broker_load_with_properties.groovy
@@ -74,9 +74,9 @@ suite("test_broker_load_with_properties", "load_p0") {
     }
 
     def check_load_result = {checklabel, testTablex ->
-        max_try_milli_secs = 10000
+        def max_try_milli_secs = 10000
         while(max_try_milli_secs) {
-            result = sql "show load where label = '${checklabel}'"
+            def result = sql "show load where label = '${checklabel}'"
             log.info("result: ${result}")
             if(result[0][2] == "FINISHED") {
                 //sql "sync"
@@ -95,9 +95,9 @@ suite("test_broker_load_with_properties", "load_p0") {
     // if 'enableHdfs' in regression-conf.groovy has been set to true,
     // the test will run these case as below.
     if (enableHdfs()) {
-        brokerName = getBrokerName()
-        hdfsUser = getHdfsUser()
-        hdfsPasswd = getHdfsPasswd()
+        def brokerName = getBrokerName()
+        def hdfsUser = getHdfsUser()
+        def hdfsPasswd = getHdfsPasswd()
         def hdfs_csv_file_path = uploadToHdfs "load_p0/broker_load/broker_load_with_properties.json"
         //def hdfs_csv_file_path = "hdfs://ip:port/testfile"
 


### PR DESCRIPTION

### What problem does this PR solve?

This pull request introduces a fallback mechanism for Broker storage import. Currently, the logic attempts to convert Broker data into actual storage backends (e.g., S3). If the conversion fails, the system will now gracefully fall back to using Broker as the storage backend. This ensures robustness and continuity in data handling when conversion to other storage types is not possible.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

