### PR TITLE
[fix](iceberg)Enforce authentication before executing branch/tag DDL operations

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/IcebergExternalTableBranchAndTagTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/IcebergExternalTableBranchAndTagTest.java
@@ -159,7 +159,7 @@ public class IcebergExternalTableBranchAndTagTest {
 
         // create an existed tag: tag1
         Assertions.assertThrows(
-                IllegalArgumentException.class,
+                RuntimeException.class,
                 () -> catalog.createOrReplaceTag(dorisTable, info));
 
         // create an existed tag with replace
@@ -241,8 +241,7 @@ public class IcebergExternalTableBranchAndTagTest {
                 true, null, null, null);
 
         // create an existed branch, failed
-        Assertions.assertThrows(
-                IllegalArgumentException.class,
+        Assertions.assertThrowsExactly(RuntimeException.class,
                 () -> catalog.createOrReplaceBranch(dorisTable, info));
 
         // create or replace an empty branch, will fail


### PR DESCRIPTION
…

### What problem does this PR solve?

```
Caused by: org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[TOKEN, KERBEROS]
        at org.apache.hadoop.security.SaslRpcClient.selectSaslClient(SaslRpcClient.java:179) ~[hadoop-common-3.3.6.jar:?]
        at org.apache.hadoop.security.SaslRpcClient.saslConnect(SaslRpcClient.java:392) ~[hadoop-common-3.3.6.jar:?]
        at org.apache.hadoop.ipc.Client$Connection.setupSaslConnection(Client.java:561) ~[hadoop-common-3.3.6.jar:?]
        at org.apache.hadoop.ipc.Client$Connection.access$2100(Client.java:347) ~[hadoop-common-3.3.6.jar:?]
        at org.apache.hadoop.ipc.Client$Connection$2.run(Client.java:783) ~[hadoop-common-3.3.6.jar:?]
        at org.apache.hadoop.ipc.Client$Connection$2.run(Client.java:779) ~[hadoop-common-3.3.6.jar:?]
        at java.security.AccessController.doPrivileged(AccessController.java:712) ~[?:?]
        at javax.security.auth.Subject.doAs(Subject.java:439) ~[?:?]
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1899) ~[hadoop-common-3.3.6.jar:?]
        at org.apache.hadoop.ipc.Client$Connection.setupIOstreams(Client.java:779) ~[hadoop-common-3.3.6.jar:?]
        at org.apache.hadoop.ipc.Client$Connection.access$3800(Client.java:347) ~[hadoop-common-3.3.6.jar:?]
        at org.apache.hadoop.ipc.Client.getConnection(Client.java:1632) ~[hadoop-common-3.3.6.jar:?]
        at org.apache.hadoop.ipc.Client.call(Client.java:1457) ~[hadoop-common-3.3.6.jar:?]
        at org.apache.hadoop.ipc.Client.call(Client.java:1410) ~[hadoop-common-3.3.6.jar:?]
        at org.apache.hadoop.ipc.ProtobufRpcEngine2$Invoker.invoke(ProtobufRpcEngine2.java:258) ~[hadoop-common-3.3.6.jar:?]
        at org.apache.hadoop.ipc.ProtobufRpcEngine2$Invoker.invoke(ProtobufRpcEngine2.java:139) ~[hadoop-common-3.3.6.jar:?]
        at jdk.proxy3.$Proxy163.getFileInfo(Unknown Source) ~[?:?]
        at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolTranslatorPB.getFileInfo(ClientNamenodeProtocolTranslatorPB.java:966) ~[hadoop-hdfs-client-3.3.6.jar:?]
        at jdk.internal.reflect.GeneratedMethodAccessor62.invoke(Unknown Source) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
        at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:433) ~[hadoop-common-3.3.6.jar:?]
        at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invokeMethod(RetryInvocationHandler.java:166) ~[hadoop-common-3.3.6.jar:?]
        at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invoke(RetryInvocationHandler.java:158) ~[hadoop-common-3.3.6.jar:?]
        at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invokeOnce(RetryInvocationHandler.java:96) ~[hadoop-common-3.3.6.jar:?]
        at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:362) ~[hadoop-common-3.3.6.jar:?]
        at jdk.proxy3.$Proxy164.getFileInfo(Unknown Source) ~[?:?]
        at org.apache.hadoop.hdfs.DFSClient.getFileInfo(DFSClient.java:1739) ~[hadoop-hdfs-client-3.3.6.jar:?]
        at org.apache.hadoop.hdfs.DistributedFileSystem$29.doCall(DistributedFileSystem.java:1829) ~[hadoop-hdfs-client-3.3.6.jar:?]
        at org.apache.hadoop.hdfs.DistributedFileSystem$29.doCall(DistributedFileSystem.java:1826) ~[hadoop-hdfs-client-3.3.6.jar:?]
        at org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81) ~[hadoop-common-3.3.6.jar:?]
        at org.apache.hadoop.hdfs.DistributedFileSystem.getFileStatus(DistributedFileSystem.java:1841) ~[hadoop-hdfs-client-3.3.6.jar:?]
        at org.apache.hadoop.fs.FileSystem.exists(FileSystem.java:1862) ~[hadoop-common-3.3.6.jar:?]
        at org.apache.iceberg.hadoop.HadoopTableOperations.getMetadataFile(HadoopTableOperations.java:241) ~[iceberg-core-1.9.1.jar:?]
        at org.apache.iceberg.hadoop.HadoopTableOperations.refresh(HadoopTableOperations.java:105) ~[iceberg-core-1.9.1.jar:?]
        ... 23 more
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

