### PR TITLE
[fix](cloud) Not log npe in unprotectUpdateCloudReplica when partition dropped

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
@@ -1039,6 +1039,10 @@ public class CloudInternalCatalog extends InternalCatalog {
     private void unprotectUpdateCloudReplica(OlapTable olapTable, UpdateCloudReplicaInfo info) {
         LOG.debug("replay update a cloud replica {}", info);
         Partition partition = olapTable.getPartition(info.getPartitionId());
+        if (partition == null) {
+            LOG.warn("replay update cloud replica, unknown partition {}, may be dropped", info.toString());
+            return;
+        }
         MaterializedIndex materializedIndex = partition.getIndex(info.getIndexId());
 
         try {


### PR DESCRIPTION
When the partition is dropped, the replay will print the exception npe log. This is normal. The outer layer of unprotectUpdateCloudReplica has already tried to catch the exception. Here, the fix is ​​to not print the npe exception log.

```
2025-08-21 18:42:38,141 WARN (leaderCheckpointer|215) [CloudInternalCatalog.replayUpdateCloudReplica():1026] unexpected exception
java.lang.NullPointerException: Cannot invoke "org.apache.doris.catalog.Partition.getIndex(long)" because "partition" is null
at org.apache.doris.cloud.datasource.CloudInternalCatalog.unprotectUpdateCloudReplica(CloudInternalCatalog.java:1035) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.cloud.datasource.CloudInternalCatalog.replayUpdateCloudReplica(CloudInternalCatalog.java:1024) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.cloud.catalog.CloudEnv.replayUpdateCloudReplica(CloudEnv.java:320) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.persist.EditLog.loadJournal(EditLog.java:1377) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.catalog.Env.replayJournal(Env.java:3102) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.master.Checkpoint.doCheckpoint(Checkpoint.java:140) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.master.Checkpoint.runAfterCatalogReady(Checkpoint.java:80) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.common.util.MasterDaemon.runOneCycle(MasterDaemon.java:58) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.common.util.Daemon.run(Daemon.java:119) ~[doris-fe.jar:1.2-SNAPSHOT]
```

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

