### PR TITLE
[opt](function) Reuse JsonbWriter to avoid repeated creation overhead

### DIFF
--- a/be/src/vec/functions/function_jsonb.cpp
+++ b/be/src/vec/functions/function_jsonb.cpp
@@ -25,7 +25,6 @@
 #include <type_traits>
 #include <utility>
 
-#include "CLucene/util/stringUtil.h"
 #include "common/compiler_util.h" // IWYU pragma: keep
 #include "common/status.h"
 #include "runtime/define_primitive_type.h"
@@ -33,7 +32,6 @@
 #include "runtime/primitive_type.h"
 #include "udf/udf.h"
 #include "util/jsonb_document.h"
-#include "util/jsonb_parser_simd.h"
 #include "util/jsonb_stream.h"
 #include "util/jsonb_utils.h"
 #include "util/jsonb_writer.h"
@@ -55,7 +53,6 @@
 #include "vec/data_types/data_type_array.h"
 #include "vec/data_types/data_type_jsonb.h"
 #include "vec/data_types/data_type_nullable.h"
-#include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
 #include "vec/functions/function.h"
 #include "vec/functions/like.h"
@@ -815,7 +812,8 @@ struct JsonbExtractStringImpl {
     static const bool only_check_exists = ValueType::only_check_exists;
 
 private:
-    static ALWAYS_INLINE void inner_loop_impl(size_t i, ColumnString::Chars& res_data,
+    static ALWAYS_INLINE void inner_loop_impl(JsonbWriter* writer, size_t i,
+                                              ColumnString::Chars& res_data,
                                               ColumnString::Offsets& res_offsets, NullMap& null_map,
                                               std::unique_ptr<JsonbToJson>& formater,
                                               const char* l_raw, size_t l_size, JsonbPath& path) {
@@ -842,29 +840,27 @@ private:
         }
 
         if constexpr (std::is_same_v<DataTypeJsonb, ReturnType>) {
-            JsonbWriter writer;
-
             if constexpr (ValueType::no_quotes) {
                 if (find_result.value->isString()) {
                     const auto* str_value = find_result.value->unpack<JsonbStringVal>();
                     const auto* blob = str_value->getBlob();
                     if (str_value->length() > 1 && blob[0] == '"' &&
                         blob[str_value->length() - 1] == '"') {
-                        writer.writeStartString();
-                        writer.writeString(blob + 1, str_value->length() - 2);
-                        writer.writeEndString();
+                        writer->writeStartString();
+                        writer->writeString(blob + 1, str_value->length() - 2);
+                        writer->writeEndString();
                         StringOP::push_value_string(
-                                std::string_view(writer.getOutput()->getBuffer(),
-                                                 writer.getOutput()->getSize()),
+                                std::string_view(writer->getOutput()->getBuffer(),
+                                                 writer->getOutput()->getSize()),
                                 i, res_data, res_offsets);
                         return;
                     }
                 }
             }
 
-            writer.writeValue(find_result.value);
-            StringOP::push_value_string(std::string_view(writer.getOutput()->getBuffer(),
-                                                         writer.getOutput()->getSize()),
+            writer->writeValue(find_result.value);
+            StringOP::push_value_string(std::string_view(writer->getOutput()->getBuffer(),
+                                                         writer->getOutput()->getSize()),
                                         i, res_data, res_offsets);
         } else {
             if (LIKELY(find_result.value->isString())) {
@@ -978,8 +974,10 @@ public:
                 if (!path_const[0]) {
                     RETURN_IF_ERROR(parse_json_path(i, 0));
                 }
-                inner_loop_impl(i, res_data, res_offsets, null_map, formater, l_raw, l_size,
-                                json_path_list[0]);
+
+                writer->reset();
+                inner_loop_impl(writer.get(), i, res_data, res_offsets, null_map, formater, l_raw,
+                                l_size, json_path_list[0]);
             } else { // will make array string to user
                 writer->reset();
                 bool has_value = false;
@@ -1046,6 +1044,7 @@ public:
 
         std::unique_ptr<JsonbToJson> formater;
 
+        JsonbWriter writer;
         for (size_t i = 0; i < input_rows_count; ++i) {
             if (l_null_map && (*l_null_map)[i]) {
                 StringOP::push_null_string(i, res_data, res_offsets, null_map);
@@ -1070,7 +1069,9 @@ public:
                         std::string_view(r_raw, r_size), i);
             }
 
-            inner_loop_impl(i, res_data, res_offsets, null_map, formater, l_raw, l_size, path);
+            writer.reset();
+            inner_loop_impl(&writer, i, res_data, res_offsets, null_map, formater, l_raw, l_size,
+                            path);
         } //for
         return Status::OK();
     } //function
@@ -1090,6 +1091,7 @@ public:
                                            std::string_view(rdata.data, rdata.size));
         }
 
+        JsonbWriter writer;
         for (size_t i = 0; i < input_rows_count; ++i) {
             if (l_null_map && (*l_null_map)[i]) {
                 StringOP::push_null_string(i, res_data, res_offsets, null_map);
@@ -1099,7 +1101,9 @@ public:
             int l_size = loffsets[i] - loffsets[i - 1];
             const char* l_raw = reinterpret_cast<const char*>(&ldata[loffsets[i - 1]]);
 
-            inner_loop_impl(i, res_data, res_offsets, null_map, formater, l_raw, l_size, path);
+            writer.reset();
+            inner_loop_impl(&writer, i, res_data, res_offsets, null_map, formater, l_raw, l_size,
+                            path);
         } //for
         return Status::OK();
     } //function
@@ -1113,6 +1117,8 @@ public:
         res_offsets.resize(input_rows_count);
 
         std::unique_ptr<JsonbToJson> formater;
+
+        JsonbWriter writer;
 
         for (size_t i = 0; i < input_rows_count; ++i) {
             if (r_null_map && (*r_null_map)[i]) {
@@ -1130,8 +1136,9 @@ public:
                         std::string_view(r_raw, r_size), i);
             }
 
-            inner_loop_impl(i, res_data, res_offsets, null_map, formater, ldata.data, ldata.size,
-                            path);
+            writer.reset();
+            inner_loop_impl(&writer, i, res_data, res_offsets, null_map, formater, ldata.data,
+                            ldata.size, path);
         } //for
         return Status::OK();
     } //function
