### PR TITLE
[compile](arm) fix arm compile failed

### DIFF
--- a/be/src/vec/functions/array/function_array_distance.cpp
+++ b/be/src/vec/functions/array/function_array_distance.cpp
@@ -21,7 +21,7 @@
 
 namespace doris::vectorized {
 
-#if defined(__x86_64__) && (defined(__clang_major__) && (__clang_major__ > 10))
+#if defined(__clang_major__) && (__clang_major__ > 10)
 #define PRAGMA_IMPRECISE_FUNCTION_BEGIN _Pragma("float_control(precise, off, push)")
 #define PRAGMA_IMPRECISE_FUNCTION_END _Pragma("float_control(pop)")
 


### PR DESCRIPTION
Fix arm compile failed：
```
FAILED: src/vec/CMakeFiles/Vec.dir/functions/array/function_array_distance.cpp.o
ccache /usr/local/bin/ldb-toolchain/bin/clang++ -DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG -DBOOST_STACKTRACE_USE_BACKTRACE -DBOOST_SYSTEM_NO_DEPRECATED -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX=1 -DBRPC_ENABLE_CPU_PROFILER -DGLOG_CUSTOM_PREFIX_SUPPORT -DHAVE_INTTYPES_H -DHAVE_NETINET_IN_H -DLIBJVM -DS2_USE_GFLAGS -DS2_USE_GLOG -DUSE_DORIS_HADOOP_HDFS -DUSE_HADOOP_HDFS -DUSE_JEMALLOC -DUSE_MEM_TRACKER -D__STDC_FORMAT_MACROS -I/home/zcp/repo_center/doris_branch-3.1/doris/be/src/apache-orc/c++/include -I/home/zcp/repo_center/doris_branch-3.1/doris/be/build_RELEASE/src/apache-orc/c++/include -I/home/zcp/repo_center/doris_branch-3.1/doris/be/build_RELEASE/src/clucene/src/shared -I/home/zcp/repo_center/doris_branch-3.1/doris/be/src/clucene/src/core -I/home/zcp/repo_center/doris_branch-3.1/doris/be/src/clucene/src/shared -I/home/zcp/repo_center/doris_branch-3.1/doris/be/src/clucene/src/contribs-lib -I/home/zcp/repo_center/doris_branch-3.1/doris/be/src -I/home/zcp/repo_center/doris_branch-3.1/doris/be/test -I/usr/local/bisheng-jdk-17/include -I/usr/local/bisheng-jdk-17/include/linux -isystem /home/zcp/repo_center/doris_branch-3.1/doris/be/../common -isystem /home/zcp/repo_center/doris_branch-3.1/doris/be/../gensrc/build -isystem /home/zcp/repo_center/doris_branch-3.1/doris/thirdparty/installed/include -isystem /home/zcp/repo_center/doris_branch-3.1/doris/thirdparty/installed/gperftools/include -DENABLE_CACHE_LOCK_DEBUG -O3 -DNDEBUG  -O3 -DNDEBUG   -D OS_LINUX -g -Wall -Wextra -Werror -pthread -fstrict-aliasing -fno-omit-frame-pointer -Wnon-virtual-dtor -Wno-unused-parameter -Wno-sign-compare -fcolor-diagnostics -Wpedantic -Wshadow-field -Wunused -Wunused-command-line-argument -Wunused-exception-parameter -Wunused-volatile-lvalue -Wunused-template -Wunused-member-function -Wunused-macros -Wconversion -Wno-gnu-statement-expression -Wno-implicit-float-conversion -Wno-implicit-int-conversion -Wno-sign-conversion -Wno-missing-field-initializers -Wno-unused-const-variable -Wno-shorten-64-to-32 -march=armv8-a+crc -std=gnu++20 -MD -MT src/vec/CMakeFiles/Vec.dir/functions/array/function_array_distance.cpp.o -MF src/vec/CMakeFiles/Vec.dir/functions/array/function_array_distance.cpp.o.d -o src/vec/CMakeFiles/Vec.dir/functions/array/function_array_distance.cpp.o -c /home/zcp/repo_center/doris_branch-3.1/doris/be/src/vec/functions/array/function_array_distance.cpp
/home/zcp/repo_center/doris_branch-3.1/doris/be/src/vec/functions/array/function_array_distance.cpp:38:1: error: unknown pragma ignored [-Werror,-Wunknown-pragmas]
PRAGMA_IMPRECISE_FUNCTION_BEGIN
^
/home/zcp/repo_center/doris_branch-3.1/doris/be/src/vec/functions/array/function_array_distance.cpp:30:5: note: expanded from macro 'PRAGMA_IMPRECISE_FUNCTION_BEGIN'
    _Pragma("GCC push_options")         \
    ^
<scratch space>:133:6: note: expanded from here
 GCC push_options
     ^
/home/zcp/repo_center/doris_branch-3.1/doris/be/src/vec/functions/array/function_array_distance.cpp:38:1: error: unknown pragma ignored [-Werror,-Wunknown-pragmas]
/home/zcp/repo_center/doris_branch-3.1/doris/be/src/vec/functions/array/function_array_distance.cpp:31:13: note: expanded from macro 'PRAGMA_IMPRECISE_FUNCTION_BEGIN'
            _Pragma("GCC optimize (\"unroll-loops,associative-math,no-signed-zeros\")")
            ^
<scratch space>:135:6: note: expanded from here
 GCC optimize ("unroll-loops,associative-math,no-signed-zeros")
     ^
/home/zcp/repo_center/doris_branch-3.1/doris/be/src/vec/functions/array/function_array_distance.cpp:81:1: error: unknown pragma ignored [-Werror,-Wunknown-pragmas]
PRAGMA_IMPRECISE_FUNCTION_END
^
/home/zcp/repo_center/doris_branch-3.1/doris/be/src/vec/functions/array/function_array_distance.cpp:32:39: note: expanded from macro 'PRAGMA_IMPRECISE_FUNCTION_END'
#define PRAGMA_IMPRECISE_FUNCTION_END _Pragma("GCC pop_options")
                                      ^
<scratch space>:137:6: note: expanded from here
 GCC pop_options
     ^
```