### PR TITLE
[fix](unique function) fix merge project with unique function

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEmptyRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEmptyRelation.java
@@ -61,11 +61,6 @@ public class LogicalEmptyRelation extends LogicalRelation
     }
 
     @Override
-    public boolean canProcessProject(List<NamedExpression> parentProjects) {
-        return true;
-    }
-
-    @Override
     public List<NamedExpression> getProjects() {
         return projects;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEmptyRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEmptyRelation.java
@@ -61,6 +61,11 @@ public class LogicalEmptyRelation extends LogicalRelation
     }
 
     @Override
+    public boolean canProcessProject(List<NamedExpression> parentProjects) {
+        return true;
+    }
+
+    @Override
     public List<NamedExpression> getProjects() {
         return projects;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOneRowRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOneRowRelation.java
@@ -78,7 +78,10 @@ public class LogicalOneRowRelation extends LogicalRelation implements OneRowRela
 
     @Override
     public boolean canProcessProject(List<NamedExpression> parentProjects) {
-        return !ExpressionUtils.containsTypes(parentProjects, FORBIDDEN_EXPRESSIONS);
+        if (ExpressionUtils.containsTypes(parentProjects, FORBIDDEN_EXPRESSIONS)) {
+            return false;
+        }
+        return ProjectMergeable.super.canProcessProject(parentProjects);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
@@ -286,9 +286,4 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
             builder.addDeps(expr.getInputSlots(), ImmutableSet.of(expr.toSlot()));
         }
     }
