### PR TITLE
[fix](unique function) fix virtual slot with unique function

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownVirtualColumnsIntoOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownVirtualColumnsIntoOlapScan.java
@@ -343,7 +343,9 @@ public class PushDownVirtualColumnsIntoOlapScan implements RewriteRuleFactory {
         // CONTINUE case: Examples like x + y, func(a, b), (x + y) * z
         // Only count expressions that meet minimum complexity requirements
         if (!(skipResult.shouldSkipCounting() || skipResult.isNotBeneficial())) {
-            if (expr.getDepth() >= MIN_EXPRESSION_DEPTH && expr.children().size() > 0) {
+            if (expr.getDepth() >= MIN_EXPRESSION_DEPTH
+                    && expr.children().size() > 0
+                    && !ExpressionUtils.containUniqueFunctionExistMultiple(ImmutableList.of(expr))) {
                 expressionCounts.put(expr, expressionCounts.getOrDefault(expr, 0) + 1);
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -1254,4 +1254,18 @@ public class ExpressionUtils {
     public static boolean hasNonWindowAggregateFunction(Expression expression) {
         return expression.accept(ExpressionVisitors.CONTAINS_AGGREGATE_CHECKER, null);
     }
+
+    /**
+     * check if the expressions contain a unique function which exists multiple times
+     */
+    public static boolean containUniqueFunctionExistMultiple(Collection<? extends Expression> expressions) {
+        Set<UniqueFunction> counterSet = Sets.newHashSet();
+        for (Expression expression : expressions) {
+            if (expression.anyMatch(
+                    expr -> expr instanceof UniqueFunction && !counterSet.add((UniqueFunction) expr))) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownVirtualColumnsIntoOlapScanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownVirtualColumnsIntoOlapScanTest.java
@@ -845,7 +845,7 @@ public class PushDownVirtualColumnsIntoOlapScanTest implements MemoPatternMatchS
     @Test
     void testOnceUniqueFunction() {
         LogicalOlapScan olapScan = new LogicalOlapScan(StatementScopeIdGenerator.newRelationId(),
-                PlanConstructor.newOlapTable(12345L, "t1",  0));
+                PlanConstructor.newOlapTable(12345L, "t1", 0));
         SlotReference id = (SlotReference) olapScan.getOutput().get(0);
         Random random1 = new Random(new IntegerLiteral(1), new IntegerLiteral(10));
         Random random2 = new Random(new IntegerLiteral(1), new IntegerLiteral(10));
@@ -879,7 +879,7 @@ public class PushDownVirtualColumnsIntoOlapScanTest implements MemoPatternMatchS
     @Test
     void testMultipleTimesUniqueFunctions() {
         LogicalOlapScan olapScan = new LogicalOlapScan(StatementScopeIdGenerator.newRelationId(),
-                PlanConstructor.newOlapTable(12345L, "t1",  0));
+                PlanConstructor.newOlapTable(12345L, "t1", 0));
         SlotReference id = (SlotReference) olapScan.getOutput().get(0);
         Random random = new Random(new IntegerLiteral(1), new IntegerLiteral(10));
         // don't extract virtual column if it contains an unique function which exists multiple times

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownVirtualColumnsIntoOlapScanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownVirtualColumnsIntoOlapScanTest.java
@@ -33,6 +33,7 @@ import org.apache.doris.nereids.trees.expressions.Multiply;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Not;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.trees.expressions.WhenClause;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Array;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.ArrayFilter;
@@ -43,8 +44,10 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.L2Distance;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Lambda;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.MultiMatch;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.MultiMatchAny;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Random;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
+import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
@@ -67,6 +70,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Test for PushDownVirtualColumnsIntoOlapScan rule.
@@ -836,5 +840,76 @@ public class PushDownVirtualColumnsIntoOlapScanTest implements MemoPatternMatchS
             // Expected for lambda expressions or other complex scenarios
             // The important thing is that type checking works correctly
         }
+    }
+
+    @Test
+    void testOnceUniqueFunction() {
+        LogicalOlapScan olapScan = new LogicalOlapScan(StatementScopeIdGenerator.newRelationId(),
+                PlanConstructor.newOlapTable(12345L, "t1",  0));
+        SlotReference id = (SlotReference) olapScan.getOutput().get(0);
+        Random random1 = new Random(new IntegerLiteral(1), new IntegerLiteral(10));
+        Random random2 = new Random(new IntegerLiteral(1), new IntegerLiteral(10));
+        Expression compareExpr = new Add(new Add(random1, random2), id);
+        LogicalFilter<LogicalOlapScan> filter = new LogicalFilter<>(
+                ImmutableSet.of(
+                        new GreaterThan(compareExpr, new IntegerLiteral(5)),
+                        new LessThan(compareExpr, new IntegerLiteral(10))
+                ),
+                olapScan);
+
+        Plan root = PlanChecker.from(MemoTestUtils.createConnectContext(), filter)
+                .applyTopDown(new PushDownVirtualColumnsIntoOlapScan())
+                .getPlan();
+        Assertions.assertInstanceOf(LogicalProject.class, root);
+        LogicalProject<?> project = (LogicalProject<?>) root;
+        Assertions.assertInstanceOf(LogicalFilter.class, project.child());
+        LogicalFilter<?> resFilter = (LogicalFilter<?>) project.child();
+        Assertions.assertInstanceOf(LogicalOlapScan.class, resFilter.child());
+        LogicalOlapScan resScan = (LogicalOlapScan) resFilter.child();
+        Assertions.assertEquals(1, resScan.getVirtualColumns().size());
+        Alias alias = (Alias) resScan.getVirtualColumns().get(0);
+        Assertions.assertEquals(compareExpr, alias.child());
+        Set<Expression> expectConjuncts = ImmutableSet.of(
+                new GreaterThan(alias.toSlot(), new IntegerLiteral(5)),
+                new LessThan(alias.toSlot(), new IntegerLiteral(10))
+        );
+        Assertions.assertEquals(expectConjuncts, resFilter.getConjuncts());
+    }
+
+    @Test
+    void testMultipleTimesUniqueFunctions() {
+        LogicalOlapScan olapScan = new LogicalOlapScan(StatementScopeIdGenerator.newRelationId(),
+                PlanConstructor.newOlapTable(12345L, "t1",  0));
+        SlotReference id = (SlotReference) olapScan.getOutput().get(0);
+        Random random = new Random(new IntegerLiteral(1), new IntegerLiteral(10));
+        // don't extract virtual column if it contains an unique function which exists multiple times
+        // compareExpr contains  the one same `random` twice, so compareExpr cann't be a virtual column.
+        // but `random()` itself can still be a virtual column.
+        Expression compareExpr = new Add(new Add(random, random), id);
+        LogicalFilter<LogicalOlapScan> filter = new LogicalFilter<>(
+                ImmutableSet.of(
+                        new GreaterThan(compareExpr, new IntegerLiteral(5)),
+                        new LessThan(compareExpr, new IntegerLiteral(10))
+                ),
+                olapScan);
+
+        Plan root = PlanChecker.from(MemoTestUtils.createConnectContext(), filter)
+                .applyTopDown(new PushDownVirtualColumnsIntoOlapScan())
+                .getPlan();
+        Assertions.assertInstanceOf(LogicalProject.class, root);
+        LogicalProject<?> project = (LogicalProject<?>) root;
+        Assertions.assertInstanceOf(LogicalFilter.class, project.child());
+        LogicalFilter<?> resFilter = (LogicalFilter<?>) project.child();
+        Assertions.assertInstanceOf(LogicalOlapScan.class, resFilter.child());
+        LogicalOlapScan resScan = (LogicalOlapScan) resFilter.child();
+        Assertions.assertEquals(1, resScan.getVirtualColumns().size());
+        Alias alias = (Alias) resScan.getVirtualColumns().get(0);
+        Assertions.assertEquals(random, alias.child());
+        Expression newCompareExpr = new Add(new Add(alias.toSlot(), alias.toSlot()), id);
+        Set<Expression> expectConjuncts = ImmutableSet.of(
+                new GreaterThan(newCompareExpr, new IntegerLiteral(5)),
+                new LessThan(newCompareExpr, new IntegerLiteral(10))
+        );
+        Assertions.assertEquals(expectConjuncts, resFilter.getConjuncts());
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

if a sub expression exists multiple time in filter,   rule PushDownVirtualColumnsIntoOlapScan will extract it as a virtual slot and push it into olap scan.

but if this sub expression itself contains an unique function which exists multiple times, then it should not push into olap scan,  rule AddProjectForUniqueFunction  will extract  the unique function for it.

But we can't construct a real example SQL satisfy the above case,  maybe it's not exists in real SQL,   we just still fix it for safe reason.   And this PR we don't add a real SQL regression test,  we just test it with fe ut.  

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

