### PR TITLE
[fix](olap) Crashing caused by incorrect rowset state checking

### DIFF
--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -39,6 +39,7 @@
 #include "olap/olap_common.h"
 #include "olap/olap_define.h"
 #include "olap/rowset/beta_rowset_reader.h"
+#include "olap/rowset/rowset.h"
 #include "olap/rowset/segment_v2/index_file_reader.h"
 #include "olap/rowset/segment_v2/inverted_index_cache.h"
 #include "olap/rowset/segment_v2/inverted_index_desc.h"
@@ -71,7 +72,9 @@ Status BetaRowset::init() {
 }
 
 Status BetaRowset::get_segment_num_rows(std::vector<uint32_t>* segment_rows) {
-    DCHECK(_rowset_state_machine.rowset_state() == ROWSET_LOADED);
+    // `ROWSET_UNLOADING` is state for closed() called but owned by some readers.
+    // So here `ROWSET_UNLOADING` is allowed.
+    DCHECK_NE(_rowset_state_machine.rowset_state(), ROWSET_UNLOADED);
 
     RETURN_IF_ERROR(_load_segment_rows_once.call([this] {
         auto segment_count = num_segments();


### PR DESCRIPTION
### What problem does this PR solve?

```text
*** tablet id: 0 ***
*** Aborted at 1756699574 (unix time) try "date -d @1756699574" if you are using GNU date ***
*** Current BE git commitID: 63937237e3 ***
*** SIGABRT unknown detail explain (@0x28f4) received by PID 10484 (TID 11254 OR 0x7b8d9112e640) from PID 10484; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:420
 1# 0x00007F90FC0D2520 in /lib/x86_64-linux-gnu/libc.so.6
 2# pthread_kill at ./nptl/pthread_kill.c:89
 3# raise at ../sysdeps/posix/raise.c:27
 4# abort at ./stdlib/abort.c:81
 5# 0x000055714CE03785 in /root/doris/be/lib/doris_be
 6# 0x000055714CDF503A in /root/doris/be/lib/doris_be
 7# google::LogMessage::SendToLog() in /root/doris/be/lib/doris_be
 8# google::LogMessage::Flush() in /root/doris/be/lib/doris_be
 9# google::LogMessageFatal::~LogMessageFatal() in /root/doris/be/lib/doris_be
10# doris::BetaRowset::get_segment_num_rows(std::vector >*) at /root/doris/be/src/olap/rowset/beta_rowset.cpp:74
11# doris::ParallelScannerBuilder::_load() at /root/doris/be/src/olap/parallel_scanner_builder.cpp:229
12# doris::ParallelScannerBuilder::build_scanners(std::__cxx11::list, std::allocator > >&) at /root/doris/be/src/olap/parallel_scanner_builder.cpp:36
13# doris::pipeline::OlapScanLocalState::_init_scanners(std::__cxx11::list, std::allocator > >*) in /root/doris/be/lib/doris_be
14# doris::pipeline::ScanLocalState::_prepare_scanners() at /root/doris/be/src/pipeline/exec/scan_operator.cpp:1017
15# doris::pipeline::ScanLocalState::open(doris::RuntimeState*) at /root/doris/be/src/pipeline/exec/scan_operator.cpp:125
16# doris::pipeline::OlapScanLocalState::open(doris::RuntimeState*) at /root/doris/be/src/pipeline/exec/olap_scan_operator.cpp:754
17# doris::pipeline::PipelineTask::_open() in /root/doris/be/lib/doris_be
18# doris::pipeline::PipelineTask::execute(bool*) at /root/doris/be/src/pipeline/pipeline_task.cpp:451
19# doris::pipeline::TaskScheduler::_do_work(int) at /root/doris/be/src/pipeline/task_scheduler.cpp:147
20# doris::ThreadPool::dispatch_thread() at /root/doris/be/src/util/threadpool.cpp:621
21# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:461
22# asan_thread_start(void*) in /root/doris/be/lib/doris_be
23# start_thread at ./nptl/pthread_create.c:442
24# 0x00007F90FC1B6850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83
```

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

