### PR TITLE
[fix](es) Fix array not supporting json subtype

### DIFF
--- a/be/src/exec/es/es_scroll_parser.cpp
+++ b/be/src/exec/es/es_scroll_parser.cpp
@@ -527,6 +527,24 @@ Status process_date_column(const rapidjson::Value& col, PrimitiveType sub_type, 
     return Status::OK();
 }
 
+Status process_jsonb_column(const rapidjson::Value& col, PrimitiveType sub_type,
+                            bool pure_doc_value, vectorized::Array& array) {
+    if (!col.IsArray()) {
+        JsonBinaryValue jsonb_value;
+        RETURN_IF_ERROR(jsonb_value.from_json_string(json_value_to_string(col)));
+        vectorized::JsonbField json(jsonb_value.value(), jsonb_value.size());
+        array.push_back(vectorized::Field::create_field<TYPE_JSONB>(json));
+    } else {
+        for (const auto& sub_col : col.GetArray()) {
+            JsonBinaryValue jsonb_value;
+            RETURN_IF_ERROR(jsonb_value.from_json_string(json_value_to_string(sub_col)));
+            vectorized::JsonbField json(jsonb_value.value(), jsonb_value.size());
+            array.push_back(vectorized::Field::create_field<TYPE_JSONB>(json));
+        }
+    }
+    return Status::OK();
+}
+
 Status ScrollParser::parse_column(const rapidjson::Value& col, PrimitiveType sub_type,
                                   bool pure_doc_value, vectorized::Array& array,
                                   const cctz::time_zone& time_zone) {
@@ -560,6 +578,9 @@ Status ScrollParser::parse_column(const rapidjson::Value& col, PrimitiveType sub
     case TYPE_DATETIMEV2: {
         return process_date_column<TYPE_DATETIMEV2>(col, sub_type, pure_doc_value, array,
                                                     time_zone);
+    }
+    case TYPE_JSONB: {
+        return process_jsonb_column(col, sub_type, pure_doc_value, array);
     }
     default:
         LOG(ERROR) << "Do not support Array type: " << sub_type;

--- a/docker/thirdparties/docker-compose/elasticsearch/scripts/data/composite_type_array_bulk.json
+++ b/docker/thirdparties/docker-compose/elasticsearch/scripts/data/composite_type_array_bulk.json
@@ -1,10 +1,10 @@
-{"name": "Andy", "sports": "soccer", "scores": 100}
-{"name": "Betty", "sports": "pingpong ball", "scores": 90}
-{"name": "Cindy", "sports": "武术", "scores": 89}
-{"name": "David", "sports": ["volleyball"], "scores": [77]}
-{"name": "Emily", "sports": ["baseball", "golf", "hockey"], "scores": [56, 78, 99]}
-{"name": "Frank", "sports": ["rugby", "cricket", "boxing"], "scores": [45, 67, 88]}
-{"name": "Grace", "sports": ["table tennis", "badminton", "athletics"], "scores": [34, 56, 78]}
-{"name": "Henry", "sports": ["archery", "fencing", "weightlifting"], "scores": [23, 45, 67]}
-{"name": "Ivy", "sports": ["judo", "karate", "taekwondo"], "scores": [12, 34, 56]}
-{"name": "Jack", "sports": ["wrestling", "gymnastics", "surfing"], "scores": [1, 23, 45]}
+{"name": "Andy", "sports": "soccer", "scores": 100, "z_details": [{"position": "forward", "club": "Manchester", "salary": 50000}]}
+{"name": "Betty", "sports": "pingpong ball", "scores": 90, "z_details": [{"position": "attacker", "club": "Beijing", "salary": 30000}]}
+{"name": "Cindy", "sports": "武术", "scores": 89, "z_details": [{"position": "fighter", "club": "Shaolin", "salary": 25000}]}
+{"name": "David", "sports": ["volleyball"], "scores": [77], "z_details": [{"position": "spiker", "club": "Tokyo", "salary": 40000}]}
+{"name": "Emily", "sports": ["baseball", "golf", "hockey"], "scores": [56, 78, 99], "z_details": [{"position": "pitcher", "club": "Yankees", "salary": 80000}, {"position": "driver", "club": "PGA", "salary": 120000}, {"position": "center", "club": "Rangers", "salary": 90000}]}
+{"name": "Frank", "sports": ["rugby", "cricket", "boxing"], "scores": [45, 67, 88], "z_details": [{"position": "scrum-half", "club": "Leicester", "salary": 60000}, {"position": "batsman", "club": "Mumbai", "salary": 70000}, {"position": "heavyweight", "club": "Vegas", "salary": 150000}]}
+{"name": "Grace", "sports": ["table tennis", "badminton", "athletics"], "scores": [34, 56, 78], "z_details": [{"position": "attacker", "club": "China", "salary": 35000}, {"position": "singles", "club": "Denmark", "salary": 45000}, {"position": "sprinter", "club": "Jamaica", "salary": 85000}]}
+{"name": "Henry", "sports": ["archery", "fencing", "weightlifting"], "scores": [23, 45, 67], "z_details": [{"position": "recurve", "club": "Korea", "salary": 20000}, {"position": "epee", "club": "France", "salary": 30000}, {"position": "heavyweight", "club": "Bulgaria", "salary": 55000}]}
+{"name": "Ivy", "sports": ["judo", "karate", "taekwondo"], "scores": [12, 34, 56], "z_details": [{"position": "lightweight", "club": "Japan", "salary": 25000}, {"position": "kata", "club": "Okinawa", "salary": 22000}, {"position": "middleweight", "club": "Korea", "salary": 28000}]}
+{"name": "Jack", "sports": ["wrestling", "gymnastics", "surfing"], "scores": [1, 23, 45], "z_details": [{"position": "freestyle", "club": "Russia", "salary": 15000}, {"position": "rings", "club": "Romania", "salary": 35000}, {"position": "longboard", "club": "Hawaii", "salary": 50000}]}

--- a/docker/thirdparties/docker-compose/elasticsearch/scripts/index/array_meta_composite_type_array.json
+++ b/docker/thirdparties/docker-compose/elasticsearch/scripts/index/array_meta_composite_type_array.json
@@ -3,7 +3,8 @@
     "doris":{
       "array_fields":[
         "sports",
-        "scores"
+        "scores",
+        "z_details"
       ]
     }
   }

--- a/docker/thirdparties/docker-compose/elasticsearch/scripts/index/es6_composite_type_array.json
+++ b/docker/thirdparties/docker-compose/elasticsearch/scripts/index/es6_composite_type_array.json
@@ -8,7 +8,15 @@
       "properties": {
         "name": { "type": "keyword" },
         "sports": { "type": "keyword", "doc_values": false},
-        "scores": { "type": "integer", "doc_values": false}
+        "scores": { "type": "integer", "doc_values": false},
+        "z_details": {
+          "type": "object",
+          "properties": {
+            "position": { "type": "keyword" },
+            "club": { "type": "keyword" },
+            "salary": { "type": "integer" }
+          }
+        }
       }
     }
   }

