### PR TITLE
[fix](function) The constant parameter of json_parse_error_to_value caused a crash

### DIFF
--- a/regression-test/data/query_p0/sql_functions/conditional_functions/test_json_parse.out
+++ b/regression-test/data/query_p0/sql_functions/conditional_functions/test_json_parse.out
@@ -53,3 +53,27 @@ null
 8	123
 9	[1,2,3]
 
+-- !parse_from_table_value3 --
+1	{}
+2	{}
+3	{}
+4	{}
+5	{}
+6	{}
+7	{}
+8	{}
+8	{}
+9	{}
+
+-- !parse_from_table_value4 --
+1	{"name":"Alice2","age":32}
+2	{"name":"Bob","age":25}
+3	{"name":"Jack","age":28}
+4	{"name":"Jim","age":33}
+5	\N
+6	\N
+7	[1,2,3]
+8	{"key":"value"}
+8	{"key2":"value2"}
+9	{"key":"value"}
+

--- a/regression-test/suites/query_p0/sql_functions/conditional_functions/test_json_parse.groovy
+++ b/regression-test/suites/query_p0/sql_functions/conditional_functions/test_json_parse.groovy
@@ -45,6 +45,8 @@ suite("test_json_parse") {
     qt_parse_from_table_null "SELECT id, json_parse_error_to_null(json_str) FROM test_json_parse_table ORDER BY id;"
     qt_parse_from_table_value1 "SELECT id, json_parse_error_to_value(json_str) FROM test_json_parse_table ORDER BY id;"
     qt_parse_from_table_value2 "SELECT id, json_parse_error_to_value(json_str, json_value) FROM test_json_parse_table ORDER BY id;"
+    qt_parse_from_table_value3 "SELECT id, json_parse_error_to_value('{}', json_value) FROM test_json_parse_table ORDER BY id;"
+    qt_parse_from_table_value4 "SELECT id, json_parse_error_to_value('{invalied}', json_value) FROM test_json_parse_table ORDER BY id;"
 
     check_fold_consistency "json_parse_error_to_null('{\"key\": \"value\"}')"
     check_fold_consistency "json_parse_error_to_null('Invalid JSON')"


### PR DESCRIPTION
### What problem does this PR solve?

```text
/root/doris/be/src/vec/exprs/vexpr_context.cpp:61:5: runtime error: member call on null pointer of type 'doris::vectorized::IColumn'
*** Query id: 4de27b4f69f442db-b95f0945ca48a16e ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1757407871 (unix time) try "date -d @1757407871" if you are using GNU date ***
*** Current BE git commitID: ecf3edb680 ***
*** SIGSEGV address not mapped to object (@0x0) received by PID 223317 (TID 226216 OR 0x7b53e70b3700) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:420
 1# 0x00007F5C38CFED10 in /lib64/libpthread.so.0
 2# doris::vectorized::VExprContext::execute(doris::vectorized::Block*, int*) at /root/doris/be/src/vec/exprs/vexpr_context.cpp:61
 3# doris::vectorized::Scanner::_do_projections(doris::vectorized::Block*, doris::vectorized::Block*) at /root/doris/be/src/vec/exec/scan/scanner.cpp:191
 4# doris::vectorized::Scanner::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /root/doris/be/src/vec/exec/scan/scanner.cpp:83
 5# doris::vectorized::ScannerScheduler::_scanner_scan(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>) at /root/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:182
 6# doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}::operator()() const::{lambda()#1}::operator()() const at /root/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:96
 7# doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}::operator()() const at /root/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:95
 8# bool std::__invoke_impl<bool, doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}&>(std::__invoke_other, doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}&) at /root/ldb_toolchain_taipan/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:63
 9# std::enable_if<is_invocable_r_v<bool, doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}&>, bool>::type std::__invoke_r<bool, doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}&>(doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}&) at /root/ldb_toolchain_taipan/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:116
10# std::_Function_handler<bool (), doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}>::_M_invoke(std::_Any_data const&) at /root/ldb_toolchain_taipan/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:292
11# std::function<bool ()>::operator()() const at /root/ldb_toolchain_taipan/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:593
12# doris::vectorized::ScannerSplitRunner::process_for(std::chrono::duration<long, std::ratio<1l, 1000000000l> >) at /root/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:410
13# doris::vectorized::PrioritizedSplitRunner::process() at /root/doris/be/src/vec/exec/executor/time_sharing/prioritized_split_runner.cpp:103
14# doris::vectorized::TimeSharingTaskExecutor::_dispatch_thread() at /root/doris/be/src/vec/exec/executor/time_sharing/time_sharing_task_executor.cpp:570
15# void std::__invoke_impl<void, void (doris::vectorized::TimeSharingTaskExecutor::*&)(), doris::vectorized::TimeSharingTaskExecutor*&>(std::__invoke_memfun_deref, void (doris::vectorized::TimeSharingTaskExecutor::*&)(), doris::vectorized::TimeSharingTaskExecutor*&) at /root/ldb_toolchain_taipan/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:76
16# std::__invoke_result<void (doris::vectorized::TimeSharingTaskExecutor::*&)(), doris::vectorized::TimeSharingTaskExecutor*&>::type std::__invoke<void (doris::vectorized::TimeSharingTaskExecutor::*&)(), doris::vectorized::TimeSharingTaskExecutor*&>(void (doris::vectorized::TimeSharingTaskExecutor::*&)(), doris::vectorized::TimeSharingTaskExecutor*&) at /root/ldb_toolchain_taipan/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:98
17# void std::_Bind<void (doris::vectorized::TimeSharingTaskExecutor::*(doris::vectorized::TimeSharingTaskExecutor*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) at /root/ldb_toolchain_taipan/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/functional:515
18# void std::_Bind<void (doris::vectorized::TimeSharingTaskExecutor::*(doris::vectorized::TimeSharingTaskExecutor*))()>::operator()<, void>() at /root/ldb_toolchain_taipan/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/functional:600
19# void std::__invoke_impl<void, std::_Bind<void (doris::vectorized::TimeSharingTaskExecutor::*(doris::vectorized::TimeSharingTaskExecutor*))()>&>(std::__invoke_other, std::_Bind<void (doris::vectorized::TimeSharingTaskExecutor::*(doris::vectorized::TimeSharingTaskExecutor*))()>&) at /root/ldb_toolchain_taipan/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:63
20# std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::vectorized::TimeSharingTaskExecutor::*(doris::vectorized::TimeSharingTaskExecutor*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::vectorized::TimeSharingTaskExecutor::*(doris::vectorized::TimeSharingTaskExecutor*))()>&>(std::_Bind<void (doris::vectorized::TimeSharingTaskExecutor::*(doris::vectorized::TimeSharingTaskExecutor*))()>&) at /root/ldb_toolchain_taipan/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:119
21# std::_Function_handler<void (), std::_Bind<void (doris::vectorized::TimeSharingTaskExecutor::*(doris::vectorized::TimeSharingTaskExecutor*))()> >::_M_invoke(std::_Any_data const&) at /root/ldb_toolchain_taipan/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:292
22# std::function<void ()>::operator()() const at /root/ldb_toolchain_taipan/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:593
23# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:460
24# asan_thread_start(void*) in /root/doris/be/output/lib/doris_be
25# start_thread in /lib64/libpthread.so.0
26# __GI___clone in /lib64/libc.so.6
```
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

