### PR TITLE
[fix](maxcompute)fix maxcompute catalog international user can not access.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/MaxComputeExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/MaxComputeExternalCatalog.java
@@ -214,6 +214,13 @@ public class MaxComputeExternalCatalog extends ExternalCatalog {
         this.odps = new Odps(account);
         odps.setDefaultProject(defaultProject);
         odps.setEndpoint(endpoint);
+
+        String accountFormatProp = props.getOrDefault(MCProperties.ACCOUNT_FORMAT, MCProperties.DEFAULT_ACCOUNT_FORMAT);
+        if (accountFormatProp.equals(MCProperties.ACCOUNT_FORMAT_NAME)) {
+            accountFormat = AccountFormat.DISPLAYNAME;
+        } else if (accountFormatProp.equals(MCProperties.ACCOUNT_FORMAT_ID)) {
+            accountFormat = AccountFormat.ID;
+        }
         odps.setAccountFormat(accountFormat);
         Credentials credentials = Credentials.newBuilder().withAccount(odps.getAccount())
                 .withAppAccount(odps.getAppAccount()).build();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/MaxComputeExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/maxcompute/MaxComputeExternalCatalog.java
@@ -31,6 +31,7 @@ import com.aliyun.odps.OdpsException;
 import com.aliyun.odps.Partition;
 import com.aliyun.odps.Project;
 import com.aliyun.odps.account.Account;
+import com.aliyun.odps.account.AccountFormat;
 import com.aliyun.odps.account.AliyunAccount;
 import com.aliyun.odps.security.SecurityManager;
 import com.aliyun.odps.table.configuration.RestOptions;
@@ -77,6 +78,8 @@ public class MaxComputeExternalCatalog extends ExternalCatalog {
     private int retryTimes;
 
     public boolean dateTimePredicatePushDown;
+
+    AccountFormat accountFormat = AccountFormat.DISPLAYNAME;
 
     private static final Map<String, ZoneId> REGION_ZONE_MAP;
     private static final List<String> REQUIRED_PROPERTIES = ImmutableList.of(
@@ -211,6 +214,7 @@ public class MaxComputeExternalCatalog extends ExternalCatalog {
         this.odps = new Odps(account);
         odps.setDefaultProject(defaultProject);
         odps.setEndpoint(endpoint);
+        odps.setAccountFormat(accountFormat);
         Credentials credentials = Credentials.newBuilder().withAccount(odps.getAccount())
                 .withAppAccount(odps.getAppAccount()).build();
 
@@ -427,6 +431,14 @@ public class MaxComputeExternalCatalog extends ExternalCatalog {
                     + MCProperties.SPLIT_ROW_COUNT + "must be an integer");
         }
 
+        String accountFormatProp = props.getOrDefault(MCProperties.ACCOUNT_FORMAT, MCProperties.DEFAULT_ACCOUNT_FORMAT);
+        if (accountFormatProp.equals(MCProperties.ACCOUNT_FORMAT_NAME)) {
+            accountFormat = AccountFormat.DISPLAYNAME;
+        } else if (accountFormatProp.equals(MCProperties.ACCOUNT_FORMAT_ID)) {
+            accountFormat = AccountFormat.ID;
+        } else {
+            throw new DdlException("property " + MCProperties.ACCOUNT_FORMAT + "only support name and id");
+        }
 
         try {
             connectTimeout = Integer.parseInt(

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/MCProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/MCProperties.java
@@ -75,6 +75,13 @@ public class MCProperties extends BaseProperties {
             "mc.datetime_predicate_push_down";
     public static final String DEFAULT_DATETIME_PREDICATE_PUSH_DOWN = "true";
 
+    // The account systems for Alibaba Cloud China and International are different. If the primary account is an
+    // International user, specify ACCOUNT_FORMAT as ACCOUNT_FORMAT_ID. Otherwise, specify ACCOUNT_FORMAT_NAME.
+    public static final String ACCOUNT_FORMAT = "mc.account_format";
+    public static final String ACCOUNT_FORMAT_NAME = "name";
+    public static final String ACCOUNT_FORMAT_ID = "id";
+    public static final String DEFAULT_ACCOUNT_FORMAT = ACCOUNT_FORMAT_NAME;
+
     public static CloudCredential getCredential(Map<String, String> props) {
         return getCloudCredential(props, ACCESS_KEY, SECRET_KEY, SESSION_TOKEN);
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx
Problem Summary:

fix : maxcompute catalog 
```
mysql> show databases;
ERROR 1105 (HY000): errCode = 2, detailMessage = ODPS-0420061: Invalid parameter in HTTP request - user 'RAM$xxxxxx:xxxxx' is not a valid aliyun account.
```

The account systems for Alibaba Cloud China and International are different. If the primary account is an International user, specify `mc.account_format` as `id`. Otherwise, specify `name`.



### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

