### PR TITLE
[opt](docker) Make hive components more robust

### DIFF
--- a/docker/thirdparties/custom_settings.env
+++ b/docker/thirdparties/custom_settings.env
@@ -21,5 +21,5 @@
 # eg: CONTAINER_UID="doris-jack-"
 # NOTICE: change this uid will modify the file in docker-compose.
 CONTAINER_UID="doris--"
-s3Endpoint="oss-cn-hongkong.aliyuncs.com"
-s3BucketName="doris-regression-hk"
+export s3Endpoint="oss-cn-hongkong.aliyuncs.com"
+export s3BucketName="doris-regression-hk"

--- a/docker/thirdparties/docker-compose/hive/hadoop-hive.env.tpl
+++ b/docker/thirdparties/docker-compose/hive/hadoop-hive.env.tpl
@@ -62,5 +62,4 @@ HADOOP_HEAPSIZE=4096
 
 NEED_LOAD_DATA=${NEED_LOAD_DATA}
 LOAD_PARALLEL=${LOAD_PARALLEL}
-s3Endpoint=${s3Endpoint}
-s3BucketName=${s3BucketName}
+

--- a/docker/thirdparties/docker-compose/hive/hadoop-hive.env.tpl
+++ b/docker/thirdparties/docker-compose/hive/hadoop-hive.env.tpl
@@ -29,6 +29,7 @@ HIVE_SITE_CONF_hive_compactor_initiator_on=true
 HIVE_SITE_CONF_hive_compactor_worker_threads=2
 HIVE_SITE_CONF_metastore_storage_schema_reader_impl=org.apache.hadoop.hive.metastore.SerDeStorageSchemaReader
 HIVE_SITE_CONF_hive_stats_column_autogather=false
+HIVE_SITE_CONF_hive_exec_parallel=true
 
 CORE_CONF_fs_defaultFS=hdfs://${IP_HOST}:${FS_PORT}
 CORE_CONF_hadoop_http_staticuser_user=root
@@ -54,5 +55,12 @@ YARN_CONF_yarn_resourcemanager_address=resourcemanager:8032
 YARN_CONF_yarn_resourcemanager_scheduler_address=resourcemanager:8030
 YARN_CONF_yarn_resourcemanager_resource__tracker_address=resourcemanager:8031
 
-NEED_LOAD_DATA=${NEED_LOAD_DATA}
+MAPRED_CONF_mapreduce_map_maxattempts=6
+MAPRED_CONF_mapreduce_reduce_maxattempts=6
+HADOOP_HEAPSIZE=4096
 
+
+NEED_LOAD_DATA=${NEED_LOAD_DATA}
+LOAD_PARALLEL=${LOAD_PARALLEL}
+s3Endpoint=${s3Endpoint}
+s3BucketName=${s3BucketName}

--- a/docker/thirdparties/docker-compose/hive/scripts/data/default/account_fund/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/default/account_fund/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/default/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/default/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/default/hive01/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/default/hive01/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/default/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/default/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/default/sale_table/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/default/sale_table/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/default/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/default/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/default/string_table/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/default/string_table/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/default/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/default/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/default/student/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/default/student/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/default/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/default/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/default/test1/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/default/test1/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/default/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/default/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/default/test2/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/default/test2/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/default/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/default/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/default/test_hive_doris/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/default/test_hive_doris/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/default/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/default/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/datev2_csv/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/datev2_csv/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/datev2_orc/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/datev2_orc/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/datev2_parquet/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/datev2_parquet/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type2/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type2/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type3/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type3/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type_delimiter/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type_delimiter/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type_delimiter2/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type_delimiter2/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type_delimiter3/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type_delimiter3/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_textfile_array_all_types/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_textfile_array_all_types/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_textfile_array_delimiter/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_textfile_array_delimiter/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_textfile_nestedarray/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_textfile_nestedarray/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_upper_case_orc/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_upper_case_orc/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_upper_case_parquet/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_upper_case_parquet/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/logs1_parquet/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/logs1_parquet/run.sh
@@ -3,16 +3,6 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-if [[ ! -d "${CUR_DIR}/data" ]]; then
-    echo "${CUR_DIR}/data does not exist"
-    cd "${CUR_DIR}" && rm -f data.tar.gz \
-    && curl -O https://s3BucketName.s3Endpoint/regression/datalake/pipeline_data/multi_catalog/logs1_parquet/data.tar.gz \
-    && tar xzf data.tar.gz
-    cd -
-else
-    echo "${CUR_DIR}/data exist, continue !"
-fi
-
 ## mkdir and put data to hdfs
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/one_partition/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/one_partition/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/orc_nested_types/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/orc_nested_types/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/orc_partitioned_columns/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/orc_partitioned_columns/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/orc_partitioned_one_column/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/orc_partitioned_one_column/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/par_fields_in_file_orc/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/par_fields_in_file_orc/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/par_fields_in_file_parquet/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/par_fields_in_file_parquet/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_bigint/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_bigint/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_boolean/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_boolean/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_char/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_char/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_date/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_date/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_decimal/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_decimal/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_double/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_double/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_float/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_float/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_int/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_int/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_smallint/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_smallint/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_string/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_string/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_timestamp/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_timestamp/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_tinyint/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_tinyint/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_varchar/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_varchar/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_lz4_compression/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_lz4_compression/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_lzo_compression/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_lzo_compression/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_nested_types/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_nested_types/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_partitioned_columns/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_partitioned_columns/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_partitioned_one_column/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_partitioned_one_column/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_predicate_table/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_predicate_table/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/partition_location_1/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/partition_location_1/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/partition_location_2/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/partition_location_2/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/partition_manual_remove/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/partition_manual_remove/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_chinese_orc/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_chinese_orc/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_chinese_parquet/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_chinese_parquet/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_chinese_text/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_chinese_text/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_complex_types/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_complex_types/run.sh
@@ -3,16 +3,6 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-if [[ ! -d "${CUR_DIR}/data" ]]; then
-    echo "${CUR_DIR}/data does not exist"
-    cd "${CUR_DIR}" && rm -f data.tar.gz \
-    && curl -O https://${s3BucketName}.${s3Endpoint}/regression/datalake/pipeline_data/multi_catalog/test_complex_types/data.tar.gz \
-    && tar xzf data.tar.gz
-    cd -
-else
-    echo "${CUR_DIR}/data exist, continue !"
-fi
-
 ## mkdir and put data to hdfs
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_complex_types/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_complex_types/run.sh
@@ -6,7 +6,7 @@ CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 if [[ ! -d "${CUR_DIR}/data" ]]; then
     echo "${CUR_DIR}/data does not exist"
     cd "${CUR_DIR}" && rm -f data.tar.gz \