--- a/docker/thirdparties/docker-compose/elasticsearch/scripts/index/es7_composite_type_array.json
+++ b/docker/thirdparties/docker-compose/elasticsearch/scripts/index/es7_composite_type_array.json
@@ -7,7 +7,15 @@
     "properties": {
       "name": { "type": "keyword" },
       "sports": { "type": "keyword", "doc_values": false},
-      "scores": { "type": "integer", "doc_values": false}
+      "scores": { "type": "integer", "doc_values": false},
+      "z_details": {
+        "type": "object",
+        "properties": {
+          "position": { "type": "keyword" },
+          "club": { "type": "keyword" },
+          "salary": { "type": "integer" }
+        }
+      }
     }
   }
 }

--- a/regression-test/data/external_table_p0/es/test_es_query.out
+++ b/regression-test/data/external_table_p0/es/test_es_query.out
@@ -64,9 +64,6 @@ text_ignore_above_10
 4444
 4444
 
--- !sql20 --
-["2020-01-01 12:00:00", "2020-01-02 13:01:01"]	[-1, 0, 1, 2]	[0, 1, 2, 3]	["d", "e", "f"]	[128, 129, -129, -130]	["192.168.0.1", "127.0.0.1"]	string1	[1, 2, 3, 4]	2022-08-08	2022-08-08T12:10:10	text#1	["2020-01-01", "2020-01-02"]	3.14	[1, 2, 3, 4]	[1, 1.1, 1.2, 1.3]	[1, 2, 3, 4]	["a", "b", "c"]	[{"name":"Andy","age":18},{"name":"Tim","age":28}]	2022-08-08T12:10:10	2022-08-08T12:10:10	2022-08-08T20:10:10	12345	[1, -2, -3, 4]	[1, 0, 1, 1]	[32768, 32769, -32769, -32770]	[{"last":"Smith","first":"John"},{"last":"White","first":"Alice"}]
-
 -- !sql21 --
 ["2020-01-01 12:00:00", "2020-01-02 13:01:01"]	[-1, 0, 1, 2]	[0, 1, 2, 3]	["d", "e", "f"]	[128, 129, -129, -130]	["192.168.0.1", "127.0.0.1"]	string1	[1, 2, 3, 4]	2022-08-08	2022-08-08T12:10:10	text#1	["2020-01-01", "2020-01-02"]	3.14	[1, 2, 3, 4]	[1, 1.1, 1.2, 1.3]	[1, 2, 3, 4]	["a", "b", "c"]	[{"name":"Andy","age":18},{"name":"Tim","age":28}]	2022-08-08T12:10:10	2022-08-08T12:10:10	2022-08-08T20:10:10	12345	[1, -2, -3, 4]	[1, 0, 1, 1]	[32768, 32769, -32769, -32770]	[{"last":"Smith","first":"John"},{"last":"White","first":"Alice"}]
 
