### PR TITLE
[fix](hive)fix querying hive text table with NULL DEFINED AS ''

### DIFF
--- a/be/src/vec/exec/format/text/text_reader.cpp
+++ b/be/src/vec/exec/format/text/text_reader.cpp
@@ -165,11 +165,9 @@ Status TextReader::_validate_line(const Slice& line, bool* success) {
 
 Status TextReader::_deserialize_nullable_string(IColumn& column, Slice& slice) {
     auto& null_column = assert_cast<ColumnNullable&>(column);
-    if (_options.null_len > 0) {
-        if (slice.compare(Slice(_options.null_format, _options.null_len)) == 0) {
-            null_column.insert_data(nullptr, 0);
-            return Status::OK();
-        }
+    if (slice.compare(Slice(_options.null_format, _options.null_len)) == 0) {
+        null_column.insert_data(nullptr, 0);
+        return Status::OK();
     }
     static DataTypeStringSerDe stringSerDe;
     auto st = stringSerDe.deserialize_one_cell_from_hive_text(null_column.get_nested_column(),

--- a/docker/thirdparties/docker-compose/hive/scripts/data/regression/serde_prop/some_serde_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/regression/serde_prop/some_serde_table.hql
@@ -170,3 +170,19 @@ INSERT INTO TABLE test_open_csv_standard_prop VALUES
 INSERT INTO TABLE test_open_csv_custom_prop VALUES 
 (1, 'John Doe', 28, 50000.75, true, '2022-01-15', '2023-10-21 14:30:00', 4.5, 'Senior Developer'),
 (2, 'Jane,Smith', NULL, NULL, false, '2020-05-20', NULL, NULL, '\"Project Manager\"');
+
+CREATE TABLE test_empty_null_format_text (
+  id INT,
+  name STRING
+)
+ROW FORMAT DELIMITED
+FIELDS TERMINATED BY '\t'
+STORED AS TEXTFILE
+TBLPROPERTIES (
+  "serialization.null.format"=""
+);
+
+INSERT INTO TABLE test_empty_null_format_text VALUES
+  (1, 'Alice'),
+  (2, NULL),
+  (3, '');

--- a/docker/thirdparties/docker-compose/hive/scripts/data/regression/serde_prop/some_serde_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/regression/serde_prop/some_serde_table.hql
@@ -186,3 +186,17 @@ INSERT INTO TABLE test_empty_null_format_text VALUES
   (1, 'Alice'),
   (2, NULL),
   (3, '');
+
+CREATE TABLE test_empty_null_defined_text (
+  id INT,
+  name STRING
+)
+ROW FORMAT DELIMITED
+FIELDS TERMINATED BY '\t'
+NULL DEFINED AS ''
+STORED AS TEXTFILE;
+
+INSERT INTO TABLE test_empty_null_defined_text VALUES
+  (1, 'Alice'),
+  (2, NULL),
+  (3, '');

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreClientHelper.java
@@ -863,7 +863,7 @@ public class HiveMetaStoreClientHelper {
 
     private static Optional<String> firstNonNullable(String... values) {
         for (String value : values) {
-            if (!Strings.isNullOrEmpty(value)) {
+            if (value != null) {
                 return Optional.of(value);
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreClientHelper.java
@@ -884,8 +884,10 @@ public class HiveMetaStoreClientHelper {
      *
      * @param altValue
      *                 The string containing a number.
+     * @param defValue
+     *                 The default value to return if altValue is invalid.
      */
-    public static String getByte(String altValue) {
+    public static String getByte(String altValue, String defValue) {
         if (altValue != null && altValue.length() > 0) {
             try {
                 return Character.toString((char) ((Byte.parseByte(altValue) + 256) % 256));
@@ -893,6 +895,6 @@ public class HiveMetaStoreClientHelper {
                 return altValue.substring(0, 1);
             }
         }
-        return null;
+        return defValue;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveProperties.java
@@ -89,8 +89,8 @@ public class HiveProperties {
         Optional<String> fieldDelim = HiveMetaStoreClientHelper.getSerdeProperty(table, PROP_FIELD_DELIMITER);
         Optional<String> serFormat = HiveMetaStoreClientHelper.getSerdeProperty(table, PROP_SERIALIZATION_FORMAT);
         String delimiter = HiveMetaStoreClientHelper.firstPresentOrDefault(
-                DEFAULT_FIELD_DELIMITER, fieldDelim, serFormat);
-        return supportMultiChar ? delimiter : HiveMetaStoreClientHelper.getByte(delimiter);
+                "", fieldDelim, serFormat);
+        return supportMultiChar ? delimiter : HiveMetaStoreClientHelper.getByte(delimiter, DEFAULT_FIELD_DELIMITER);
     }
 
     public static String getSeparatorChar(Table table) {
@@ -102,13 +102,13 @@ public class HiveProperties {
     public static String getLineDelimiter(Table table) {
         Optional<String> lineDelim = HiveMetaStoreClientHelper.getSerdeProperty(table, PROP_LINE_DELIMITER);
         return HiveMetaStoreClientHelper.getByte(HiveMetaStoreClientHelper.firstPresentOrDefault(
-                DEFAULT_LINE_DELIMITER, lineDelim));
+                "", lineDelim), DEFAULT_LINE_DELIMITER);
     }
 
     public static String getMapKvDelimiter(Table table) {
         Optional<String> mapkvDelim = HiveMetaStoreClientHelper.getSerdeProperty(table, PROP_MAP_KV_DELIMITER);
         return HiveMetaStoreClientHelper.getByte(HiveMetaStoreClientHelper.firstPresentOrDefault(
-                DEFAULT_MAP_KV_DELIMITER, mapkvDelim));
+                "", mapkvDelim), DEFAULT_MAP_KV_DELIMITER);
     }
 
     public static String getCollectionDelimiter(Table table) {
@@ -117,18 +117,13 @@ public class HiveProperties {
         Optional<String> collectionDelimHive3 = HiveMetaStoreClientHelper.getSerdeProperty(table,
                 PROP_COLLECTION_DELIMITER_HIVE3);
         return HiveMetaStoreClientHelper.getByte(HiveMetaStoreClientHelper.firstPresentOrDefault(
-                DEFAULT_COLLECTION_DELIMITER, collectionDelimHive2, collectionDelimHive3));
+                "", collectionDelimHive2, collectionDelimHive3), DEFAULT_COLLECTION_DELIMITER);
     }
 
     public static Optional<String> getEscapeDelimiter(Table table) {
         Optional<String> escapeDelim = HiveMetaStoreClientHelper.getSerdeProperty(table, PROP_ESCAPE_DELIMITER);
         if (escapeDelim.isPresent()) {
-            String escape = HiveMetaStoreClientHelper.getByte(escapeDelim.get());
-            if (escape != null) {
-                return Optional.of(escape);
-            } else {
-                return Optional.of(DEFAULT_ESCAPE_DELIMIER);
-            }
+            return Optional.of(HiveMetaStoreClientHelper.getByte(escapeDelim.get(), DEFAULT_ESCAPE_DELIMIER));
         }
         return Optional.empty();
     }

--- a/regression-test/data/external_table_p0/hive/test_hive_serde_prop.out
+++ b/regression-test/data/external_table_p0/hive/test_hive_serde_prop.out
@@ -41,15 +41,26 @@ b	2.2
 
 -- !test_open_csv_default_prop --
 1	John Doe	28	50000.75	TRUE	2022-01-15	2023-10-21 14:30:00	4.5	Senior Developer
-2	Jane,Smith				2020-05-20			"Project Manager"
+2	Jane,Smith			FALSE	2020-05-20			"Project Manager"
 
 -- !test_open_csv_standard_prop --
 1	John Doe	28	50000.75	TRUE	2022-01-15	2023-10-21 14:30:00	4.5	Senior Developer
-2	Jane,Smith				2020-05-20			"Project Manager"
+2	Jane,Smith			FALSE	2020-05-20			"Project Manager"
 
 -- !test_open_csv_custom_prop --
 1	John Doe	28	50000.75	TRUE	2022-01-15	2023-10-21 14:30:00	4.5	Senior Developer
-2	Jane,Smith				2020-05-20			"Project Manager"
+2	Jane,Smith			FALSE	2020-05-20			"Project Manager"
+
+-- !test_empty_null_format_text --
+1	Alice
+2	\N
+3	\N
+
+-- !test_empty_null_format_text2 --
+2	\N
+3	\N
+
+-- !test_empty_null_format_text3 --
 
 -- !1 --
 a	1.1
@@ -102,4 +113,15 @@ b	2.2
 -- !test_open_csv_custom_prop --
 1	John Doe	28	50000.75	TRUE	2022-01-15	2023-10-21 14:30:00	4.5	Senior Developer
 2	Jane,Smith			FALSE	2020-05-20			"Project Manager"
+
+-- !test_empty_null_format_text --
+1	Alice
+2	\N
+3	\N
+
+-- !test_empty_null_format_text2 --
+2	\N
+3	\N
+
+-- !test_empty_null_format_text3 --
 

--- a/regression-test/data/external_table_p0/hive/test_hive_serde_prop.out
+++ b/regression-test/data/external_table_p0/hive/test_hive_serde_prop.out
@@ -62,6 +62,17 @@ b	2.2
 
 -- !test_empty_null_format_text3 --
 
+-- !test_empty_null_defined_text --
+1	Alice
+2	\N
+3	\N
+
+-- !test_empty_null_defined_text2 --
+2	\N
+3	\N
+
+-- !test_empty_null_defined_text3 --
+
 -- !1 --
 a	1.1
 b	2.2
@@ -124,4 +135,15 @@ b	2.2
 3	\N
 
 -- !test_empty_null_format_text3 --
+
+-- !test_empty_null_defined_text --
+1	Alice
+2	\N
+3	\N
+
+-- !test_empty_null_defined_text2 --
+2	\N
+3	\N
+
+-- !test_empty_null_defined_text3 --
 

--- a/regression-test/data/external_table_p0/hive/test_hive_serde_prop.out
+++ b/regression-test/data/external_table_p0/hive/test_hive_serde_prop.out
@@ -41,15 +41,15 @@ b	2.2
 
 -- !test_open_csv_default_prop --
 1	John Doe	28	50000.75	TRUE	2022-01-15	2023-10-21 14:30:00	4.5	Senior Developer
-2	Jane,Smith			FALSE	2020-05-20			"Project Manager"
+2	Jane,Smith				2020-05-20			"Project Manager"
 
 -- !test_open_csv_standard_prop --
 1	John Doe	28	50000.75	TRUE	2022-01-15	2023-10-21 14:30:00	4.5	Senior Developer
-2	Jane,Smith			FALSE	2020-05-20			"Project Manager"
+2	Jane,Smith				2020-05-20			"Project Manager"
 
 -- !test_open_csv_custom_prop --
 1	John Doe	28	50000.75	TRUE	2022-01-15	2023-10-21 14:30:00	4.5	Senior Developer
-2	Jane,Smith			FALSE	2020-05-20			"Project Manager"
+2	Jane,Smith				2020-05-20			"Project Manager"
 
 -- !test_empty_null_format_text --
 1	Alice

--- a/regression-test/suites/external_table_p0/hive/test_hive_serde_prop.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_serde_prop.groovy
@@ -55,6 +55,10 @@ suite("test_hive_serde_prop", "external_docker,hive,external_docker_hive,p0,exte
         qt_test_open_csv_default_prop """select * from ${catalog_name}.regression.test_open_csv_default_prop order by id;"""
         qt_test_open_csv_standard_prop """select * from ${catalog_name}.regression.test_open_csv_standard_prop order by id;"""
         qt_test_open_csv_custom_prop """select * from ${catalog_name}.regression.test_open_csv_custom_prop order by id;"""
+
+        qt_test_empty_null_format_text """select * from ${catalog_name}.regression.test_empty_null_format_text order by id;"""
+        qt_test_empty_null_format_text2 """select * from ${catalog_name}.regression.test_empty_null_format_text where name is null order by id;"""
+        qt_test_empty_null_format_text3 """select * from ${catalog_name}.regression.test_empty_null_format_text where name = '' order by id;"""
     }
 }
 

--- a/regression-test/suites/external_table_p0/hive/test_hive_serde_prop.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_serde_prop.groovy
@@ -59,6 +59,10 @@ suite("test_hive_serde_prop", "external_docker,hive,external_docker_hive,p0,exte
         qt_test_empty_null_format_text """select * from ${catalog_name}.regression.test_empty_null_format_text order by id;"""
         qt_test_empty_null_format_text2 """select * from ${catalog_name}.regression.test_empty_null_format_text where name is null order by id;"""
         qt_test_empty_null_format_text3 """select * from ${catalog_name}.regression.test_empty_null_format_text where name = '' order by id;"""
+
+        qt_test_empty_null_defined_text """select * from ${catalog_name}.regression.test_empty_null_defined_text order by id;"""
+        qt_test_empty_null_defined_text2 """select * from ${catalog_name}.regression.test_empty_null_defined_text where name is null order by id;"""
+        qt_test_empty_null_defined_text3 """select * from ${catalog_name}.regression.test_empty_null_defined_text where name = '' order by id;"""
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
This pull request improves the handling of empty string null formats and delimiter properties for Hive external tables, ensuring more robust and consistent behavior when parsing data.

For hive text table like this:
```sql
CREATE TABLE test_empty_null_defined_text (
  id INT,
  name STRING
)
ROW FORMAT DELIMITED
FIELDS TERMINATED BY '\t'
NULL DEFINED AS ''
STORED AS TEXTFILE;

INSERT INTO TABLE test_empty_null_defined_text VALUES
  (1, 'Alice'),
  (2, NULL);
```
Query in Doris:
```sql
select * from test_empty_null_defined_text;
```
Before Result:
```text
+------+-------+
| id   | name  |
+------+-------+
|    1 | Alice |
|    2 |       |
+------+-------+
```
After Result:
```text
+------+-------+
| id   | name  |
+------+-------+
|    1 | Alice |
|    2 | NULL  |
+------+-------+
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

