### PR TITLE
branch-3.1: [fix](meta) make OP_CERATE_DB compatible with 3.0

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -131,6 +131,12 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table>,
     // from dbProperties;
     private BinlogConfig binlogConfig = new BinlogConfig();
 
+    // ATTN: This field is only used for compatible with old version
+    // Do not use it except for replaying OP_CREATE_DB
+    // it will be removed in version 4.0
+    @SerializedName(value = "cn")
+    private String ctlName;
+
     public Database() {
         this(0, null);
     }
@@ -153,6 +159,18 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table>,
         this.dbState = DbState.NORMAL;
         this.attachDbName = "";
         this.dbEncryptKey = new DatabaseEncryptKey();
+    }
+
+    // Only used for creating external database.
+    // DO NOT use it for internal database
+    public Database(String ctlName, String dbName) {
+        this.ctlName = ctlName;
+        this.fullQualifiedName = dbName;
+    }
+
+    // DO NOT use it except for replaying OP_CREATE_DB
+    public String getCtlName() {
+        return ctlName;
     }
 
     public void markDropped() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -164,10 +164,9 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table>,
     // Only used for creating external database.
     // DO NOT use it for internal database
     public Database(String ctlName, String dbName) {
+        this(0, dbName);
+        Preconditions.checkState(!Strings.isNullOrEmpty(ctlName), dbName);
         this.ctlName = ctlName;
-        this.fullQualifiedName = dbName;
-        this.idToTable = Maps.newConcurrentMap();
-        this.lowerCaseToTableName = Maps.newConcurrentMap();
     }
 
     // DO NOT use it except for replaying OP_CREATE_DB

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -166,6 +166,8 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table>,
     public Database(String ctlName, String dbName) {
         this.ctlName = ctlName;
         this.fullQualifiedName = dbName;
+        this.idToTable = Maps.newConcurrentMap();
+        this.lowerCaseToTableName = Maps.newConcurrentMap();
     }
 
     // DO NOT use it except for replaying OP_CREATE_DB

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -22,6 +22,7 @@ import org.apache.doris.analysis.CreateTableStmt;
 import org.apache.doris.analysis.PartitionNames;
 import org.apache.doris.analysis.TableName;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.InfoSchemaDb;
@@ -1057,8 +1058,9 @@ public abstract class ExternalCatalog
             boolean res = metadataOps.createDb(dbName, ifNotExists, properties);
             if (!res) {
                 // we should get the db stored in Doris, and use local name in edit log.
-                CreateDbInfo info = new CreateDbInfo(getName(), dbName, null);
-                Env.getCurrentEnv().getEditLog().logCreateDb(info);
+                // CreateDbInfo info = new CreateDbInfo(getName(), dbName, null);
+                Database db = new Database(getName(), dbName);
+                Env.getCurrentEnv().getEditLog().logCreateDb(db);
             }
         } catch (Exception e) {
             LOG.warn("Failed to create database {} in catalog {}.", dbName, getName(), e);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -62,7 +62,6 @@ import org.apache.doris.nereids.trees.plans.commands.info.CreateOrReplaceBranchI
 import org.apache.doris.nereids.trees.plans.commands.info.CreateOrReplaceTagInfo;
 import org.apache.doris.nereids.trees.plans.commands.info.DropBranchInfo;
 import org.apache.doris.nereids.trees.plans.commands.info.DropTagInfo;
-import org.apache.doris.persist.CreateDbInfo;
 import org.apache.doris.persist.CreateTableInfo;
 import org.apache.doris.persist.DropDbInfo;
 import org.apache.doris.persist.DropInfo;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -448,8 +448,8 @@ public class InternalCatalog implements CatalogIf<Database> {
                 }
                 try {
                     unprotectCreateDb(db);
-                    CreateDbInfo dbInfo = new CreateDbInfo(InternalCatalog.INTERNAL_CATALOG_NAME, db.getName(), db);
-                    Env.getCurrentEnv().getEditLog().logCreateDb(dbInfo);
+                    // CreateDbInfo dbInfo = new CreateDbInfo(InternalCatalog.INTERNAL_CATALOG_NAME, db.getName(), db);
+                    Env.getCurrentEnv().getEditLog().logCreateDb(db);
                 } finally {
                     db.writeUnlock();
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -148,7 +148,6 @@ import org.apache.doris.nereids.trees.plans.commands.info.TableNameInfo;
 import org.apache.doris.persist.AlterDatabasePropertyInfo;
 import org.apache.doris.persist.AutoIncrementIdUpdateLog;
 import org.apache.doris.persist.ColocatePersistInfo;
-import org.apache.doris.persist.CreateDbInfo;
 import org.apache.doris.persist.DatabaseInfo;
 import org.apache.doris.persist.DropDbInfo;
 import org.apache.doris.persist.DropInfo;

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -311,7 +311,14 @@ public class EditLog {
                 }
                 case OperationType.OP_CREATE_DB: {
                     Database db = (Database) journal.getData();
-                    CreateDbInfo info = new CreateDbInfo(db.getCatalog().getName(), db.getName(), db);
+                    CreateDbInfo info;
+                    if (!Strings.isNullOrEmpty(db.getCtlName())) {
+                        // if ctlName is not empty, it means this db is created in an external catalog
+                        // we just need db name and ctl name
+                        info = new CreateDbInfo(db.getCtlName(), db.getName(), null);
+                    } else {
+                        info = new CreateDbInfo(db.getCatalog().getName(), db.getName(), db);
+                    }
                     env.replayCreateDb(info);
                     break;
                 }
@@ -1615,8 +1622,8 @@ public class EditLog {
         logEdit(OperationType.OP_SAVE_TRANSACTION_ID, new Text(Long.toString(transactionId)));
     }
 
-    public void logCreateDb(CreateDbInfo info) {
-        logEdit(OperationType.OP_NEW_CREATE_DB, info);
+    public void logCreateDb(Database db) {
+        logEdit(OperationType.OP_CREATE_DB, db);
     }
 
     public void logDropDb(DropDbInfo dropDbInfo) {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
@@ -28,13 +28,13 @@ public class OperationType {
     public static final short OP_LOCAL_EOF = -1;
     public static final short OP_SAVE_NEXTID = 0;
     @Deprecated
-    public static final short OP_CREATE_DB = 1; // deprecated, use OP_NEW_CREATE_DB instead
+    public static final short OP_CREATE_DB = 1; // deprecated in 4.0, use OP_NEW_CREATE_DB instead
     public static final short OP_DROP_DB = 2;
     public static final short OP_ALTER_DB = 3;
     public static final short OP_ERASE_DB = 4;
     public static final short OP_RECOVER_DB = 5;
     public static final short OP_RENAME_DB = 6;
-    public static final short OP_NEW_CREATE_DB = 7;
+    public static final short OP_NEW_CREATE_DB = 7; // do not use this code before 4.0
 
     // 10~19 110~119 210~219 ...
     public static final short OP_CREATE_TABLE = 10;


### PR DESCRIPTION
### What problem does this PR solve?

Previously, we introduced a new opcode `OP_NEW_CREATE_DB` in #46326.
If use upgrade to 3.1 from 3.0, and create a database, he can not downgrade to the old version
because old version can not recognize `OP_NEW_CREATE_DB`.

This PR make it compatible by still using the old opcode `OP_CREATE_DB`, but add catalog name in `Database`
temporarily.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

