### PR TITLE
Update thirdparty library vectorscan

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -395,10 +395,10 @@ fi
 # patch hyperscan
 # https://github.com/intel/hyperscan/issues/292
 if [[ " ${TP_ARCHIVES[*]} " =~ " HYPERSCAN " ]]; then
-    if [[ "${HYPERSCAN_SOURCE}" == "vectorscan-vectorscan-5.4.11" ]]; then
+    if [[ "${HYPERSCAN_SOURCE}" == "vectorscan-vectorscan-5.4.12" ]]; then
         cd "${TP_SOURCE_DIR}/${HYPERSCAN_SOURCE}"
         if [[ ! -f "${PATCHED_MARK}" ]]; then
-            patch -p1 <"${TP_PATCH_DIR}/vectorscan-5.4.11.patch"
+            patch -p1 <"${TP_PATCH_DIR}/vectorscan-5.4.12.patch"
             touch "${PATCHED_MARK}"
         fi
         cd -

--- a/thirdparty/patches/vectorscan-5.4.11.patch
+++ b/thirdparty/patches/vectorscan-5.4.11.patch
@@ -1,40 +1,23 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1db128b..1ffad0d 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -1196,9 +1196,9 @@ endif ()
- add_subdirectory(util)
- add_subdirectory(unit)
- 
--if (EXISTS ${CMAKE_SOURCE_DIR}/tools/CMakeLists.txt)
--    add_subdirectory(tools)
--endif()
-+# if (EXISTS ${CMAKE_SOURCE_DIR}/tools/CMakeLists.txt)
-+#     add_subdirectory(tools)
-+# endif()
- if (EXISTS ${CMAKE_SOURCE_DIR}/chimera/CMakeLists.txt AND BUILD_CHIMERA)
-     add_subdirectory(chimera)
- endif()
 diff --git a/cmake/build_wrapper.sh b/cmake/build_wrapper.sh
-index 895610c..becfbf4 100755
+index d0a7e923..d7aea222 100755
 --- a/cmake/build_wrapper.sh
 +++ b/cmake/build_wrapper.sh
-@@ -17,11 +17,11 @@ KEEPSYMS=$(mktemp -p /tmp keep.syms.XXXXX)
- LIBC_SO=$("$@" --print-file-name=libc.so.6)
+@@ -25,11 +25,11 @@ if [ `uname` = "FreeBSD" ]; then
+ fi
  cp ${KEEPSYMS_IN} ${KEEPSYMS}
  # get all symbols from libc and turn them into patterns
--nm -f p -g -D ${LIBC_SO} | sed -s 's/\([^ @]*\).*/^\1$/' >> ${KEEPSYMS}
-+nm -f posix -g -D ${LIBC_SO} | sed -s 's/\([^ @]*\).*/^\1$/' >> ${KEEPSYMS}
+-nm ${NM_FLAG} p -g -D ${LIBC_SO} | sed 's/\([^ @]*\).*/^\1$/' >> ${KEEPSYMS}
++nm ${NM_FLAG} posix -g -D ${LIBC_SO} | sed 's/\([^ @]*\).*/^\1$/' >> ${KEEPSYMS}
  # build the object
  "$@"
  # rename the symbols in the object
--nm -f p -g ${OUT} | cut -f1 -d' ' | grep -v -f ${KEEPSYMS} | sed -e "s/\(.*\)/\1\ ${PREFIX}_\1/" >> ${SYMSFILE}
-+nm -f posix -g ${OUT} | cut -f1 -d' ' | grep -v -f ${KEEPSYMS} | sed -e "s/\(.*\)/\1\ ${PREFIX}_\1/" >> ${SYMSFILE}
+-nm ${NM_FLAG} p -g ${OUT} | cut -f1 -d' ' | grep -v -f ${KEEPSYMS} | sed -e "s/\(.*\)/\1\ ${PREFIX}_\1/" >> ${SYMSFILE}
++nm ${NM_FLAG} posix -g ${OUT} | cut -f1 -d' ' | grep -v -f ${KEEPSYMS} | sed -e "s/\(.*\)/\1\ ${PREFIX}_\1/" >> ${SYMSFILE}
  if test -s ${SYMSFILE}
  then
      objcopy --redefine-syms=${SYMSFILE} ${OUT}
 diff --git a/src/util/arch/arm/cpuid_inline.h b/src/util/arch/arm/cpuid_inline.h
-index f8a59af..3e28d00 100644
+index f8a59af3..3e28d009 100644
 --- a/src/util/arch/arm/cpuid_inline.h
 +++ b/src/util/arch/arm/cpuid_inline.h
 @@ -39,6 +39,10 @@
@@ -48,3 +31,4 @@ index f8a59af..3e28d00 100644
  #include "ue2common.h"
  #include "util/arch/common/cpuid_flags.h"
  
+

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -161,10 +161,10 @@ HYPERSCAN_MD5SUM="202f4b42f5dd4a7bb2506445e51a33b9"
 MACHINE_TYPE=$(uname -m)
 if [[ "${MACHINE_TYPE}" == "aarch64" || "${MACHINE_TYPE}" == 'arm64' ]]; then
     echo "use vectorscan instead of hyperscan on aarch64"
-    HYPERSCAN_DOWNLOAD="https://github.com/VectorCamp/vectorscan/archive/refs/tags/vectorscan/5.4.11.tar.gz"
-    HYPERSCAN_NAME=vectorscan-5.4.11.tar.gz
-    HYPERSCAN_SOURCE=vectorscan-vectorscan-5.4.11
-    HYPERSCAN_MD5SUM="e67b70403cba6c1654a9fef4fd15a2f2"
+    HYPERSCAN_DOWNLOAD="https://github.com/VectorCamp/vectorscan/archive/refs/tags/vectorscan/5.4.12.tar.gz"
+    HYPERSCAN_NAME=vectorscan-5.4.12.tar.gz
+    HYPERSCAN_SOURCE=vectorscan-vectorscan-5.4.12
+    HYPERSCAN_MD5SUM="384eab5b23831993df96e5fa55f9951e"
 fi
 
 # ragel (dependency for hyperscan)


### PR DESCRIPTION
Currently, Doris bundles and uses an older version of vectorscan (a fork of HyperScan optimized for SIMD). To address known bugs, improve stability, support risc-v,and gain performance benefits, it is necessary to upgrade this dependency to the latest release version.

**Proposal**
Update the bundled vectorscan library from its current version to 5.4.12.

**Reason for Change**
This upgrade brings a multitude of fixes and optimizations, most notably:
Performance Improvement: Utilizes 256-bit TBL instructions to significantly speed up the truffle instruction.
Critical Bugfixes: Resolves several severe issues that could lead to incorrect results or runtime failures

**Reference**
Full changelog and release notes: https://github.com/VectorCamp/vectorscan/releases/tag/vectorscan%2F5.4.12
