### PR TITLE
branch-3.1: [fix](variant) Compatibility error when the sparse column is empty

### DIFF
--- a/be/src/olap/rowset/segment_v2/variant/variant_column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/variant/variant_column_reader.cpp
@@ -225,6 +225,11 @@ Status VariantColumnReader::_new_iterator_with_flat_leaves(ColumnIteratorUPtr* i
             target_col.has_path_info() ? _subcolumns_meta_info->find_leaf(relative_path) : nullptr;
     if (!node) {
         if (relative_path.get_path() == SPARSE_COLUMN_PATH) {
+            if (_sparse_column_reader == nullptr) {
+                return Status::InternalError(
+                        "Sparse column reader is not initialize, variant column is: {}",
+                        target_col.path_info_ptr()->get_path());
+            }
             // read sparse column and filter extracted columns in subcolumn_path_map
             std::unique_ptr<ColumnIterator> inner_iter;
             RETURN_IF_ERROR(_sparse_column_reader->new_iterator(&inner_iter, nullptr));

--- a/be/test/olap/rowset/segment_v2/variant_column_writer_reader_test.cpp
+++ b/be/test/olap/rowset/segment_v2/variant_column_writer_reader_test.cpp
@@ -715,6 +715,14 @@ TEST_F(VariantColumnWriterReaderTest, test_write_data_normal) {
     EXPECT_TRUE(st.ok()) << st.msg();
     EXPECT_TRUE(assert_cast<DefaultValueColumnIterator*>(it7.get()) != nullptr);
     EXPECT_TRUE(io::global_local_filesystem()->delete_directory(_tablet->tablet_path()).ok());
+
+    // 20. check sparse column reader is nullptr
+    ColumnIteratorUPtr it_error;
+    variant_column_reader->_sparse_column_reader = nullptr;
+    st = variant_column_reader->new_iterator(&it_error, &sparse_column, &storage_read_opts,
+                                             &column_reader_cache);
+    EXPECT_FALSE(st.ok()) << st.msg();
+    EXPECT_TRUE(it_error == nullptr);
 }
 
 TEST_F(VariantColumnWriterReaderTest, test_write_data_advanced) {


### PR DESCRIPTION
### What problem does this PR solve?

In master #55127, the compaction process was made compatible with both the new and old variants, while in 3.1 a defensive strategy was used to prevent errors from occurring.

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

