### PR TITLE
[Fix](mow) Fix mow coreudmp in `BaseTablet::get_rowset_by_ids()`

### DIFF
--- a/be/src/cloud/cloud_rowset_builder.cpp
+++ b/be/src/cloud/cloud_rowset_builder.cpp
@@ -129,7 +129,7 @@ Status CloudRowsetBuilder::set_txn_related_delete_bitmap() {
     if (_tablet->enable_unique_key_merge_on_write()) {
         if (config::enable_merge_on_write_correctness_check && _rowset->num_rows() != 0) {
             auto st = _tablet->check_delete_bitmap_correctness(
-                    _delete_bitmap, _rowset->end_version() - 1, _req.txn_id, _rowset_ids);
+                    _delete_bitmap, _rowset->end_version() - 1, _req.txn_id, *_rowset_ids);
             if (!st.ok()) {
                 LOG(WARNING) << fmt::format(
                         "[tablet_id:{}][txn_id:{}][load_id:{}][partition_id:{}] "
@@ -140,7 +140,7 @@ Status CloudRowsetBuilder::set_txn_related_delete_bitmap() {
             }
         }
         _engine.txn_delete_bitmap_cache().set_tablet_txn_info(
-                _req.txn_id, _tablet->tablet_id(), _delete_bitmap, _rowset_ids, _rowset,
+                _req.txn_id, _tablet->tablet_id(), _delete_bitmap, *_rowset_ids, _rowset,
                 _req.txn_expiration, _partial_update_info);
     }
     return Status::OK();

--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -588,11 +588,11 @@ struct CalcDeleteBitmapTask {
 
 // merge on write context
 struct MowContext {
-    MowContext(int64_t version, int64_t txnid, const RowsetIdUnorderedSet& ids,
+    MowContext(int64_t version, int64_t txnid, std::shared_ptr<RowsetIdUnorderedSet> ids,
                std::vector<RowsetSharedPtr> rowset_ptrs, std::shared_ptr<DeleteBitmap> db)
             : max_version(version),
               txn_id(txnid),
-              rowset_ids(ids),
+              rowset_ids(std::move(ids)),
               rowset_ptrs(std::move(rowset_ptrs)),
               delete_bitmap(std::move(db)) {}
 
@@ -603,7 +603,7 @@ struct MowContext {
 
     int64_t max_version;
     int64_t txn_id;
-    const RowsetIdUnorderedSet& rowset_ids;
+    std::shared_ptr<RowsetIdUnorderedSet> rowset_ids;
     std::vector<RowsetSharedPtr> rowset_ptrs;
     std::shared_ptr<DeleteBitmap> delete_bitmap;
 

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -331,7 +331,8 @@ Status BaseBetaRowsetWriter::_generate_delete_bitmap(int32_t segment_id) {
     std::vector<RowsetSharedPtr> specified_rowsets;
     {
         std::shared_lock meta_rlock(_context.tablet->get_header_lock());
-        specified_rowsets = _context.tablet->get_rowset_by_ids(&_context.mow_context->rowset_ids);
+        specified_rowsets =
+                _context.tablet->get_rowset_by_ids(_context.mow_context->rowset_ids.get());
     }
     OlapStopWatch watch;
     auto finish_callback = [this](segment_v2::SegmentSharedPtr segment, Status st) {
@@ -346,7 +347,7 @@ Status BaseBetaRowsetWriter::_generate_delete_bitmap(int32_t segment_id) {
             segments.begin(), segments.end(), 0,
             [](size_t sum, const segment_v2::SegmentSharedPtr& s) { return sum += s->num_rows(); });
     LOG(INFO) << "[Memtable Flush] construct delete bitmap tablet: " << _context.tablet->tablet_id()
-              << ", rowset_ids: " << _context.mow_context->rowset_ids.size()
+              << ", rowset_ids: " << _context.mow_context->rowset_ids->size()
               << ", cur max_version: " << _context.mow_context->max_version
               << ", transaction_id: " << _context.mow_context->txn_id << ", delete_bitmap_count: "
               << _context.mow_context->delete_bitmap->get_delete_bitmap_count()

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -611,7 +611,7 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
 
     if (config::enable_merge_on_write_correctness_check) {
         _tablet->add_sentinel_mark_to_delete_bitmap(_mow_context->delete_bitmap.get(),
-                                                    _mow_context->rowset_ids);
+                                                    *_mow_context->rowset_ids);
     }
 
     // read to fill full block

--- a/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
@@ -598,7 +598,7 @@ Status VerticalSegmentWriter::_append_block_with_partial_content(RowsInBlock& da
 
     if (config::enable_merge_on_write_correctness_check) {
         _tablet->add_sentinel_mark_to_delete_bitmap(_mow_context->delete_bitmap.get(),
-                                                    _mow_context->rowset_ids);
+                                                    *_mow_context->rowset_ids);
     }
 
     // read to fill full_block
@@ -736,7 +736,7 @@ Status VerticalSegmentWriter::_append_block_with_flexible_partial_content(
 
     if (config::enable_merge_on_write_correctness_check) {
         _tablet->add_sentinel_mark_to_delete_bitmap(_mow_context->delete_bitmap.get(),
-                                                    _mow_context->rowset_ids);
+                                                    *_mow_context->rowset_ids);
     }
 
     // 6. read according plan to fill full_block

--- a/be/src/olap/rowset_builder.cpp
+++ b/be/src/olap/rowset_builder.cpp
@@ -135,11 +135,11 @@ Status BaseRowsetBuilder::init_mow_context(std::shared_ptr<MowContext>& mow_cont
                     "Unable to do 'partial_update' when "
                     "the tablet is undergoing a 'schema changing process'");
         }
-        _rowset_ids.clear();
+        _rowset_ids->clear();
     } else {
         RETURN_IF_ERROR(
-                tablet()->get_all_rs_id_unlocked(_max_version_in_flush_phase, &_rowset_ids));
-        rowset_ptrs = tablet()->get_rowset_by_ids(&_rowset_ids);
+                tablet()->get_all_rs_id_unlocked(_max_version_in_flush_phase, _rowset_ids.get()));
+        rowset_ptrs = tablet()->get_rowset_by_ids(_rowset_ids.get());
     }
     _delete_bitmap = std::make_shared<DeleteBitmap>(tablet()->tablet_id());
     mow_context = std::make_shared<MowContext>(_max_version_in_flush_phase, _req.txn_id,
@@ -293,7 +293,7 @@ Status BaseRowsetBuilder::submit_calc_delete_bitmap_task() {
                 "rowset_ids({}), cur max_version({}), bitmap num({}), bitmap_cardinality({}), num "
                 "rows updated({}), num rows new added({}), num rows deleted({}), total rows({})",
                 _partial_update_info->partial_update_mode_str(), tablet()->tablet_id(), _req.txn_id,
-                _rowset_ids.size(), rowset_writer()->context().mow_context->max_version,
+                _rowset_ids->size(), rowset_writer()->context().mow_context->max_version,
                 _delete_bitmap->get_delete_bitmap_count(), _delete_bitmap->cardinality(),
                 rowset_writer()->num_rows_updated(), rowset_writer()->num_rows_new_added(),
                 rowset_writer()->num_rows_deleted(), rowset_writer()->num_rows());
@@ -302,7 +302,7 @@ Status BaseRowsetBuilder::submit_calc_delete_bitmap_task() {
 
     LOG(INFO) << "submit calc delete bitmap task to executor, tablet_id: " << tablet()->tablet_id()
               << ", txn_id: " << _req.txn_id;
-    return BaseTablet::commit_phase_update_delete_bitmap(_tablet, _rowset, _rowset_ids,
+    return BaseTablet::commit_phase_update_delete_bitmap(_tablet, _rowset, *_rowset_ids,
                                                          _delete_bitmap, segments, _req.txn_id,
                                                          _calc_delete_bitmap_token.get(), nullptr);
 }
@@ -322,7 +322,7 @@ Status RowsetBuilder::commit_txn() {
         config::enable_merge_on_write_correctness_check && _rowset->num_rows() != 0 &&
         tablet()->tablet_state() != TABLET_NOTREADY) {
         auto st = tablet()->check_delete_bitmap_correctness(
-                _delete_bitmap, _rowset->end_version() - 1, _req.txn_id, _rowset_ids);
+                _delete_bitmap, _rowset->end_version() - 1, _req.txn_id, *_rowset_ids);
         if (!st.ok()) {
             LOG(WARNING) << fmt::format(
                     "[tablet_id:{}][txn_id:{}][load_id:{}][partition_id:{}] "
@@ -348,7 +348,7 @@ Status RowsetBuilder::commit_txn() {
     if (_tablet->enable_unique_key_merge_on_write()) {
         _engine.txn_manager()->set_txn_related_delete_bitmap(
                 _req.partition_id, _req.txn_id, tablet()->tablet_id(), tablet()->tablet_uid(), true,
-                _delete_bitmap, _rowset_ids, _partial_update_info);
+                _delete_bitmap, *_rowset_ids, _partial_update_info);
     }
 
     _is_committed = true;

--- a/be/src/olap/rowset_builder.h
+++ b/be/src/olap/rowset_builder.h
@@ -104,7 +104,7 @@ protected:
     DeleteBitmapPtr _delete_bitmap;
     std::unique_ptr<CalcDeleteBitmapToken> _calc_delete_bitmap_token;
     // current rowset_ids, used to do diff in publish_version
-    RowsetIdUnorderedSet _rowset_ids;
+    std::shared_ptr<RowsetIdUnorderedSet> _rowset_ids {std::make_shared<RowsetIdUnorderedSet>()};
     int64_t _max_version_in_flush_phase {-1};
 
     std::shared_ptr<PartialUpdateInfo> _partial_update_info;

--- a/be/test/olap/segcompaction_mow_test.cpp
+++ b/be/test/olap/segcompaction_mow_test.cpp
@@ -314,7 +314,7 @@ TEST_P(SegCompactionMoWTest, SegCompactionThenRead) {
         RowsetWriterContext writer_context;
         int raw_rsid = rand();
         create_rowset_writer_context(raw_rsid, tablet_schema, &writer_context);
-        RowsetIdUnorderedSet rsids;
+        std::shared_ptr<RowsetIdUnorderedSet> rsids {std::make_shared<RowsetIdUnorderedSet>()};
         std::vector<RowsetSharedPtr> rowset_ptrs;
         writer_context.mow_context =
                 std::make_shared<MowContext>(1, 1, rsids, rowset_ptrs, delete_bitmap);
@@ -419,7 +419,7 @@ TEST_F(SegCompactionMoWTest, SegCompactionInterleaveWithBig_ooooOOoOooooooooO) {
     { // write `num_segments * rows_per_segment` rows to rowset
         RowsetWriterContext writer_context;
         create_rowset_writer_context(20048, tablet_schema, &writer_context);
-        RowsetIdUnorderedSet rsids;
+        std::shared_ptr<RowsetIdUnorderedSet> rsids {std::make_shared<RowsetIdUnorderedSet>()};
         std::vector<RowsetSharedPtr> rowset_ptrs;
         writer_context.mow_context =
                 std::make_shared<MowContext>(1, 1, rsids, rowset_ptrs, delete_bitmap);
@@ -660,7 +660,7 @@ TEST_F(SegCompactionMoWTest, SegCompactionInterleaveWithBig_OoOoO) {
     { // write `num_segments * rows_per_segment` rows to rowset
         RowsetWriterContext writer_context;
         create_rowset_writer_context(20049, tablet_schema, &writer_context);
-        RowsetIdUnorderedSet rsids;
+        std::shared_ptr<RowsetIdUnorderedSet> rsids {std::make_shared<RowsetIdUnorderedSet>()};
         std::vector<RowsetSharedPtr> rowset_ptrs;
         writer_context.mow_context =
                 std::make_shared<MowContext>(1, 1, rsids, rowset_ptrs, delete_bitmap);
@@ -854,7 +854,7 @@ TEST_F(SegCompactionMoWTest, SegCompactionNotTrigger) {
     { // write `num_segments * rows_per_segment` rows to rowset
         RowsetWriterContext writer_context;
         create_rowset_writer_context(20050, tablet_schema, &writer_context);
-        RowsetIdUnorderedSet rsids;
+        std::shared_ptr<RowsetIdUnorderedSet> rsids {std::make_shared<RowsetIdUnorderedSet>()};
         std::vector<RowsetSharedPtr> rowset_ptrs;
         writer_context.mow_context =
                 std::make_shared<MowContext>(1, 1, rsids, rowset_ptrs, delete_bitmap);


### PR DESCRIPTION
### What problem does this PR solve?

```
*** Query id: 7b4f7bbcecef464c-81b65c1731e755ee ***
*** is nereids: 0 ***
*** tablet id: 1756432156986 ***
*** Aborted at 1756473436 (unix time) try "date -d @1756473436" if you are using GNU date ***
*** Current BE git commitID: d26c87df051 ***
*** SIGSEGV unknown detail explain (@0x0) received by PID 333577 (TID 379616 OR 0x7fed07dd9640) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk3/pipeline/repo/selectdb-core_selectdb-second-branch/be/src/common/signal_handler.h:421
 1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 3# 0x00007FEE2C7EA520 in /lib/x86_64-linux-gnu/libc.so.6
 4# std::_Hashtable<doris::RowsetId, doris::RowsetId, std::allocator<doris::RowsetId>, std::__detail::_Identity, std::equal_to<doris::RowsetId>, std::hash<doris::RowsetId>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, true, true> >::find(doris::RowsetId const&) const at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/hashtable.h:1587
 5# doris::BaseTablet::get_rowset_by_ids(std::unordered_set<doris::RowsetId, std::hash<doris::RowsetId>, std::equal_to<doris::RowsetId>, std::allocator<doris::RowsetId> > const*) at /mnt/disk3/pipeline/repo/selectdb-core_selectdb-second-branch/be/src/olap/base_tablet.cpp:440
 6# doris::BaseBetaRowsetWriter::_generate_delete_bitmap(int) at /mnt/disk3/pipeline/repo/selectdb-core_selectdb-second-branch/be/src/olap/rowset/beta_rowset_writer.cpp:332
 7# doris::BaseBetaRowsetWriter::add_segment(unsigned int, doris::SegmentStatistics const&, std::shared_ptr<doris::TabletSchema>) at /mnt/disk3/pipeline/repo/selectdb-core_selectdb-second-branch/be/src/olap/rowset/beta_rowset_writer.cpp:1104
 8# doris::SegmentCollectorT<doris::BaseBetaRowsetWriter>::add(unsigned int, doris::SegmentStatistics&, std::shared_ptr<doris::TabletSchema>) at /mnt/disk3/pipeline/repo/selectdb-core_selectdb-second-branch/be/src/olap/rowset/segment_creator.h:91
 9# doris::SegmentFlusher::_flush_segment_writer(std::unique_ptr<doris::segment_v2::VerticalSegmentWriter, std::default_delete<doris::segment_v2::VerticalSegmentWriter> >&, std::shared_ptr<doris::TabletSchema>, long*) at /mnt/disk3/pipeline/repo/selectdb-core_selectdb-second-branch/be/src/olap/rowset/segment_creator.cpp:263
10# doris::SegmentFlusher::flush_single_block(doris::vectorized::Block const*, int, long*) at /mnt/disk3/pipeline/repo/selectdb-core_selectdb-second-branch/be/src/olap/rowset/segment_creator.cpp:76
11# doris::SegmentCreator::flush_single_block(doris::vectorized::Block const*, int, long*) at /mnt/disk3/pipeline/repo/selectdb-core_selectdb-second-branch/be/src/olap/rowset/segment_creator.cpp:416
12# doris::BaseBetaRowsetWriter::flush_memtable(doris::vectorized::Block*, int, long*) at /mnt/disk3/pipeline/repo/selectdb-core_selectdb-second-branch/be/src/olap/rowset/beta_rowset_writer.cpp:719
13# doris::FlushToken::_do_flush_memtable(doris::MemTable*, int, long*) at /mnt/disk3/pipeline/repo/selectdb-core_selectdb-second-branch/be/src/olap/memtable_flush_executor.cpp:160
14# doris::FlushToken::_flush_memtable(std::shared_ptr<doris::MemTable>, int, long) in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be
15# doris::MemtableFlushTask::run() at /mnt/disk3/pipeline/repo/selectdb-core_selectdb-second-branch/be/src/olap/memtable_flush_executor.cpp:60
16# doris::ThreadPool::dispatch_thread() at /mnt/disk3/pipeline/repo/selectdb-core_selectdb-second-branch/be/src/util/threadpool.cpp:609
17# doris::Thread::supervise_thread(void*) at /mnt/disk3/pipeline/repo/selectdb-core_selectdb-second-branch/be/src/util/thread.cpp:499
18# start_thread at ./nptl/pthread_create.c:442
19# 0x00007FEE2C8CE850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

