### PR TITLE
[feature]support build index for inverted/ngram in cloud

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -236,6 +236,10 @@ void AgentServer::cloud_start_workers(CloudStorageEngine& engine, ExecEnv* exec_
             "RELEASE_SNAPSHOT", config::release_snapshot_worker_count,
             [&engine](auto&& task) { return release_snapshot_callback(engine, task); });
 
+    _workers[TTaskType::ALTER_INVERTED_INDEX] = std::make_unique<TaskWorkerPool>(
+            "ALTER_INVERTED_INDEX", config::alter_index_worker_count,
+            [&engine](auto&& task) { return alter_cloud_index_callback(engine, task); });
+
     _report_workers.push_back(std::make_unique<ReportWorker>(
             "REPORT_TASK", _cluster_info, config::report_task_interval_seconds,
             [&cluster_info = _cluster_info] { report_task_callback(cluster_info); }));

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -77,6 +77,7 @@
 #include "olap/task/engine_batch_load_task.h"
 #include "olap/task/engine_checksum_task.h"
 #include "olap/task/engine_clone_task.h"
+#include "olap/task/engine_cloud_index_change_task.h"
 #include "olap/task/engine_index_change_task.h"
 #include "olap/task/engine_publish_version_task.h"
 #include "olap/task/engine_storage_migration_task.h"
