### PR TITLE
[fix](load): fix incorrect progress on finished loads

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -448,7 +448,7 @@ void FragmentMgr::coordinator_callback(const ReportStatusRequest& req) {
     } else if (!req.runtime_states.empty()) {
         for (auto* rs : req.runtime_states) {
             if (rs->num_rows_load_total() > 0 || rs->num_rows_load_filtered() > 0 ||
-                req.runtime_state->num_finished_range() > 0) {
+                rs->num_finished_range() > 0) {
                 params.__isset.load_counters = true;
                 num_rows_load_success += rs->num_rows_load_success();
                 num_rows_load_filtered += rs->num_rows_load_filtered();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: CIR-17562

Problem Summary:

Finished load jobs could show less than 100% progress because the status
was not reported correctly when any file scanner had
`num_rows_load_total == 0` and `num_rows_load_filtered == 0`.

This fix ensures the status is reported correctly and finished loads
now display 100% progress.

Before:
```
| 1756660232981 | load_data_4_objects_large_high_column | FINISHED | 0.00% (0/1000)            | BROKER | ...
```

After:
```
| 1756660232984 | load_data_5_objects_large_high_column | FINISHED | 100.00% (1000/1000)       | BROKER | ...
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

