### PR TITLE
[fix](constant fold)Fmod should return null when second argument is 0.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/NumericArithmetic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/NumericArithmetic.java
@@ -35,6 +35,7 @@ import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 import org.apache.doris.nereids.types.DecimalV3Type;
 import org.apache.doris.nereids.types.DoubleType;
+import org.apache.doris.nereids.types.FloatType;
 
 import org.apache.commons.math3.util.ArithmeticUtils;
 import org.apache.commons.math3.util.FastMath;
@@ -937,6 +938,9 @@ public class NumericArithmetic {
      */
     @ExecFunction(name = "fmod")
     public static Expression fmod(DoubleLiteral first, DoubleLiteral second) {
+        if (second.getValue() == 0) {
+            return new NullLiteral(DoubleType.INSTANCE);
+        }
         return new DoubleLiteral(first.getValue() % second.getValue());
     }
 
@@ -945,6 +949,9 @@ public class NumericArithmetic {
      */
     @ExecFunction(name = "fmod")
     public static Expression fmod(FloatLiteral first, FloatLiteral second) {
+        if (second.getValue() == 0) {
+            return new NullLiteral(FloatType.INSTANCE);
+        }
         return new FloatLiteral(first.getValue() % second.getValue());
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
@@ -106,6 +106,7 @@ import org.apache.doris.nereids.trees.expressions.literal.DateTimeV2Literal;
 import org.apache.doris.nereids.trees.expressions.literal.DateV2Literal;
 import org.apache.doris.nereids.trees.expressions.literal.DecimalV3Literal;
 import org.apache.doris.nereids.trees.expressions.literal.DoubleLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.FloatLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.Interval.TimeUnit;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
@@ -117,6 +118,7 @@ import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.types.DateTimeV2Type;
 import org.apache.doris.nereids.types.DecimalV3Type;
 import org.apache.doris.nereids.types.DoubleType;
+import org.apache.doris.nereids.types.FloatType;
 import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.nereids.types.TinyIntType;
 import org.apache.doris.nereids.types.VarcharType;
@@ -936,6 +938,22 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
         fmod = new Fmod(new DoubleLiteral(Double.NaN), new DoubleLiteral(1));
         rewritten = executor.rewrite(fmod, context);
         Assertions.assertEquals(new DoubleLiteral(Double.NaN), rewritten);
+        fmod = new Fmod(new DoubleLiteral(Double.NaN), new DoubleLiteral(0));
+        rewritten = executor.rewrite(fmod, context);
+        Assertions.assertEquals(new NullLiteral(DoubleType.INSTANCE), rewritten);
+
+        fmod = new Fmod(new FloatLiteral(Float.POSITIVE_INFINITY), new FloatLiteral(1));
+        rewritten = executor.rewrite(fmod, context);
+        Assertions.assertEquals(new FloatLiteral(Float.NaN), rewritten);
+        fmod = new Fmod(new FloatLiteral(Float.NEGATIVE_INFINITY), new FloatLiteral(1));
+        rewritten = executor.rewrite(fmod, context);
+        Assertions.assertEquals(new FloatLiteral(Float.NaN), rewritten);
+        fmod = new Fmod(new FloatLiteral(Float.NaN), new FloatLiteral(1));
+        rewritten = executor.rewrite(fmod, context);
+        Assertions.assertEquals(new FloatLiteral(Float.NaN), rewritten);
+        fmod = new Fmod(new FloatLiteral(Float.NaN), new FloatLiteral(0));
+        rewritten = executor.rewrite(fmod, context);
+        Assertions.assertEquals(new NullLiteral(FloatType.INSTANCE), rewritten);
 
         Radians radians = new Radians(new DoubleLiteral(Double.POSITIVE_INFINITY));
         rewritten = executor.rewrite(radians, context);

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_numeric_arithmatic.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_numeric_arithmatic.groovy
@@ -321,6 +321,7 @@ suite("fold_constant_numeric_arithmatic") {
     testFoldConst("SELECT MOD(10.5, -3.2) AS fmod_case_3") //fmod(10.5 % -3.2)
     testFoldConst("SELECT MOD(10.5, 0) AS fmod_case_exception") //undefined (returns NULL or error)
     testFoldConst("SELECT fmod(10.5, 3), fmod(-10.5, 3), fmod(10.5, -3)")
+    testFoldConst("SELECT fmod(10.5, 0) AS fmod_case_1") //fmod(10.5 % 0)
     testFoldConst("SELECT MOD(NULL, 3)") // NULL dividend
     testFoldConst("SELECT MOD(10, NULL)") // NULL divisor
     testFoldConst("SELECT MOD(0, 3)") // Zero dividend


### PR DESCRIPTION
### What problem does this PR solve?

Fmod should return null when second argument is 0.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

