### PR TITLE
[fix](iceberg) Add missing iceberg-aws dependency to metadata scanner

### DIFF
--- a/fe/be-java-extensions/iceberg-metadata-scanner/pom.xml
+++ b/fe/be-java-extensions/iceberg-metadata-scanner/pom.xml
@@ -53,6 +53,11 @@ under the License.
             <version>${iceberg.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-aws</artifactId>
+            <version>${iceberg.version}</version>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>auth</artifactId>
             <version>${awssdk.version}</version>


### PR DESCRIPTION
  ## Issue
  Fixed `NoSuchMethodException` when accessing S3-based Iceberg tables:
  - `Cannot create org.apache.iceberg.aws.ApacheHttpClientConfigurations`
  - Missing `ApacheHttpClientConfigurations.create` method

  ## Root Cause
  The `iceberg-metadata-scanner` module was missing the `iceberg-aws` dependency, causing runtime failures when accessing S3 storage.

  ## Solution
  Added `iceberg-aws` dependency to `iceberg-metadata-scanner/pom.xml`

  ## Why This Issue Is Not Always Reproducible
  This is a **classpath race condition** that only occurs under specific circumstances:

  1. **Environment Dependency**: Only affects deployments where `preload-extensions` module is not loaded or `iceberg-aws` classes are not in runtime classpath
  2. **ClassLoader Isolation**: Error depends on module loading order:
     - ✅ `preload-extensions` loads first → classes available → no error
     - ❌ `iceberg-metadata-scanner` loads first → classes missing → error occurs
  3. **Storage Backend Dependency**: Only triggers when accessing S3-based Iceberg tables (not HDFS/local files)
  4. **Runtime Loading Order**: Depends on which module's ClassLoader gets `ApacheHttpClientConfigurations` first