@@ -221,15 +218,15 @@ text_ignore_above_10
 2022-08-08T20:10:10
 
 -- !sql_5_27 --
-Andy	[100]	["soccer"]
-Betty	[90]	["pingpong ball"]
-Cindy	[89]	["武术"]
-David	[77]	["volleyball"]
-Emily	[56, 78, 99]	["baseball", "golf", "hockey"]
-Frank	[45, 67, 88]	["rugby", "cricket", "boxing"]
-Grace	[34, 56, 78]	["table tennis", "badminton", "athletics"]
-Henry	[23, 45, 67]	["archery", "fencing", "weightlifting"]
-Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]
+Andy	[100]	["soccer"]	["{"club":"Manchester","position":"forward","salary":50000}"]
+Betty	[90]	["pingpong ball"]	["{"club":"Beijing","position":"attacker","salary":30000}"]
+Cindy	[89]	["武术"]	["{"club":"Shaolin","position":"fighter","salary":25000}"]
+David	[77]	["volleyball"]	["{"club":"Tokyo","position":"spiker","salary":40000}"]
+Emily	[56, 78, 99]	["baseball", "golf", "hockey"]	["{"club":"Yankees","position":"pitcher","salary":80000}", "{"club":"PGA","position":"driver","salary":120000}", "{"club":"Rangers","position":"center","salary":90000}"]
+Frank	[45, 67, 88]	["rugby", "cricket", "boxing"]	["{"club":"Leicester","position":"scrum-half","salary":60000}", "{"club":"Mumbai","position":"batsman","salary":70000}", "{"club":"Vegas","position":"heavyweight","salary":150000}"]
+Grace	[34, 56, 78]	["table tennis", "badminton", "athletics"]	["{"club":"China","position":"attacker","salary":35000}", "{"club":"Denmark","position":"singles","salary":45000}", "{"club":"Jamaica","position":"sprinter","salary":85000}"]
+Henry	[23, 45, 67]	["archery", "fencing", "weightlifting"]	["{"club":"Korea","position":"recurve","salary":20000}", "{"club":"France","position":"epee","salary":30000}", "{"club":"Bulgaria","position":"heavyweight","salary":55000}"]
+Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]	["{"club":"Japan","position":"lightweight","salary":25000}", "{"club":"Okinawa","position":"kata","salary":22000}", "{"club":"Korea","position":"middleweight","salary":28000}"]
 
 -- !sql_5_28 --
 value1	value2
