### PR TITLE
[Fix](regression) fix wrong regression result of bool_agg

### DIFF
--- a/regression-test/data/query_p0/sql_functions/aggregate_functions/test_aggregate_all_functions2.out
+++ b/regression-test/data/query_p0/sql_functions/aggregate_functions/test_aggregate_all_functions2.out
@@ -164,18 +164,18 @@ false
 
 -- !bool_and --
 \N
-true
+false
+false
+false
+false
+false
+false
 false
 true
 false
-false
-false
-false
 true
-false
-false
 true
-false
+true
 true
 true
 true
@@ -216,19 +216,19 @@ false
 
 -- !bool_xor --
 \N
-true
-false
-false
 false
 true
-true
-false
-false
-false
-false
 false
 true
 true
+true
+true
+false
+false
+false
+false
+false
+false
 false
 true
 

--- a/regression-test/suites/query_p0/sql_functions/aggregate_functions/test_aggregate_all_functions2.groovy
+++ b/regression-test/suites/query_p0/sql_functions/aggregate_functions/test_aggregate_all_functions2.groovy
@@ -106,14 +106,14 @@ suite("test_aggregate_all_functions2") {
     qt_bool_and """SELECT bool_and(k0) FROM baseall;"""
     qt_bool_and """SELECT bool_and(k1) FROM baseall;"""
     qt_bool_and """SELECT bool_and(k8) over(partition by k6) from baseall order by k1;"""
-    qt_bool_and """SELECT booland_agg(k0) over(partition by k8) from baseall order by k3;"""
+    qt_bool_and """SELECT booland_agg(k0) over(partition by k8) from baseall order by k1;"""
     qt_bool_or """SELECT bool_or(k2) FROM baseall group by k6 order by 1;"""
     qt_bool_or """SELECT bool_or(k3) FROM baseall;"""
-    qt_bool_or """SELECT boolor_agg(k4) over(partition by k9) from baseall order by k7;"""
+    qt_bool_or """SELECT boolor_agg(k4) over(partition by k9) from baseall order by k1;"""
     qt_bool_xor """SELECT bool_xor(k4) FROM baseall;"""
     qt_bool_xor """SELECT bool_xor(k5) FROM baseall group by k6 order by 1;"""
-    qt_bool_xor """SELECT boolxor_agg(k13) over(partition by k10) from baseall order by k2;"""
-    
+    qt_bool_xor """SELECT boolxor_agg(k13) over(partition by k10) from baseall order by k1;"""
+
     test {
         sql """SELECT booland_agg(k7) FROM baseall;"""
         exception "requires a boolean or numeric argument"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

the regression test output order was inconsistent when using `ORDER BY k3 / k2`, due to multiple rows having the same value for k3. By change the constraint to `ORDER BY k1`, the output order is now stabilized.

### Release note

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

