### PR TITLE
[fix](regression) fix unstable case initial_join_order

### DIFF
--- a/regression-test/suites/nereids_p0/join/initial_join_order/initial_join_order.groovy
+++ b/regression-test/suites/nereids_p0/join/initial_join_order/initial_join_order.groovy
@@ -38,7 +38,7 @@ suite("initial_join_order") {
         v varchar(50) NOT NULL COMMENT ""
         ) ENGINE=OLAP
         DUPLICATE KEY(k)
-        DISTRIBUTED BY HASH(k) BUCKETS 57
+        DISTRIBUTED BY HASH(v) BUCKETS 57
         PROPERTIES ("replication_num" = "1");
 
         insert into t2 values (1, 'a');


### PR DESCRIPTION
### What problem does this PR solve?
in regression case :[initial_join_order.groovy] 
bucket shuffle join or broadcast join are both good for "t1 join t2", and leads to unstable plan.
in order to get statble plan, set t2 bucket key to v in order to avoid bucket shuffle join

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