@@ -375,15 +372,15 @@ text_ignore_above_10
 2022-08-08T20:10:10
 
 -- !sql_6_27 --
-Andy	[100]	["soccer"]
-Betty	[90]	["pingpong ball"]
-Cindy	[89]	["武术"]
-David	[77]	["volleyball"]
-Emily	[56, 78, 99]	["baseball", "golf", "hockey"]
-Frank	[45, 67, 88]	["rugby", "cricket", "boxing"]
-Grace	[34, 56, 78]	["table tennis", "badminton", "athletics"]
-Henry	[23, 45, 67]	["archery", "fencing", "weightlifting"]
-Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]
+Andy	[100]	["soccer"]	["{"club":"Manchester","position":"forward","salary":50000}"]
+Betty	[90]	["pingpong ball"]	["{"club":"Beijing","position":"attacker","salary":30000}"]
+Cindy	[89]	["武术"]	["{"club":"Shaolin","position":"fighter","salary":25000}"]
+David	[77]	["volleyball"]	["{"club":"Tokyo","position":"spiker","salary":40000}"]
+Emily	[56, 78, 99]	["baseball", "golf", "hockey"]	["{"club":"Yankees","position":"pitcher","salary":80000}", "{"club":"PGA","position":"driver","salary":120000}", "{"club":"Rangers","position":"center","salary":90000}"]
+Frank	[45, 67, 88]	["rugby", "cricket", "boxing"]	["{"club":"Leicester","position":"scrum-half","salary":60000}", "{"club":"Mumbai","position":"batsman","salary":70000}", "{"club":"Vegas","position":"heavyweight","salary":150000}"]
+Grace	[34, 56, 78]	["table tennis", "badminton", "athletics"]	["{"club":"China","position":"attacker","salary":35000}", "{"club":"Denmark","position":"singles","salary":45000}", "{"club":"Jamaica","position":"sprinter","salary":85000}"]
+Henry	[23, 45, 67]	["archery", "fencing", "weightlifting"]	["{"club":"Korea","position":"recurve","salary":20000}", "{"club":"France","position":"epee","salary":30000}", "{"club":"Bulgaria","position":"heavyweight","salary":55000}"]
+Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]	["{"club":"Japan","position":"lightweight","salary":25000}", "{"club":"Okinawa","position":"kata","salary":22000}", "{"club":"Korea","position":"middleweight","salary":28000}"]
 
 -- !sql_6_28 --
 value1	value2
@@ -571,15 +568,15 @@ text_ignore_above_10
 1660191010000
 
 -- !sql_7_34 --
