### PR TITLE
[opt](nereids)set topn lazy materialization threshold to avoid useless lazy materiation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/PlanPostProcessors.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/PlanPostProcessors.java
@@ -65,7 +65,7 @@ public class PlanPostProcessors {
         Builder<PlanPostProcessor> builder = ImmutableList.builder();
         builder.add(new PushDownFilterThroughProject());
         builder.add(new RemoveUselessProjectPostProcessor());
-        if (cascadesContext.getConnectContext().getSessionVariable().enableTopnLazyMaterialization) {
+        if (cascadesContext.getConnectContext().getSessionVariable().enableTopnLazyMaterialization()) {
             // LazyMaterializeTopN should run before MergeProjectPostProcessor
             builder.add(new LazyMaterializeTopN());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/materialize/LazyMaterializeTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/materialize/LazyMaterializeTopN.java
@@ -32,6 +32,8 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalCatalogRelation;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalLazyMaterialize;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalTopN;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -64,6 +66,9 @@ public class LazyMaterializeTopN extends PlanPostProcessor {
     @Override
     public Plan visitPhysicalTopN(PhysicalTopN topN, CascadesContext ctx) {
         if (hasMaterialized) {
+            return topN;
+        }
+        if (SessionVariable.getTopNLazyMaterializationThreshold() < topN.getLimit() + topN.getOffset()) {
             return topN;
         }
         /*

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/materialize/LazyMaterializeTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/materialize/LazyMaterializeTopN.java
@@ -32,7 +32,6 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalCatalogRelation;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalLazyMaterialize;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalTopN;
-import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.collect.BiMap;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/materialize/MaterializeProbeVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/materialize/MaterializeProbeVisitor.java
@@ -33,8 +33,6 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalOlapScan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalSetOperation;
 import org.apache.doris.nereids.trees.plans.visitor.DefaultPlanVisitor;
-import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.collect.ImmutableSet;
 import org.apache.logging.log4j.LogManager;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/materialize/MaterializeProbeVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/materialize/MaterializeProbeVisitor.java
@@ -33,6 +33,8 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalOlapScan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalSetOperation;
 import org.apache.doris.nereids.trees.plans.visitor.DefaultPlanVisitor;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.collect.ImmutableSet;
 import org.apache.logging.log4j.LogManager;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/DeferMaterializeTopNResult.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/DeferMaterializeTopNResult.java
@@ -261,7 +261,7 @@ public class DeferMaterializeTopNResult implements RewriteRuleFactory {
     private Plan deferMaterialize(LogicalResultSink<? extends Plan> logicalResultSink,
             LogicalTopN<? extends Plan> logicalTopN, Optional<LogicalProject<? extends Plan>> logicalProject,
             Optional<LogicalFilter<? extends Plan>> logicalFilter, LogicalOlapScan logicalOlapScan) {
-        if (ConnectContext.get() != null && ConnectContext.get().getSessionVariable().enableTopnLazyMaterialization) {
+        if (ConnectContext.get() != null && ConnectContext.get().getSessionVariable().enableTopnLazyMaterialization()) {
             return null;
         }
         IdGenerator<ExprId> exprIdGenerator = StatementScopeIdGenerator.getExprIdGenerator();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1384,10 +1384,23 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = USE_RF_DEFAULT)
     public boolean useRuntimeFilterDefaultSize = false;
 
-    @VariableMgr.VarAttr(name = "enable_topn_lazy_materialization", needForward = true,
+    @VariableMgr.VarAttr(name = "topn_lazy_materialization_threshold", needForward = true,
             fuzzy = false,
             varType = VariableAnnotation.EXPERIMENTAL)
-    public boolean enableTopnLazyMaterialization = true;
+    public int topNLazyMaterializationThreshold = 512 * 1024;
+
+    public boolean enableTopnLazyMaterialization() {
+        return ConnectContext.get() != null
+                && ConnectContext.get().getSessionVariable().topNLazyMaterializationThreshold > 0;
+    }
+
+    public static int getTopNLazyMaterializationThreshold() {
+        if (ConnectContext.get()!= null) {
+            return ConnectContext.get().getSessionVariable().topNLazyMaterializationThreshold;
+        } else {
+            return VariableMgr.getDefaultSessionVariable().topNLazyMaterializationThreshold;
+        }
+    }
 
     @VariableMgr.VarAttr(name = DISABLE_INVERTED_INDEX_V1_FOR_VARIANT, needForward = true)
     private boolean disableInvertedIndexV1ForVaraint = true;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1395,7 +1395,7 @@ public class SessionVariable implements Serializable, Writable {
     }
 
     public static int getTopNLazyMaterializationThreshold() {
-        if (ConnectContext.get()!= null) {
+        if (ConnectContext.get() != null) {
             return ConnectContext.get().getSessionVariable().topNLazyMaterializationThreshold;
         } else {
             return VariableMgr.getDefaultSessionVariable().topNLazyMaterializationThreshold;

--- a/regression-test/suites/external_table_p0/hive/test_hive_topn_lazy_mat.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_topn_lazy_mat.groovy
@@ -160,7 +160,7 @@ suite("test_hive_topn_lazy_mat", "p0,external,hive,external_docker,external_dock
 
 
         sql """
-        set enable_topn_lazy_materialization=true;
+        set topn_lazy_materialization_threshold=1024;
         set runtime_filter_mode=GLOBAL;
         set TOPN_FILTER_RATIO=0.5;
         set disable_join_reorder=true;
@@ -199,7 +199,7 @@ suite("test_hive_topn_lazy_mat", "p0,external,hive,external_docker,external_dock
         runTopNLazyMatTests()
 
 
-        sql """ set enable_topn_lazy_materialization=false; """
+        sql """ set topn_lazy_materialization_threshold=-1; """
         runTopNLazyMatTests()
 
 

--- a/regression-test/suites/nereids_rules_p0/defer_materialize_topn/lazy_materialize_topn.groovy
+++ b/regression-test/suites/nereids_rules_p0/defer_materialize_topn/lazy_materialize_topn.groovy
@@ -18,7 +18,7 @@ suite("lazy_materialize_topn") {
     sql """
         set enable_two_phase_read_opt = true;
         set topn_opt_limit_threshold = 1000;
-        set enable_topn_lazy_materialization = false;
+        set topn_lazy_materialization_threshold = -1;
     """
 
     sql """

--- a/regression-test/suites/query_p0/sort/sort.groovy
+++ b/regression-test/suites/query_p0/sort/sort.groovy
@@ -21,7 +21,7 @@
 
 suite("sort") {
     // this case is used to test defer materialze, and hence turn topn_lazy_materialization off
-    sql """set enable_topn_lazy_materialization=false;"""
+    sql """set topn_lazy_materialization_threshold=-1;"""
     qt_sort_string_single_column """ select * from ( select '汇总' as a union all select '2022-01-01' as a ) a order by 1 """
     qt_sort_string_multiple_columns """ select * from ( select '汇总' as a,1 as b union all select '2022-01-01' as a,1 as b ) a order by 1,2 """
     qt_sort_string_on_fe """ select '汇总' > '2022-01-01' """

--- a/regression-test/suites/query_p0/sort/topn_2pr_rule.groovy
+++ b/regression-test/suites/query_p0/sort/topn_2pr_rule.groovy
@@ -19,7 +19,7 @@ suite("topn_2pr_rule") {
     sql """set topn_opt_limit_threshold = 1024"""
     sql """set enable_two_phase_read_opt= true"""
     // this case is used to test defer materialze, and hence turn topn_lazy_materialization off
-    sql """set enable_topn_lazy_materialization=false;"""
+    sql """set topn_lazy_materialization_threshold=-1;"""
 
     def create_table = { table_name, key_type="DUPLICATE" ->
         sql "DROP TABLE IF EXISTS ${table_name}"

--- a/regression-test/suites/query_p0/sort_spill/sort_spill.groovy
+++ b/regression-test/suites/query_p0/sort_spill/sort_spill.groovy
@@ -32,7 +32,7 @@ suite("sort_spill") {
     sql """ set parallel_pipeline_task_num = 2; """
     sql """ set batch_size = 100; """
     sql """ set enable_force_spill=true; """
-    sql """ set enable_topn_lazy_materialization=false;"""
+    sql """ set topn_lazy_materialization_threshold=-1;"""
     sql """ set enable_reserve_memory=true; """
     sql """ set force_sort_algorithm = "full"; """
     sql """ set enable_parallel_result_sink=true; """

--- a/regression-test/suites/query_p0/topn_lazy/topn_lazy.groovy
+++ b/regression-test/suites/query_p0/topn_lazy/topn_lazy.groovy
@@ -17,7 +17,7 @@
 
 suite("topn_lazy") {
     sql """
-        set enable_topn_lazy_materialization=true;
+        set topn_lazy_materialization_threshold=1024;
         set runtime_filter_mode=GLOBAL;
         set TOPN_FILTER_RATIO=0.5;
         set disable_join_reorder=true;
@@ -32,6 +32,11 @@ suite("topn_lazy") {
         contains("row_ids: [__DORIS_GLOBAL_ROWID_COL__lineorder]")
     }
 
+    // no topn lazy since huge limit
+    explain {
+        sql "select lo_suppkey, lo_commitdate from lineorder where lo_orderkey>100 order by lo_orderkey  limit 1025;"
+        notContains("VMaterializeNode")
+    }
 
     // single table select some slots
     explain {


### PR DESCRIPTION
### What problem does this PR solve?
if topn limit is huge, lazy materialization is useless.
In this pr, SessionVariable.enableTopnLazyMaterialization is replaced by topNLazyMaterializationThreshold，
when topNLazyMaterializationThreshold <  topn.limit+topn.offset, lazy materialization is diabled

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

