### PR TITLE
[bugfix](catalog) replace Math.abs with bitwise AND to ensure non-negative ID generation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
@@ -714,7 +714,12 @@ public class Util {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             byte[] hash = digest.digest(str.getBytes(StandardCharsets.UTF_8));
             ByteBuffer buffer = ByteBuffer.wrap(hash);
-            return buffer.getLong();
+            long result = buffer.getLong();
+            // Handle Long.MIN_VALUE case to ensure non-negative ID generation
+            if (result == Long.MIN_VALUE) {
+                return str.hashCode();
+            }
+            return result;
         } catch (NoSuchAlgorithmException e) {
             return str.hashCode();
         }
@@ -723,7 +728,7 @@ public class Util {
     // Only used for external db/table's id generation
     // And the db/table's id must >=0, see DescriptorTable.toThrift()
     public static long genIdByName(String... names) {
-        return sha256long(String.join(".", names)) & Long.MAX_VALUE;
+        return Math.abs(sha256long(String.join(".", names)));
     }
 
     public static String generateTempTableInnerName(String tableName) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
@@ -723,7 +723,7 @@ public class Util {
     // Only used for external db/table's id generation
     // And the db/table's id must >=0, see DescriptorTable.toThrift()
     public static long genIdByName(String... names) {
-        return Math.abs(sha256long(String.join(".", names)));
+        return sha256long(String.join(".", names)) & Long.MAX_VALUE;
     }
 
     public static String generateTempTableInnerName(String tableName) {

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/UtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/UtilTest.java
@@ -90,4 +90,16 @@ public class UtilTest {
         String str1 = "东方卫视";
         Assertions.assertNotEquals(Util.sha256long(str), Util.sha256long(str1));
     }
+
+    @Test
+    public void sha256longHandlesLongMinValue() {
+        String testStr = "test_long_min_value_case";
+        long result = Util.sha256long(testStr);
+
+        Assertions.assertNotEquals(Long.MIN_VALUE, result,
+                "sha256long should not return Long.MIN_VALUE");
+
+        Assertions.assertEquals(result, Util.sha256long(testStr),
+                "Same input should produce same output");
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/ListPartitionPrunerV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/ListPartitionPrunerV2Test.java
@@ -108,8 +108,8 @@ public class ListPartitionPrunerV2Test {
         PartitionValueCacheKey key = new PartitionValueCacheKey(NameMapping.createForTest("db", "tb"), types);
         HiveMetaStoreCache.HivePartitionValues partitionValues = cache.getPartitionValues(key);
         Assert.assertEquals(1, partitionValues.getIdToPartitionItem().size());
-        Assert.assertTrue(partitionValues.getIdToPartitionItem().containsKey(340570103551932031L));
-        List<PartitionKey> items = partitionValues.getIdToPartitionItem().get(340570103551932031L).getItems();
+        Assert.assertTrue(partitionValues.getIdToPartitionItem().containsKey(8882801933302843777L));
+        List<PartitionKey> items = partitionValues.getIdToPartitionItem().get(8882801933302843777L).getItems();
         Assert.assertEquals(1, items.size());
         PartitionKey partitionKey = items.get(0);
         Assert.assertEquals("1.234", partitionKey.getKeys().get(0).toString());
@@ -135,8 +135,8 @@ public class ListPartitionPrunerV2Test {
         HiveMetaStoreCache.HivePartitionValues partitionValues3 = cache.getPartitionValues(
                 new PartitionValueCacheKey(NameMapping.createForTest(dbName, tblName), types));
         Assert.assertEquals(1, partitionValues3.getIdToPartitionItem().size());
-        Assert.assertTrue(partitionValues3.getIdToPartitionItem().containsKey(340570103551932031L));
-        List<PartitionKey> items3 = partitionValues3.getIdToPartitionItem().get(340570103551932031L).getItems();
+        Assert.assertTrue(partitionValues3.getIdToPartitionItem().containsKey(8882801933302843777L));
+        List<PartitionKey> items3 = partitionValues3.getIdToPartitionItem().get(8882801933302843777L).getItems();
         Assert.assertEquals(1, items3.size());
         PartitionKey partitionKey3 = items3.get(0);
         Assert.assertEquals("1.234", partitionKey3.getKeys().get(0).toString());

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/ListPartitionPrunerV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/ListPartitionPrunerV2Test.java
@@ -108,8 +108,8 @@ public class ListPartitionPrunerV2Test {
         PartitionValueCacheKey key = new PartitionValueCacheKey(NameMapping.createForTest("db", "tb"), types);
         HiveMetaStoreCache.HivePartitionValues partitionValues = cache.getPartitionValues(key);
         Assert.assertEquals(1, partitionValues.getIdToPartitionItem().size());
-        Assert.assertTrue(partitionValues.getIdToPartitionItem().containsKey(8882801933302843777L));
-        List<PartitionKey> items = partitionValues.getIdToPartitionItem().get(8882801933302843777L).getItems();
+        Assert.assertTrue(partitionValues.getIdToPartitionItem().containsKey(340570103551932031L));
+        List<PartitionKey> items = partitionValues.getIdToPartitionItem().get(340570103551932031L).getItems();
         Assert.assertEquals(1, items.size());
         PartitionKey partitionKey = items.get(0);
         Assert.assertEquals("1.234", partitionKey.getKeys().get(0).toString());
@@ -135,8 +135,8 @@ public class ListPartitionPrunerV2Test {
         HiveMetaStoreCache.HivePartitionValues partitionValues3 = cache.getPartitionValues(
                 new PartitionValueCacheKey(NameMapping.createForTest(dbName, tblName), types));
         Assert.assertEquals(1, partitionValues3.getIdToPartitionItem().size());
-        Assert.assertTrue(partitionValues3.getIdToPartitionItem().containsKey(8882801933302843777L));
-        List<PartitionKey> items3 = partitionValues3.getIdToPartitionItem().get(8882801933302843777L).getItems();
+        Assert.assertTrue(partitionValues3.getIdToPartitionItem().containsKey(340570103551932031L));
+        List<PartitionKey> items3 = partitionValues3.getIdToPartitionItem().get(340570103551932031L).getItems();
         Assert.assertEquals(1, items3.size());
         PartitionKey partitionKey3 = items3.get(0);
         Assert.assertEquals("1.234", partitionKey3.getKeys().get(0).toString());


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
`Replace Math.abs() with bitwise AND operation in genIdByName() method`

problem:
- Math.abs(Long.MIN_VALUE) returns Long.MIN_VALUE (still negative) due to overflow
- This violates the requirement that external db/table IDs must be >= 0
- Could cause issues in DescriptorTable.toThrift() as mentioned in comments

fix:
- Use bitwise AND with Long.MAX_VALUE to clear the sign bit
- Guarantees non-negative result in range [0, Long.MAX_VALUE]
- Better performance than Math.abs() conditional check

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

