### PR TITLE
[enhancement](recycle bin) optimize the recycle bin to reduce the potential of FE hang

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -35,12 +35,10 @@ import org.apache.doris.thrift.TStorageMedium;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
-import com.google.common.collect.Table.Cell;
 import com.google.gson.annotations.SerializedName;
 import org.apache.commons.lang3.time.StopWatch;
 import org.apache.logging.log4j.LogManager;
@@ -55,6 +53,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -69,6 +68,16 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
     private Map<Long, RecycleTableInfo> idToTable;
     private Map<Long, RecyclePartitionInfo> idToPartition;
     private Map<Long, Long> idToRecycleTime;
+
+    // Caches below to avoid calculate meta with same name every demon run cycle.
+    // When the meta is updated, these caches should be updated too. No need to
+    // persist these caches because they can be recalculated when FE restarting.
+    // String:<DbName> -> Set:<Db Ids with same name>
+    Map<String, Set<Long>> dbNameToIds = new ConcurrentHashMap<>();
+    // (DbId, TableName) -> Set:<Table Ids with same name>
+    Map<Pair<Long, String>, Set<Long>> dbIdTableNameToIds = new ConcurrentHashMap<>();
+    // (DbId, TblId) -> (PartitionName -> Set:<Partition Ids with same name>)
+    Map<Pair<Long, Long>, Map<String, Set<Long>>> dbTblIdPartitionNameToIds = new ConcurrentHashMap<>();
 
     // for compatible in the future
     @SerializedName("u")
@@ -158,6 +167,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             recycleTime = replayRecycleTime;
         }
         idToRecycleTime.put(db.getId(), recycleTime);
+        dbNameToIds.computeIfAbsent(db.getFullName(), k -> ConcurrentHashMap.newKeySet()).add(db.getId());
         LOG.info("recycle db[{}-{}], is force drop: {}", db.getId(), db.getFullName(), isForceDrop);
         return true;
     }
@@ -182,6 +192,8 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         }
         idToRecycleTime.put(table.getId(), recycleTime);
         idToTable.put(table.getId(), tableInfo);
+        dbIdTableNameToIds.computeIfAbsent(Pair.of(dbId, table.getName()),
+                k -> ConcurrentHashMap.newKeySet()).add(table.getId());
         LOG.info("recycle table[{}-{}], is force drop: {}", table.getId(), table.getName(), isForceDrop);
         return true;
     }
@@ -200,6 +212,8 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                 range, listPartitionItem, dataProperty, replicaAlloc, isInMemory, isMutable);
         idToRecycleTime.put(partition.getId(), System.currentTimeMillis());
         idToPartition.put(partition.getId(), partitionInfo);
+        dbTblIdPartitionNameToIds.computeIfAbsent(Pair.of(dbId, tableId), k -> new ConcurrentHashMap<>())
+                .computeIfAbsent(partition.getName(), k -> ConcurrentHashMap.newKeySet()).add(partition.getId());
         LOG.info("recycle partition[{}-{}] of table [{}-{}]", partition.getId(), partition.getName(),
                 tableId, tableName);
         return true;
@@ -251,6 +265,12 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                     // erase db
                     dbIter.remove();
                     idToRecycleTime.remove(entry.getKey());
+
+                    dbNameToIds.computeIfPresent(db.getFullName(), (k, v) -> {
+                        v.remove(db.getId());
+                        return v.isEmpty() ? null : v;
+                    });
+
                     Env.getCurrentEnv().eraseDatabase(db.getId(), true);
                     LOG.info("erase db[{}]", db.getId());
                     eraseNum++;
@@ -260,10 +280,9 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             if (keepNum < 0) {
                 return;
             }
-            Set<String> dbNames = idToDatabase.values().stream().map(d -> d.getDb().getFullName())
-                    .collect(Collectors.toSet());
-            for (String dbName : dbNames) {
-                eraseDatabaseWithSameName(dbName, currentTimeMs, keepNum);
+            for (Map.Entry<String, Set<Long>> entry : dbNameToIds.entrySet()) {
+                String dbName = entry.getKey();
+                eraseDatabaseWithSameName(dbName, currentTimeMs, keepNum, Lists.newArrayList(entry.getValue()));
             }
         } finally {
             watch.stop();
@@ -271,37 +290,9 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         }
     }
 
-    private synchronized List<Long> getSameNameDbIdListToErase(String dbName, int maxSameNameTrashNum) {
-        Iterator<Map.Entry<Long, RecycleDatabaseInfo>> iterator = idToDatabase.entrySet().iterator();
-        List<List<Long>> dbRecycleTimeLists = Lists.newArrayList();
-        while (iterator.hasNext()) {
-            Map.Entry<Long, RecycleDatabaseInfo> entry = iterator.next();
-            RecycleDatabaseInfo dbInfo = entry.getValue();
-            Database db = dbInfo.getDb();
-            if (db.getFullName().equals(dbName)) {
-                List<Long> dbRecycleTimeInfo = Lists.newArrayList();
-                dbRecycleTimeInfo.add(entry.getKey());
-                dbRecycleTimeInfo.add(idToRecycleTime.get(entry.getKey()));
-
-                dbRecycleTimeLists.add(dbRecycleTimeInfo);
-            }
-        }
-        List<Long> dbIdToErase = Lists.newArrayList();
-        if (dbRecycleTimeLists.size() <= maxSameNameTrashNum) {
-            return dbIdToErase;
-        }
-        // order by recycle time desc
-        dbRecycleTimeLists.sort((x, y) ->
-                (x.get(1).longValue() < y.get(1).longValue()) ? 1 : ((x.get(1).equals(y.get(1))) ? 0 : -1));
-
-        for (int i = maxSameNameTrashNum; i < dbRecycleTimeLists.size(); i++) {
-            dbIdToErase.add(dbRecycleTimeLists.get(i).get(0));
-        }
-        return dbIdToErase;
-    }
-
-    private synchronized void eraseDatabaseWithSameName(String dbName, long currentTimeMs, int maxSameNameTrashNum) {
-        List<Long> dbIdToErase = getSameNameDbIdListToErase(dbName, maxSameNameTrashNum);
+    private synchronized void eraseDatabaseWithSameName(String dbName, long currentTimeMs,
+                                                        int maxSameNameTrashNum, List<Long> sameNameDbIdList) {
+        List<Long> dbIdToErase = getIdListToEraseByRecycleTime(sameNameDbIdList, maxSameNameTrashNum);
         for (Long dbId : dbIdToErase) {
             RecycleDatabaseInfo dbInfo = idToDatabase.get(dbId);
             if (!isExpireMinLatency(dbId, currentTimeMs)) {
@@ -310,6 +301,12 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             eraseAllTables(dbInfo);
             idToDatabase.remove(dbId);
             idToRecycleTime.remove(dbId);
+
+            dbNameToIds.computeIfPresent(dbName, (k, v) -> {
+                v.remove(dbId);
+                return v.isEmpty() ? null : v;
+            });
+
             Env.getCurrentEnv().eraseDatabase(dbId, true);
             LOG.info("erase database[{}] name: {}", dbId, dbName);
         }
@@ -340,14 +337,28 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             iterator.remove();
             idToRecycleTime.remove(table.getId());
             tableNames.remove(table.getName());
+
+            dbIdTableNameToIds.computeIfPresent(Pair.of(tableInfo.getDbId(), table.getName()), (k, v) -> {
+                v.remove(table.getId());
+                return v.isEmpty() ? null : v;
+            });
+
             Env.getCurrentEnv().getEditLog().logEraseTable(table.getId());
             LOG.info("erase db[{}] with table[{}]: {}", dbId, table.getId(), table.getName());
         }
     }
 
     public synchronized void replayEraseDatabase(long dbId) {
-        idToDatabase.remove(dbId);
+        RecycleDatabaseInfo dbInfo = idToDatabase.remove(dbId);
         idToRecycleTime.remove(dbId);
+
+        if (dbInfo != null) {
+            dbNameToIds.computeIfPresent(dbInfo.getDb().getFullName(), (k, v) -> {
+                v.remove(dbId);
+                return v.isEmpty() ? null : v;
+            });
+        }
+
         Env.getCurrentEnv().eraseDatabase(dbId, false);
         LOG.info("replay erase db[{}]", dbId);
     }
@@ -373,6 +384,12 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                     tableIter.remove();
                     idToRecycleTime.remove(tableId);
 
+                    dbIdTableNameToIds.computeIfPresent(Pair.of(tableInfo.getDbId(), table.getName()),
+                            (k, v) -> {
+                            v.remove(tableId);
+                            return v.isEmpty() ? null : v;
+                        });
+
                     // log
                     Env.getCurrentEnv().getEditLog().logEraseTable(tableId);
                     LOG.info("erase table[{}]", tableId);
@@ -384,19 +401,9 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             if (keepNum < 0) {
                 return;
             }
-            Map<Long, Set<String>> dbId2TableNames = Maps.newHashMap();
-            for (RecycleTableInfo tableInfo : idToTable.values()) {
-                Set<String> tblNames = dbId2TableNames.get(tableInfo.dbId);
-                if (tblNames == null) {
-                    tblNames = Sets.newHashSet();
-                    dbId2TableNames.put(tableInfo.dbId, tblNames);
-                }
-                tblNames.add(tableInfo.getTable().getName());
-            }
-            for (Map.Entry<Long, Set<String>> entry : dbId2TableNames.entrySet()) {
-                for (String tblName : entry.getValue()) {
-                    eraseTableWithSameName(entry.getKey(), tblName, currentTimeMs, keepNum);
-                }
+            for (Map.Entry<Pair<Long, String>, Set<Long>> entry : dbIdTableNameToIds.entrySet()) {
+                eraseTableWithSameName(entry.getKey().first, entry.getKey().second, currentTimeMs, keepNum,
+                        Lists.newArrayList(entry.getValue()));
             }
         } finally {
             watch.stop();
@@ -404,43 +411,9 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         }
     }
 
