### PR TITLE
[feat](load): directly report the first data quality error in load response

### DIFF
--- a/be/src/io/fs/multi_table_pipe.cpp
+++ b/be/src/io/fs/multi_table_pipe.cpp
@@ -281,6 +281,10 @@ Status MultiTablePipe::exec_plans(ExecEnv* exec_env,
                             _ctx->error_url =
                                     to_load_error_http_path(state->get_error_log_file_path());
                         }
+                        if (!state->get_first_error_msg().empty()) {
+                            _ctx->first_error_msg =
+                                    to_load_error_http_path(state->get_first_error_msg());
+                        }
                         if (!status->ok()) {
                             LOG(WARNING) << "plan fragment exec failed. errmsg=" << *status
                                          << _ctx->brief();

--- a/be/src/io/fs/multi_table_pipe.cpp
+++ b/be/src/io/fs/multi_table_pipe.cpp
@@ -282,8 +282,7 @@ Status MultiTablePipe::exec_plans(ExecEnv* exec_env,
                                     to_load_error_http_path(state->get_error_log_file_path());
                         }
                         if (!state->get_first_error_msg().empty()) {
-                            _ctx->first_error_msg =
-                                    to_load_error_http_path(state->get_first_error_msg());
+                            _ctx->first_error_msg = state->get_first_error_msg();
                         }
                         if (!status->ok()) {
                             LOG(WARNING) << "plan fragment exec failed. errmsg=" << *status

--- a/be/src/pipeline/exec/group_commit_block_sink_operator.cpp
+++ b/be/src/pipeline/exec/group_commit_block_sink_operator.cpp
@@ -307,7 +307,8 @@ Status GroupCommitBlockSinkOperatorX::sink(RuntimeState* state, vectorized::Bloc
                 if (num_selected_rows > 0 &&
                     (double)state->num_rows_load_filtered() / (double)num_selected_rows >
                             _max_filter_ratio) {
-                    return Status::DataQualityError("too many filtered rows");
+                    return Status::DataQualityError("too many filtered rows, {}",
+                                                    state->get_first_error_msg());
                 }
                 RETURN_IF_ERROR(local_state._add_blocks(state, true));
             }

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -207,6 +207,10 @@ void PipelineFragmentContext::cancel(const Status reason) {
         _query_ctx->set_load_error_url(error_url);
     }
 
+    if (auto first_error_msg = get_first_error_msg(); !first_error_msg.empty()) {
+        _query_ctx->set_first_error_msg(first_error_msg);
+    }
+
     _query_ctx->cancel(reason, _fragment_id);
     if (reason.is<ErrorCode::LIMIT_REACH>()) {
         _is_report_on_cancel = false;
@@ -224,6 +228,7 @@ void PipelineFragmentContext::cancel(const Status reason) {
         // We need to set the error URL at this point to ensure error information is properly
         // propagated to the client.
         stream_load_ctx->error_url = get_load_error_url();
+        stream_load_ctx->first_error_msg = get_first_error_msg();
     }
 
     for (auto& tasks : _tasks) {
@@ -1839,6 +1844,23 @@ std::string PipelineFragmentContext::get_load_error_url() {
     return "";
 }
 
+std::string PipelineFragmentContext::get_first_error_msg() {
+    if (const auto& str = _runtime_state->get_first_error_msg(); !str.empty()) {
+        return str;
+    }
+    for (auto& task_states : _task_runtime_states) {
+        for (auto& task_state : task_states) {
+            if (!task_state) {
+                continue;
+            }
+            if (const auto& str = task_state->get_first_error_msg(); !str.empty()) {
+                return str;
+            }
+        }
+    }
+    return "";
+}
+
 Status PipelineFragmentContext::send_report(bool done) {
     Status exec_status = _query_ctx->exec_status();
     // If plan is done successfully, but _is_report_success is false,
@@ -1872,6 +1894,9 @@ Status PipelineFragmentContext::send_report(bool done) {
     std::string load_eror_url = _query_ctx->get_load_error_url().empty()
                                         ? get_load_error_url()
                                         : _query_ctx->get_load_error_url();
+    std::string first_error_msg = _query_ctx->get_first_error_msg().empty()
+                                          ? get_first_error_msg()
+                                          : _query_ctx->get_first_error_msg();
 
     ReportStatusRequest req {exec_status,
                              runtime_states,
@@ -1883,6 +1908,7 @@ Status PipelineFragmentContext::send_report(bool done) {
                              -1,
                              _runtime_state.get(),
                              load_eror_url,
+                             first_error_msg,
                              [this](const Status& reason) { cancel(reason); }};
 
     return _report_status_cb(

--- a/be/src/pipeline/pipeline_fragment_context.h
+++ b/be/src/pipeline/pipeline_fragment_context.h
@@ -125,6 +125,7 @@ public:
     }
 
     std::string get_load_error_url();
+    std::string get_first_error_msg();
 
 private:
     Status _build_pipelines(ObjectPool* pool, const doris::TPipelineFragmentParams& request,

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -470,6 +470,9 @@ void FragmentMgr::coordinator_callback(const ReportStatusRequest& req) {
     if (!req.load_error_url.empty()) {
         params.__set_tracking_url(req.load_error_url);
     }
+    if (!req.first_error_msg.empty()) {
+        params.__set_first_error_msg(req.first_error_msg);
+    }
     for (auto* rs : req.runtime_states) {
         if (rs->wal_id() > 0) {
             params.__set_txn_id(rs->wal_id());

--- a/be/src/runtime/group_commit_mgr.cpp
+++ b/be/src/runtime/group_commit_mgr.cpp
@@ -564,6 +564,9 @@ Status GroupCommitTable::_finish_group_commit_load(int64_t db_id, int64_t table_
         if (!state->get_error_log_file_path().empty()) {
             ss << ", error_url=" << state->get_error_log_file_path();
         }
+        if (!state->get_first_error_msg().empty()) {
+            ss << ", first_error_msg=" << state->get_first_error_msg();
+        }
         ss << ", rows=" << state->num_rows_load_success();
     }
     LOG(INFO) << ss.str();

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -314,6 +314,16 @@ std::string QueryContext::get_load_error_url() {
     return _load_error_url;
 }
 
+void QueryContext::set_first_error_msg(std::string error_msg) {
+    std::lock_guard<std::mutex> lock(_error_url_lock);
+    _first_error_msg = error_msg;
+}
+
+std::string QueryContext::get_first_error_msg() {
+    std::lock_guard<std::mutex> lock(_error_url_lock);
+    return _first_error_msg;
+}
+
 void QueryContext::cancel_all_pipeline_context(const Status& reason, int fragment_id) {
     std::vector<std::weak_ptr<pipeline::PipelineFragmentContext>> ctx_to_cancel;
     {

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -61,6 +61,7 @@ struct ReportStatusRequest {
     int backend_num;
     RuntimeState* runtime_state;
     std::string load_error_url;
+    std::string first_error_msg;
     std::function<void(const Status&)> cancel_fn;
 };
 
@@ -289,6 +290,8 @@ public:
 
     void set_load_error_url(std::string error_url);
     std::string get_load_error_url();
+    void set_first_error_msg(std::string error_msg);
+    std::string get_first_error_msg();
 
 private:
     friend class QueryTaskController;
@@ -366,6 +369,7 @@ private:
 
     std::mutex _error_url_lock;
     std::string _load_error_url;
+    std::string _first_error_msg;
 
 public:
     // when fragment of pipeline is closed, it will register its profile to this map by using add_fragment_profile

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -384,8 +384,7 @@ Status RuntimeState::append_error_msg_to_file(std::function<std::string()> line,
             return Status::DataQualityError(
                     "Encountered unqualified data, stop processing. Please check if the source "
                     "data matches the schema, and consider disabling strict mode or increasing "
-                    "max_filter_ratio. first_error_msg: {}",
-                    _first_error_msg);
+                    "max_filter_ratio.");
         }
         return Status::OK();
     }

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -371,6 +371,9 @@ Status RuntimeState::append_error_msg_to_file(std::function<std::string()> line,
             }
             return status;
         }
+        // record the first error message if the file is just created
+        _first_error_msg = error_msg() + ". Src line: " + line();
+        LOG(INFO) << "The first error message: " << _first_error_msg;
     }
 
     // if num of printed error row exceeds the limit, and this is not a summary message,
@@ -381,7 +384,8 @@ Status RuntimeState::append_error_msg_to_file(std::function<std::string()> line,
             return Status::DataQualityError(
                     "Encountered unqualified data, stop processing. Please check if the source "
                     "data matches the schema, and consider disabling strict mode or increasing "
-                    "max_filter_ratio.");
+                    "max_filter_ratio. first_error_msg: {}",
+                    _first_error_msg);
         }
         return Status::OK();
     }

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -280,6 +280,8 @@ public:
 
     std::string get_error_log_file_path();
 
+    std::string get_first_error_msg() const { return _first_error_msg; }
+
     // append error msg and error line to file when loading data.
     // is_summary is true, means we are going to write the summary line
     // If we need to stop the processing, set stop_processing to true
@@ -768,6 +770,7 @@ private:
     int64_t _error_row_number;
     std::string _error_log_file_path;
     std::unique_ptr<std::ofstream> _error_log_file; // error file path, absolute path
+    std::string _first_error_msg = "";
     mutable std::mutex _tablet_infos_mutex;
     std::vector<TTabletCommitInfo> _tablet_commit_infos;
     std::vector<TErrorTabletInfo> _error_tablet_infos;

--- a/be/src/runtime/stream_load/stream_load_context.cpp
+++ b/be/src/runtime/stream_load/stream_load_context.cpp
@@ -244,15 +244,6 @@ void StreamLoadContext::parse_stream_load_record(const std::string& stream_load_
         ss << ", ErrorURL: N/A";
     }
 
-    if (document.HasMember("FirstErrorMsg")) {
-        const rapidjson::Value& first_error_msg = document["FirstErrorMsg"];
-        stream_load_item.__set_url(first_error_msg.GetString());
-        ss << ", FirstErrorMsg: " << first_error_msg.GetString();
-    } else {
-        stream_load_item.__set_url("N/A");
-        ss << ", FirstErrorMsg: N/A";
-    }
-
     if (document.HasMember("NumberTotalRows")) {
         const rapidjson::Value& total_rows = document["NumberTotalRows"];
         stream_load_item.__set_total_rows(total_rows.GetInt64());
@@ -299,6 +290,15 @@ void StreamLoadContext::parse_stream_load_record(const std::string& stream_load_
         const rapidjson::Value& comment_value = document["Comment"];
         stream_load_item.__set_comment(comment_value.GetString());
         ss << ", Comment: " << comment_value.GetString();
+    }
+
+    if (document.HasMember("FirstErrorMsg")) {
+        const rapidjson::Value& first_error_msg = document["FirstErrorMsg"];
+        stream_load_item.__set_first_error_msg(first_error_msg.GetString());
+        ss << ", FirstErrorMsg: " << first_error_msg.GetString();
+    } else {
+        stream_load_item.__set_first_error_msg("N/A");
+        ss << ", FirstErrorMsg: N/A";
     }
 
     VLOG(1) << "parse json from rocksdb. " << ss.str();

--- a/be/src/runtime/stream_load/stream_load_context.cpp
+++ b/be/src/runtime/stream_load/stream_load_context.cpp
@@ -119,6 +119,10 @@ std::string StreamLoadContext::to_json() const {
         writer.Key("ErrorURL");
         writer.String(error_url.c_str());
     }
+    if (!first_error_msg.empty()) {
+        writer.Key("FirstErrorMsg");
+        writer.String(first_error_msg.c_str());
+    }
     writer.EndObject();
     return s.GetString();
 }
@@ -238,6 +242,15 @@ void StreamLoadContext::parse_stream_load_record(const std::string& stream_load_
     } else {
         stream_load_item.__set_url("N/A");
         ss << ", ErrorURL: N/A";
+    }
+
+    if (document.HasMember("FirstErrorMsg")) {
+        const rapidjson::Value& first_error_msg = document["FirstErrorMsg"];
+        stream_load_item.__set_url(first_error_msg.GetString());
+        ss << ", FirstErrorMsg: " << first_error_msg.GetString();
+    } else {
+        stream_load_item.__set_url("N/A");
+        ss << ", FirstErrorMsg: N/A";
     }
 
     if (document.HasMember("NumberTotalRows")) {

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -227,6 +227,7 @@ public:
     int64_t begin_receive_and_read_data_cost_nanos = 0;
 
     std::string error_url = "";
+    std::string first_error_msg = "";
     // if label already be used, set existing job's status here
     // should be RUNNING or FINISHED
     std::string existing_job_status = "";

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -92,8 +92,8 @@ Status StreamLoadExecutor::execute_plan_fragment(std::shared_ptr<StreamLoadConte
             // NOTE: Do not modify the error message here, for historical reasons,
             // some users may rely on this error message.
             if (ctx->need_commit_self) {
-                *status = Status::DataQualityError("too many filtered rows, url: {}",
-                                                   ctx->error_url);
+                *status =
+                        Status::DataQualityError("too many filtered rows, url: {}", ctx->error_url);
             } else {
                 *status = Status::DataQualityError("too many filtered rows");
             }

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -92,10 +92,11 @@ Status StreamLoadExecutor::execute_plan_fragment(std::shared_ptr<StreamLoadConte
             // NOTE: Do not modify the error message here, for historical reasons,
             // some users may rely on this error message.
             if (ctx->need_commit_self) {
-                *status =
-                        Status::DataQualityError("too many filtered rows, url: " + ctx->error_url);
+                *status = Status::DataQualityError("too many filtered rows, {}, url: {}",
+                                                   state->get_first_error_msg(), ctx->error_url);
             } else {
-                *status = Status::DataQualityError("too many filtered rows");
+                *status = Status::DataQualityError("too many filtered rows {}",
+                                                   state->get_first_error_msg());
             }
         }
 

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -92,11 +92,10 @@ Status StreamLoadExecutor::execute_plan_fragment(std::shared_ptr<StreamLoadConte
             // NOTE: Do not modify the error message here, for historical reasons,
             // some users may rely on this error message.
             if (ctx->need_commit_self) {
-                *status = Status::DataQualityError("too many filtered rows, {}, url: {}",
-                                                   state->get_first_error_msg(), ctx->error_url);
+                *status = Status::DataQualityError("too many filtered rows, url: {}",
+                                                   ctx->error_url);
             } else {
-                *status = Status::DataQualityError("too many filtered rows {}",
-                                                   state->get_first_error_msg());
+                *status = Status::DataQualityError("too many filtered rows");
             }
         }
 
@@ -107,6 +106,7 @@ Status StreamLoadExecutor::execute_plan_fragment(std::shared_ptr<StreamLoadConte
             LOG(WARNING) << "fragment execute failed"
                          << ", err_msg=" << status->to_string() << ", " << ctx->brief();
             ctx->number_loaded_rows = 0;
+            ctx->first_error_msg = state->get_first_error_msg();
             // cancel body_sink, make sender known it
             if (ctx->body_sink != nullptr) {
                 ctx->body_sink->cancel(status->to_string());

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -2228,6 +2228,9 @@ void PInternalService::group_commit_insert(google::protobuf::RpcController* cont
                                 response->set_error_url(
                                         to_load_error_http_path(state->get_error_log_file_path()));
                             }
+                            if (!state->get_first_error_msg().empty()) {
+                                response->set_first_error_msg(state->get_first_error_msg());
+                            }
                             _exec_env->new_load_stream_mgr()->remove(load_id);
                         });
             } catch (const Exception& e) {

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3601,6 +3601,12 @@ public class Config extends ConfigBase {
     })
     public static String doris_tde_algorithm = "PLAINTEXT";
 
+    @ConfField(mutable = true, description = {
+        "数据质量错误时，第一行错误信息的最大长度，默认 256 字节",
+        "The maximum length of the first row error message when data quality error occurs, default is 256 bytes"
+    })
+    public static int first_error_msg_max_length = 256;
+
     @ConfField
     public static String cloud_snapshot_handler_class = "org.apache.doris.cloud.snapshot.CloudSnapshotHandler";
     @ConfField

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertJob.java
@@ -112,6 +112,7 @@ public class InsertJob extends AbstractJob<InsertTask, Map<Object, Object>> impl
                     .addColumn(new Column("TrackingUrl", ScalarType.createVarchar(200)))
                     .addColumn(new Column("LoadStatistic", ScalarType.createVarchar(200)))
                     .addColumn(new Column("User", ScalarType.createVarchar(50)))
+                    .addColumn(new Column("FirstErrorMsg", ScalarType.createVarchar(200)))
                     .build();
 
     public static final ImmutableMap<String, Integer> COLUMN_TO_INDEX;
@@ -517,6 +518,21 @@ public class InsertJob extends AbstractJob<InsertTask, Map<Object, Object>> impl
             }
             // comment
             jobInfo.add(getComment());
+            // tracking urls
+            List<String> firstErrorMsg = insertTaskQueue.stream()
+                    .map(task -> {
+                        if (StringUtils.isNotEmpty(task.getFirstErrorMsg())) {
+                            return task.getFirstErrorMsg();
+                        } else {
+                            return FeConstants.null_string;
+                        }
+                    })
+                    .collect(Collectors.toList());
+            if (firstErrorMsg.isEmpty()) {
+                jobInfo.add(FeConstants.null_string);
+            } else {
+                jobInfo.add(firstErrorMsg.toString());
+            }
             return jobInfo;
         } catch (DdlException e) {
             throw new RuntimeException(e);

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertJob.java
@@ -518,7 +518,7 @@ public class InsertJob extends AbstractJob<InsertTask, Map<Object, Object>> impl
             }
             // comment
             jobInfo.add(getComment());
-            // tracking urls
+            // first error message
             List<String> firstErrorMsg = insertTaskQueue.stream()
                     .map(task -> {
                         if (StringUtils.isNotEmpty(task.getFirstErrorMsg())) {

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertTask.java
@@ -67,7 +67,8 @@ public class InsertTask extends AbstractTask {
             new Column("FinishTime", ScalarType.createStringType()),
             new Column("TrackingUrl", ScalarType.createStringType()),
             new Column("LoadStatistic", ScalarType.createStringType()),
-            new Column("User", ScalarType.createStringType()));
+            new Column("User", ScalarType.createStringType()),
+            new Column("FirstErrorMsg", ScalarType.createStringType()));
 
     public static final ImmutableMap<String, Integer> COLUMN_TO_INDEX;
 
@@ -95,6 +96,8 @@ public class InsertTask extends AbstractTask {
     private FailMsg failMsg;
     @Getter
     private String trackingUrl;
+    @Getter
+    private String firstErrorMsg;
 
     @Getter
     @Setter
@@ -272,6 +275,7 @@ public class InsertTask extends AbstractTask {
         } else {
             trow.addToColumnValue(new TCell().setStringVal(userIdentity.getQualifiedUser()));
         }
+        trow.addToColumnValue(new TCell().setStringVal(firstErrorMsg == null ? "" : firstErrorMsg));
         return trow;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/EtlStatus.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/EtlStatus.java
@@ -39,6 +39,8 @@ public class EtlStatus implements Writable {
     private TEtlState state;
     @SerializedName(value = "tu")
     private String trackingUrl;
+    @SerializedName(value = "fem")
+    private String firstErrorMsg;
     @SerializedName(value = "st")
     private Map<String, String> stats;
     @SerializedName(value = "c")
@@ -55,6 +57,7 @@ public class EtlStatus implements Writable {
     public EtlStatus() {
         this.state = TEtlState.RUNNING;
         this.trackingUrl = DEFAULT_TRACKING_URL;
+        this.firstErrorMsg = "";
         this.stats = Maps.newHashMap();
         this.counters = Maps.newHashMap();
         this.fileMap = Maps.newHashMap();
@@ -82,6 +85,14 @@ public class EtlStatus implements Writable {
 
     public void setTrackingUrl(String trackingUrl) {
         this.trackingUrl = Strings.nullToEmpty(trackingUrl);
+    }
+
+    public String getFirstErrorMsg() {
+        return firstErrorMsg;
+    }
+
+    public void setFirstErrorMsg(String firstErrorMsg) {
+        this.firstErrorMsg = Strings.nullToEmpty(firstErrorMsg);
     }
 
     public Map<String, String> getStats() {
@@ -154,6 +165,7 @@ public class EtlStatus implements Writable {
         return "EtlStatus{"
                 + "state=" + state
                 + ", trackingUrl='" + trackingUrl + '\''
+                + ", firstErrorMsg='" + firstErrorMsg + '\''
                 + ", stats=" + stats
                 + ", counters=" + counters
                 + ", fileMap=" + fileMap

--- a/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadRecord.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadRecord.java
@@ -42,11 +42,12 @@ public class StreamLoadRecord {
     private String startTime;
     private String finishTime;
     private String comment;
+    private String firstErrorMsg;
 
 
     public StreamLoadRecord(String label, String db, String table, String clientIp, String status,
             String message, String url, String totalRows, String loadedRows, String filteredRows, String unselectedRows,
-            String loadBytes, String startTime, String finishTime, String user, String comment) {
+            String loadBytes, String startTime, String finishTime, String user, String comment, String firstErrorMsg) {
         this.label = label;
         this.db = db;
         this.table = table;
@@ -63,6 +64,7 @@ public class StreamLoadRecord {
         this.startTime = startTime;
         this.finishTime = finishTime;
         this.comment = comment;
+        this.firstErrorMsg = firstErrorMsg;
     }
 
     public List<Comparable> getStreamLoadInfo() {
@@ -83,6 +85,7 @@ public class StreamLoadRecord {
         streamLoadInfo.add(this.finishTime);
         streamLoadInfo.add(this.user);
         streamLoadInfo.add(this.comment);
+        streamLoadInfo.add(this.firstErrorMsg);
         return streamLoadInfo;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadRecordMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadRecordMgr.java
@@ -274,13 +274,14 @@ public class StreamLoadRecordMgr extends MasterDaemon {
                                         + " label: {}, db: {}, tbl: {}, user: {}, user_ip: {},"
                                         + " status: {}, message: {}, error_url: {},"
                                         + " total_rows: {}, loaded_rows: {}, filtered_rows: {}, unselected_rows: {},"
-                                        + " load_bytes: {}, start_time: {}, finish_time: {}.",
+                                        + " load_bytes: {}, start_time: {}, finish_time: {}, first_error_msg: {}.",
                                 backend.getHost(), streamLoadItem.getLabel(), streamLoadItem.getDb(),
                                 streamLoadItem.getTbl(), streamLoadItem.getUser(), streamLoadItem.getUserIp(),
                                 streamLoadItem.getStatus(), streamLoadItem.getMessage(), streamLoadItem.getUrl(),
                                 streamLoadItem.getTotalRows(), streamLoadItem.getLoadedRows(),
                                 streamLoadItem.getFilteredRows(), streamLoadItem.getUnselectedRows(),
-                                streamLoadItem.getLoadBytes(), startTime, finishTime);
+                                streamLoadItem.getLoadBytes(), startTime, finishTime,
+                                streamLoadItem.getFirstErrorMsg());
                     }
 
                     AuditEvent auditEvent =
@@ -312,7 +313,8 @@ public class StreamLoadRecordMgr extends MasterDaemon {
                                     String.valueOf(streamLoadItem.getFilteredRows()),
                                     String.valueOf(streamLoadItem.getUnselectedRows()),
                                     String.valueOf(streamLoadItem.getLoadBytes()),
-                                    startTime, finishTime, streamLoadItem.getUser(), streamLoadItem.getComment());
+                                    startTime, finishTime, streamLoadItem.getUser(), streamLoadItem.getComment(),
+                                    String.valueOf(streamLoadItem.getFirstErrorMsg()));
 
                     String fullDbName = streamLoadItem.getDb();
                     Database db = Env.getCurrentInternalCatalog().getDbNullable(fullDbName);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -488,6 +488,9 @@ public class BrokerLoadJob extends BulkLoadJob {
         if (attachment.getTrackingUrl() != null) {
             loadingStatus.setTrackingUrl(attachment.getTrackingUrl());
         }
+        if (attachment.getFirstErrorMsg() != null) {
+            loadingStatus.setFirstErrorMsg(attachment.getFirstErrorMsg());
+        }
         commitInfos.addAll(attachment.getCommitInfoList());
         errorTabletInfos.addAll(attachment.getErrorTabletInfos().stream().limit(Config.max_error_tablet_of_broker_load)
                 .collect(Collectors.toList()));

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadingTaskAttachment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadingTaskAttachment.java
@@ -28,15 +28,17 @@ public class BrokerLoadingTaskAttachment extends TaskAttachment {
 
     private Map<String, String> counters;
     private String trackingUrl;
+    private String firstErrorMsg;
     private List<TabletCommitInfo> commitInfoList;
     List<ErrorTabletInfo> errorTabletInfos;
     private Status status = new Status();
 
     public BrokerLoadingTaskAttachment(long taskId, Map<String, String> counters, String trackingUrl,
-                                       List<TabletCommitInfo> commitInfoList,
+                                       String firstErrorMsg, List<TabletCommitInfo> commitInfoList,
                                        List<ErrorTabletInfo> errorTabletInfos, Status status) {
         super(taskId);
         this.trackingUrl = trackingUrl;
+        this.firstErrorMsg = firstErrorMsg;
         this.counters = counters;
         this.commitInfoList = commitInfoList;
         this.errorTabletInfos = errorTabletInfos;
@@ -49,6 +51,10 @@ public class BrokerLoadingTaskAttachment extends TaskAttachment {
 
     public String getTrackingUrl() {
         return trackingUrl;
+    }
+
+    public String getFirstErrorMsg() {
+        return firstErrorMsg;
     }
 
     public List<TabletCommitInfo> getCommitInfoList() {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/InsertLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/InsertLoadJob.java
@@ -54,7 +54,7 @@ public class InsertLoadJob extends LoadJob {
     }
 
     public InsertLoadJob(String label, long transactionId, long dbId, long tableId,
-            long createTimestamp, String failMsg, String trackingUrl,
+            long createTimestamp, String failMsg, String trackingUrl, String firstErrorMsg,
             UserIdentity userInfo) throws MetaNotFoundException {
         super(EtlJobType.INSERT, dbId, label);
         this.tableId = tableId;
@@ -72,11 +72,12 @@ public class InsertLoadJob extends LoadJob {
         }
         this.authorizationInfo = gatherAuthInfo();
         this.loadingStatus.setTrackingUrl(trackingUrl);
+        this.loadingStatus.setFirstErrorMsg(firstErrorMsg);
         this.userInfo = userInfo;
     }
 
     public InsertLoadJob(String label, long transactionId, long dbId, long tableId,
-                         long createTimestamp, String failMsg, String trackingUrl,
+                         long createTimestamp, String failMsg, String trackingUrl, String firstErrorMsg,
                          UserIdentity userInfo, Long jobId) throws MetaNotFoundException {
         super(EtlJobType.INSERT_JOB, dbId, label, jobId);
         this.tableId = tableId;
@@ -94,6 +95,7 @@ public class InsertLoadJob extends LoadJob {
         }
         this.authorizationInfo = gatherAuthInfo();
         this.loadingStatus.setTrackingUrl(trackingUrl);
+        this.loadingStatus.setFirstErrorMsg(firstErrorMsg);
         this.userInfo = userInfo;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -802,7 +802,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback
         // comment
         jobInfo.add(comment);
         // first error message
-        jobInfo.add(StringUtils.abbreviate(loadingStatus.getFirstErrorMsg(), 256));
+        jobInfo.add(StringUtils.abbreviate(loadingStatus.getFirstErrorMsg(), Config.first_error_msg_max_length));
         return jobInfo;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -70,6 +70,7 @@ import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -800,6 +801,8 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback
         }
         // comment
         jobInfo.add(comment);
+        // first error message
+        jobInfo.add(StringUtils.abbreviate(loadingStatus.getFirstErrorMsg(), 256));
         return jobInfo;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
@@ -209,6 +209,7 @@ public class LoadLoadingTask extends LoadTask {
                 attachment = new BrokerLoadingTaskAttachment(signature,
                         curCoordinator.getLoadCounters(),
                         curCoordinator.getTrackingUrl(),
+                        curCoordinator.getFirstErrorMsg(),
                         TabletCommitInfo.fromThrift(curCoordinator.getCommitInfos()),
                         ErrorTabletInfo.fromThrift(curCoordinator.getErrorTabletInfos()
                                 .stream().limit(Config.max_error_tablet_of_broker_load).collect(Collectors.toList())),

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -206,7 +206,7 @@ public class LoadManager implements Writable {
      * Record finished load job by editLog.
      **/
     public void recordFinishedLoadJob(String label, long transactionId, String dbName, long tableId, EtlJobType jobType,
-                                      long createTimestamp, String failMsg, String trackingUrl,
+                                      long createTimestamp, String failMsg, String trackingUrl, String firstErrorMsg,
                                       UserIdentity userInfo, long jobId) throws MetaNotFoundException {
 
         // get db id
@@ -216,11 +216,11 @@ public class LoadManager implements Writable {
         switch (jobType) {
             case INSERT:
                 loadJob = new InsertLoadJob(label, transactionId, db.getId(), tableId, createTimestamp, failMsg,
-                        trackingUrl, userInfo);
+                        trackingUrl, firstErrorMsg, userInfo);
                 break;
             case INSERT_JOB:
                 loadJob = new InsertLoadJob(label, transactionId, db.getId(), tableId, createTimestamp, failMsg,
-                        trackingUrl, userInfo, jobId);
+                        trackingUrl, firstErrorMsg, userInfo, jobId);
                 break;
             default:
                 return;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowLoadCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowLoadCommand.java
@@ -74,6 +74,7 @@ public class ShowLoadCommand extends ShowCommand {
             .add("Type").add("EtlInfo").add("TaskInfo").add("ErrorMsg").add("CreateTime")
             .add("EtlStartTime").add("EtlFinishTime").add("LoadStartTime").add("LoadFinishTime")
             .add("URL").add("JobDetails").add("TransactionId").add("ErrorTablets").add("User").add("Comment")
+            .add("FirstErrorMsg")
             .build();
 
     // STREAM_LOAD_TITLE_NAMES copy from org.apache.doris.analysis.org.apache.doris.analysis
@@ -82,6 +83,7 @@ public class ShowLoadCommand extends ShowCommand {
             .add("ClientIp").add("Status").add("Message").add("Url").add("TotalRows")
             .add("LoadedRows").add("FilteredRows").add("UnselectedRows").add("LoadBytes")
             .add("StartTime").add("FinishTime").add("User").add("Comment")
+            .add("FirstErrorMsg")
             .build();
     protected String labelValue;
     protected String stateValue;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowLoadCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowLoadCommand.java
@@ -255,7 +255,7 @@ public class ShowLoadCommand extends ShowCommand {
             }
 
             for (Comparable element : loadInfo) {
-                oneInfo.add(element.toString());
+                oneInfo.add(String.valueOf(element));
             }
             rows.add(oneInfo);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
@@ -43,9 +43,7 @@ import org.apache.doris.thrift.TStatusCode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Arrays;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Abstract insert executor.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
@@ -43,7 +43,9 @@ import org.apache.doris.thrift.TStatusCode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Arrays;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Abstract insert executor.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/BaseExternalTableInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/BaseExternalTableInsertExecutor.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.plans.commands.insert;
 
 import org.apache.doris.catalog.Env;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.profile.SummaryProfile;
@@ -38,6 +39,7 @@ import org.apache.doris.transaction.TransactionStatus;
 import org.apache.doris.transaction.TransactionType;
 
 import com.google.common.base.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -137,7 +139,8 @@ public abstract class BaseExternalTableInsertExecutor extends AbstractInsertExec
         if (txnId != INVALID_TXN_ID) {
             LOG.warn("insert [{}] with query id {} abort txn {} failed", labelName, queryId, txnId);
             if (!Strings.isNullOrEmpty(coordinator.getFirstErrorMsg())) {
-                sb.append(". first_error_msg: ").append(coordinator.getFirstErrorMsg());
+                sb.append(". first_error_msg: ").append(
+                        StringUtils.abbreviate(coordinator.getFirstErrorMsg(), Config.first_error_msg_max_length));
             }
             if (!Strings.isNullOrEmpty(coordinator.getTrackingUrl())) {
                 sb.append(". url: ").append(coordinator.getTrackingUrl());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/BaseExternalTableInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/BaseExternalTableInsertExecutor.java
@@ -136,6 +136,9 @@ public abstract class BaseExternalTableInsertExecutor extends AbstractInsertExec
         StringBuilder sb = new StringBuilder(t.getMessage());
         if (txnId != INVALID_TXN_ID) {
             LOG.warn("insert [{}] with query id {} abort txn {} failed", labelName, queryId, txnId);
+            if (!Strings.isNullOrEmpty(coordinator.getFirstErrorMsg())) {
+                sb.append(". first_error_msg: ").append(coordinator.getFirstErrorMsg());
+            }
             if (!Strings.isNullOrEmpty(coordinator.getTrackingUrl())) {
                 sb.append(". url: ").append(coordinator.getTrackingUrl());
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/JdbcInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/JdbcInsertExecutor.java
@@ -78,6 +78,9 @@ public class JdbcInsertExecutor extends BaseExternalTableInsertExecutor {
         StringBuilder sb = new StringBuilder(t.getMessage());
         if (txnId != INVALID_TXN_ID) {
             LOG.warn("insert [{}] with query id {} abort txn {} failed", labelName, queryId, txnId);
+            if (!Strings.isNullOrEmpty(coordinator.getFirstErrorMsg())) {
+                sb.append(". first_error_msg: ").append(coordinator.getFirstErrorMsg());
+            }
             if (!Strings.isNullOrEmpty(coordinator.getTrackingUrl())) {
                 sb.append(". url: ").append(coordinator.getTrackingUrl());
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/JdbcInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/JdbcInsertExecutor.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.trees.plans.commands.insert;
 
+import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.profile.SummaryProfile;
@@ -32,6 +33,7 @@ import org.apache.doris.transaction.TransactionStatus;
 import org.apache.doris.transaction.TransactionType;
 
 import com.google.common.base.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -79,7 +81,8 @@ public class JdbcInsertExecutor extends BaseExternalTableInsertExecutor {
         if (txnId != INVALID_TXN_ID) {
             LOG.warn("insert [{}] with query id {} abort txn {} failed", labelName, queryId, txnId);
             if (!Strings.isNullOrEmpty(coordinator.getFirstErrorMsg())) {
-                sb.append(". first_error_msg: ").append(coordinator.getFirstErrorMsg());
+                sb.append(". first_error_msg: ").append(
+                        StringUtils.abbreviate(coordinator.getFirstErrorMsg(), Config.first_error_msg_max_length));
             }
             if (!Strings.isNullOrEmpty(coordinator.getTrackingUrl())) {
                 sb.append(". url: ").append(coordinator.getTrackingUrl());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapGroupCommitInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapGroupCommitInsertExecutor.java
@@ -191,6 +191,9 @@ public class OlapGroupCommitInsertExecutor extends OlapInsertExecutor {
         // if any throwable being thrown during insert operation, first we should abort this txn
         LOG.warn("insert [{}] with query id {} failed, url={}", labelName, queryId, coordinator.getTrackingUrl(), t);
         StringBuilder sb = new StringBuilder(t.getMessage());
+        if (!Strings.isNullOrEmpty(coordinator.getFirstErrorMsg())) {
+            sb.append(". first_error_msg: ").append(coordinator.getFirstErrorMsg());
+        }
         if (!Strings.isNullOrEmpty(coordinator.getTrackingUrl())) {
             sb.append(". url: ").append(coordinator.getTrackingUrl());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapGroupCommitInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapGroupCommitInsertExecutor.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.MTMV;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.TableIf;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Pair;
@@ -44,6 +45,7 @@ import org.apache.doris.system.Backend;
 import org.apache.doris.transaction.TransactionStatus;
 
 import com.google.common.base.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -192,7 +194,8 @@ public class OlapGroupCommitInsertExecutor extends OlapInsertExecutor {
         LOG.warn("insert [{}] with query id {} failed, url={}", labelName, queryId, coordinator.getTrackingUrl(), t);
         StringBuilder sb = new StringBuilder(t.getMessage());
         if (!Strings.isNullOrEmpty(coordinator.getFirstErrorMsg())) {
-            sb.append(". first_error_msg: ").append(coordinator.getFirstErrorMsg());
+            sb.append(". first_error_msg: ").append(
+                    StringUtils.abbreviate(coordinator.getFirstErrorMsg(), Config.first_error_msg_max_length));
         }
         if (!Strings.isNullOrEmpty(coordinator.getTrackingUrl())) {
             sb.append(". url: ").append(coordinator.getTrackingUrl());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutor.java
@@ -280,7 +280,9 @@ public class OlapInsertExecutor extends AbstractInsertExecutor {
                         .recordFinishedLoadJob(labelName, txnId, database.getFullName(),
                                 table.getId(),
                                 etlJobType, createTime, errMsg,
-                                coordinator.getTrackingUrl(), userIdentity, jobId);
+                                coordinator.getTrackingUrl(),
+                                coordinator.getFirstErrorMsg(),
+                                userIdentity, jobId);
             }
         } catch (MetaNotFoundException e) {
             LOG.warn("Record info of insert load with error {}", e.getMessage(), e);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutor.java
@@ -245,6 +245,9 @@ public class OlapInsertExecutor extends AbstractInsertExecutor {
             return;
         }
         StringBuilder sb = new StringBuilder(t.getMessage());
+        if (!Strings.isNullOrEmpty(coordinator.getFirstErrorMsg())) {
+            sb.append(". first_error_msg: ").append(coordinator.getFirstErrorMsg());
+        }
         if (!Strings.isNullOrEmpty(coordinator.getTrackingUrl())) {
             sb.append(". url: ").append(coordinator.getTrackingUrl());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutor.java
@@ -62,6 +62,7 @@ import org.apache.doris.transaction.TransactionStatus;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -246,7 +247,8 @@ public class OlapInsertExecutor extends AbstractInsertExecutor {
         }
         StringBuilder sb = new StringBuilder(t.getMessage());
         if (!Strings.isNullOrEmpty(coordinator.getFirstErrorMsg())) {
-            sb.append(". first_error_msg: ").append(coordinator.getFirstErrorMsg());
+            sb.append(". first_error_msg: ").append(
+                    StringUtils.abbreviate(coordinator.getFirstErrorMsg(), Config.first_error_msg_max_length));
         }
         if (!Strings.isNullOrEmpty(coordinator.getTrackingUrl())) {
             sb.append(". url: ").append(coordinator.getTrackingUrl());

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/GroupCommitPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/GroupCommitPlanner.java
@@ -24,6 +24,7 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.EnvFactory;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.TableIf.TableType;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
@@ -65,6 +66,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.ProtocolStringList;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
@@ -266,7 +268,8 @@ public class GroupCommitPlanner {
                 + ", query: " + DebugUtil.printId(ctx.queryId()) + ", backend: " + backendId
                 + ", status: " + response.getStatus();
         if (response.hasFirstErrorMsg()) {
-            errMsg += ", first_error_msg: " + response.getFirstErrorMsg();
+            errMsg += ", first_error_msg: "
+                + StringUtils.abbreviate(response.getFirstErrorMsg(), Config.first_error_msg_max_length);
         }
         if (response.hasErrorUrl()) {
             errMsg += ", error url: " + response.getErrorUrl();
@@ -295,7 +298,8 @@ public class GroupCommitPlanner {
             sb.append(", 'err':'").append(errMsg).append("'");
         }*/
         if (!Strings.isNullOrEmpty(firstErrorMsg)) {
-            sb.append(", 'first_error_msg':'").append(firstErrorMsg).append("'");
+            sb.append(", 'first_error_msg':'").append(
+                    StringUtils.abbreviate(firstErrorMsg, Config.first_error_msg_max_length)).append("'");
         }
         if (!Strings.isNullOrEmpty(errorUrl)) {
             sb.append(", 'err_url':'").append(errorUrl).append("'");

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/GroupCommitPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/GroupCommitPlanner.java
@@ -265,6 +265,9 @@ public class GroupCommitPlanner {
         String errMsg = "group commit insert failed. db: " + db.getId() + ", table: " + table.getId()
                 + ", query: " + DebugUtil.printId(ctx.queryId()) + ", backend: " + backendId
                 + ", status: " + response.getStatus();
+        if (response.hasFirstErrorMsg()) {
+            errMsg += ", first_error_msg: " + response.getFirstErrorMsg();
+        }
         if (response.hasErrorUrl()) {
             errMsg += ", error url: " + response.getErrorUrl();
         }
@@ -278,6 +281,7 @@ public class GroupCommitPlanner {
         long loadedRows = response.getLoadedRows();
         long filteredRows = (int) response.getFilteredRows();
         String errorUrl = response.getErrorUrl();
+        String firstErrorMsg = response.getFirstErrorMsg();
         // the same as {@OlapInsertExecutor#setReturnInfo}
         // {'label':'my_label1', 'status':'visible', 'txnId':'123'}
         // {'label':'my_label1', 'status':'visible', 'txnId':'123' 'err':'error messages'}
@@ -290,6 +294,9 @@ public class GroupCommitPlanner {
         /*if (!Strings.isNullOrEmpty(errMsg)) {
             sb.append(", 'err':'").append(errMsg).append("'");
         }*/
+        if (!Strings.isNullOrEmpty(firstErrorMsg)) {
+            sb.append(", 'first_error_msg':'").append(firstErrorMsg).append("'");
+        }
         if (!Strings.isNullOrEmpty(errorUrl)) {
             sb.append(", 'err_url':'").append(errorUrl).append("'");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -241,6 +241,7 @@ public class Coordinator implements CoordInterface {
     private List<String> deltaUrls;
     private Map<String, String> loadCounters;
     private String trackingUrl;
+    private String firstErrorMsg;
     // related txnId and label of group commit
     private long txnId;
     private String label;
@@ -464,6 +465,10 @@ public class Coordinator implements CoordInterface {
 
     public String getTrackingUrl() {
         return trackingUrl;
+    }
+
+    public String getFirstErrorMsg() {
+        return firstErrorMsg;
     }
 
     public long getTxnId() {
@@ -2447,6 +2452,10 @@ public class Coordinator implements CoordInterface {
         if (params.isSetTrackingUrl()) {
             LOG.info("query_id={} tracking_url: {}", DebugUtil.printId(queryId), params.getTrackingUrl());
             trackingUrl = params.getTrackingUrl();
+        }
+        if (params.isSetFirstErrorMsg()) {
+            LOG.info("query_id={} first_error_msg: {}", DebugUtil.printId(queryId), params.getFirstErrorMsg());
+            firstErrorMsg = params.getFirstErrorMsg();
         }
         if (params.isSetTxnId()) {
             txnId = params.getTxnId();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/LoadContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/LoadContext.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 public class LoadContext {
 
     private volatile String trackingUrl;
+    private volatile String firstErrorMsg;
     private volatile long transactionId;
     private volatile String label;
     private final List<String> exportFiles = Lists.newCopyOnWriteArrayList();
@@ -115,6 +116,14 @@ public class LoadContext {
 
     public String getTrackingUrl() {
         return trackingUrl;
+    }
+
+    public void updateFirstErrorMsg(String firstErrorMsg) {
+        this.firstErrorMsg = firstErrorMsg;
+    }
+
+    public String getFirstErrorMsg() {
+        return firstErrorMsg;
     }
 
     public void updateTransactionId(long transactionId) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
@@ -322,6 +322,11 @@ public class NereidsCoordinator extends Coordinator {
     }
 
     @Override
+    public String getFirstErrorMsg() {
+        return coordinatorContext.asLoadProcessor().loadContext.getFirstErrorMsg();
+    }
+
+    @Override
     public List<TErrorTabletInfo> getErrorTabletInfos() {
         return coordinatorContext.asLoadProcessor().loadContext.getErrorTabletInfos();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/LoadProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/LoadProcessor.java
@@ -192,6 +192,9 @@ public class LoadProcessor extends AbstractJobProcessor {
         if (params.isSetTrackingUrl()) {
             loadContext.updateTrackingUrl(params.getTrackingUrl());
         }
+        if (params.isSetFirstErrorMsg()) {
+            loadContext.updateFirstErrorMsg(params.getFirstErrorMsg());
+        }
         if (params.isSetTxnId()) {
             loadContext.updateTransactionId(params.getTxnId());
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/InsertLoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/InsertLoadJobTest.java
@@ -40,7 +40,7 @@ public class InsertLoadJobTest {
     public void testGetTableNames(@Mocked Env env, @Mocked InternalCatalog catalog, @Injectable Database database,
             @Injectable Table table) throws MetaNotFoundException {
         UserIdentity userInfo = new UserIdentity("root", "localhost");
-        InsertLoadJob insertLoadJob = new InsertLoadJob("label", 1L, 1L, 1L, 1000, "", "", userInfo);
+        InsertLoadJob insertLoadJob = new InsertLoadJob("label", 1L, 1L, 1L, 1000, "", "", "", userInfo);
         String tableName = "table1";
         new Expectations() {
             {

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/LoadManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/LoadManagerTest.java
@@ -85,7 +85,7 @@ public class LoadManagerTest {
         };
 
         loadManager = new LoadManager(new LoadJobScheduler());
-        LoadJob job1 = new InsertLoadJob("job1", 1L, 1L, 1L, System.currentTimeMillis(), "", "", userInfo);
+        LoadJob job1 = new InsertLoadJob("job1", 1L, 1L, 1L, System.currentTimeMillis(), "", "", "", userInfo);
         Deencapsulation.invoke(loadManager, "addLoadJob", job1);
 
         File file = serializeToFile(loadManager);
@@ -123,7 +123,7 @@ public class LoadManagerTest {
         };
 
         loadManager = new LoadManager(new LoadJobScheduler());
-        LoadJob job1 = new InsertLoadJob("job1", 1L, 1L, 1L, System.currentTimeMillis(), "", "", userInfo);
+        LoadJob job1 = new InsertLoadJob("job1", 1L, 1L, 1L, System.currentTimeMillis(), "", "", "", userInfo);
         Deencapsulation.invoke(loadManager, "addLoadJob", job1);
 
         // make job1 don't serialize
@@ -164,9 +164,9 @@ public class LoadManagerTest {
         };
 
         loadManager = new LoadManager(new LoadJobScheduler());
-        LoadJob job1 = new InsertLoadJob("job1", 1L, 1L, 1L, System.currentTimeMillis(), "", "", userInfo);
+        LoadJob job1 = new InsertLoadJob("job1", 1L, 1L, 1L, System.currentTimeMillis(), "", "", "", userInfo);
         Thread.sleep(100);
-        LoadJob job2 = new InsertLoadJob("job2", 1L, 1L, 1L, System.currentTimeMillis(), "", "", userInfo);
+        LoadJob job2 = new InsertLoadJob("job2", 1L, 1L, 1L, System.currentTimeMillis(), "", "", "", userInfo);
         Deencapsulation.invoke(loadManager, "addLoadJob", job2);
         Deencapsulation.invoke(loadManager, "addLoadJob", job1);
         Config.label_num_threshold = 1;

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -932,6 +932,7 @@ message PGroupCommitInsertResponse {
     optional int64 loaded_rows = 4;
     optional int64 filtered_rows = 5;
     optional string error_url = 6;
+    optional string first_error_msg = 7;
 }
 
 message POpenLoadStreamRequest {

--- a/gensrc/thrift/BackendService.thrift
+++ b/gensrc/thrift/BackendService.thrift
@@ -117,6 +117,7 @@ struct TStreamLoadRecord {
     17: required i64 start_time
     18: required i64 finish_time
     19: optional string comment
+    20: optional string first_error_msg
 }
 
 struct TStreamLoadRecordResult {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -307,6 +307,8 @@ struct TReportExecStatusParams {
   30: optional string label
 
   31: optional list<TFragmentInstanceReport> fragment_instance_reports;
+
+  33: optional string first_error_msg
 }
 
 struct TFeResult {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -943,11 +943,14 @@ class Suite implements GroovyInterceptable {
         return randomBoolean ? "true" : "false"
     }
 
-    void expectExceptionLike(Closure userFunction, String errMsg = null) {
+    void expectExceptionLike(Closure userFunction, String errMsg = null, String errMsg2 = null) {
         try {
             userFunction()
         } catch (Exception e) {
             if (!Strings.isNullOrEmpty(errMsg) && !e.getMessage().contains(errMsg)) {
+                throw e
+            }
+            if (!Strings.isNullOrEmpty(errMsg2) && !e.getMessage().contains(errMsg2)) {
                 throw e
             }
         }

--- a/regression-test/suites/doc/table-design/data-partitioning/manual-partitioning.md.groovy
+++ b/regression-test/suites/doc/table-design/data-partitioning/manual-partitioning.md.groovy
@@ -67,7 +67,8 @@ suite("docs/table-design/data-partitioning/manual-partitioning.md") {
             sql " insert into null_range2 values (null) "
             Assertions.fail("The SQL above should throw an exception as follows:\n\t\terrCode = 2, detailMessage = Insert has filtered data in strict mode. url: http://127.0.0.1:8040/api/_load_error_log?file=__shard_0/error_log_insert_stmt_b3a6d1f1fac74750-b3bb5d6e92a66da4_b3a6d1f1fac74750_b3bb5d6e92a66da4")
         } catch (Exception e) {
-            assertTrue(e.getMessage().contains("errCode = 2, detailMessage = Insert has filtered data in strict mode. url:"))
+            assertTrue(e.getMessage().contains("errCode = 2, detailMessage = Insert has filtered data in strict mode."))
+            assertTrue(e.getMessage().contains("url:"))
         }
     } catch (Throwable t) {
         Assertions.fail("examples in docs/table-design/data-partitioning/manual-partitioning.md failed to exec, please fix it", t)

--- a/regression-test/suites/insert_p0/test_insert_docs_demo.groovy
+++ b/regression-test/suites/insert_p0/test_insert_docs_demo.groovy
@@ -107,5 +107,5 @@ suite("test_insert_docs_demo") {
                 (NULL, "Alexander", 60),
                 (5, "Ava", 17);
         """
-    }, "Insert has too many filtered data 1/5 insert_max_filter_ratio is 0.1")
+    }, "Insert has too many filtered data 1/5 insert_max_filter_ratio is 0.1", "first_error_msg")
 }

--- a/regression-test/suites/insert_p0/test_insert_partition_fail_url.groovy
+++ b/regression-test/suites/insert_p0/test_insert_partition_fail_url.groovy
@@ -84,7 +84,7 @@ suite("test_insert_partition_fail_url") {
         sql """
             INSERT INTO ${dstName} SELECT `id`, `score` FROM ${srcName};
         """
-    }, "error_log")
+    }, "error_log", "first_error_msg")
 
     sql """
         INSERT INTO ${srcName} SELECT * FROM ${srcName};
@@ -94,5 +94,5 @@ suite("test_insert_partition_fail_url") {
         sql """
             INSERT INTO ${dstName} SELECT `id`, `score` FROM ${srcName};
         """
-    }, "error_log")
+    }, "error_log", "first_error_msg")
 }

--- a/regression-test/suites/insert_p0/test_insert_strict_fail_url.groovy
+++ b/regression-test/suites/insert_p0/test_insert_strict_fail_url.groovy
@@ -80,7 +80,7 @@ suite("test_insert_strict_fail_url") {
         sql """
             INSERT INTO ${dstName} SELECT `id`, `score` FROM ${srcName};
         """
-    }, "error_log")
+    }, "error_log", "first_error_msg")
 
     sql """
         INSERT INTO ${srcName} SELECT * FROM ${srcName};
@@ -90,5 +90,5 @@ suite("test_insert_strict_fail_url") {
         sql """
             INSERT INTO ${dstName} SELECT `id`, `score` FROM ${srcName};
         """
-    }, "error_log") 
+    }, "error_log", "first_error_msg")
 }

--- a/regression-test/suites/load_p0/broker_load/test_etl_failed.groovy
+++ b/regression-test/suites/load_p0/broker_load/test_etl_failed.groovy
@@ -63,7 +63,8 @@ suite("test_etl_failed", "load_p0") {
             assertTrue(1 == 2, "etl should be failed")
             break;
         }
-        if (result[0][2].equals("CANCELLED") && result[0][13].contains("error_log")) {
+        if (result[0][2].equals("CANCELLED") && result[0].any{ it != null && it.contains("error_log") }
+                && result[0].any{ it != null && it.contains("Src line:") }) {
             break;
         }
         Thread.sleep(1000)

--- a/regression-test/suites/load_p0/stream_load/test_stream_load_with_filtered_rows.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_stream_load_with_filtered_rows.groovy
@@ -66,6 +66,7 @@ suite("test_stream_load_with_filtered_rows", "p0") {
                 assertEquals("fail", json.Status.toLowerCase())
                 assertTrue(result.contains("ErrorURL"))
                 assertTrue(json.Message.contains("Encountered unqualified data, stop processing. Please"))
+                assertTrue(result.contains("FirstErrorMsg"))
             }
         }
 
@@ -82,7 +83,7 @@ suite("test_stream_load_with_filtered_rows", "p0") {
                 def json = parseJson(result)
                 assertEquals("fail", json.Status.toLowerCase())
                 assertTrue(result.contains("ErrorURL"))
-                assertTrue(json.Message.contains("Encountered unqualified data, stop processing. Please"))
+                assertTrue(json.Message.contains("Encountered unqualified data, stop processing. Please"), json.Message.toString())
             }
         }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Previously, when a load job failed due to data quality issues, the response only contained an `error_url`. Users had to manually access this URL to view the error details and the problematic data rows. This process was inconvenient and slowed down the debugging cycle.

This commit enhances the error reporting mechanism to provide immediate feedback. Now, the details of the first data quality error encountered are printed directly in the synchronous load job's response or the BE log.

The new inline error message includes:
- The specific reason for the failure.
- The raw data of the offending row.

This allows users to quickly identify and fix issues in their source data. For asynchronous jobs like Broker Load, this information is exposed in a new `FirstErrorMsg` column in the output of the `SHOW LOAD` command.

The `error_url` is still provided for users who need a comprehensive list of all filtered rows.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

