### PR TITLE
[bugfix](memtracker) memory not consumed by memtracker

### DIFF
--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -93,6 +93,7 @@ PipelineTask::PipelineTask(PipelinePtr& pipeline, uint32_t task_id, RuntimeState
 
 PipelineTask::~PipelineTask() {
     SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_query_mem_tracker);
+    _shared_state_map.clear();
     _sink_shared_state.reset();
     _op_shared_states.clear();
     _sink.reset();

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -92,6 +92,10 @@ PipelineTask::PipelineTask(PipelinePtr& pipeline, uint32_t task_id, RuntimeState
 }
 
 PipelineTask::~PipelineTask() {
+    // PipelineTask is also hold by task queue( https://github.com/apache/doris/pull/49753),
+    // so that it maybe the last one to be destructed.
+    // But pipeline task hold some objects, like operators, shared state, etc. So that should release
+    // memory manually.
     SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_query_mem_tracker);
     _shared_state_map.clear();
     _sink_shared_state.reset();

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -81,6 +81,7 @@ PipelineTask::PipelineTask(PipelinePtr& pipeline, uint32_t task_id, RuntimeState
           _task_idx(task_idx),
           _memory_sufficient_dependency(state->get_query_ctx()->get_memory_sufficient_dependency()),
           _pipeline_name(_pipeline->name()) {
+    _query_mem_tracker = fragment_context->get_query_ctx()->query_mem_tracker();
     _execution_dependencies.push_back(state->get_query_ctx()->get_execution_dependency());
     if (!_shared_state_map.contains(_sink->dests_id().front())) {
         auto shared_state = _sink->create_shared_state();
@@ -88,6 +89,17 @@ PipelineTask::PipelineTask(PipelinePtr& pipeline, uint32_t task_id, RuntimeState
             _sink_shared_state = shared_state;
         }
     }
+}
+
+PipelineTask::~PipelineTask() {
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_query_mem_tracker);
+    _sink_shared_state.reset();
+    _op_shared_states.clear();
+    _sink.reset();
+    _operators.clear();
+    _spill_context.reset();
+    _block.reset();
+    _pipeline.reset();
 }
 
 Status PipelineTask::prepare(const std::vector<TScanRangeParams>& scan_range, const int sender_id,

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -81,7 +81,9 @@ PipelineTask::PipelineTask(PipelinePtr& pipeline, uint32_t task_id, RuntimeState
           _task_idx(task_idx),
           _memory_sufficient_dependency(state->get_query_ctx()->get_memory_sufficient_dependency()),
           _pipeline_name(_pipeline->name()) {
+#ifndef BE_TEST
     _query_mem_tracker = fragment_context->get_query_ctx()->query_mem_tracker();
+#endif
     _execution_dependencies.push_back(state->get_query_ctx()->get_execution_dependency());
     if (!_shared_state_map.contains(_sink->dests_id().front())) {
         auto shared_state = _sink->create_shared_state();
@@ -92,11 +94,13 @@ PipelineTask::PipelineTask(PipelinePtr& pipeline, uint32_t task_id, RuntimeState
 }
 
 PipelineTask::~PipelineTask() {
-    // PipelineTask is also hold by task queue( https://github.com/apache/doris/pull/49753),
-    // so that it maybe the last one to be destructed.
-    // But pipeline task hold some objects, like operators, shared state, etc. So that should release
-    // memory manually.
+// PipelineTask is also hold by task queue( https://github.com/apache/doris/pull/49753),
+// so that it maybe the last one to be destructed.
+// But pipeline task hold some objects, like operators, shared state, etc. So that should release
+// memory manually.
+#ifndef BE_TEST
     SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_query_mem_tracker);
+#endif
     _shared_state_map.clear();
     _sink_shared_state.reset();
     _op_shared_states.clear();

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -55,6 +55,8 @@ public:
                          shared_state_map,
                  int task_idx);
 
+    ~PipelineTask();
+
     Status prepare(const std::vector<TScanRangeParams>& scan_range, const int sender_id,
                    const TDataSink& tsink);
 
@@ -259,6 +261,8 @@ private:
     std::atomic<bool> _running {false};
     std::atomic<bool> _eos {false};
     std::atomic<bool> _wake_up_early {false};
+    // PipelineTask maybe hold by TaskQueue
+    std::shared_ptr<MemTrackerLimiter> _query_mem_tracker;
 
     /**
          *


### PR DESCRIPTION
### What problem does this PR solve?

PipelineTask is also hold by task queue( https://github.com/apache/doris/pull/49753), so that it maybe the last one to be destructed.  But pipeline task hold some objects, like operators, shared state, etc. So that should release memory manually.

F20250908 20:07:41.329619 39575 mem_tracker_limiter.cpp:112] mem tracker label: Query#Id=ec8535b35ed34f54-afd752d5d1dd97c1, consumption: 16640, peak consumption: 16640, mem tracker not equal to 0 when mem
 tracker destruct, this usually means that memory tracking is inaccurate and SCOPED_ATTACH_TASK and SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER are not used correctly. If the log is truncated, search for `Address Sanitizer` in the be.INFO log to see more information.1. For query and load, memory leaks may have occurred, it is expected that the query mem tracker will be bound to the thread context using SCOPED_ATTACH_TASK and SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER before all memory alloc and free. 2. If a memory alloc is recorded by this tracker, it is expected that be recorded in this tracker when memory is freed. 3. Merge the remaining memory tracking value by this tracker into Orphan, if you observe that Orphan is not equal to 0 in the mem tracker web or log, this indicates that there may be a memory leak. 4. If you need to transfer memory tracking value between two trackers, can use transfer_to..[Address Sanitizer]:
 memory not be freed:
    [Address Sanitizer] buf not be freed, mem tracker label: Query#Id=ec8535b35ed34f54-afd752d5d1dd97c1, consumption: 16640, peak consumption: 16640, buf: 0x7d87c8761d00, size 4096, strack trace: 
        0#  doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>::alloc(unsigned long, unsigned long)
        1#  void doris::vectorized::PODArrayBase<1ul, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul>::alloc<>(unsigned long)
        2#  void doris::vectorized::PODArray<signed char, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul>::push_back<long>(long&&)
        3#  doris::vectorized::ColumnVector<(doris::PrimitiveType)3>::insert(doris::vectorized::Field const&)
        4#  doris::vectorized::IDataType::create_column_const(unsigned long, doris::vectorized::Field const&) const
        5#  doris::vectorized::VLiteral::init(doris::TExprNode const&)
        6#  doris::vectorized::VLiteral::VLiteral(doris::TExprNode const&, bool)
        7#  std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<doris::vectorized::VLiteral, std::allocator<void>, doris::TExprNode const&>(doris::vectorized::VLiteral*&, std::_Sp_alloc_shared_tag<std::allocator<void> >, doris::TExprNode const&)
        8#  doris::vectorized::VExpr::create_expr(doris::TExprNode const&, std::shared_ptr<doris::vectorized::VExpr>&)
        9#  doris::vectorized::VExpr::create_tree_from_thrift(std::vector<doris::TExprNode, std::allocator<doris::TExprNode> > const&, int*, std::shared_ptr<doris::vectorized::VExpr>&, std::shared_ptr<doris::vectorized::VExprContext>&)
        10# doris::vectorized::VExpr::create_expr_tree(doris::TExpr const&, std::shared_ptr<doris::vectorized::VExprContext>&)
        11# doris::pipeline::OperatorXBase::init(doris::TPlanNode const&, doris::RuntimeState*)
        12# doris::pipeline::ScanOperatorX<doris::pipeline::OlapScanLocalState>::init(doris::TPlanNode const&, doris::RuntimeState*)
        13# doris::pipeline::PipelineFragmentContext::_create_tree_helper(doris::ObjectPool*, std::vector<doris::TPlanNode, std::allocator<doris::TPlanNode> > const&, doris::TPipelineFragmentParams const&, doris::DescriptorTbl const&, std::shared_ptr<doris::pipeline::OperatorXBase>, int*, std::shared_ptr<doris::pipeline::OperatorXBase>*, std::shared_ptr<doris::pipeline::Pipeline>&, int, bool)
        14# doris::pipeline::PipelineFragmentContext::_build_pipelines(doris::ObjectPool*, doris::TPipelineFragmentParams const&, doris::DescriptorTbl const&, std::shared_ptr<doris::pipeline::OperatorXBase>*, std::shared_ptr<doris::pipeline::Pipeline>)
        15# doris::pipeline::PipelineFragmentContext::prepare(doris::TPipelineFragmentParams const&, doris::ThreadPool*)
        16# doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, doris::QuerySource, std::function<void (doris::RuntimeState*, doris::Status*)> const&, doris::TPipelineFragmentParamsList const&)
        17# doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, doris::QuerySource, doris::TPipelineFragmentParamsList const&)
        18# doris::PInternalService::_exec_plan_fragment_impl(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, doris::PFragmentRequestVersion, bool, std::function<void (doris::RuntimeState*, doris::Status*)> const&)
        19# doris::PInternalService::_exec_plan_fragment_in_pthread(google::protobuf::RpcController*, doris::PExecPlanFragmentRequest const*, doris::PExecPlanFragmentResult*, google::protobuf::Closure*)
        20# doris::WorkThreadPool<false>::work_thread(int)
        21# execute_native_thread_routine
        22# asan_thread_start(void*)
        23# ? 

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

