### PR TITLE
[Feat](Snapshot) Implement alter_instance interface for snapshot

### DIFF
--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -49,7 +49,7 @@ constexpr char pattern_str[] = "^[a-zA-Z][0-9a-zA-Z_]*$";
 
 constexpr char SNAPSHOT_ENABLED_KEY[] = "enabled";
 constexpr char SNAPSHOT_MAX_RESERVED_KEY[] = "max_reserved_snapshots";
-constexpr char SNAPSHOT_INTERVALS_KEY[] = "snapshot_intervals";
+constexpr char SNAPSHOT_INTERVAL_SECONDS_KEY[] = "snapshot_interval_seconds";
 
 bool is_valid_storage_vault_name(const std::string& str) {
     const std::regex pattern(pattern_str);
@@ -2090,7 +2090,7 @@ void MetaServiceImpl::alter_instance(google::protobuf::RpcController* controller
                 } else if (key == SNAPSHOT_MAX_RESERVED_KEY) {
                     result = handle_max_reserved_snapshots(request->instance_id(), key, value,
                                                            instance);
-                } else if (key == SNAPSHOT_INTERVALS_KEY) {
+                } else if (key == SNAPSHOT_INTERVAL_SECONDS_KEY) {
                     result =
                             handle_snapshot_intervals(request->instance_id(), key, value, instance);
                 } else {

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -46,6 +46,11 @@ using namespace std::chrono;
 
 namespace {
 constexpr char pattern_str[] = "^[a-zA-Z][0-9a-zA-Z_]*$";
+
+constexpr char SNAPSHOT_ENABLED_KEY[] = "enabled";
+constexpr char SNAPSHOT_MAX_RESERVED_KEY[] = "max_reserved_snapshots";
+constexpr char SNAPSHOT_INTERVALS_KEY[] = "snapshot_intervals";
+
 bool is_valid_storage_vault_name(const std::string& str) {
     const std::regex pattern(pattern_str);
     return std::regex_match(str, pattern);
@@ -2080,12 +2085,12 @@ void MetaServiceImpl::alter_instance(google::protobuf::RpcController* controller
 
                 std::pair<MetaServiceCode, std::string> result;
 
-                if (key == "enabled") {
+                if (key == SNAPSHOT_ENABLED_KEY) {
                     result = handle_snapshot_switch(request->instance_id(), key, value, instance);
-                } else if (key == "max_reserved_snapshots") {
+                } else if (key == SNAPSHOT_MAX_RESERVED_KEY) {
                     result = handle_max_reserved_snapshots(request->instance_id(), key, value,
                                                            instance);
-                } else if (key == "snapshot_intervals") {
+                } else if (key == SNAPSHOT_INTERVALS_KEY) {
                     result =
                             handle_snapshot_intervals(request->instance_id(), key, value, instance);
                 } else {
@@ -2093,6 +2098,10 @@ void MetaServiceImpl::alter_instance(google::protobuf::RpcController* controller
                     LOG(WARNING) << msg;
                     return std::make_pair(MetaServiceCode::INVALID_ARGUMENT, msg);
                 }
+
+                LOG(INFO) << "Property handling result for key=" << key
+                          << ", result_code=" << static_cast<int>(result.first)
+                          << ", result_msg=" << result.second;
 
                 if (result.first != MetaServiceCode::OK) {
                     msg = result.second;

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -1842,19 +1842,19 @@ std::pair<MetaServiceCode, std::string> handle_snapshot_intervals(const std::str
     int intervals;
     try {
         intervals = std::stoi(value);
-        if (intervals < 60) {
+        if (intervals < 3600) {
             return std::make_pair(
                     MetaServiceCode::INVALID_ARGUMENT,
-                    "snapshot_intervals too small, minimum is 60 minutes, got: " + value);
+                    "snapshot_intervals too small, minimum is 3600 seconds, got: " + value);
         }
     } catch (const std::exception& e) {
         return std::make_pair(MetaServiceCode::INVALID_ARGUMENT,
                               "Invalid numeric value for snapshot_intervals: " + value);
     }
 
-    instance->set_snapshot_interval_minutes(intervals);
+    instance->set_snapshot_interval_seconds(intervals);
 
-    std::string msg = "Set snapshot_intervals to " + value + " minutes for instance " + instance_id;
+    std::string msg = "Set snapshot_intervals to " + value + " seconds for instance " + instance_id;
     LOG(INFO) << msg;
 
     return std::make_pair(MetaServiceCode::OK, "");

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -11674,7 +11674,7 @@ TEST(MetaServiceTest, SetSnapshotPropertyTest) {
         AlterInstanceResponse res;
         req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
         req.set_instance_id("test_snapshot_instance");
-        (*req.mutable_properties())["snapshot_intervals"] = "60";
+        (*req.mutable_properties())["snapshot_intervals"] = "3600";
 
         meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -11688,7 +11688,7 @@ TEST(MetaServiceTest, SetSnapshotPropertyTest) {
         AlterInstanceResponse res;
         req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
         req.set_instance_id("test_snapshot_instance");
-        (*req.mutable_properties())["snapshot_intervals"] = "1440";
+        (*req.mutable_properties())["snapshot_intervals"] = "14400";
 
         meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -11702,7 +11702,7 @@ TEST(MetaServiceTest, SetSnapshotPropertyTest) {
         AlterInstanceResponse res;
         req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
         req.set_instance_id("test_snapshot_instance");
-        (*req.mutable_properties())["snapshot_intervals"] = "59";
+        (*req.mutable_properties())["snapshot_intervals"] = "3599";
 
         meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -11760,7 +11760,7 @@ TEST(MetaServiceTest, SetSnapshotPropertyTest) {
         req.set_instance_id("test_snapshot_instance");
         (*req.mutable_properties())["enabled"] = "true";
         (*req.mutable_properties())["max_reserved_snapshots"] = "20";
-        (*req.mutable_properties())["snapshot_intervals"] = "120";
+        (*req.mutable_properties())["snapshot_intervals"] = "12000";
 
         meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -11667,56 +11667,56 @@ TEST(MetaServiceTest, SetSnapshotPropertyTest) {
         ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT);
     }
 
-    // Test case 11: Valid "snapshot_intervals" property (minimum value)
+    // Test case 11: Valid "snapshot_interval_seconds" property (minimum value)
     {
         brpc::Controller cntl;
         AlterInstanceRequest req;
         AlterInstanceResponse res;
         req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
         req.set_instance_id("test_snapshot_instance");
-        (*req.mutable_properties())["snapshot_intervals"] = "3600";
+        (*req.mutable_properties())["snapshot_interval_seconds"] = "3600";
 
         meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
     }
 
-    // Test case 12: Valid "snapshot_intervals" property (large value)
+    // Test case 12: Valid "snapshot_interval_seconds" property (large value)
     {
         brpc::Controller cntl;
         AlterInstanceRequest req;
         AlterInstanceResponse res;
         req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
         req.set_instance_id("test_snapshot_instance");
-        (*req.mutable_properties())["snapshot_intervals"] = "14400";
+        (*req.mutable_properties())["snapshot_interval_seconds"] = "14400";
 
         meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
     }
 
-    // Test case 13: Invalid "snapshot_intervals" property (too small value)
+    // Test case 13: Invalid "snapshot_interval_seconds" property (too small value)
     {
         brpc::Controller cntl;
         AlterInstanceRequest req;
         AlterInstanceResponse res;
         req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
         req.set_instance_id("test_snapshot_instance");
-        (*req.mutable_properties())["snapshot_intervals"] = "3599";
+        (*req.mutable_properties())["snapshot_interval_seconds"] = "3599";
 
         meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
         ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT);
     }
 
-    // Test case 14: Invalid "snapshot_intervals" property (non-numeric value)
+    // Test case 14: Invalid "snapshot_interval_seconds" property (non-numeric value)
     {
         brpc::Controller cntl;
         AlterInstanceRequest req;
         AlterInstanceResponse res;
         req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
         req.set_instance_id("test_snapshot_instance");
-        (*req.mutable_properties())["snapshot_intervals"] = "invalid";
+        (*req.mutable_properties())["snapshot_interval_seconds"] = "invalid";
 
         meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
@@ -11760,7 +11760,7 @@ TEST(MetaServiceTest, SetSnapshotPropertyTest) {
         req.set_instance_id("test_snapshot_instance");
         (*req.mutable_properties())["enabled"] = "true";
         (*req.mutable_properties())["max_reserved_snapshots"] = "20";
-        (*req.mutable_properties())["snapshot_intervals"] = "12000";
+        (*req.mutable_properties())["snapshot_interval_seconds"] = "12000";
 
         meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -11479,4 +11479,323 @@ TEST(MetaServiceTest, RestoreJobTest) {
     }
 }
 
+TEST(MetaServiceTest, SetSnapshotPropertyTest) {
+    auto meta_service = get_meta_service();
+
+    // Create a test instance first
+    {
+        brpc::Controller cntl;
+        CreateInstanceRequest req;
+        req.set_instance_id("test_snapshot_instance");
+        req.set_user_id("test_user");
+        req.set_name("test_name");
+
+        auto* sp = SyncPoint::get_instance();
+        sp->set_call_back("encrypt_ak_sk:get_encryption_key", [](auto&& args) {
+            auto* ret = try_any_cast<int*>(args[0]);
+            *ret = 0;
+            auto* key = try_any_cast<std::string*>(args[1]);
+            *key = "test";
+            auto* key_id = try_any_cast<int64_t*>(args[2]);
+            *key_id = 1;
+        });
+        sp->enable_processing();
+        CreateInstanceResponse res;
+        meta_service->create_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                      &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+        sp->clear_all_call_backs();
+        sp->clear_trace();
+        sp->disable_processing();
+    }
+
+    // Test case 1: Snapshot not ready (SNAPSHOT_SWITCH_DISABLED) - should fail
+    {
+        brpc::Controller cntl;
+        AlterInstanceRequest req;
+        AlterInstanceResponse res;
+        req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
+        req.set_instance_id("test_snapshot_instance");
+        (*req.mutable_properties())["enabled"] = "true";
+
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT);
+        ASSERT_TRUE(res.status().msg().find("Snapshot not ready") != std::string::npos);
+    }
+
+    // Initialize snapshot switch status to OFF so we can test snapshot functionality
+    {
+        InstanceKeyInfo key_info {"test_snapshot_instance"};
+        std::string key;
+        std::string val;
+        instance_key(key_info, &key);
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+        ASSERT_EQ(txn->get(key, &val), TxnErrorCode::TXN_OK);
+        InstanceInfoPB instance;
+        instance.ParseFromString(val);
+        instance.set_snapshot_switch_status(SNAPSHOT_SWITCH_OFF);
+        val = instance.SerializeAsString();
+        txn->put(key, val);
+        ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+    }
+
+    // Test case 2: Valid "enabled" property with "true" value (after initialization)
+    {
+        brpc::Controller cntl;
+        AlterInstanceRequest req;
+        AlterInstanceResponse res;
+        req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
+        req.set_instance_id("test_snapshot_instance");
+        (*req.mutable_properties())["enabled"] = "true";
+
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+    }
+
+    // Test case 3: Valid "enabled" property with "false" value
+    {
+        brpc::Controller cntl;
+        AlterInstanceRequest req;
+        AlterInstanceResponse res;
+        req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
+        req.set_instance_id("test_snapshot_instance");
+        (*req.mutable_properties())["enabled"] = "false";
+
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+    }
+
+    // Test case 4: Invalid "enabled" property value
+    {
+        brpc::Controller cntl;
+        AlterInstanceRequest req;
+        AlterInstanceResponse res;
+        req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
+        req.set_instance_id("test_snapshot_instance");
+        (*req.mutable_properties())["enabled"] = "invalid";
+
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT);
+    }
+
+    // Test case 5: Valid "max_reserved_snapshots" property (minimum value)
+    {
+        brpc::Controller cntl;
+        AlterInstanceRequest req;
+        AlterInstanceResponse res;
+        req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
+        req.set_instance_id("test_snapshot_instance");
+        (*req.mutable_properties())["max_reserved_snapshots"] = "0";
+
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+    }
+
+    // Test case 6: Valid "max_reserved_snapshots" property (maximum value)
+    {
+        brpc::Controller cntl;
+        AlterInstanceRequest req;
+        AlterInstanceResponse res;
+        req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
+        req.set_instance_id("test_snapshot_instance");
+        (*req.mutable_properties())["max_reserved_snapshots"] = "35";
+
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+    }
+
+    // Test case 7: Valid "max_reserved_snapshots" property (middle value)
+    {
+        brpc::Controller cntl;
+        AlterInstanceRequest req;
+        AlterInstanceResponse res;
+        req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
+        req.set_instance_id("test_snapshot_instance");
+        (*req.mutable_properties())["max_reserved_snapshots"] = "10";
+
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+    }
+
+    // Test case 8: Invalid "max_reserved_snapshots" property (negative value)
+    {
+        brpc::Controller cntl;
+        AlterInstanceRequest req;
+        AlterInstanceResponse res;
+        req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
+        req.set_instance_id("test_snapshot_instance");
+        (*req.mutable_properties())["max_reserved_snapshots"] = "-1";
+
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT);
+    }
+
+    // Test case 9: Invalid "max_reserved_snapshots" property (too large value)
+    {
+        brpc::Controller cntl;
+        AlterInstanceRequest req;
+        AlterInstanceResponse res;
+        req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
+        req.set_instance_id("test_snapshot_instance");
+        (*req.mutable_properties())["max_reserved_snapshots"] = "36";
+
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT);
+    }
+
+    // Test case 10: Invalid "max_reserved_snapshots" property (non-numeric value)
+    {
+        brpc::Controller cntl;
+        AlterInstanceRequest req;
+        AlterInstanceResponse res;
+        req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
+        req.set_instance_id("test_snapshot_instance");
+        (*req.mutable_properties())["max_reserved_snapshots"] = "abc";
+
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT);
+    }
+
+    // Test case 11: Valid "snapshot_intervals" property (minimum value)
+    {
+        brpc::Controller cntl;
+        AlterInstanceRequest req;
+        AlterInstanceResponse res;
+        req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
+        req.set_instance_id("test_snapshot_instance");
+        (*req.mutable_properties())["snapshot_intervals"] = "60";
+
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+    }
+
+    // Test case 12: Valid "snapshot_intervals" property (large value)
+    {
+        brpc::Controller cntl;
+        AlterInstanceRequest req;
+        AlterInstanceResponse res;
+        req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
+        req.set_instance_id("test_snapshot_instance");
+        (*req.mutable_properties())["snapshot_intervals"] = "1440";
+
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+    }
+
+    // Test case 13: Invalid "snapshot_intervals" property (too small value)
+    {
+        brpc::Controller cntl;
+        AlterInstanceRequest req;
+        AlterInstanceResponse res;
+        req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
+        req.set_instance_id("test_snapshot_instance");
+        (*req.mutable_properties())["snapshot_intervals"] = "59";
+
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT);
+    }
+
+    // Test case 14: Invalid "snapshot_intervals" property (non-numeric value)
+    {
+        brpc::Controller cntl;
+        AlterInstanceRequest req;
+        AlterInstanceResponse res;
+        req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
+        req.set_instance_id("test_snapshot_instance");
+        (*req.mutable_properties())["snapshot_intervals"] = "invalid";
+
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT);
+    }
+
+    // Test case 15: Unsupported property key
+    {
+        brpc::Controller cntl;
+        AlterInstanceRequest req;
+        AlterInstanceResponse res;
+        req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
+        req.set_instance_id("test_snapshot_instance");
+        (*req.mutable_properties())["unsupported_property"] = "value";
+
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT);
+    }
+
+    // Test case 16: Empty properties map
+    {
+        brpc::Controller cntl;
+        AlterInstanceRequest req;
+        AlterInstanceResponse res;
+        req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
+        req.set_instance_id("test_snapshot_instance");
+        // Don't add any properties - properties map will be empty
+
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT);
+    }
+
+    // Test case 17: Multiple valid properties in single request
+    {
+        brpc::Controller cntl;
+        AlterInstanceRequest req;
+        AlterInstanceResponse res;
+        req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
+        req.set_instance_id("test_snapshot_instance");
+        (*req.mutable_properties())["enabled"] = "true";
+        (*req.mutable_properties())["max_reserved_snapshots"] = "20";
+        (*req.mutable_properties())["snapshot_intervals"] = "120";
+
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+    }
+
+    // Test case 18: Mixed valid and invalid properties (should fail on first invalid)
+    {
+        brpc::Controller cntl;
+        AlterInstanceRequest req;
+        AlterInstanceResponse res;
+        req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
+        req.set_instance_id("test_snapshot_instance");
+        (*req.mutable_properties())["enabled"] = "true";
+        (*req.mutable_properties())["invalid_property"] = "value";
+        (*req.mutable_properties())["max_reserved_snapshots"] = "10";
+
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT);
+    }
+
+    // Test case 19: Non-existent instance ID
+    {
+        brpc::Controller cntl;
+        AlterInstanceRequest req;
+        AlterInstanceResponse res;
+        req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
+        req.set_instance_id("non_existent_instance");
+        (*req.mutable_properties())["enabled"] = "true";
+
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::CLUSTER_NOT_FOUND);
+    }
+}
+
 } // namespace doris::cloud

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -107,7 +107,7 @@ message InstanceInfoPB {
 
     // Snapshot properties.
     optional int64 max_reserved_snapshot = 117;
-    optional int64 snapshot_interval_seconds = 118;
+    optional int64 snapshot_interval_minutes = 118;
 }
 
 message StagePB {
@@ -1354,18 +1354,13 @@ message AlterInstanceRequest {
         DISABLE_SSE                 = 5;
         SET_OVERDUE                 = 6;
         SET_NORMAL                  = 7;
-        SNAPSHOT_SWITCH_ON          = 8;
-        SNAPSHOT_SWITCH_OFF         = 9;
-        WRITE_MULTI_VERSION_KEYS    = 10;
-        READ_MULTI_VERSION_KEYS     = 11;
-        DISABLE_SINGLE_VERSION_KEYS = 12;
-        SET_SNAPSHOT_PROPERTY       = 13;
+        SET_SNAPSHOT_PROPERTY       = 8;
     }
     optional string instance_id = 1;
     optional Operation op = 2;
     optional string name = 3;
     optional string request_ip = 4;
-    optional string value = 5;
+    map<string, string> properties = 5;
 }
 
 message AlterInstanceResponse {

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -107,7 +107,7 @@ message InstanceInfoPB {
 
     // Snapshot properties.
     optional int64 max_reserved_snapshot = 117;
-    optional int64 snapshot_interval_minutes = 118;
+    optional int64 snapshot_interval_seconds = 118;
 }
 
 message StagePB {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

This pr implement alter_instance interface for managing instance snapshot properties through the SET_SNAPSHOT_PROPERTY operation, replacing multiple specific snapshot operations with a single flexible property-based approach.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

