### PR TITLE
[feat](hdfs)Add HDFS HA Configuration Validation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogProperty.java
@@ -155,7 +155,6 @@ public class CatalogProperty {
                 msClass.isInstance(msProperties),
                 String.format("Metastore properties type is not correct. Expected %s but got %s",
                         msClass.getName(), msProperties.getClass().getName()));
-
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogProperty.java
@@ -21,9 +21,11 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.property.metastore.MetastoreProperties;
 import org.apache.doris.datasource.property.storage.StorageProperties;
 
+import com.aliyun.odps.table.utils.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -127,12 +129,34 @@ public class CatalogProperty {
                                 .collect(Collectors.toMap(StorageProperties::getType, Function.identity()));
                     } catch (UserException e) {
                         LOG.warn("Failed to initialize catalog storage properties", e);
-                        throw new RuntimeException("Failed to initialize storage properties for catalog", e);
+                        throw new RuntimeException("Failed to initialize storage properties, error: "
+                                + ExceptionUtils.getRootCauseMessage(e), e);
                     }
                 }
             }
         }
         return storagePropertiesMap;
+    }
+
+    public void checkMetaStoreAndStorageProperties(Class msClass) {
+        MetastoreProperties msProperties;
+        List<StorageProperties> storageProperties;
+        try {
+            msProperties = MetastoreProperties.create(getProperties());
+            storageProperties = StorageProperties.createAll(getProperties());
+        } catch (UserException e) {
+            throw new RuntimeException("Failed to initialize Catalog properties, error: "
+                    + ExceptionUtils.getRootCauseMessage(e), e);
+        }
+        Preconditions.checkNotNull(storageProperties,
+                "Storage properties are not configured properly");
+        Preconditions.checkNotNull(msProperties, "Metastore properties are not configured properly");
+        Preconditions.checkArgument(
+                msClass.isInstance(msProperties),
+                "Metastore properties type is not correct. Expected %s but got %s"
+                        + msClass.getName()
+                        + msProperties.getClass().getName());
+
     }
 
     /**
@@ -150,7 +174,8 @@ public class CatalogProperty {
                         metastoreProperties = MetastoreProperties.create(getProperties());
                     } catch (UserException e) {
                         LOG.warn("Failed to create metastore properties", e);
-                        throw new RuntimeException("Failed to create metastore properties", e);
+                        throw new RuntimeException("Failed to create metastore properties, error: "
+                                + ExceptionUtils.getRootCause(e), e);
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogProperty.java
@@ -153,9 +153,8 @@ public class CatalogProperty {
         Preconditions.checkNotNull(msProperties, "Metastore properties are not configured properly");
         Preconditions.checkArgument(
                 msClass.isInstance(msProperties),
-                "Metastore properties type is not correct. Expected %s but got %s"
-                        + msClass.getName()
-                        + msProperties.getClass().getName());
+                String.format("Metastore properties type is not correct. Expected %s but got %s",
+                        msClass.getName(), msProperties.getClass().getName()));
 
     }
 
@@ -175,7 +174,7 @@ public class CatalogProperty {
                     } catch (UserException e) {
                         LOG.warn("Failed to create metastore properties", e);
                         throw new RuntimeException("Failed to create metastore properties, error: "
-                                + ExceptionUtils.getRootCause(e), e);
+                                + ExceptionUtils.getRootCauseMessage(e), e);
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalog.java
@@ -18,14 +18,12 @@
 package org.apache.doris.datasource.paimon;
 
 import org.apache.doris.common.DdlException;
-import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.CatalogProperty;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.InitCatalogLog;
 import org.apache.doris.datasource.NameMapping;
 import org.apache.doris.datasource.SessionContext;
 import org.apache.doris.datasource.property.metastore.AbstractPaimonProperties;
-import org.apache.doris.datasource.property.metastore.MetastoreProperties;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
@@ -60,12 +58,7 @@ public class PaimonExternalCatalog extends ExternalCatalog {
 
     @Override
     protected void initLocalObjectsImpl() {
-        try {
-            paimonProperties = (AbstractPaimonProperties) MetastoreProperties.create(catalogProperty.getProperties());
-        } catch (UserException e) {
-            throw new IllegalArgumentException("Failed to create Paimon properties from catalog properties,exception: "
-                    + ExceptionUtils.getRootCauseMessage(e), e);
-        }
+        paimonProperties = (AbstractPaimonProperties) catalogProperty.getMetastoreProperties();
         catalogType = paimonProperties.getPaimonCatalogType();
         catalog = createCatalog();
         initPreExecutionAuthenticator();
@@ -194,14 +187,7 @@ public class PaimonExternalCatalog extends ExternalCatalog {
 
     @Override
     public void checkProperties() throws DdlException {
-        if (null != paimonProperties) {
-            try {
-                this.paimonProperties = (AbstractPaimonProperties) MetastoreProperties
-                        .create(catalogProperty.getProperties());
-            } catch (UserException e) {
-                throw new DdlException("Failed to create Paimon properties from catalog properties, exception: "
-                        + ExceptionUtils.getRootCauseMessage(e), e);
-            }
-        }
+        super.checkProperties();
+        catalogProperty.checkMetaStoreAndStorageProperties(AbstractPaimonProperties.class);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/HdfsProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/HdfsProperties.java
@@ -119,6 +119,7 @@ public class HdfsProperties extends HdfsCompatibleProperties {
         initBackendConfigProperties();
         this.hadoopStorageConfig = new Configuration();
         this.backendConfigProperties.forEach(hadoopStorageConfig::set);
+        HdfsPropertiesUtils.checkHaConfig(backendConfigProperties);
         hadoopAuthenticator = HadoopAuthenticator.getHadoopAuthenticator(hadoopStorageConfig);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/HdfsPropertiesUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/HdfsPropertiesUtils.java
@@ -20,7 +20,9 @@ package org.apache.doris.datasource.property.storage;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.property.storage.exception.StoragePropertiesException;
 
+import com.google.common.base.Strings;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -28,8 +30,12 @@ import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class HdfsPropertiesUtils {
     private static final String URI_KEY = "uri";
@@ -127,7 +133,7 @@ public class HdfsPropertiesUtils {
     }
 
     public static String validateAndNormalizeUri(String location, String host, String defaultFs,
-                                                  Set<String> supportedSchemas) {
+                                                 Set<String> supportedSchemas) {
         if (StringUtils.isBlank(location)) {
             throw new IllegalArgumentException("Property 'uri' is required.");
         }
@@ -179,4 +185,76 @@ public class HdfsPropertiesUtils {
             throw new StoragePropertiesException("Failed to parse URI: " + location, e);
         }
     }
+
+    /**
+     * Validate the required HDFS HA configuration properties.
+     *
+     * <p>This method checks the following:
+     * <ul>
+     *   <li>{@code dfs.nameservices} must be defined if HA is enabled.</li>
+     *   <li>{@code dfs.ha.namenodes.<nameservice>} must be defined and contain at least 2 namenodes.</li>
+     *   <li>For each namenode, {@code dfs.namenode.rpc-address.<nameservice>.<namenode>} must be defined.</li>
+     *   <li>{@code dfs.client.failover.proxy.provider.<nameservice>} must be defined.</li>
+     * </ul>
+     *
+     * @param hdfsProperties configuration map (similar to core-site.xml/hdfs-site.xml properties)
+     */
+    public static void checkHaConfig(Map<String, String> hdfsProperties) {
+        if (hdfsProperties == null) {
+            return;
+        }
+        // 1. Check dfs.nameservices
+        String dfsNameservices = hdfsProperties.getOrDefault(HdfsClientConfigKeys.DFS_NAMESERVICES, "");
+        if (Strings.isNullOrEmpty(dfsNameservices)) {
+            // No nameservice configured => HA is not enabled, nothing to validate
+            return;
+        }
+        for (String dfsservice : splitAndTrim(dfsNameservices)) {
+            if (dfsservice.isEmpty()) {
+                continue;
+            }
+            // 2. Check dfs.ha.namenodes.<nameservice>
+            String haNnKey = HdfsClientConfigKeys.DFS_HA_NAMENODES_KEY_PREFIX + "." + dfsservice;
+            String namenodes = hdfsProperties.getOrDefault(haNnKey, "");
+            if (Strings.isNullOrEmpty(namenodes)) {
+                throw new IllegalArgumentException("Missing property: " + haNnKey);
+            }
+            List<String> names = splitAndTrim(namenodes);
+            if (names.size() < 2) {
+                throw new IllegalArgumentException("HA requires at least 2 namenodes for service: " + dfsservice);
+            }
+            // 3. Check dfs.namenode.rpc-address.<nameservice>.<namenode>
+            for (String name : names) {
+                String rpcKey = HdfsClientConfigKeys.DFS_NAMENODE_RPC_ADDRESS_KEY + "." + dfsservice + "." + name;
+                String address = hdfsProperties.getOrDefault(rpcKey, "");
+                if (Strings.isNullOrEmpty(address)) {
+                    throw new IllegalArgumentException("Missing property: " + rpcKey + " (expected format: host:port)");
+                }
+            }
+            // 4. Check dfs.client.failover.proxy.provider.<nameservice>
+            String failoverKey = HdfsClientConfigKeys.Failover.PROXY_PROVIDER_KEY_PREFIX + "." + dfsservice;
+            String failoverProvider = hdfsProperties.getOrDefault(failoverKey, "");
+            if (Strings.isNullOrEmpty(failoverProvider)) {
+                throw new IllegalArgumentException("Missing property: " + failoverKey);
+            }
+        }
+    }
+
+    /**
+     * Utility method to split a comma-separated string, trim whitespace,
+     * and remove empty tokens.
+     *
+     * @param s the input string
+     * @return list of trimmed non-empty values
+     */
+    private static List<String> splitAndTrim(String s) {
+        if (Strings.isNullOrEmpty(s)) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(s.split(","))
+                .map(String::trim)
+                .filter(tok -> !tok.isEmpty())
+                .collect(Collectors.toList());
+    }
 }
