### PR TITLE
[chore](cast) Add a unified error code to cast

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -80,7 +80,8 @@ namespace ErrorCode {
     TStatusError(NOT_MASTER, true);                       \
     TStatusError(OBTAIN_LOCK_FAILED, false);              \
     TStatusError(SNAPSHOT_EXPIRED, false);                \
-    TStatusError(DELETE_BITMAP_LOCK_ERROR, false);
+    TStatusError(DELETE_BITMAP_LOCK_ERROR, false);        \
+    TStatusError(CONVERSION, false);
 // E error_name, error_code, print_stacktrace
 #define APPLY_FOR_OLAP_ERROR_CODES(E)                        \
     E(OK, 0, false);                                         \
@@ -512,6 +513,7 @@ public:
     ERROR_CTOR_NOSTACK(CgroupError, CGROUP_ERROR)
     ERROR_CTOR_NOSTACK(ObtainLockFailed, OBTAIN_LOCK_FAILED)
     ERROR_CTOR_NOSTACK(NetworkError, NETWORK_ERROR)
+    ERROR_CTOR_NOSTACK(Conversion, CONVERSION)
 #undef ERROR_CTOR
 
     template <int code>

--- a/be/src/vec/functions/cast/function_cast.cpp
+++ b/be/src/vec/functions/cast/function_cast.cpp
@@ -312,7 +312,6 @@ protected:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
         auto st = wrapper_function(context, block, arguments, result, input_rows_count, nullptr);
-        ;
         if (!st.ok()) {
             return Status::Conversion(st.msg());
         }

--- a/be/src/vec/functions/cast/function_cast.cpp
+++ b/be/src/vec/functions/cast/function_cast.cpp
@@ -29,6 +29,7 @@
 #include "cast_to_string.h"
 #include "cast_to_struct.h"
 #include "cast_to_variant.h"
+#include "common/status.h"
 #include "runtime/primitive_type.h"
 #include "vec/data_types/data_type_agg_state.h"
 #include "vec/data_types/data_type_decimal.h"
@@ -310,7 +311,12 @@ public:
 protected:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
-        return wrapper_function(context, block, arguments, result, input_rows_count, nullptr);
+        auto st = wrapper_function(context, block, arguments, result, input_rows_count, nullptr);
+        ;
+        if (!st.ok()) {
+            return Status::Conversion(st.msg());
+        }
+        return Status::OK();
     }
 
     bool use_default_implementation_for_nulls() const override { return false; }

--- a/gensrc/thrift/Status.thrift
+++ b/gensrc/thrift/Status.thrift
@@ -110,6 +110,8 @@ enum TStatusCode {
 
     SNAPSHOT_EXPIRED = 75,
 
+    CONVERSION = 76,
+
     // used for cloud
     DELETE_BITMAP_LOCK_ERROR = 100,
     // Not be larger than 200, see status.h


### PR DESCRIPTION
### What problem does this PR solve?

```
mysql> select cast('abc' as int);
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]parse number fail, string: 'abc'
```
now
```
mysql> select cast('abc' as int);
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[CONVERSION]parse number fail, string: 'abc'
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

