### PR TITLE
[chore](thirdparty) update vectorscan to 5.4.12 to incorporate bugfixes

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -395,10 +395,10 @@ fi
 # patch hyperscan
 # https://github.com/intel/hyperscan/issues/292
 if [[ " ${TP_ARCHIVES[*]} " =~ " HYPERSCAN " ]]; then
-    if [[ "${HYPERSCAN_SOURCE}" == "vectorscan-vectorscan-5.4.11" ]]; then
+    if [[ "${HYPERSCAN_SOURCE}" == "vectorscan-vectorscan-5.4.12" ]]; then
         cd "${TP_SOURCE_DIR}/${HYPERSCAN_SOURCE}"
         if [[ ! -f "${PATCHED_MARK}" ]]; then
-            patch -p1 <"${TP_PATCH_DIR}/vectorscan-5.4.11.patch"
+            patch -p1 <"${TP_PATCH_DIR}/vectorscan-5.4.12.patch"
             touch "${PATCHED_MARK}"
         fi
         cd -

--- a/thirdparty/patches/vectorscan-5.4.12.patch
+++ b/thirdparty/patches/vectorscan-5.4.12.patch
@@ -1,0 +1,52 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 577f90e2..c5f054d6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1317,10 +1317,10 @@ if(BUILD_UNIT)
+     add_subdirectory(unit)
+ endif()
+ 
+-option(BUILD_TOOLS "Build Hyperscan tools (default TRUE)" TRUE)
+-if(EXISTS ${CMAKE_SOURCE_DIR}/tools/CMakeLists.txt AND BUILD_TOOLS)
+-    add_subdirectory(tools)
+-endif()
++#option(BUILD_TOOLS "Build Hyperscan tools (default TRUE)" TRUE)
++#if(EXISTS ${CMAKE_SOURCE_DIR}/tools/CMakeLists.txt AND BUILD_TOOLS)
++#    add_subdirectory(tools)
++#endif()
+ 
+ if (EXISTS ${CMAKE_SOURCE_DIR}/chimera/CMakeLists.txt AND BUILD_CHIMERA)
+     add_subdirectory(chimera)
+diff --git a/cmake/build_wrapper.sh b/cmake/build_wrapper.sh
+index d0a7e923..d7aea222 100755
+--- a/cmake/build_wrapper.sh
++++ b/cmake/build_wrapper.sh
+@@ -25,11 +25,11 @@ if [ `uname` = "FreeBSD" ]; then
+ fi
+ cp ${KEEPSYMS_IN} ${KEEPSYMS}
+ # get all symbols from libc and turn them into patterns
+-nm ${NM_FLAG} p -g -D ${LIBC_SO} | sed 's/\([^ @]*\).*/^\1$/' >> ${KEEPSYMS}
++nm ${NM_FLAG} posix -g -D ${LIBC_SO} | sed 's/\([^ @]*\).*/^\1$/' >> ${KEEPSYMS}
+ # build the object
+ "$@"
+ # rename the symbols in the object
+-nm ${NM_FLAG} p -g ${OUT} | cut -f1 -d' ' | grep -v -f ${KEEPSYMS} | sed -e "s/\(.*\)/\1\ ${PREFIX}_\1/" >> ${SYMSFILE}
++nm ${NM_FLAG} posix -g ${OUT} | cut -f1 -d' ' | grep -v -f ${KEEPSYMS} | sed -e "s/\(.*\)/\1\ ${PREFIX}_\1/" >> ${SYMSFILE}
+ if test -s ${SYMSFILE}
+ then
+     objcopy --redefine-syms=${SYMSFILE} ${OUT}
+diff --git a/src/util/arch/arm/cpuid_inline.h b/src/util/arch/arm/cpuid_inline.h
+index f8a59af3..3e28d009 100644
+--- a/src/util/arch/arm/cpuid_inline.h
++++ b/src/util/arch/arm/cpuid_inline.h
+@@ -39,6 +39,10 @@
+ #endif
+ #endif
+ 
++#if !defined(HWCAP2_SVE2)
++#define HWCAP2_SVE2 0
++#endif
++
+ #include "ue2common.h"
+ #include "util/arch/common/cpuid_flags.h"
+ 

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -161,10 +161,10 @@ HYPERSCAN_MD5SUM="202f4b42f5dd4a7bb2506445e51a33b9"
 MACHINE_TYPE=$(uname -m)
 if [[ "${MACHINE_TYPE}" == "aarch64" || "${MACHINE_TYPE}" == 'arm64' ]]; then
     echo "use vectorscan instead of hyperscan on aarch64"
-    HYPERSCAN_DOWNLOAD="https://github.com/VectorCamp/vectorscan/archive/refs/tags/vectorscan/5.4.11.tar.gz"
-    HYPERSCAN_NAME=vectorscan-5.4.11.tar.gz
-    HYPERSCAN_SOURCE=vectorscan-vectorscan-5.4.11
-    HYPERSCAN_MD5SUM="e67b70403cba6c1654a9fef4fd15a2f2"
+    HYPERSCAN_DOWNLOAD="https://github.com/VectorCamp/vectorscan/archive/refs/tags/vectorscan/5.4.12.tar.gz"
+    HYPERSCAN_NAME=vectorscan-5.4.12.tar.gz
+    HYPERSCAN_SOURCE=vectorscan-vectorscan-5.4.12
+    HYPERSCAN_MD5SUM="384eab5b23831993df96e5fa55f9951e"
 fi
 
 # ragel (dependency for hyperscan)


### PR DESCRIPTION
### What problem does this PR solve?
Currently, doris bundles and uses an older version of vectorscan (a fork of HyperScan optimized for SIMD). To address known bugs, support risc-v, improve stability, support risc-v,and gain performance benefits, it is necessary to upgrade this dependency to the latest release version.

Issue Number: close #55228

Related PR: #xxx

Problem Summary:
Update the bundled vectorscan library from its current version to 5.4.12

### Release note
Reason for Change
This upgrade brings a multitude of fixes and optimizations, most notably:
Performance Improvement: Utilizes 256-bit TBL instructions to significantly speed up the truffle instruction.
Critical Bugfixes: Resolves several severe issues that could lead to incorrect results or runtime failures, including:
Fixes a potential failure in partial_load_u64 when handling zero-length buffers.
Corrects an out-of-bounds read in the AVX512VBMI implementation of fdr_exec_fat_teddy.
Fixes an off-by-one error in the SVE2 noodle implementation.
Allows patterns that start with a null character (\0), improving compatibility.
Resolves a false positive issue at the end of a vector in the double shufti algorithm.
Fixes regressions related to AVX512VBMI.
System & Compatibility:
Fixes the SSE4.2 platform check in hs_valid_platform.
Resolves a regression in the configuration step that was introduced in version 5.4.11.
Removes build warnings related to Clang 17+ and Boost on macOS.
Adds the missing hs_version.h header file.
Addresses various Clang Tidy warnings, improving code quality.

Reference
Full changelog and release notes: https://github.com/VectorCamp/vectorscan/releases/tag/vectorscan%2F5.4.12

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

