### PR TITLE
[chore](ubsan) fix some ubsan error 

### DIFF
--- a/be/src/util/counts.h
+++ b/be/src/util/counts.h
@@ -99,7 +99,8 @@ public:
             double u = (_nums.size() - 1) * quantile;
             auto index = static_cast<uint32_t>(u);
             return _nums[index] +
-                   (u - static_cast<double>(index)) * (_nums[index + 1] - _nums[index]);
+                   (u - static_cast<double>(index)) * (static_cast<double>(_nums[index + 1]) -
+                                                       static_cast<double>(_nums[index]));
         } else {
             DCHECK(_nums.empty());
             size_t rows = 0;
@@ -124,7 +125,9 @@ public:
             if (quantile == 1) {
                 return second_number;
             }
-            return first_number + (u - static_cast<double>(index)) * (second_number - first_number);
+            return first_number +
+                   (u - static_cast<double>(index)) *
+                           (static_cast<double>(second_number) - static_cast<double>(first_number));
         }
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_avg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_avg.h
@@ -143,8 +143,8 @@ public:
     }
 
     template <bool is_add>
-    void update_value(AggregateDataPtr __restrict place, const IColumn** columns,
-                      ssize_t row_num) const {
+    NO_SANITIZE_UNDEFINED void update_value(AggregateDataPtr __restrict place,
+                                            const IColumn** columns, ssize_t row_num) const {
 #ifdef __clang__
 #pragma clang fp reassociate(on)
 #endif
@@ -177,8 +177,8 @@ public:
         this->data(place).count = 0;
     }
 
-    void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
-               Arena&) const override {
+    NO_SANITIZE_UNDEFINED void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
+                                     Arena&) const override {
         if constexpr (is_decimal(T)) {
             this->data(place).sum += this->data(rhs).sum.value;
         } else {
@@ -235,8 +235,9 @@ public:
         }
     }
 
-    void deserialize_and_merge_from_column(AggregateDataPtr __restrict place, const IColumn& column,
-                                           Arena&) const override {
+    NO_SANITIZE_UNDEFINED void deserialize_and_merge_from_column(AggregateDataPtr __restrict place,
+                                                                 const IColumn& column,
+                                                                 Arena&) const override {
         auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
         const size_t num_rows = column.size();
         DCHECK(col.size() >= num_rows) << "source column's size should greater than num_rows";
@@ -248,9 +249,9 @@ public:
         }
     }
 