-Andy	[100]	["soccer"]
-Betty	[90]	["pingpong ball"]
-Cindy	[89]	["武术"]
-David	[77]	["volleyball"]
-Emily	[56, 78, 99]	["baseball", "golf", "hockey"]
-Frank	[45, 67, 88]	["rugby", "cricket", "boxing"]
-Grace	[34, 56, 78]	["table tennis", "badminton", "athletics"]
-Henry	[23, 45, 67]	["archery", "fencing", "weightlifting"]
-Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]
+Andy	[100]	["soccer"]	["{"club":"Manchester","position":"forward","salary":50000}"]
+Betty	[90]	["pingpong ball"]	["{"club":"Beijing","position":"attacker","salary":30000}"]
+Cindy	[89]	["武术"]	["{"club":"Shaolin","position":"fighter","salary":25000}"]
+David	[77]	["volleyball"]	["{"club":"Tokyo","position":"spiker","salary":40000}"]
+Emily	[56, 78, 99]	["baseball", "golf", "hockey"]	["{"club":"Yankees","position":"pitcher","salary":80000}", "{"club":"PGA","position":"driver","salary":120000}", "{"club":"Rangers","position":"center","salary":90000}"]
+Frank	[45, 67, 88]	["rugby", "cricket", "boxing"]	["{"club":"Leicester","position":"scrum-half","salary":60000}", "{"club":"Mumbai","position":"batsman","salary":70000}", "{"club":"Vegas","position":"heavyweight","salary":150000}"]
+Grace	[34, 56, 78]	["table tennis", "badminton", "athletics"]	["{"club":"China","position":"attacker","salary":35000}", "{"club":"Denmark","position":"singles","salary":45000}", "{"club":"Jamaica","position":"sprinter","salary":85000}"]
+Henry	[23, 45, 67]	["archery", "fencing", "weightlifting"]	["{"club":"Korea","position":"recurve","salary":20000}", "{"club":"France","position":"epee","salary":30000}", "{"club":"Bulgaria","position":"heavyweight","salary":55000}"]
+Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]	["{"club":"Japan","position":"lightweight","salary":25000}", "{"club":"Okinawa","position":"kata","salary":22000}", "{"club":"Korea","position":"middleweight","salary":28000}"]
 
 -- !sql_7_35 --
 string1	text#1
@@ -769,15 +766,15 @@ text_ignore_above_10
 1660191010000
 
 -- !sql_8_32 --
-Andy	[100]	["soccer"]
-Betty	[90]	["pingpong ball"]
-Cindy	[89]	["武术"]
-David	[77]	["volleyball"]
-Emily	[56, 78, 99]	["baseball", "golf", "hockey"]
-Frank	[45, 67, 88]	["rugby", "cricket", "boxing"]
-Grace	[34, 56, 78]	["table tennis", "badminton", "athletics"]
-Henry	[23, 45, 67]	["archery", "fencing", "weightlifting"]
-Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]
+Andy	[100]	["soccer"]	["{"club":"Manchester","position":"forward","salary":50000}"]
+Betty	[90]	["pingpong ball"]	["{"club":"Beijing","position":"attacker","salary":30000}"]
+Cindy	[89]	["武术"]	["{"club":"Shaolin","position":"fighter","salary":25000}"]
+David	[77]	["volleyball"]	["{"club":"Tokyo","position":"spiker","salary":40000}"]
+Emily	[56, 78, 99]	["baseball", "golf", "hockey"]	["{"club":"Yankees","position":"pitcher","salary":80000}", "{"club":"PGA","position":"driver","salary":120000}", "{"club":"Rangers","position":"center","salary":90000}"]
+Frank	[45, 67, 88]	["rugby", "cricket", "boxing"]	["{"club":"Leicester","position":"scrum-half","salary":60000}", "{"club":"Mumbai","position":"batsman","salary":70000}", "{"club":"Vegas","position":"heavyweight","salary":150000}"]
+Grace	[34, 56, 78]	["table tennis", "badminton", "athletics"]	["{"club":"China","position":"attacker","salary":35000}", "{"club":"Denmark","position":"singles","salary":45000}", "{"club":"Jamaica","position":"sprinter","salary":85000}"]
+Henry	[23, 45, 67]	["archery", "fencing", "weightlifting"]	["{"club":"Korea","position":"recurve","salary":20000}", "{"club":"France","position":"epee","salary":30000}", "{"club":"Bulgaria","position":"heavyweight","salary":55000}"]
+Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]	["{"club":"Japan","position":"lightweight","salary":25000}", "{"club":"Okinawa","position":"kata","salary":22000}", "{"club":"Korea","position":"middleweight","salary":28000}"]
 
 -- !sql_8_33 --
 string1	text#1
@@ -874,9 +871,6 @@ text_ignore_above_10
 4444
 4444
 