-    private synchronized List<Long> getSameNameTableIdListToErase(long dbId, String tableName,
-                                                                  int maxSameNameTrashNum) {
-        Iterator<Map.Entry<Long, RecycleTableInfo>> iterator = idToTable.entrySet().iterator();
-        List<List<Long>> tableRecycleTimeLists = Lists.newArrayList();
-        while (iterator.hasNext()) {
-            Map.Entry<Long, RecycleTableInfo> entry = iterator.next();
-            RecycleTableInfo tableInfo = entry.getValue();
-            if (tableInfo.getDbId() != dbId) {
-                continue;
-            }
-
-            Table table = tableInfo.getTable();
-            if (table.getName().equals(tableName)) {
-                List<Long> tableRecycleTimeInfo = Lists.newArrayList();
-                tableRecycleTimeInfo.add(entry.getKey());
-                tableRecycleTimeInfo.add(idToRecycleTime.get(entry.getKey()));
-
-                tableRecycleTimeLists.add(tableRecycleTimeInfo);
-            }
-        }
-        List<Long> tableIdToErase = Lists.newArrayList();
-        if (tableRecycleTimeLists.size() <= maxSameNameTrashNum) {
-            return tableIdToErase;
-        }
-        // order by recycle time desc
-        tableRecycleTimeLists.sort((x, y) ->
-                (x.get(1).longValue() < y.get(1).longValue()) ? 1 : ((x.get(1).equals(y.get(1))) ? 0 : -1));
-
-        for (int i = maxSameNameTrashNum; i < tableRecycleTimeLists.size(); i++) {
-            tableIdToErase.add(tableRecycleTimeLists.get(i).get(0));
-        }
-        return tableIdToErase;
-    }
-
     private synchronized void eraseTableWithSameName(long dbId, String tableName, long currentTimeMs,
-            int maxSameNameTrashNum) {
-        List<Long> tableIdToErase = getSameNameTableIdListToErase(dbId, tableName, maxSameNameTrashNum);
+            int maxSameNameTrashNum, List<Long> sameNameTableIdList) {
+        List<Long> tableIdToErase = getIdListToEraseByRecycleTime(sameNameTableIdList, maxSameNameTrashNum);
         for (Long tableId : tableIdToErase) {
             RecycleTableInfo tableInfo = idToTable.get(tableId);
             if (!isExpireMinLatency(tableId, currentTimeMs)) {
@@ -453,6 +426,12 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
 
             idToTable.remove(tableId);
             idToRecycleTime.remove(tableId);
+
+            dbIdTableNameToIds.computeIfPresent(Pair.of(dbId, tableName), (k, v) -> {
+                v.remove(tableId);
+                return v.isEmpty() ? null : v;
+            });
+
             Env.getCurrentEnv().getEditLog().logEraseTable(tableId);
             LOG.info("erase table[{}] name: {} from db[{}]", tableId, tableName, dbId);
         }
@@ -467,6 +446,13 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             // finish drop db, especially in the case of drop db with many tables.
             return;
         }
+
+        dbIdTableNameToIds.computeIfPresent(Pair.of(tableInfo.getDbId(), tableInfo.getTable().getName()),
+                (k, v) -> {
+                v.remove(tableId);
+                return v.isEmpty() ? null : v;
+            });
+
         Table table = tableInfo.getTable();
         if (table.isManagedTable()) {
             Env.getCurrentEnv().onEraseOlapTable(tableInfo.dbId, (OlapTable) table, true);
@@ -491,6 +477,15 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                     // erase partition
                     iterator.remove();
                     idToRecycleTime.remove(partitionId);
+
+                    dbTblIdPartitionNameToIds.computeIfPresent(
+                            Pair.of(partitionInfo.getDbId(), partitionInfo.getTableId()), (pair, partitionMap) -> {
+                                partitionMap.computeIfPresent(partition.getName(), (name, idSet) -> {
+                                    idSet.remove(partitionId);
+                                    return idSet.isEmpty() ? null : idSet;
+                                });
+                                return partitionMap.isEmpty() ? null : partitionMap;
+                            });
                     // log
                     Env.getCurrentEnv().getEditLog().logErasePartition(partitionId);
                     LOG.info("erase partition[{}]. reason: expired", partitionId);
@@ -502,19 +497,12 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             if (keepNum < 0) {
                 return;
             }
-            com.google.common.collect.Table<Long, Long, Set<String>> dbTblId2PartitionNames = HashBasedTable.create();
-            for (RecyclePartitionInfo partitionInfo : idToPartition.values()) {
-                Set<String> partitionNames = dbTblId2PartitionNames.get(partitionInfo.dbId, partitionInfo.tableId);
-                if (partitionNames == null) {
-                    partitionNames = Sets.newHashSet();
-                    dbTblId2PartitionNames.put(partitionInfo.dbId, partitionInfo.tableId, partitionNames);
-                }
-                partitionNames.add(partitionInfo.getPartition().getName());
-            }
-            for (Cell<Long, Long, Set<String>> cell : dbTblId2PartitionNames.cellSet()) {
-                for (String partitionName : cell.getValue()) {
-                    erasePartitionWithSameName(cell.getRowKey(), cell.getColumnKey(), partitionName, currentTimeMs,
-                            keepNum);
+            for (Map.Entry<Pair<Long, Long>, Map<String, Set<Long>>> entry : dbTblIdPartitionNameToIds.entrySet()) {
+                long dbId = entry.getKey().first;
+                long tableId = entry.getKey().second;
+                for (Map.Entry<String, Set<Long>> partitionEntry : entry.getValue().entrySet()) {
+                    erasePartitionWithSameName(dbId, tableId, partitionEntry.getKey(), currentTimeMs, keepNum,
+                            Lists.newArrayList(partitionEntry.getValue()));
                 }
             }
         } finally {
@@ -523,43 +511,9 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         }
     }
 
-    private synchronized List<Long> getSameNamePartitionIdListToErase(long dbId, long tableId, String partitionName,
-                                                                      int maxSameNameTrashNum) {
-        Iterator<Map.Entry<Long, RecyclePartitionInfo>> iterator = idToPartition.entrySet().iterator();
-        List<List<Long>> partitionRecycleTimeLists = Lists.newArrayList();
-        while (iterator.hasNext()) {
-            Map.Entry<Long, RecyclePartitionInfo> entry = iterator.next();
-            RecyclePartitionInfo partitionInfo = entry.getValue();
-            if (partitionInfo.getDbId() != dbId || partitionInfo.getTableId() != tableId) {
-                continue;
-            }
-
-            Partition partition = partitionInfo.getPartition();
-            if (partition.getName().equals(partitionName)) {
-                List<Long> partitionRecycleTimeInfo = Lists.newArrayList();
-                partitionRecycleTimeInfo.add(entry.getKey());
-                partitionRecycleTimeInfo.add(idToRecycleTime.get(entry.getKey()));
-
-                partitionRecycleTimeLists.add(partitionRecycleTimeInfo);
-            }
-        }
-        List<Long> partitionIdToErase = Lists.newArrayList();
-        if (partitionRecycleTimeLists.size() <= maxSameNameTrashNum) {
-            return partitionIdToErase;
-        }
-        // order by recycle time desc
-        partitionRecycleTimeLists.sort((x, y) ->
-                (x.get(1).longValue() < y.get(1).longValue()) ? 1 : ((x.get(1).equals(y.get(1))) ? 0 : -1));
-
-        for (int i = maxSameNameTrashNum; i < partitionRecycleTimeLists.size(); i++) {
-            partitionIdToErase.add(partitionRecycleTimeLists.get(i).get(0));
-        }
-        return partitionIdToErase;
-    }
-
     private synchronized void erasePartitionWithSameName(long dbId, long tableId, String partitionName,
-            long currentTimeMs, int maxSameNameTrashNum) {
-        List<Long> partitionIdToErase = getSameNamePartitionIdListToErase(dbId, tableId, partitionName,
+            long currentTimeMs, int maxSameNameTrashNum, List<Long> sameNamePartitionIdList) {
+        List<Long> partitionIdToErase = getIdListToEraseByRecycleTime(sameNamePartitionIdList,
                 maxSameNameTrashNum);
         for (Long partitionId : partitionIdToErase) {
             RecyclePartitionInfo partitionInfo = idToPartition.get(partitionId);
@@ -571,9 +525,18 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             Env.getCurrentEnv().onErasePartition(partition);
             idToPartition.remove(partitionId);
             idToRecycleTime.remove(partitionId);
+
+            dbTblIdPartitionNameToIds.computeIfPresent(Pair.of(dbId, tableId), (pair, partitionMap) -> {
+                partitionMap.computeIfPresent(partitionName, (name, idSet) -> {
+                    idSet.remove(partitionId);
+                    return idSet.isEmpty() ? null : idSet;
+                });
+                return partitionMap.isEmpty() ? null : partitionMap;
+            });
+
             Env.getCurrentEnv().getEditLog().logErasePartition(partitionId);
-            LOG.info("erase partition[{}] name: {} from table[{}] from db[{}]", partitionId, partitionName, tableId,
-                    dbId);
+            LOG.info("erase partition[{}] name: {} from table[{}] from db[{}]", partitionId,
+                    partitionName, tableId, dbId);
         }
     }
 
@@ -586,10 +549,33 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             return;
         }
 
+        dbTblIdPartitionNameToIds.computeIfPresent(
+                Pair.of(partitionInfo.getDbId(), partitionInfo.getTableId()), (pair, partitionMap) -> {
+                    partitionMap.computeIfPresent(partitionInfo.getPartition().getName(), (name, idSet) -> {
+                        idSet.remove(partitionId);
+                        return idSet.isEmpty() ? null : idSet;
+                    });
+                    return partitionMap.isEmpty() ? null : partitionMap;
+                });
+
         Partition partition = partitionInfo.getPartition();
         Env.getCurrentEnv().onErasePartition(partition);
 
         LOG.info("replay erase partition[{}]", partitionId);
+    }
+
+    private synchronized List<Long> getIdListToEraseByRecycleTime(List<Long> ids, int maxTrashNum) {
+        List<Long> idToErase = Lists.newArrayList();
+        if (ids.size() <= maxTrashNum) {
+            return idToErase;
+        }
+        // order by recycle time desc
+        ids.sort((x, y) -> Long.compare(idToRecycleTime.get(y), idToRecycleTime.get(x)));
+
+        for (int i = maxTrashNum; i < ids.size(); i++) {
+            idToErase.add(ids.get(i));
+        }
+        return idToErase;
     }
 
     public synchronized Database recoverDatabase(String dbName, long dbId) throws DdlException {
@@ -625,6 +611,11 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         idToDatabase.remove(db.getId());
         idToRecycleTime.remove(db.getId());
 
+        dbNameToIds.computeIfPresent(dbInfo.getDb().getFullName(), (k, v) -> {
+            v.remove(dbId);
+            return v.isEmpty() ? null : v;
+        });
+
         return db;
     }
 
@@ -640,6 +631,11 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
 
         idToDatabase.remove(dbId);
         idToRecycleTime.remove(dbId);
+
+        dbNameToIds.computeIfPresent(dbInfo.getDb().getFullName(), (k, v) -> {
+            v.remove(dbId);
+            return v.isEmpty() ? null : v;
+        });
 
         return dbInfo.getDb();
     }
