### PR TITLE
[fix](auth)fix not allow set query_timeout property <0

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/CommonUserProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/CommonUserProperties.java
@@ -141,9 +141,6 @@ public class CommonUserProperties implements GsonPostProcessable {
     }
 
     public void setQueryTimeout(int timeout) {
-        if (timeout <= 0) {
-            LOG.warn("Setting 0 query timeout", new RuntimeException(""));
-        }
         this.queryTimeout = timeout;
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/UserPropertyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/UserPropertyTest.java
@@ -141,6 +141,18 @@ public class UserPropertyTest {
             Assert.assertTrue(e.getMessage().contains("is not valid"));
         }
         Assert.assertEquals(-1, userProperty.getCpuResourceLimit());
+        // we should allow query_timeout  < 0, otherwise, not have command reset query_timeout of user
+        properties = Lists.newArrayList();
+        properties.add(Pair.of("query_timeout", "-2"));
+        userProperty = new UserProperty();
+        userProperty.update(properties);
+        Assert.assertEquals(-2, userProperty.getQueryTimeout());
+        // we should allow insert_timeout  < 0, otherwise, not have command reset insert_timeout of user
+        properties = Lists.newArrayList();
+        properties.add(Pair.of("insert_timeout", "-2"));
+        userProperty = new UserProperty();
+        userProperty.update(properties);
+        Assert.assertEquals(-2, userProperty.getInsertTimeout());
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?
we should allow query_timeout  < 0, otherwise, not have command reset query_timeout of user

if <0, we think it is not set

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
fix not allow set query_timeout property <0
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

