### PR TITLE
[opt](compatibility) let version mutable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlHandshakePacket.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlHandshakePacket.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.mysql;
 
+import org.apache.doris.qe.GlobalVariable;
+
 // MySQL protocol handshake packet.
 public class MysqlHandshakePacket extends MysqlPacket {
     private static final int SCRAMBLE_LENGTH = 20;
@@ -25,7 +27,7 @@ public class MysqlHandshakePacket extends MysqlPacket {
     // JDBC uses this version to check which protocol the server support
     // Set the patch version to 99 to prevent the vulnerability scanning tool from
     // falsely reporting MySQL vulnerabilities
-    public static final String SERVER_VERSION = "5.7.99";
+    public static final String DEFAULT_SERVER_VERSION = "5.7.99";
     // 33 stands for UTF-8 character set
     private static final int CHARACTER_SET = 33;
     // use default capability for all
@@ -53,7 +55,7 @@ public class MysqlHandshakePacket extends MysqlPacket {
         MysqlCapability capability = MysqlProto.SERVER_USE_SSL ? SSL_CAPABILITY : CAPABILITY;
 
         serializer.writeInt1(PROTOCOL_VERSION);
-        serializer.writeNulTerminateString(SERVER_VERSION);
+        serializer.writeNulTerminateString(GlobalVariable.version);
         serializer.writeInt4(connectionId);
         // first 8 bytes of auth plugin data
         serializer.writeBytes(authPluginData, 0, 8);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
@@ -91,8 +91,8 @@ public final class GlobalVariable {
             + Version.DORIS_BUILD_VERSION + "-" + Version.DORIS_BUILD_SHORT_HASH
             + (Config.isCloudMode() ? " (Cloud Mode)" : "");
 
-    @VariableMgr.VarAttr(name = VERSION, flag = VariableMgr.READ_ONLY)
-    public static String version = MysqlHandshakePacket.SERVER_VERSION;
+    @VariableMgr.VarAttr(name = VERSION)
+    public static String version = MysqlHandshakePacket.DEFAULT_SERVER_VERSION;
 
     // 0: table names are stored as specified and comparisons are case sensitive.
     // 1: table names are stored in lowercase on disk and comparisons are not case sensitive.


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

For some BI tools and data development tools, they send different requests depending on the MySQL version. This PR makes the version configurable, enhancing compatibility with various BI tools by allowing the setting of different server version numbers.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