@@ -668,6 +664,11 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             iterator.remove();
             idToRecycleTime.remove(table.getId());
             tableNames.remove(table.getName());
+
+            dbIdTableNameToIds.computeIfPresent(Pair.of(dbId, table.getName()), (k, v) -> {
+                v.remove(table.getId());
+                return v.isEmpty() ? null : v;
+            });
         }
 
         if (!tableNames.isEmpty()) {
@@ -770,6 +771,12 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                 idToTable.remove(table.getId());
             }
             idToRecycleTime.remove(table.getId());
+
+            dbIdTableNameToIds.computeIfPresent(Pair.of(db.getId(), tableName), (k, v) -> {
+                v.remove(table.getId());
+                return v.isEmpty() ? null : v;
+            });
+
             if (isReplay) {
                 LOG.info("replay recover table[{}]", table.getId());
             } else {
@@ -878,6 +885,15 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             table.updateVisibleVersionAndTime(version, System.currentTimeMillis());
         }
 
+        dbTblIdPartitionNameToIds.computeIfPresent(
+                Pair.of(recoverPartitionInfo.getDbId(), recoverPartitionInfo.getTableId()), (pair, partitionMap) -> {
+                    partitionMap.computeIfPresent(partitionName, (name, idSet) -> {
+                        idSet.remove(recoverPartition.getId());
+                        return idSet.isEmpty() ? null : idSet;
+                    });
+                    return partitionMap.isEmpty() ? null : partitionMap;
+                });
+
         // log
         RecoverInfo recoverInfo = new RecoverInfo(dbId, table.getId(), partitionId, "",
                                                     table.getName(), "", partitionName, newPartitionName);
@@ -923,10 +939,21 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             iterator.remove();
             idToRecycleTime.remove(partitionId);
 
+<<<<<<< HEAD
             if (!currentEnv.invalidCacheForCloud()) {
                 long version = table.getNextVersion();
                 table.updateVisibleVersionAndTime(version, System.currentTimeMillis());
             }
+=======
+            dbTblIdPartitionNameToIds.computeIfPresent(
+                    Pair.of(recyclePartitionInfo.getDbId(), table.getId()), (pair, partitionMap) -> {
+                        partitionMap.computeIfPresent(recyclePartitionInfo.getPartition().getName(), (name, idSet) -> {
+                            idSet.remove(partitionId);
+                            return idSet.isEmpty() ? null : idSet;
+                        });
+                        return partitionMap.isEmpty() ? null : partitionMap;
+                    });
+>>>>>>> c48a5adfe7 (save)
 
             LOG.info("replay recover partition[{}]", partitionId);
             break;
@@ -944,6 +971,11 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             // erase db from idToDatabase and idToRecycleTime
             idToDatabase.remove(dbId);
             idToRecycleTime.remove(dbId);
+
+            dbNameToIds.computeIfPresent(dbInfo.getDb().getFullName(), (k, v) -> {
+                v.remove(dbId);
+                return v.isEmpty() ? null : v;
+            });
 
             // log for erase db
             String dbName = dbInfo.getDb().getName();
@@ -1000,6 +1032,11 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             idToTable.remove(tableId);
             idToRecycleTime.remove(tableId);
 
+            dbIdTableNameToIds.computeIfPresent(Pair.of(dbId, table.getName()), (k, v) -> {
+                v.remove(tableId);
+                return v.isEmpty() ? null : v;
+            });
+
             // log for erase table
             String tableName = table.getName();
             Env.getCurrentEnv().getEditLog().logEraseTable(tableId);
@@ -1041,6 +1078,15 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         // 3. erase partition in idToPartition and idToRecycleTime
         idToPartition.remove(partitionId);
         idToRecycleTime.remove(partitionId);
+
+        dbTblIdPartitionNameToIds.computeIfPresent(
+                Pair.of(partitionInfo.getDbId(), partitionInfo.getTableId()), (pair, partitionMap) -> {
+                    partitionMap.computeIfPresent(partition.getName(), (name, idSet) -> {
+                        idSet.remove(partitionId);
+                        return idSet.isEmpty() ? null : idSet;
+                    });
+                    return partitionMap.isEmpty() ? null : partitionMap;
+                });
 
         // 4. log for erase partition
         long tableId = partitionInfo.getTableId();
@@ -1337,6 +1383,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             RecycleDatabaseInfo dbInfo = new RecycleDatabaseInfo();
             dbInfo.readFields(in);
             idToDatabase.put(id, dbInfo);
+            dbNameToIds.computeIfAbsent(dbInfo.getDb().getFullName(), k -> ConcurrentHashMap.newKeySet()).add(id);
         }
 
         count = in.readInt();
@@ -1345,6 +1392,8 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             RecycleTableInfo tableInfo = new RecycleTableInfo();
             tableInfo = tableInfo.read(in);
             idToTable.put(id, tableInfo);
+            dbIdTableNameToIds.computeIfAbsent(Pair.of(tableInfo.getDbId(), tableInfo.getTable().getName()),
+                    k -> ConcurrentHashMap.newKeySet()).add(id);
         }
 
         count = in.readInt();
@@ -1353,6 +1402,10 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             RecyclePartitionInfo partitionInfo = new RecyclePartitionInfo();
             partitionInfo = partitionInfo.read(in);
             idToPartition.put(id, partitionInfo);