@@ -776,6 +777,40 @@ void ReportWorker::stop() {
     if (_thread) {
         _thread->join();
     }
+}
+
+void alter_cloud_index_callback(CloudStorageEngine& engine, const TAgentTaskRequest& req) {
+    const auto& alter_inverted_index_rq = req.alter_inverted_index_req;
+    LOG(INFO) << "[index_change]get alter index task. signature=" << req.signature
+              << ", tablet_id=" << alter_inverted_index_rq.tablet_id
+              << ", job_id=" << alter_inverted_index_rq.job_id;
+
+    Status status = Status::OK();
+    auto tablet_ptr = engine.tablet_mgr().get_tablet(alter_inverted_index_rq.tablet_id);
+    if (tablet_ptr != nullptr) {
+        EngineCloudIndexChangeTask engine_task(engine, req.alter_inverted_index_req);
+        status = engine_task.execute();
+    } else {
+        status = Status::NotFound("could not find tablet {}", alter_inverted_index_rq.tablet_id);
+    }
+
+    // Return result to fe
+    TFinishTaskRequest finish_task_request;
+    finish_task_request.__set_backend(BackendOptions::get_local_backend());
+    finish_task_request.__set_task_type(req.task_type);
+    finish_task_request.__set_signature(req.signature);
+    if (!status.ok()) {
+        LOG(WARNING) << "[index_change]failed to alter inverted index task, signature="
+                     << req.signature << ", tablet_id=" << alter_inverted_index_rq.tablet_id
+                     << ", job_id=" << alter_inverted_index_rq.job_id << ", error=" << status;
+    } else {
+        LOG(INFO) << "[index_change]successfully alter inverted index task, signature="
+                  << req.signature << ", tablet_id=" << alter_inverted_index_rq.tablet_id
+                  << ", job_id=" << alter_inverted_index_rq.job_id;
+    }
+    finish_task_request.__set_task_status(status.to_thrift());
+    finish_task(finish_task_request);
+    remove_task_info(req.task_type, req.signature);
 }
 
 void alter_inverted_index_callback(StorageEngine& engine, const TAgentTaskRequest& req) {

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -134,6 +134,8 @@ private:
 
 void alter_inverted_index_callback(StorageEngine& engine, const TAgentTaskRequest& req);
 
+void alter_cloud_index_callback(CloudStorageEngine& engine, const TAgentTaskRequest& req);
+
 void check_consistency_callback(StorageEngine& engine, const TAgentTaskRequest& req);
 
 void upload_callback(StorageEngine& engine, ExecEnv* env, const TAgentTaskRequest& req);

--- a/be/src/cloud/cloud_delete_task.cpp
+++ b/be/src/cloud/cloud_delete_task.cpp
@@ -66,6 +66,8 @@ Status CloudDeleteTask::execute(CloudStorageEngine& engine, const TPushReq& requ
     auto tablet_schema = std::make_shared<TabletSchema>();
     // FIXME(plat1ko): Rewrite columns updating logic
     tablet_schema->update_tablet_columns(*tablet->tablet_schema(), request.columns_desc);
+    tablet_schema->update_indexes_from_thrift(request.index_list);
+
     tablet_schema->set_schema_version(request.schema_version);
     RETURN_IF_ERROR(DeleteHandler::generate_delete_predicate(*tablet_schema,
                                                              request.delete_conditions, &del_pred));

--- a/be/src/cloud/cloud_index_change_compaction.cpp
+++ b/be/src/cloud/cloud_index_change_compaction.cpp
@@ -260,7 +260,7 @@ Status CloudIndexChangeCompaction::modify_rowsets() {
     compaction_job->set_size_output_rowsets(_output_rowset->total_disk_size());
     compaction_job->set_num_input_segments(_input_segments);
     compaction_job->set_num_output_segments(_output_rowset->num_segments());
-    compaction_job->set_num_input_rowsets(_input_rowsets.size());
+    compaction_job->set_num_input_rowsets(num_input_rowsets());
     compaction_job->set_num_output_rowsets(1);
     compaction_job->add_input_versions(_input_rowsets.front()->start_version());
     compaction_job->add_input_versions(_input_rowsets.back()->end_version());

--- a/be/src/cloud/cloud_index_change_compaction.cpp
+++ b/be/src/cloud/cloud_index_change_compaction.cpp
@@ -1,0 +1,476 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "cloud/cloud_index_change_compaction.h"
+
+#include "cloud/cloud_meta_mgr.h"
+#include "cloud/config.h"
+#include "common/status.h"
+#include "cpp/sync_point.h"
+
+namespace doris {
+
+CloudIndexChangeCompaction::~CloudIndexChangeCompaction() = default;
+
+CloudIndexChangeCompaction::CloudIndexChangeCompaction(CloudStorageEngine& engine,
+                                                       CloudTabletSPtr tablet,
+                                                       int32_t schema_version,
+                                                       std::vector<TOlapTableIndex>& index_list,
+                                                       std::vector<TColumn>& columns)
+        : CloudCompactionMixin(engine, tablet,
+                               "CloudIndexChangeCompaction:" + std::to_string(tablet->tablet_id())),
+          _schema_version(schema_version),
+          _index_list(index_list),
+          _columns(columns) {}
+
+Status CloudIndexChangeCompaction::prepare_compact() {
+    TEST_SYNC_POINT_RETURN_WITH_VALUE("CloudIndexChangeCompaction::prepare_compact", Status::OK());
+
+    if (_tablet->tablet_state() != TABLET_RUNNING) {
+        LOG(WARNING) << "[index_change] tablet state is not running. tablet_id="
+                     << _tablet->tablet_id();
+        return Status::InternalError("invalid tablet state. tablet_id={}", _tablet->tablet_id());
+    }
+
+    RETURN_IF_ERROR(cloud_tablet()->sync_rowsets());
+
+    {
+        std::shared_lock rlock(_tablet->get_header_lock());
+        _base_compaction_cnt = cloud_tablet()->base_compaction_cnt();
+        _cumulative_compaction_cnt = cloud_tablet()->cumulative_compaction_cnt();
+    }
+
+    bool is_base_rowset = false;
+    auto input_rowset = DORIS_TRY(
+            cloud_tablet()->pick_a_rowset_for_index_change(_schema_version, is_base_rowset));
+    if (input_rowset == nullptr) {
+        return Status::OK();
+    }
+
+    if (is_base_rowset) {
+        _compact_type = cloud::TabletCompactionJobPB::BASE;
+    } else {
+        _compact_type = cloud::TabletCompactionJobPB::CUMULATIVE;
+    }
+
+    _input_rowsets.push_back(input_rowset);
+
+    for (auto& rs : _input_rowsets) {
+        _input_row_num += rs->num_rows();
+        _input_segments += rs->num_segments();
+        _input_rowsets_data_size += rs->data_disk_size();
+        _input_rowsets_index_size += rs->index_disk_size();
+        _input_rowsets_total_size += rs->total_disk_size();
+    }
+
+    _enable_inverted_index_compaction = false;
+    LOG_INFO("[index_change]prepare CloudIndexChangeCompaction, tablet_id={}, range=[{}-{}]",
+             _tablet->tablet_id(), _input_rowsets.front()->start_version(),
+             _input_rowsets.back()->end_version())
+            .tag("job_id", _uuid)
+            .tag("input_rowsets", _input_rowsets.size())
+            .tag("input_rows", _input_row_num)
+            .tag("input_segments", _input_segments)
+            .tag("input_rowsets_data_size", _input_rowsets_data_size)
+            .tag("input_rowsets_index_size", _input_rowsets_index_size)
+            .tag("input_rowsets_total_size", _input_rowsets_total_size)
+            .tag("tablet_max_version", cloud_tablet()->max_version_unlocked())
+            .tag("cumulative_point", cloud_tablet()->cumulative_layer_point())
+            .tag("num_rowsets", cloud_tablet()->fetch_add_approximate_num_rowsets(0))
+            .tag("cumu_num_rowsets", cloud_tablet()->fetch_add_approximate_cumu_num_rowsets(0));
+
+    return Status::OK();
+}
+
+Status CloudIndexChangeCompaction::rebuild_tablet_schema() {
+    DCHECK(_input_rowsets.size() == 1);
+    auto input_schema_ptr = _input_rowsets.back()->tablet_schema();
+
+    _cur_tablet_schema = std::make_shared<TabletSchema>();
+    _cur_tablet_schema->copy_from(*input_schema_ptr);
+    // rebuild tablet schema
+    _cur_tablet_schema->clear_columns();
+    _cur_tablet_schema->clear_index();
+
+    for (int i = 0; i < _columns.size(); i++) {
+        _cur_tablet_schema->append_column(TabletColumn(_columns[i]));
+    }
+
+    for (int i = 0; i < _index_list.size(); i++) {
+        TabletIndex index;
+        const auto& t_idx = _index_list[i];
+        index.init_from_thrift(t_idx, *_cur_tablet_schema);
+        _cur_tablet_schema->append_index(std::move(index));
+    }
+
+    _cur_tablet_schema->set_schema_version(_schema_version);
+
+    _final_tablet_schema = std::make_shared<TabletSchema>();
+    _final_tablet_schema->copy_from(*_cur_tablet_schema);
+    return Status::OK();
+}
+
+Status CloudIndexChangeCompaction::request_global_lock(bool& should_skip_err) {
+    cloud::TabletJobInfoPB job;
+    auto idx = job.mutable_idx();
+    idx->set_tablet_id(_tablet->tablet_id());
+    idx->set_table_id(_tablet->table_id());
+    idx->set_index_id(_tablet->index_id());
+    idx->set_partition_id(_tablet->partition_id());
+    auto compaction_job = job.add_compaction();
+    compaction_job->set_id(_uuid);
+    compaction_job->set_initiator(BackendOptions::get_localhost() + ':' +
+                                  std::to_string(config::heartbeat_service_port));
+    compaction_job->set_base_compaction_cnt(_base_compaction_cnt);
+    compaction_job->set_cumulative_compaction_cnt(_cumulative_compaction_cnt);
+    using namespace std::chrono;
+    int64_t now = duration_cast<seconds>(system_clock::now().time_since_epoch()).count();
+    _expiration = now + config::compaction_timeout_seconds;
+    compaction_job->set_expiration(_expiration);
+    compaction_job->set_lease(now + config::lease_compaction_interval_seconds * 4);
+
+    compaction_job->add_input_versions(_input_rowsets.front()->start_version());
+    compaction_job->add_input_versions(_input_rowsets.back()->end_version());
+
+    if (is_base_compaction()) {
+        compaction_job->set_type(cloud::TabletCompactionJobPB::BASE);
+    } else {
+        compaction_job->set_type(cloud::TabletCompactionJobPB::CUMULATIVE);
+        // Set input version range to let meta-service check version range conflict
+        compaction_job->set_check_input_versions_range(config::enable_parallel_cumu_compaction);
+    }
+
+    cloud::StartTabletJobResponse resp;
+    Status st = _engine.meta_mgr().prepare_tablet_job(job, &resp);
+    if (!st.ok()) {
+        if (resp.status().code() == cloud::STALE_TABLET_CACHE) {
+            // set last_sync_time to 0 to force sync tablet next time
+            cloud_tablet()->last_sync_time_s = 0;
+            should_skip_err = true;
+        } else if (resp.status().code() == cloud::TABLET_NOT_FOUND) {
+            // tablet not found
+#ifndef BE_TEST
+            cloud_tablet()->clear_cache();
+#endif
+        } else if (resp.status().code() == cloud::JOB_TABLET_BUSY) {
+            LOG_WARNING("[index_change]failed to prepare index change compaction")
+                    .tag("job_id", _uuid)
+                    .tag("msg", resp.status().msg());
+            return Status::Error<ErrorCode::CUMULATIVE_NO_SUITABLE_VERSION>(
+                    "index change compaction no suitable versions: job tablet busy");
+        } else if (resp.status().code() == cloud::JOB_CHECK_ALTER_VERSION) {
+            // NOTE: usually index change job and schema change job won't run run simultaneously.
+            // just log here in case;
+            (static_cast<CloudTablet*>(_tablet.get()))->set_alter_version(resp.alter_version());
+            std::stringstream ss;
+            ss << "[index_change]failed to prepare index change compaction. Check compaction input "
+                  "versions "
+                  "failed in schema change. "
+                  "input_version_start="
+               << compaction_job->input_versions(0)
+               << " input_version_end=" << compaction_job->input_versions(1)
+               << " schema_change_alter_version=" << resp.alter_version();
+            std::string msg = ss.str();
+            LOG(WARNING) << msg;
+            return Status::InternalError(msg);
+        }
+        return st;
+    }
+
+    return Status::OK();
+}
+
+Status CloudIndexChangeCompaction::execute_compact() {
+    TEST_SYNC_POINT_RETURN_WITH_VALUE("CloudIndexChangeCompaction::execute_compact", Status::OK());
+    SCOPED_ATTACH_TASK(_mem_tracker);
+
+    using namespace std::chrono;
+    auto start = steady_clock::now();
+    Status st;
+    st = CloudCompactionMixin::execute_compact();
+    if (!st.ok()) {
+        LOG(WARNING) << "[index_change]fail to do " << compaction_name() << ". res=" << st
+                     << ", tablet=" << _tablet->tablet_id()
+                     << ", output_version=" << _output_version;
+        return st;
+    }
+    LOG_INFO(
+            "[index_change]finish CloudIndexChangeCompaction, tablet_id={}, cost={}ms, "
+            "range=[{}-{}]",
+            _tablet->tablet_id(), duration_cast<milliseconds>(steady_clock::now() - start).count(),
+            _input_rowsets.front()->start_version(), _input_rowsets.back()->end_version())
+            .tag("job_id", _uuid)
+            .tag("input_rowsets", _input_rowsets.size())
+            .tag("input_rows", _input_row_num)
+            .tag("input_segments", _input_segments)
+            .tag("input_rowsets_data_size", _input_rowsets_data_size)
+            .tag("input_rowsets_index_size", _input_rowsets_index_size)
+            .tag("input_rowsets_total_size", _input_rowsets_total_size)
+            .tag("output_rows", _output_rowset->num_rows())
+            .tag("output_segments", _output_rowset->num_segments())
+            .tag("output_rowset_data_size", _output_rowset->data_disk_size())
+            .tag("output_rowset_index_size", _output_rowset->index_disk_size())
+            .tag("output_rowset_total_size", _output_rowset->total_disk_size())
+            .tag("tablet_max_version", _tablet->max_version_unlocked())
+            .tag("cumulative_point", cloud_tablet()->cumulative_layer_point())
+            .tag("num_rowsets", cloud_tablet()->fetch_add_approximate_num_rowsets(0))
+            .tag("cumu_num_rowsets", cloud_tablet()->fetch_add_approximate_cumu_num_rowsets(0))
+            .tag("local_read_time_us", _stats.cloud_local_read_time)
+            .tag("remote_read_time_us", _stats.cloud_remote_read_time)
+            .tag("local_read_bytes", _local_read_bytes_total)
+            .tag("remote_read_bytes", _remote_read_bytes_total);
+
+    _state = CompactionState::SUCCESS;
+
+    st = Status::OK();
+    return st;
+}
+
+Status CloudIndexChangeCompaction::modify_rowsets() {
+    // commit compaction job
+    cloud::TabletJobInfoPB job;
+    auto idx = job.mutable_idx();
+    idx->set_tablet_id(_tablet->tablet_id());
+    idx->set_table_id(_tablet->table_id());
+    idx->set_index_id(_tablet->index_id());
+    idx->set_partition_id(_tablet->partition_id());
+    auto compaction_job = job.add_compaction();
+    compaction_job->set_id(_uuid);
+    compaction_job->set_initiator(BackendOptions::get_localhost() + ':' +
+                                  std::to_string(config::heartbeat_service_port));
+    compaction_job->set_input_cumulative_point(cloud_tablet()->cumulative_layer_point());
+    compaction_job->set_output_cumulative_point(cloud_tablet()->cumulative_layer_point());
+    compaction_job->set_num_input_rows(_input_row_num);
+    compaction_job->set_num_output_rows(_output_rowset->num_rows());
+    compaction_job->set_size_input_rowsets(_input_rowsets_total_size);
+    compaction_job->set_size_output_rowsets(_output_rowset->total_disk_size());
+    compaction_job->set_num_input_segments(_input_segments);
+    compaction_job->set_num_output_segments(_output_rowset->num_segments());
+    compaction_job->set_num_input_rowsets(_input_rowsets.size());
+    compaction_job->set_num_output_rowsets(1);
+    compaction_job->add_input_versions(_input_rowsets.front()->start_version());
+    compaction_job->add_input_versions(_input_rowsets.back()->end_version());
+    compaction_job->add_output_versions(_output_rowset->end_version());
+    compaction_job->add_txn_id(_output_rowset->txn_id());
+    compaction_job->add_output_rowset_ids(_output_rowset->rowset_id().to_string());
+    compaction_job->set_index_size_input_rowsets(_input_rowsets_index_size);
+    compaction_job->set_segment_size_input_rowsets(_input_rowsets_data_size);
+    compaction_job->set_index_size_output_rowsets(_output_rowset->index_disk_size());
+    compaction_job->set_segment_size_output_rowsets(_output_rowset->data_disk_size());
+    compaction_job->set_type(_compact_type);
+
+    DeleteBitmapPtr output_rowset_delete_bitmap = nullptr;
+    int64_t initiator = this->initiator();
+    int64_t get_delete_bitmap_lock_start_time = 0;
+    if (_tablet->keys_type() == KeysType::UNIQUE_KEYS &&
+        _tablet->enable_unique_key_merge_on_write()) {
+        RETURN_IF_ERROR(cloud_tablet()->calc_delete_bitmap_for_compaction(
+                _input_rowsets, _output_rowset, *_rowid_conversion, compaction_type(),
+                _stats.merged_rows, _stats.filtered_rows, initiator, output_rowset_delete_bitmap,
+                _allow_delete_in_cumu_compaction, get_delete_bitmap_lock_start_time));
+        LOG_INFO(
+                "[index_change]update delete bitmap in CloudIndexChangeCompaction, tablet_id={}, "
+                "range=[{}-{}]",
+                _tablet->tablet_id(), _input_rowsets.front()->start_version(),
+                _input_rowsets.back()->end_version())
+                .tag("job_id", _uuid)
+                .tag("initiator", initiator)
+                .tag("input_rowsets", _input_rowsets.size())
+                .tag("input_rows", _input_row_num)
+                .tag("input_segments", _input_segments)
+                .tag("number_output_delete_bitmap",
+                     output_rowset_delete_bitmap->delete_bitmap.size());
+        compaction_job->set_delete_bitmap_lock_initiator(initiator);
+    }
+
+    cloud::FinishTabletJobResponse resp;
+    auto st = _engine.meta_mgr().commit_tablet_job(job, &resp);
+    //TODO: add metric for record hold delete bitmap's lock.
+
+    if (!st.ok()) {
+        if (resp.status().code() == cloud::TABLET_NOT_FOUND) {
+#ifndef BE_TEST
+            cloud_tablet()->clear_cache();
+#endif
+        } else if (resp.status().code() == cloud::JOB_CHECK_ALTER_VERSION) {
+            std::stringstream ss;
+            ss << "[index_change]failed to prepare index change compaction. Check compaction input "
+                  "versions "
+                  "failed in schema change. "
+                  "input_version_start="
+               << compaction_job->input_versions(0)
+               << " input_version_end=" << compaction_job->input_versions(1)
+               << " schema_change_alter_version=" << resp.alter_version();
+            std::string msg = ss.str();
+            LOG(WARNING) << msg;
+            cloud_tablet()->set_alter_version(resp.alter_version());
+            return Status::InternalError(msg);
+        }
+        return st;
+    }
+
+    cloud_tablet()->update_max_version_schema(_final_tablet_schema);
+
+    {
+        if (is_base_compaction()) {
+            _update_tablet_for_base_compaction(resp, output_rowset_delete_bitmap);
+        } else {
+            _update_tablet_for_cumu_compaction(resp, output_rowset_delete_bitmap);
+        }
+    }
+    return Status::OK();
+}
+
+void CloudIndexChangeCompaction::_update_tablet_for_base_compaction(
+        cloud::FinishTabletJobResponse resp, DeleteBitmapPtr output_rowset_delete_bitmap) {
+    auto& stats = resp.stats();
+    LOG(INFO) << "[index_change] tablet stats=" << stats.ShortDebugString();
+
+    {
+        std::unique_lock wrlock(_tablet->get_header_lock());
+        // clang-format off
+        cloud_tablet()->set_last_base_compaction_success_time(std::max(cloud_tablet()->last_base_compaction_success_time(), stats.last_base_compaction_time_ms()));
+        cloud_tablet()->set_last_cumu_compaction_success_time(std::max(cloud_tablet()->last_cumu_compaction_success_time(), stats.last_cumu_compaction_time_ms()));
+        cloud_tablet()->set_last_full_compaction_success_time(std::max(cloud_tablet()->last_full_compaction_success_time(), stats.last_full_compaction_time_ms()));
+        // clang-format on
+        if (cloud_tablet()->base_compaction_cnt() >= stats.base_compaction_cnt()) {
+            // This could happen while calling `sync_tablet_rowsets` during `commit_tablet_job`
+            return;
+        }
+        // Try to make output rowset visible immediately in tablet cache, instead of waiting for next synchronization from meta-service.
+        if (_input_rowsets.size() == 1) {
+            DCHECK_EQ(_output_rowset->version(), _input_rowsets[0]->version());
+            // MUST NOT move input rowset to stale path.
+            cloud_tablet()->add_rowsets({_output_rowset}, true, wrlock);
+        } else {
+            cloud_tablet()->delete_rowsets(_input_rowsets, wrlock);
+            cloud_tablet()->add_rowsets({_output_rowset}, false, wrlock);
+        }
+        // ATTN: MUST NOT update `cumu_compaction_cnt` or `cumu_point` which are used when sync rowsets, otherwise may cause
+        // the tablet to be unable to synchronize the rowset meta changes generated by cumu compaction.
+        cloud_tablet()->set_base_compaction_cnt(stats.base_compaction_cnt());
+        if (output_rowset_delete_bitmap) {
+            _tablet->tablet_meta()->delete_bitmap().merge(*output_rowset_delete_bitmap);
+        }
+        if (stats.cumulative_compaction_cnt() >= cloud_tablet()->cumulative_compaction_cnt()) {
+            cloud_tablet()->reset_approximate_stats(stats.num_rowsets(), stats.num_segments(),
+                                                    stats.num_rows(), stats.data_size());
+        }
+    }
+}
+
+void CloudIndexChangeCompaction::_update_tablet_for_cumu_compaction(
+        cloud::FinishTabletJobResponse resp, DeleteBitmapPtr output_rowset_delete_bitmap) {
+    auto& stats = resp.stats();
+    LOG(INFO) << "[index_change]tablet stats=" << stats.ShortDebugString();
+    {
+        std::unique_lock wrlock(_tablet->get_header_lock());
+        // clang-format off
+        cloud_tablet()->set_last_base_compaction_success_time(std::max(cloud_tablet()->last_base_compaction_success_time(), stats.last_base_compaction_time_ms()));
+        cloud_tablet()->set_last_cumu_compaction_success_time(std::max(cloud_tablet()->last_cumu_compaction_success_time(), stats.last_cumu_compaction_time_ms()));
+        cloud_tablet()->set_last_full_compaction_success_time(std::max(cloud_tablet()->last_full_compaction_success_time(), stats.last_full_compaction_time_ms()));
+        // clang-format on
+        if (cloud_tablet()->cumulative_compaction_cnt() >= stats.cumulative_compaction_cnt()) {
+            // This could happen while calling `sync_tablet_rowsets` during `commit_tablet_job`, or parallel cumu compactions which are
+            // committed later increase tablet.cumulative_compaction_cnt (see CloudCompactionTest.parallel_cumu_compaction)
+            return;
+        }
+        // Try to make output rowset visible immediately in tablet cache, instead of waiting for next synchronization from meta-service.
+        if (stats.cumulative_point() > cloud_tablet()->cumulative_layer_point() &&
+            stats.cumulative_compaction_cnt() != cloud_tablet()->cumulative_compaction_cnt() + 1) {
+            // This could happen when there are multiple parallel cumu compaction committed, tablet cache lags several
+            // cumu compactions behind meta-service (stats.cumulative_compaction_cnt > tablet.cumulative_compaction_cnt + 1).
+            // If `cumu_point` of the tablet cache also falls behind, MUST ONLY synchronize tablet cache from meta-service,
+            // otherwise may cause the tablet to be unable to synchronize the rowset meta changes generated by other cumu compaction.
+            return;
+        }
+        if (_input_rowsets.size() == 1) {
+            DCHECK_EQ(_output_rowset->version(), _input_rowsets[0]->version());
+            // MUST NOT move input rowset to stale path.
+            cloud_tablet()->add_rowsets({_output_rowset}, true, wrlock);
+        } else {
+            cloud_tablet()->delete_rowsets(_input_rowsets, wrlock);
+            cloud_tablet()->add_rowsets({_output_rowset}, false, wrlock);
+        }
+        // ATTN: MUST NOT update `base_compaction_cnt` which are used when sync rowsets, otherwise may cause
+        // the tablet to be unable to synchronize the rowset meta changes generated by base compaction.
+        cloud_tablet()->set_cumulative_compaction_cnt(stats.cumulative_compaction_cnt());
+        cloud_tablet()->set_cumulative_layer_point(stats.cumulative_point());
+        if (output_rowset_delete_bitmap) {
+            _tablet->tablet_meta()->delete_bitmap().merge(*output_rowset_delete_bitmap);
+        }
+        if (stats.base_compaction_cnt() >= cloud_tablet()->base_compaction_cnt()) {
+            cloud_tablet()->reset_approximate_stats(stats.num_rowsets(), stats.num_segments(),
+                                                    stats.num_rows(), stats.data_size());
+        }
+    }
+}
+
+void CloudIndexChangeCompaction::do_lease() {
+    cloud::TabletJobInfoPB job;
+    if (_state == CompactionState::SUCCESS) {
+        return;
+    }
+    auto idx = job.mutable_idx();
+    idx->set_tablet_id(_tablet->tablet_id());
+    idx->set_table_id(_tablet->table_id());
+    idx->set_index_id(_tablet->index_id());
+    idx->set_partition_id(_tablet->partition_id());
+    auto compaction_job = job.add_compaction();
+    compaction_job->set_id(_uuid);
+    using namespace std::chrono;
+    int64_t lease_time = duration_cast<seconds>(system_clock::now().time_since_epoch()).count() +
+                         config::lease_compaction_interval_seconds * 4;
+    compaction_job->set_lease(lease_time);
+    auto st = _engine.meta_mgr().lease_tablet_job(job);
+    if (!st.ok()) {
+        LOG_WARNING("[index_change]failed to lease compaction job")
+                .tag("job_id", _uuid)
+                .tag("tablet_id", _tablet->tablet_id())
+                .error(st);
+    }
+}
+
+Status CloudIndexChangeCompaction::garbage_collection() {
+    RETURN_IF_ERROR(CloudCompactionMixin::garbage_collection());
+    cloud::TabletJobInfoPB job;
+    auto idx = job.mutable_idx();
+    idx->set_tablet_id(_tablet->tablet_id());
+    idx->set_table_id(_tablet->table_id());
+    idx->set_index_id(_tablet->index_id());
+    idx->set_partition_id(_tablet->partition_id());
+    auto compaction_job = job.add_compaction();
+    compaction_job->set_id(_uuid);
+    compaction_job->set_initiator(BackendOptions::get_localhost() + ':' +
+                                  std::to_string(config::heartbeat_service_port));
+    compaction_job->set_type(_compact_type);
+
+    if (_tablet->keys_type() == KeysType::UNIQUE_KEYS &&
+        _tablet->enable_unique_key_merge_on_write()) {
+        compaction_job->set_delete_bitmap_lock_initiator(this->initiator());
+    }
+    auto st = _engine.meta_mgr().abort_tablet_job(job);
+    if (!st.ok()) {
+        LOG_WARNING("[index_change]failed to abort compaction job")
+                .tag("job_id", _uuid)
+                .tag("tablet_id", _tablet->tablet_id())
+                .error(st);
+    }
+    return st;
+}
+
+} // namespace doris

--- a/be/src/cloud/cloud_index_change_compaction.h
+++ b/be/src/cloud/cloud_index_change_compaction.h
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "cloud/cloud_storage_engine.h"
+#include "cloud/cloud_tablet.h"
+#include "olap/compaction.h"
+
+namespace doris {
+
+class CloudIndexChangeCompaction : public CloudCompactionMixin {
+public:
+    CloudIndexChangeCompaction(CloudStorageEngine& engine, CloudTabletSPtr tablet,
+                               int32_t schema_version, std::vector<TOlapTableIndex>& index_list,
+                               std::vector<TColumn>& columns);
+
+    ~CloudIndexChangeCompaction();
+
+    Status prepare_compact() override;
+    Status execute_compact() override;
+    Status request_global_lock(bool& should_skip_err);
+
+    void do_lease();
+
+    bool is_finish_index_change() { return _input_rowsets.size() == 0; }
+
+    bool is_index_change_compaction() override { return true; }
+
+    bool is_base_compaction() const { return _compact_type == cloud::TabletCompactionJobPB::BASE; }
+
+    Status rebuild_tablet_schema() override;
+
+private:
+    void _update_tablet_for_cumu_compaction(cloud::FinishTabletJobResponse resp,
+                                            DeleteBitmapPtr output_rowset_delete_bitmap);
+    void _update_tablet_for_base_compaction(cloud::FinishTabletJobResponse resp,
+                                            DeleteBitmapPtr output_rowset_delete_bitmap);
+
+protected:
+    std::string_view compaction_name() const override { return "CloudIndexChangeCompaction"; }
+
+    // if cumu rowset is modified, cumu compaction should sync rowset before execute.
+    // if base rowset is modified, base compaction should sync rowset before execute.
+    ReaderType compaction_type() const override {
+        return is_base_compaction() ? ReaderType::READER_BASE_COMPACTION
+                                    : ReaderType::READER_CUMULATIVE_COMPACTION;
+    }
+
+    Status modify_rowsets() override;
+
+    Status garbage_collection() override;
+
+    int32_t _schema_version;
+
+    std::vector<TOlapTableIndex>& _index_list;
+
+    std::vector<TColumn>& _columns;
+
+    cloud::TabletCompactionJobPB::CompactionType _compact_type;
+
+    int64_t _base_compaction_cnt {0};
+    int64_t _cumulative_compaction_cnt {0};
+
+    int64_t _input_segments {0};
+
+    TabletSchemaSPtr _final_tablet_schema = nullptr;
+};
+
+}; // namespace doris

--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -35,6 +35,7 @@
 #include "cloud/cloud_cumulative_compaction.h"
 #include "cloud/cloud_cumulative_compaction_policy.h"
 #include "cloud/cloud_full_compaction.h"
+#include "cloud/cloud_index_change_compaction.h"
 #include "cloud/cloud_meta_mgr.h"
 #include "cloud/cloud_snapshot_mgr.h"
 #include "cloud/cloud_tablet_hotspot.h"
@@ -541,6 +542,51 @@ void CloudStorageEngine::_compaction_tasks_producer_callback() {
     } while (!_stop_background_threads_latch.wait_for(std::chrono::milliseconds(interval)));
 }
 
+void CloudStorageEngine::unregister_index_change_compaction(int64_t tablet_id,
+                                                            bool is_base_compact) {
+    std::lock_guard lock(_compaction_mtx);
+    if (is_base_compact) {
+        _submitted_index_change_base_compaction.erase(tablet_id);
+    } else {
+        _submitted_index_change_cumu_compaction.erase(tablet_id);
+    }
+}
+
+bool CloudStorageEngine::register_index_change_compaction(
+        std::shared_ptr<CloudIndexChangeCompaction> compact, int64_t tablet_id,
+        bool is_base_compact, std::string& err_reason) {
+    std::lock_guard lock(_compaction_mtx);
+    if (is_base_compact) {
+        if (_submitted_base_compactions.contains(tablet_id) ||
+            _submitted_full_compactions.contains(tablet_id) ||
+            _submitted_index_change_base_compaction.contains(tablet_id)) {
+            std::stringstream ss;
+            ss << "reason:" << ((int)_submitted_base_compactions.contains(tablet_id)) << ", "
+               << ((int)_submitted_full_compactions.contains(tablet_id)) << ", "
+               << ((int)_submitted_index_change_base_compaction.contains(tablet_id));
+            err_reason = ss.str();
+            return false;
+        } else {
+            _submitted_index_change_base_compaction[tablet_id] = compact;
+            return true;
+        }
+    } else {
+        if (_tablet_preparing_cumu_compaction.contains(tablet_id) ||
+            _submitted_cumu_compactions.contains(tablet_id) ||
+            _submitted_index_change_cumu_compaction.contains(tablet_id)) {
+            std::stringstream ss;
+            ss << "reason:" << ((int)_tablet_preparing_cumu_compaction.contains(tablet_id)) << ", "
+               << ((int)_submitted_cumu_compactions.contains(tablet_id)) << ", "
+               << ((int)_submitted_index_change_cumu_compaction.contains(tablet_id));
+            err_reason = ss.str();
+            return false;
+        } else {
+            _submitted_index_change_cumu_compaction[tablet_id] = compact;
+        }
+        return true;
+    }
+}
+
 std::vector<CloudTabletSPtr> CloudStorageEngine::_generate_cloud_compaction_tasks(
         CompactionType compaction_type, bool check_score) {
     std::vector<std::shared_ptr<CloudTablet>> tablets_compaction;
@@ -551,12 +597,18 @@ std::vector<CloudTabletSPtr> CloudStorageEngine::_generate_cloud_compaction_task
             submitted_cumu_compactions;
     std::unordered_map<int64_t, std::shared_ptr<CloudBaseCompaction>> submitted_base_compactions;
     std::unordered_map<int64_t, std::shared_ptr<CloudFullCompaction>> submitted_full_compactions;
+    std::unordered_map<int64_t, std::shared_ptr<CloudIndexChangeCompaction>>
+            submitted_index_change_cumu_compactions;
+    std::unordered_map<int64_t, std::shared_ptr<CloudIndexChangeCompaction>>
+            submitted_index_change_base_compactions;
     {
         std::lock_guard lock(_compaction_mtx);
         tablet_preparing_cumu_compaction = _tablet_preparing_cumu_compaction;
         submitted_cumu_compactions = _submitted_cumu_compactions;
         submitted_base_compactions = _submitted_base_compactions;
         submitted_full_compactions = _submitted_full_compactions;
+        submitted_index_change_cumu_compactions = _submitted_index_change_cumu_compaction;
+        submitted_index_change_base_compactions = _submitted_index_change_base_compaction;
     }
 
     bool need_pick_tablet = true;
@@ -585,21 +637,26 @@ std::vector<CloudTabletSPtr> CloudStorageEngine::_generate_cloud_compaction_task
     // Return true for skipping compaction
     std::function<bool(CloudTablet*)> filter_out;
     if (compaction_type == CompactionType::BASE_COMPACTION) {
-        filter_out = [&submitted_base_compactions, &submitted_full_compactions](CloudTablet* t) {
+        filter_out = [&submitted_base_compactions, &submitted_full_compactions,
+                      &submitted_index_change_base_compactions](CloudTablet* t) {
             return submitted_base_compactions.contains(t->tablet_id()) ||
                    submitted_full_compactions.contains(t->tablet_id()) ||
+                   submitted_index_change_base_compactions.contains(t->tablet_id()) ||
                    t->tablet_state() != TABLET_RUNNING;
         };
     } else if (config::enable_parallel_cumu_compaction) {
-        filter_out = [&tablet_preparing_cumu_compaction](CloudTablet* t) {
+        filter_out = [&tablet_preparing_cumu_compaction,
+                      &submitted_index_change_cumu_compactions](CloudTablet* t) {
             return tablet_preparing_cumu_compaction.contains(t->tablet_id()) ||
+                   submitted_index_change_cumu_compactions.contains(t->tablet_id()) ||
                    (t->tablet_state() != TABLET_RUNNING &&
                     (!config::enable_new_tablet_do_compaction || t->alter_version() == -1));
         };
     } else {
-        filter_out = [&tablet_preparing_cumu_compaction,
-                      &submitted_cumu_compactions](CloudTablet* t) {
+        filter_out = [&tablet_preparing_cumu_compaction, &submitted_cumu_compactions,
+                      &submitted_index_change_cumu_compactions](CloudTablet* t) {
             return tablet_preparing_cumu_compaction.contains(t->tablet_id()) ||
+                   submitted_index_change_cumu_compactions.contains(t->tablet_id()) ||
                    submitted_cumu_compactions.contains(t->tablet_id()) ||
                    (t->tablet_state() != TABLET_RUNNING &&
                     (!config::enable_new_tablet_do_compaction || t->alter_version() == -1));
@@ -988,6 +1045,7 @@ void CloudStorageEngine::_lease_compaction_thread_callback() {
         std::vector<std::shared_ptr<CloudBaseCompaction>> base_compactions;
         std::vector<std::shared_ptr<CloudCumulativeCompaction>> cumu_compactions;
         std::vector<std::shared_ptr<CloudCompactionStopToken>> compation_stop_tokens;
+        std::vector<std::shared_ptr<CloudIndexChangeCompaction>> index_change_compations;
         {
             std::lock_guard lock(_compaction_mtx);
             for (auto& [_, base] : _executing_base_compactions) {
@@ -1010,6 +1068,16 @@ void CloudStorageEngine::_lease_compaction_thread_callback() {
                     compation_stop_tokens.push_back(stop_token);
                 }
             }
+            for (auto& [_, index_change] : _submitted_index_change_cumu_compaction) {
+                if (index_change) {
+                    index_change_compations.push_back(index_change);
+                }
+            }
+            for (auto& [_, index_change] : _submitted_index_change_base_compaction) {
+                if (index_change) {
+                    index_change_compations.push_back(index_change);
+                }
+            }
         }
         // TODO(plat1ko): Support batch lease rpc
         for (auto& stop_token : compation_stop_tokens) {
@@ -1022,6 +1090,9 @@ void CloudStorageEngine::_lease_compaction_thread_callback() {
             comp->do_lease();
         }
         for (auto& comp : base_compactions) {
+            comp->do_lease();
+        }
+        for (auto& comp : index_change_compations) {
             comp->do_lease();
         }
     }

--- a/be/src/cloud/cloud_storage_engine.h
+++ b/be/src/cloud/cloud_storage_engine.h
@@ -49,6 +49,7 @@ class TabletHotspot;
 class CloudWarmUpManager;
 class CloudCompactionStopToken;
 class CloudSnapshotMgr;
+class CloudIndexChangeCompaction;
 
 class CloudStorageEngine final : public BaseStorageEngine {
 public:
@@ -153,6 +154,12 @@ public:
 
     Status unregister_compaction_stop_token(CloudTabletSPtr tablet, bool clear_ms);
 
+    bool register_index_change_compaction(std::shared_ptr<CloudIndexChangeCompaction> compact,
+                                          int64_t tablet_id, bool is_base_compact,
+                                          std::string& err_reason);
+
+    void unregister_index_change_compaction(int64_t tablet_id, bool is_base_compact);
+
 private:
     void _refresh_storage_vault_info_thread_callback();
     void _vacuum_stale_rowsets_thread_callback();
@@ -214,6 +221,12 @@ private:
     std::unordered_map<int64_t, std::shared_ptr<CloudBaseCompaction>> _executing_base_compactions;
     // tablet_id -> executing full compactions, guarded by `_compaction_mtx`
     std::unordered_map<int64_t, std::shared_ptr<CloudFullCompaction>> _executing_full_compactions;
+
+    // for index change compaction
+    std::unordered_map<int64_t, std::shared_ptr<CloudIndexChangeCompaction>>
+            _submitted_index_change_cumu_compaction;
+    std::unordered_map<int64_t, std::shared_ptr<CloudIndexChangeCompaction>>
+            _submitted_index_change_base_compaction;
 
     using CumuPolices =
             std::unordered_map<std::string_view, std::shared_ptr<CloudCumulativeCompactionPolicy>>;

--- a/be/src/cloud/cloud_tablet.h
+++ b/be/src/cloud/cloud_tablet.h
@@ -218,6 +218,9 @@ public:
     int64_t base_size() const { return _base_size; }
 
     std::vector<RowsetSharedPtr> pick_candidate_rowsets_to_full_compaction();
+    Result<RowsetSharedPtr> pick_a_rowset_for_index_change(int schema_version,
+                                                           bool& is_base_rowset);
+    Status check_rowset_schema_for_build_index(std::vector<TColumn>& columns, int schema_version);
 
     std::mutex& get_base_compaction_lock() { return _base_compaction_lock; }
     std::mutex& get_cumulative_compaction_lock() { return _cumulative_compaction_lock; }

--- a/be/src/cloud/config.cpp
+++ b/be/src/cloud/config.cpp
@@ -93,6 +93,8 @@ DEFINE_Bool(enable_check_storage_vault, "true");
 
 DEFINE_mBool(skip_writing_empty_rowset_metadata, "false");
 
+DEFINE_mInt64(cloud_index_change_task_timeout_second, "3600");
+
 DEFINE_mInt64(warmup_tablet_replica_info_cache_ttl_sec, "600");
 
 DEFINE_mInt64(warm_up_rowset_slow_log_ms, "1000");

--- a/be/src/cloud/config.h
+++ b/be/src/cloud/config.h
@@ -130,6 +130,8 @@ DECLARE_mInt32(meta_service_conflict_error_retry_times);
 
 DECLARE_Bool(enable_check_storage_vault);
 
+DECLARE_mInt64(cloud_index_change_task_timeout_second);
+
 DECLARE_mInt64(warmup_tablet_replica_info_cache_ttl_sec);
 
 DECLARE_mInt64(warm_up_rowset_slow_log_ms);

--- a/be/src/olap/compaction.h
+++ b/be/src/olap/compaction.h
@@ -75,6 +75,15 @@ public:
     virtual ReaderType compaction_type() const = 0;
     virtual std::string_view compaction_name() const = 0;
 
+    // the difference between index change compmaction and other compaction.
+    // 1. delete predicate should be kept when input is cumu rowset.
+    // 2. inverted compaction should be skipped.
+    // 3. compute level should not be changed.
+    virtual bool is_index_change_compaction() { return false; }
+
+private:
+    void set_delete_predicate_for_output_rowset();
+
 protected:
     Status merge_input_rowsets();
 
@@ -135,6 +144,8 @@ protected:
     TabletSchemaSPtr _cur_tablet_schema;
 
     std::unique_ptr<RuntimeProfile> _profile;
+
+    bool _enable_inverted_index_compaction {false};
 
     RuntimeProfile::Counter* _input_rowsets_data_size_counter = nullptr;
     RuntimeProfile::Counter* _input_rowsets_counter = nullptr;
@@ -219,6 +230,8 @@ protected:
     std::string _uuid;
 
     int64_t _expiration = 0;
+
+    virtual Status rebuild_tablet_schema() { return Status::OK(); }
 
 private:
     Status construct_output_rowset_writer(RowsetWriterContext& ctx) override;

--- a/be/src/olap/task/engine_cloud_index_change_task.cpp
+++ b/be/src/olap/task/engine_cloud_index_change_task.cpp
@@ -1,0 +1,152 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "olap/task/engine_cloud_index_change_task.h"
+
+#include "cloud/cloud_index_change_compaction.h"
+#include "cloud/cloud_tablet_mgr.h"
+#include "cpp/sync_point.h"
+#include "olap/tablet_manager.h"
+
+namespace doris {
+
+EngineCloudIndexChangeTask::EngineCloudIndexChangeTask(CloudStorageEngine& engine,
+                                                       const TAlterInvertedIndexReq& request)
+        : _engine(engine),
+          _index_list(request.indexes_desc),
+          _columns(request.columns),
+          _tablet_id(request.tablet_id),
+          _schema_version(request.schema_version) {
+    _mem_tracker = MemTrackerLimiter::create_shared(
+            MemTrackerLimiter::Type::SCHEMA_CHANGE,
+            fmt::format("EngineCloudIndexChangeTask#tabletId={}", std::to_string(_tablet_id)),
+            engine.memory_limitation_bytes_per_thread_for_schema_change());
+}
+
+EngineCloudIndexChangeTask::~EngineCloudIndexChangeTask() = default;
+
+Result<std::shared_ptr<CloudTablet>> EngineCloudIndexChangeTask::_get_tablet() {
+    TEST_SYNC_POINT_RETURN_WITH_VALUE("EngineCloudIndexChangeTask::_get_tablet",
+                                      Result<std::shared_ptr<CloudTablet>>(nullptr));
+    return _engine.tablet_mgr().get_tablet(_tablet_id);
+}
+
+Status EngineCloudIndexChangeTask::execute() {
+    int64_t begin_time = MonotonicSeconds();
+    std::string tablet_id_str = " tableid:" + std::to_string(_tablet_id);
+    // get tablet
+    CloudTabletSPtr tablet = DORIS_TRY(_get_tablet());
+    if (tablet == nullptr) {
+        LOG(WARNING) << "[index_change]tablet: " << _tablet_id << " not exist";
+        return Status::InternalError("tablet not exist, tablet_id={}.", _tablet_id);
+    }
+    RETURN_IF_ERROR(tablet->sync_rowsets());
+    RETURN_IF_ERROR(tablet->check_rowset_schema_for_build_index(_columns, _schema_version));
+
+    while (true) {
+        int64_t time_cost = MonotonicSeconds() - begin_time;
+        if (time_cost > config::cloud_index_change_task_timeout_second) {
+            return Status::InternalError("index change compaction timeout, tablet_id={}.",
+                                         _tablet_id);
+        }
+
+        // get tablet
+        CloudTabletSPtr tablet = DORIS_TRY(_get_tablet());
+        if (tablet == nullptr) {
+            LOG(WARNING) << "[index_change]tablet: " << _tablet_id << " not exist";
+            return Status::InternalError("tablet not exist, tablet_id={}.", _tablet_id);
+        }
+
+        // pre check to determine whether this round of iteration is base compaction or cumu compaction.
+        bool is_current_iter_base_compact = false;
+        RETURN_IF_ERROR(tablet->sync_rowsets());
+        auto pre_input_rowset = DORIS_TRY(tablet->pick_a_rowset_for_index_change(
+                _schema_version, is_current_iter_base_compact));
+        if (pre_input_rowset == nullptr) {
+            LOG(INFO) << "[index_change]there are no rowsets need to do index change, task finish."
+                      << tablet_id_str << ";"
+                      << "sc version:" << _schema_version;
+            return Status::OK();
+        }
+
+        std::shared_ptr<CloudIndexChangeCompaction> index_change_compact =
+                std::make_shared<CloudIndexChangeCompaction>(_engine, tablet, _schema_version,
+                                                             _index_list, _columns);
+
+        Defer defer {[&]() {
+            _engine.unregister_index_change_compaction(_tablet_id, is_current_iter_base_compact);
+            VLOG_DEBUG << "[index_change] unregister compaction , " << tablet_id_str;
+        }};
+
+        std::string err_msg;
+        bool is_register_succ = _engine.register_index_change_compaction(
+                index_change_compact, _tablet_id, is_current_iter_base_compact, err_msg);
+        if (!is_register_succ) {
+            LOG_EVERY_T(INFO, 60) << "[index_change]register index change compaction failed,"
+                                  << tablet_id_str << ", reason:" << err_msg;
+            sleep(30);
+            continue;
+        }
+
+        VLOG_DEBUG << "[index_change] begin prepare index change compact, " << tablet_id_str;
+        Status prepare_ret = index_change_compact->prepare_compact();
+        if (!prepare_ret.ok()) {
+            LOG(WARNING) << "[index_change] prepare index compact failed, " << tablet_id_str
+                         << ", err reason:" << prepare_ret.to_string_no_stack();
+            return prepare_ret;
+        }
+
+        if (index_change_compact->is_finish_index_change()) {
+            LOG(INFO) << "[index_change] index change task finish." << tablet_id_str;
+            return Status::OK();
+        }
+
+        // if pre check type is not same with prepare result, it can retry at once;
+        // because this case should rarely happen.
+        bool could_continue_execution =
+                (is_current_iter_base_compact && index_change_compact->is_base_compaction()) ||
+                (!is_current_iter_base_compact && !index_change_compact->is_base_compaction());
+        if (!could_continue_execution) {
+            LOG_EVERY_T(INFO, 10) << "[index_change] pre rowset type not match real rowset type."
+                                  << tablet_id_str;
+            continue;
+        }
+
+        bool should_skip_err = false;
+        Status ret = index_change_compact->request_global_lock(should_skip_err);
+        if (!ret.ok()) {
+            // if request lock failed because of stale rowset, we can sync rowsets and retry.
+            if (should_skip_err) {
+                continue;
+            } else {
+                LOG(WARNING) << "[index_change] request global lock failed." << tablet_id_str;
+                return ret;
+            }
+        }
+
+        VLOG_DEBUG << "[index_change] begin execute index change compact." << tablet_id_str;
+        Status exec_ret = index_change_compact->execute_compact();
+        if (!exec_ret.ok()) {
+            LOG(WARNING) << "[index_change] exec index change compaction failed." << tablet_id_str;
+            return exec_ret;
+        }
+        VLOG_DEBUG << "[index_change] exec compaction succ." << tablet_id_str;
+    }
+
+    return Status::OK();
+}
+} // namespace doris

--- a/be/src/olap/task/engine_cloud_index_change_task.h
+++ b/be/src/olap/task/engine_cloud_index_change_task.h
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "olap/tablet_fwd.h"
+#include "olap/task/engine_task.h"
+
+namespace doris {
+class CloudStorageEngine;
+class TAlterInvertedIndexReq;
+class TOlapTableIndex;
+class CloudTablet;
+class TColumn;
+
+class EngineCloudIndexChangeTask final : public EngineTask {
+public:
+    Status execute() override;
+
+    EngineCloudIndexChangeTask(CloudStorageEngine& engine, const TAlterInvertedIndexReq& request);
+    ~EngineCloudIndexChangeTask();
+
+private:
+    Result<std::shared_ptr<CloudTablet>> _get_tablet();
+
+    CloudStorageEngine& _engine;
+    std::vector<TOlapTableIndex> _index_list;
+    std::vector<TColumn> _columns;
+    int64_t _tablet_id;
+    int32_t _schema_version;
+}; // EngineTask
+
+} // namespace doris

--- a/be/test/olap/cloud_index_change_compaction_test.cpp
+++ b/be/test/olap/cloud_index_change_compaction_test.cpp
@@ -1,0 +1,395 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "cloud/cloud_index_change_compaction.h"
+
+#include <gtest/gtest.h>
+
+#include "cloud/cloud_base_compaction.h"
+#include "cloud/cloud_cumulative_compaction.h"
+#include "cpp/sync_point.h"
+#include "json2pb/json_to_pb.h"
+#include "olap/rowset/beta_rowset.h"
+
+namespace doris {
+
+class CloudIndexChangeCompactionTest : public testing::Test {
+public:
+    void SetUp() {
+        _engine = std::make_unique<CloudStorageEngine>(EngineOptions {});
+        auto sp = SyncPoint::get_instance();
+        sp->enable_processing();
+    }
+
+    void TearDown() {}
+
+    void init_rs_meta(RowsetMetaSharedPtr& pb1, int64_t start, int64_t end) {
+        std::string json_rowset_meta = R"({
+            "rowset_id": 540085,
+            "tablet_id": 15674,
+            "partition_id": 10000,
+            "txn_id": 4045,
+            "tablet_schema_hash": 567997588,
+            "rowset_type": "BETA_ROWSET",
+            "rowset_state": "VISIBLE",
+            "start_version": 2,
+            "end_version": 2,
+            "num_rows": 3929,
+            "total_disk_size": 84699,
+            "data_disk_size": 84464,
+            "index_disk_size": 235,
+            "empty": false,
+            "load_id": {
+                "hi": -5350970832824939812,
+                "lo": -6717994719194512122
+            },
+            "creation_time": 1553765670
+        })";
+
+        RowsetMetaPB rowset_meta_pb;
+        json2pb::JsonToProtoMessage(json_rowset_meta, &rowset_meta_pb);
+        rowset_meta_pb.set_start_version(start);
+        rowset_meta_pb.set_end_version(end);
+        rowset_meta_pb.set_creation_time(10000);
+
+        pb1->init_from_pb(rowset_meta_pb);
+    }
+
+    bool contains_str(std::string origin, std::string sub_str) {
+        return origin.find(sub_str) != std::string::npos;
+    }
+
+public:
+    std::unique_ptr<CloudStorageEngine> _engine;
+};
+
+TEST_F(CloudIndexChangeCompactionTest, ms_ret_status_test) {
+    std::vector<TOlapTableIndex> index_list;
+    TOlapTableIndex index;
+    index.index_id = 1;
+    index.columns.emplace_back("col1");
+    index_list.push_back(index);
+
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(KeysType::DUP_KEYS);
+
+    ColumnPB* column_pb = schema_pb.add_column();
+    column_pb->set_unique_id(10000);
+    column_pb->set_name("col1");
+    column_pb->set_type("int");
+    column_pb->set_is_key(true);
+    column_pb->set_is_nullable(true);
+    auto tablet_schema = std::make_shared<TabletSchema>();
+    tablet_schema->init_from_pb(schema_pb);
+
+    auto rowset_meta = std::make_shared<RowsetMeta>();
+    init_rs_meta(rowset_meta, 1, 1);
+    rowset_meta->set_num_segments(2);
+    RowsetSharedPtr rowset_ptr = std::make_shared<BetaRowset>(tablet_schema, rowset_meta, "");
+
+    TabletMetaPB input_meta_pb;
+    input_meta_pb.set_tablet_id(1000);
+    input_meta_pb.set_schema_hash(123456);
+    input_meta_pb.set_tablet_state(PB_RUNNING);
+    *input_meta_pb.mutable_tablet_uid() = TabletUid::gen_uid().to_proto();
+
+    auto tablet_meta = std::make_shared<TabletMeta>();
+    tablet_meta->init_from_pb(input_meta_pb);
+
+    CloudTabletSPtr tablet = std::make_shared<CloudTablet>(*_engine, tablet_meta);
+
+    Version v1;
+    v1.first = 1;
+    v1.second = 2;
+    tablet->_rs_version_map[v1] = rowset_ptr;
+
+    std::vector<TColumn> columns;
+
+    // 1 test prepare
+    {
+        auto sp = SyncPoint::get_instance();
+        sp->set_call_back("CloudMetaMgr::sync_tablet_rowsets", [](auto&& outcome) {
+            auto* pairs = try_any_cast_ret<Status>(outcome);
+            pairs->second = true;
+            pairs->first = Status::OK();
+        });
+        std::shared_ptr<CloudIndexChangeCompaction> index_change_compact =
+                std::make_shared<CloudIndexChangeCompaction>(*_engine, tablet, 0, index_list,
+                                                             columns);
+        Status prepare_ret = index_change_compact->prepare_compact();
+        ASSERT_TRUE(prepare_ret.ok());
+    }
+
+    {
+        auto sp = SyncPoint::get_instance();
+        sp->set_call_back("CloudMetaMgr::sync_tablet_rowsets", [](auto&& outcome) {
+            auto* pairs = try_any_cast_ret<Status>(outcome);
+            pairs->second = true;
+            pairs->first = Status::InternalError<false>("mock sync meta failed");
+        });
+
+        std::shared_ptr<CloudIndexChangeCompaction> index_change_compact =
+                std::make_shared<CloudIndexChangeCompaction>(*_engine, tablet, 0, index_list,
+                                                             columns);
+        Status prepare_ret = index_change_compact->prepare_compact();
+        ASSERT_TRUE(!prepare_ret.ok());
+        ASSERT_TRUE(contains_str(prepare_ret.to_string(), "mock sync meta failed"));
+    }
+
+    // 2 test request global lock
+    {
+        auto sp = SyncPoint::get_instance();
+        sp->set_call_back("CloudMetaMgr::prepare_tablet_job", [](auto&& outcome) {
+            auto* pairs = try_any_cast_ret<Status>(outcome);
+            pairs->second = true;
+            pairs->first = Status::OK();
+        });
+
+        std::shared_ptr<CloudIndexChangeCompaction> index_change_compact =
+                std::make_shared<CloudIndexChangeCompaction>(*_engine, tablet, 0, index_list,
+                                                             columns);
+        index_change_compact->_input_rowsets.push_back(rowset_ptr);
+        bool should_skip_err = false;
+        Status ret = index_change_compact->request_global_lock(should_skip_err);
+        ASSERT_TRUE(ret.ok());
+        ASSERT_TRUE(!should_skip_err);
+    }
+
+    {
+        // stale tablet error
+        auto sp = SyncPoint::get_instance();
+        sp->set_call_back("CloudMetaMgr::prepare_tablet_job", [](auto&& outcome) {
+            auto* pairs = try_any_cast_ret<Status>(outcome);
+            pairs->second = true;
+            pairs->first = Status::InternalError<false>("mock stale tablet error");
+
+            auto* resp = try_any_cast<cloud::StartTabletJobResponse*>(outcome[1]);
+            resp->mutable_status()->set_code(cloud::STALE_TABLET_CACHE);
+            resp->mutable_status()->set_msg("mock stale tablet error");
+        });
+
+        std::shared_ptr<CloudIndexChangeCompaction> index_change_compact =
+                std::make_shared<CloudIndexChangeCompaction>(*_engine, tablet, 0, index_list,
+                                                             columns);
+        index_change_compact->_input_rowsets.push_back(rowset_ptr);
+        bool should_skip_err = false;
+        Status ret = index_change_compact->request_global_lock(should_skip_err);
+        ASSERT_TRUE(!ret.ok());
+        ASSERT_TRUE(should_skip_err);
+        ASSERT_TRUE(contains_str(ret.to_string(), "mock stale tablet error"));
+    }
+
+    {
+        // tablet not found
+        auto sp = SyncPoint::get_instance();
+        sp->set_call_back("CloudMetaMgr::prepare_tablet_job", [](auto&& outcome) {
+            auto* pairs = try_any_cast_ret<Status>(outcome);
+            pairs->second = true;
+            pairs->first = Status::InternalError<false>("mock tablet not found");
+
+            auto* resp = try_any_cast<cloud::StartTabletJobResponse*>(outcome[1]);
+            resp->mutable_status()->set_code(cloud::TABLET_NOT_FOUND);
+            resp->mutable_status()->set_msg("mock tablet not found");
+        });
+
+        std::shared_ptr<CloudIndexChangeCompaction> index_change_compact =
+                std::make_shared<CloudIndexChangeCompaction>(*_engine, tablet, 0, index_list,
+                                                             columns);
+        index_change_compact->_input_rowsets.push_back(rowset_ptr);
+        bool should_skip_err = false;
+        Status ret = index_change_compact->request_global_lock(should_skip_err);
+        ASSERT_TRUE(!ret.ok());
+        ASSERT_TRUE(!should_skip_err);
+        ASSERT_TRUE(contains_str(ret.to_string(), "mock tablet not found"));
+    }
+
+    {
+        // job tablet busy
+        auto sp = SyncPoint::get_instance();
+        sp->set_call_back("CloudMetaMgr::prepare_tablet_job", [](auto&& outcome) {
+            auto* pairs = try_any_cast_ret<Status>(outcome);
+            pairs->second = true;
+            pairs->first = Status::InternalError<false>("mock job tablet busy");
+
+            auto* resp = try_any_cast<cloud::StartTabletJobResponse*>(outcome[1]);
+            resp->mutable_status()->set_code(cloud::JOB_TABLET_BUSY);
+            resp->mutable_status()->set_msg("mock job tablet busy");
+        });
+        std::shared_ptr<CloudIndexChangeCompaction> index_change_compact =
+                std::make_shared<CloudIndexChangeCompaction>(*_engine, tablet, 0, index_list,
+                                                             columns);
+        index_change_compact->_input_rowsets.push_back(rowset_ptr);
+        bool should_skip_err = false;
+        Status ret = index_change_compact->request_global_lock(should_skip_err);
+        ASSERT_TRUE(!ret.ok());
+        ASSERT_TRUE(!should_skip_err);
+        ASSERT_TRUE(contains_str(ret.to_string(), "index change compaction no suitable versions"));
+    }
+
+    {
+        // job check alter version
+        auto sp = SyncPoint::get_instance();
+        sp->set_call_back("CloudMetaMgr::prepare_tablet_job", [](auto&& outcome) {
+            auto* pairs = try_any_cast_ret<Status>(outcome);
+            pairs->second = true;
+            pairs->first = Status::InternalError<false>("mock job check alter version");
+
+            auto* resp = try_any_cast<cloud::StartTabletJobResponse*>(outcome[1]);
+            resp->mutable_status()->set_code(cloud::JOB_CHECK_ALTER_VERSION);
+            resp->mutable_status()->set_msg("mock job check alter version");
+        });
+
+        std::shared_ptr<CloudIndexChangeCompaction> index_change_compact =
+                std::make_shared<CloudIndexChangeCompaction>(*_engine, tablet, 0, index_list,
+                                                             columns);
+        index_change_compact->_input_rowsets.push_back(rowset_ptr);
+        bool should_skip_err = false;
+        Status ret = index_change_compact->request_global_lock(should_skip_err);
+        ASSERT_TRUE(!ret.ok());
+        ASSERT_TRUE(!should_skip_err);
+        ASSERT_TRUE(contains_str(ret.to_string(), "failed in schema change."));
+    }
+
+    // modify rowsets
+    {
+        // tablet not found
+        auto sp = SyncPoint::get_instance();
+        sp->set_call_back("CloudMetaMgr::commit_tablet_job", [](auto&& outcome) {
+            auto* pairs = try_any_cast_ret<Status>(outcome);
+            pairs->second = true;
+            pairs->first = Status::InternalError<false>("mock tablet not found");
+
+            auto* resp = try_any_cast<cloud::FinishTabletJobResponse*>(outcome[1]);
+            resp->mutable_status()->set_code(cloud::TABLET_NOT_FOUND);
+            resp->mutable_status()->set_msg("mock tablet not found");
+        });
+
+        std::shared_ptr<CloudIndexChangeCompaction> index_change_compact =
+                std::make_shared<CloudIndexChangeCompaction>(*_engine, tablet, 0, index_list,
+                                                             columns);
+        index_change_compact->_input_rowsets.push_back(rowset_ptr);
+        index_change_compact->_output_rowset = rowset_ptr;
+        index_change_compact->_compact_type = cloud::TabletCompactionJobPB::BASE;
+        Status ret = index_change_compact->modify_rowsets();
+        ASSERT_TRUE(!ret.ok());
+        ASSERT_TRUE(contains_str(ret.to_string(), "mock tablet not found"));
+    }
+
+    {
+        // job check alter version
+        auto sp = SyncPoint::get_instance();
+        sp->set_call_back("CloudMetaMgr::commit_tablet_job", [](auto&& outcome) {
+            auto* pairs = try_any_cast_ret<Status>(outcome);
+            pairs->second = true;
+            pairs->first = Status::InternalError<false>("mock check alter version");
+
+            auto* resp = try_any_cast<cloud::FinishTabletJobResponse*>(outcome[1]);
+            resp->mutable_status()->set_code(cloud::JOB_CHECK_ALTER_VERSION);
+            resp->mutable_status()->set_msg("mock check alter version");
+        });
+
+        std::shared_ptr<CloudIndexChangeCompaction> index_change_compact =
+                std::make_shared<CloudIndexChangeCompaction>(*_engine, tablet, 0, index_list,
+                                                             columns);
+        index_change_compact->_input_rowsets.push_back(rowset_ptr);
+        index_change_compact->_output_rowset = rowset_ptr;
+        index_change_compact->_compact_type = cloud::TabletCompactionJobPB::BASE;
+        Status ret = index_change_compact->modify_rowsets();
+        ASSERT_TRUE(!ret.ok());
+        ASSERT_TRUE(contains_str(ret.to_string(), "failed in schema change"));
+    }
+}
+
+TEST_F(CloudIndexChangeCompactionTest, basic_compaction_test) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(KeysType::DUP_KEYS);
+
+    ColumnPB* column_pb = schema_pb.add_column();
+    column_pb->set_unique_id(10000);
+    column_pb->set_name("col1");
+    column_pb->set_type("int");
+    column_pb->set_is_key(true);
+    column_pb->set_is_nullable(true);
+    auto tablet_schema1 = std::make_shared<TabletSchema>();
+    tablet_schema1->init_from_pb(schema_pb);
+
+    auto tablet_schema2 = std::make_shared<TabletSchema>();
+    tablet_schema2->init_from_pb(schema_pb);
+
+    auto rowset_meta = std::make_shared<RowsetMeta>();
+    init_rs_meta(rowset_meta, 0, 1);
+    rowset_meta->set_num_segments(2);
+    rowset_meta->_schema = tablet_schema1;
+    RowsetSharedPtr rowset_ptr = std::make_shared<BetaRowset>(tablet_schema1, rowset_meta, "");
+
+    auto output_rowset_meta = std::make_shared<RowsetMeta>();
+    init_rs_meta(output_rowset_meta, 0, 1);
+    output_rowset_meta->set_num_segments(2);
+    output_rowset_meta->_schema = tablet_schema1;
+    Version v0;
+    v0.first = 10;
+    v0.second = 10;
+    output_rowset_meta->set_version(v0);
+    RowsetSharedPtr output_rowset_ptr =
+            std::make_shared<BetaRowset>(tablet_schema1, output_rowset_meta, "");
+
+    CloudTabletSPtr tablet =
+            std::make_shared<CloudTablet>(*_engine, std::make_shared<TabletMeta>());
+
+    Version v1;
+    v1.first = 0;
+    v1.second = 2;
+    tablet->_rs_version_map[v1] = rowset_ptr;
+
+    std::vector<TOlapTableIndex> index_list;
+    std::vector<TColumn> columns;
+    CloudIndexChangeCompaction cloud_index_change_compaction(*_engine, tablet, 0, index_list,
+                                                             columns);
+
+    // test is_index_change_compaction
+    CloudBaseCompaction cloud_base_compaction(*_engine, tablet);
+    CloudCumulativeCompaction cloud_cumu_compaction(*_engine, tablet);
+    ASSERT_TRUE(cloud_index_change_compaction.is_index_change_compaction());
+    ASSERT_FALSE(cloud_base_compaction.is_index_change_compaction());
+    ASSERT_FALSE(cloud_cumu_compaction.is_index_change_compaction());
+
+    // test delete predicate
+    cloud_index_change_compaction._input_rowsets.clear();
+    cloud_index_change_compaction._input_rowsets.push_back(rowset_ptr);
+    cloud_index_change_compaction._output_rowset = output_rowset_ptr;
+
+    DeletePredicatePB del_pred_pb;
+    InPredicatePB* in_pred = del_pred_pb.add_in_predicates();
+    in_pred->set_column_name("col1");
+    in_pred->set_is_not_in(true);
+    in_pred->add_values("123");
+    in_pred->add_values("456");
+    rowset_ptr->rowset_meta()->set_delete_predicate(del_pred_pb);
+
+    cloud_index_change_compaction._allow_delete_in_cumu_compaction = false;
+    reinterpret_cast<Compaction*>(&cloud_index_change_compaction)
+            ->set_delete_predicate_for_output_rowset();
+
+    auto& in_predicates = cloud_index_change_compaction._output_rowset->rowset_meta()
+                                  ->delete_predicate()
+                                  .in_predicates();
+    ASSERT_TRUE(in_predicates[0].column_name() == "col1");
+    ASSERT_TRUE(in_predicates[0].is_not_in() == true);
+    ASSERT_TRUE(in_predicates[0].values().size() == 2);
+}
+
+} // namespace doris

--- a/be/test/olap/cloud_index_change_task_test.cpp
+++ b/be/test/olap/cloud_index_change_task_test.cpp
@@ -1,0 +1,313 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "cloud/cloud_storage_engine.h"
+#include "cloud/cloud_tablet.h"
+#include "common/status.h"
+#include "cpp/sync_point.h"
+#include "json2pb/json_to_pb.h"
+#include "olap/rowset/beta_rowset.h"
+#include "olap/task/engine_cloud_index_change_task.h"
+
+namespace doris {
+
+class CloudIndexChangeTaskTest : public testing::Test {
+public:
+    void SetUp() {
+        _engine = std::make_unique<CloudStorageEngine>(EngineOptions {});
+        auto sp = SyncPoint::get_instance();
+        sp->enable_processing();
+    }
+
+    void TearDown() {}
+
+    void init_rs_meta(RowsetMetaSharedPtr& pb1, int64_t start, int64_t end) {
+        std::string json_rowset_meta = R"({
+            "rowset_id": 540085,
+            "tablet_id": 15674,
+            "partition_id": 10000,
+            "txn_id": 4045,
+            "tablet_schema_hash": 567997588,
+            "rowset_type": "BETA_ROWSET",
+            "rowset_state": "VISIBLE",
+            "start_version": 2,
+            "end_version": 2,
+            "num_rows": 3929,
+            "total_disk_size": 84699,
+            "data_disk_size": 84464,
+            "index_disk_size": 235,
+            "empty": false,
+            "load_id": {
+                "hi": -5350970832824939812,
+                "lo": -6717994719194512122
+            },
+            "creation_time": 1553765670
+        })";
+
+        RowsetMetaPB rowset_meta_pb;
+        json2pb::JsonToProtoMessage(json_rowset_meta, &rowset_meta_pb);
+        rowset_meta_pb.set_start_version(start);
+        rowset_meta_pb.set_end_version(end);
+        rowset_meta_pb.set_creation_time(10000);
+
+        pb1->init_from_pb(rowset_meta_pb);
+    }
+
+    bool contains_str(std::string origin, std::string sub_str) {
+        return origin.find(sub_str) != std::string::npos;
+    }
+
+public:
+    std::unique_ptr<CloudStorageEngine> _engine;
+};
+
+TOlapTableIndex make_t_index(int index_id, std::string index_name, std::string col_name,
+                             int col_unique_id, TIndexType::type index_type) {
+    TOlapTableIndex index;
+    index.index_id = index_id;
+    index.index_name = index_name;
+    index.columns.emplace_back(col_name);
+    index.column_unique_ids.push_back(col_unique_id);
+    index.index_type = index_type;
+    return index;
+}
+
+TEST_F(CloudIndexChangeTaskTest, task_execute_err_exit) {
+    auto sp = SyncPoint::get_instance();
+    sp->clear_all_call_backs();
+
+    TabletMetaPB input_meta_pb;
+    input_meta_pb.set_tablet_id(1000);
+    input_meta_pb.set_schema_hash(123456);
+    input_meta_pb.set_tablet_state(PB_RUNNING);
+    *input_meta_pb.mutable_tablet_uid() = TabletUid::gen_uid().to_proto();
+
+    auto tablet_meta = std::make_shared<TabletMeta>();
+    tablet_meta->init_from_pb(input_meta_pb);
+
+    CloudTabletSPtr tablet = std::make_shared<CloudTablet>(*_engine, tablet_meta);
+
+    {
+        sp->set_call_back("EngineCloudIndexChangeTask::_get_tablet", [](auto&& outcome) {
+            auto* pair = try_any_cast_ret<Result<std::shared_ptr<CloudTablet>>>(outcome);
+            pair->second = true;
+            pair->first = ResultError(Status::InternalError("mock no tablet error"));
+        });
+
+        TAlterInvertedIndexReq request;
+        EngineCloudIndexChangeTask task(*_engine, request);
+        Status ret = task.execute();
+        ASSERT_TRUE(!ret.ok());
+        ASSERT_TRUE(contains_str(ret.to_string(), "mock no tablet error"));
+    }
+
+    sp->set_call_back("EngineCloudIndexChangeTask::_get_tablet", [tablet](auto&& outcome) {
+        auto* pair = try_any_cast_ret<Result<std::shared_ptr<CloudTablet>>>(outcome);
+        pair->second = true;
+        pair->first = Result<std::shared_ptr<CloudTablet>>(tablet);
+    });
+
+    // test sync failed
+    sp->set_call_back("CloudMetaMgr::sync_tablet_rowsets", [](auto&& outcome) {
+        auto* pairs = try_any_cast_ret<Status>(outcome);
+        pairs->second = true;
+        pairs->first = Status::InternalError<false>("mock sync meta failed");
+    });
+
+    {
+        TAlterInvertedIndexReq request;
+        EngineCloudIndexChangeTask task(*_engine, request);
+        Status ret = task.execute();
+        ASSERT_TRUE(!ret.ok());
+        ASSERT_TRUE(contains_str(ret.to_string(), "mock sync meta failed"));
+    }
+
+    sp->set_call_back("CloudMetaMgr::sync_tablet_rowsets", [](auto&& outcome) {
+        auto* pairs = try_any_cast_ret<Status>(outcome);
+        pairs->second = true;
+        pairs->first = Status::OK();
+    });
+
+    // test get null rowset
+    sp->set_call_back("CloudTablet::pick_a_rowset_for_index_change", [](auto&& outcome) {
+        auto* pairs = try_any_cast_ret<Result<RowsetSharedPtr>>(outcome);
+        pairs->second = true;
+        pairs->first = Result<RowsetSharedPtr>(nullptr);
+    });
+
+    {
+        TAlterInvertedIndexReq request;
+        EngineCloudIndexChangeTask task(*_engine, request);
+        Status ret = task.execute();
+        ASSERT_TRUE(ret.ok());
+    }
+
+    RowsetSharedPtr rowset = std::make_shared<BetaRowset>(std::make_shared<TabletSchema>(),
+                                                          std::make_shared<RowsetMeta>(), "");
+
+    sp->set_call_back("CloudTablet::pick_a_rowset_for_index_change", [rowset](auto&& outcome) {
+        auto* pairs = try_any_cast_ret<Result<RowsetSharedPtr>>(outcome);
+        pairs->second = true;
+        pairs->first = Result<RowsetSharedPtr>(rowset);
+    });
+
+    // test prepare failed
+    sp->set_call_back("CloudIndexChangeCompaction::prepare_compact", [](auto&& outcome) {
+        auto* pairs = try_any_cast_ret<Status>(outcome);
+        pairs->second = true;
+        pairs->first = Status::InternalError<false>("mock prepare compact failed");
+    });
+
+    {
+        TAlterInvertedIndexReq request;
+        EngineCloudIndexChangeTask task(*_engine, request);
+        Status ret = task.execute();
+        ASSERT_TRUE(!ret.ok());
+        ASSERT_TRUE(contains_str(ret.to_string(), "prepare compact failed"));
+    }
+}
+
+TEST_F(CloudIndexChangeTaskTest, task_execute_err_exit2) {
+    auto sp = SyncPoint::get_instance();
+    sp->clear_all_call_backs();
+
+    TabletMetaPB input_meta_pb;
+    input_meta_pb.set_tablet_id(1000);
+    input_meta_pb.set_schema_hash(123456);
+    input_meta_pb.set_tablet_state(PB_RUNNING);
+    *input_meta_pb.mutable_tablet_uid() = TabletUid::gen_uid().to_proto();
+
+    auto tablet_meta = std::make_shared<TabletMeta>();
+    tablet_meta->init_from_pb(input_meta_pb);
+
+    CloudTabletSPtr tablet = std::make_shared<CloudTablet>(*_engine, tablet_meta);
+
+    TAlterInvertedIndexReq request;
+    std::vector<TOlapTableIndex> index_list;
+    TOlapTableIndex index;
+    index.index_id = 1;
+    index.columns.emplace_back("col1");
+    index.index_type = TIndexType::type::INVERTED;
+    index_list.push_back(index);
+    request.__set_alter_inverted_indexes(std::move(index_list));
+
+    sp->set_call_back("EngineCloudIndexChangeTask::_get_tablet", [tablet](auto&& outcome) {
+        auto* pair = try_any_cast_ret<Result<std::shared_ptr<CloudTablet>>>(outcome);
+        pair->second = true;
+        pair->first = Result<std::shared_ptr<CloudTablet>>(tablet);
+    });
+
+    sp->set_call_back("CloudMetaMgr::sync_tablet_rowsets", [](auto&& outcome) {
+        auto* pairs = try_any_cast_ret<Status>(outcome);
+        pairs->second = true;
+        pairs->first = Status::OK();
+    });
+
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(KeysType::DUP_KEYS);
+
+    ColumnPB* column_pb = schema_pb.add_column();
+    column_pb->set_unique_id(10000);
+    column_pb->set_name("col1");
+    column_pb->set_type("int");
+    column_pb->set_is_key(true);
+    column_pb->set_is_nullable(true);
+    auto tablet_schema = std::make_shared<TabletSchema>();
+    tablet_schema->init_from_pb(schema_pb);
+
+    auto rowset_meta = std::make_shared<RowsetMeta>();
+    init_rs_meta(rowset_meta, 1, 1);
+    rowset_meta->set_num_segments(2);
+    RowsetSharedPtr rowset_ptr = std::make_shared<BetaRowset>(tablet_schema, rowset_meta, "");
+
+    sp->set_call_back("CloudTablet::pick_a_rowset_for_index_change", [rowset_ptr](auto&& outcome) {
+        auto* pairs = try_any_cast_ret<Result<RowsetSharedPtr>>(outcome);
+        pairs->second = true;
+        pairs->first = Result<RowsetSharedPtr>(rowset_ptr);
+    });
+
+    // test request lock failed
+    sp->set_call_back("CloudMetaMgr::prepare_tablet_job", [](auto&& outcome) {
+        auto* pairs = try_any_cast_ret<Status>(outcome);
+        pairs->second = true;
+        pairs->first = Status::InternalError<false>("mock tablet not found");
+
+        auto* resp = try_any_cast<cloud::StartTabletJobResponse*>(outcome[1]);
+        resp->mutable_status()->set_code(cloud::TABLET_NOT_FOUND);
+        resp->mutable_status()->set_msg("mock tablet not found");
+    });
+
+    {
+        EngineCloudIndexChangeTask task(*_engine, request);
+        Status ret = task.execute();
+        ASSERT_TRUE(!ret.ok());
+        ASSERT_TRUE(contains_str(ret.to_string(), "mock tablet not found"));
+    }
+
+    // test execute failed
+    sp->set_call_back("CloudMetaMgr::prepare_tablet_job", [](auto&& outcome) {
+        auto* pairs = try_any_cast_ret<Status>(outcome);
+        pairs->second = true;
+        pairs->first = Status::OK();
+    });
+
+    sp->set_call_back("CloudIndexChangeCompaction::execute_compact", [](auto&& outcome) {
+        auto* pairs = try_any_cast_ret<Status>(outcome);
+        pairs->second = true;
+        pairs->first = Status::InternalError<false>("compaction exec failed");
+    });
+
+    {
+        EngineCloudIndexChangeTask task(*_engine, request);
+        Status ret = task.execute();
+        ASSERT_TRUE(!ret.ok());
+        ASSERT_TRUE(contains_str(ret.to_string(), "compaction exec failed"));
+    }
+}
+
+TEST_F(CloudIndexChangeTaskTest, register_task_conflict_test) {
+    _engine->_submitted_base_compactions.clear();
+    _engine->_submitted_index_change_base_compaction.clear();
+    _engine->_submitted_cumu_compactions.clear();
+    _engine->_submitted_index_change_cumu_compaction.clear();
+
+    std::shared_ptr<CloudIndexChangeCompaction> index_change_compact = nullptr;
+
+    int64_t tablet_id = 10001;
+    std::string err_reason = "";
+    // conflict with base compaction
+    bool ret = _engine->register_index_change_compaction(index_change_compact, tablet_id, true,
+                                                         err_reason);
+    ASSERT_TRUE(ret);
+    _engine->_submitted_base_compactions[tablet_id] = nullptr;
+    ret = _engine->register_index_change_compaction(index_change_compact, tablet_id, true,
+                                                    err_reason);
+    ASSERT_FALSE(ret);
+
+    // conflict with cumu compaction
+    ret = _engine->register_index_change_compaction(index_change_compact, tablet_id, false,
+                                                    err_reason);
+    ASSERT_TRUE(ret);
+    _engine->_submitted_cumu_compactions[tablet_id] = {};
+    ret = _engine->register_index_change_compaction(index_change_compact, tablet_id, false,
+                                                    err_reason);
+    ASSERT_FALSE(ret);
+}
+
+} // namespace doris

--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -195,7 +195,7 @@ supportedCreateStatement
         USING LEFT_PAREN booleanExpression RIGHT_PAREN                    #createRowPolicy
     | CREATE STORAGE POLICY (IF NOT EXISTS)?
         name=identifier properties=propertyClause?                              #createStoragePolicy
-    | BUILD INDEX name=identifier ON tableName=multipartIdentifier
+    | BUILD INDEX (name=identifier)? ON tableName=multipartIdentifier
         partitionSpec?                                                          #buildIndex
     | CREATE INDEX (IF NOT EXISTS)? name=identifier
         ON tableName=multipartIdentifier identifierList

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/IndexChangeJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/IndexChangeJob.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.alter;
 
+import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
@@ -27,6 +28,7 @@ import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.catalog.Tablet;
+import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
@@ -35,12 +37,12 @@ import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.persist.gson.GsonUtils;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.task.AgentBatchTask;
 import org.apache.doris.task.AgentTask;
 import org.apache.doris.task.AgentTaskExecutor;
 import org.apache.doris.task.AgentTaskQueue;
 import org.apache.doris.task.AlterInvertedIndexTask;
-import org.apache.doris.thrift.TColumn;
 import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TTaskType;
 
@@ -48,6 +50,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -110,18 +113,19 @@ public class IndexChangeJob implements Writable {
     AgentBatchTask invertedIndexBatchTask = new AgentBatchTask();
     @SerializedName(value = "timeoutMs")
     protected long timeoutMs = -1;
+    @SerializedName(value = "clsname")
+    private String cloudClusterName = "";
+    // in cloud mode, schemaVersion/colList/idxList is used for rebuilding a full tablet schema in BE.
+    @SerializedName(value = "sv")
+    private int schemaVersion;
+    @SerializedName(value = "cols")
+    private List<Column> colList = null;
+    @SerializedName(value = "idxs")
+    private List<Index> idxList = null;
 
-    public IndexChangeJob() {
-        this.jobId = -1;
-        this.dbId = -1;
-        this.tableId = -1;
-        this.tableName = "";
-
-        this.createTimeMs = System.currentTimeMillis();
-        this.jobState = JobState.WAITING_TXN;
-    }
-
-    public IndexChangeJob(long jobId, long dbId, long tableId, String tableName, long timeoutMs) throws Exception {
+    public IndexChangeJob(long jobId, long dbId, long tableId, String tableName, long timeoutMs, int schemaVersion,
+            List<Column> colList, List<Index> indexList)
+            throws Exception {
         this.jobId = jobId;
         this.dbId = dbId;
         this.tableId = tableId;
@@ -131,6 +135,9 @@ public class IndexChangeJob implements Writable {
         this.jobState = JobState.WAITING_TXN;
         this.watershedTxnId = Env.getCurrentGlobalTransactionMgr().getNextTransactionId();
         this.timeoutMs = timeoutMs;
+        this.schemaVersion = schemaVersion;
+        this.colList = colList;
+        this.idxList = indexList;
     }
 
     public long getJobId() {
@@ -177,6 +184,10 @@ public class IndexChangeJob implements Writable {
             }
         }
         return false;
+    }
+
+    public void setCloudClusterName(String cloudClusterName) {
+        this.cloudClusterName = cloudClusterName;
     }
 
     public long getDbId() {
@@ -226,6 +237,8 @@ public class IndexChangeJob implements Writable {
      *      db lock
      */
     public synchronized void run() {
+        setCloudCluster();
+
         if (isTimeout()) {
             cancelImpl("Timeout");
             return;
@@ -246,6 +259,15 @@ public class IndexChangeJob implements Writable {
         }
     }
 
+    private void setCloudCluster() {
+        if (!StringUtils.isEmpty(cloudClusterName)) {
+            ConnectContext ctx = new ConnectContext();
+            ctx.setThreadLocalInfo();
+            ctx.setCloudCluster(cloudClusterName);
+            ctx.setCurrentUserIdentity(UserIdentity.ADMIN);
+        }
+    }
+
     public final synchronized boolean cancel(String errMsg) {
         return cancelImpl(errMsg);
     }
@@ -255,6 +277,10 @@ public class IndexChangeJob implements Writable {
      * return false if table is not stable.
      */
     protected boolean checkTableStable(OlapTable tbl) throws AlterCancelException {
+        // cloud mode need not check tablet stable
+        if (Config.isCloudMode()) {
+            return true;
+        }
         tbl.writeLockOrAlterCancelException();
         try {
             boolean isStable = tbl.isStable(Env.getCurrentSystemInfo(),
@@ -283,9 +309,16 @@ public class IndexChangeJob implements Writable {
 
     protected void runWaitingTxnJob() throws AlterCancelException {
         Preconditions.checkState(jobState == JobState.WAITING_TXN, jobState);
+        // NOTE: Cloud mode using compaction to alter index, so it won't conflict with load job.
+        // but previous load is the load job begins before create index,their output rowset not carries index.
+        // we need to wait them finish then begin alter index; otherwise they may finish after alter index job
+        // finish, so there could be some rowset without index in BE.
+        // TODO: record a exact transaction id before create index, this requires visit table index meta and get global
+        // transaction id is a atomic operator.
         try {
             if (!isPreviousLoadFinished()) {
-                LOG.info("wait transactions before {} to be finished, inverted index job: {}", watershedTxnId, jobId);
+                LOG.info("wait transactions before {} to be finished, inverted index job: {}", watershedTxnId,
+                        jobId);
                 return;
             }
         } catch (AnalysisException e) {
@@ -309,11 +342,6 @@ public class IndexChangeJob implements Writable {
 
         olapTable.readLock();
         try {
-            List<Column> originSchemaColumns = olapTable.getSchemaByIndexId(originIndexId, true);
-            for (Column col : originSchemaColumns) {
-                TColumn tColumn = col.toThrift();
-                col.setIndexFlag(tColumn, olapTable);
-            }
             int originSchemaHash = olapTable.getSchemaHashByIndexId(originIndexId);
             Partition partition = olapTable.getPartition(partitionId);
             MaterializedIndex origIdx = partition.getIndex(originIndexId);
@@ -328,12 +356,13 @@ public class IndexChangeJob implements Writable {
                         throw new AlterCancelException("originReplica:" + originReplica.getId()
                                 + " backendId < 0");
                     }
+
                     AlterInvertedIndexTask alterInvertedIndexTask = new AlterInvertedIndexTask(
                             originReplica.getBackendIdWithoutException(), db.getId(), olapTable.getId(),
                             partitionId, originIndexId, originTabletId,
-                            originSchemaHash, olapTable.getIndexes(),
-                            alterInvertedIndexes, originSchemaColumns,
-                            isDropOp, taskSignature, jobId);
+                            originSchemaHash, idxList,
+                            alterInvertedIndexes, colList,
+                            isDropOp, taskSignature, jobId, schemaVersion);
                     invertedIndexBatchTask.addTask(alterInvertedIndexTask);
                 }
             } // end for tablet
@@ -349,6 +378,29 @@ public class IndexChangeJob implements Writable {
         this.jobState = JobState.RUNNING;
         // DO NOT write edit log here, tasks will be sent again if FE restart or master changed.
         LOG.info("transfer inverted index job {} state to {}", jobId, this.jobState);
+    }
+
+    // if cloud cluster is removed, we should cancel task early and release resource
+    private void ensureCloudClusterExist(List<AgentTask> tasks) throws AlterCancelException {
+        if (Config.isNotCloudMode()) {
+            return;
+        }
+        CloudSystemInfoService systemInfoService = (CloudSystemInfoService) Env.getCurrentSystemInfo();
+        if (StringUtils.isEmpty(systemInfoService.getCloudClusterIdByName(cloudClusterName))) {
+            // actually agenttask could be removed in cancelInternal()
+            // remove task here just for code robust
+            for (AgentTask task : tasks) {
+                task.setFinished(true);
+                AgentTaskQueue.removeTask(task.getBackendId(), TTaskType.ALTER, task.getSignature());
+            }
+            StringBuilder sb = new StringBuilder("cloud cluster(");
+            sb.append(cloudClusterName);
+            sb.append(") has been removed, jobId=");
+            sb.append(jobId);
+            String msg = sb.toString();
+            LOG.warn(msg);
+            throw new AlterCancelException(msg);
+        }
     }
 
     protected void runRunningJob() throws AlterCancelException {
@@ -367,6 +419,7 @@ public class IndexChangeJob implements Writable {
         if (!invertedIndexBatchTask.isFinished()) {
             LOG.info("inverted index tasks not finished. job: {}, partitionId: {}", jobId, partitionId);
             List<AgentTask> tasks = invertedIndexBatchTask.getUnfinishedTasks(2000);
+            ensureCloudClusterExist(tasks);
             for (AgentTask task : tasks) {
                 if (task.getFailedTimes() >= MIN_FAILED_NUM) {
                     LOG.warn("alter inverted index task failed: " + task.getErrorMsg());

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -2167,10 +2167,12 @@ public class SchemaChangeHandler extends AlterHandler {
                     // for inverted index, light schema change is supported in both cloud and local mode;
                     // for ngram index, light schema change is supported only in cloud mode;
                     boolean supportLightIndexChange = false;
-                    if (Config.isCloudMode() && enableAddIndexForNewData) {
-                        supportLightIndexChange = (
-                                found.getIndexType() == IndexType.NGRAM_BF
-                                        || found.getIndexType() == IndexDef.IndexType.INVERTED);
+                    if (Config.isCloudMode()) {
+                        if (enableAddIndexForNewData) {
+                            supportLightIndexChange = (
+                                    found.getIndexType() == IndexType.NGRAM_BF
+                                            || found.getIndexType() == IndexDef.IndexType.INVERTED);
+                        }
                     } else {
                         supportLightIndexChange = found.getIndexType() == IndexDef.IndexType.INVERTED
                                 || found.getIndexType() == IndexDef.IndexType.ANN;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BuildIndexClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BuildIndexClause.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.alter.AlterOpType;
+import org.apache.doris.analysis.IndexDef.IndexType;
 import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.Index;
@@ -25,6 +26,7 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 
 import com.google.common.collect.Maps;
 
@@ -116,9 +118,10 @@ public class BuildIndexClause extends AlterTableClause {
         }
 
         IndexDef.IndexType indexType = existedIdx.getIndexType();
-        if (indexType == IndexDef.IndexType.NGRAM_BF
+        if ((Config.isNotCloudMode() && indexType == IndexDef.IndexType.NGRAM_BF)
+                || (Config.isCloudMode() && indexType == IndexType.INVERTED & !existedIdx.isInvertedIndexParserNone())
                 || indexType == IndexDef.IndexType.BLOOMFILTER) {
-            throw new AnalysisException("ngram bloomfilter or bloomfilter index is not needed to build.");
+            throw new AnalysisException("bloomfilter index is not needed to build.");
         }
         indexDef = new IndexDef(indexName, partitionNames, indexType, true);
         if (!table.isPartitionedTable()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Index.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Index.java
@@ -18,6 +18,7 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.analysis.IndexDef;
+import org.apache.doris.analysis.IndexDef.IndexType;
 import org.apache.doris.analysis.InvertedIndexUtil;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
@@ -186,7 +187,7 @@ public class Index implements Writable {
 
     // Whether the index can be changed in light mode
     public boolean isLightIndexChangeSupported() {
-        return indexType == IndexDef.IndexType.INVERTED;
+        return indexType == IndexDef.IndexType.INVERTED || indexType == IndexType.NGRAM_BF;
     }
 
     // Whether the index can be added in light mode

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -5656,7 +5656,7 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
 
     @Override
     public Command visitBuildIndex(BuildIndexContext ctx) {
-        String name = ctx.name.getText();
+        String name = ctx.name == null ? "" : ctx.name.getText();
         TableNameInfo tableName = new TableNameInfo(visitMultipartIdentifier(ctx.tableName));
         PartitionNamesInfo partitionNamesInfo = null;
         if (ctx.partitionSpec() != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/task/AlterInvertedIndexTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/AlterInvertedIndexTask.java
@@ -45,12 +45,13 @@ public class AlterInvertedIndexTask extends AgentTask {
     private List<Index> existIndexes;
     private boolean isDropOp = false;
     private long jobId;
+    private int schemaVersion;
 
     public AlterInvertedIndexTask(long backendId, long dbId, long tableId,
             long partitionId, long indexId, long tabletId, int schemaHash,
             List<Index> existIndexes, List<Index> alterInvertedIndexes,
             List<Column> schemaColumns, boolean isDropOp, long taskSignature,
-            long jobId) {
+            long jobId, int schemaVersion) {
         super(null, backendId, TTaskType.ALTER_INVERTED_INDEX, dbId, tableId,
                 partitionId, indexId, tabletId, taskSignature);
         this.tabletId = tabletId;
@@ -60,6 +61,7 @@ public class AlterInvertedIndexTask extends AgentTask {
         this.schemaColumns = schemaColumns;
         this.isDropOp = isDropOp;
         this.jobId = jobId;
+        this.schemaVersion = schemaVersion;
     }
 
     public long getTabletId() {
@@ -96,6 +98,7 @@ public class AlterInvertedIndexTask extends AgentTask {
         TAlterInvertedIndexReq req = new TAlterInvertedIndexReq();
         req.setTabletId(tabletId);
         req.setSchemaHash(schemaHash);
+        req.setSchemaVersion(schemaVersion);
         req.setIsDropOp(isDropOp);
         // set jonId for debugging in BE
         req.setJobId(jobId);

--- a/fe/fe-core/src/main/java/org/apache/doris/task/PushTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/PushTask.java
@@ -30,6 +30,7 @@ import org.apache.doris.thrift.TBrokerScanRange;
 import org.apache.doris.thrift.TColumn;
 import org.apache.doris.thrift.TCondition;
 import org.apache.doris.thrift.TDescriptorTable;
+import org.apache.doris.thrift.TOlapTableIndex;
 import org.apache.doris.thrift.TPriority;
 import org.apache.doris.thrift.TPushReq;
 import org.apache.doris.thrift.TPushType;
@@ -76,6 +77,7 @@ public class PushTask extends AgentTask {
     // for light schema change
     private int schemaVersion;
     private List<TColumn> columnsDesc = null;
+    private List<TOlapTableIndex> indexList = null;
 
     private String vaultId;
     private Map<String, TColumn> colNameToColDesc;
@@ -84,7 +86,8 @@ public class PushTask extends AgentTask {
             long tabletId, long replicaId, int schemaHash, long version, String filePath, long fileSize,
             int timeoutSecond, long loadJobId, TPushType pushType, List<Predicate> conditions, boolean needDecompress,
             TPriority priority, TTaskType taskType, long transactionId, long signature, List<TColumn> columnsDesc,
-            Map<String, TColumn> colNameToColDesc, String vaultId, int schemaVersion) {
+            Map<String, TColumn> colNameToColDesc, String vaultId, int schemaVersion,
+            List<TOlapTableIndex> tIndexList) {
         super(resourceInfo, backendId, taskType, dbId, tableId, partitionId, indexId, tabletId, signature);
         this.replicaId = replicaId;
         this.schemaHash = schemaHash;
@@ -107,6 +110,7 @@ public class PushTask extends AgentTask {
         this.colNameToColDesc = colNameToColDesc;
         this.vaultId = vaultId;
         this.schemaVersion = schemaVersion;
+        this.indexList = tIndexList;
     }
 
     // for load v2 (SparkLoadJob)
@@ -116,7 +120,7 @@ public class PushTask extends AgentTask {
             List<TColumn> columnsDesc, Map<String, TColumn> colNameToColDesc, String vaultId, int schemaVersion) {
         this(null, backendId, dbId, tableId, partitionId, indexId, tabletId, replicaId, schemaHash, -1, null, 0,
                 timeoutSecond, loadJobId, pushType, null, false, priority, TTaskType.REALTIME_PUSH, transactionId,
-                signature, columnsDesc, colNameToColDesc, vaultId, schemaVersion);
+                signature, columnsDesc, colNameToColDesc, vaultId, schemaVersion, null);
         this.tBrokerScanRange = tBrokerScanRange;
         this.tDescriptorTable = tDescriptorTable;
     }
@@ -189,6 +193,7 @@ public class PushTask extends AgentTask {
         request.setColumnsDesc(columnsDesc);
         request.setStorageVaultId(this.vaultId);
         request.setSchemaVersion(schemaVersion);
+        request.setIndexList(indexList);
         return request;
     }
 

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -287,6 +287,7 @@ struct TAlterInvertedIndexReq {
     8: optional list<Descriptors.TColumn> columns
     9: optional i64 job_id
     10: optional i64 expiration
+    11: optional i32 schema_version
 }
 
 struct TTabletGcBinlogInfo {
@@ -334,6 +335,7 @@ struct TPushReq {
     16: optional list<Descriptors.TColumn> columns_desc
     17: optional string storage_vault_id
     18: optional i32 schema_version
+    19: optional list<Descriptors.TOlapTableIndex> index_list;
 }
 
 struct TCloneReq {

--- a/regression-test/plugins/plugin_index_change.groovy
+++ b/regression-test/plugins/plugin_index_change.groovy
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.Suite
+
+def delta_time = 1000
+
+Suite.metaClass.wait_for_last_build_index_finish = {table_name, OpTimeout ->
+    def useTime = 0
+    for(int t = delta_time; t <= OpTimeout; t += delta_time){
+        def alter_res = sql """show build index order by CreateTime desc limit 1;"""
+        alter_res = alter_res.toString()
+        if(alter_res.contains("FINISHED")) {
+            sleep(3000) // wait change table state to normal
+            logger.info(table_name + " latest alter job finished, detail: " + alter_res)
+            break
+        } else if (alter_res.contains("CANCELLED")) {
+            logger.info(table_name + " latest alter job failed, detail: " + alter_res)
+            assertTrue(false)
+        }
+        useTime = t
+        sleep(delta_time)
+    }
+    assertTrue(useTime <= OpTimeout, "wait for last build index finish timeout")
+}
+
+Suite.metaClass.wait_for_latest_col_change_table_finish = { table_name, OpTimeout ->
+    def useTime = 0
+
+    for (int t = delta_time; t <= OpTimeout; t += delta_time) {
+        def alter_res = sql """SHOW ALTER TABLE COLUMN WHERE TableName = "${table_name}" ORDER BY CreateTime DESC LIMIT 1;"""
+        alter_res = alter_res.toString()
+        if (alter_res.contains("FINISHED")) {
+            sleep(3000) // wait change table state to normal
+            logger.info(table_name + " latest alter job finished, detail: " + alter_res)
+            break
+        }
+        useTime = t
+        sleep(delta_time)
+    }
+    assertTrue(useTime <= OpTimeout, "wait_for_latest_op_on_table_finish timeout")
+}

--- a/regression-test/suites/index_p0/test_ngram_bloomfilter_index_change.groovy
+++ b/regression-test/suites/index_p0/test_ngram_bloomfilter_index_change.groovy
@@ -136,6 +136,7 @@ suite("test_ngram_bloomfilter_index_change") {
     // Drop index
     sql "DROP INDEX idx_ngram_customer_name ON ${tableName};"
     wait_for_latest_op_on_table_finish(tableName, timeout)
+    wait_for_last_build_index_finish(tableName, timeout)
 
     // Test after dropping index
     profile("sql_select_like_with_ngram_index_light_mode_dropped") {
@@ -200,6 +201,7 @@ suite("test_ngram_bloomfilter_index_change") {
     // Add NGRAM Bloom Filter index (will trigger schema change in this mode)
     sql "ALTER TABLE ${tableName} ADD INDEX idx_ngram_customer_name(customer_name) USING NGRAM_BF PROPERTIES('bf_size' = '1024', 'gram_size' = '3');"
     wait_for_latest_op_on_table_finish(tableName, timeout)
+    wait_for_last_build_index_finish(tableName, timeout)
 
     // Test after adding NGRAM Bloom Filter index (should filter existing data)
     profile("sql_select_like_with_ngram_index_schema_change_mode_added") {
@@ -235,6 +237,7 @@ suite("test_ngram_bloomfilter_index_change") {
     // Drop index
     sql "DROP INDEX idx_ngram_customer_name ON ${tableName};"
     wait_for_latest_op_on_table_finish(tableName, timeout)
+    wait_for_last_build_index_finish(tableName, timeout)
 
     // Test after dropping index
     profile("sql_select_like_with_ngram_index_schema_change_mode_dropped") {
@@ -282,6 +285,7 @@ suite("test_ngram_bloomfilter_index_change") {
     // Add ngram bf index before data insertion
     sql "ALTER TABLE ${tableName} ADD INDEX idx_ngram_customer_name(customer_name) USING NGRAM_BF PROPERTIES('bf_size' = '1024', 'gram_size' = '3');"
     wait_for_latest_op_on_table_finish(tableName, timeout)
+    wait_for_last_build_index_finish(tableName, timeout)
 
     // Insert data after index creation
     insertTestData()

--- a/regression-test/suites/inverted_index_p0/index_format_v2/test_add_build_index_with_format_v2.groovy
+++ b/regression-test/suites/inverted_index_p0/index_format_v2/test_add_build_index_with_format_v2.groovy
@@ -113,9 +113,13 @@ suite("test_add_build_index_with_format_v2", "inverted_index_format_v2"){
     String ip = backendId_to_backendIP.get(backend_id)
     String port = backendId_to_backendHttpPort.get(backend_id)
 
-    // cloud mode is directly schema change, local mode is light schema change.
     // cloud mode is 12, local mode is 6
     if (isCloudMode()) {
+        // build index
+        sql """
+        BUILD INDEX ON ${tableName};
+        """
+        wait_for_build_index_on_partition_finish(tableName, timeout)
         check_nested_index_file(ip, port, tablet_id, 7, 2, "V2")
         qt_sql "SELECT * FROM $tableName WHERE name match 'andy' order by id, name, score;"
         return


### PR DESCRIPTION
### What problem does this PR solve?
Cloud mode not support build inverted index without parser and ngram bf index by lightweight index change previously.
This PR introduce a new kind of Compaction named ```IndexChangeCompaction``` to solve this problem.
Build index is just like executing Compaction which means it's lightweight and won't  conflict with other Compaction and Load job.



### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

