### PR TITLE
[chore](logs)Print logs of Export split tablet IDs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
@@ -276,6 +276,7 @@ public class ExportJob implements Writable {
         List<List<Long>> tabletsListPerParallel = splitTablets();
 
         // Each Outfile clause responsible for MAXIMUM_TABLETS_OF_OUTFILE_IN_EXPORT tablets
+        int index = 0;
         for (List<Long> tabletsList : tabletsListPerParallel) {
             // generate LogicalPlan
             LogicalPlan plan = generateOneLogicalPlan(qualifiedTableName, tabletsList,
@@ -283,6 +284,10 @@ public class ExportJob implements Writable {
             // generate  LogicalPlanAdapter
             StatementBase statementBase = generateLogicalPlanAdapter(plan);
             selectStmtPerParallel.add(Optional.of(statementBase));
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Export Job [{}]: parallelism {} tablets: {}", id, index, tabletsList);
+            }
+            index++;
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?
`2025-08-22 12:25:54,099 DEBUG (mysql-nio-pool-0|234) [ExportJob.generateOlapTableOutfile():288] Export Job [1755836749233]: parallelism 0 tablets: [1755777688615]`