+            Pair<Long, Long> dbTblId = Pair.of(partitionInfo.getDbId(), partitionInfo.getTableId());
+            dbTblIdPartitionNameToIds.computeIfAbsent(dbTblId, k -> new ConcurrentHashMap<>())
+                    .computeIfAbsent(partitionInfo.getPartition().getName(), k -> ConcurrentHashMap.newKeySet())
+                    .add(id);
         }
 
         count = in.readInt();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -313,7 +313,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
     }
 
     private synchronized boolean isExpireMinLatency(long id, long currentTimeMs) {
-        return (currentTimeMs - idToRecycleTime.get(id)) > minEraseLatency;
+        return (currentTimeMs - idToRecycleTime.get(id)) > minEraseLatency || FeConstants.runningUnitTest;
     }
 
     private void eraseAllTables(RecycleDatabaseInfo dbInfo) {
@@ -939,12 +939,11 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             iterator.remove();
             idToRecycleTime.remove(partitionId);
 
-<<<<<<< HEAD
             if (!currentEnv.invalidCacheForCloud()) {
                 long version = table.getNextVersion();
                 table.updateVisibleVersionAndTime(version, System.currentTimeMillis());
             }
-=======
+
             dbTblIdPartitionNameToIds.computeIfPresent(
                     Pair.of(recyclePartitionInfo.getDbId(), table.getId()), (pair, partitionMap) -> {
                         partitionMap.computeIfPresent(recyclePartitionInfo.getPartition().getName(), (name, idSet) -> {
@@ -953,7 +952,6 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                         });
                         return partitionMap.isEmpty() ? null : partitionMap;
                     });
->>>>>>> c48a5adfe7 (save)
 
             LOG.info("replay recover partition[{}]", partitionId);
             break;
@@ -1607,5 +1605,17 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
     // currently only used when loading image. So no synchronized protected.
     public List<Long> getAllDbIds() {
         return Lists.newArrayList(idToDatabase.keySet());
+    }
+
+    // only for unit test
+    public synchronized void clearAll() {
+        idToDatabase.clear();
+        idToTable.clear();
+        idToPartition.clear();
+        idToRecycleTime.clear();
+        dbNameToIds.clear();
+        dbIdTableNameToIds.clear();
+        dbTblIdPartitionNameToIds.clear();
+        LOG.info("Cleared all objects in recycle bin");
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CatalogRecycleBinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CatalogRecycleBinTest.java
@@ -42,8 +42,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static java.lang.Thread.sleep;
-
 public class CatalogRecycleBinTest {
 
     private static String runningDir;
@@ -73,13 +71,13 @@ public class CatalogRecycleBinTest {
         CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
 
         Database db = CatalogTestUtil.createSimpleDb(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testPartitionId1,
-            CatalogTestUtil.testIndexId1,
-            CatalogTestUtil.testTabletId1,
-            CatalogTestUtil.testStartVersion
-        );
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testPartitionId1,
+                CatalogTestUtil.testIndexId1,
+                CatalogTestUtil.testTabletId1,
+                CatalogTestUtil.testStartVersion
+            );
 
         Set<String> tableNames = Sets.newHashSet(CatalogTestUtil.testTable1);
         Set<Long> tableIds = Sets.newHashSet(CatalogTestUtil.testTableId1);
@@ -122,7 +120,7 @@ public class CatalogRecycleBinTest {
 
         // sleep 0.1 second to make sure the recycle time is different
         try {
-            sleep(100);
+            Thread.sleep(100);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
@@ -165,13 +163,13 @@ public class CatalogRecycleBinTest {
         CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
 
         Database db = CatalogTestUtil.createSimpleDb(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testPartitionId1,
-            CatalogTestUtil.testIndexId1,
-            CatalogTestUtil.testTabletId1,
-            CatalogTestUtil.testStartVersion
-        );
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testPartitionId1,
+                CatalogTestUtil.testIndexId1,
+                CatalogTestUtil.testTabletId1,
+                CatalogTestUtil.testStartVersion
+            );
 
         Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
         Assert.assertTrue(table.isPresent());
@@ -190,13 +188,13 @@ public class CatalogRecycleBinTest {
         CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
 
         Database db = CatalogTestUtil.createSimpleDb(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testPartitionId1,
-            CatalogTestUtil.testIndexId1,
-            CatalogTestUtil.testTabletId1,
-            CatalogTestUtil.testStartVersion
-        );
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testPartitionId1,
+                CatalogTestUtil.testIndexId1,
+                CatalogTestUtil.testTabletId1,
+                CatalogTestUtil.testStartVersion
+            );
 
         Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
         Assert.assertTrue(table.isPresent());
@@ -222,13 +220,13 @@ public class CatalogRecycleBinTest {
         CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
 
         Database db = CatalogTestUtil.createSimpleDb(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testPartitionId1,
-            CatalogTestUtil.testIndexId1,
-            CatalogTestUtil.testTabletId1,
-            CatalogTestUtil.testStartVersion
-        );
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testPartitionId1,
+                CatalogTestUtil.testIndexId1,
+                CatalogTestUtil.testTabletId1,
+                CatalogTestUtil.testStartVersion
+            );
 
         Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
         Assert.assertTrue(table.isPresent());
@@ -238,32 +236,32 @@ public class CatalogRecycleBinTest {
         Partition partition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
 
         boolean result = recycleBin.recyclePartition(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testTable1,
-            partition,
-            null,
-            null,
-            new DataProperty(TStorageMedium.HDD),
-            new ReplicaAllocation((short) 3),
-            false,
-            false
-        );
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testTable1,
+                partition,
+                null,
+                null,
+                new DataProperty(TStorageMedium.HDD),
+                new ReplicaAllocation((short) 3),
+                false,
+                false
+            );
         Assert.assertTrue(result);
         Assert.assertTrue(recycleBin.isRecyclePartition(CatalogTestUtil.testDbId1, CatalogTestUtil.testTableId1, CatalogTestUtil.testPartitionId1));
 
         result = recycleBin.recyclePartition(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testTable1,
-            partition,
-            null,
-            null,
-            new DataProperty(TStorageMedium.HDD),
-            new ReplicaAllocation((short) 3),
-            false,
-            false
-        );
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testTable1,
+                partition,
+                null,
+                null,
+                new DataProperty(TStorageMedium.HDD),
+                new ReplicaAllocation((short) 3),
+                false,
+                false
+            );
         // test recycling same partition again should fail
         Assert.assertFalse(result);
     }
@@ -281,6 +279,31 @@ public class CatalogRecycleBinTest {
             RandomDistributionInfo distributionInfo = new RandomDistributionInfo(1);
             Partition partition = new Partition(recyclePartitionNum, "same name", index, distributionInfo);
             boolean result = recycleBin.recyclePartition(
+                    CatalogTestUtil.testDbId1,
+                    CatalogTestUtil.testTableId1,
+                    CatalogTestUtil.testTable1,
+                    partition,
+                    null,
+                    null,
+                    new DataProperty(TStorageMedium.HDD),
+                    new ReplicaAllocation((short) 3),
+                    false,
+                    false
+            );
+            Assert.assertTrue(result);
+            Assert.assertTrue(recycleBin.isRecyclePartition(CatalogTestUtil.testDbId1, CatalogTestUtil.testTableId1, recyclePartitionNum));
+        } while (recyclePartitionNum++ < 100);
+
+        // sleep 0.1 second to make sure the recycle time is different
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        MaterializedIndex index = new MaterializedIndex(1005, IndexState.NORMAL);
+        RandomDistributionInfo distributionInfo = new RandomDistributionInfo(1);
+        Partition partition = new Partition(recyclePartitionNum, "same name", index, distributionInfo);
+        boolean result = recycleBin.recyclePartition(
                 CatalogTestUtil.testDbId1,
                 CatalogTestUtil.testTableId1,
                 CatalogTestUtil.testTable1,
@@ -292,31 +315,6 @@ public class CatalogRecycleBinTest {
                 false,
                 false
             );
-            Assert.assertTrue(result);
-            Assert.assertTrue(recycleBin.isRecyclePartition(CatalogTestUtil.testDbId1, CatalogTestUtil.testTableId1, recyclePartitionNum));
-        } while (recyclePartitionNum++ < 100);
-
-        // sleep 0.1 second to make sure the recycle time is different
-        try {
-            sleep(100);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-        MaterializedIndex index = new MaterializedIndex(1005, IndexState.NORMAL);
-        RandomDistributionInfo distributionInfo = new RandomDistributionInfo(1);
-        Partition partition = new Partition(recyclePartitionNum, "same name", index, distributionInfo);
-        boolean result = recycleBin.recyclePartition(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testTable1,
-            partition,
-            null,
-            null,
-            new DataProperty(TStorageMedium.HDD),
-            new ReplicaAllocation((short) 3),
-            false,
-            false
-        );
         Assert.assertTrue(result);
         Assert.assertTrue(recycleBin.isRecyclePartition(CatalogTestUtil.testDbId1, CatalogTestUtil.testTableId1, recyclePartitionNum));
 
@@ -356,13 +354,13 @@ public class CatalogRecycleBinTest {
         CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
 
         Database db = CatalogTestUtil.createSimpleDb(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testPartitionId1,
-            CatalogTestUtil.testIndexId1,
-            CatalogTestUtil.testTabletId1,
-            CatalogTestUtil.testStartVersion
-        );
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testPartitionId1,
+                CatalogTestUtil.testIndexId1,
+                CatalogTestUtil.testTabletId1,
+                CatalogTestUtil.testStartVersion
+            );
 
         Set<String> tableNames = db.getTableNames();
         Set<Long> tableIds = Sets.newHashSet(db.getTableIds());
@@ -386,16 +384,16 @@ public class CatalogRecycleBinTest {
 
     @Test
     public void testRecoverTable() throws Exception {
-        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();;
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
 
         Database db = CatalogTestUtil.createSimpleDb(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testPartitionId1,
-            CatalogTestUtil.testIndexId1,
-            CatalogTestUtil.testTabletId1,
-            CatalogTestUtil.testStartVersion
-        );
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testPartitionId1,
+                CatalogTestUtil.testIndexId1,
+                CatalogTestUtil.testTabletId1,
+                CatalogTestUtil.testStartVersion
+            );
 
         Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
         Assert.assertTrue(table.isPresent());
@@ -410,16 +408,16 @@ public class CatalogRecycleBinTest {
 
     @Test
     public void testRecoverPartition() throws Exception {
-        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();;
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
 
         Database db = CatalogTestUtil.createSimpleDb(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testPartitionId1,
-            CatalogTestUtil.testIndexId1,
-            CatalogTestUtil.testTabletId1,
-            CatalogTestUtil.testStartVersion
-        );
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testPartitionId1,
+                CatalogTestUtil.testIndexId1,
+                CatalogTestUtil.testTabletId1,
+                CatalogTestUtil.testStartVersion
+            );
 
         Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
         Assert.assertTrue(table.isPresent());
@@ -429,16 +427,16 @@ public class CatalogRecycleBinTest {
         Partition partition = olapTable.getPartition(CatalogTestUtil.testPartition1);
 
         recycleBin.recyclePartition(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testTable1,
-            partition,
-            null,
-            null,
-            new DataProperty(TStorageMedium.HDD),
-            new ReplicaAllocation((short) 3),
-            false,
-            false
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testTable1,
+                partition,
+                null,
+                null,
+                new DataProperty(TStorageMedium.HDD),
+                new ReplicaAllocation((short) 3),
+                false,
+                false
         );
 
         recycleBin.recoverPartition(CatalogTestUtil.testDbId1, olapTable, CatalogTestUtil.testPartition1, -1, null);
@@ -448,16 +446,16 @@ public class CatalogRecycleBinTest {
 
     @Test
     public void testGetRecycleIds() {
-        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();;
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
 
         Database db = CatalogTestUtil.createSimpleDb(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testPartitionId1,
-            CatalogTestUtil.testIndexId1,
-            CatalogTestUtil.testTabletId1,
-            CatalogTestUtil.testStartVersion
-        );
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testPartitionId1,
+                CatalogTestUtil.testIndexId1,
+                CatalogTestUtil.testTabletId1,
+                CatalogTestUtil.testStartVersion
+            );
 
         Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
         Assert.assertTrue(table.isPresent());
@@ -469,16 +467,16 @@ public class CatalogRecycleBinTest {
         recycleBin.recycleTable(CatalogTestUtil.testDbId1, olapTable, false, false, 0);
 
         recycleBin.recyclePartition(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testTable1,
-            partition,
-            null,
-            null,
-            new DataProperty(TStorageMedium.HDD),
-            new ReplicaAllocation((short) 3),
-            false,
-            false
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testTable1,
+                partition,
+                null,
+                null,
+                new DataProperty(TStorageMedium.HDD),
+                new ReplicaAllocation((short) 3),
+                false,
+                false
         );
 
         Set<Long> dbIds = Sets.newHashSet();
@@ -497,13 +495,13 @@ public class CatalogRecycleBinTest {
         CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
 
         Database db = CatalogTestUtil.createSimpleDb(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testPartitionId1,
-            CatalogTestUtil.testIndexId1,
-            CatalogTestUtil.testTabletId1,
-            CatalogTestUtil.testStartVersion
-        );
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testPartitionId1,
+                CatalogTestUtil.testIndexId1,
+                CatalogTestUtil.testTabletId1,
+                CatalogTestUtil.testStartVersion
+            );
 
         Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
         Assert.assertTrue(table.isPresent());
@@ -546,13 +544,13 @@ public class CatalogRecycleBinTest {
         CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
 
         Database db = CatalogTestUtil.createSimpleDb(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testPartitionId1,
-            CatalogTestUtil.testIndexId1,
-            CatalogTestUtil.testTabletId1,
-            CatalogTestUtil.testStartVersion
-        );
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testPartitionId1,
+                CatalogTestUtil.testIndexId1,
+                CatalogTestUtil.testTabletId1,
+                CatalogTestUtil.testStartVersion
+            );
 
         Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
         Assert.assertTrue(table.isPresent());
@@ -571,13 +569,13 @@ public class CatalogRecycleBinTest {
         CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
 
         Database db = CatalogTestUtil.createSimpleDb(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testPartitionId1,
-            CatalogTestUtil.testIndexId1,
-            CatalogTestUtil.testTabletId1,
-            CatalogTestUtil.testStartVersion
-        );
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testPartitionId1,
+                CatalogTestUtil.testIndexId1,
+                CatalogTestUtil.testTabletId1,
+                CatalogTestUtil.testStartVersion
+            );
 
         Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
         Assert.assertTrue(table.isPresent());
@@ -587,16 +585,16 @@ public class CatalogRecycleBinTest {
         Partition partition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
 
         recycleBin.recyclePartition(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testTable1,
-            partition,
-            null,
-            null,
-            new DataProperty(TStorageMedium.HDD),
-            new ReplicaAllocation((short) 3),
-            false,
-            false
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testTable1,
+                partition,
+                null,
+                null,
+                new DataProperty(TStorageMedium.HDD),
+                new ReplicaAllocation((short) 3),
+                false,
+                false
         );
 
         recycleBin.erasePartitionInstantly(CatalogTestUtil.testPartitionId1);
@@ -610,13 +608,13 @@ public class CatalogRecycleBinTest {
         CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
 
         Database db = CatalogTestUtil.createSimpleDb(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testPartitionId1,
-            CatalogTestUtil.testIndexId1,
-            CatalogTestUtil.testTabletId1,
-            CatalogTestUtil.testStartVersion
-        );
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testPartitionId1,
+                CatalogTestUtil.testIndexId1,
+                CatalogTestUtil.testTabletId1,
+                CatalogTestUtil.testStartVersion
+            );
 
         Set<String> tableNames = Sets.newHashSet(db.getTableNames());
         Set<Long> tableIds = Sets.newHashSet(db.getTableIds());
@@ -628,16 +626,16 @@ public class CatalogRecycleBinTest {
 
         Partition partition = olapTable1.getPartition(CatalogTestUtil.testPartitionId1);
         recycleBin.recyclePartition(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testTable1,
-            partition,
-            null,
-            null,
-            new DataProperty(TStorageMedium.HDD),
-            new ReplicaAllocation((short) 3),
-            false,
-            false
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testTable1,
+                partition,
+                null,
+                null,
+                new DataProperty(TStorageMedium.HDD),
+                new ReplicaAllocation((short) 3),
+                false,
+                false
         );
 
         recycleAllTables(db, recycleBin);
@@ -662,13 +660,13 @@ public class CatalogRecycleBinTest {
         CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
 
         Database db = CatalogTestUtil.createSimpleDb(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testPartitionId1,
-            CatalogTestUtil.testIndexId1,
-            CatalogTestUtil.testTabletId1,
-            CatalogTestUtil.testStartVersion
-        );
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testPartitionId1,
+                CatalogTestUtil.testIndexId1,
+                CatalogTestUtil.testTabletId1,
+                CatalogTestUtil.testStartVersion
+            );
 
         Set<String> tableNames = Sets.newHashSet(db.getTableNames());
         Set<Long> tableIds = Sets.newHashSet(db.getTableIds());
@@ -680,16 +678,16 @@ public class CatalogRecycleBinTest {
 
         Partition partition = olapTable1.getPartition(CatalogTestUtil.testPartitionId1);
         recycleBin.recyclePartition(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testTable1,
-            partition,
-            null,
-            null,
-            new DataProperty(TStorageMedium.HDD),
-            new ReplicaAllocation((short) 3),
-            false,
-            false
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testTable1,
+                partition,
+                null,
+                null,
+                new DataProperty(TStorageMedium.HDD),
+                new ReplicaAllocation((short) 3),
+                false,
+                false
         );
 
         recycleAllTables(db, recycleBin);
@@ -711,13 +709,13 @@ public class CatalogRecycleBinTest {
         CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
 
         Database db = CatalogTestUtil.createSimpleDb(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testPartitionId1,
-            CatalogTestUtil.testIndexId1,
-            CatalogTestUtil.testTabletId1,
-            CatalogTestUtil.testStartVersion
-        );
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testPartitionId1,
+                CatalogTestUtil.testIndexId1,
+                CatalogTestUtil.testTabletId1,
+                CatalogTestUtil.testStartVersion
+            );
 
         Set<String> tableNames = Sets.newHashSet(db.getTableNames());
         Set<Long> tableIds = Sets.newHashSet(db.getTableIds());
@@ -747,12 +745,12 @@ public class CatalogRecycleBinTest {
         CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
 
         Database db = CatalogTestUtil.createSimpleDb(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testPartitionId1,
-            CatalogTestUtil.testIndexId1,
-            CatalogTestUtil.testTabletId1,
-            CatalogTestUtil.testStartVersion
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testPartitionId1,
+                CatalogTestUtil.testIndexId1,
+                CatalogTestUtil.testTabletId1,
+                CatalogTestUtil.testStartVersion
         );
         // try to recover a non-existent table
         recycleBin.recoverTable(db, "non_existent_table", -1, null);
@@ -763,13 +761,13 @@ public class CatalogRecycleBinTest {
         CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
 
         Database db = CatalogTestUtil.createSimpleDb(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testPartitionId1,
-            CatalogTestUtil.testIndexId1,
-            CatalogTestUtil.testTabletId1,
-            CatalogTestUtil.testStartVersion
-        );
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testPartitionId1,
+                CatalogTestUtil.testIndexId1,
+                CatalogTestUtil.testTabletId1,
+                CatalogTestUtil.testStartVersion
+            );
 
         Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
         Assert.assertTrue(table.isPresent());
@@ -785,13 +783,13 @@ public class CatalogRecycleBinTest {
         CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
 
         Database db = CatalogTestUtil.createSimpleDb(
-            CatalogTestUtil.testDbId1,
-            CatalogTestUtil.testTableId1,
-            CatalogTestUtil.testPartitionId1,
-            CatalogTestUtil.testIndexId1,
-            CatalogTestUtil.testTabletId1,
-            CatalogTestUtil.testStartVersion
-        );
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testPartitionId1,
+                CatalogTestUtil.testIndexId1,
+                CatalogTestUtil.testTabletId1,
+                CatalogTestUtil.testStartVersion
+            );
 
         Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
         Assert.assertTrue(table.isPresent());

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CatalogRecycleBinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CatalogRecycleBinTest.java
@@ -1,0 +1,841 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
+import org.apache.doris.catalog.MaterializedIndex.IndexState;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.Pair;
+import org.apache.doris.thrift.TStorageMedium;
+import org.apache.doris.utframe.UtFrameUtils;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static java.lang.Thread.sleep;
+
+public class CatalogRecycleBinTest {
+
+    private static String runningDir;
+    private static Env env;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        FeConstants.runningUnitTest = true;
+        runningDir = "fe/mocked/CatalogRecycleBinTest/" + UUID.randomUUID() + "/";
+        UtFrameUtils.createDorisCluster(runningDir);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        env = CatalogTestUtil.createTestCatalog();
+        Env.getCurrentRecycleBin().clearAll();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        File file = new File(runningDir);
+        file.delete();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testRecycleNotEmptyDatabase() {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+
+        Database db = CatalogTestUtil.createSimpleDb(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testPartitionId1,
+            CatalogTestUtil.testIndexId1,
+            CatalogTestUtil.testTabletId1,
+            CatalogTestUtil.testStartVersion
+        );
+
+        Set<String> tableNames = Sets.newHashSet(CatalogTestUtil.testTable1);
+        Set<Long> tableIds = Sets.newHashSet(CatalogTestUtil.testTableId1);
+
+        recycleBin.recycleDatabase(db, tableNames, tableIds, false, false, 0);
+        Assert.fail("recycle no empty database should fail");
+    }
+
+    @Test
+    public void testRecycleEmptyDatabase() {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+
+        Database emptyDb1 = new Database(CatalogTestUtil.testDbId1, CatalogTestUtil.testDb1);
+
+        Set<String> emptyTableNames = Sets.newHashSet();
+        Set<Long> emptyTableIds = Sets.newHashSet();
+
+        Assert.assertTrue(recycleBin.recycleDatabase(emptyDb1, emptyTableNames, emptyTableIds, false, false, 0));
+        Assert.assertTrue(recycleBin.isRecycleDatabase(CatalogTestUtil.testDbId1));
+    }
+
+    @Test
+    public void testRecycleSameNameDatabase() {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+
+        // keep the newest one in recycle bin
+        Config.max_same_name_catalog_trash_num = 1;
+
+        Database emptyDb1 = new Database(1001, CatalogTestUtil.testDb1);
+        Database emptyDb2 = new Database(1002, CatalogTestUtil.testDb1);
+        Database emptyDb3 = new Database(1003, CatalogTestUtil.testDb1);
+
+        Set<String> emptyTableNames = Sets.newHashSet();
+        Set<Long> emptyTableIds = Sets.newHashSet();
+
+        Assert.assertTrue(recycleBin.recycleDatabase(emptyDb1, emptyTableNames, emptyTableIds, false, false, 0));
+        Assert.assertTrue(recycleBin.recycleDatabase(emptyDb2, emptyTableNames, emptyTableIds, false, false, 0));
+        Assert.assertTrue(recycleBin.isRecycleDatabase(1001));
+        Assert.assertTrue(recycleBin.isRecycleDatabase(1002));
+
+        // sleep 0.1 second to make sure the recycle time is different
+        try {
+            sleep(100);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        Assert.assertTrue(recycleBin.recycleDatabase(emptyDb3, emptyTableNames, emptyTableIds, false, false, 0));
+        Assert.assertTrue(recycleBin.isRecycleDatabase(1003));
+
+        recycleBin.runAfterCatalogReady();
+
+        // verify that only newest one is left in recycle bin
+        Assert.assertFalse(recycleBin.isRecycleDatabase(1001));
+        Assert.assertFalse(recycleBin.isRecycleDatabase(1002));
+        Assert.assertTrue(recycleBin.isRecycleDatabase(1003));
+    }
+
+    @Test
+    public void testForceDropDatabase() {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+
+        Database emptyDb = new Database(CatalogTestUtil.testDbId1, CatalogTestUtil.testDb1);
+
+        Set<String> tableNames = Sets.newHashSet();
+        Set<Long> tableIds = Sets.newHashSet();
+
+        Assert.assertTrue(recycleBin.recycleDatabase(emptyDb, tableNames, tableIds, false, true, 0));
+        Assert.assertTrue(recycleBin.isRecycleDatabase(CatalogTestUtil.testDbId1));
+
+        Long recycleTime = recycleBin.getRecycleTimeById(CatalogTestUtil.testDbId1);
+        Assert.assertNotNull(recycleTime);
+        Assert.assertEquals(0L, recycleTime.longValue());
+
+        recycleBin.runAfterCatalogReady();
+        // verify that the db has been immediately dropped from recycle bin
+        Assert.assertFalse(recycleBin.isRecycleDatabase(CatalogTestUtil.testDbId1));
+        // verify recycle time is no longer present
+        Assert.assertNull(recycleBin.getRecycleTimeById(CatalogTestUtil.testDbId1));
+    }
+
+    @Test
+    public void testRecycleTable() {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+
+        Database db = CatalogTestUtil.createSimpleDb(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testPartitionId1,
+            CatalogTestUtil.testIndexId1,
+            CatalogTestUtil.testTabletId1,
+            CatalogTestUtil.testStartVersion
+        );
+
+        Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
+        Assert.assertTrue(table.isPresent());
+        Assert.assertTrue(table.get() instanceof OlapTable);
+
+        OlapTable olapTable = (OlapTable) table.get();
+        Assert.assertTrue(recycleBin.recycleTable(CatalogTestUtil.testDbId1, olapTable, false, false, 0));
+        Assert.assertTrue(recycleBin.isRecycleTable(CatalogTestUtil.testDbId1, CatalogTestUtil.testTableId1));
+
+        // test recycling same table again should fail
+        Assert.assertFalse(recycleBin.recycleTable(CatalogTestUtil.testDbId1, olapTable, false, false, 0));
+    }
+
+    @Test
+    public void testForceDropTable() {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+
+        Database db = CatalogTestUtil.createSimpleDb(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testPartitionId1,
+            CatalogTestUtil.testIndexId1,
+            CatalogTestUtil.testTabletId1,
+            CatalogTestUtil.testStartVersion
+        );
+
+        Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
+        Assert.assertTrue(table.isPresent());
+        Assert.assertTrue(table.get() instanceof OlapTable);
+
+        OlapTable olapTable = (OlapTable) table.get();
+        Assert.assertTrue(recycleBin.recycleTable(CatalogTestUtil.testDbId1, olapTable, false, true, 0));
+
+        Long recycleTime = recycleBin.getRecycleTimeById(CatalogTestUtil.testTableId1);
+        Assert.assertNotNull(recycleTime);
+        Assert.assertEquals(0L, recycleTime.longValue());
+        Assert.assertTrue(recycleBin.isRecycleTable(CatalogTestUtil.testDbId1, CatalogTestUtil.testTableId1));
+
+        recycleBin.runAfterCatalogReady();
+        // verify that the table has been immediately dropped from recycle bin
+        Assert.assertFalse(recycleBin.isRecycleTable(CatalogTestUtil.testDbId1, CatalogTestUtil.testTableId1));
+        // verify recycle time is no longer present
+        Assert.assertNull(recycleBin.getRecycleTimeById(CatalogTestUtil.testTableId1));
+    }
+
+    @Test
+    public void testRecyclePartition() {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+
+        Database db = CatalogTestUtil.createSimpleDb(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testPartitionId1,
+            CatalogTestUtil.testIndexId1,
+            CatalogTestUtil.testTabletId1,
+            CatalogTestUtil.testStartVersion
+        );
+
+        Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
+        Assert.assertTrue(table.isPresent());
+        Assert.assertTrue(table.get() instanceof OlapTable);
+
+        OlapTable olapTable = (OlapTable) table.get();
+        Partition partition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
+
+        boolean result = recycleBin.recyclePartition(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testTable1,
+            partition,
+            null,
+            null,
+            new DataProperty(TStorageMedium.HDD),
+            new ReplicaAllocation((short) 3),
+            false,
+            false
+        );
+        Assert.assertTrue(result);
+        Assert.assertTrue(recycleBin.isRecyclePartition(CatalogTestUtil.testDbId1, CatalogTestUtil.testTableId1, CatalogTestUtil.testPartitionId1));
+
+        result = recycleBin.recyclePartition(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testTable1,
+            partition,
+            null,
+            null,
+            new DataProperty(TStorageMedium.HDD),
+            new ReplicaAllocation((short) 3),
+            false,
+            false
+        );
+        // test recycling same partition again should fail
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void testRecycleSameNamePartition() {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+
+        // keep the newest one in recycle bin
+        Config.max_same_name_catalog_trash_num = 1;
+
+        int recyclePartitionNum = 1;
+        do {
+            MaterializedIndex index = new MaterializedIndex(1005, IndexState.NORMAL);
+            RandomDistributionInfo distributionInfo = new RandomDistributionInfo(1);
+            Partition partition = new Partition(recyclePartitionNum, "same name", index, distributionInfo);
+            boolean result = recycleBin.recyclePartition(
+                CatalogTestUtil.testDbId1,
+                CatalogTestUtil.testTableId1,
+                CatalogTestUtil.testTable1,
+                partition,
+                null,
+                null,
+                new DataProperty(TStorageMedium.HDD),
+                new ReplicaAllocation((short) 3),
+                false,
+                false
+            );
+            Assert.assertTrue(result);
+            Assert.assertTrue(recycleBin.isRecyclePartition(CatalogTestUtil.testDbId1, CatalogTestUtil.testTableId1, recyclePartitionNum));
+        } while (recyclePartitionNum++ < 100);
+
+        // sleep 0.1 second to make sure the recycle time is different
+        try {
+            sleep(100);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        MaterializedIndex index = new MaterializedIndex(1005, IndexState.NORMAL);
+        RandomDistributionInfo distributionInfo = new RandomDistributionInfo(1);
+        Partition partition = new Partition(recyclePartitionNum, "same name", index, distributionInfo);
+        boolean result = recycleBin.recyclePartition(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testTable1,
+            partition,
+            null,
+            null,
+            new DataProperty(TStorageMedium.HDD),
+            new ReplicaAllocation((short) 3),
+            false,
+            false
+        );
+        Assert.assertTrue(result);
+        Assert.assertTrue(recycleBin.isRecyclePartition(CatalogTestUtil.testDbId1, CatalogTestUtil.testTableId1, recyclePartitionNum));
+
+        recycleBin.runAfterCatalogReady();
+
+        // verify that only newest one is left in recycle bin
+        Set<Long> dbIds = Sets.newHashSet();
+        Set<Long> tableIds = Sets.newHashSet();
+        Set<Long> partitionIds = Sets.newHashSet();
+        recycleBin.getRecycleIds(dbIds, tableIds, partitionIds);
+
+        Assert.assertEquals(0, dbIds.size());
+        Assert.assertEquals(0, tableIds.size());
+        Assert.assertEquals(1, partitionIds.size());
+        Assert.assertTrue(recycleBin.isRecyclePartition(CatalogTestUtil.testDbId1, CatalogTestUtil.testTableId1, recyclePartitionNum));
+    }
+
+    @Test
+    public void testRecoverEmptyDatabase() throws Exception {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+
+        Database emptyDb = new Database(CatalogTestUtil.testDbId1, CatalogTestUtil.testDb1);
+
+        Set<String> tableNames = Sets.newHashSet();
+        Set<Long> tableIds = Sets.newHashSet();
+
+        recycleBin.recycleDatabase(emptyDb, tableNames, tableIds, false, false, 0);
+
+        Database recoveredDb = recycleBin.recoverDatabase(CatalogTestUtil.testDb1, -1);
+        Assert.assertNotNull(recoveredDb);
+        Assert.assertEquals(CatalogTestUtil.testDbId1, recoveredDb.getId());
+        Assert.assertFalse(recycleBin.isRecycleDatabase(CatalogTestUtil.testDbId1));
+    }
+
+    @Test
+    public void testRecoverDatabaseWithTable() throws Exception {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+
+        Database db = CatalogTestUtil.createSimpleDb(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testPartitionId1,
+            CatalogTestUtil.testIndexId1,
+            CatalogTestUtil.testTabletId1,
+            CatalogTestUtil.testStartVersion
+        );
+
+        Set<String> tableNames = db.getTableNames();
+        Set<Long> tableIds = Sets.newHashSet(db.getTableIds());
+
+        recycleAllTables(db, recycleBin);
+        recycleBin.recycleDatabase(db, tableNames, tableIds, false, false, 0);
+
+        // test recovering database with table
+        Database recoveredDb = recycleBin.recoverDatabase(CatalogTestUtil.testDb1, -1);
+        Assert.assertNotNull(recoveredDb);
+        Assert.assertEquals(CatalogTestUtil.testDbId1, recoveredDb.getId());
+        Assert.assertFalse(recycleBin.isRecycleDatabase(CatalogTestUtil.testDbId1));
+        Assert.assertTrue(recoveredDb.getTable(CatalogTestUtil.testTableId1).isPresent());
+        Assert.assertFalse(recycleBin.isRecycleTable(CatalogTestUtil.testDbId1, CatalogTestUtil.testTableId1));
+        Assert.assertTrue(recoveredDb.getTable(CatalogTestUtil.testTableId2).isPresent());
+        Assert.assertFalse(recycleBin.isRecycleTable(CatalogTestUtil.testDbId1, CatalogTestUtil.testTableId2));
+        // non olap table should not be recovered
+        Assert.assertFalse(recoveredDb.getTable(CatalogTestUtil.testEsTableId1).isPresent());
+        Assert.assertFalse(recycleBin.isRecycleTable(CatalogTestUtil.testDbId1, CatalogTestUtil.testEsTableId1));
+    }
+
+    @Test
+    public void testRecoverTable() throws Exception {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();;
+
+        Database db = CatalogTestUtil.createSimpleDb(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testPartitionId1,
+            CatalogTestUtil.testIndexId1,
+            CatalogTestUtil.testTabletId1,
+            CatalogTestUtil.testStartVersion
+        );
+
+        Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
+        Assert.assertTrue(table.isPresent());
+        Assert.assertTrue(table.get() instanceof OlapTable);
+
+        OlapTable olapTable = (OlapTable) table.get();
+        recycleBin.recycleTable(CatalogTestUtil.testDbId1, olapTable, false, false, 0);
+        Assert.assertTrue(recycleBin.recoverTable(db, CatalogTestUtil.testTable1, -1, null));
+        Assert.assertFalse(recycleBin.isRecycleTable(CatalogTestUtil.testDbId1, CatalogTestUtil.testTableId1));
+        Assert.assertNotNull(db.getTable(CatalogTestUtil.testTableId1));
+    }
+
+    @Test
+    public void testRecoverPartition() throws Exception {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();;
+
+        Database db = CatalogTestUtil.createSimpleDb(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testPartitionId1,
+            CatalogTestUtil.testIndexId1,
+            CatalogTestUtil.testTabletId1,
+            CatalogTestUtil.testStartVersion
+        );
+
+        Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
+        Assert.assertTrue(table.isPresent());
+        Assert.assertTrue(table.get() instanceof OlapTable);
+
+        OlapTable olapTable = (OlapTable) table.get();
+        Partition partition = olapTable.getPartition(CatalogTestUtil.testPartition1);
+
+        recycleBin.recyclePartition(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testTable1,
+            partition,
+            null,
+            null,
+            new DataProperty(TStorageMedium.HDD),
+            new ReplicaAllocation((short) 3),
+            false,
+            false
+        );
+
+        recycleBin.recoverPartition(CatalogTestUtil.testDbId1, olapTable, CatalogTestUtil.testPartition1, -1, null);
+        Assert.assertFalse(recycleBin.isRecyclePartition(CatalogTestUtil.testDbId1, CatalogTestUtil.testTableId1, CatalogTestUtil.testPartitionId1));
+        Assert.assertNotNull(olapTable.getPartition(CatalogTestUtil.testPartition1));
+    }
+
+    @Test
+    public void testGetRecycleIds() {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();;
+
+        Database db = CatalogTestUtil.createSimpleDb(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testPartitionId1,
+            CatalogTestUtil.testIndexId1,
+            CatalogTestUtil.testTabletId1,
+            CatalogTestUtil.testStartVersion
+        );
+
+        Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
+        Assert.assertTrue(table.isPresent());
+        Assert.assertTrue(table.get() instanceof OlapTable);
+
+        OlapTable olapTable = (OlapTable) table.get();
+        Partition partition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
+
+        recycleBin.recycleTable(CatalogTestUtil.testDbId1, olapTable, false, false, 0);
+
+        recycleBin.recyclePartition(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testTable1,
+            partition,
+            null,
+            null,
+            new DataProperty(TStorageMedium.HDD),
+            new ReplicaAllocation((short) 3),
+            false,
+            false
+        );
+
+        Set<Long> dbIds = Sets.newHashSet();
+        Set<Long> tableIdsResult = Sets.newHashSet();
+        Set<Long> partitionIds = Sets.newHashSet();
+
+        recycleBin.getRecycleIds(dbIds, tableIdsResult, partitionIds);
+
+        Assert.assertEquals(0, dbIds.size());
+        Assert.assertTrue(tableIdsResult.contains(CatalogTestUtil.testTableId1));
+        Assert.assertTrue(partitionIds.contains(CatalogTestUtil.testPartitionId1));
+    }
+
+    @Test
+    public void testAllTabletsInRecycledStatus() {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+
+        Database db = CatalogTestUtil.createSimpleDb(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testPartitionId1,
+            CatalogTestUtil.testIndexId1,
+            CatalogTestUtil.testTabletId1,
+            CatalogTestUtil.testStartVersion
+        );
+
+        Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
+        Assert.assertTrue(table.isPresent());
+        Assert.assertTrue(table.get() instanceof OlapTable);
+
+        OlapTable olapTable = (OlapTable) table.get();
+        recycleBin.recycleTable(CatalogTestUtil.testDbId1, olapTable, false, false, 0);
+
+        // get tablet ids from the table
+        List<Long> recycleTabletIds = Lists.newArrayList();
+        for (Partition partition : olapTable.getAllPartitions()) {
+            for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.ALL)) {
+                for (Tablet tablet : index.getTablets()) {
+                    recycleTabletIds.add(tablet.getId());
+                }
+            }
+        }
+
+        List<Long> nonRecycledTabletIds = Lists.newArrayList(999L, 1000L);
+        Assert.assertTrue(recycleBin.allTabletsInRecycledStatus(recycleTabletIds));
+        Assert.assertFalse(recycleBin.allTabletsInRecycledStatus(nonRecycledTabletIds));
+    }
+
+    @Test
+    public void testEraseDatabaseInstantly() throws Exception {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+
+        Database emptyDb = new Database(CatalogTestUtil.testDbId1, CatalogTestUtil.testDb1);
+
+        Set<String> tableNames = Sets.newHashSet();
+        Set<Long> tableIds = Sets.newHashSet();
+
+        recycleBin.recycleDatabase(emptyDb, tableNames, tableIds, false, false, 0);
+        recycleBin.eraseDatabaseInstantly(CatalogTestUtil.testDbId1);
+        Assert.assertFalse(recycleBin.isRecycleDatabase(CatalogTestUtil.testDbId1));
+    }
+
+    @Test
+    public void testEraseTableInstantly() throws Exception {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+
+        Database db = CatalogTestUtil.createSimpleDb(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testPartitionId1,
+            CatalogTestUtil.testIndexId1,
+            CatalogTestUtil.testTabletId1,
+            CatalogTestUtil.testStartVersion
+        );
+
+        Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
+        Assert.assertTrue(table.isPresent());
+        Assert.assertTrue(table.get() instanceof OlapTable);
+
+        OlapTable olapTable = (OlapTable) table.get();
+        recycleBin.recycleTable(CatalogTestUtil.testDbId1, olapTable, false, false, 0);
+        recycleBin.eraseTableInstantly(CatalogTestUtil.testTableId1);
+
+        // verify table is no longer in recycle bin
+        Assert.assertFalse(recycleBin.isRecycleTable(CatalogTestUtil.testDbId1, CatalogTestUtil.testTableId1));
+    }
+
+    @Test
+    public void testErasePartitionInstantly() throws Exception {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+
+        Database db = CatalogTestUtil.createSimpleDb(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testPartitionId1,
+            CatalogTestUtil.testIndexId1,
+            CatalogTestUtil.testTabletId1,
+            CatalogTestUtil.testStartVersion
+        );
+
+        Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
+        Assert.assertTrue(table.isPresent());
+        Assert.assertTrue(table.get() instanceof OlapTable);
+
+        OlapTable olapTable = (OlapTable) table.get();
+        Partition partition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
+
+        recycleBin.recyclePartition(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testTable1,
+            partition,
+            null,
+            null,
+            new DataProperty(TStorageMedium.HDD),
+            new ReplicaAllocation((short) 3),
+            false,
+            false
+        );
+
+        recycleBin.erasePartitionInstantly(CatalogTestUtil.testPartitionId1);
+
+        // verify partition is no longer in recycle bin
+        Assert.assertFalse(recycleBin.isRecyclePartition(CatalogTestUtil.testDbId1, CatalogTestUtil.testTableId1, CatalogTestUtil.testPartitionId1));
+    }
+
+    @Test
+    public void testReplayOperations() {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+
+        Database db = CatalogTestUtil.createSimpleDb(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testPartitionId1,
+            CatalogTestUtil.testIndexId1,
+            CatalogTestUtil.testTabletId1,
+            CatalogTestUtil.testStartVersion
+        );
+
+        Set<String> tableNames = Sets.newHashSet(db.getTableNames());
+        Set<Long> tableIds = Sets.newHashSet(db.getTableIds());
+
+        Optional<Table> table1 = db.getTable(CatalogTestUtil.testTableId1);
+        Assert.assertTrue(table1.isPresent());
+        Assert.assertTrue(table1.get() instanceof OlapTable);
+        OlapTable olapTable1 = (OlapTable) table1.get();
+
+        Partition partition = olapTable1.getPartition(CatalogTestUtil.testPartitionId1);
+        recycleBin.recyclePartition(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testTable1,
+            partition,
+            null,
+            null,
+            new DataProperty(TStorageMedium.HDD),
+            new ReplicaAllocation((short) 3),
+            false,
+            false
+        );
+
+        recycleAllTables(db, recycleBin);
+        recycleBin.recycleDatabase(db, tableNames, tableIds, false, false, 0);
+
+        recycleBin.replayEraseDatabase(CatalogTestUtil.testDbId1);
+        recycleBin.replayEraseTable(CatalogTestUtil.testTableId1);
+        recycleBin.replayEraseTable(CatalogTestUtil.testTableId2);
+        recycleBin.replayEraseTable(CatalogTestUtil.testEsTableId1);
+        recycleBin.replayErasePartition(CatalogTestUtil.testPartitionId1);
+
+        // verify objects are no longer in recycle bin
+        Assert.assertFalse(recycleBin.isRecycleDatabase(CatalogTestUtil.testDbId1));
+        Assert.assertFalse(recycleBin.isRecycleTable(CatalogTestUtil.testDbId1, CatalogTestUtil.testTableId1));
+        Assert.assertFalse(recycleBin.isRecycleTable(CatalogTestUtil.testDbId1, CatalogTestUtil.testTableId2));
+        Assert.assertFalse(recycleBin.isRecycleTable(CatalogTestUtil.testDbId1, CatalogTestUtil.testEsTableId1));
+        Assert.assertFalse(recycleBin.isRecyclePartition(CatalogTestUtil.testDbId1, CatalogTestUtil.testTableId1, CatalogTestUtil.testPartitionId1));
+    }
+
+    @Test
+    public void testGetInfo() {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+
+        Database db = CatalogTestUtil.createSimpleDb(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testPartitionId1,
+            CatalogTestUtil.testIndexId1,
+            CatalogTestUtil.testTabletId1,
+            CatalogTestUtil.testStartVersion
+        );
+
+        Set<String> tableNames = Sets.newHashSet(db.getTableNames());
+        Set<Long> tableIds = Sets.newHashSet(db.getTableIds());
+
+        Optional<Table> table1 = db.getTable(CatalogTestUtil.testTableId1);
+        Assert.assertTrue(table1.isPresent());
+        Assert.assertTrue(table1.get() instanceof OlapTable);
+        OlapTable olapTable1 = (OlapTable) table1.get();
+
+        Partition partition = olapTable1.getPartition(CatalogTestUtil.testPartitionId1);
+        recycleBin.recyclePartition(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testTable1,
+            partition,
+            null,
+            null,
+            new DataProperty(TStorageMedium.HDD),
+            new ReplicaAllocation((short) 3),
+            false,
+            false
+        );
+
+        recycleAllTables(db, recycleBin);
+        recycleBin.recycleDatabase(db, tableNames, tableIds, false, false, 0);
+
+        List<List<String>> info = recycleBin.getInfo();
+        Assert.assertNotNull(info);
+        Assert.assertFalse(info.isEmpty());
+
+        // verify info contains database information
+        Set<String> itemTypes = info.stream().map(item -> item.get(0)).collect(Collectors.toSet());
+        Assert.assertTrue(itemTypes.contains("Database"));
+        Assert.assertTrue(itemTypes.contains("Table"));
+        Assert.assertTrue(itemTypes.contains("Partition"));
+    }
+
+    @Test
+    public void testGetDbToRecycleSize() {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+
+        Database db = CatalogTestUtil.createSimpleDb(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testPartitionId1,
+            CatalogTestUtil.testIndexId1,
+            CatalogTestUtil.testTabletId1,
+            CatalogTestUtil.testStartVersion
+        );
+
+        Set<String> tableNames = Sets.newHashSet(db.getTableNames());
+        Set<Long> tableIds = Sets.newHashSet(db.getTableIds());
+
+        recycleAllTables(db, recycleBin);
+        recycleBin.recycleDatabase(db, tableNames, tableIds, false, false, 0);
+
+        Map<Long, Pair<Long, Long>> sizeMap = recycleBin.getDbToRecycleSize();
+        Assert.assertNotNull(sizeMap);
+        Assert.assertTrue(sizeMap.containsKey(CatalogTestUtil.testDbId1));
+
+        Pair<Long, Long> sizes = sizeMap.get(CatalogTestUtil.testDbId1);
+        Assert.assertNotNull(sizes);
+        Assert.assertTrue(sizes.first >= 0);
+        Assert.assertTrue(sizes.second >= 0);
+    }
+
+    @Test(expected = DdlException.class)
+    public void testRecoverNonExistentDatabase() throws Exception {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+        // try to recover a non-existent database
+        recycleBin.recoverDatabase("non_existent_db", -1);
+    }
+
+    @Test(expected = DdlException.class)
+    public void testRecoverNonExistentTable() throws Exception {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+
+        Database db = CatalogTestUtil.createSimpleDb(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testPartitionId1,
+            CatalogTestUtil.testIndexId1,
+            CatalogTestUtil.testTabletId1,
+            CatalogTestUtil.testStartVersion
+        );
+        // try to recover a non-existent table
+        recycleBin.recoverTable(db, "non_existent_table", -1, null);
+    }
+
+    @Test(expected = DdlException.class)
+    public void testRecoverNonExistentPartition() throws Exception {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+
+        Database db = CatalogTestUtil.createSimpleDb(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testPartitionId1,
+            CatalogTestUtil.testIndexId1,
+            CatalogTestUtil.testTabletId1,
+            CatalogTestUtil.testStartVersion
+        );
+
+        Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
+        Assert.assertTrue(table.isPresent());
+        Assert.assertTrue(table.get() instanceof OlapTable);
+
+        OlapTable olapTable = (OlapTable) table.get();
+        // try to recover a non-existent partition
+        recycleBin.recoverPartition(CatalogTestUtil.testDbId1, olapTable, "non_existent_partition", -1, null);
+    }
+
+    @Test
+    public void testAddTabletToInvertedIndex() {
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
+
+        Database db = CatalogTestUtil.createSimpleDb(
+            CatalogTestUtil.testDbId1,
+            CatalogTestUtil.testTableId1,
+            CatalogTestUtil.testPartitionId1,
+            CatalogTestUtil.testIndexId1,
+            CatalogTestUtil.testTabletId1,
+            CatalogTestUtil.testStartVersion
+        );
+
+        Optional<Table> table = db.getTable(CatalogTestUtil.testTableId1);
+        Assert.assertTrue(table.isPresent());
+        Assert.assertTrue(table.get() instanceof OlapTable);
+
+        OlapTable olapTable = (OlapTable) table.get();
+        recycleBin.recycleTable(CatalogTestUtil.testDbId1, olapTable, false, false, 0);
+
+        TabletInvertedIndex invertedIndex = Env.getCurrentInvertedIndex();
+        invertedIndex.clear();
+        TabletMeta tabletMeta = invertedIndex.getTabletMeta(CatalogTestUtil.testTabletId1);
+        Assert.assertNull(tabletMeta);
+
+        recycleBin.addTabletToInvertedIndex();
+
+        // verify tablets are added to inverted index
+        tabletMeta = invertedIndex.getTabletMeta(CatalogTestUtil.testTabletId1);
+        Assert.assertNotNull(tabletMeta);
+    }
+
+    public void recycleAllTables(Database db, CatalogRecycleBin recycleBin) {
+        Optional<Table> table1 = db.getTable(CatalogTestUtil.testTableId1);
+        Assert.assertTrue(table1.isPresent());
+        Assert.assertTrue(table1.get() instanceof OlapTable);
+        OlapTable olapTable1 = (OlapTable) table1.get();
+
+        Optional<Table> table2 = db.getTable(CatalogTestUtil.testTableId2);
+        Assert.assertTrue(table2.isPresent());
+        Assert.assertTrue(table2.get() instanceof OlapTable);
+        OlapTable olapTable2 = (OlapTable) table2.get();
+
+        Optional<Table> table3 = db.getTable(CatalogTestUtil.testEsTableId1);
+        Assert.assertTrue(table3.isPresent());
+        Assert.assertTrue(table3.get() instanceof EsTable);
+        EsTable esTable = (EsTable) table3.get();
+
+        db.unregisterTable(CatalogTestUtil.testTableId1);
+        recycleBin.recycleTable(CatalogTestUtil.testDbId1, olapTable1, false, false, 0);
+
+        db.unregisterTable(CatalogTestUtil.testTableId2);
+        recycleBin.recycleTable(CatalogTestUtil.testDbId1, olapTable2, false, false, 0);
+
+        db.unregisterTable(CatalogTestUtil.testEsTableId1);
+        recycleBin.recycleTable(CatalogTestUtil.testDbId1, esTable, false, false, 0);
+    }
+}
+


### PR DESCRIPTION
### What problem does this PR solve?

I found when there are large amount of garbage(about 90000 partitions) in recycle bin, the Fe's table lock will be hold for long time by DynamicPartitionScheduler thread, the stack is like:

```
"recycle bin" #28 daemon prio=5 os_prio=0 cpu=73880509.81ms elapsed=96569.50s allocated=9212M defined_classes=9 tid=0x00007f0b545c1800 nid=0x2f4540 runnable  [0x00007f0b251fd000]
   java.lang.Thread.State: RUNNABLE
        at org.apache.doris.catalog.CatalogRecycleBin.getSameNamePartitionIdListToErase(CatalogRecycleBin.java:539)
        - locked <0x000000020d6d6130> (a org.apache.doris.catalog.CatalogRecycleBin)
        at org.apache.doris.catalog.CatalogRecycleBin.erasePartitionWithSameName(CatalogRecycleBin.java:556)
        - locked <0x000000020d6d6130> (a org.apache.doris.catalog.CatalogRecycleBin)
        at org.apache.doris.catalog.CatalogRecycleBin.erasePartition(CatalogRecycleBin.java:510)
        - locked <0x000000020d6d6130> (a org.apache.doris.catalog.CatalogRecycleBin)
        at org.apache.doris.catalog.CatalogRecycleBin.runAfterCatalogReady(CatalogRecycleBin.java:1012)
        at org.apache.doris.common.util.MasterDaemon.runOneCycle(MasterDaemon.java:58)
        at org.apache.doris.common.util.Daemon.run(Daemon.java:119)

   Locked ownable synchronizers:
        - None

"DynamicPartitionScheduler" #41 daemon prio=5 os_prio=0 cpu=115405.50ms elapsed=87942.53s allocated=16637M defined_classes=96 tid=0x00007f0b545cc800 nid=0x2f4545 waiting for monitor entry  [0x00007f0b247fe000]
   java.lang.Thread.State: BLOCKED (on object monitor)
        at org.apache.doris.catalog.CatalogRecycleBin.recyclePartition(CatalogRecycleBin.java:187)
        - waiting to lock <0x000000020d6d6130> (a org.apache.doris.catalog.CatalogRecycleBin)
        at org.apache.doris.catalog.OlapTable.dropPartition(OlapTable.java:1164)
        at org.apache.doris.catalog.OlapTable.dropPartition(OlapTable.java:1207)
        at org.apache.doris.datasource.InternalCatalog.dropPartitionWithoutCheck(InternalCatalog.java:1895)
        at org.apache.doris.datasource.InternalCatalog.dropPartition(InternalCatalog.java:1884)
        at org.apache.doris.catalog.Env.dropPartition(Env.java:3212)
        at org.apache.doris.clone.DynamicPartitionScheduler.executeDynamicPartition(DynamicPartitionScheduler.java:605)
        at org.apache.doris.clone.DynamicPartitionScheduler.runAfterCatalogReady(DynamicPartitionScheduler.java:729)
        at org.apache.doris.common.util.MasterDaemon.runOneCycle(MasterDaemon.java:58)
        at org.apache.doris.clone.DynamicPartitionScheduler.run(DynamicPartitionScheduler.java:688)
```

The DynamicPartitionScheduler thread is waiting the CatalogRecycleBin thread while the table write lock is holding by itself .
In Fe log, you can see the CatalogRecycleBin thread is running something big and cost almost 5~10 mins every run:

```
fe.log.20250907-2:2025-09-07 04:15:50,740 INFO (recycle bin|28) [CatalogRecycleBin.erasePartition():516] erasePartition eraseNum: 0 cost: 375503ms
fe.log.20250907-2:2025-09-07 04:23:14,109 INFO (recycle bin|28) [CatalogRecycleBin.erasePartition():516] erasePartition eraseNum: 0 cost: 413369ms
fe.log.20250907-2:2025-09-07 04:30:01,187 INFO (recycle bin|28) [CatalogRecycleBin.erasePartition():516] erasePartition eraseNum: 0 cost: 377077ms
fe.log.20250907-2:2025-09-07 04:38:22,769 INFO (recycle bin|28) [CatalogRecycleBin.erasePartition():516] erasePartition eraseNum: 0 cost: 471581ms
fe.log.20250907-2:2025-09-07 04:45:42,552 INFO (recycle bin|28) [CatalogRecycleBin.erasePartition():516] erasePartition eraseNum: 0 cost: 409782ms
fe.log.20250907-2:2025-09-07 04:54:30,825 INFO (recycle bin|28) [CatalogRecycleBin.erasePartition():516] erasePartition eraseNum: 0 cost: 498272ms
fe.log.20250907-2:2025-09-07 05:01:36,311 INFO (recycle bin|28) [CatalogRecycleBin.erasePartition():516] erasePartition eraseNum: 0 cost: 395485ms
```

The most costly task of the CatalogRecycleBin thread is erasing the partition with same name:

```
2025-09-07 04:16:20,884 INFO (recycle bin|28) [CatalogRecycleBin.erasePartitionWithSameName():569] erase partition[62638463] name: p_2019051116000
0_20190511170000 from table[32976073] from db[682022]
2025-09-07 04:16:20,994 INFO (recycle bin|28) [CatalogRecycleBin.erasePartitionWithSameName():569] erase partition[62640651] name: p_2019043016000
0_20190430170000 from table[32976073] from db[682022]
2025-09-07 04:16:21,438 INFO (recycle bin|28) [CatalogRecycleBin.erasePartitionWithSameName():569] erase partition[60264769] name: p_2019051721000
0_20190517220000 from table[32976073] from db[682022]
2025-09-07 04:16:21,787 INFO (recycle bin|28) [CatalogRecycleBin.erasePartitionWithSameName():569] erase partition[62651922] name: p_2019051015000
0_20190510160000 from table[32976073] from db[682022]
2025-09-07 04:16:21,893 INFO (recycle bin|28) [CatalogRecycleBin.erasePartitionWithSameName():569] erase partition[59222503] name: p_2019052708000
0_20190527090000 from table[32976073] from db[682022]
2025-09-07 04:16:22,204 INFO (recycle bin|28) [CatalogRecycleBin.erasePartitionWithSameName():569] erase partition[62656398] name: p_2019051109000
0_20190511100000 from table[32976073] from db[682022]
2025-09-07 04:16:22,430 INFO (recycle bin|28) [CatalogRecycleBin.erasePartitionWithSameName():569] erase partition[59228497] name: p_2019051812000
0_20190518130000 from table[32976073] from db[682022]
2025-09-07 04:16:22,493 INFO (recycle bin|28) [CatalogRecycleBin.erasePartitionWithSameName():569] erase partition[62658335] name: p_2019051217000
0_20190512180000 from table[32976073] from db[682022]
...
```

This may leads to whole Fe hang because the table lock is used for many threads.
<img width="1230" height="438" alt="Clipboard_Screenshot_1757283600" src="https://github.com/user-attachments/assets/59ec8707-82f8-4daf-8dae-b9ebea2b2959" />

This commit mainly optimize the logic of recycling the same name meta, adding caches to reduce the time complexity.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