@@ -1597,31 +1604,31 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
         auto return_data_type = std::make_shared<DataTypeJsonb>();
-        DorisVector<JsonbWriter> writers(input_rows_count);
+        auto column = return_data_type->create_column();
+        column->reserve(input_rows_count);
 
+        JsonbWriter writer;
         for (size_t i = 0; i < input_rows_count; ++i) {
-            writers[i].writeStartArray();
-        }
+            writer.writeStartArray();
+            for (auto argument : arguments) {
+                auto&& [arg_column, is_const] =
+                        unpack_if_const(block.get_by_position(argument).column);
+                if (arg_column->is_nullable()) {
+                    const auto& nullable_column =
+                            assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(
+                                    *arg_column);
+                    const auto& null_map = nullable_column.get_null_map_data();
+                    const auto& nested_column = nullable_column.get_nested_column();
+                    const auto& jsonb_column =
+                            assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(
+                                    nested_column);
 
-        for (auto argument : arguments) {
-            auto&& [arg_column, is_const] = unpack_if_const(block.get_by_position(argument).column);
-
-            auto& data_type = block.get_by_position(argument).type;
-            auto serde = data_type->get_serde();
-
-            if (arg_column->is_nullable()) {
-                const auto& nullable_column = assert_cast<const ColumnNullable&>(*arg_column);
-                const auto& null_map = nullable_column.get_null_map_data();
-                const auto& nested_column = nullable_column.get_nested_column();
-                const auto& jsonb_column = assert_cast<const ColumnString&>(nested_column);
-
-                for (size_t i = 0; i < input_rows_count; ++i) {
                     auto index = index_check_const(i, is_const);
                     if (null_map[index]) {
                         if constexpr (ignore_null) {
                             continue;
                         } else {
-                            writers[i].writeNull();
+                            writer.writeNull();
                         }
                     } else {
                         auto jsonb_binary = jsonb_column.get_data_at(index);
@@ -1632,17 +1639,17 @@ public:
                             if constexpr (ignore_null) {
                                 continue;
                             } else {
-                                writers[i].writeNull();
+                                writer.writeNull();
                             }
                         } else {
-                            writers[i].writeValue(doc->getValue());
+                            writer.writeValue(doc->getValue());
                         }
                     }
-                }
-            } else {
-                const auto& jsonb_column = assert_cast<const ColumnString&>(*arg_column);
+                } else {
+                    const auto& jsonb_column =
+                            assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(
+                                    *arg_column);
 
-                for (size_t i = 0; i < input_rows_count; ++i) {
                     auto index = index_check_const(i, is_const);
                     auto jsonb_binary = jsonb_column.get_data_at(index);
                     JsonbDocument* doc = nullptr;
@@ -1652,21 +1659,16 @@ public:
                         if constexpr (ignore_null) {
                             continue;
                         } else {
-                            writers[i].writeNull();
+                            writer.writeNull();
                         }
                     } else {
-                        writers[i].writeValue(doc->getValue());
+                        writer.writeValue(doc->getValue());
                     }
                 }
             }
-        }
-
-        auto column = return_data_type->create_column();
-        column->reserve(input_rows_count);
-        for (size_t i = 0; i < input_rows_count; ++i) {
-            writers[i].writeEndArray();
-            column->insert_data(writers[i].getOutput()->getBuffer(),
-                                writers[i].getOutput()->getSize());
+            writer.writeEndArray();
+            column->insert_data(writer.getOutput()->getBuffer(), writer.getOutput()->getSize());
+            writer.reset();
         }
 
         block.get_by_position(result).column = std::move(column);
