### PR TITLE
[fix](cloud) Delete useless table lock in replayUpdateCloudReplica

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
@@ -1035,6 +1035,15 @@ public class CloudInternalCatalog extends InternalCatalog {
             return;
         }
         LOG.debug("replay update a cloud replica {}", info);
+
+        try {
+            unprotectUpdateCloudReplica(olapTable, info);
+        } catch (Exception e) {
+            LOG.warn("unexpected exception", e);
+        }
+    }
+
+    private void unprotectUpdateCloudReplica(OlapTable olapTable, UpdateCloudReplicaInfo info) {
         Partition partition = olapTable.getPartition(info.getPartitionId());
         if (partition == null) {
             LOG.warn("replay update cloud replica, unknown partition {}, may be dropped", info.toString());
@@ -1047,14 +1056,6 @@ public class CloudInternalCatalog extends InternalCatalog {
             return;
         }
 
-        try {
-            unprotectUpdateCloudReplica(materializedIndex, info);
-        } catch (Exception e) {
-            LOG.warn("unexpected exception", e);
-        }
-    }
-
-    private void unprotectUpdateCloudReplica(MaterializedIndex materializedIndex, UpdateCloudReplicaInfo info) {
         try {
             if (info.getTabletId() != -1) {
                 Tablet tablet = materializedIndex.getTablet(info.getTabletId());


### PR DESCRIPTION
### What problem does this PR solve?

Here, replayUpdateCloudReplica adds a table write lock, which seems to protect nothing. Try deleting it.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

