### PR TITLE
[fix](cloud) get_tablet_merged_stats should returns the tablet idx

### DIFF
--- a/cloud/src/meta-store/meta_reader.cpp
+++ b/cloud/src/meta-store/meta_reader.cpp
@@ -354,6 +354,11 @@ TxnErrorCode MetaReader::get_tablet_merged_stats(Transaction* txn, int64_t table
         tablet_stats->set_data_size(load_stats.data_size() + compact_stats.data_size());
         tablet_stats->set_index_size(load_stats.index_size() + compact_stats.index_size());
         tablet_stats->set_segment_size(load_stats.segment_size() + compact_stats.segment_size());
+        if (load_stats.has_idx()) {
+            tablet_stats->mutable_idx()->CopyFrom(load_stats.idx());
+        } else if (compact_stats.has_idx()) {
+            tablet_stats->mutable_idx()->CopyFrom(compact_stats.idx());
+        }
     }
     Versionstamp read_version = std::min(load_version, compact_version);
     if (versionstamp) {

--- a/cloud/test/meta_service_versioned_read_test.cpp
+++ b/cloud/test/meta_service_versioned_read_test.cpp
@@ -768,6 +768,13 @@ TEST(MetaServiceVersionedReadTest, GetTabletStats) {
         EXPECT_EQ(res.tablet_stats(0).num_segments(), 0);
         EXPECT_EQ(res.tablet_stats(0).index_size(), 0);
         EXPECT_EQ(res.tablet_stats(0).segment_size(), 0);
+
+        // The tablet idx should be set.
+        auto tablet_stats = res.tablet_stats(0);
+        EXPECT_EQ(tablet_stats.idx().tablet_id(), tablet_id);
+        EXPECT_EQ(tablet_stats.idx().index_id(), index_id);
+        EXPECT_EQ(tablet_stats.idx().partition_id(), partition_id);
+        EXPECT_EQ(tablet_stats.idx().table_id(), table_id);
     }
 
     {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