--- !sql20 --
-["2020-01-01 12:00:00", "2020-01-02 13:01:01"]	[-1, 0, 1, 2]	[0, 1, 2, 3]	["d", "e", "f"]	[128, 129, -129, -130]	["192.168.0.1", "127.0.0.1"]	string1	[1, 2, 3, 4]	2022-08-08	2022-08-08T12:10:10	text#1	["2020-01-01", "2020-01-02"]	3.14	[1, 2, 3, 4]	[1, 1.1, 1.2, 1.3]	[1, 2, 3, 4]	["a", "b", "c"]	[{"name":"Andy","age":18},{"name":"Tim","age":28}]	2022-08-08T12:10:10	2022-08-08T12:10:10	2022-08-08T20:10:10	12345	[1, -2, -3, 4]	[1, 0, 1, 1]	[32768, 32769, -32769, -32770]	[{"last":"Smith","first":"John"},{"last":"White","first":"Alice"}]
-
 -- !sql21 --
 ["2020-01-01 12:00:00", "2020-01-02 13:01:01"]	[-1, 0, 1, 2]	[0, 1, 2, 3]	["d", "e", "f"]	[128, 129, -129, -130]	["192.168.0.1", "127.0.0.1"]	string1	[1, 2, 3, 4]	2022-08-08	2022-08-08T12:10:10	text#1	["2020-01-01", "2020-01-02"]	3.14	[1, 2, 3, 4]	[1, 1.1, 1.2, 1.3]	[1, 2, 3, 4]	["a", "b", "c"]	[{"name":"Andy","age":18},{"name":"Tim","age":28}]	2022-08-08T12:10:10	2022-08-08T12:10:10	2022-08-08T20:10:10	12345	[1, -2, -3, 4]	[1, 0, 1, 1]	[32768, 32769, -32769, -32770]	[{"last":"Smith","first":"John"},{"last":"White","first":"Alice"}]
 
@@ -1031,15 +1025,15 @@ text_ignore_above_10
 2022-08-08T20:10:10
 
 -- !sql_5_27 --
-Andy	[100]	["soccer"]
-Betty	[90]	["pingpong ball"]
-Cindy	[89]	["武术"]
-David	[77]	["volleyball"]
-Emily	[56, 78, 99]	["baseball", "golf", "hockey"]
-Frank	[45, 67, 88]	["rugby", "cricket", "boxing"]
-Grace	[34, 56, 78]	["table tennis", "badminton", "athletics"]
-Henry	[23, 45, 67]	["archery", "fencing", "weightlifting"]
-Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]
+Andy	[100]	["soccer"]	["{"club":"Manchester","position":"forward","salary":50000}"]
+Betty	[90]	["pingpong ball"]	["{"club":"Beijing","position":"attacker","salary":30000}"]
+Cindy	[89]	["武术"]	["{"club":"Shaolin","position":"fighter","salary":25000}"]
+David	[77]	["volleyball"]	["{"club":"Tokyo","position":"spiker","salary":40000}"]
+Emily	[56, 78, 99]	["baseball", "golf", "hockey"]	["{"club":"Yankees","position":"pitcher","salary":80000}", "{"club":"PGA","position":"driver","salary":120000}", "{"club":"Rangers","position":"center","salary":90000}"]
+Frank	[45, 67, 88]	["rugby", "cricket", "boxing"]	["{"club":"Leicester","position":"scrum-half","salary":60000}", "{"club":"Mumbai","position":"batsman","salary":70000}", "{"club":"Vegas","position":"heavyweight","salary":150000}"]
+Grace	[34, 56, 78]	["table tennis", "badminton", "athletics"]	["{"club":"China","position":"attacker","salary":35000}", "{"club":"Denmark","position":"singles","salary":45000}", "{"club":"Jamaica","position":"sprinter","salary":85000}"]
+Henry	[23, 45, 67]	["archery", "fencing", "weightlifting"]	["{"club":"Korea","position":"recurve","salary":20000}", "{"club":"France","position":"epee","salary":30000}", "{"club":"Bulgaria","position":"heavyweight","salary":55000}"]
+Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]	["{"club":"Japan","position":"lightweight","salary":25000}", "{"club":"Okinawa","position":"kata","salary":22000}", "{"club":"Korea","position":"middleweight","salary":28000}"]
 
 -- !sql_5_28 --
 value1	value2
