### PR TITLE
[fix](txn lazy commit) fix txn lazy commit conflict with schema change

### DIFF
--- a/cloud/src/meta-service/txn_lazy_committer.cpp
+++ b/cloud/src/meta-service/txn_lazy_committer.cpp
@@ -121,6 +121,7 @@ void convert_tmp_rowsets(
                 LOG(WARNING) << msg;
                 return;
             }
+
             VersionPB version_pb;
             if (!version_pb.ParseFromString(ver_val)) {
                 code = MetaServiceCode::PROTOBUF_PARSE_ERR;
@@ -130,6 +131,17 @@ void convert_tmp_rowsets(
             }
             LOG(INFO) << "txn_id=" << txn_id << " key=" << hex(ver_key)
                       << " version_pb:" << version_pb.ShortDebugString();
+
+            if (version_pb.pending_txn_ids_size() == 0 || version_pb.pending_txn_ids(0) != txn_id) {
+                LOG(INFO) << "txn_id=" << txn_id << " partition_id=" << tmp_rowset_pb.partition_id()
+                          << " tmp_rowset_key=" << hex(tmp_rowset_key)
+                          << " version has already been converted."
+                          << " version_pb:" << version_pb.ShortDebugString();
+                TEST_SYNC_POINT_CALLBACK("convert_tmp_rowsets::already_been_converted",
+                                         &version_pb);
+                return;
+            }
+
             partition_versions.emplace(tmp_rowset_pb.partition_id(), version_pb);
             DCHECK_EQ(partition_versions.size(), 1) << partition_versions.size();
         }
@@ -279,6 +291,8 @@ void make_committed_txn_visible(const std::string& instance_id, int64_t db_id, i
         txn->put(recycle_key, recycle_val);
         LOG(INFO) << "put recycle_key=" << hex(recycle_key) << " txn_id=" << txn_id;
 
+        TEST_SYNC_POINT_RETURN_WITH_VOID("TxnLazyCommitTask::make_committed_txn_visible::commit",
+                                         &code);
         err = txn->commit();
         if (err != TxnErrorCode::TXN_OK) {
             code = cast_as<ErrCategory::COMMIT>(err);


### PR DESCRIPTION
* step1: MS txn lazy commit convert tmp rowsets and make txn visible commit failed due to unexpected fdb error
* step2: BE schema change job convert historical data and prepare/commit rowsets with the same txn_id and tablet_id for new tablet rowset meta, tmp rowset key is decided by (txn_id, tablet_id)
* step3: MS retry lazy commit will convert tmp rowset which write by schema change job

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

