### PR TITLE
branch-3.0: [fix](job) use cluster name rather than cluster id to find available be (#52911)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/load/CloudRoutineLoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/load/CloudRoutineLoadManager.java
@@ -51,14 +51,8 @@ public class CloudRoutineLoadManager extends RoutineLoadManager {
     @Override
     protected List<Long> getAvailableBackendIds(long jobId) throws LoadException {
         RoutineLoadJob routineLoadJob = getJob(jobId);
-        String cloudClusterId = routineLoadJob.getCloudClusterId();
-        if (Strings.isNullOrEmpty(cloudClusterId)) {
-            LOG.warn("cluster id is empty");
-            throw new LoadException("cluster id is empty");
-        }
-
         return ((CloudSystemInfoService) Env.getCurrentSystemInfo())
-                .getBackendsByClusterId(cloudClusterId)
+                .getBackendsByClusterName(routineLoadJob.getCloudCluster())
                 .stream()
                 .filter(Backend::isAlive)
                 .map(Backend::getId)
@@ -67,13 +61,13 @@ public class CloudRoutineLoadManager extends RoutineLoadManager {
 
     @Override
     public void replayCreateRoutineLoadJob(RoutineLoadJob routineLoadJob) {
-        routineLoadJob.setCloudClusterById();
+        routineLoadJob.setCloudCluster();
         super.replayCreateRoutineLoadJob(routineLoadJob);
     }
 
     @Override
     public void replayChangeRoutineLoadJob(RoutineLoadOperation operation) {
-        getJob(operation.getId()).setCloudClusterById();
+        getJob(operation.getId()).setCloudCluster();
         super.replayChangeRoutineLoadJob(operation);
     }
 }


### PR DESCRIPTION
pick #52911 and https://github.com/apache/doris/pull/53768

In multi cluster scenario, users perceive the cluster name, so it should be used cluster name rather than cluster id to find available be node.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