+

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/LocationPathTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/LocationPathTest.java
@@ -38,7 +38,6 @@ public class LocationPathTest {
 
     static {
         Map<String, String> props = new HashMap<>();
-        props.put("dfs.nameservices", "namenode:8020");
         props.put("dfs.nameservices", "ns1");
         // NameNodes for this nameservice
         props.put("dfs.ha.namenodes.ns1", "nn1,nn2");

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/LocationPathTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/LocationPathTest.java
@@ -39,6 +39,14 @@ public class LocationPathTest {
     static {
         Map<String, String> props = new HashMap<>();
         props.put("dfs.nameservices", "namenode:8020");
+        props.put("dfs.nameservices", "ns1");
+        // NameNodes for this nameservice
+        props.put("dfs.ha.namenodes.ns1", "nn1,nn2");
+        // RPC addresses for each NameNode
+        props.put("dfs.namenode.rpc-address.ns1.nn1", "127.0.0.1:8020");
+        props.put("dfs.namenode.rpc-address.ns1.nn2", "127.0.0.2:8020");
+        props.put("dfs.client.failover.proxy.provider.ns1",
+                "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider");
         props.put("s3.endpoint", "s3.us-east-2.amazonaws.com");
         props.put("s3.access_key", "access_key");
         props.put("s3.secret_key", "secret_key");
@@ -74,7 +82,14 @@ public class LocationPathTest {
 
         // HA props
         Map<String, String> props = new HashMap<>();
-        props.put("dfs.nameservices", "ns");
+        props.put("dfs.nameservices", "ns1");
+        // NameNodes for this nameservice
+        props.put("dfs.ha.namenodes.ns1", "nn1,nn2");
+        // RPC addresses for each NameNode
+        props.put("dfs.namenode.rpc-address.ns1.nn1", "127.0.0.1:8020");
+        props.put("dfs.namenode.rpc-address.ns1.nn2", "127.0.0.2:8020");
+        props.put("dfs.client.failover.proxy.provider.ns1",
+                "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider");
         //HdfsProperties hdfsProperties = (HdfsProperties) StorageProperties.createPrimary( props);
         Map<StorageProperties.Type, StorageProperties> storagePropertiesMap = StorageProperties.createAll(props).stream()
                 .collect(java.util.stream.Collectors.toMap(StorageProperties::getType, Function.identity()));
@@ -231,7 +246,7 @@ public class LocationPathTest {
         assertNormalize("cosn://bucket/path/to/file", "s3://bucket/path/to/file");
         assertNormalize("viewfs://cluster/path/to/file", "viewfs://cluster/path/to/file");
         assertNormalize("/path/to/file", "hdfs://namenode:8020/path/to/file");
-        assertNormalize("hdfs:///path/to/file", "hdfs://namenode:8020/path/to/file");
+        assertNormalize("hdfs:///path/to/file", "hdfs://ns1/path/to/file");
     }
 
     private void assertNormalize(String input, String expected) {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/HdfsPropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/HdfsPropertiesTest.java
@@ -76,6 +76,10 @@ public class HdfsPropertiesTest {
 
         // Test 3: Valid config resources (should succeed)
         origProps.put("hadoop.config.resources", "hadoop1/core-site.xml,hadoop1/hdfs-site.xml");
+        origProps.put("dfs.ha.namenodes.ns1", "nn1,nn2");
+        origProps.put("dfs.namenode.rpc-address.ns1.nn1", "localhost:9000");
+        origProps.put("dfs.namenode.rpc-address.ns1.nn2", "localhost:9001");
+        origProps.put("dfs.client.failover.proxy.provider.ns1", "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider");
         List<StorageProperties> storageProperties = StorageProperties.createAll(origProps);
         HdfsProperties hdfsProperties = (HdfsProperties) storageProperties.get(0);
         Configuration conf = hdfsProperties.getHadoopStorageConfig();
@@ -129,6 +133,8 @@ public class HdfsPropertiesTest {
         origProps.put("dfs.nameservices", "ns1");
         origProps.put("dfs.ha.namenodes.ns1", "nn1,nn2");
         origProps.put("dfs.namenode.rpc-address.ns1.nn1", "localhost:9000");
+        origProps.put("dfs.namenode.rpc-address.ns1.nn2", "localhost:9001");
+        origProps.put("dfs.client.failover.proxy.provider.ns1", "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider");
         origProps.put("hadoop.async.threads.max", "10");
         properties = StorageProperties.createAll(origProps).get(0);
         Assertions.assertEquals(properties.getClass(), HdfsProperties.class);

--- a/regression-test/suites/auth_call/test_assistant_command_auth.groovy
+++ b/regression-test/suites/auth_call/test_assistant_command_auth.groovy
@@ -56,7 +56,9 @@ suite("test_assistant_command_auth","p0,auth_call") {
     logger.info("insert_res: " + insert_res)
 
     sql """create catalog if not exists ${catalogName} properties (
-            'type'='hms'
+            'type'='hms',
+            'hive.metastore.uris' = 'thrift://127.0.0.1:9083'
+        
         );"""
 
 

--- a/regression-test/suites/auth_call/test_ddl_catalog_auth.groovy
+++ b/regression-test/suites/auth_call/test_ddl_catalog_auth.groovy
@@ -25,7 +25,8 @@ suite("test_ddl_catalog_auth","p0,auth_call") {
     String catalogNameOther = 'test_ddl_catalog_auth_catalog_other'
 
     sql """create catalog if not exists ${catalogNameOther} properties (
-            'type'='hms'
+            'type'='hms',
+            'hive.metastore.uris'='thrift://127.0.0.1:9083'
         );"""
 
     try_sql("DROP USER ${user}")
@@ -46,7 +47,8 @@ suite("test_ddl_catalog_auth","p0,auth_call") {
     connect(user, "${pwd}", context.config.jdbcUrl) {
         test {
             sql """create catalog if not exists ${catalogName} properties (
-                    'type'='hms'
+                    'type'='hms',
+                    'hive.metastore.uris'='thrift://127.0.0.1:9083'
                 );"""
             exception "denied"
         }
@@ -54,13 +56,15 @@ suite("test_ddl_catalog_auth","p0,auth_call") {
         assertTrue(ctl_res.size() == 1)
     }
     sql """create catalog if not exists ${catalogName} properties (
-            'type'='hms'
+            'type'='hms',
+            'hive.metastore.uris'='thrift://127.0.0.1:9083'
         );"""
     sql """grant Create_priv on ${catalogName}.*.* to ${user}"""
     sql """drop catalog ${catalogName}"""
     connect(user, "${pwd}", context.config.jdbcUrl) {
         sql """create catalog if not exists ${catalogName} properties (
-            'type'='hms'
+            'type'='hms',
+            'hive.metastore.uris'='thrift://127.0.0.1:9083'
         );"""
         sql """show create catalog ${catalogName}"""
         def ctl_res = sql """show catalogs;"""


### PR DESCRIPTION


### What problem does this PR solve?

Previously, HDFS High Availability (HA) configuration checks were only performed for the HMS catalog. This PR extends HA validation to all components that interact with HDFS, including:

- All catalog types (HMS, Hive, Iceberg, etc.)
- Table-valued functions (TVFs) accessing HDFS resources
- Any future features that depend on HDFS HA

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

