### PR TITLE
[Fix](kerberos)Ensure Hadoop Configuration sets kerberos authentication for HMS access

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/HadoopKerberosAuthenticator.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/HadoopKerberosAuthenticator.java
@@ -163,10 +163,10 @@ public class HadoopKerberosAuthenticator implements HadoopAuthenticator {
                 }
                 Map<String, String> options = builder.build();
                 return new AppConfigurationEntry[]{
-                        new AppConfigurationEntry(
-                                "com.sun.security.auth.module.Krb5LoginModule",
-                                AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
-                                options)};
+                    new AppConfigurationEntry(
+                        "com.sun.security.auth.module.Krb5LoginModule",
+                        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+                        options)};
             }
         };
     }

--- a/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/HadoopKerberosAuthenticator.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/security/authentication/HadoopKerberosAuthenticator.java
@@ -64,6 +64,11 @@ public class HadoopKerberosAuthenticator implements HadoopAuthenticator {
         if (ugi == null) {
             subject = getSubject(config.getKerberosKeytab(), config.getKerberosPrincipal(), config.isPrintDebugLog());
             ugi = Objects.requireNonNull(login(subject), "login result is null");
+            if (LOG.isDebugEnabled()) {
+                Date lastTicketEndTime = getTicketEndTime(subject);
+                LOG.debug("Kerberos principal: {}, last ticket end time: {}",
+                        config.getKerberosPrincipal(), lastTicketEndTime);
+            }
             return ugi;
         }
         if (nextRefreshTime < System.currentTimeMillis()) {
@@ -97,6 +102,11 @@ public class HadoopKerberosAuthenticator implements HadoopAuthenticator {
                 LOG.debug("Refresh kerberos ticket succeeded, last time is {}, next time is {}",
                         lastRefreshTime, nextRefreshTime);
             }
+        }
+        if (LOG.isDebugEnabled()) {
+            Date lastTicketEndTime = getTicketEndTime(subject);
+            LOG.debug("Kerberos principal: {}, last ticket end time: {}",
+                    config.getKerberosPrincipal(), lastTicketEndTime);
         }
         return ugi;
     }
@@ -153,10 +163,10 @@ public class HadoopKerberosAuthenticator implements HadoopAuthenticator {
                 }
                 Map<String, String> options = builder.build();
                 return new AppConfigurationEntry[]{
-                    new AppConfigurationEntry(
-                        "com.sun.security.auth.module.Krb5LoginModule",
-                        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
-                        options)};
+                        new AppConfigurationEntry(
+                                "com.sun.security.auth.module.Krb5LoginModule",
+                                AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+                                options)};
             }
         };
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/HMSBaseProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/HMSBaseProperties.java
@@ -165,6 +165,7 @@ public class HMSBaseProperties {
                 && this.hdfsAuthenticationType.equalsIgnoreCase("kerberos")) {
             KerberosAuthenticationConfig authenticationConfig = new KerberosAuthenticationConfig(
                     this.hdfsKerberosPrincipal, this.hdfsKerberosKeytab, hiveConf);
+            hiveConf.set("hadoop.security.authentication", "kerberos");
             this.hmsAuthenticator = HadoopAuthenticator.getHadoopAuthenticator(authenticationConfig);
             return;
         }


### PR DESCRIPTION


### What problem does this PR solve?

When connecting to a Hive Metastore (HMS) that uses Kerberos authentication, Hadoop clients must have `hadoop.security.authentication` set to `kerberos`. Without this setting, RPC calls may fail with authentication errors, such as "org.apache.hadoop.security.AccessControlException: SIMPLE authentication is not enabled.  Available:[TOKEN, KERBEROS]".

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

