### PR TITLE
[fix](exec)  fix VDataStreamRecvr not removed from VDataStreamMgr.

### DIFF
--- a/be/src/pipeline/exec/exchange_source_operator.h
+++ b/be/src/pipeline/exec/exchange_source_operator.h
@@ -41,6 +41,8 @@ public:
     using Base = PipelineXLocalState<>;
     ExchangeLocalState(RuntimeState* state, OperatorXBase* parent);
 
+    ~ExchangeLocalState() override;
+
     Status init(RuntimeState* state, LocalStateInfo& info) override;
     Status open(RuntimeState* state) override;
     Status close(RuntimeState* state) override;


### PR DESCRIPTION
### What problem does this PR solve?

It is necessary to call stream_recvr->close() in ~ExchangeLocalState.
This is because VDataStreamRecvr is initialized during init and then added to VDataStreamMgr.
When closing, VDataStreamRecvr is removed from VDataStreamMgr.
However, in some error situations, the pipeline may not be opened and therefore may not be closed either.
The close method of VDataStreamRecvr contains checks and will not be closed multiple times.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

