### PR TITLE
[enhancement](fe) Make sure the FE Catalog is not ready before add.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -3197,7 +3197,7 @@ public class Env {
                 editLog.logAddFrontend(fe);
             } else {
                 bdbha.removeUnReadyElectableNode(nodeName, getFollowerCount());
-                throw new DdlException("the catalog of " + nodeName " is ready, cannot be added, please check again");
+                throw new DdlException("the catalog of " + nodeName + " is ready, cannot be added, please check again");
             }
         } finally {
             unlock();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
This enhancement ensures that the Frontend (FE) Catalog in Apache Doris is not marked as ready before all necessary preparations and initializations are completed. It should be noted that in this case, if you drop a normal fe node that has been added, you cannot directly add it back, but you need to completely empty it before adding it.

### Release note

Enhancement: Ensure FE nodes are in a pending state before being added to the cluster to prevent simultaneous addition of multiple master nodes, improving system reliability and consistency.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

