### PR TITLE
[Fix](Load) Use deferred file format properties for broker load without format (#55450)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DataDescription.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DataDescription.java
@@ -1073,7 +1073,8 @@ public class DataDescription {
         analyzeMultiLoadColumns();
         analyzeSequenceCol(fullDbName);
 
-        fileFormatProperties = FileFormatProperties.createFileFormatProperties(analysisMap);
+        fileFormatProperties = FileFormatProperties.createFileFormatPropertiesOrDeferred(
+                analysisMap.getOrDefault(FileFormatProperties.PROP_FORMAT, ""));
         fileFormatProperties.analyzeFileFormatProperties(analysisMap, false);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/fileformat/DeferredFileFormatProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/fileformat/DeferredFileFormatProperties.java
@@ -1,0 +1,117 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.property.fileformat;
+
+import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.thrift.TFileAttributes;
+import org.apache.doris.thrift.TFileCompressType;
+import org.apache.doris.thrift.TFileFormatType;
+import org.apache.doris.thrift.TResultFileSinkOptions;
+
+import com.google.common.base.Preconditions;
+
+import java.util.Map;
+
+/**
+ * A wrapper of FileFormatProperties, which defers the initialization of the actual FileFormatProperties.
+ * Currently, this is only used in broker load.
+ * In broker load, user may not specify the file format properties, and we can not even infer the file format
+ * from path at the beginning, because the path may be a directory with wildcard.
+ * So we can only get the file suffix after listing files, and then initialize the actual.
+ *
+ * When using this class, you must call {@link #deferInit(TFileFormatType)} after getting the actual file format type
+ * before using other methods.
+ * And all methods must override and delegate to the actual FileFormatProperties.
+ */
+public class DeferredFileFormatProperties extends FileFormatProperties {
+
+    private FileFormatProperties delegate;
+    private Map<String, String> origProperties;
+
+    public DeferredFileFormatProperties() {
+        super(null, null);
+    }
+
+    @Override
+    public void analyzeFileFormatProperties(Map<String, String> formatProperties, boolean isRemoveOriginProperty)
+            throws AnalysisException {
+        this.origProperties = formatProperties;
+    }
+
+    @Override
+    public void fullTResultFileSinkOptions(TResultFileSinkOptions sinkOptions) {
+        Preconditions.checkNotNull(delegate);
+        delegate.fullTResultFileSinkOptions(sinkOptions);
+    }
+
+    @Override
+    public TFileAttributes toTFileAttributes() {
+        Preconditions.checkNotNull(delegate);
+        return delegate.toTFileAttributes();
+    }
+
+    @Override
+    protected String getOrDefault(Map<String, String> props, String key, String defaultValue,
+            boolean isRemove) {
+        Preconditions.checkNotNull(delegate);
+        return delegate.getOrDefault(props, key, defaultValue, isRemove);
+    }
+
+    public TFileFormatType getFileFormatType() {
+        Preconditions.checkNotNull(delegate);
+        return delegate.getFileFormatType();
+    }
+
+    public TFileCompressType getCompressionType() {
+        Preconditions.checkNotNull(delegate);
+        return delegate.getCompressionType();
+    }
+
+    public String getFormatName() {
+        Preconditions.checkNotNull(delegate);
+        return delegate.getFormatName();
+    }
+
+    public FileFormatProperties getDelegate() {
+        Preconditions.checkNotNull(delegate);
+        return delegate;
+    }
+
+    public void deferInit(TFileFormatType formatType) {
+        switch (formatType) {
+            case FORMAT_PARQUET: {
+                this.formatName = FORMAT_PARQUET;
+                break;
+            }
+            case FORMAT_ORC: {
+                this.formatName = FORMAT_ORC;
+                break;
+            }
+            case FORMAT_JSON: {
+                this.formatName = FORMAT_JSON;
+                break;
+            }
+            default: {
+                this.formatName = FORMAT_CSV;
+                break;
+            }
+        }
+        delegate = FileFormatProperties.createFileFormatProperties(this.formatName);
+        delegate.analyzeFileFormatProperties(origProperties, false);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/fileformat/FileFormatProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/fileformat/FileFormatProperties.java
@@ -23,6 +23,8 @@ import org.apache.doris.thrift.TFileCompressType;
 import org.apache.doris.thrift.TFileFormatType;
 import org.apache.doris.thrift.TResultFileSinkOptions;
 
+import com.google.common.base.Strings;
+
 import java.util.Map;
 
 public abstract class FileFormatProperties {
@@ -101,10 +103,17 @@ public abstract class FileFormatProperties {
         }
     }
 
-    public static FileFormatProperties createFileFormatProperties(Map<String, String> formatProperties)
+    /**
+     * Create a FileFormatProperties
+     * If the format property is not specified, return a DeferredFileFormatProperties
+     */
+    public static FileFormatProperties createFileFormatPropertiesOrDeferred(String formatString)
             throws AnalysisException {
-        String formatString = formatProperties.getOrDefault(PROP_FORMAT, "csv");
-        return createFileFormatProperties(formatString);
+        if (Strings.isNullOrEmpty(formatString)) {
+            return new DeferredFileFormatProperties();
+        } else {
+            return createFileFormatProperties(formatString);
+        }
     }
 
     protected String getOrDefault(Map<String, String> props, String key, String defaultValue,

--- a/fe/fe-core/src/main/java/org/apache/doris/load/BrokerFileGroup.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/BrokerFileGroup.java
@@ -34,7 +34,9 @@ import org.apache.doris.catalog.Table;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.property.fileformat.CsvFileFormatProperties;
+import org.apache.doris.datasource.property.fileformat.DeferredFileFormatProperties;
 import org.apache.doris.datasource.property.fileformat.FileFormatProperties;
 import org.apache.doris.datasource.property.fileformat.OrcFileFormatProperties;
 import org.apache.doris.datasource.property.fileformat.ParquetFileFormatProperties;
@@ -43,7 +45,10 @@ import org.apache.doris.nereids.load.NereidsBrokerFileGroup;
 import org.apache.doris.nereids.load.NereidsImportColumnDesc;
 import org.apache.doris.nereids.load.NereidsLoadUtils;
 import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.thrift.TBrokerFileStatus;
+import org.apache.doris.thrift.TFileFormatType;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;
@@ -62,6 +67,9 @@ public class BrokerFileGroup {
     private static final Logger LOG = LogManager.getLogger(BrokerFileGroup.class);
 
     private long tableId;
+    // columnSeparator and lineDelimiter here are only for toString(),
+    // and may be null if format will be decided by file's suffix
+    // we should get them from fileFormatProperties
     private String columnSeparator;
     private String lineDelimiter;
     // fileFormat may be null, which means format will be decided by file's suffix
@@ -172,8 +180,8 @@ public class BrokerFileGroup {
         }
 
         fileFormatProperties = dataDescription.getFileFormatProperties();
-        fileFormat = fileFormatProperties.getFormatName();
         if (fileFormatProperties instanceof CsvFileFormatProperties) {
+            fileFormat = fileFormatProperties.getFormatName();
             columnSeparator = ((CsvFileFormatProperties) fileFormatProperties).getColumnSeparator();
             lineDelimiter = ((CsvFileFormatProperties) fileFormatProperties).getLineDelimiter();
         }
@@ -285,7 +293,17 @@ public class BrokerFileGroup {
         this.fileSize = fileSize;
     }
 
+    public void initDeferredFileFormatPropertiesIfNecessary(List<TBrokerFileStatus> fileStatuses) {
+        if (fileFormatProperties instanceof DeferredFileFormatProperties) {
+            Preconditions.checkState(fileStatuses != null && !fileStatuses.isEmpty());
+            TBrokerFileStatus fileStatus = fileStatuses.get(0);
+            TFileFormatType formatType = Util.getFileFormatTypeFromPath(fileStatus.path);
+            ((DeferredFileFormatProperties) fileFormatProperties).deferInit(formatType);
+        }
+    }
+
     public boolean isBinaryFileFormat() {
+        // Must call initDeferredFileFormatPropertiesIfNecessary before
         return fileFormatProperties instanceof ParquetFileFormatProperties
                 || fileFormatProperties instanceof OrcFileFormatProperties;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/MysqlLoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/MysqlLoadManager.java
@@ -47,7 +47,6 @@ import org.apache.doris.system.Backend;
 import org.apache.doris.system.BeSelectionPolicy;
 import org.apache.doris.system.SystemInfoService;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.EvictingQueue;
@@ -233,80 +232,8 @@ public class MysqlLoadManager {
         return loadResult;
     }
 
-    public LoadJobRowResult executeMySqlLoadJobFromStmt(ConnectContext context, LoadStmt stmt, String loadId)
-            throws IOException, UserException {
-        return executeMySqlLoadJobFromStmt(context, stmt.getDataDescriptions().get(0), loadId);
-    }
-
     public LoadJobRowResult executeMySqlLoadJobFromCommand(ConnectContext context, NereidsDataDescription dataDesc,
                                                                String loadId) throws IOException, UserException {
-        LoadJobRowResult loadResult = new LoadJobRowResult();
-        List<String> filePaths = dataDesc.getFilePaths();
-        String database = ClusterNamespace.getNameFromFullName(dataDesc.getDbName());
-        String table = dataDesc.getTableName();
-        int oldTimeout = context.getExecTimeoutS();
-        int newTimeOut = extractTimeOut(dataDesc);
-        if (newTimeOut > oldTimeout) {
-            // set query timeout avoid by killed TimeoutChecker
-            SessionVariable sessionVariable = context.getSessionVariable();
-            sessionVariable.setIsSingleSetVar(true);
-            VariableMgr.setVar(sessionVariable,
-                    new SetVar(SessionVariable.QUERY_TIMEOUT, new StringLiteral(String.valueOf(newTimeOut))));
-        }
-        String token = Env.getCurrentEnv().getTokenManager().acquireToken();
-        boolean clientLocal = dataDesc.isClientLocal();
-        MySqlLoadContext loadContext = new MySqlLoadContext();
-        loadContextMap.put(loadId, loadContext);
-        LOG.info("Executing mysql load with id: {}.", loadId);
-        try (final CloseableHttpClient httpclient = HttpClients.createDefault()) {
-            for (String file : filePaths) {
-                InputStreamEntity entity = getInputStreamEntity(context, clientLocal, file, loadId);
-                HttpPut request = generateRequestForMySqlLoad(entity, dataDesc, database, table, token);
-                loadContext.setRequest(request);
-                try (final CloseableHttpResponse response = httpclient.execute(request)) {
-                    String body = EntityUtils.toString(response.getEntity());
-                    JsonObject result = JsonParser.parseString(body).getAsJsonObject();
-                    if (!result.get("Status").getAsString().equalsIgnoreCase("Success")) {
-                        String errorUrl = Optional.ofNullable(result.get("ErrorURL"))
-                                .map(JsonElement::getAsString).orElse("");
-                        failedRecords.offer(new MySqlLoadFailRecord(loadId, errorUrl));
-                        LOG.warn("Execute mysql load failed with request: {} and response: {}, job id: {}",
-                                request, body, loadId);
-                        throw new LoadException(result.get("Message").getAsString() + " with load id " + loadId);
-                    }
-                    loadResult.incRecords(result.get("NumberLoadedRows").getAsLong());
-                    loadResult.incSkipped(result.get("NumberFilteredRows").getAsInt());
-                }
-            }
-        } catch (Throwable t) {
-            LOG.warn("Execute mysql load {} failed, msg: {}", loadId, t);
-            // drain the data from client conn util empty packet received, otherwise the connection will be reset
-            if (clientLocal && loadContextMap.containsKey(loadId) && !loadContextMap.get(loadId).isFinished()) {
-                LOG.warn("Not drained yet, try reading left data from client connection for load {}.", loadId);
-                ByteBuffer buffer = context.getMysqlChannel().fetchOnePacket();
-                // MySql client will send an empty packet when eof
-                while (buffer != null && buffer.limit() != 0) {
-                    buffer = context.getMysqlChannel().fetchOnePacket();
-                }
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Finished reading the left bytes.");
-                }
-            }
-            // make cancel message to user
-            if (loadContextMap.containsKey(loadId) && loadContextMap.get(loadId).isCancelled()) {
-                throw new LoadException("Cancelled");
-            } else {
-                throw t;
-            }
-        } finally {
-            LOG.info("Mysql load job {} finished, loaded records: {}", loadId, loadResult.getRecords());
-            loadContextMap.remove(loadId);
-        }
-        return loadResult;
-    }
-
-    public LoadJobRowResult executeMySqlLoadJobFromStmt(ConnectContext context, DataDescription dataDesc, String loadId)
-            throws IOException, UserException {
         LoadJobRowResult loadResult = new LoadJobRowResult();
         List<String> filePaths = dataDesc.getFilePaths();
         String database = ClusterNamespace.getNameFromFullName(dataDesc.getDbName());
@@ -524,247 +451,9 @@ public class MysqlLoadManager {
         });
     }
 
-    public HttpPut generateRequestForMySqlLoad(
+    private HttpPut generateRequestForMySqlLoad(
             InputStreamEntity entity,
             NereidsDataDescription desc,
-            String database,
-            String table,
-            String token) throws LoadException {
-        final HttpPut httpPut = new HttpPut(selectBackendForMySqlLoad(database, table));
-
-        httpPut.addHeader("Expect", "100-continue");
-        httpPut.addHeader("Content-Type", "text/plain");
-        httpPut.addHeader("token", token);
-
-        UserIdentity uid = ConnectContext.get().getCurrentUserIdentity();
-        if (uid == null || StringUtils.isEmpty(uid.getQualifiedUser())) {
-            throw new LoadException("user is null");
-        }
-        // NOTE: set pass word empty here because password is only used when login from mysql client.
-        // All authentication actions after login in do not require a password
-        String auth = String.format("%s:%s", uid.getQualifiedUser(), "");
-        String authEncoding = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
-        httpPut.addHeader("Authorization", "Basic " + authEncoding);
-
-        Map<String, String> props = desc.getProperties();
-        FileFormatProperties fileFormatProperties = desc.getFileFormatProperties();
-        if (props != null) {
-            // max_filter_ratio
-            if (props.containsKey(LoadStmt.KEY_IN_PARAM_MAX_FILTER_RATIO)) {
-                String maxFilterRatio = props.get(LoadStmt.KEY_IN_PARAM_MAX_FILTER_RATIO);
-                httpPut.addHeader(LoadStmt.KEY_IN_PARAM_MAX_FILTER_RATIO, maxFilterRatio);
-            }
-
-            // exec_mem_limit
-            if (props.containsKey(LoadStmt.EXEC_MEM_LIMIT)) {
-                String memory = props.get(LoadStmt.EXEC_MEM_LIMIT);
-                httpPut.addHeader(LoadStmt.EXEC_MEM_LIMIT, memory);
-            }
-
-            // strict_mode
-            if (props.containsKey(LoadStmt.STRICT_MODE)) {
-                String strictMode = props.get(LoadStmt.STRICT_MODE);
-                httpPut.addHeader(LoadStmt.STRICT_MODE, strictMode);
-            }
-
-            // timeout
-            if (props.containsKey(LoadStmt.TIMEOUT_PROPERTY)) {
-                String timeout = props.get(LoadStmt.TIMEOUT_PROPERTY);
-                httpPut.addHeader(LoadStmt.TIMEOUT_PROPERTY, timeout);
-            }
-
-            // timezone
-            if (props.containsKey(LoadStmt.TIMEZONE)) {
-                String timezone = props.get(LoadStmt.TIMEZONE);
-                httpPut.addHeader(LoadStmt.TIMEZONE, timezone);
-            }
-
-            if (fileFormatProperties instanceof CsvFileFormatProperties) {
-                CsvFileFormatProperties csvFileFormatProperties = (CsvFileFormatProperties) fileFormatProperties;
-                httpPut.addHeader(LoadStmt.KEY_TRIM_DOUBLE_QUOTES,
-                        String.valueOf(csvFileFormatProperties.isTrimDoubleQuotes()));
-                httpPut.addHeader(LoadStmt.KEY_ENCLOSE, new String(new byte[]{csvFileFormatProperties.getEnclose()}));
-                httpPut.addHeader(LoadStmt.KEY_ESCAPE, new String(new byte[]{csvFileFormatProperties.getEscape()}));
-            }
-        }
-
-        if (fileFormatProperties instanceof CsvFileFormatProperties) {
-            CsvFileFormatProperties csvFileFormatProperties = (CsvFileFormatProperties) fileFormatProperties;
-            httpPut.addHeader(LoadStmt.KEY_SKIP_LINES, Integer.toString(csvFileFormatProperties.getSkipLines()));
-            httpPut.addHeader(LoadStmt.KEY_IN_PARAM_COLUMN_SEPARATOR, csvFileFormatProperties.getColumnSeparator());
-            httpPut.addHeader(LoadStmt.KEY_IN_PARAM_LINE_DELIMITER, csvFileFormatProperties.getLineDelimiter());
-        }
-
-        // columns
-        String columns = getColumns(desc);
-        if (columns != null) {
-            httpPut.addHeader(LoadStmt.KEY_IN_PARAM_COLUMNS, columns);
-        }
-
-        // partitions
-        if (desc.getPartitionNames() != null && !desc.getPartitionNames().getPartitionNames().isEmpty()) {
-            List<String> ps = desc.getPartitionNames().getPartitionNames();
-            String pNames = Joiner.on(",").join(ps);
-            if (desc.getPartitionNames().isTemp()) {
-                httpPut.addHeader(LoadStmt.KEY_IN_PARAM_TEMP_PARTITIONS, pNames);
-            } else {
-                httpPut.addHeader(LoadStmt.KEY_IN_PARAM_PARTITIONS, pNames);
-            }
-        }
-
-        // cloud cluster
-        if (Config.isCloudMode()) {
-            String clusterName = "";
-            try {
-                clusterName = ConnectContext.get().getCloudCluster();
-            } catch (Exception e) {
-                LOG.warn("failed to get compute group: " + e.getMessage());
-                throw new LoadException("failed to get compute group: " + e.getMessage());
-            }
-            if (Strings.isNullOrEmpty(clusterName)) {
-                throw new LoadException("cloud compute group is empty");
-            }
-            httpPut.addHeader(LoadStmt.KEY_CLOUD_CLUSTER, clusterName);
-        }
-
-        httpPut.setEntity(entity);
-        return httpPut;
-    }
-
-    public HttpPut generateRequestForMySqlLoadV2(
-            InputStreamEntity entity,
-            MysqlDataDescription desc,
-            String database,
-            String table,
-            String token) throws LoadException {
-        final HttpPut httpPut = new HttpPut(selectBackendForMySqlLoad(database, table));
-
-        httpPut.addHeader("Expect", "100-continue");
-        httpPut.addHeader("Content-Type", "text/plain");
-        httpPut.addHeader("token", token);
-
-        UserIdentity uid = ConnectContext.get().getCurrentUserIdentity();
-        if (uid == null || StringUtils.isEmpty(uid.getQualifiedUser())) {
-            throw new LoadException("user is null");
-        }
-        // NOTE: set pass word empty here because password is only used when login from mysql client.
-        // All authentication actions after login in do not require a password
-        String auth = String.format("%s:%s", uid.getQualifiedUser(), "");
-        String authEncoding = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
-        httpPut.addHeader("Authorization", "Basic " + authEncoding);
-
-        Map<String, String> props = desc.getProperties();
-        FileFormatProperties fileFormatProperties = desc.getFileFormatProperties();
-
-        if (props != null) {
-            // max_filter_ratio
-            if (props.containsKey(MysqlLoadCommand.MAX_FILTER_RATIO_PROPERTY)) {
-                String maxFilterRatio = props.get(MysqlLoadCommand.MAX_FILTER_RATIO_PROPERTY);
-                httpPut.addHeader(MysqlLoadCommand.MAX_FILTER_RATIO_PROPERTY, maxFilterRatio);
-            }
-
-            // exec_mem_limit
-            if (props.containsKey(MysqlLoadCommand.EXEC_MEM_LIMIT_PROPERTY)) {
-                String memory = props.get(MysqlLoadCommand.EXEC_MEM_LIMIT_PROPERTY);
-                httpPut.addHeader(MysqlLoadCommand.EXEC_MEM_LIMIT_PROPERTY, memory);
-            }
-
-            // strict_mode
-            if (props.containsKey(MysqlLoadCommand.STRICT_MODE_PROPERTY)) {
-                String strictMode = props.get(MysqlLoadCommand.STRICT_MODE_PROPERTY);
-                httpPut.addHeader(MysqlLoadCommand.STRICT_MODE_PROPERTY, strictMode);
-            }
-
-            // timeout
-            if (props.containsKey(MysqlLoadCommand.TIMEOUT_PROPERTY)) {
-                String timeout = props.get(MysqlLoadCommand.TIMEOUT_PROPERTY);
-                httpPut.addHeader(MysqlLoadCommand.TIMEOUT_PROPERTY, timeout);
-            }
-
-            // timezone
-            if (props.containsKey(MysqlLoadCommand.TIMEZONE_PROPERTY)) {
-                String timezone = props.get(MysqlLoadCommand.TIMEZONE_PROPERTY);
-                httpPut.addHeader(MysqlLoadCommand.TIMEZONE_PROPERTY, timezone);
-            }
-
-            if (fileFormatProperties instanceof CsvFileFormatProperties) {
-                // trim quotes
-                if (props.containsKey(MysqlLoadCommand.TRIM_DOUBLE_QUOTES_PROPERTY)) {
-                    String trimQuotes = props.get(MysqlLoadCommand.TRIM_DOUBLE_QUOTES_PROPERTY);
-                    httpPut.addHeader(MysqlLoadCommand.TRIM_DOUBLE_QUOTES_PROPERTY, trimQuotes);
-                }
-
-                // enclose
-                if (props.containsKey(MysqlLoadCommand.ENCLOSE_PROPERTY)) {
-                    String enclose = props.get(MysqlLoadCommand.ENCLOSE_PROPERTY);
-                    httpPut.addHeader(MysqlLoadCommand.ENCLOSE_PROPERTY, enclose);
-                }
-
-                //escape
-                if (props.containsKey(MysqlLoadCommand.ESCAPE_PROPERTY)) {
-                    String escape = props.get(MysqlLoadCommand.ESCAPE_PROPERTY);
-                    httpPut.addHeader(MysqlLoadCommand.ESCAPE_PROPERTY, escape);
-                }
-            }
-        }
-
-        if (fileFormatProperties instanceof CsvFileFormatProperties) {
-            // skip_lines
-            if (desc.getSkipLines() != 0) {
-                httpPut.addHeader(MysqlLoadCommand.KEY_SKIP_LINES, Integer.toString(desc.getSkipLines()));
-            }
-
-            // column_separator
-            if (desc.getColumnSeparator() != null) {
-                httpPut.addHeader(MysqlLoadCommand.KEY_IN_PARAM_COLUMN_SEPARATOR, desc.getColumnSeparator());
-            }
-
-            // line_delimiter
-            if (desc.getLineDelimiter() != null) {
-                httpPut.addHeader(MysqlLoadCommand.KEY_IN_PARAM_LINE_DELIMITER, desc.getLineDelimiter());
-            }
-        }
-
-        // columns
-        String columns = getColumns(desc);
-        if (columns != null) {
-            httpPut.addHeader(MysqlLoadCommand.KEY_IN_PARAM_COLUMNS, columns);
-        }
-
-        // partitions
-        if (!desc.getPartitionNamesInfo().getPartitionNames().isEmpty()) {
-            List<String> ps = desc.getPartitionNamesInfo().getPartitionNames();
-            String pNames = Joiner.on(",").join(ps);
-            if (desc.getPartitionNamesInfo().isTemp()) {
-                httpPut.addHeader(MysqlLoadCommand.KEY_IN_PARAM_TEMP_PARTITIONS, pNames);
-            } else {
-                httpPut.addHeader(MysqlLoadCommand.KEY_IN_PARAM_PARTITIONS, pNames);
-            }
-        }
-
-        // cloud cluster
-        if (Config.isCloudMode()) {
-            String clusterName = "";
-            try {
-                clusterName = ConnectContext.get().getCloudCluster();
-            } catch (Exception e) {
-                LOG.warn("failed to get compute group: " + e.getMessage());
-                throw new LoadException("failed to get compute group: " + e.getMessage());
-            }
-            if (Strings.isNullOrEmpty(clusterName)) {
-                throw new LoadException("cloud compute group is empty");
-            }
-            httpPut.addHeader(MysqlLoadCommand.KEY_CLOUD_CLUSTER, clusterName);
-        }
-
-        httpPut.setEntity(entity);
-        return httpPut;
-    }
-
-    @VisibleForTesting
-    public HttpPut generateRequestForMySqlLoad(
-            InputStreamEntity entity,
-            DataDescription desc,
             String database,
             String table,
             String token) throws LoadException {
@@ -820,16 +509,18 @@ public class MysqlLoadManager {
                 String timezone = props.get(LoadStmt.TIMEZONE);
                 httpPut.addHeader(LoadStmt.TIMEZONE, timezone);
             }
-
-            httpPut.addHeader(LoadStmt.KEY_TRIM_DOUBLE_QUOTES,
-                    String.valueOf(csvFileFormatProperties.isTrimDoubleQuotes()));
-            httpPut.addHeader(LoadStmt.KEY_ENCLOSE, new String(new byte[]{csvFileFormatProperties.getEnclose()}));
-            httpPut.addHeader(LoadStmt.KEY_ESCAPE, new String(new byte[]{csvFileFormatProperties.getEscape()}));
         }
 
-        httpPut.addHeader(LoadStmt.KEY_SKIP_LINES, Integer.toString(csvFileFormatProperties.getSkipLines()));
-        httpPut.addHeader(LoadStmt.KEY_IN_PARAM_COLUMN_SEPARATOR, csvFileFormatProperties.getColumnSeparator());
-        httpPut.addHeader(LoadStmt.KEY_IN_PARAM_LINE_DELIMITER, csvFileFormatProperties.getLineDelimiter());
+        httpPut.addHeader(CsvFileFormatProperties.PROP_TRIM_DOUBLE_QUOTES,
+                String.valueOf(csvFileFormatProperties.isTrimDoubleQuotes()));
+        httpPut.addHeader(CsvFileFormatProperties.PROP_ENCLOSE,
+                new String(new byte[] {csvFileFormatProperties.getEnclose()}));
+        httpPut.addHeader(CsvFileFormatProperties.PROP_ESCAPE,
+                new String(new byte[] {csvFileFormatProperties.getEscape()}));
+        httpPut.addHeader(CsvFileFormatProperties.PROP_SKIP_LINES,
+                Integer.toString(csvFileFormatProperties.getSkipLines()));
+        httpPut.addHeader(CsvFileFormatProperties.PROP_COLUMN_SEPARATOR, csvFileFormatProperties.getColumnSeparator());
+        httpPut.addHeader(CsvFileFormatProperties.PROP_LINE_DELIMITER, csvFileFormatProperties.getLineDelimiter());
 
         // columns
         String columns = getColumns(desc);
@@ -861,6 +552,113 @@ public class MysqlLoadManager {
                 throw new LoadException("cloud compute group is empty");
             }
             httpPut.addHeader(LoadStmt.KEY_CLOUD_CLUSTER, clusterName);
+        }
+
+        httpPut.setEntity(entity);
+        return httpPut;
+    }
+
+    private HttpPut generateRequestForMySqlLoadV2(
+            InputStreamEntity entity,
+            MysqlDataDescription desc,
+            String database,
+            String table,
+            String token) throws LoadException {
+        final HttpPut httpPut = new HttpPut(selectBackendForMySqlLoad(database, table));
+
+        httpPut.addHeader("Expect", "100-continue");
+        httpPut.addHeader("Content-Type", "text/plain");
+        httpPut.addHeader("token", token);
+
+        UserIdentity uid = ConnectContext.get().getCurrentUserIdentity();
+        if (uid == null || StringUtils.isEmpty(uid.getQualifiedUser())) {
+            throw new LoadException("user is null");
+        }
+        // NOTE: set pass word empty here because password is only used when login from mysql client.
+        // All authentication actions after login in do not require a password
+        String auth = String.format("%s:%s", uid.getQualifiedUser(), "");
+        String authEncoding = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
+        httpPut.addHeader("Authorization", "Basic " + authEncoding);
+
+        Map<String, String> props = desc.getProperties();
+        FileFormatProperties fileFormatProperties = desc.getFileFormatProperties();
+        if (!(fileFormatProperties instanceof CsvFileFormatProperties)) {
+            throw new LoadException("Only support csv file format for mysql load");
+        }
+        CsvFileFormatProperties csvFileFormatProperties = (CsvFileFormatProperties) fileFormatProperties;
+        if (props != null) {
+            // max_filter_ratio
+            if (props.containsKey(MysqlLoadCommand.MAX_FILTER_RATIO_PROPERTY)) {
+                String maxFilterRatio = props.get(MysqlLoadCommand.MAX_FILTER_RATIO_PROPERTY);
+                httpPut.addHeader(MysqlLoadCommand.MAX_FILTER_RATIO_PROPERTY, maxFilterRatio);
+            }
+
+            // exec_mem_limit
+            if (props.containsKey(MysqlLoadCommand.EXEC_MEM_LIMIT_PROPERTY)) {
+                String memory = props.get(MysqlLoadCommand.EXEC_MEM_LIMIT_PROPERTY);
+                httpPut.addHeader(MysqlLoadCommand.EXEC_MEM_LIMIT_PROPERTY, memory);
+            }
+
+            // strict_mode
+            if (props.containsKey(MysqlLoadCommand.STRICT_MODE_PROPERTY)) {
+                String strictMode = props.get(MysqlLoadCommand.STRICT_MODE_PROPERTY);
+                httpPut.addHeader(MysqlLoadCommand.STRICT_MODE_PROPERTY, strictMode);
+            }
+
+            // timeout
+            if (props.containsKey(MysqlLoadCommand.TIMEOUT_PROPERTY)) {
+                String timeout = props.get(MysqlLoadCommand.TIMEOUT_PROPERTY);
+                httpPut.addHeader(MysqlLoadCommand.TIMEOUT_PROPERTY, timeout);
+            }
+
+            // timezone
+            if (props.containsKey(MysqlLoadCommand.TIMEZONE_PROPERTY)) {
+                String timezone = props.get(MysqlLoadCommand.TIMEZONE_PROPERTY);
+                httpPut.addHeader(MysqlLoadCommand.TIMEZONE_PROPERTY, timezone);
+            }
+        }
+
+        httpPut.addHeader(CsvFileFormatProperties.PROP_TRIM_DOUBLE_QUOTES,
+                String.valueOf(csvFileFormatProperties.isTrimDoubleQuotes()));
+        httpPut.addHeader(CsvFileFormatProperties.PROP_ENCLOSE,
+                new String(new byte[] {csvFileFormatProperties.getEnclose()}));
+        httpPut.addHeader(CsvFileFormatProperties.PROP_ESCAPE,
+                new String(new byte[] {csvFileFormatProperties.getEscape()}));
+        httpPut.addHeader(CsvFileFormatProperties.PROP_SKIP_LINES,
+                Integer.toString(csvFileFormatProperties.getSkipLines()));
+        httpPut.addHeader(CsvFileFormatProperties.PROP_COLUMN_SEPARATOR, csvFileFormatProperties.getColumnSeparator());
+        httpPut.addHeader(CsvFileFormatProperties.PROP_LINE_DELIMITER, csvFileFormatProperties.getLineDelimiter());
+
+        // columns
+        String columns = getColumns(desc);
+        if (columns != null) {
+            httpPut.addHeader(MysqlLoadCommand.KEY_IN_PARAM_COLUMNS, columns);
+        }
+
+        // partitions
+        if (!desc.getPartitionNamesInfo().getPartitionNames().isEmpty()) {
+            List<String> ps = desc.getPartitionNamesInfo().getPartitionNames();
+            String pNames = Joiner.on(",").join(ps);
+            if (desc.getPartitionNamesInfo().isTemp()) {
+                httpPut.addHeader(MysqlLoadCommand.KEY_IN_PARAM_TEMP_PARTITIONS, pNames);
+            } else {
+                httpPut.addHeader(MysqlLoadCommand.KEY_IN_PARAM_PARTITIONS, pNames);
+            }
+        }
+
+        // cloud cluster
+        if (Config.isCloudMode()) {
+            String clusterName = "";
+            try {
+                clusterName = ConnectContext.get().getCloudCluster();
+            } catch (Exception e) {
+                LOG.warn("failed to get compute group: " + e.getMessage());
+                throw new LoadException("failed to get compute group: " + e.getMessage());
+            }
+            if (Strings.isNullOrEmpty(clusterName)) {
+                throw new LoadException("cloud compute group is empty");
+            }
+            httpPut.addHeader(MysqlLoadCommand.KEY_CLOUD_CLUSTER, clusterName);
         }
 
         httpPut.setEntity(entity);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsDataDescription.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsDataDescription.java
@@ -1064,7 +1064,8 @@ public class NereidsDataDescription {
         analyzeMultiLoadColumns();
         analyzeSequenceCol(fullDbName);
 
-        fileFormatProperties = FileFormatProperties.createFileFormatProperties(analysisMap);
+        fileFormatProperties = FileFormatProperties.createFileFormatPropertiesOrDeferred(
+                analysisMap.getOrDefault(FileFormatProperties.PROP_FORMAT, ""));
         fileFormatProperties.analyzeFileFormatProperties(analysisMap, false);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -7848,6 +7848,8 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
             properties = ImmutableMap.of();
         }
 
+        // MySQL load only support csv, set it explicitly
+        properties.put("format", "csv");
         MysqlDataDescription mysqlDataDescription = new MysqlDataDescription(
                 filePaths,
                 tableNameInfo,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -7849,7 +7849,11 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
         }
 
         // MySQL load only support csv, set it explicitly
-        properties.put("format", "csv");
+        if (!properties.containsKey("format")) {
+            Map<String, String> newProperties = Maps.newHashMap(properties);
+            newProperties.put("format", "csv");
+            properties = ImmutableMap.copyOf(newProperties);
+        }
         MysqlDataDescription mysqlDataDescription = new MysqlDataDescription(
                 filePaths,
                 tableNameInfo,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/load/MysqlDataDescription.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/load/MysqlDataDescription.java
@@ -199,7 +199,8 @@ public class MysqlDataDescription {
         analyzeLoadAttributes();
         analyzeColumns();
 
-        fileFormatProperties = FileFormatProperties.createFileFormatProperties(analysisMap);
+        fileFormatProperties = FileFormatProperties.createFileFormatPropertiesOrDeferred(
+                analysisMap.getOrDefault(FileFormatProperties.PROP_FORMAT, ""));
         fileFormatProperties.analyzeFileFormatProperties(analysisMap, false);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/load/MysqlDataDescription.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/load/MysqlDataDescription.java
@@ -18,7 +18,6 @@
 package org.apache.doris.nereids.trees.plans.commands.load;
 
 import org.apache.doris.analysis.ImportColumnDesc;
-import org.apache.doris.analysis.Separator;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.AnalysisException;
@@ -26,6 +25,7 @@ import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.datasource.property.fileformat.CsvFileFormatProperties;
 import org.apache.doris.datasource.property.fileformat.FileFormatProperties;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.expressions.Expression;
@@ -54,8 +54,8 @@ public class MysqlDataDescription {
     private String dbName;
     private String tableName;
     private final PartitionNamesInfo partitionNamesInfo;
-    private final Separator columnSeparator;
-    private Separator lineDelimiter;
+    private final String columnSeparator;
+    private final String lineDelimiter;
     private int skipLines = 0;
     private List<String> columns;
     private final List<Expression> columnMappingList;
@@ -97,8 +97,8 @@ public class MysqlDataDescription {
         this.tableName = tableNameInfo.getTbl();
         this.clientLocal = clientLocal;
         this.partitionNamesInfo = partitionNamesInfo;
-        this.columnSeparator = new Separator(columnSeparator.orElse(null));
-        this.lineDelimiter = new Separator(lineDelimiter.orElse(null));
+        this.columnSeparator = columnSeparator.orElse(null);
+        this.lineDelimiter = lineDelimiter.orElse(null);
         this.skipLines = skipLines;
         this.columns = columns;
         this.columnMappingList = columnMappingList;
@@ -120,24 +120,6 @@ public class MysqlDataDescription {
 
     public PartitionNamesInfo getPartitionNamesInfo() {
         return partitionNamesInfo;
-    }
-
-    public String getColumnSeparator() {
-        if (columnSeparator == null) {
-            return null;
-        }
-        return columnSeparator.getSeparator();
-    }
-
-    public String getLineDelimiter() {
-        if (lineDelimiter == null) {
-            return null;
-        }
-        return lineDelimiter.getSeparator();
-    }
-
-    public int getSkipLines() {
-        return skipLines;
     }
 
     public List<String> getColumns() {
@@ -199,6 +181,16 @@ public class MysqlDataDescription {
         analyzeLoadAttributes();
         analyzeColumns();
 
+        // get csv properties to analysisMap first
+        if (!Strings.isNullOrEmpty(columnSeparator)) {
+            analysisMap.put(CsvFileFormatProperties.PROP_COLUMN_SEPARATOR, columnSeparator);
+        }
+        if (!Strings.isNullOrEmpty(lineDelimiter)) {
+            analysisMap.put(CsvFileFormatProperties.PROP_LINE_DELIMITER, lineDelimiter);
+        }
+        if (skipLines > 0) {
+            analysisMap.put(CsvFileFormatProperties.PROP_SKIP_LINES, String.valueOf(skipLines));
+        }
         fileFormatProperties = FileFormatProperties.createFileFormatPropertiesOrDeferred(
                 analysisMap.getOrDefault(FileFormatProperties.PROP_FORMAT, ""));
         fileFormatProperties.analyzeFileFormatProperties(analysisMap, false);
@@ -212,14 +204,6 @@ public class MysqlDataDescription {
     }
 
     private void analyzeLoadAttributes() throws UserException {
-        if (columnSeparator.getOriSeparator() != null) {
-            columnSeparator.analyze(false);
-        }
-
-        if (lineDelimiter.getOriSeparator() != null) {
-            lineDelimiter.analyze(true);
-        }
-
         if (partitionNamesInfo.getPartitionNames() != null && !partitionNamesInfo.getPartitionNames().isEmpty()) {
             partitionNamesInfo.validate();
         }
@@ -254,10 +238,10 @@ public class MysqlDataDescription {
         sb.append(partitionNamesInfo.toSql());
 
         if (columnSeparator != null) {
-            sb.append(" COLUMNS TERMINATED BY ").append(columnSeparator.toSql());
+            sb.append(" COLUMNS TERMINATED BY ").append(columnSeparator);
         }
         if (lineDelimiter != null) {
-            sb.append(" LINES TERMINATED BY ").append(lineDelimiter.toSql());
+            sb.append(" LINES TERMINATED BY ").append(lineDelimiter);
         }
         if (!columns.isEmpty()) {
             sb.append(" (");
@@ -276,3 +260,4 @@ public class MysqlDataDescription {
         return sb.toString();
     }
 }
+

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/load/MysqlLoadCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/load/MysqlLoadCommand.java
@@ -178,7 +178,7 @@ public class MysqlLoadCommand extends Command implements NoForward {
     @Override
     public void run(ConnectContext ctx, StmtExecutor executor) throws Exception {
         validate(ctx);
-        handleMysqlLoadComand(ctx);
+        handleMysqlLoadCommand(ctx);
     }
 
     /**
@@ -216,7 +216,7 @@ public class MysqlLoadCommand extends Command implements NoForward {
         }
     }
 
-    private void handleMysqlLoadComand(ConnectContext ctx) {
+    private void handleMysqlLoadCommand(ConnectContext ctx) {
         try {
             LoadManager loadManager = ctx.getEnv().getLoadManager();
             if (!ctx.getCapability().supportClientLocalFile()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/LoadCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/LoadCommandTest.java
@@ -22,6 +22,7 @@ import org.apache.doris.analysis.LabelName;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Pair;
 import org.apache.doris.datasource.property.fileformat.CsvFileFormatProperties;
+import org.apache.doris.datasource.property.fileformat.DeferredFileFormatProperties;
 import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.analyzer.UnboundSlot;
 import org.apache.doris.nereids.load.NereidsDataDescription;
@@ -32,6 +33,7 @@ import org.apache.doris.nereids.trees.expressions.GreaterThan;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLikeLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.StringLikeLiteral;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.thrift.TFileFormatType;
 import org.apache.doris.thrift.TFileType;
 import org.apache.doris.utframe.TestWithFeService;
 
@@ -168,10 +170,13 @@ public class LoadCommandTest extends TestWithFeService {
 
         // column separator and line delimiter
         dataDescription.analyzeWithoutCheckPriv("nereids_load");
-        CsvFileFormatProperties fileFormatProperties =
-                (CsvFileFormatProperties) dataDescription.getFileFormatProperties();
+        DeferredFileFormatProperties fileFormatProperties =
+                (DeferredFileFormatProperties) dataDescription.getFileFormatProperties();
         Assertions.assertNotNull(fileFormatProperties);
-        Assertions.assertEquals("|", fileFormatProperties.getColumnSeparator());
-        Assertions.assertEquals("\n", fileFormatProperties.getLineDelimiter());
+        fileFormatProperties.deferInit(TFileFormatType.FORMAT_CSV_PLAIN);
+        Assertions.assertTrue(fileFormatProperties.getDelegate() instanceof CsvFileFormatProperties);
+        CsvFileFormatProperties csvFileFormatProperties = (CsvFileFormatProperties) fileFormatProperties.getDelegate();
+        Assertions.assertEquals("|", csvFileFormatProperties.getColumnSeparator());
+        Assertions.assertEquals("\n", csvFileFormatProperties.getLineDelimiter());
     }
 }

--- a/regression-test/suites/ddl_p0/test_create_table_generated_column/stream_load_and_mysql_load.groovy
+++ b/regression-test/suites/ddl_p0/test_create_table_generated_column/stream_load_and_mysql_load.groovy
@@ -165,7 +165,8 @@ suite("test_generated_column_stream_mysql_load") {
         "enable_single_replica_compaction" = "false",
         "group_commit_interval_ms" = "5000",
         "group_commit_data_bytes" = "134217728",
-        "enable_mow_light_delete" = "false"
+        "enable_mow_light_delete" = "false",
+        "replication_num" = "1"
     );
     """
     streamLoad {

--- a/regression-test/suites/external_table_p0/refactor_storage_param/hdfs_load_default_file_format.groovy
+++ b/regression-test/suites/external_table_p0/refactor_storage_param/hdfs_load_default_file_format.groovy
@@ -1,0 +1,119 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import org.awaitility.Awaitility;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static groovy.test.GroovyAssert.shouldFail
+
+suite("hdfs_load_default_file_format", "external_docker,hive,external_docker_hive,p0,external") {
+    String enabled = context.config.otherConfigs.get("enableHiveTest")
+    if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+        logger.info("disable Hive test.")
+        return;
+    }
+    String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+    String hdfsPort = context.config.otherConfigs.get("hive3HdfsPort")
+    def defaultFS = "hdfs://${externalEnvIp}:${hdfsPort}"
+
+    def table = "hdfs_load_default_file_format_tbl";
+    def table2 = "hdfs_load_default_file_format_tbl2";
+
+    def outfile_to_hdfs = { defaultFs, format, format_prop ->
+        def outFilePath = "${defaultFs}/tmp/hdfs_load_default_file_format_"
+        // select ... into outfile ...
+        def res = sql """
+            SELECT * FROM ${table}
+            INTO OUTFILE "${outFilePath}"
+            FORMAT AS ${format}
+            PROPERTIES (
+                ${format_prop}
+                "fs.defaultFS" = "${defaultFs}"
+            );
+        """
+        println res
+        return res[0][3]
+    }
+
+    def hdfsLoad = { filePath, column_sep, defaultFs ->
+        def dataCountResult = sql """
+            SELECT count(*) FROM ${table}
+        """
+        sql """truncate table ${table2}"""
+        def dataCount = dataCountResult[0][0]
+        def label = "hdfs_load_label_" + System.currentTimeMillis()
+        // test: do not specify the format, infer from file suffix.
+        def load = sql """
+            LOAD LABEL `${label}` (
+            data infile ("${filePath}")
+            into table ${table2}
+            ${column_sep}
+            (k1, k2))
+            with hdfs
+            (
+               "fs.defaultFS" = "${defaultFs}"
+            );
+        """
+        Awaitility.await().atMost(60, SECONDS).pollInterval(1, SECONDS).until({
+            def loadResult = sql """
+                show load where label = '${label}';
+            """
+            println loadResult
+
+            if (null == loadResult || loadResult.isEmpty() || null == loadResult.get(0) || loadResult.get(0).size() < 3) {
+                return false;
+            }
+            if (loadResult.get(0).get(2) == 'CANCELLED' || loadResult.get(0).get(2) == 'FAILED') {
+                throw new RuntimeException("load failed")
+            }
+
+            return loadResult.get(0).get(2) == 'FINISHED'
+        })
+
+
+        def expectedCount = dataCount;
+        Awaitility.await().atMost(5, SECONDS).pollInterval(1, SECONDS).until({
+            def loadResult = sql """
+                select count(*) from ${table2}
+            """
+            println "loadResult: ${loadResult}, expected: ${expectedCount}"
+            return loadResult.get(0).get(0) == expectedCount
+        })
+    }
+
+    sql """drop table if exists ${table}"""
+    sql """drop table if exists ${table2}"""
+    sql """create table ${table}
+        (k1 int, k2 string) distributed by hash(k1) buckets 1
+        properties("replication_num" = "1");
+    """
+    sql """create table ${table2} like ${table}"""
+
+    sql """insert into ${table} values(1, "name");"""
+    for (int i = 0; i < 10; i++) {
+        sql """insert into ${table} select k1 + ${i}, concat(k2, k1 + ${i}) from ${table}"""
+    }
+
+    // outfile parquet and load
+    def outfile = outfile_to_hdfs("hdfs://${externalEnvIp}:${hdfsPort}", "parquet", "");
+    println outfile
+    hdfsLoad(outfile, "", "hdfs://${externalEnvIp}:${hdfsPort}")
+
+    // outfile csv and load
+    outfile = outfile_to_hdfs("hdfs://${externalEnvIp}:${hdfsPort}", "csv", "\"column_separator\" = \"xx\",");
+    println outfile
+    hdfsLoad(outfile, "COLUMNS TERMINATED BY \"xx\"", "hdfs://${externalEnvIp}:${hdfsPort}")
+}
+


### PR DESCRIPTION
### What problem does this PR solve?

User may not specify data format in broker load, so we can only infer the data format
after listing the files.
So we have to defer the initialization of file properties object

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

