### PR TITLE
[opt](outfile) change suffix of compressed file

### DIFF
--- a/be/src/vec/sink/writer/vfile_result_writer.cpp
+++ b/be/src/vec/sink/writer/vfile_result_writer.cpp
@@ -209,9 +209,9 @@ std::string VFileResultWriter::_file_format_to_name() {
 std::string VFileResultWriter::_compression_type_to_name() {
     switch (_file_opts->compression_type) {
     case TFileCompressType::GZ:
-        return ".gzip";
+        return ".gz";
     case TFileCompressType::BZ2:
-        return ".bzip2";
+        return ".bz2";
     case TFileCompressType::SNAPPYBLOCK:
         return ".snappy";
     case TFileCompressType::LZ4BLOCK:


### PR DESCRIPTION
### What problem does this PR solve?

Followup #55392
Change gzip to gz, bzip2 to bz2.
So that tools like `gunzip` can recognize it directly

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

