### PR TITLE
[fix](constant fold)Do not do BE constant fold when float/double is NaN

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
@@ -419,25 +419,23 @@ public class FoldConstantRuleOnBE implements ExpressionPatternRuleFactory {
             int num = resultContent.getFloatValueCount();
             for (int i = 0; i < num; ++i) {
                 float value = resultContent.getFloatValue(i);
-                Literal literal = null;
                 if (Float.isNaN(value)) {
-                    literal = new NullLiteral(type);
+                    return Collections.emptyList();
                 } else {
-                    literal = new FloatLiteral(value);
+                    Literal literal = new FloatLiteral(value);
+                    res.add(literal);
                 }
-                res.add(literal);
             }
         } else if (type.isDoubleType()) {
             int num = resultContent.getDoubleValueCount();
             for (int i = 0; i < num; ++i) {
                 double value = resultContent.getDoubleValue(i);
-                Literal literal = null;
                 if (Double.isNaN(value)) {
-                    literal = new NullLiteral(type);
+                    return Collections.emptyList();
                 } else {
-                    literal = new DoubleLiteral(value);
+                    Literal literal = new DoubleLiteral(value);
+                    res.add(literal);
                 }
-                res.add(literal);
             }
         } else if (type.isDecimalV2Type()) {
             int num = resultContent.getBytesValueCount();
@@ -516,8 +514,13 @@ public class FoldConstantRuleOnBE implements ExpressionPatternRuleFactory {
             int childCount = resultContent.getChildElementCount();
             List<Literal> allLiterals = new ArrayList<>();
             for (int i = 0; i < childCount; ++i) {
-                allLiterals.addAll(getResultExpression(arrayType.getItemType(),
-                        resultContent.getChildElement(i)));
+                List<Literal> resultExpression = getResultExpression(arrayType.getItemType(),
+                        resultContent.getChildElement(i));
+                // If any child element couldn't fold, stop folding this Array.
+                if (resultExpression.isEmpty()) {
+                    return Collections.emptyList();
+                }
+                allLiterals.addAll(resultExpression);
             }
             int offsetCount = resultContent.getChildOffsetCount();
             if (offsetCount == 1) {
@@ -541,10 +544,19 @@ public class FoldConstantRuleOnBE implements ExpressionPatternRuleFactory {
             List<Literal> allKeys = new ArrayList<>();
             List<Literal> allValues = new ArrayList<>();
             for (int i = 0; i < childCount; i = i + 2) {
-                allKeys.addAll(getResultExpression(mapType.getKeyType(),
-                        resultContent.getChildElement(i)));
-                allValues.addAll(getResultExpression(mapType.getValueType(),
-                        resultContent.getChildElement(i + 1)));
+                // If any key or value couldn't fold, stop folding this Map.
+                List<Literal> key = getResultExpression(mapType.getKeyType(),
+                        resultContent.getChildElement(i));
+                if (key.isEmpty()) {
+                    return Collections.emptyList();
+                }
+                allKeys.addAll(key);
+                List<Literal> value = getResultExpression(mapType.getValueType(),
+                        resultContent.getChildElement(i + 1));
+                if (value.isEmpty()) {
+                    return Collections.emptyList();
+                }
+                allValues.addAll(value);
             }
             int offsetCount = resultContent.getChildOffsetCount();
             if (offsetCount == 1) {
@@ -569,8 +581,13 @@ public class FoldConstantRuleOnBE implements ExpressionPatternRuleFactory {
             int childCount = resultContent.getChildElementCount();
             List<List<Literal>> allFields = new ArrayList<>();
             for (int i = 0; i < childCount; ++i) {
-                allFields.add(getResultExpression(structType.getFields().get(i).getDataType(),
-                        resultContent.getChildElement(i)));
+                List<Literal> resultExpression = getResultExpression(structType.getFields().get(i).getDataType(),
+                        resultContent.getChildElement(i));
+                // If any field couldn't fold, stop folding this Struct.
+                if (resultExpression.isEmpty()) {
+                    return Collections.emptyList();
+                }
+                allFields.add(resultExpression);
             }
             for (int i = 0; i < allFields.get(0).size(); ++i) {
                 List<Literal> fields = new ArrayList<>();

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_by_be.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_by_be.groovy
@@ -96,4 +96,27 @@ suite("fold_constant_by_be") {
          sql "select IS_IPV4_MAPPED(NULLABLE(ipv6_string_to_num_or_default('192.168.1.1')));"
          contains "192.168.1.1"
     }
+    explain {
+        sql "select cosine_distance([0], [0]);"
+        contains "cosine_distance"
+        notContains("NULL")
+    }
+
+    explain {
+        sql "select array(cosine_distance([1], [1]), cast(\"NaN\" as float));"
+        contains "array(cosine_distance"
+        notContains("[0, ")
+    }
+
+    explain {
+        sql "select map(cosine_distance([1], [1]), cast(\"NaN\" as float));"
+        contains "map(cosine_distance"
+        notContains("MAP{0")
+    }
+
+    explain {
+        sql "select map(cast(\"NaN\" as float), cosine_distance([1], [1]));"
+        contains "map(NaN, cosine_distance"
+        notContains("MAP{NaN")
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?
Do not do BE constant fold when float/double is NaN
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

