### PR TITLE
[fix](connection)Fix kill connection will make current connection killed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -1039,7 +1039,7 @@ public class ConnectContext {
                 killConnection);
 
         if (killConnection) {
-           killConnection();
+            killConnection();
         }
         // Now, cancel running query.
         cancelQuery(new Status(TStatusCode.CANCELLED, "cancel query by user from " + getRemoteHostPortString()));

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -1026,7 +1026,7 @@ public class ConnectContext {
         if (killConnection) {
             isKilled = true;
             // Close channel to break connection with client
-            closeChannel();
+            // closeChannel();
         }
         // Now, cancel running query.
         cancelQuery(new Status(TStatusCode.CANCELLED, "cancel query by user from " + getRemoteHostPortString()));

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -1030,10 +1030,6 @@ public class ConnectContext {
         }
         // Now, cancel running query.
         cancelQuery(new Status(TStatusCode.CANCELLED, "cancel query by user from " + getRemoteHostPortString()));
-        // Clean up after cancelQuery to avoid needing session variables etc. inside cancelQuery
-        if (killConnection) {
-            cleanup();
-        }
     }
 
     // kill operation with no protect by timeout.

--- a/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/sessions/FlightSqlConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/sessions/FlightSqlConnectContext.java
@@ -74,16 +74,10 @@ public class FlightSqlConnectContext extends ConnectContext {
         LOG.warn("kill query from {}, kill flight sql connection: {}", getRemoteHostPortString(), killConnection);
 
         if (killConnection) {
-            isKilled = true;
-            // Close channel and break connection with client.
-            closeChannel();
+            killConnection();
         }
         // Now, cancel running query.
         cancelQuery(new Status(TStatusCode.CANCELLED, "arrow flight query killed by user"));
-        // Clean up after cancelQuery to avoid needing session variables etc. inside cancelQuery
-        if (killConnection) {
-            cleanup();
-        }
     }
 
     @Override


### PR DESCRIPTION
### What problem does this PR solve?

kill connection should not call `threadLocalInfo.remove();`,it will make current thread `getConnection` is null

The current historical legacy issue: after killing the connection, it is not possible to execute threadLocalInfo. remove() on the corresponding thread; Resulting in more memory usage

Related PR: #55008 

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

