### PR TITLE
[bugfix](compaction) the avg segment size should always be less than input rows

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -297,11 +297,14 @@ int64_t Compaction::get_avg_segment_rows() {
     const auto& meta = _tablet->tablet_meta();
     if (meta->compaction_policy() == CUMULATIVE_TIME_SERIES_POLICY) {
         int64_t compaction_goal_size_mbytes = meta->time_series_compaction_goal_size_mbytes();
-        return (compaction_goal_size_mbytes * 1024 * 1024 * 2) /
-               (_input_rowsets_data_size / (_input_row_num + 1) + 1);
+        // The output segment rows should be less than total input rows
+        return std::max((compaction_goal_size_mbytes * 1024 * 1024 * 2) /
+                                (_input_rowsets_data_size / (_input_row_num + 1) + 1),
+                        _input_row_num + 1);
     }
-    return config::vertical_compaction_max_segment_size /
-           (_input_rowsets_data_size / (_input_row_num + 1) + 1);
+    return std::max(config::vertical_compaction_max_segment_size /
+                            (_input_rowsets_data_size / (_input_row_num + 1) + 1),
+                    _input_row_num + 1);
 }
 
 CompactionMixin::CompactionMixin(StorageEngine& engine, TabletSharedPtr tablet,

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -298,11 +298,11 @@ int64_t Compaction::get_avg_segment_rows() {
     if (meta->compaction_policy() == CUMULATIVE_TIME_SERIES_POLICY) {
         int64_t compaction_goal_size_mbytes = meta->time_series_compaction_goal_size_mbytes();
         // The output segment rows should be less than total input rows
-        return std::max((compaction_goal_size_mbytes * 1024 * 1024 * 2) /
+        return std::min((compaction_goal_size_mbytes * 1024 * 1024 * 2) /
                                 (_input_rowsets_data_size / (_input_row_num + 1) + 1),
                         _input_row_num + 1);
     }
-    return std::max(config::vertical_compaction_max_segment_size /
+    return std::min(config::vertical_compaction_max_segment_size /
                             (_input_rowsets_data_size / (_input_row_num + 1) + 1),
                     _input_row_num + 1);
 }

--- a/be/test/olap/base_compaction_test.cpp
+++ b/be/test/olap/base_compaction_test.cpp
@@ -44,7 +44,7 @@ static RowsetSharedPtr create_rowset(Version version, int num_segments, bool ove
     rs_meta->set_rowset_type(BETA_ROWSET); // important
     rs_meta->_rowset_meta_pb.set_start_version(version.first);
     rs_meta->_rowset_meta_pb.set_end_version(version.second);
-    rs_meta->_rowset_meta_pb.set_rows_num(rows_num);
+    rs_meta->_rowset_meta_pb.set_num_rows(rows_num);
     rs_meta->set_num_segments(num_segments);
     rs_meta->set_segments_overlap(overlapping ? OVERLAPPING : NONOVERLAPPING);
     rs_meta->set_total_disk_size(data_size);

--- a/be/test/olap/base_compaction_test.cpp
+++ b/be/test/olap/base_compaction_test.cpp
@@ -106,7 +106,7 @@ TEST_F(TestBaseCompaction, zero_input_rows) {
 
     EXPECT_EQ(compaction._input_rowsets.back()->start_version(), 21);
     EXPECT_EQ(compaction._input_rowsets.back()->end_version(), 21);
-    std::cout << "input rowsets: " << compaction.get_avg_segment_rows() << std::endl;
+    EXPECT_EQ(compaction.get_avg_segment_rows(), 1);
 }
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

If the input rows ==0 and the vertical_compaction_max_segment_size == 40g, the return value is 40g rows, it is larger than int32.max value, so that it will core.

But actually, the avg segment rows is always less or equal than the input rows num.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