-    && curl -O https://s3BucketName.s3Endpoint/regression/datalake/pipeline_data/multi_catalog/test_complex_types/data.tar.gz \
+    && curl -O https://${s3BucketName}.${s3Endpoint}/regression/datalake/pipeline_data/multi_catalog/test_complex_types/data.tar.gz \
     && tar xzf data.tar.gz
     cd -
 else

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_compress_partitioned/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_compress_partitioned/run.sh
@@ -3,16 +3,6 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-if [[ ! -d "${CUR_DIR}/data" ]]; then
-    echo "${CUR_DIR}/data does not exist"
-    cd "${CUR_DIR}" && rm -f data.tar.gz \
-    && curl -O https://${s3BucketName}.${s3Endpoint}/regression/datalake/pipeline_data/multi_catalog/test_compress_partitioned/data.tar.gz \
-    && tar xzf data.tar.gz
-    cd -
-else
-    echo "${CUR_DIR}/data exist, continue !"
-fi
-
 ## mkdir and put data to hdfs
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_compress_partitioned/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_compress_partitioned/run.sh
@@ -6,7 +6,7 @@ CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 if [[ ! -d "${CUR_DIR}/data" ]]; then
     echo "${CUR_DIR}/data does not exist"
     cd "${CUR_DIR}" && rm -f data.tar.gz \
-    && curl -O https://s3BucketName.s3Endpoint/regression/datalake/pipeline_data/multi_catalog/test_compress_partitioned/data.tar.gz \
+    && curl -O https://${s3BucketName}.${s3Endpoint}/regression/datalake/pipeline_data/multi_catalog/test_compress_partitioned/data.tar.gz \
     && tar xzf data.tar.gz
     cd -
 else

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_csv_format_error/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_csv_format_error/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_date_string_partition/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_date_string_partition/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_hive_same_db_table_name/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_hive_same_db_table_name/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_hive_special_char_partition/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_hive_special_char_partition/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_mixed_par_locations_orc/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_mixed_par_locations_orc/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_mixed_par_locations_parquet/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_mixed_par_locations_parquet/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_multi_langs_orc/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_multi_langs_orc/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_multi_langs_parquet/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_multi_langs_parquet/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_multi_langs_text/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_multi_langs_text/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_special_orc_formats/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_special_orc_formats/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_truncate_char_or_varchar_columns_orc/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_truncate_char_or_varchar_columns_orc/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_truncate_char_or_varchar_columns_parquet/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_truncate_char_or_varchar_columns_parquet/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_truncate_char_or_varchar_columns_text/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_truncate_char_or_varchar_columns_text/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_wide_table/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_wide_table/run.sh
@@ -6,7 +6,7 @@ CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 if [[ ! -d "${CUR_DIR}/data" ]]; then
     echo "${CUR_DIR}/data does not exist"
     cd "${CUR_DIR}" && rm -f data.tar.gz \
