### PR TITLE
[Fix](iceberg) Fix NoSuchElementException in IcebergSysTableJniScanner when reading empty system tables

### DIFF
--- a/fe/be-java-extensions/iceberg-metadata-scanner/src/main/java/org/apache/doris/iceberg/IcebergSysTableJniScanner.java
+++ b/fe/be-java-extensions/iceberg-metadata-scanner/src/main/java/org/apache/doris/iceberg/IcebergSysTableJniScanner.java
@@ -101,9 +101,12 @@ public class IcebergSysTableJniScanner extends JniScanner {
     @Override
     protected int getNext() throws IOException {
         int rows = 0;
-        while ((reader.hasNext() || scanTasks.hasNext()) && rows < getBatchSize()) {
-            if (!reader.hasNext()) {
+        while (rows < getBatchSize()) {
+            while (!reader.hasNext() && scanTasks.hasNext()) {
                 nextScanTask();
+            }
+            if (!reader.hasNext()) {
+                break;
             }
             StructLike row = reader.next();
             for (int i = 0; i < fields.size(); i++) {


### PR DESCRIPTION
Fix NoSuchElementException that occurs when querying Iceberg system tables with empty scan tasks by ensuring proper iterator state checking before calling reader.next().