### PR TITLE
[enhance](nereids) EliminateGroupByKeyByUniform support rewrite in cte

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Rewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Rewriter.java
@@ -663,7 +663,6 @@ public class Rewriter extends AbstractBatchJobExecutor {
                         cascadesContext -> cascadesContext.rewritePlanContainsTypes(LogicalAggregate.class)
                                 || cascadesContext.rewritePlanContainsTypes(LogicalJoin.class)
                                 || cascadesContext.rewritePlanContainsTypes(LogicalUnion.class),
-                        custom(RuleType.ELIMINATE_GROUP_BY_KEY_BY_UNIFORM, EliminateGroupByKeyByUniform::new),
                         topDown(new EliminateGroupByKey()),
                         topDown(new PushDownAggThroughJoinOnPkFk()),
                         topDown(new PullUpJoinFromUnionAll())
@@ -877,6 +876,8 @@ public class Rewriter extends AbstractBatchJobExecutor {
                         )));
                 rewriteJobs.addAll(jobs(topic("convert outer join to anti",
                         custom(RuleType.CONVERT_OUTER_JOIN_TO_ANTI, ConvertOuterJoinToAntiJoin::new))));
+                rewriteJobs.addAll(jobs(topic("eliminate group by key by uniform",
+                        custom(RuleType.ELIMINATE_GROUP_BY_KEY_BY_UNIFORM, EliminateGroupByKeyByUniform::new))));
                 if (needOrExpansion) {
                     rewriteJobs.addAll(jobs(topic("or expansion",
                             custom(RuleType.OR_EXPANSION, () -> OrExpansion.INSTANCE))));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupByKeyByUniform.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupByKeyByUniform.java
@@ -101,7 +101,7 @@ public class EliminateGroupByKeyByUniform extends DefaultPlanRewriter<Map<ExprId
         if (removedExpression.isEmpty()) {
             return aggregate;
         }
-        /* select 1 c1 from test group by c; -> select 1 c1 from test limit 1 */
+        /* select 1 c1 from test group by c1; -> select 1 c1 from test limit 1 */
         if (newGroupBy.isEmpty() && aggregate.getAggregateFunctions().isEmpty()) {
             LogicalProject<Plan> newProject = new LogicalProject<>(
                     Utils.fastToImmutableList(aggregate.getOutput()), aggregate.child());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupByKeyByUniform.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupByKeyByUniform.java
@@ -20,7 +20,6 @@ package org.apache.doris.nereids.rules.rewrite;
 import org.apache.doris.nereids.jobs.JobContext;
 import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.trees.expressions.Alias;
-import org.apache.doris.nereids.trees.expressions.CTEId;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
@@ -42,7 +41,6 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -61,8 +59,7 @@ public class EliminateGroupByKeyByUniform extends DefaultPlanRewriter<Map<ExprId
 
     @Override
     public Plan rewriteRoot(Plan plan, JobContext jobContext) {
-        Optional<CTEId> cteId = jobContext.getCascadesContext().getCurrentTree();
-        if (cteId.isPresent() || !plan.containsType(Aggregate.class)) {
+        if (!plan.containsType(Aggregate.class)) {
             return plan;
         }
         Map<ExprId, ExprId> replaceMap = new HashMap<>();

--- a/regression-test/data/nereids_rules_p0/constant_propagation/constant_propagation.out
+++ b/regression-test/data/nereids_rules_p0/constant_propagation/constant_propagation.out
@@ -621,13 +621,14 @@ PhysicalResultSink
 -- !union_3_shape --
 PhysicalResultSink
 --PhysicalLimit[GLOBAL]
-----PhysicalUnion
-------PhysicalProject[-1 AS `k2`, 3 AS `k1`, c AS `k3`]
---------filter((t1.a = 1) and (t1.b = 2) and (t1.c = 3))
-----------PhysicalOlapScan[t1]
-------PhysicalProject[-1 AS `k2`, 3 AS `k1`, z AS `k3`]
---------filter((t2.x = 1) and (t2.y = 2) and (t2.z = 3))
-----------PhysicalOlapScan[t2]
+----PhysicalProject[-1 AS `k2`, 3 AS `k1`, 3 AS `k3`]
+------PhysicalUnion
+--------PhysicalProject[1 AS `1`]
+----------filter((t1.a = 1) and (t1.b = 2) and (t1.c = 3))
+------------PhysicalOlapScan[t1]
+--------PhysicalProject[1 AS `1`]
+----------filter((t2.x = 1) and (t2.y = 2) and (t2.z = 3))
+------------PhysicalOlapScan[t2]
 
 -- !union_3_result --
 3	-1	3
@@ -780,10 +781,11 @@ PhysicalResultSink
 -- !union_17_shape --
 PhysicalResultSink
 --PhysicalLimit[GLOBAL]
-----PhysicalUnion
-------PhysicalProject[3 AS `a + b`, t1.a]
---------filter((t1.a = 1) and (t1.b = 2))
-----------PhysicalOlapScan[t1]
+----PhysicalProject[1 AS `1`, 3 AS `3`]
+------PhysicalUnion
+--------PhysicalProject[1 AS `1`]
+----------filter((t1.a = 1) and (t1.b = 2))
+------------PhysicalOlapScan[t1]
 
 -- !union_17_result --
 1	3
@@ -792,7 +794,8 @@ PhysicalResultSink
 PhysicalResultSink
 --PhysicalUnion
 ----PhysicalLimit[GLOBAL]
-------PhysicalUnion
+------PhysicalProject[1 AS `1`, 3 AS `3`]
+--------PhysicalUnion
 ----PhysicalProject[3 AS `a + b`, t1.a]
 ------filter((t1.a = 1) and (t1.b = 2))
 --------PhysicalOlapScan[t1]


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #43391

Problem Summary:
EliminateGroupByKeyByUniform not support rewrite in cte in #43391, and the restriction can be removed after 
#52798, because #52798 implement the cteconsumer expression rewrite.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