-
-    @Override
-    public boolean canProcessProject(List<NamedExpression> parentProjects) {
-        return canMergeParentProjections(parentProjects);
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/ProjectMergeable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/ProjectMergeable.java
@@ -35,6 +35,12 @@ import java.util.Optional;
  * 3. project(emptyRelation) -> emptyRelation
  */
 public interface ProjectMergeable extends ProjectProcessor, OutputPrunable, Plan {
+
+    @Override
+    default boolean canProcessProject(List<NamedExpression> parentProjects) {
+        return PlanUtils.canMergeWithProjections(getProjects(), parentProjects);
+    }
+
     @Override
     default Optional<Plan> processProject(List<NamedExpression> parentProjects) {
         return mergeContinuedProjects(parentProjects, this);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalProject.java
@@ -371,9 +371,4 @@ public class PhysicalProject<CHILD_TYPE extends Plan> extends PhysicalUnary<CHIL
         }
         return withProjects(allProjects);
     }
-
-    @Override
-    public boolean canProcessProject(List<NamedExpression> parentProjects) {
-        return true;
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/PlanUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/PlanUtils.java
@@ -165,7 +165,7 @@ public class PlanUtils {
      * if replace with the projects, then result expressions: [ t + random(),  t + random() + 10 ],
      * it will calculate random two times, this is error.
      */
-    public static boolean canReplaceWithProjections(List<? extends NamedExpression> childProjects,
+    public static boolean canMergeWithProjections(List<? extends NamedExpression> childProjects,
             List<? extends Expression> targetExpressions) {
         Set<Slot> uniqueFunctionSlots = Sets.newHashSet();
         for (Entry<Slot, Expression> kv : ExpressionUtils.generateReplaceMap(childProjects).entrySet()) {

--- a/regression-test/data/nereids_rules_p0/unique_function/merge_project_with_unique_function.out
+++ b/regression-test/data/nereids_rules_p0/unique_function/merge_project_with_unique_function.out
@@ -27,3 +27,80 @@ PhysicalResultSink
 ----PhysicalProject[(cast(id as BIGINT) + random(1, 10)) AS `a`]
 ------PhysicalOlapScan[t1]
 
+-- !merge_one_row_1 --
+PhysicalResultSink
+--PhysicalOneRowRelation[100 AS `b`, 100 AS `c`]
+
+-- !merge_one_row_2 --
+PhysicalResultSink
+--PhysicalProject[a AS `b`, a AS `c`]
+----PhysicalOneRowRelation[random(1, 10) AS `a`]
+
+-- !merge_one_row_3 --
+PhysicalResultSink
+--PhysicalOneRowRelation[random(1, 10) AS `b`]
+
+-- !merge_one_row_4 --
+PhysicalResultSink
+--PhysicalProject[((a + a) + 10) AS `b`]
+----PhysicalOneRowRelation[random(1, 10) AS `a`]
+
+-- !merge_one_row_5 --
+PhysicalResultSink
+--PhysicalProject[(a + 10) AS `c`, a AS `b`]
+----PhysicalOneRowRelation[random(1, 10) AS `a`]
+
+-- !merge_empty_1 --
+PhysicalResultSink
+--PhysicalEmptyRelation
+
+-- !merge_empty_2 --
+PhysicalResultSink
+--PhysicalEmptyRelation
+
+-- !merge_empty_3 --
+PhysicalResultSink
+--PhysicalEmptyRelation
+
+-- !merge_empty_4 --
+PhysicalResultSink
+--PhysicalEmptyRelation
+
+-- !merge_empty_5 --
+PhysicalResultSink
+--PhysicalEmptyRelation
+
+-- !merge_union_1 --
+PhysicalResultSink
+--PhysicalProject[a AS `b`, a AS `c`]
+----PhysicalUnion
+------PhysicalProject[(cast(id as BIGINT) + 100) AS `a`]
+--------PhysicalOlapScan[t1]
+
+-- !merge_union_2 --
+PhysicalResultSink
+--PhysicalProject[a AS `b`, a AS `c`]
+----PhysicalUnion
+------PhysicalProject[(cast(id as BIGINT) + random(1, 10)) AS `a`]
+--------PhysicalOlapScan[t1]
+
+-- !merge_union_3 --
+PhysicalResultSink
+--PhysicalUnion
+----PhysicalProject[(cast(id as BIGINT) + random(1, 10)) AS `b`]
+------PhysicalOlapScan[t1]
+
+-- !merge_union_4 --
+PhysicalResultSink
+--PhysicalProject[((a + a) + 10) AS `b`]
+----PhysicalUnion
+------PhysicalProject[(cast(id as BIGINT) + random(1, 10)) AS `a`]
+--------PhysicalOlapScan[t1]
+
+-- !merge_union_5 --
+PhysicalResultSink
+--PhysicalProject[(a + 10) AS `c`, a AS `b`]
+----PhysicalUnion
+------PhysicalProject[(cast(id as BIGINT) + random(1, 10)) AS `a`]
+--------PhysicalOlapScan[t1]
+

--- a/regression-test/suites/nereids_rules_p0/unique_function/merge_project_with_unique_function.groovy
+++ b/regression-test/suites/nereids_rules_p0/unique_function/merge_project_with_unique_function.groovy
@@ -20,7 +20,7 @@ suite('merge_project_with_unique_function') {
     sql 'SET runtime_filter_mode=OFF'
     sql 'SET enable_fallback_to_original_planner=false'
     sql "SET ignore_shape_nodes='PhysicalDistribute'"
-    sql "SET detail_shape_nodes='PhysicalProject'"
+    sql "SET detail_shape_nodes='PhysicalProject,PhysicalOneRowRelation'"
     sql 'SET disable_nereids_rules=PRUNE_EMPTY_PARTITION'
 
     qt_merge_project_1 '''
@@ -41,5 +41,65 @@ suite('merge_project_with_unique_function') {
 
     qt_merge_project_5 '''
         explain shape plan select a as b, a + 10 as c from (select id + random(1, 10) as a from t1) t
+        '''
+
+    qt_merge_one_row_1 '''
+        explain shape plan select a as b, a as c from (select 100 as a) t
+        '''
+
+    qt_merge_one_row_2 '''
+        explain shape plan select a as b, a as c from (select random(1, 10) as a) t
+        '''
+
+    qt_merge_one_row_3 '''
+        explain shape plan select a as b from (select random(1, 10) as a) t
+        '''
+
+    qt_merge_one_row_4 '''
+        explain shape plan select a + 10 + a as b from (select random(1, 10) as a) t
+        '''
+
+    qt_merge_one_row_5 '''
+        explain shape plan select a as b, a + 10 as c from (select random(1, 10) as a) t
+        '''
+
+    qt_merge_empty_1 '''
+        explain shape plan select a as b, a as c from (select id + 100 as a from t1 where false) t
+        '''
+
+    qt_merge_empty_2 '''
+        explain shape plan select a as b, a as c from (select id + random(1, 10) as a from t1 where false) t
+        '''
+
+    qt_merge_empty_3 '''
+        explain shape plan select a as b from (select id + random(1, 10) as a from t1 where false) t
+        '''
+
+    qt_merge_empty_4 '''
+        explain shape plan select a + 10 + a as b from (select id + random(1, 10) as a from t1 where false) t
+        '''
+
+    qt_merge_empty_5 '''
+        explain shape plan select a as b, a + 10 as c from (select id + random(1, 10) as a from t1 where false) t
+        '''
+
+    qt_merge_union_1 '''
+        explain shape plan select a as b, a as c from (select id + 100 as a from t1 union all select 100) t
+        '''
+
+    qt_merge_union_2 '''
+        explain shape plan select a as b, a as c from (select id + random(1, 10) as a from t1 union all select random(1, 10)) t
+        '''
+
+    qt_merge_union_3 '''
+        explain shape plan select a as b from (select id + random(1, 10) as a from t1 union all select random(1, 10)) t
+        '''
+
+    qt_merge_union_4 '''
+        explain shape plan select a + 10 + a as b from (select id + random(1, 10) as a from t1 union all select random(1, 10)) t
+        '''
+
+    qt_merge_union_5 '''
+        explain shape plan select a as b, a + 10 as c from (select id + random(1, 10) as a from t1 union all select random(1, 10)) t
         '''
 }


### PR DESCRIPTION
### What problem does this PR solve?

when merge project, if the slot reference in parent project exists multiple times,  and the slot reference's origin expression contains unique expression,  then shouldn't merge these projects,  otherwise be will calculate the unique function multiple time.

for example:

```
LogicalProject( k + k)
|
LogicalProject(random() as k)
```

after merge project, it will got:
```
LogicalProject(random() + random())
```

then be wil calcute  twice random() for each row.

relate PR:  #43546

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

