### PR TITLE
[Enhancement](sql-dialect) Support retrying original sql after error

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -492,6 +492,11 @@ public abstract class ConnectProcessor {
                 ctx.setSqlHash(originalSqlHash);
                 return stmts;
             } catch (Exception e) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Retry with original SQL failed. "
+                                    + "Reason: {}. Original Statement: \"{}\". Converted Statement: \"{}\".",
+                            e.getMessage(), originStmt, convertedStmt, e);
+                }
                 // Retry failed, return null
                 return null;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -565,6 +565,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String SQL_DIALECT = "sql_dialect";
 
+    public static final String ENABLE_SQL_CONVERTER_RETRY_ORIGINAL = "enable_sql_converter_retry_original";
+
     public static final String SERDE_DIALECT = "serde_dialect";
 
     public static final String EXPAND_RUNTIME_FILTER_BY_INNER_JION = "expand_runtime_filter_by_inner_join";
@@ -2182,6 +2184,10 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = SQL_DIALECT, needForward = true, checker = "checkSqlDialect",
             description = {"解析sql使用的方言", "The dialect used to parse sql."})
     public String sqlDialect = "doris";
+
+    @VariableMgr.VarAttr(name = ENABLE_SQL_CONVERTER_RETRY_ORIGINAL, needForward = true,
+            description = {"开启SQL转换器重试原始SQL功能", "Enable SQL converter retry original SQL feature."})
+    public boolean enableSqlConverterRetryOriginal = false;
 
     @VariableMgr.VarAttr(name = SERDE_DIALECT, needForward = true, checker = "checkSerdeDialect",
             description = {"返回给 MySQL 客户端时各数据类型的输出格式方言",
@@ -3854,6 +3860,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public String getSqlDialect() {
         return sqlDialect;
+    }
+
+    public boolean isEnableSqlConverterRetryOriginal() {
+        return enableSqlConverterRetryOriginal;
     }
 
     public String[] getSqlConvertorFeatures() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -565,7 +565,7 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String SQL_DIALECT = "sql_dialect";
 
-    public static final String ENABLE_SQL_CONVERTER_RETRY_ORIGINAL = "enable_sql_converter_retry_original";
+    public static final String RETRY_ORIGIN_SQL_ON_CONVERT_FAIL = "retry_origin_sql_on_convert_fail";
 
     public static final String SERDE_DIALECT = "serde_dialect";
 
@@ -2185,9 +2185,10 @@ public class SessionVariable implements Serializable, Writable {
             description = {"解析sql使用的方言", "The dialect used to parse sql."})
     public String sqlDialect = "doris";
 
-    @VariableMgr.VarAttr(name = ENABLE_SQL_CONVERTER_RETRY_ORIGINAL, needForward = true,
-            description = {"开启SQL转换器重试原始SQL功能", "Enable SQL converter retry original SQL feature."})
-    public boolean enableSqlConverterRetryOriginal = false;
+    @VariableMgr.VarAttr(name = RETRY_ORIGIN_SQL_ON_CONVERT_FAIL, needForward = true,
+            description = {"当转换后的SQL解析失败时，是否重试原始SQL",
+                    "Enable retrying original SQL when converted SQL parsing fails."})
+    public boolean retryOriginSqlOnConvertFail = false;
 
     @VariableMgr.VarAttr(name = SERDE_DIALECT, needForward = true, checker = "checkSerdeDialect",
             description = {"返回给 MySQL 客户端时各数据类型的输出格式方言",
@@ -3862,8 +3863,8 @@ public class SessionVariable implements Serializable, Writable {
         return sqlDialect;
     }
 
-    public boolean isEnableSqlConverterRetryOriginal() {
-        return enableSqlConverterRetryOriginal;
+    public boolean isRetryOriginSqlOnConvertFail() {
+        return retryOriginSqlOnConvertFail;
     }
 
     public String[] getSqlConvertorFeatures() {

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectProcessorRetryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectProcessorRetryTest.java
@@ -1,0 +1,181 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.qe;
+
+import org.apache.doris.analysis.StatementBase;
+import org.apache.doris.common.ConnectionException;
+import org.apache.doris.utframe.TestWithFeService;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+public class ConnectProcessorRetryTest extends TestWithFeService {
+
+    @Mock
+    private SessionVariable mockSessionVariable;
+
+    private TestableConnectProcessor testProcessor;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        testProcessor = new TestableConnectProcessor(connectContext);
+    }
+
+    // parseWithFallback tests
+    @Test
+    public void testParseWithFallbackRetryEnabledCorrectConvertedStmt() throws ConnectionException {
+        Mockito.when(mockSessionVariable.isRetryOriginSqlOnConvertFail()).thenReturn(true);
+
+        List<StatementBase> result = testProcessor.parseWithFallback(
+                "SELECT 1",
+                "SELECT 1",
+                mockSessionVariable
+        );
+
+        Assertions.assertNotNull(result, "Should return parsed statements for correct convertedStmt");
+        Assertions.assertFalse(result.isEmpty(), "Should return non-empty list for correct convertedStmt");
+    }
+
+    @Test
+    public void testParseWithFallbackRetryEnabledIncorrectConvertedStmtCorrectOriginStmt() throws ConnectionException {
+        Mockito.when(mockSessionVariable.isRetryOriginSqlOnConvertFail()).thenReturn(true);
+
+        List<StatementBase> result = testProcessor.parseWithFallback(
+                "SELECT 1",
+                "INVALID SQL SYNTAX;;;",
+                mockSessionVariable
+        );
+
+        Assertions.assertNotNull(result, "Should return parsed statements from origin SQL when convertedStmt fails");
+        Assertions.assertFalse(result.isEmpty(), "Should return non-empty list from origin SQL");
+    }
+
+    @Test
+    public void testParseWithFallbackRetryDisabledCorrectConvertedStmt() throws ConnectionException {
+        Mockito.when(mockSessionVariable.isRetryOriginSqlOnConvertFail()).thenReturn(false);
+
+        List<StatementBase> result = testProcessor.parseWithFallback(
+                "SELECT 1",
+                "SELECT 1",
+                mockSessionVariable
+        );
+
+        Assertions.assertNotNull(result, "Should return parsed statements for correct convertedStmt");
+        Assertions.assertFalse(result.isEmpty(), "Should return non-empty list for correct convertedStmt");
+    }
+
+    @Test
+    public void testParseWithFallbackRetryDisabledIncorrectConvertedStmtCorrectOriginStmt() throws ConnectionException {
+        Mockito.when(mockSessionVariable.isRetryOriginSqlOnConvertFail()).thenReturn(false);
+
+        List<StatementBase> result = testProcessor.parseWithFallback(
+                "SELECT 1",
+                "INVALID SQL SYNTAX;;;",
+                mockSessionVariable
+        );
+
+        Assertions.assertNull(result, "Should return null when retry is disabled and convertedStmt fails");
+    }
+
+    // tryRetryOriginalSql tests
+    @Test
+    public void testTryRetryOriginalSqlRetryEnabledCorrectOriginStmt() {
+        Mockito.when(mockSessionVariable.isRetryOriginSqlOnConvertFail()).thenReturn(true);
+
+        List<StatementBase> result = testProcessor.tryRetryOriginalSql(
+                "SELECT 1",
+                "DIFFERENT CONVERTED SQL",
+                mockSessionVariable
+        );
+
+        Assertions.assertNotNull(result, "Should return parsed statements for correct origin SQL");
+        Assertions.assertFalse(result.isEmpty(), "Should return non-empty list for correct origin SQL");
+    }
+
+    @Test
+    public void testTryRetryOriginalSqlRetryEnabledIncorrectOriginStmt() {
+        Mockito.when(mockSessionVariable.isRetryOriginSqlOnConvertFail()).thenReturn(true);
+
+        List<StatementBase> result = testProcessor.tryRetryOriginalSql(
+                "INVALID SQL SYNTAX;;;",
+                "DIFFERENT CONVERTED SQL",
+                mockSessionVariable
+        );
+
+        Assertions.assertNull(result, "Should return null when origin SQL parsing fails");
+    }
+
+    @Test
+    public void testTryRetryOriginalSqlRetryDisabledCorrectOriginStmt() {
+        Mockito.when(mockSessionVariable.isRetryOriginSqlOnConvertFail()).thenReturn(false);
+
+        List<StatementBase> result = testProcessor.tryRetryOriginalSql(
+                "SELECT 1",
+                "DIFFERENT CONVERTED SQL",
+                mockSessionVariable
+        );
+
+        Assertions.assertNull(result, "Should return null when retry is disabled");
+    }
+
+    @Test
+    public void testTryRetryOriginalSqlRetryDisabledIncorrectOriginStmt() {
+        Mockito.when(mockSessionVariable.isRetryOriginSqlOnConvertFail()).thenReturn(false);
+
+        List<StatementBase> result = testProcessor.tryRetryOriginalSql(
+                "INVALID SQL SYNTAX;;;",
+                "DIFFERENT CONVERTED SQL",
+                mockSessionVariable
+        );
+
+        Assertions.assertNull(result, "Should return null when retry is disabled");
+    }
+
+    /**
+     * Testable concrete implementation of ConnectProcessor for testing purposes
+     */
+    private static class TestableConnectProcessor extends ConnectProcessor {
+
+        public TestableConnectProcessor(ConnectContext context) {
+            super(context);
+        }
+
+        @Override
+        public void processOnce() {
+            // Test implementation - do nothing
+        }
+
+        // Expose protected methods for testing
+        public List<StatementBase> parseWithFallback(String originStmt, String convertedStmt,
+                SessionVariable sessionVariable) throws ConnectionException {
+            return super.parseWithFallback(originStmt, convertedStmt, sessionVariable);
+        }
+
+        public List<StatementBase> tryRetryOriginalSql(String originStmt, String convertedStmt,
+                SessionVariable sessionVariable) {
+            return super.tryRetryOriginalSql(originStmt, convertedStmt, sessionVariable);
+        }
+    }
+}


### PR DESCRIPTION
Add a retry logic. When using SqlConverter for dialect conversion, in some cases we use the doris dialect instead of others, but these SQLs will also be converted once by SqlConverter, which may cause errors. Therefore, you can use the enable_sql_converter_retry_original variable to control whether to use the original SQL to retry the parser.


```sql
Doris > set sql_dialect = 'hive';
Query OK, 0 rows affected (0.03 sec)

Doris > SELECT   DATE(     DATE_SUB(       requirement_created_date,       INTERVAL DAYOFWEEK (requirement_created_date) - 1 DAY     )   ) AS requirement_created_date,   COUNT(distinct tapd_id) AS count FROM   test.test_tapd_data GROUP BY   DATE(     DATE_SUB(       requirement_created_date,       INTERVAL DAYOFWEEK (requirement_created_date) - 1 DAY     )   ) LIMIT   10000;
ERROR 1105 (HY000): errCode = 2, detailMessage = 
Only supported: +(line 1, pos 61)

== SQL ==
SELECT DATE(DATE_ADD(CAST(requirement_created_date AS DATE), (INTERVAL (DAYOFWEEK(requirement_created_date) - 1) DAY) * -1)) AS requirement_created_date, COUNT(DISTINCT tapd_id) AS `count` FROM test.test_tapd_data AS test_tapd_data GROUP BY DATE(DATE_ADD(CAST(requirement_created_date AS DATE), (INTERVAL (DAYOFWEEK(requirement_created_date) - 1) DAY) * -1)) LIMIT 10000;
-------------------------------------------------------------^^^
Doris > set retry_origin_sql_on_convert_fail = true;
Query OK, 0 rows affected (0.02 sec)

Doris > SELECT   DATE(     DATE_SUB(       requirement_created_date,       INTERVAL DAYOFWEEK (requirement_created_date) - 1 DAY     )   ) AS requirement_created_date,   COUNT(distinct tapd_id) AS count FROM   test.test_tapd_data GROUP BY   DATE(     DATE_SUB(       requirement_created_date,       INTERVAL DAYOFWEEK (requirement_created_date) - 1 DAY     )   ) LIMIT   10000;
Empty set (0.07 sec)
```