### PR TITLE
[fix](test) Buffer stdout/stderr to avoid blocking the curl command

### DIFF
--- a/regression-test/plugins/plugin_curl_requester.groovy
+++ b/regression-test/plugins/plugin_curl_requester.groovy
@@ -144,14 +144,21 @@ Suite.metaClass.curl = { String method, String url, String body = null, Integer 
 
     while (retryCount < maxRetries) {
         process = cmd.execute()
-        code = process.waitFor()
-        err = IOGroovyMethods.getText(new BufferedReader(new InputStreamReader(process.getErrorStream())))
-        out = process.getText()
+
+        def outputGlobber = new ByteArrayOutputStream()
+        def errorGlobber = new ByteArrayOutputStream()
+        process.waitForProcessOutput(outputGlobber, errorGlobber)
+
+        code = process.exitValue()
+        err = errorGlobber.toString()
+        out = outputGlobber.toString()
 
         // If the command was successful, break the loop
         if (code == 0) {
             break
         }
+
+        logger.error("Command curl failed, code: " + code + ", err: " + err + ", retry after " + sleepTime + " ms")
 
         // If the command was not successful, increment the retry count, sleep for a while and try again
         retryCount++

--- a/regression-test/suites/compaction/test_compaction_fail_release_lock.groovy
+++ b/regression-test/suites/compaction/test_compaction_fail_release_lock.groovy
@@ -81,15 +81,12 @@ suite("test_compaction_fail_release_lock", "nonConcurrent") {
         boolean running = true
         Thread.sleep(1000)
         StringBuilder sb = new StringBuilder();
-        sb.append("curl -X GET http://${be_host}:${be_http_port}")
+        sb.append("http://${be_host}:${be_http_port}")
         sb.append("/api/compaction/show?tablet_id=")
         sb.append(tablet_id)
 
         String command = sb.toString()
-        logger.info(command)
-        def process = command.execute()
-        def code = process.waitFor()
-        def out = process.getText()
+        def (code, out, err) = curl('GET', command)
         logger.info("Get tablet status:  =" + code + ", out=" + out)
         assertEquals(code, 0)
         def tabletStatus = parseJson(out.trim())
@@ -101,15 +98,12 @@ suite("test_compaction_fail_release_lock", "nonConcurrent") {
         do {
             Thread.sleep(1000)
             StringBuilder sb = new StringBuilder();
-            sb.append("curl -X GET http://${be_host}:${be_http_port}")
+            sb.append("http://${be_host}:${be_http_port}")
             sb.append("/api/compaction/run_status?tablet_id=")
             sb.append(tablet_id)
 
             String command = sb.toString()
-            logger.info(command)
-            def process = command.execute()
-            def code = process.waitFor()
-            def out = process.getText()
+            def (code, out, err) = curl('GET', command)
             logger.info("Get compaction status: code=" + code + ", out=" + out)
             assertEquals(code, 0)
             def compactionStatus = parseJson(out.trim())


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Fix curl subprocess blocking by properly consuming output streams

- Block occurs when stdout/stderr buffers fill up without being read
- Used consumeProcessOutput() to continuously drain both streams
- Maintained output capture while preventing process hangs
- Ensures process completion isn't blocked by unread output

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