-    && curl -O https://s3BucketName.s3Endpoint/regression/datalake/pipeline_data/multi_catalog/test_wide_table/data.tar.gz \
+    && curl -O https://${s3BucketName}.${s3Endpoint}/regression/datalake/pipeline_data/multi_catalog/test_wide_table/data.tar.gz \
     && tar xzf data.tar.gz
     cd -
 else

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_wide_table/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_wide_table/run.sh
@@ -3,16 +3,6 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-if [[ ! -d "${CUR_DIR}/data" ]]; then
-    echo "${CUR_DIR}/data does not exist"
-    cd "${CUR_DIR}" && rm -f data.tar.gz \
-    && curl -O https://${s3BucketName}.${s3Endpoint}/regression/datalake/pipeline_data/multi_catalog/test_wide_table/data.tar.gz \
-    && tar xzf data.tar.gz
-    cd -
-else
-    echo "${CUR_DIR}/data exist, continue !"
-fi
-
 ## mkdir and put data to hdfs
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/text_partitioned_columns/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/text_partitioned_columns/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/text_partitioned_one_column/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/text_partitioned_one_column/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/timestamp_with_time_zone/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/timestamp_with_time_zone/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/two_partition/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/two_partition/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/type_change_orc/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/type_change_orc/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/type_change_origin/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/type_change_origin/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/type_change_parquet/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/type_change_parquet/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/multi_catalog/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/multi_catalog/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/bigint_partition/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/bigint_partition/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/partition_type/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/partition_type/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/char_partition/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/char_partition/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/partition_type/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/partition_type/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/date_partition/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/date_partition/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/partition_type/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/partition_type/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/decimal_partition/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/decimal_partition/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/partition_type/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/partition_type/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/double_partition/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/double_partition/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/partition_type/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/partition_type/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/float_partition/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/float_partition/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/partition_type/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/partition_type/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/int_partition/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/int_partition/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/partition_type/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/partition_type/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/smallint_partition/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/smallint_partition/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/partition_type/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/partition_type/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/string_partition/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/string_partition/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/partition_type/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/partition_type/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/tinyint_partition/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/tinyint_partition/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/partition_type/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/partition_type/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/varchar_partition/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/partition_type/varchar_partition/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/partition_type/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/partition_type/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/regression/crdmm_data/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/regression/crdmm_data/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/regression/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/regression/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/statistics/statistics/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/statistics/statistics/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/statistics/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/statistics/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/statistics/stats/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/statistics/stats/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/statistics/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/statistics/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/test/hive_test/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/test/hive_test/run.sh
@@ -3,8 +3,7 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-## mkdir and put data to hdfs
-cd "${CUR_DIR}" && rm -rf data/ && tar xzf data.tar.gz
+
 hadoop fs -mkdir -p /user/doris/suites/test/
 hadoop fs -put "${CUR_DIR}"/data/* /user/doris/suites/test/
 

--- a/docker/thirdparties/docker-compose/hive/scripts/data/tpch_1000_parquet/part/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/tpch_1000_parquet/part/run.sh
@@ -6,7 +6,7 @@ set -x
 # if [[ ! -d "${CUR_DIR}/data" ]]; then
 #     echo "${CUR_DIR}/data does not exist"
 #     cd "${CUR_DIR}" && rm -f data.tar.gz \
-#     && curl -O https://s3BucketName.s3Endpoint/regression/datalake/pipeline_data/tpch_1000_parquet/part/data.tar.gz \
+#     && curl -O https://${s3BucketName}.${s3Endpoint}/regression/datalake/pipeline_data/tpch_1000_parquet/part/data.tar.gz \
 #     && tar xzf data.tar.gz
 #     cd -
 # else

--- a/docker/thirdparties/docker-compose/hive/scripts/data/tvf/test_hdfs_tvf_compression/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/tvf/test_hdfs_tvf_compression/run.sh
@@ -7,7 +7,7 @@ CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 if [[ ! -d "${CUR_DIR}/test_data" ]]; then
     echo "${CUR_DIR}/test_data does not exist"
     cd ${CUR_DIR}/ && rm -f test_data.tar.gz \
-    && curl -O https://s3BucketName.s3Endpoint/regression/datalake/pipeline_data/test_hdfs_tvf_compression/test_data.tar.gz \
+    && curl -O https://${s3BucketName}.${s3Endpoint}/regression/datalake/pipeline_data/test_hdfs_tvf_compression/test_data.tar.gz \
     && tar xzf test_data.tar.gz
     cd -
 else

--- a/docker/thirdparties/docker-compose/hive/scripts/data/tvf/test_hdfs_tvf_compression/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/tvf/test_hdfs_tvf_compression/run.sh
@@ -4,16 +4,6 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-if [[ ! -d "${CUR_DIR}/test_data" ]]; then
-    echo "${CUR_DIR}/test_data does not exist"
-    cd ${CUR_DIR}/ && rm -f test_data.tar.gz \
-    && curl -O https://${s3BucketName}.${s3Endpoint}/regression/datalake/pipeline_data/test_hdfs_tvf_compression/test_data.tar.gz \
-    && tar xzf test_data.tar.gz
-    cd -
-else
-    echo "${CUR_DIR}/test_data exist, continue !"
-fi
-
 ## mkdir and put data to hdfs
 hadoop fs -mkdir -p /test_data
 hadoop fs -put "${CUR_DIR}"/test_data/* /test_data/

--- a/docker/thirdparties/docker-compose/hive/scripts/data/tvf/test_tvf/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/tvf/test_tvf/run.sh
@@ -4,16 +4,6 @@ set -x
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-if [[ ! -d "${CUR_DIR}/tvf" ]]; then
-    echo "${CUR_DIR}/tvf does not exist"
-    cd ${CUR_DIR}/ && rm -f data.tar.gz \
-    && curl -O https://${s3BucketName}.${s3Endpoint}/regression/datalake/pipeline_data/test_tvf/data.tar.gz \
-    && tar xzf data.tar.gz
-    cd -
-else
-    echo "${CUR_DIR}/tvf exist, continue !"
-fi
-
 ## mkdir and put data to hdfs
 hadoop fs -mkdir -p /catalog/tvf/
 hadoop fs -put "${CUR_DIR}"/tvf/* /catalog/tvf/

--- a/docker/thirdparties/docker-compose/hive/scripts/data/tvf/test_tvf/run.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/tvf/test_tvf/run.sh
@@ -7,7 +7,7 @@ CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 if [[ ! -d "${CUR_DIR}/tvf" ]]; then
     echo "${CUR_DIR}/tvf does not exist"
     cd ${CUR_DIR}/ && rm -f data.tar.gz \
-    && curl -O https://s3BucketName.s3Endpoint/regression/datalake/pipeline_data/test_tvf/data.tar.gz \
+    && curl -O https://${s3BucketName}.${s3Endpoint}/regression/datalake/pipeline_data/test_tvf/data.tar.gz \
     && tar xzf data.tar.gz
     cd -
 else

--- a/docker/thirdparties/docker-compose/hive/scripts/download-hive-data.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/download-hive-data.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -42,6 +43,77 @@ else
     echo "${CUR_DIR}/tvf_data exist, continue !"
 fi
 
+# download test_complex_types data
+if [[ ! -d "${CUR_DIR}/data/multi_catalog/test_complex_types/data" ]]; then
+    echo "${CUR_DIR}/data/multi_catalog/test_complex_types/data does not exist"
+    cd "${CUR_DIR}/data/multi_catalog/test_complex_types"
+    curl -O https://${s3BucketName}.${s3Endpoint}/regression/datalake/pipeline_data/multi_catalog/test_complex_types/data.tar.gz
+    tar xzf data.tar.gz
+    rm -rf data.tar.gz
+    cd -
+else
+    echo "${CUR_DIR}/data/multi_catalog/test_complex_types/data exist, continue !"
+fi
+
+# download test_compress_partitioned data
+if [[ ! -d "${CUR_DIR}/data/multi_catalog/test_compress_partitioned/data" ]]; then
+    echo "${CUR_DIR}/data/multi_catalog/test_compress_partitioned/data does not exist"
+    cd "${CUR_DIR}/data/multi_catalog/test_compress_partitioned"
+    curl -O https://${s3BucketName}.${s3Endpoint}/regression/datalake/pipeline_data/multi_catalog/test_compress_partitioned/data.tar.gz
+    tar xzf data.tar.gz
+    rm -rf data.tar.gz
+    cd -
+else
+    echo "${CUR_DIR}/data/multi_catalog/test_compress_partitioned/data exist, continue !"
+fi
+
+# download test_wide_table data
+if [[ ! -d "${CUR_DIR}/data/multi_catalog/test_wide_table/data" ]]; then
+    echo "${CUR_DIR}/data/multi_catalog/test_wide_table/data does not exist"
+    cd "${CUR_DIR}/data/multi_catalog/test_wide_table"
+    curl -O https://${s3BucketName}.${s3Endpoint}/regression/datalake/pipeline_data/multi_catalog/test_wide_table/data.tar.gz
+    tar xzf data.tar.gz
+    rm -rf data.tar.gz
+    cd -
+else
+    echo "${CUR_DIR}/data/multi_catalog/test_wide_table/data exist, continue !"
+fi
+
+# download test_hdfs_tvf_compression data
+if [[ ! -d "${CUR_DIR}/data/tvf/test_hdfs_tvf_compression/test_data" ]]; then
+    echo "${CUR_DIR}/data/tvf/test_hdfs_tvf_compression/test_data does not exist"
+    cd "${CUR_DIR}/data/tvf/test_hdfs_tvf_compression"
+    curl -O https://${s3BucketName}.${s3Endpoint}/regression/datalake/pipeline_data/test_hdfs_tvf_compression/test_data.tar.gz
+    tar xzf test_data.tar.gz
+    rm -rf test_data.tar.gz
+    cd -
+else
+    echo "${CUR_DIR}/data/tvf/test_hdfs_tvf_compression/test_data exist, continue !"
+fi
+
+# download test_tvf data
+if [[ ! -d "${CUR_DIR}/data/tvf/test_tvf/tvf" ]]; then
+    echo "${CUR_DIR}/data/tvf/test_tvf/tvf does not exist"
+    cd "${CUR_DIR}/data/tvf/test_tvf"
+    curl -O https://${s3BucketName}.${s3Endpoint}/regression/datalake/pipeline_data/test_tvf/data.tar.gz
+    tar xzf data.tar.gz
+    rm -rf data.tar.gz
+    cd -
+else
+    echo "${CUR_DIR}/data/tvf/test_tvf/tvf exist, continue !"
+fi
+
+# download logs1_parquet data
+if [[ ! -d "${CUR_DIR}/data/multi_catalog/logs1_parquet/data" ]]; then
+    echo "${CUR_DIR}/data/multi_catalog/logs1_parquet/data does not exist"
+    cd "${CUR_DIR}/data/multi_catalog/logs1_parquet"
+    curl -O https://${s3BucketName}.${s3Endpoint}/regression/datalake/pipeline_data/multi_catalog/logs1_parquet/data.tar.gz
+    tar xzf data.tar.gz
+    rm -rf data.tar.gz
+    cd -
+else
+    echo "${CUR_DIR}/data/multi_catalog/logs1_parquet/data exist, continue !"
+fi
 
 # download auxiliary jars
 jars=(

--- a/docker/thirdparties/docker-compose/hive/scripts/download-hive-data.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/download-hive-data.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+# download tpch1_data
+if [[ ! -d "${CUR_DIR}/tpch1.db" ]]; then
+    echo "${CUR_DIR}/tpch1.db does not exist"
+    cd ${CUR_DIR}/
+    curl -O https://${s3BucketName}.${s3Endpoint}/regression/datalake/pipeline_data/tpch1.db.tar.gz
+    tar -zxf tpch1.db.tar.gz
+    rm -rf tpch1.db.tar.gz
+    cd -
+else
+    echo "${CUR_DIR}/tpch1.db exist, continue !"
+fi
+
+# download tvf_data
+if [[ ! -d "${CUR_DIR}/tvf_data" ]]; then
+    echo "${CUR_DIR}/tvf_data does not exist"
+    cd ${CUR_DIR}/
+    curl -O https://${s3BucketName}.${s3Endpoint}/regression/datalake/pipeline_data/tvf_data.tar.gz
+    tar -zxf tvf_data.tar.gz
+    rm -rf tvf_data.tar.gz
+    cd -
+else
+    echo "${CUR_DIR}/tvf_data exist, continue !"
+fi
+
+
+# download auxiliary jars
+jars=(
+    jdom-1.1.jar
+    aliyun-java-sdk-core-3.4.0.jar
+    aliyun-java-sdk-ecs-4.2.0.jar
+    aliyun-java-sdk-ram-3.0.0.jar
+    aliyun-java-sdk-sts-3.0.0.jar
+    aliyun-sdk-oss-3.4.1.jar
+    hadoop-aliyun-3.2.1.jar
+    aws-java-sdk-bundle-1.11.375.jar
+    hadoop-huaweicloud-3.1.1-hw-54.5.jar
+    hadoop-cos-3.1.0-8.3.22.jar
+    cos_api-bundle-5.6.244.4.jar
+    hadoop-aws-3.2.1.jar
+    paimon-hive-connector-3.1-1.3-SNAPSHOT.jar
+    gcs-connector-hadoop3-2.2.24-shaded.jar
+)
+
+cd ${CUR_DIR}/auxlib
+for jar in "${jars[@]}"; do
+    curl -O "https://${s3BucketName}.${s3Endpoint}/regression/docker/hive3/${jar}"
+done
+

--- a/docker/thirdparties/docker-compose/hive/scripts/hive-metastore.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/hive-metastore.sh
@@ -19,8 +19,6 @@
 set -e -x
 
 
-parallel=$(getconf _NPROCESSORS_ONLN)
-
 AUX_LIB="/mnt/scripts/auxlib"
 for file in "${AUX_LIB}"/*.tar.gz; do
     [ -e "$file" ] || continue
@@ -28,33 +26,13 @@ for file in "${AUX_LIB}"/*.tar.gz; do
     echo "file = ${file}"
 done
 ls "${AUX_LIB}/"
-cp -r "${AUX_LIB}"/ /opt/hive
 
-#  download auxiliary jars
-cd /opt/hive/auxlib
-curl -O https://s3BucketName.s3Endpoint/regression/docker/hive3/jdom-1.1.jar
-curl -O https://s3BucketName.s3Endpoint/regression/docker/hive3/aliyun-java-sdk-core-3.4.0.jar
-curl -O https://s3BucketName.s3Endpoint/regression/docker/hive3/aliyun-java-sdk-ecs-4.2.0.jar
-curl -O https://s3BucketName.s3Endpoint/regression/docker/hive3/aliyun-java-sdk-ram-3.0.0.jar
-curl -O https://s3BucketName.s3Endpoint/regression/docker/hive3/aliyun-java-sdk-sts-3.0.0.jar
-curl -O https://s3BucketName.s3Endpoint/regression/docker/hive3/aliyun-sdk-oss-3.4.1.jar
-curl -O https://s3BucketName.s3Endpoint/regression/docker/hive3/hadoop-aliyun-3.2.1.jar
-curl -O https://s3BucketName.s3Endpoint/regression/docker/hive3/aws-java-sdk-bundle-1.11.375.jar
-curl -O https://s3BucketName.s3Endpoint/regression/docker/hive3/hadoop-huaweicloud-3.1.1-hw-54.5.jar
-curl -O https://s3BucketName.s3Endpoint/regression/docker/hive3/hadoop-cos-3.1.0-8.3.22.jar
-curl -O https://s3BucketName.s3Endpoint/regression/docker/hive3/cos_api-bundle-5.6.244.4.jar
-curl -O https://s3BucketName.s3Endpoint/regression/docker/hive3/hadoop-aws-3.2.1.jar
-curl -O https://s3BucketName.s3Endpoint/regression/docker/hive3/paimon-hive-connector-3.1-1.3-SNAPSHOT.jar
-curl -O https://s3BucketName.s3Endpoint/regression/docker/hive3/gcs-connector-hadoop3-2.2.24-shaded.jar
+# copy auxiliary jars to hive lib, avoid jars copy
+cp -r "${AUX_LIB}"/* /opt/hive/lib/
 
+# start metastore
 nohup /opt/hive/bin/hive --service metastore &
 
-# wait lockfile
-lockfile1="/mnt/scripts/run-data.lock"
-while [[ -f "${lockfile1}" ]]; do
-    sleep 10
-done
-touch "${lockfile1}"
 
 # wait metastore start
 while ! $(nc -z localhost "${HMS_PORT:-9083}"); do
@@ -62,61 +40,34 @@ while ! $(nc -z localhost "${HMS_PORT:-9083}"); do
 done
 
 if [[ ${NEED_LOAD_DATA} = "0" ]]; then
-    rm -f "${lockfile1}"
     echo "NEED_LOAD_DATA is 0, skip load data"
     touch /mnt/SUCCESS
     # Avoid container exit
     tail -f /dev/null
 fi
+# create paimon external table
+if [[ ${enablePaimonHms} == "true" ]]; then
+    START_TIME=$(date +%s)
+    hive -f /mnt/scripts/create_external_paimon_scripts/create_paimon_tables.hql || (echo "Failed to executing create_paimon_table.hql" && exit 1)
+    END_TIME=$(date +%s)
+    EXECUTION_TIME=$((END_TIME - START_TIME))
+    echo "Script: create_paimon_table.hql executed in $EXECUTION_TIME seconds"
+else
+    echo "enablePaimonHms is false, skip create paimon table"
+fi
+
 # create tables for other cases
 # new cases should use separate dir
 hadoop fs -mkdir -p /user/doris/suites/
 
 DATA_DIR="/mnt/scripts/data/"
-find "${DATA_DIR}" -type f -name "run.sh" -print0 | xargs -0 -n 1 -P "${parallel}" -I {} bash -ec '
+find "${DATA_DIR}" -type f -name "run.sh" -print0 | xargs -0 -n 1 -P "${LOAD_PARALLEL}" -I {} bash -ec '
     START_TIME=$(date +%s)
     bash -e "{}" || (echo "Failed to executing script: {}" && exit 1)
     END_TIME=$(date +%s)
     EXECUTION_TIME=$((END_TIME - START_TIME))
     echo "Script: {} executed in $EXECUTION_TIME seconds"
 '
-
-rm -f "${lockfile1}"
-
-lockfile2="/mnt/scripts/download-data.lock"
-
-# wait lockfile
-while [[ -f "${lockfile2}" ]]; do
-    sleep 10
-done
-
-touch "${lockfile2}"
-
-# if you test in your local，better use # to annotation section about tpch1.db
-if [[ ! -d "/mnt/scripts/tpch1.db" ]]; then
-    echo "/mnt/scripts/tpch1.db does not exist"
-    cd /mnt/scripts/
-    curl -O https://s3BucketName.s3Endpoint/regression/datalake/pipeline_data/tpch1.db.tar.gz
-    tar -zxf tpch1.db.tar.gz
-    rm -rf tpch1.db.tar.gz
-    cd -
-else
-    echo "/mnt/scripts/tpch1.db exist, continue !"
-fi
-
-# download tvf_data
-if [[ ! -d "/mnt/scripts/tvf_data" ]]; then
-    echo "/mnt/scripts/tvf_data does not exist"
-    cd /mnt/scripts/
-    curl -O https://s3BucketName.s3Endpoint/regression/datalake/pipeline_data/tvf_data.tar.gz
-    tar -zxf tvf_data.tar.gz
-    rm -rf tvf_data.tar.gz
-    cd -
-else
-    echo "/mnt/scripts/tvf_data exist, continue !"
-fi
-
-rm -f "${lockfile2}"
 
 # put data file
 hadoop_put_pids=()
@@ -135,16 +86,6 @@ hadoop_put_pids+=($!)
 hadoop fs -copyFromLocal -f /mnt/scripts/paimon1 /user/doris/ &
 hadoop_put_pids+=($!)
 
-# create paimon external table
-if [[ ${enablePaimonHms} == "true" ]]; then
-    START_TIME=$(date +%s)
-    hive -f /mnt/scripts/create_external_paimon_scripts/create_paimon_tables.hql || (echo "Failed to executing create_paimon_table.hql" && exit 1)
-    END_TIME=$(date +%s)
-    EXECUTION_TIME=$((END_TIME - START_TIME))
-    echo "Script: create_paimon_table.hql executed in $EXECUTION_TIME seconds"
-else
-    echo "enablePaimonHms is false, skip create paimon table"
-fi
 
 ## put tvf_data
 if [[ -z "$(ls /mnt/scripts/tvf_data)" ]]; then
@@ -160,9 +101,7 @@ hadoop_put_pids+=($!)
 
 
 # wait put finish
-set +e
 wait "${hadoop_put_pids[@]}"
-set -e
 if [[ -z "$(hadoop fs -ls /user/doris/paimon1)" ]]; then
     echo "paimon1 put failed"
     exit 1
@@ -177,7 +116,7 @@ if [[ -z "$(hadoop fs -ls /user/doris/tvf_data)" ]]; then
 fi
 
 # create tables
-ls /mnt/scripts/create_preinstalled_scripts/*.hql | xargs -n 1 -P "${parallel}" -I {} bash -ec '
+ls /mnt/scripts/create_preinstalled_scripts/*.hql | xargs -n 1 -P "${LOAD_PARALLEL}" -I {} bash -ec '
     START_TIME=$(date +%s)
     hive -f {} || (echo "Failed to executing hql: {}" && exit 1)
     END_TIME=$(date +%s)

--- a/docker/thirdparties/docker-compose/hive/scripts/prepare-hive-data.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/prepare-hive-data.sh
@@ -18,6 +18,14 @@ set -eo pipefail
 # under the License.
 
 CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+# Extract all tar.gz files under the repo
+find ${CUR_DIR}/data -type f -name "*.tar.gz" -print0 | \
+xargs -0 -n1 -P"${LOAD_PARALLEL}" bash -c '
+  f="$0"
+  echo "Extracting hive data $f"
+  dir=$(dirname "$f")
+  tar -xzf "$f" -C "$dir"
+'
 
 # download tpch1_data
 if [[ ! -d "${CUR_DIR}/tpch1.db" ]]; then

--- a/docker/thirdparties/run-thirdparties-docker.sh
+++ b/docker/thirdparties/run-thirdparties-docker.sh
@@ -37,6 +37,7 @@ Usage: $0 <options>
      --stop             stop the specified components
      --reserve-ports    reserve host ports by setting 'net.ipv4.ip_local_reserved_ports' to avoid port already bind error
      --no-load-data     do not load data into the components
+     --load-parallel <num>  set the parallel number to load data, default is the 50% of CPU cores
 
   All valid components:
     mysql,pg,oracle,sqlserver,clickhouse,es,hive2,hive3,iceberg,iceberg-rest,hudi,trino,kafka,mariadb,db2,oceanbase,lakesoul,kerberos,ranger,polaris
@@ -50,6 +51,7 @@ HELP=0
 STOP=0
 NEED_RESERVE_PORTS=0
 export NEED_LOAD_DATA=1
+export LOAD_PARALLEL=$(( $(getconf _NPROCESSORS_ONLN) / 2 ))
 
 if ! OPTS="$(getopt \
     -n "$0" \
@@ -58,6 +60,7 @@ if ! OPTS="$(getopt \
     -l 'stop' \
     -l 'reserve-ports' \
     -l 'no-load-data' \
+    -l 'load-parallel:' \
     -o 'hc:' \
     -- "$@")"; then
     usage
@@ -94,6 +97,10 @@ else
         --no-load-data)
             export NEED_LOAD_DATA=0
             shift
+            ;;
+        --load-parallel)
+            export LOAD_PARALLEL=$2
+            shift 2
             ;;
         --)
             shift
@@ -380,19 +387,6 @@ start_hive2() {
         exit -1
     fi
     # before start it, you need to download parquet file package, see "README" in "docker-compose/hive/scripts/"
-    sed -i "s/s3Endpoint/${s3Endpoint}/g" "${ROOT}"/docker-compose/hive/scripts/hive-metastore.sh
-    sed -i "s/s3BucketName/${s3BucketName}/g" "${ROOT}"/docker-compose/hive/scripts/hive-metastore.sh
-
-    # sed all s3 info in run.sh of each suite
-    find "${ROOT}/docker-compose/hive/scripts/data/" -type f -name "run.sh" | while read -r file; do
-        if [ -f "$file" ]; then
-            echo "Processing $file"
-            sed -i "s/s3Endpoint/${s3Endpoint}/g" "${file}"
-            sed -i "s/s3BucketName/${s3BucketName}/g" "${file}"
-        else
-            echo "File not found: $file"
-        fi
-    done
 
     # generate hive-2x.yaml
     export IP_HOST=${IP_HOST}
@@ -419,20 +413,7 @@ start_hive3() {
         exit -1
     fi
     # before start it, you need to download parquet file package, see "README" in "docker-compose/hive/scripts/"
-    sed -i "s/s3Endpoint/${s3Endpoint}/g" "${ROOT}"/docker-compose/hive/scripts/hive-metastore.sh
-    sed -i "s/s3BucketName/${s3BucketName}/g" "${ROOT}"/docker-compose/hive/scripts/hive-metastore.sh
-
-    # sed all s3 info in run.sh of each suite
-    find "${ROOT}/docker-compose/hive/scripts/data" -type f -name "run.sh" | while read -r file; do
-        if [ -f "$file" ]; then
-            echo "Processing $file"
-            sed -i "s/s3Endpoint/${s3Endpoint}/g" "${file}"
-            sed -i "s/s3BucketName/${s3BucketName}/g" "${file}"
-        else
-            echo "File not found: $file"
-        fi
-    done
-
+    
     # generate hive-3x.yaml
     export IP_HOST=${IP_HOST}
     export CONTAINER_UID=${CONTAINER_UID}
@@ -719,6 +700,19 @@ echo "starting dockers in parallel"
 
 reserve_ports
 
+# Ensure hive data is downloaded before starting hive2/hive3, but only once
+need_download_hive_data=0
+if [[ "$NEED_LOAD_DATA" -eq 1 ]]; then
+    if [[ "${RUN_HIVE2}" -eq 1 ]] || [[ "${RUN_HIVE3}" -eq 1 ]]; then
+        need_download_hive_data=1
+    fi
+fi
+
+if [[ $need_download_hive_data -eq 1 ]]; then
+    echo "download hive2/hive3 data"
+    bash "${ROOT}/docker-compose/hive/scripts/download-hive-data.sh"
+fi
+
 declare -A pids
 
 if [[ "${RUN_ES}" -eq 1 ]]; then
@@ -830,7 +824,6 @@ if [[ "${RUN_RANGER}" -eq 1 ]]; then
     start_ranger > start_ranger.log 2>&1 &
     pids["ranger"]=$!
 fi
-
 echo "waiting all dockers starting done"
 
 for compose in "${!pids[@]}"; do

--- a/docker/thirdparties/run-thirdparties-docker.sh
+++ b/docker/thirdparties/run-thirdparties-docker.sh
@@ -701,16 +701,16 @@ echo "starting dockers in parallel"
 reserve_ports
 
 # Ensure hive data is downloaded before starting hive2/hive3, but only once
-need_download_hive_data=0
+need_prepare_hive_data=0
 if [[ "$NEED_LOAD_DATA" -eq 1 ]]; then
     if [[ "${RUN_HIVE2}" -eq 1 ]] || [[ "${RUN_HIVE3}" -eq 1 ]]; then
-        need_download_hive_data=1
+        need_prepare_hive_data=1
     fi
 fi
 
-if [[ $need_download_hive_data -eq 1 ]]; then
-    echo "download hive2/hive3 data"
-    bash "${ROOT}/docker-compose/hive/scripts/download-hive-data.sh"
+if [[ $need_prepare_hive_data -eq 1 ]]; then
+    echo "prepare hive2/hive3 data"
+    bash "${ROOT}/docker-compose/hive/scripts/prepare-hive-data.sh"
 fi
 
 declare -A pids


### PR DESCRIPTION
### What problem does this PR solve?
1. Optimize  hive docker scripts to make them more robust and readable.
2. Increase the heap size for Hive and Hadoop to prevent task failures caused by OutOfMemoryErrors.
3. Increase maxattempts for map and reduce to improve task success rate.
4. Move the Hadoop JAR files from the auxlib directory to the lib directory to prevent them from being copied to the local temporary directory when running tasks in local mode.In order to enhance performance and work around a bug in Hadoop 2.1.
5. Add the `load-parallel` flag to control the parallel number of preparing test data.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

