### PR TITLE
[chore](cloud) Fix txn_lazy_commit_test ut not stable

### DIFF
--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -1608,7 +1608,7 @@ int InstanceRecycler::recycle_tablets(int64_t table_id, int64_t index_id,
         int64_t tablet_id = tablet_meta_pb.tablet_id();
 
         if (!check_lazy_txn_finished(txn_kv_, instance_id_, tablet_meta_pb.tablet_id())) {
-            LOG(WARNING) << "lazy txn not finished tablet_meta_pb=" << tablet_meta_pb.tablet_id();
+            LOG(WARNING) << "lazy txn not finished tablet_id=" << tablet_meta_pb.tablet_id();
             return -1;
         }
 

--- a/cloud/test/txn_lazy_commit_test.cpp
+++ b/cloud/test/txn_lazy_commit_test.cpp
@@ -522,7 +522,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithoutDbIdTest) {
     auto sp = SyncPoint::get_instance();
     sp->set_call_back("commit_txn_eventually::need_repair_tablet_idx", [&](auto&& args) {
         bool need_repair_tablet_idx = *try_any_cast<bool*>(args[0]);
-        LOG(INFO) << "zhangleixxx2" << need_repair_tablet_idx;
+        LOG(INFO) << "need_repair_tablet_idx:" << need_repair_tablet_idx;
         if (repair_tablet_idx_count == 0) {
             ASSERT_TRUE(need_repair_tablet_idx);
             repair_tablet_idx_count++;
@@ -3300,10 +3300,10 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithHugeRowsetMetaTest) {
     req.set_cloud_unique_id("test_cloud_unique_id");
     TxnInfoPB txn_info_pb;
     txn_info_pb.set_db_id(db_id);
-    txn_info_pb.set_label("test_label_multi_table_commit_txn");
+    txn_info_pb.set_label("test_label_with_huge_rowsetmeta_test");
     txn_info_pb.add_table_ids(table_id);
     txn_info_pb.add_table_ids(table_id2);
-    txn_info_pb.set_timeout_ms(36000);
+    txn_info_pb.set_timeout_ms(600000);
     req.mutable_txn_info()->CopyFrom(txn_info_pb);
     BeginTxnResponse res;
     meta_service->begin_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res,
@@ -3397,7 +3397,6 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithSchemaChangeTest) {
 
     auto sp = SyncPoint::get_instance();
     sp->set_call_back("TxnLazyCommitTask::make_committed_txn_visible::commit", [&](auto&& args) {
-        LOG(INFO) << "zhangleiyyy";
         {
             std::unique_lock<std::mutex> _lock(go_mutex);
             if (make_committed_txn_visible_count == 0) {
@@ -3433,7 +3432,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithSchemaChangeTest) {
     txn_info_pb.set_db_id(db_id);
     txn_info_pb.set_label("test_sc_with_commit_txn_label");
     txn_info_pb.add_table_ids(table_id);
-    txn_info_pb.set_timeout_ms(36000);
+    txn_info_pb.set_timeout_ms(600000);
     req.mutable_txn_info()->CopyFrom(txn_info_pb);
     BeginTxnResponse res;
     meta_service->begin_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res,


### PR DESCRIPTION
* txn timeout 36000 ms is too short for asan, txn has been aborted by recycler , it will cause case failed.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