@@ -1701,63 +1703,49 @@ public:
         }
 
         auto return_data_type = std::make_shared<DataTypeJsonb>();
-        DorisVector<JsonbWriter> writers(input_rows_count);
 
-        for (size_t i = 0; i < input_rows_count; ++i) {
-            writers[i].writeStartObject();
-        }
-
-        auto write_keys = [&writers](const ColumnString& key_col, const bool is_const,
-                                     const NullMap* null_map, const size_t rows,
-                                     const size_t arg_index) {
-            for (size_t row_idx = 0; row_idx != rows; ++row_idx) {
-                auto index = index_check_const(row_idx, is_const);
-                if (null_map && (*null_map)[index]) {
-                    return Status::InvalidArgument(
-                            "JSON documents may not contain NULL member name(argument "
-                            "index:  "
-                            "{}, row index: {})",
-                            row_idx, arg_index);
-                }
-
-                auto key_string = key_col.get_data_at(index);
-                if (key_string.size > 255) {
-                    return Status::InvalidArgument(
-                            "JSON object keys(argument index: {}) must be less than 256 "
-                            "bytes, but got size: {}",
-                            arg_index, key_string.size);
-                }
-                writers[row_idx].writeKey(key_string.data, static_cast<uint8_t>(key_string.size));
+        auto write_key = [](JsonbWriter& writer, const ColumnString& key_col, const bool is_const,
+                            const NullMap* null_map, const size_t arg_index, const size_t row_idx) {
+            auto index = index_check_const(row_idx, is_const);
+            if (null_map && (*null_map)[index]) {
+                return Status::InvalidArgument(
+                        "JSON documents may not contain NULL member name(argument "
+                        "index:  "
+                        "{}, row index: {})",
+                        row_idx, arg_index);
             }
+
+            auto key_string = key_col.get_data_at(index);
+            if (key_string.size > 255) {
+                return Status::InvalidArgument(
+                        "JSON object keys(argument index: {}) must be less than 256 "
+                        "bytes, but got size: {}",
+                        arg_index, key_string.size);
+            }
+            writer.writeKey(key_string.data, static_cast<uint8_t>(key_string.size));
             return Status::OK();
         };
 
-        auto write_values = [&writers](const ColumnString& value_col, const bool is_const,
-                                       const NullMap* null_map, const size_t rows,
-                                       const size_t arg_index) {
-            for (size_t row_idx = 0; row_idx != rows; ++row_idx) {
-                auto index = index_check_const(row_idx, is_const);
-                if (null_map && (*null_map)[index]) {
-                    writers[row_idx].writeNull();
-                    continue;
-                }
-
-                auto value_string = value_col.get_data_at(index);
-                JsonbDocument* doc = nullptr;
-                RETURN_IF_ERROR(JsonbDocument::checkAndCreateDocument(value_string.data,
-                                                                      value_string.size, &doc));
-                writers[row_idx].writeValue(doc->getValue());
+        auto write_value = [](JsonbWriter& writer, const ColumnString& value_col,
+                              const bool is_const, const NullMap* null_map, const size_t arg_index,
+                              const size_t row_idx) {
+            auto index = index_check_const(row_idx, is_const);
+            if (null_map && (*null_map)[index]) {
+                writer.writeNull();
+                return Status::OK();
             }
+
+            auto value_string = value_col.get_data_at(index);
+            JsonbDocument* doc = nullptr;
+            RETURN_IF_ERROR(JsonbDocument::checkAndCreateDocument(value_string.data,
+                                                                  value_string.size, &doc));
+            writer.writeValue(doc->getValue());
             return Status::OK();
         };
 
-        for (size_t i = 0; i < arguments.size(); i += 2) {
-            auto key_argument = arguments[i];
-            auto value_argument = arguments[i + 1];
-            auto&& [key_column, key_const] =
-                    unpack_if_const(block.get_by_position(key_argument).column);
-            auto&& [value_column, value_const] =
-                    unpack_if_const(block.get_by_position(value_argument).column);
+        for (size_t arg_idx = 0; arg_idx != arguments.size(); arg_idx += 2) {
+            auto key_argument = arguments[arg_idx];
+            auto value_argument = arguments[arg_idx + 1];
 
             auto& key_data_type = block.get_by_position(key_argument).type;
             auto& value_data_type = block.get_by_position(value_argument).type;
@@ -1765,51 +1753,75 @@ public:
                 return Status::InvalidArgument(
                         "JSON object key(argument index: {}) must be String, but got type: "
                         "{}(primitive type: {})",
-                        i, key_data_type->get_name(),
+                        arg_idx, key_data_type->get_name(),
                         static_cast<int>(key_data_type->get_primitive_type()));
             }
 
             if (value_data_type->get_primitive_type() != PrimitiveType::TYPE_JSONB) {
                 return Status::InvalidArgument(
-                        "JSON object value(argument index: {}) must be JSON, but got type: {}", i,
-                        value_data_type->get_name());
-            }
-
-            if (key_column->is_nullable()) {
-                const auto& nullable_column = assert_cast<const ColumnNullable&>(*key_column);
-                const auto& null_map = nullable_column.get_null_map_data();
-                const auto& nested_column = nullable_column.get_nested_column();
-                const auto& key_arg_column = assert_cast<const ColumnString&>(nested_column);
-
-                RETURN_IF_ERROR(
-                        write_keys(key_arg_column, key_const, &null_map, input_rows_count, i));
-            } else {
-                const auto& key_arg_column = assert_cast<const ColumnString&>(*key_column);
-                RETURN_IF_ERROR(
-                        write_keys(key_arg_column, key_const, nullptr, input_rows_count, i));
-            }
-
-            if (value_column->is_nullable()) {
-                const auto& nullable_column = assert_cast<const ColumnNullable&>(*value_column);
-                const auto& null_map = nullable_column.get_null_map_data();
-                const auto& nested_column = nullable_column.get_nested_column();
-                const auto& value_arg_column = assert_cast<const ColumnString&>(nested_column);
-
-                RETURN_IF_ERROR(write_values(value_arg_column, value_const, &null_map,
-                                             input_rows_count, i + 1));
-            } else {
-                const auto& value_arg_column = assert_cast<const ColumnString&>(*value_column);
-                RETURN_IF_ERROR(write_values(value_arg_column, value_const, nullptr,
-                                             input_rows_count, i + 1));
+                        "JSON object value(argument index: {}) must be JSON, but got type: {}",
+                        arg_idx, value_data_type->get_name());
             }
         }
 
         auto column = return_data_type->create_column();
         column->reserve(input_rows_count);
-        for (size_t i = 0; i < input_rows_count; ++i) {
-            writers[i].writeEndObject();
-            column->insert_data(writers[i].getOutput()->getBuffer(),
-                                writers[i].getOutput()->getSize());
+
+        JsonbWriter writer;
+        for (size_t i = 0; i != input_rows_count; ++i) {
+            writer.writeStartObject();
+            for (size_t arg_idx = 0; arg_idx != arguments.size(); arg_idx += 2) {
+                auto key_argument = arguments[arg_idx];
+                auto value_argument = arguments[arg_idx + 1];
+                auto&& [key_column, key_const] =
+                        unpack_if_const(block.get_by_position(key_argument).column);
+                auto&& [value_column, value_const] =
+                        unpack_if_const(block.get_by_position(value_argument).column);
+
+                if (key_column->is_nullable()) {
+                    const auto& nullable_column =
+                            assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(
+                                    *key_column);
+                    const auto& null_map = nullable_column.get_null_map_data();
+                    const auto& nested_column = nullable_column.get_nested_column();
+                    const auto& key_arg_column =
+                            assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(
+                                    nested_column);
+
+                    RETURN_IF_ERROR(
+                            write_key(writer, key_arg_column, key_const, &null_map, arg_idx, i));
+                } else {
+                    const auto& key_arg_column =
+                            assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(
+                                    *key_column);
+                    RETURN_IF_ERROR(
+                            write_key(writer, key_arg_column, key_const, nullptr, arg_idx, i));
+                }
+
+                if (value_column->is_nullable()) {
+                    const auto& nullable_column =
+                            assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(
+                                    *value_column);
+                    const auto& null_map = nullable_column.get_null_map_data();
+                    const auto& nested_column = nullable_column.get_nested_column();
+                    const auto& value_arg_column =
+                            assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(
+                                    nested_column);
+
+                    RETURN_IF_ERROR(write_value(writer, value_arg_column, value_const, &null_map,
+                                                arg_idx + 1, i));
+                } else {
+                    const auto& value_arg_column =
+                            assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(
+                                    *value_column);
+                    RETURN_IF_ERROR(write_value(writer, value_arg_column, value_const, nullptr,
+                                                arg_idx + 1, i));
+                }
+            }
+
+            writer.writeEndObject();
+            column->insert_data(writer.getOutput()->getBuffer(), writer.getOutput()->getSize());
+            writer.reset();
         }
 
         block.get_by_position(result).column = std::move(column);
@@ -1881,7 +1893,6 @@ public:
         const size_t keys_count = (arguments.size() - 1) / 2;
 
         auto return_data_type = make_nullable(std::make_shared<DataTypeJsonb>());
-        DorisVector<JsonbWriter> writers(input_rows_count);
 
         auto result_column = return_data_type->create_column();
         auto& result_nullable_col = assert_cast<ColumnNullable&>(*result_column);
@@ -1989,19 +2000,27 @@ public:
 
         DorisVector<DorisVector<JsonbPath>> json_paths(keys_count);
         DorisVector<DorisVector<JsonbValue*>> json_values(keys_count);
-        DorisVector<JsonbWriter> writer_holders(input_rows_count);
 
         RETURN_IF_ERROR(parse_paths_and_values(json_paths, json_values, arguments, input_rows_count,
                                                json_path_columns, json_path_constant,
                                                json_path_null_maps, json_value_columns,
                                                json_value_constant, json_value_null_maps));
 
-        for (size_t i = 1; i < arguments.size(); i += 2) {
-            const size_t index = i / 2;
-            auto& json_path = json_paths[index];
-            auto& json_value = json_values[index];
+        JsonbWriter writer;
+        struct DocumentBuffer {
+            std::unique_ptr<char[]> ptr;
+            size_t size = 0;
+            size_t capacity = 0;
+        };
 
-            for (size_t row_idx = 0; row_idx != input_rows_count; ++row_idx) {
+        DocumentBuffer tmp_buffer;
+
+        for (size_t row_idx = 0; row_idx != input_rows_count; ++row_idx) {
+            for (size_t i = 1; i < arguments.size(); i += 2) {
+                const size_t index = i / 2;
+                auto& json_path = json_paths[index];
+                auto& json_value = json_values[index];
+
                 const auto path_index = index_check_const(row_idx, json_path_constant[index]);
                 const auto value_index = index_check_const(row_idx, json_value_constant[index]);
 
@@ -2040,7 +2059,6 @@ public:
                 }
 
                 std::vector<const JsonbValue*> parents;
-                JsonbWriter writer;
 
                 bool replace = false;
                 parents.emplace_back(json_documents[row_idx]->getValue());
@@ -2078,29 +2096,38 @@ public:
                                                  json_value[value_index], replace, last_leg,
                                                  writer));
 
-                json_documents[row_idx] = writer.getDocument();
-                writer_holders[row_idx] = std::move(writer);
-            }
-        }
+                auto* writer_output = writer.getOutput();
+                if (writer_output->getSize() > tmp_buffer.capacity) {
+                    tmp_buffer.capacity =
+                            ((size_t(writer_output->getSize()) + 1024 - 1) / 1024) * 1024;
+                    tmp_buffer.ptr = std::make_unique<char[]>(tmp_buffer.capacity);
+                    DCHECK_LE(writer_output->getSize(), tmp_buffer.capacity);
+                }
 
-        for (size_t i = 0; i < input_rows_count; ++i) {
-            if (!null_map[i]) {
-                const auto* jsonb_document = json_documents[i];
+                memcpy(tmp_buffer.ptr.get(), writer_output->getBuffer(), writer_output->getSize());
+                tmp_buffer.size = writer_output->getSize();
+
+                writer.reset();
+
+                RETURN_IF_ERROR(JsonbDocument::checkAndCreateDocument(
+                        tmp_buffer.ptr.get(), tmp_buffer.size, &json_documents[row_idx]));
+            }
+
+            if (!null_map[row_idx]) {
+                const auto* jsonb_document = json_documents[row_idx];
                 const auto size = jsonb_document->numPackedBytes();
                 res_chars.insert(reinterpret_cast<const char*>(jsonb_document),
                                  reinterpret_cast<const char*>(jsonb_document) + size);
             }
 
-            res_offsets[i] = static_cast<uint32_t>(res_chars.size());
+            res_offsets[row_idx] = static_cast<uint32_t>(res_chars.size());
 
-            if (!null_map[i]) {
-                auto* ptr = res_chars.data() + res_offsets[i - 1];
-                auto size = res_offsets[i] - res_offsets[i - 1];
+            if (!null_map[row_idx]) {
+                auto* ptr = res_chars.data() + res_offsets[row_idx - 1];
+                auto size = res_offsets[row_idx] - res_offsets[row_idx - 1];
                 JsonbDocument* doc = nullptr;
                 THROW_IF_ERROR(JsonbDocument::checkAndCreateDocument(
-                        reinterpret_cast<const char*>(ptr), size,
-                        &doc)); // doc is NOT necessary to be deleted since
-                                // JsonbDocument will not allocate memory
+                        reinterpret_cast<const char*>(ptr), size, &doc));
             }
         }
 
@@ -2436,8 +2463,8 @@ private:
         }
     }
 
