### PR TITLE
[fix](adjust nullable) fix compare datetime like throw adjust nullable exception 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicate.java
@@ -66,7 +66,6 @@ import org.apache.doris.nereids.util.TypeCoercionUtils;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;

--- a/regression-test/data/nereids_rules_p0/adjust_nullable/test_adjust_nullable.out
+++ b/regression-test/data/nereids_rules_p0/adjust_nullable/test_adjust_nullable.out
@@ -2,7 +2,8 @@
 -- !avg_shape --
 PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalCteProducer ( cteId=CTEId#0 )
-----PhysicalOlapScan[test_adjust_nullable_t]
+----PhysicalProject[test_adjust_nullable_t.a, test_adjust_nullable_t.b, test_adjust_nullable_t.c]
+------PhysicalOlapScan[test_adjust_nullable_t]
 --PhysicalResultSink
 ----PhysicalProject[(cast(sum(DISTINCT b) as DOUBLE) / cast(count(DISTINCT b) as DOUBLE)) AS `AVG(distinct b)`, non_nullable((cast(sum(DISTINCT a) as DOUBLE) / cast(count(DISTINCT a) as DOUBLE))) AS `AVG(distinct a)`]
 ------hashJoin[INNER_JOIN colocated] hashCondition=((c <=> .c)) otherCondition=()
@@ -16,4 +17,14 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------hashAgg[GLOBAL]
 --------------PhysicalDistribute[DistributionSpecHash]
 ----------------PhysicalCteConsumer ( cteId=CTEId#0 )
+
+-- !null_safe_equal_datetime --
+PhysicalResultSink
+--PhysicalProject[AND[(non_nullable(d) >= '2000-01-02 12:34:56.000'),(non_nullable(d) <= '2000-01-02 12:34:56.999'),( not d IS NULL)] AS `cast(d as datetime(0)) <=> '2000-01-02 12:34:56'`]
+----PhysicalOlapScan[test_adjust_nullable_t]
+
+-- !null_safe_equal_date --
+PhysicalResultSink
+--PhysicalProject[AND[(non_nullable(d) >= '2000-01-02 00:00:00.000'),(non_nullable(d) <= '2000-01-02 23:59:59.999'),( not d IS NULL)] AS `cast(d as date) <=> '2000-01-02'`]
+----PhysicalOlapScan[test_adjust_nullable_t]
 

--- a/regression-test/suites/nereids_rules_p0/adjust_nullable/test_adjust_nullable.groovy
+++ b/regression-test/suites/nereids_rules_p0/adjust_nullable/test_adjust_nullable.groovy
@@ -23,8 +23,8 @@ suite('test_adjust_nullable') {
     sql "SET detail_shape_nodes='PhysicalProject'"
     sql "DROP TABLE IF EXISTS ${tbl} FORCE"
     sql "set runtime_filter_mode=OFF"
-    sql "CREATE TABLE ${tbl}(a int not null, b int, c int not null) distributed by hash(a) properties('replication_num' = '1')"
-    sql "INSERT INTO ${tbl} VALUES(1, 2, 3)"
+    sql "CREATE TABLE ${tbl}(a int not null, b int, c int not null, d datetime(3)) distributed by hash(a) properties('replication_num' = '1')"
+    sql "INSERT INTO ${tbl} VALUES(1, 2, 3, '2020-12-01 01:02:03.456')"
 
     // avg => sum / count
     // avg is not nullable,  while divide '/' is nullable, need add non_nullable
@@ -32,6 +32,14 @@ suite('test_adjust_nullable') {
     qt_avg_shape """explain shape plan
         SELECT AVG(distinct a), AVG(distinct b) FROM ${tbl} GROUP BY c
     """
+
+    qt_null_safe_equal_datetime '''explain shape plan
+        select cast(d as datetime(0)) <=> '2000-01-02 12:34:56' from test_adjust_nullable_t
+    '''
+
+    qt_null_safe_equal_date '''explain shape plan
+        select cast(d as date) <=> '2000-01-02' from test_adjust_nullable_t
+    '''
 
     sql "DROP TABLE IF EXISTS ${tbl} FORCE"
 }


### PR DESCRIPTION
### What problem does this PR solve?

for sql `select cast(c_datetime as date) <=> '2000-01-02' from test_adjust_nullable_t` will throw

```
java.sql.SQLException: errCode = 2, detailMessage = AdjustNullable convert slot __null_safe_equal_0#4 from not-nullable to nullable. You can disable check by set fe_debug = false.
```

because for expression  `cast(c_datetime as date) <=> '2000-01-02'`  is non-nullable,  but the rewritten experssion is `AND[c_datetime >= '2000-01-02 00:00:00',    c_datetime <= '2000-01-02 23:59:50',  c_datetime is not null]` is nullable, need add non-nullable function for c_datetime in the rewritten expression.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

