### PR TITLE
[fix](scheduler) Fix coredump due to different queue size

### DIFF
--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -703,9 +703,10 @@ std::string PipelineTask::debug_string() {
     fmt::format_to(debug_string_buffer,
                    "PipelineTask[id = {}, open = {}, eos = {}, state = {}, dry run = "
                    "{}, _wake_up_early = {}, time elapsed since last state changing = {}s, spilling"
-                   " = {}, is running = {}]",
+                   " = {}, is running = {}, _on_blocking_scheduler = {}, thread_id = {}]",
                    _index, _opened, _eos, _to_string(_exec_state), _dry_run, _wake_up_early.load(),
-                   _state_change_watcher.elapsed_time() / NANOS_PER_SEC, _spilling, is_running());
+                   _state_change_watcher.elapsed_time() / NANOS_PER_SEC, _spilling, is_running(),
+                   _on_blocking_scheduler, get_thread_id());
     std::unique_lock<std::mutex> lc(_dependency_lock);
     auto* cur_blocked_dep = _blocked_dep;
     auto fragment = _fragment_context.lock();

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -79,11 +79,11 @@ public:
         return _on_blocking_scheduler ? _tracking.blocking_thread_id : _tracking.simple_thread_id;
     }
 
-    PipelineTask& incr_thread_id(int num_threads) {
+    PipelineTask& set_thread_id(int thread_id) {
         if (_on_blocking_scheduler) {
-            _tracking.blocking_thread_id = (_tracking.blocking_thread_id + 1) % num_threads;
+            _tracking.blocking_thread_id = thread_id;
         } else {
-            _tracking.simple_thread_id = (_tracking.simple_thread_id + 1) % num_threads;
+            _tracking.simple_thread_id = thread_id;
         }
         COUNTER_UPDATE(_core_change_times, 1);
         return *this;

--- a/be/src/pipeline/task_queue.cpp
+++ b/be/src/pipeline/task_queue.cpp
@@ -205,6 +205,8 @@ Status MultiCoreTaskQueue::push_back(PipelineTaskSPtr task, int core_id) {
 }
 
 void MultiCoreTaskQueue::update_statistics(PipelineTask* task, int64_t time_spent) {
+    // if the task not execute but exception early close, core_id == -1
+    // should not do update_statistics
     if (auto core_id = task->get_thread_id(); core_id >= 0) {
         task->inc_runtime_ns(time_spent);
         _prio_task_queues[core_id].inc_sub_queue_runtime(task->get_queue_level(), time_spent);

--- a/be/src/pipeline/task_queue.cpp
+++ b/be/src/pipeline/task_queue.cpp
@@ -205,10 +205,10 @@ Status MultiCoreTaskQueue::push_back(PipelineTaskSPtr task, int core_id) {
 }
 
 void MultiCoreTaskQueue::update_statistics(PipelineTask* task, int64_t time_spent) {
-    auto core_id = task->get_thread_id();
-    DCHECK_GE(core_id, 0);
-    task->inc_runtime_ns(time_spent);
-    _prio_task_queues[core_id].inc_sub_queue_runtime(task->get_queue_level(), time_spent);
+    if (auto core_id = task->get_thread_id(); core_id >= 0) {
+        task->inc_runtime_ns(time_spent);
+        _prio_task_queues[core_id].inc_sub_queue_runtime(task->get_queue_level(), time_spent);
+    }
 }
 
 } // namespace doris::pipeline

--- a/be/src/pipeline/task_queue.cpp
+++ b/be/src/pipeline/task_queue.cpp
@@ -191,8 +191,11 @@ PipelineTaskSPtr MultiCoreTaskQueue::_steal_take(int core_id) {
 }
 
 Status MultiCoreTaskQueue::push_back(PipelineTaskSPtr task) {
-    task->incr_thread_id(_core_size);
-    return push_back(task, task->get_thread_id());
+    int thread_id = task->get_thread_id();
+    if (thread_id < 0) {
+        thread_id = _next_core.fetch_add(1) % _core_size;
+    }
+    return push_back(task, thread_id);
 }
 
 Status MultiCoreTaskQueue::push_back(PipelineTaskSPtr task, int core_id) {

--- a/be/src/pipeline/task_scheduler.cpp
+++ b/be/src/pipeline/task_scheduler.cpp
@@ -116,8 +116,7 @@ void TaskScheduler::_do_work(int index) {
             // Fragment already finished
             continue;
         }
-        task->set_running(true);
-        DCHECK_EQ(task->get_thread_id(), index);
+        task->set_running(true).set_thread_id(index);
         bool done = false;
         auto status = Status::OK();
         int64_t exec_ns = 0;

--- a/be/src/pipeline/task_scheduler.h
+++ b/be/src/pipeline/task_scheduler.h
@@ -61,14 +61,18 @@ private:
     friend class HybridTaskScheduler;
 
     TaskScheduler(int core_num, std::string name, std::shared_ptr<CgroupCpuCtl> cgroup_cpu_ctl)
-            : _name(std::move(name)), _task_queue(core_num), _cgroup_cpu_ctl(cgroup_cpu_ctl) {}
-    TaskScheduler() : _task_queue(0) {}
+            : _name(std::move(name)),
+              _task_queue(core_num),
+              _num_threads(core_num),
+              _cgroup_cpu_ctl(cgroup_cpu_ctl) {}
+    TaskScheduler() : _task_queue(0), _num_threads(0) {}
     std::string _name;
     std::unique_ptr<ThreadPool> _fix_thread_pool;
 
     MultiCoreTaskQueue _task_queue;
     bool _need_to_stop = false;
     bool _shutdown = false;
+    const int _num_threads;
     std::weak_ptr<CgroupCpuCtl> _cgroup_cpu_ctl;
 
     void _do_work(int index);


### PR DESCRIPTION
### What problem does this PR solve?

start BE in local mode
*** Query id: d82def8526424e69-b00c82d310ccaa1d ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1757020283 (unix time) try "date -d @1757020283" if you are using GNU date ***
*** Current BE git commitID: 0cbb0bfca3 ***
*** SIGSEGV unknown detail explain (@0x0) received by PID 8317 (TID 10279 OR 0x7fa9b984b640) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:420
 1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 3# 0x00007FAD203E7520 in /lib/x86_64-linux-gnu/libc.so.6
 4# doris::pipeline::PriorityTaskQueue::push(std::shared_ptr) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_queue.cpp:129
 5# doris::pipeline::MultiCoreTaskQueue::push_back(std::shared_ptr, int) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_queue.cpp:204
 6# doris::pipeline::MultiCoreTaskQueue::push_back(std::shared_ptr) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_queue.cpp:198
 7# doris::pipeline::TaskScheduler::submit(std::shared_ptr) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:74
 8# doris::pipeline::HybridTaskScheduler::submit(std::shared_ptr) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:189
 9# doris::pipeline::PipelineTask::wake_up(doris::pipeline::Dependency*) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_task.cpp:803
10# doris::pipeline::Dependency::set_ready() at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/dependency.cpp:88
11# doris::vectorized::VDataStreamRecvr::SenderQueue::add_block(std::unique_ptr >, int, long, google::protobuf::Closure**, long, unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vdata_stream_recvr.cpp:194
12# doris::vectorized::VDataStreamRecvr::add_block(std::unique_ptr >, int, int, long, google::protobuf::Closure**, long, unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vdata_stream_recvr.cpp:403
13# doris::vectorized::VDataStreamMgr::transmit_block(doris::PTransmitDataParams const*, google::protobuf::Closure**, long) at /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vdata_stream_mgr.cpp:167
14# doris::PInternalService::_transmit_block(google::protobuf::RpcController*, doris::PTransmitDataParams const*, doris::PTransmitDataResult*, google::protobuf::Closure*, doris::Status const&, long) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
15# doris::PInternalService::transmit_block(google::protobuf::RpcController*, doris::PTransmitDataParams const*, doris::PTransmitDataResult*, google::protobuf::Closure*) at /home/zcp/repo_center/doris_master/doris/be/src/service/internal_service.cpp:1624
16# brpc::policy::ProcessRpcRequest(brpc::InputMessageBase*) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
17# brpc::ProcessInputMessage(void*) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
18# bthread::TaskGroup::task_runner(long) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
19# bthread_make_fcontext in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
172.20.57.180 last coredump sql: 2025-09-05 05:11:54,768 [query] Query d82def8526424e69-b00c82d310ccaa1d 1 times with new query id: fc55dbd3bbf24d9d-b18012e9210c6be0

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

