### PR TITLE
[fix][catalog] Fix desc command null meta_cache issue when max_meta_object_cache_num=0

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -246,7 +246,8 @@ public abstract class ExternalCatalog
         if (catalogProperty.getOrDefault(USE_META_CACHE, "").isEmpty()) {
             // If not setting USE_META_CACHE in replay logic,
             // set default value to false to be compatible with older version meta data.
-            catalogProperty.addProperty(USE_META_CACHE, isReplay ? "false" : String.valueOf(DEFAULT_USE_META_CACHE));
+            catalogProperty.addProperty(USE_META_CACHE, isReplay ? "false"
+                    : Config.max_meta_object_cache_num > 0 ? String.valueOf(DEFAULT_USE_META_CACHE) : "false");
         }
         useMetaCache = Optional.of(
                 Boolean.valueOf(catalogProperty.getOrDefault(USE_META_CACHE, String.valueOf(DEFAULT_USE_META_CACHE))));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -249,8 +249,10 @@ public abstract class ExternalCatalog
             catalogProperty.addProperty(USE_META_CACHE, isReplay ? "false"
                     : Config.max_meta_object_cache_num > 0 ? String.valueOf(DEFAULT_USE_META_CACHE) : "false");
         }
-        useMetaCache = Optional.of(
-                Boolean.valueOf(catalogProperty.getOrDefault(USE_META_CACHE, String.valueOf(DEFAULT_USE_META_CACHE))));
+        // If max_meta_object_cache_num equals zero, force use_meta_cache to false.
+        // otherwise meta operations will use meta cache.
+        String configuredValue = catalogProperty.getOrDefault(USE_META_CACHE, String.valueOf(DEFAULT_USE_META_CACHE));
+        useMetaCache = Optional.of(Boolean.parseBoolean(configuredValue) && (Config.max_meta_object_cache_num > 0));
     }
 
     // we need check auth fallback for kerberos or simple

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -430,7 +430,7 @@ public abstract class ExternalDatabase<T extends ExternalTable>
         }
 
         // Step 3: Resolve remote table name if using meta cache and it is not provided
-        if (remoteTableName == null && extCatalog.useMetaCache.get() && Config.max_meta_object_cache_num > 0) {
+        if (remoteTableName == null && extCatalog.useMetaCache.get()) {
             if (Boolean.parseBoolean(extCatalog.getLowerCaseMetaNames())
                     || !Strings.isNullOrEmpty(extCatalog.getMetaNamesMapping())
                     || this.isStoredTableNamesLowerCase()) {
@@ -593,7 +593,7 @@ public abstract class ExternalDatabase<T extends ExternalTable>
     @Override
     public List<T> getTables() {
         makeSureInitialized();
-        if (extCatalog.getUseMetaCache().get() && Config.max_meta_object_cache_num > 0) {
+        if (extCatalog.getUseMetaCache().get()) {
             List<T> tables = Lists.newArrayList();
             Set<String> tblNames = getTableNamesWithLock();
             for (String tblName : tblNames) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -164,7 +164,7 @@ public abstract class ExternalDatabase<T extends ExternalTable>
             isInitializing = true;
             try {
                 if (!initialized) {
-                    if (extCatalog.getUseMetaCache().get() && Config.max_meta_object_cache_num > 0) {
+                    if (extCatalog.getUseMetaCache().get()) {
                         buildMetaCache();
                         setLastUpdateTime(System.currentTimeMillis());
                     } else {
@@ -430,7 +430,7 @@ public abstract class ExternalDatabase<T extends ExternalTable>
         }
 
         // Step 3: Resolve remote table name if using meta cache and it is not provided
-        if (remoteTableName == null && extCatalog.useMetaCache.get()) {
+        if (remoteTableName == null && extCatalog.useMetaCache.get() && Config.max_meta_object_cache_num > 0) {
             if (Boolean.parseBoolean(extCatalog.getLowerCaseMetaNames())
                     || !Strings.isNullOrEmpty(extCatalog.getMetaNamesMapping())
                     || this.isStoredTableNamesLowerCase()) {
@@ -593,7 +593,7 @@ public abstract class ExternalDatabase<T extends ExternalTable>
     @Override
     public List<T> getTables() {
         makeSureInitialized();
-        if (extCatalog.getUseMetaCache().get()) {
+        if (extCatalog.getUseMetaCache().get() && Config.max_meta_object_cache_num > 0) {
             List<T> tables = Lists.newArrayList();
             Set<String> tblNames = getTableNamesWithLock();
             for (String tblName : tblNames) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -708,7 +708,7 @@ public abstract class ExternalDatabase<T extends ExternalTable>
     @Override
     public T getTableNullable(long tableId) {
         makeSureInitialized();
-        if (extCatalog.getUseMetaCache().get()) {
+        if (extCatalog.getUseMetaCache().get() && metaCache != null) {
             return metaCache.getMetaObjById(tableId).orElse(null);
         } else {
             return idToTbl.get(tableId);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -164,7 +164,7 @@ public abstract class ExternalDatabase<T extends ExternalTable>
             isInitializing = true;
             try {
                 if (!initialized) {
-                    if (extCatalog.getUseMetaCache().get()) {
+                    if (extCatalog.getUseMetaCache().get() && Config.max_meta_object_cache_num > 0) {
                         buildMetaCache();
                         setLastUpdateTime(System.currentTimeMillis());
                     } else {
@@ -708,7 +708,7 @@ public abstract class ExternalDatabase<T extends ExternalTable>
     @Override
     public T getTableNullable(long tableId) {
         makeSureInitialized();
-        if (extCatalog.getUseMetaCache().get() && metaCache != null) {
+        if (extCatalog.getUseMetaCache().get()) {
             return metaCache.getMetaObjById(tableId).orElse(null);
         } else {
             return idToTbl.get(tableId);


### PR DESCRIPTION
### What problem does this PR solve?

When max_meta_object_cache_num = 0, the desc command fails because it tries to access disabled meta cache.

#### Error reproduction:
When use_meta_cache = true (shown in catalog properties), executing desc t_ts_ntz; fails with:
```
ERROR 1105 (HY000): errCode = 2, detailMessage = Unknown table '7311664922056505694'
```
When use_meta_cache = false is explicitly set, the same desc t_ts_ntz; command works correctly

#### Solution
- Force disable use_meta_cache when max_meta_object_cache_num = 0
- Add validation for invalid configuration values
- Add warning logs when cache settings are adjusted
- Improve code readability

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

