### PR TITLE
[fix](unique function) fix in predicate extract non-constant for unique function

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/InPredicateExtractNonConstant.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/InPredicateExtractNonConstant.java
@@ -43,10 +43,14 @@ public class InPredicateExtractNonConstant implements ExpressionPatternRuleFacto
 
     @Override
     public List<ExpressionPatternMatcher<? extends Expression>> buildRules() {
+        // If compare expr contains unique function, don't extract it.
+        // For example: `a + random() in (x, x + 10)`, if extracted, `a + random() = x or a + random() = x + 10`,
+        // then the expression will contain RANDOM two times.
         return ImmutableList.of(
                 matchesType(InPredicate.class)
-                        .when(inPredicate -> inPredicate.getOptions().size()
-                                <= InPredicateDedup.REWRITE_OPTIONS_MAX_SIZE)
+                        .when(inPredicate ->
+                                inPredicate.getOptions().size() <= InPredicateDedup.REWRITE_OPTIONS_MAX_SIZE
+                                && !inPredicate.getCompareExpr().containsUniqueFunction())
                         .then(this::rewrite)
                         .toRule(ExpressionRuleType.IN_PREDICATE_EXTRACT_NON_CONSTANT)
         );


### PR DESCRIPTION
### What problem does this PR solve?

InPredicateExtractNonConstant will extract non-constant options from in predicate,  for the purpose of be speed up evaluating the in predicate.

but for the sql `a + random() in (b, 10,  20, 30)`,  it will rewrite as `a + random() = b or a + random() in (10, 20, 30)`,  then BE will calculate the random() twice for one row.

so if the in predicate's compare expression contains unique function,  don't extract it.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