@@ -1185,15 +1179,15 @@ text_ignore_above_10
 2022-08-08T20:10:10
 
 -- !sql_6_27 --
-Andy	[100]	["soccer"]
-Betty	[90]	["pingpong ball"]
-Cindy	[89]	["武术"]
-David	[77]	["volleyball"]
-Emily	[56, 78, 99]	["baseball", "golf", "hockey"]
-Frank	[45, 67, 88]	["rugby", "cricket", "boxing"]
-Grace	[34, 56, 78]	["table tennis", "badminton", "athletics"]
-Henry	[23, 45, 67]	["archery", "fencing", "weightlifting"]
-Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]
+Andy	[100]	["soccer"]	["{"club":"Manchester","position":"forward","salary":50000}"]
+Betty	[90]	["pingpong ball"]	["{"club":"Beijing","position":"attacker","salary":30000}"]
+Cindy	[89]	["武术"]	["{"club":"Shaolin","position":"fighter","salary":25000}"]
+David	[77]	["volleyball"]	["{"club":"Tokyo","position":"spiker","salary":40000}"]
+Emily	[56, 78, 99]	["baseball", "golf", "hockey"]	["{"club":"Yankees","position":"pitcher","salary":80000}", "{"club":"PGA","position":"driver","salary":120000}", "{"club":"Rangers","position":"center","salary":90000}"]
+Frank	[45, 67, 88]	["rugby", "cricket", "boxing"]	["{"club":"Leicester","position":"scrum-half","salary":60000}", "{"club":"Mumbai","position":"batsman","salary":70000}", "{"club":"Vegas","position":"heavyweight","salary":150000}"]
+Grace	[34, 56, 78]	["table tennis", "badminton", "athletics"]	["{"club":"China","position":"attacker","salary":35000}", "{"club":"Denmark","position":"singles","salary":45000}", "{"club":"Jamaica","position":"sprinter","salary":85000}"]
+Henry	[23, 45, 67]	["archery", "fencing", "weightlifting"]	["{"club":"Korea","position":"recurve","salary":20000}", "{"club":"France","position":"epee","salary":30000}", "{"club":"Bulgaria","position":"heavyweight","salary":55000}"]
+Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]	["{"club":"Japan","position":"lightweight","salary":25000}", "{"club":"Okinawa","position":"kata","salary":22000}", "{"club":"Korea","position":"middleweight","salary":28000}"]
 
 -- !sql_6_28 --
 value1	value2
@@ -1381,15 +1375,15 @@ text_ignore_above_10
 1660191010000
 
 -- !sql_7_34 --
