### PR TITLE
[Fix](Load) Use defered file format properties for broker load without format

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -2668,6 +2668,8 @@ mysql_data_desc ::=
     opt_col_mapping_list:colMappingList
     opt_properties:properties
     {:
+        // MySQL load only support csv, set it explicitly
+        properties.put("format", "csv");
         RESULT = new DataDescription(tableName, partitionNames, file, clientLocal, colList, colSep, lineDelimiter,
         skipLines, colMappingList, properties);
     :}

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DataDescription.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DataDescription.java
@@ -1010,7 +1010,8 @@ public class DataDescription implements InsertStmt.DataDesc {
         analyzeMultiLoadColumns();
         analyzeSequenceCol(fullDbName);
 
-        fileFormatProperties = FileFormatProperties.createFileFormatPropertiesOrAuto(analysisMap);
+        fileFormatProperties = FileFormatProperties.createFileFormatPropertiesOrDeferred(
+                analysisMap.getOrDefault(FileFormatProperties.PROP_FORMAT, ""));
         fileFormatProperties.analyzeFileFormatProperties(analysisMap, false);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DataDescription.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DataDescription.java
@@ -1010,7 +1010,7 @@ public class DataDescription implements InsertStmt.DataDesc {
         analyzeMultiLoadColumns();
         analyzeSequenceCol(fullDbName);
 
-        fileFormatProperties = FileFormatProperties.createFileFormatProperties(analysisMap);
+        fileFormatProperties = FileFormatProperties.createFileFormatPropertiesOrAuto(analysisMap);
         fileFormatProperties.analyzeFileFormatProperties(analysisMap, false);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/fileformat/DeferredFileFormatProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/fileformat/DeferredFileFormatProperties.java
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.property.fileformat;
+
+import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.thrift.TFileAttributes;
+import org.apache.doris.thrift.TResultFileSinkOptions;
+
+import com.google.common.base.Strings;
+
+import java.util.Map;
+
+public class DeferredFileFormatProperties extends FileFormatProperties {
+
+    private String formatStr;
+    private FileFormatProperties delegate;
+    private Map<String, String> origProperties;
+
+    public DeferredFileFormatProperties() {
+        super(null, null);
+    }
+
+    @Override
+    public void analyzeFileFormatProperties(Map<String, String> formatProperties, boolean isRemoveOriginProperty)
+            throws AnalysisException {
+        if (!Strings.isNullOrEmpty(formatStr)) {
+            delegate = FileFormatProperties.createFileFormatProperties(formatStr);
+            this.origProperties = formatProperties;
+            delegate.analyzeFileFormatProperties(formatProperties, isRemoveOriginProperty);
+        } else {
+            this.origProperties = formatProperties;
+        }
+    }
+
+    @Override
+    public void fullTResultFileSinkOptions(TResultFileSinkOptions sinkOptions) {
+
+    }
+
+    @Override
+    public TFileAttributes toTFileAttributes() {
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/fileformat/DeferredFileFormatProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/fileformat/DeferredFileFormatProperties.java
@@ -19,15 +19,28 @@ package org.apache.doris.datasource.property.fileformat;
 
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.thrift.TFileAttributes;
+import org.apache.doris.thrift.TFileCompressType;
+import org.apache.doris.thrift.TFileFormatType;
 import org.apache.doris.thrift.TResultFileSinkOptions;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
 import java.util.Map;
 
+/**
+ * A wrapper of FileFormatProperties, which defers the initialization of the actual FileFormatProperties.
+ * Currently, this is only used in broker load.
+ * In broker load, user may not specify the file format properties, and we can not even infer the file format
+ * from path at the beginning, because the path may be a directory with wildcard.
+ * So we can only get the file suffix after listing files, and then initialize the actual.
+ *
+ * When using this class, you must call {@link #deferInit(TFileFormatType)} after getting the actual file format type
+ * before using other methods.
+ * And all methods must override and delegate to the actual FileFormatProperties.
+ */
 public class DeferredFileFormatProperties extends FileFormatProperties {
 
-    private String formatStr;
     private FileFormatProperties delegate;
     private Map<String, String> origProperties;
 
@@ -38,22 +51,68 @@ public class DeferredFileFormatProperties extends FileFormatProperties {
     @Override
     public void analyzeFileFormatProperties(Map<String, String> formatProperties, boolean isRemoveOriginProperty)
             throws AnalysisException {
-        if (!Strings.isNullOrEmpty(formatStr)) {
-            delegate = FileFormatProperties.createFileFormatProperties(formatStr);
-            this.origProperties = formatProperties;
-            delegate.analyzeFileFormatProperties(formatProperties, isRemoveOriginProperty);
-        } else {
-            this.origProperties = formatProperties;
-        }
+        this.origProperties = formatProperties;
     }
 
     @Override
     public void fullTResultFileSinkOptions(TResultFileSinkOptions sinkOptions) {
-
+        Preconditions.checkNotNull(delegate);
+        delegate.fullTResultFileSinkOptions(sinkOptions);
     }
 
     @Override
     public TFileAttributes toTFileAttributes() {
-        return null;
+        Preconditions.checkNotNull(delegate);
+        return delegate.toTFileAttributes();
+    }
+
+    @Override
+    protected String getOrDefault(Map<String, String> props, String key, String defaultValue,
+            boolean isRemove) {
+        Preconditions.checkNotNull(delegate);
+        return delegate.getOrDefault(props, key, defaultValue, isRemove);
+    }
+
+    public TFileFormatType getFileFormatType() {
+        Preconditions.checkNotNull(delegate);
+        return delegate.getFileFormatType();
+    }
+
+    public TFileCompressType getCompressionType() {
+        Preconditions.checkNotNull(delegate);
+        return delegate.getCompressionType();
+    }
+
+    public String getFormatName() {
+        Preconditions.checkNotNull(delegate);
+        return delegate.getFormatName();
+    }
+
+    public FileFormatProperties getDelegate() {
+        Preconditions.checkNotNull(delegate);
+        return delegate;
+    }
+
+    public void deferInit(TFileFormatType formatType) {
+        switch (formatType) {
+            case FORMAT_PARQUET: {
+                this.formatName = FORMAT_PARQUET;
+                break;
+            }
+            case FORMAT_ORC: {
+                this.formatName = FORMAT_ORC;
+                break;
+            }
+            case FORMAT_JSON: {
+                this.formatName = FORMAT_JSON;
+                break;
+            }
+            default: {
+                this.formatName = FORMAT_CSV;
+                break;
+            }
+        }
+        delegate = FileFormatProperties.createFileFormatProperties(this.formatName);
+        delegate.analyzeFileFormatProperties(origProperties, false);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/fileformat/DeferredFileFormatProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/fileformat/DeferredFileFormatProperties.java
@@ -24,7 +24,6 @@ import org.apache.doris.thrift.TFileFormatType;
 import org.apache.doris.thrift.TResultFileSinkOptions;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 
 import java.util.Map;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/fileformat/FileFormatProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/fileformat/FileFormatProperties.java
@@ -103,21 +103,14 @@ public abstract class FileFormatProperties {
         }
     }
 
-    public static FileFormatProperties createFileFormatProperties(Map<String, String> formatProperties)
-            throws AnalysisException {
-        String formatString = formatProperties.getOrDefault(PROP_FORMAT, "csv");
-        return createFileFormatProperties(formatString);
-    }
-
     /**
-     * Create a FileFormatProperties that may be AUTO if format is not specified.
-     * The actual format should be inferred later by other business logic.
+     * Create a FileFormatProperties
+     * If the format property is not specified, return a DeferredFileFormatProperties
      */
-    public static FileFormatProperties createFileFormatPropertiesOrAuto(Map<String, String> formatProperties)
+    public static FileFormatProperties createFileFormatPropertiesOrDeferred(String formatString)
             throws AnalysisException {
-        String formatString = formatProperties.get(PROP_FORMAT);
         if (Strings.isNullOrEmpty(formatString)) {
-            return new DeferredFileFormatProperties(formatProperties)
+            return new DeferredFileFormatProperties();
         } else {
             return createFileFormatProperties(formatString);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/fileformat/FileFormatProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/fileformat/FileFormatProperties.java
@@ -23,6 +23,8 @@ import org.apache.doris.thrift.TFileCompressType;
 import org.apache.doris.thrift.TFileFormatType;
 import org.apache.doris.thrift.TResultFileSinkOptions;
 
+import com.google.common.base.Strings;
+
 import java.util.Map;
 
 public abstract class FileFormatProperties {
@@ -105,6 +107,20 @@ public abstract class FileFormatProperties {
             throws AnalysisException {
         String formatString = formatProperties.getOrDefault(PROP_FORMAT, "csv");
         return createFileFormatProperties(formatString);
+    }
+
+    /**
+     * Create a FileFormatProperties that may be AUTO if format is not specified.
+     * The actual format should be inferred later by other business logic.
+     */
+    public static FileFormatProperties createFileFormatPropertiesOrAuto(Map<String, String> formatProperties)
+            throws AnalysisException {
+        String formatString = formatProperties.get(PROP_FORMAT);
+        if (Strings.isNullOrEmpty(formatString)) {
+            return new DeferredFileFormatProperties(formatProperties)
+        } else {
+            return createFileFormatProperties(formatString);
+        }
     }
 
     protected String getOrDefault(Map<String, String> props, String key, String defaultValue,

--- a/fe/fe-core/src/main/java/org/apache/doris/load/BrokerFileGroup.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/BrokerFileGroup.java
@@ -35,11 +35,16 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.common.util.Util;
+import org.apache.doris.datasource.property.fileformat.DeferredFileFormatProperties;
 import org.apache.doris.datasource.property.fileformat.FileFormatProperties;
 import org.apache.doris.datasource.property.fileformat.OrcFileFormatProperties;
 import org.apache.doris.datasource.property.fileformat.ParquetFileFormatProperties;
 import org.apache.doris.load.loadv2.LoadTask;
+import org.apache.doris.thrift.TBrokerFileStatus;
+import org.apache.doris.thrift.TFileFormatType;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -284,7 +289,17 @@ public class BrokerFileGroup implements Writable {
         this.fileSize = fileSize;
     }
 
+    public void initDeferredFileFormatPropertiesIfNecessary(List<TBrokerFileStatus> fileStatuses) {
+        if (fileFormatProperties instanceof DeferredFileFormatProperties) {
+            Preconditions.checkState(fileStatuses != null && !fileStatuses.isEmpty());
+            TBrokerFileStatus fileStatus = fileStatuses.get(0);
+            TFileFormatType formatType = Util.getFileFormatTypeFromPath(fileStatus.path);
+            ((DeferredFileFormatProperties) fileFormatProperties).deferInit(formatType);
+        }
+    }
+
     public boolean isBinaryFileFormat() {
+        // Must call initDeferredFileFormatPropertiesIfNecessary before
         return fileFormatProperties instanceof ParquetFileFormatProperties
                 || fileFormatProperties instanceof OrcFileFormatProperties;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/BrokerFileGroup.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/BrokerFileGroup.java
@@ -36,6 +36,7 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.Util;
+import org.apache.doris.datasource.property.fileformat.CsvFileFormatProperties;
 import org.apache.doris.datasource.property.fileformat.DeferredFileFormatProperties;
 import org.apache.doris.datasource.property.fileformat.FileFormatProperties;
 import org.apache.doris.datasource.property.fileformat.OrcFileFormatProperties;
@@ -66,6 +67,9 @@ public class BrokerFileGroup implements Writable {
     private static final Logger LOG = LogManager.getLogger(BrokerFileGroup.class);
 
     private long tableId;
+    // columnSeparator and lineDelimiter here are only for toString(),
+    // and may be null if format will be decided by file's suffix
+    // we should get them from fileFormatProperties
     private String columnSeparator;
     private String lineDelimiter;
     // fileFormat may be null, which means format will be decided by file's suffix
@@ -176,11 +180,11 @@ public class BrokerFileGroup implements Writable {
         }
 
         fileFormatProperties = dataDescription.getFileFormatProperties();
-        // fileFormat = fileFormatProperties.getFormatName();
-        // if (fileFormatProperties instanceof CsvFileFormatProperties) {
-        //     columnSeparator = ((CsvFileFormatProperties) fileFormatProperties).getColumnSeparator();
-        //     lineDelimiter = ((CsvFileFormatProperties) fileFormatProperties).getLineDelimiter();
-        // }
+        if (fileFormatProperties instanceof CsvFileFormatProperties) {
+            fileFormat = fileFormatProperties.getFormatName();
+            columnSeparator = ((CsvFileFormatProperties) fileFormatProperties).getColumnSeparator();
+            lineDelimiter = ((CsvFileFormatProperties) fileFormatProperties).getLineDelimiter();
+        }
 
         isNegative = dataDescription.isNegative();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/BrokerFileGroup.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/BrokerFileGroup.java
@@ -35,7 +35,6 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
-import org.apache.doris.datasource.property.fileformat.CsvFileFormatProperties;
 import org.apache.doris.datasource.property.fileformat.FileFormatProperties;
 import org.apache.doris.datasource.property.fileformat.OrcFileFormatProperties;
 import org.apache.doris.datasource.property.fileformat.ParquetFileFormatProperties;
@@ -172,11 +171,11 @@ public class BrokerFileGroup implements Writable {
         }
 
         fileFormatProperties = dataDescription.getFileFormatProperties();
-        fileFormat = fileFormatProperties.getFormatName();
-        if (fileFormatProperties instanceof CsvFileFormatProperties) {
-            columnSeparator = ((CsvFileFormatProperties) fileFormatProperties).getColumnSeparator();
-            lineDelimiter = ((CsvFileFormatProperties) fileFormatProperties).getLineDelimiter();
-        }
+        // fileFormat = fileFormatProperties.getFormatName();
+        // if (fileFormatProperties instanceof CsvFileFormatProperties) {
+        //     columnSeparator = ((CsvFileFormatProperties) fileFormatProperties).getColumnSeparator();
+        //     lineDelimiter = ((CsvFileFormatProperties) fileFormatProperties).getLineDelimiter();
+        // }
 
         isNegative = dataDescription.isNegative();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/MysqlLoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/MysqlLoadManager.java
@@ -43,6 +43,7 @@ import org.apache.doris.system.Backend;
 import org.apache.doris.system.BeSelectionPolicy;
 import org.apache.doris.system.SystemInfoService;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.EvictingQueue;
@@ -335,7 +336,7 @@ public class MysqlLoadManager {
         });
     }
 
-    // public only for test
+    @VisibleForTesting
     public HttpPut generateRequestForMySqlLoad(
             InputStreamEntity entity,
             DataDescription desc,
@@ -350,6 +351,10 @@ public class MysqlLoadManager {
 
         Map<String, String> props = desc.getProperties();
         FileFormatProperties fileFormatProperties = desc.getFileFormatProperties();
+        if (!(fileFormatProperties instanceof CsvFileFormatProperties)) {
+            throw new LoadException("Only support csv file format for mysql load");
+        }
+        CsvFileFormatProperties csvFileFormatProperties = (CsvFileFormatProperties) fileFormatProperties;
         if (props != null) {
             // max_filter_ratio
             if (props.containsKey(LoadStmt.KEY_IN_PARAM_MAX_FILTER_RATIO)) {
@@ -381,21 +386,15 @@ public class MysqlLoadManager {
                 httpPut.addHeader(LoadStmt.TIMEZONE, timezone);
             }
 
-            if (fileFormatProperties instanceof CsvFileFormatProperties) {
-                CsvFileFormatProperties csvFileFormatProperties = (CsvFileFormatProperties) fileFormatProperties;
-                httpPut.addHeader(LoadStmt.KEY_TRIM_DOUBLE_QUOTES,
-                        String.valueOf(csvFileFormatProperties.isTrimDoubleQuotes()));
-                httpPut.addHeader(LoadStmt.KEY_ENCLOSE, new String(new byte[]{csvFileFormatProperties.getEnclose()}));
-                httpPut.addHeader(LoadStmt.KEY_ESCAPE, new String(new byte[]{csvFileFormatProperties.getEscape()}));
-            }
+            httpPut.addHeader(LoadStmt.KEY_TRIM_DOUBLE_QUOTES,
+                    String.valueOf(csvFileFormatProperties.isTrimDoubleQuotes()));
+            httpPut.addHeader(LoadStmt.KEY_ENCLOSE, new String(new byte[]{csvFileFormatProperties.getEnclose()}));
+            httpPut.addHeader(LoadStmt.KEY_ESCAPE, new String(new byte[]{csvFileFormatProperties.getEscape()}));
         }
 
-        if (fileFormatProperties instanceof CsvFileFormatProperties) {
-            CsvFileFormatProperties csvFileFormatProperties = (CsvFileFormatProperties) fileFormatProperties;
-            httpPut.addHeader(LoadStmt.KEY_SKIP_LINES, Integer.toString(csvFileFormatProperties.getSkipLines()));
-            httpPut.addHeader(LoadStmt.KEY_IN_PARAM_COLUMN_SEPARATOR, csvFileFormatProperties.getColumnSeparator());
-            httpPut.addHeader(LoadStmt.KEY_IN_PARAM_LINE_DELIMITER, csvFileFormatProperties.getLineDelimiter());
-        }
+        httpPut.addHeader(LoadStmt.KEY_SKIP_LINES, Integer.toString(csvFileFormatProperties.getSkipLines()));
+        httpPut.addHeader(LoadStmt.KEY_IN_PARAM_COLUMN_SEPARATOR, csvFileFormatProperties.getColumnSeparator());
+        httpPut.addHeader(LoadStmt.KEY_IN_PARAM_LINE_DELIMITER, csvFileFormatProperties.getLineDelimiter());
 
         // columns
         String columns = getColumns(desc);

--- a/regression-test/suites/external_table_p0/refactor_storage_param/hdfs_load_default_file_format.groovy
+++ b/regression-test/suites/external_table_p0/refactor_storage_param/hdfs_load_default_file_format.groovy
@@ -18,7 +18,12 @@ import org.awaitility.Awaitility;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static groovy.test.GroovyAssert.shouldFail
 
-suite("hdfs_load_default_file_format", "p0,external,kerberos,external_docker") {
+suite("hdfs_load_default_file_format", "external_docker,hive,external_docker_hive,p0,external") {
+    String enabled = context.config.otherConfigs.get("enableHiveTest")
+    if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+        logger.info("disable Hive test.")
+        return;
+    }
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String hdfsPort = context.config.otherConfigs.get("hive3HdfsPort")
     def defaultFS = "hdfs://${externalEnvIp}:${hdfsPort}"

--- a/regression-test/suites/external_table_p0/refactor_storage_param/hdfs_load_default_file_format.groovy
+++ b/regression-test/suites/external_table_p0/refactor_storage_param/hdfs_load_default_file_format.groovy
@@ -1,0 +1,109 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import org.awaitility.Awaitility;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static groovy.test.GroovyAssert.shouldFail
+
+suite("hdfs_load_default_file_format", "p0,external,kerberos,external_docker") {
+    String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+    String hdfsPort = context.config.otherConfigs.get("hive3HdfsPort")
+    def defaultFS = "hdfs://${externalEnvIp}:${hdfsPort}"
+
+    def table = "hdfs_load_default_file_format_tbl";
+    def table2 = "hdfs_load_default_file_format_tbl2";
+
+    def outfile_to_hdfs = { defaultFs ->
+        def outFilePath = "${defaultFs}/tmp/hdfs_load_default_file_format_"
+        // select ... into outfile ...
+        def res = sql """
+            SELECT * FROM ${table}
+            INTO OUTFILE "${outFilePath}"
+            FORMAT AS PARQUET
+            PROPERTIES (
+               "fs.defaultFS" = "${defaultFs}" 
+            );
+        """
+        println res
+        return res[0][3]
+    }
+
+    def hdfsLoad = { filePath, defaultFs ->
+        def dataCountResult = sql """
+            SELECT count(*) FROM ${table}
+        """
+        def dataCount = dataCountResult[0][0]
+        def label = "hdfs_load_label_" + System.currentTimeMillis()
+        def load = sql """
+            LOAD LABEL `${label}` (
+            data infile ("${filePath}")
+            into table ${table2}
+              (k1, k2))
+              with hdfs
+              (
+                 "fs.defaultFS" = "${defaultFs}"
+              );
+        """
+        Awaitility.await().atMost(60, SECONDS).pollInterval(1, SECONDS).until({
+            def loadResult = sql """
+                show load where label = '${label}';
+            """
+            println loadResult
+
+            if (null == loadResult || loadResult.isEmpty() || null == loadResult.get(0) || loadResult.get(0).size() < 3) {
+                return false;
+            }
+            if (loadResult.get(0).get(2) == 'CANCELLED' || loadResult.get(0).get(2) == 'FAILED') {
+                throw new RuntimeException("load failed")
+            }
+
+            return loadResult.get(0).get(2) == 'FINISHED'
+        })
+
+
+        def expectedCount = dataCount;
+        Awaitility.await().atMost(5, SECONDS).pollInterval(1, SECONDS).until({
+            def loadResult = sql """
+                select count(*) from ${table2}
+            """
+            println "loadResult: ${loadResult}, expected: ${expectedCount}"
+            return loadResult.get(0).get(0) == expectedCount
+        })
+    }
+
+    sql """drop table if exists ${table}"""
+    sql """drop table if exists ${table2}"""
+    sql """create table ${table}
+        (k1 int, k2 string) distributed by hash(k1) buckets 1
+        properties("replication_num" = "1");
+    """
+    sql """create table ${table2} like ${table}"""
+
+    sql """insert into ${table} values(1, "name");"""
+    for (int i = 0; i < 10; i++) {
+        sql """insert into ${table} select k1 + ${i}, concat(k2, k1 + ${i}) from ${table}"""
+    }
+
+    // outfile 
+    // set enable_parallel_outfile to outfile multi files
+    // sql """set enable_parallel_outfile=true"""
+
+    def outfile = outfile_to_hdfs("hdfs://${externalEnvIp}:${hdfsPort}");
+    println outfile
+
+    hdfsLoad(outfile, "hdfs://${externalEnvIp}:${hdfsPort}")
+
+}


### PR DESCRIPTION
### What problem does this PR solve?

User may not specify data format in broker load, so we can only infer the data format
after listing the files.
So we have to defer the initialization of file properties object

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

