### PR TITLE
[Bug](routine load) Fix routine load task failed with MEM_LIMIT_EXCEED never be scheduled again

### DIFF
--- a/regression-test/suites/load_p0/routine_load/test_routine_load_job_schedule.groovy
+++ b/regression-test/suites/load_p0/routine_load/test_routine_load_job_schedule.groovy
@@ -22,7 +22,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.ProducerConfig
 import java.util.Collections
 
-suite("test_routine_load_job_schedule","p0") {
+suite("test_routine_load_job_schedule","nonConcurrent") {
     def kafkaCsvTpoics = [
                   "test_routine_load_job_schedule",
                 ]

--- a/regression-test/suites/load_p0/routine_load/test_routine_load_job_schedule.groovy
+++ b/regression-test/suites/load_p0/routine_load/test_routine_load_job_schedule.groovy
@@ -22,7 +22,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.ProducerConfig
 import java.util.Collections
 
-suite("test_routine_load_job_schedule","nonConcurrent") {
+suite("test_routine_load_job_schedule","p0") {
     def kafkaCsvTpoics = [
                   "test_routine_load_job_schedule",
                 ]
@@ -112,7 +112,7 @@ suite("test_routine_load_job_schedule","nonConcurrent") {
             }
         }
 
-        sql "truncate table ${table_name}"
+        sql "truncate table ${tableName}"
         def memJob = "test_routine_load_job_schedule_mem_limit"
         try {
             GetDebugPoint().enableDebugPointForAllBEs("FE.ROUTINE_LOAD_TASK_SUBMIT_FAILED.MEM_LIMIT_EXCEEDED")


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #53853

Problem Summary:

A routine load task which submit failed with following msg will never be scheduled again, causing the corresponding kafka partition to no longer be consumed.

```
2025-08-29 03:42:24:errCode = 2, detailMessage = failed to send task: errCode = 2, 
detailMessage = failed to submit task. error code: MEM_LIMIT_EXCEEDED, 
msg: (10.0.72.47)[MEM_LIMIT_EXCEEDED]
is_exceed_soft_mem_limit: 0 
current_load_mem_value: 114837740081 
_load_mem_limit: 112722727424
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

