### PR TITLE
[fix](nereids) avoid NPE in SHOW TRANSACTION when label does not exist

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowTransactionCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowTransactionCommand.java
@@ -92,10 +92,11 @@ public class ShowTransactionCommand extends ShowCommand {
             resultSet = new ShowResultSet(getMetaData(), transactionMgr.getDbTransInfoByLabelMatch(db.getId(), label));
         } else {
             if (!label.isEmpty()) {
-                txnId = transactionMgr.getTransactionId(db.getId(), label);
-                if (txnId == -1) {
+                Long transactionId = transactionMgr.getTransactionId(db.getId(), label);
+                if (transactionId == null) {
                     throw new AnalysisException("transaction with label " + label + " does not exist");
                 }
+                txnId = transactionId;
             }
             resultSet = new ShowResultSet(getMetaData(), transactionMgr.getSingleTranInfo(db.getId(), txnId));
         }

--- a/regression-test/suites/query_p0/show/test_show_transaction.groovy
+++ b/regression-test/suites/query_p0/show/test_show_transaction.groovy
@@ -43,4 +43,11 @@ suite("test_show_transaction", "p0") {
         assertTrue(res.equals(reslike))
     }
 
+    // show transaction with label not exist
+    test {
+        def not_exist_label = 'label_test_show_transaction_${uuid}_not_exist'
+        sql """ show transaction where label = '${not_exist_label}'  """
+
+        exception """transaction with label ${not_exist_label} does not exist"""
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #55729

Problem Summary:

In `ShowTransactionCommand`, the branch that checks `txnId == -1` is dead code.
`TransactionMgr.getTransactionId()` never returns `-1`.
When the label does not exist, it returns `null`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

