### PR TITLE
fix(docker): disaggregated probe does not support ipv6

### DIFF
--- a/docker/runtime/be/resource/be_disaggregated_probe.sh
+++ b/docker/runtime/be/resource/be_disaggregated_probe.sh
@@ -42,20 +42,30 @@ function alive_probe()
     fi
 }
 
-function ready_probe()
-{
+function ready_probe() {
     local webserver_port=$(parse_config_file_with_key "webserver_port")
     webserver_port=${webserver_port:=$DEFAULT_WEBSERVER_PORT}
-    local ip=`hostname -i | awk '{print $1}'`
-    local url="http://${ip}:${webserver_port}/api/health"
-    local res=$(curl -s $url)
-    local status=$(jq -r ".status" <<< $res)
-    if [[ "x$status" == "xOK" ]]; then
+    if netstat -lntp | grep ":$webserver_port" > /dev/null ; then
         exit 0
     else
         exit 1
     fi
 }
+
+#function ready_probe()
+#{
+#    local webserver_port=$(parse_config_file_with_key "webserver_port")
+#    webserver_port=${webserver_port:=$DEFAULT_WEBSERVER_PORT}
+#    local ip=`hostname -i | awk '{print $1}'`
+#    local url="http://${ip}:${webserver_port}/api/health"
+#    local res=$(curl -s $url)
+#    local status=$(jq -r ".status" <<< $res)
+#    if [[ "x$status" == "xOK" ]]; then
+#        exit 0
+#    else
+#        exit 1
+#    fi
+#}
 
 if [[ "$PROBE_TYPE" == "ready" ]]; then
     ready_probe

--- a/docker/runtime/fe/resource/fe_disaggregated_probe.sh
+++ b/docker/runtime/fe/resource/fe_disaggregated_probe.sh
@@ -42,21 +42,31 @@ function alive_probe()
     fi
 }
 
-function ready_probe()
-{
+function ready_probe() {
     local http_port=$(parse_config_file_with_key "http_port")
     http_port=${http_port:=$DEFAULT_HTTP_PORT}
-    local ip=`hostname -i | awk '{print $1}'`
-    local url="http://${ip}:${http_port}/api/health"
-    local res=$(curl -s $url)
-    local code=$(jq -r ".code" <<< $res)
-    if [[ "x$code" == "x0" ]]; then
+    if netstat -lntp | grep ":$http_port" > /dev/null ; then
         exit 0
     else
         exit 1
     fi
 }
 
+#function ready_probe()
+#{
+#    local http_port=$(parse_config_file_with_key "http_port")
+#    http_port=${http_port:=$DEFAULT_HTTP_PORT}
+#    local ip=`hostname -i | awk '{print $1}'`
+#    local url="http://${ip}:${http_port}/api/health"
+#    local res=$(curl -s $url)
+#    local code=$(jq -r ".code" <<< $res)
+#    if [[ "x$code" == "x0" ]]; then
+#        exit 0
+#    else
+#        exit 1
+#    fi
+#}
+#
 if [[ "$PROBE_TYPE" == "ready" ]]; then
     ready_probe
 else


### PR DESCRIPTION
### What problem does this PR solve?

Disaggregated probe does not support ipv6 on K8s.
Just remove the health checking (the `curl`), we may add it back later.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. Remove health checking (the `curl` )

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