-    void deserialize_and_merge_from_column_range(AggregateDataPtr __restrict place,
-                                                 const IColumn& column, size_t begin, size_t end,
-                                                 Arena&) const override {
+    NO_SANITIZE_UNDEFINED void deserialize_and_merge_from_column_range(
+            AggregateDataPtr __restrict place, const IColumn& column, size_t begin, size_t end,
+            Arena&) const override {
         DCHECK(end <= column.size() && begin <= end)
                 << ", begin:" << begin << ", end:" << end << ", column.size():" << column.size();
         auto& col = assert_cast<const ColumnFixedLengthObject&>(column);

--- a/be/src/vec/aggregate_functions/aggregate_function_sum.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sum.h
@@ -214,12 +214,11 @@ public:
 
     bool supported_incremental_mode() const override { return true; }
 
-    void execute_function_with_incremental(int64_t partition_start, int64_t partition_end,
-                                           int64_t frame_start, int64_t frame_end,
-                                           AggregateDataPtr place, const IColumn** columns,
-                                           Arena& arena, bool previous_is_nul, bool end_is_nul,
-                                           bool has_null, UInt8* use_null_result,
-                                           UInt8* could_use_previous_result) const override {
+    NO_SANITIZE_UNDEFINED void execute_function_with_incremental(
+            int64_t partition_start, int64_t partition_end, int64_t frame_start, int64_t frame_end,
+            AggregateDataPtr place, const IColumn** columns, Arena& arena, bool previous_is_nul,
+            bool end_is_nul, bool has_null, UInt8* use_null_result,
+            UInt8* could_use_previous_result) const override {
         int64_t current_frame_start = std::max<int64_t>(frame_start, partition_start);
         int64_t current_frame_end = std::min<int64_t>(frame_end, partition_end);
 

--- a/be/src/vec/functions/minus.cpp
+++ b/be/src/vec/functions/minus.cpp
@@ -63,7 +63,7 @@ struct MinusImpl {
     static constexpr auto name = "subtract";
     static constexpr PrimitiveType PType = Type;
     using Arg = typename PrimitiveTypeTraits<Type>::ColumnItemType;
-    static inline Arg apply(Arg a, Arg b) { return a - b; }
+    NO_SANITIZE_UNDEFINED static inline Arg apply(Arg a, Arg b) { return a - b; }
 };
 
 void register_function_minus(SimpleFunctionFactory& factory) {

--- a/be/src/vec/runtime/vdatetime_value.h
+++ b/be/src/vec/runtime/vdatetime_value.h
@@ -1415,13 +1415,14 @@ public:
 
     int64_t to_int64() const {
         if constexpr (is_datetime) {
-            return (date_v2_value_.year_ * 10000L + date_v2_value_.month_ * 100 +
+            return (date_v2_value_.year_ * 10000LL + date_v2_value_.month_ * 100LL +
                     date_v2_value_.day_) *
-                           1000000L +
-                   date_v2_value_.hour_ * 10000 + date_v2_value_.minute_ * 100 +
+                           1000000LL +
+                   date_v2_value_.hour_ * 10000LL + date_v2_value_.minute_ * 100LL +
                    date_v2_value_.second_;
         } else {
-            return date_v2_value_.year_ * 10000 + date_v2_value_.month_ * 100 + date_v2_value_.day_;
+            return date_v2_value_.year_ * 10000LL + date_v2_value_.month_ * 100LL +
+                   date_v2_value_.day_;
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?


```
/home/zcp/repo_center/doris_master/doris/be/src/util/counts.h:127:85: runtime error: signed integer overflow: 147483648 - -2147483648 cannot be represented in type 'int'
    #0 0x558c5a9d58cd in doris::Counts::terminate(double) /home/zcp/repo_center/doris_master/doris/be/src/util/counts.h:127:85
    #1 0x558c5ab0ce99 in doris::vectorized::PercentileState<(doris::PrimitiveType)5>::insert_result_into(doris::vectorized::IColumn&) const /home/zcp/repo_center/doris_master/doris/be/src/vec/aggregate_functions/aggregate_function_percentile.h:430:49
    #2 0x558c5ab0812f in doris::vectorized::AggregateFunctionPercentileArray<(doris::PrimitiveType)5>::insert_result_into(char const*, doris::vectorized::IColumn&) const /home/zcp/repo_center/doris_master/doris/be/src/vec/aggregate_functions/aggregate_function_percentile.h:557:59
    #3 0x558c5ab086a8 in doris::vectorized::IAggregateFunctionHelper>::insert_result_into_vec(std::vector> const&, unsigned long, doris::vectorized::IColumn&, unsigned long) const /home/zcp/repo_center/doris_master/doris/be/src/vec/aggregate_functions/aggregate_function.h:393:22
    #4 0x558c68af8445 in _ZZN5doris8pipeline13AggLocalState31_get_with_serialized_key_resultEPNS_12RuntimeStateEPNS_10vectorized5BlockEPbENK3$_1clINS4_15MethodKeysFixedI9PHHashMapIN4wide7integerILm256EjEEPc9HashCRC32ISE_EEEEEEvRT_ /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/aggregation_source_operator.cpp:287:67
    #5 0x558c68af8445 in void std::__invoke_impl, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>&>(std::__invoke_other, doris::vectorized::Overload&&, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>&) /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:63:14
    #6 0x558c68af8445 in std::__invoke_result, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>&>::type std::__invoke, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>&>(doris::vectorized::Overload&&, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>&) /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:98:14
    #7 0x558c68af8445 in std::__detail::__variant::__gen_vtable_impl (*)(doris::vectorized::Overload&&, std::variant>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodStringNoCache>>, doris::vectorized::MethodOneNumber, PHHashMap, char*, HashCRC32>>>, doris::vectorized::MethodOneNumber, PHHashMap, char*, HashCRC32>>>, doris::vectorized::MethodOneNumber>>>, doris::vectorized::MethodOneNumber>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>>, doris::vectorized::MethodSingleNullableColumn>>>>>, doris::vectorized::MethodSingleNullableColumn, doris::vectorized::DataWithNullKey, char*, HashCRC32>>>>>, doris::vectorized::MethodSingleNullableColumn, doris::vectorized::DataWithNullKey, char*, HashCRC32>>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodKeysFixed>>, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>, doris::vectorized::MethodKeysFixed>>>&)>, std::integer_sequence>::__visit_invoke(doris::vectorized::Overload&&, std::variant>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodStringNoCache>>, doris::vectorized::MethodOneNumber, PHHashMap, char*, HashCRC32>>>, doris::vectorized::MethodOneNumber, PHHashMap, char*, HashCRC32>>>, doris::vectorized::MethodOneNumber>>>, doris::vectorized::MethodOneNumber>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>>, doris::vectorized::MethodSingleNullableColumn>>>>>, doris::vectorized::MethodSingleNullableColumn, doris::vectorized::DataWithNullKey, char*, HashCRC32>>>>>, doris::vectorized::MethodSingleNullableColumn, doris::vectorized::DataWithNullKey, char*, HashCRC32>>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodKeysFixed>>, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>, doris::vectorized::MethodKeysFixed>>>&) /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/variant:1055:11
    #8 0x558c68a85790 in decltype(auto) std::__do_visit, doris::vectorized::Overload, std::variant>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodStringNoCache>>, doris::vectorized::MethodOneNumber, PHHashMap, char*, HashCRC32>>>, doris::vectorized::MethodOneNumber, PHHashMap, char*, HashCRC32>>>, doris::vectorized::MethodOneNumber>>>, doris::vectorized::MethodOneNumber>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>>, doris::vectorized::MethodSingleNullableColumn>>>>>, doris::vectorized::MethodSingleNullableColumn, doris::vectorized::DataWithNullKey, char*, HashCRC32>>>>>, doris::vectorized::MethodSingleNullableColumn, doris::vectorized::DataWithNullKey, char*, HashCRC32>>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodKeysFixed>>, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>, doris::vectorized::MethodKeysFixed>>>&>(doris::vectorized::Overload&&, std::variant>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodStringNoCache>>, doris::vectorized::MethodOneNumber, PHHashMap, char*, HashCRC32>>>, doris::vectorized::MethodOneNumber, PHHashMap, char*, HashCRC32>>>, doris::vectorized::MethodOneNumber>>>, doris::vectorized::MethodOneNumber>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>>, doris::vectorized::MethodSingleNullableColumn>>>>>, doris::vectorized::MethodSingleNullableColumn, doris::vectorized::DataWithNullKey, char*, HashCRC32>>>>>, doris::vectorized::MethodSingleNullableColumn, doris::vectorized::DataWithNullKey, char*, HashCRC32>>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodKeysFixed>>, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>, doris::vectorized::MethodKeysFixed>>>&) /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/variant:1858:15
    #9 0x558c68a85790 in std::invoke_result, std::__conditional>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodStringNoCache>>, doris::vectorized::MethodOneNumber, PHHashMap, char*, HashCRC32>>>, doris::vectorized::MethodOneNumber, PHHashMap, char*, HashCRC32>>>, doris::vectorized::MethodOneNumber>>>, doris::vectorized::MethodOneNumber>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>>, doris::vectorized::MethodSingleNullableColumn>>>>>, doris::vectorized::MethodSingleNullableColumn, doris::vectorized::DataWithNullKey, char*, HashCRC32>>>>>, doris::vectorized::MethodSingleNullableColumn, doris::vectorized::DataWithNullKey, char*, HashCRC32>>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodKeysFixed>>, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>, doris::vectorized::MethodKeysFixed>>>&>>::type>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodStringNoCache>>, doris::vectorized::MethodOneNumber, PHHashMap, char*, HashCRC32>>>, doris::vectorized::MethodOneNumber, PHHashMap, char*, HashCRC32>>>, doris::vectorized::MethodOneNumber>>>, doris::vectorized::MethodOneNumber>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>>, doris::vectorized::MethodSingleNullableColumn>>>>>, doris::vectorized::MethodSingleNullableColumn, doris::vectorized::DataWithNullKey, char*, HashCRC32>>>>>, doris::vectorized::MethodSingleNullableColumn, doris::vectorized::DataWithNullKey, char*, HashCRC32>>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodKeysFixed>>, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>, doris::vectorized::MethodKeysFixed>>>&>()))>::type>::type&, std::variant_alternative<0ul, std::remove_reference>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodStringNoCache>>, doris::vectorized::MethodOneNumber, PHHashMap, char*, HashCRC32>>>, doris::vectorized::MethodOneNumber, PHHashMap, char*, HashCRC32>>>, doris::vectorized::MethodOneNumber>>>, doris::vectorized::MethodOneNumber>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>>, doris::vectorized::MethodSingleNullableColumn>>>>>, doris::vectorized::MethodSingleNullableColumn, doris::vectorized::DataWithNullKey, char*, HashCRC32>>>>>, doris::vectorized::MethodSingleNullableColumn, doris::vectorized::DataWithNullKey, char*, HashCRC32>>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodKeysFixed>>, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>, doris::vectorized::MethodKeysFixed>>>&>()))>::type>::type&&>>::type std::visit, std::variant>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodStringNoCache>>, doris::vectorized::MethodOneNumber, PHHashMap, char*, HashCRC32>>>, doris::vectorized::MethodOneNumber, PHHashMap, char*, HashCRC32>>>, doris::vectorized::MethodOneNumber>>>, doris::vectorized::MethodOneNumber>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>>, doris::vectorized::MethodSingleNullableColumn>>>>>, doris::vectorized::MethodSingleNullableColumn, doris::vectorized::DataWithNullKey, char*, HashCRC32>>>>>, doris::vectorized::MethodSingleNullableColumn, doris::vectorized::DataWithNullKey, char*, HashCRC32>>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodKeysFixed>>, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>, doris::vectorized::MethodKeysFixed>>>&>(doris::vectorized::Overload&&, std::variant>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodOneNumber>>, doris::vectorized::MethodStringNoCache>>, doris::vectorized::MethodOneNumber, PHHashMap, char*, HashCRC32>>>, doris::vectorized::MethodOneNumber, PHHashMap, char*, HashCRC32>>>, doris::vectorized::MethodOneNumber>>>, doris::vectorized::MethodOneNumber>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodSingleNullableColumn>>>>>, doris::vectorized::MethodSingleNullableColumn>>>>>, doris::vectorized::MethodSingleNullableColumn, doris::vectorized::DataWithNullKey, char*, HashCRC32>>>>>, doris::vectorized::MethodSingleNullableColumn, doris::vectorized::DataWithNullKey, char*, HashCRC32>>>>>, doris::vectorized::MethodSingleNullableColumn>>>>, doris::vectorized::MethodKeysFixed>>, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>, doris::vectorized::MethodKeysFixed, char*, HashCRC32>>>, doris::vectorized::MethodKeysFixed>>>&) /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/variant:1954:13
    #10 0x558c68a85790 in doris::pipeline::AggLocalState::_get_with_serialized_key_result(doris::RuntimeState*, doris::vectorized::Block*, bool*) /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/aggregation_source_operator.cpp:251:5
    #11 0x558c68b3e3e7 in doris::pipeline::AggLocalState::init(doris::RuntimeState*, doris::pipeline::LocalStateInfo&)::$_2::operator()(doris::RuntimeState*, doris::vectorized::Block*, bool*) const /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/aggregation_source_operator.cpp:75:24
    #12 0x558c68b3e3e7 in doris::Status std::__invoke_impl(std::__invoke_other, doris::pipeline::AggLocalState::init(doris::RuntimeState*, doris::pipeline::LocalStateInfo&)::$_2&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:63:14
    #13 0x558c68b3e3e7 in std::enable_if, doris::Status>::type std::__invoke_r(doris::pipeline::AggLocalState::init(doris::RuntimeState*, doris::pipeline::LocalStateInfo&)::$_2&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:116:9
    #14 0x558c68b3e3e7 in std::_Function_handler::_M_invoke(std::_Any_data const&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:292:9
    #15 0x558c68a8b819 in std::function::operator()(doris::RuntimeState*, doris::vectorized::Block*, bool*) const /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:593:9
    #16 0x558c68a8b819 in doris::pipeline::AggSourceOperatorX::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/aggregation_source_operator.cpp:448:5
    #17 0x558c68f652cb in doris::pipeline::PartitionedAggSourceOperatorX::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/partitioned_aggregation_source_operator.cpp:167:36
    #18 0x558c676b1ddd in doris::pipeline::OperatorXBase::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/operator.cpp:391:18
    #19 0x558c69b0493d in doris::pipeline::PipelineTask::execute(bool*) /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_task.cpp:521:13
    #20 0x558c69b52916 in doris::pipeline::TaskScheduler::_do_work(int) /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:147:9
    #21 0x558c54fa66f2 in doris::ThreadPool::dispatch_thread() /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:614:24
    #22 0x558c54f83766 in std::function::operator()() const /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:593:9
    #23 0x558c54f83766 in doris::Thread::supervise_thread(void*) /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:460:5
    #24 0x558c507cbd26 in asan_thread_start(void*) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x1f57fd26)
    #25 0x7fb97f744ac2 in start_thread nptl/pthread_create.c:442:8
    #26 0x7fb97f7d684f  misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/zcp/repo_center/doris_master/doris/be/src/util/counts.h:127:85 

```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

