### PR TITLE
[opt](nereids) variant sub path pruning check circular reference

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/VariantSubPathPruning.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/VariantSubPathPruning.java
@@ -139,6 +139,7 @@ public class VariantSubPathPruning extends DefaultPlanRewriter<PruneContext> imp
         private final Map<Slot, Map<List<String>, SlotReference>> slotToSlotsMap = Maps.newHashMap();
 
         public boolean hasCircularReference() {
+            // alias(a as b),  alias(b as c), alias(c as a) will cause dead loop
             for (Slot key : slotToOriginalExprMap.keySet()) {
                 Set<Slot> visited = Sets.newHashSet();
                 Expression expr = key;


### PR DESCRIPTION
### What problem does this PR solve?

VariantSubPathPruning contains code:
```
 while (context.slotToOriginalExprMap.containsKey(key)) {
         key = context.slotToOriginalExprMap.get(key);
 }
```

if there's curcular references in slotToOriginalExprMap,  it will make a dead loop in the while statement,

so add a check, if there's a curcular refenrence for slotToOriginalExprMap,  will skip this rule rewritten.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