-    void make_result_str(std::unordered_set<std::string>& matches, ColumnString* result_col) const {
-        JsonbWriter writer;
+    void make_result_str(JsonbWriter& writer, std::unordered_set<std::string>& matches,
+                         ColumnString* result_col) const {
         if (matches.size() == 1) {
             for (const auto& str_ref : matches) {
                 writer.writeStartString();
@@ -2476,6 +2503,7 @@ private:
 
         bool is_one = false;
 
+        JsonbWriter writer;
         for (size_t i = 0; i < input_rows_count; ++i) {
             // an error occurs if the json_doc argument is not a valid json document.
             if (json_null_check(i)) {
@@ -2534,7 +2562,9 @@ private:
                 result_col->insert_data("", 0);
                 continue;
             }
-            make_result_str(matches, result_col.get());
+
+            writer.reset();
+            make_result_str(writer, matches, result_col.get());
         }
         auto result_col_nullable =
                 ColumnNullable::create(std::move(result_col), std::move(null_map));


### PR DESCRIPTION
### What problem does this PR solve?

```sql
select count(*) from json_bench_var where json_replace(var, "$.commit.record.subject.cid", "value") is not null;
```
69s vs 29s

```sql
select count(*) from json_bench_var where json_array(k, "name", "value") is not null;
````
19s vs 4.41s

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