-Andy	[100]	["soccer"]
-Betty	[90]	["pingpong ball"]
-Cindy	[89]	["武术"]
-David	[77]	["volleyball"]
-Emily	[56, 78, 99]	["baseball", "golf", "hockey"]
-Frank	[45, 67, 88]	["rugby", "cricket", "boxing"]
-Grace	[34, 56, 78]	["table tennis", "badminton", "athletics"]
-Henry	[23, 45, 67]	["archery", "fencing", "weightlifting"]
-Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]
+Andy	[100]	["soccer"]	["{"club":"Manchester","position":"forward","salary":50000}"]
+Betty	[90]	["pingpong ball"]	["{"club":"Beijing","position":"attacker","salary":30000}"]
+Cindy	[89]	["武术"]	["{"club":"Shaolin","position":"fighter","salary":25000}"]
+David	[77]	["volleyball"]	["{"club":"Tokyo","position":"spiker","salary":40000}"]
+Emily	[56, 78, 99]	["baseball", "golf", "hockey"]	["{"club":"Yankees","position":"pitcher","salary":80000}", "{"club":"PGA","position":"driver","salary":120000}", "{"club":"Rangers","position":"center","salary":90000}"]
+Frank	[45, 67, 88]	["rugby", "cricket", "boxing"]	["{"club":"Leicester","position":"scrum-half","salary":60000}", "{"club":"Mumbai","position":"batsman","salary":70000}", "{"club":"Vegas","position":"heavyweight","salary":150000}"]
+Grace	[34, 56, 78]	["table tennis", "badminton", "athletics"]	["{"club":"China","position":"attacker","salary":35000}", "{"club":"Denmark","position":"singles","salary":45000}", "{"club":"Jamaica","position":"sprinter","salary":85000}"]
+Henry	[23, 45, 67]	["archery", "fencing", "weightlifting"]	["{"club":"Korea","position":"recurve","salary":20000}", "{"club":"France","position":"epee","salary":30000}", "{"club":"Bulgaria","position":"heavyweight","salary":55000}"]
+Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]	["{"club":"Japan","position":"lightweight","salary":25000}", "{"club":"Okinawa","position":"kata","salary":22000}", "{"club":"Korea","position":"middleweight","salary":28000}"]
 
 -- !sql_7_35 --
 string1	text#1
@@ -1579,15 +1573,15 @@ text_ignore_above_10
 1660191010000
 
 -- !sql_8_32 --
-Andy	[100]	["soccer"]
-Betty	[90]	["pingpong ball"]
-Cindy	[89]	["武术"]
-David	[77]	["volleyball"]
-Emily	[56, 78, 99]	["baseball", "golf", "hockey"]
-Frank	[45, 67, 88]	["rugby", "cricket", "boxing"]
-Grace	[34, 56, 78]	["table tennis", "badminton", "athletics"]
-Henry	[23, 45, 67]	["archery", "fencing", "weightlifting"]
-Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]
+Andy	[100]	["soccer"]	["{"club":"Manchester","position":"forward","salary":50000}"]
+Betty	[90]	["pingpong ball"]	["{"club":"Beijing","position":"attacker","salary":30000}"]
+Cindy	[89]	["武术"]	["{"club":"Shaolin","position":"fighter","salary":25000}"]
+David	[77]	["volleyball"]	["{"club":"Tokyo","position":"spiker","salary":40000}"]
+Emily	[56, 78, 99]	["baseball", "golf", "hockey"]	["{"club":"Yankees","position":"pitcher","salary":80000}", "{"club":"PGA","position":"driver","salary":120000}", "{"club":"Rangers","position":"center","salary":90000}"]
+Frank	[45, 67, 88]	["rugby", "cricket", "boxing"]	["{"club":"Leicester","position":"scrum-half","salary":60000}", "{"club":"Mumbai","position":"batsman","salary":70000}", "{"club":"Vegas","position":"heavyweight","salary":150000}"]
+Grace	[34, 56, 78]	["table tennis", "badminton", "athletics"]	["{"club":"China","position":"attacker","salary":35000}", "{"club":"Denmark","position":"singles","salary":45000}", "{"club":"Jamaica","position":"sprinter","salary":85000}"]
+Henry	[23, 45, 67]	["archery", "fencing", "weightlifting"]	["{"club":"Korea","position":"recurve","salary":20000}", "{"club":"France","position":"epee","salary":30000}", "{"club":"Bulgaria","position":"heavyweight","salary":55000}"]
+Ivy	[12, 34, 56]	["judo", "karate", "taekwondo"]	["{"club":"Japan","position":"lightweight","salary":25000}", "{"club":"Okinawa","position":"kata","salary":22000}", "{"club":"Korea","position":"middleweight","salary":28000}"]
 
 -- !sql_8_33 --
 string1	text#1


### PR DESCRIPTION
An issue introduced by https://github.com/apache/doris/pull/40614, which omitted handling of json subtypes when parsing single value for array column.