### PR TITLE
[opt](nereids) improve performance of cast big string to complex type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
@@ -519,7 +519,7 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         // }
         try {
             // TODO: support no throw exception in `checkedCastTo` and return Optional<Expression>
-            if (dataType.isComplexType()) {
+            if (cast.child().getDataType().isStringLikeType() && dataType.isComplexType()) {
                 return cast;
             }
             Expression castResult = child.checkedCastTo(dataType);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
@@ -518,6 +518,10 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         //     }
         // }
         try {
+            // TODO: support no throw exception in `checkedCastTo` and return Optional<Expression>
+            if (dataType.isComplexType()) {
+                return cast;
+            }
             Expression castResult = child.checkedCastTo(dataType);
             if (!Objects.equals(castResult, cast) && !Objects.equals(castResult, child)) {
                 castResult = rewrite(castResult, context);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteral.java
@@ -440,6 +440,24 @@ public abstract class StringLikeLiteral extends Literal implements ComparableLit
     }
 
     @Override
+    public int fastChildrenHashCode() {
+        return doComputeHashCode();
+    }
+
+    @Override
+    protected int computeHashCode() {
+        return doComputeHashCode();
+    }
+
+    private int doComputeHashCode() {
+        if (value != null && value.length() > 36) {
+            return value.substring(0, 36).hashCode();
+        } else {
+            return Objects.hashCode(getValue());
+        }
+    }
+
+    @Override
     public String toString() {
         return "'" + value + "'";
     }


### PR DESCRIPTION
### What problem does this PR solve?

improve performance of cast big string to complex type
1. avoid throw cast exception
2. avoid compute full hash code of the big string literal


```sql
select cast('[1,2,3,4,5,6,7,8,...,99999]' as array<float>);
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

