### PR TITLE
[opt](nereids) support simplify string range

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/RangeInference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/RangeInference.java
@@ -32,6 +32,7 @@ import org.apache.doris.nereids.trees.expressions.Or;
 import org.apache.doris.nereids.trees.expressions.literal.ComparableLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
+import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.util.ExpressionUtils;
 
 import com.google.common.collect.BoundType;
@@ -75,9 +76,11 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
         if (right.isNullLiteral()) {
             return new UnknownValue(context, predicate);
         }
-        // only handle `NumericType` and `DateLikeType`
+        // only handle `NumericType` and `DateLikeType` and `StringLikeType`
+        DataType rightDataType = right.getDataType();
         if (right instanceof ComparableLiteral
-                && (right.getDataType().isNumericType() || right.getDataType().isDateLikeType())) {
+                && (rightDataType.isNumericType() || rightDataType.isDateLikeType()
+                    || rightDataType.isStringLikeType())) {
             return ValueDesc.range(context, predicate);
         }
         return new UnknownValue(context, predicate);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
@@ -236,6 +236,8 @@ public class SimplifyRangeTest extends ExpressionRewrite {
         assertRewrite("(TA + TC > 3 and TA + TC < 1) or TB < 5", "((TA + TC) is null and null) OR TB < 5");
 
         assertRewrite("(TA + TC > 3 OR TA < 1) AND TB = 2 AND IA =1", "(TA + TC > 3 OR TA < 1) AND TB = 2 AND IA =1");
+        assertRewrite("SA = '20250101' and SA < '20200101'", "SA is null and null");
+        assertRewrite("SA > '20250101' and SA > '20260110'", "SA > '20260110'");
 
         // random is non-foldable, so the two random(1, 10) are distinct, cann't merge range for them.
         Expression expr = rewrite("TA + random(1, 10) > 10 AND  TA + random(1, 10) < 1", Maps.newHashMap());


### PR DESCRIPTION
### What problem does this PR solve?

support simplify string range:

```sql
where dt > '20250101' and dt > '20260101' -- simplify to dt > '20260101'
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

