### PR TITLE
[fix](paimon) Fix Paimon DLF catalog caching issue by adding dlf.catalog.id to cache key

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonAliyunDLFMetaStoreProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonAliyunDLFMetaStoreProperties.java
@@ -108,6 +108,7 @@ public class PaimonAliyunDLFMetaStoreProperties extends AbstractPaimonProperties
     @Override
     protected void appendCustomCatalogOptions() {
         catalogOptions.set("metastore.client.class", ProxyMetaStoreClient.class.getName());
+        catalogOptions.set("client-pool-cache.keys", "conf:" + DataLakeConfig.CATALOG_ID);
     }
 
     @Override


### PR DESCRIPTION
### What problem does this PR solve?

#### Problem:
  Paimon's CachedClientPool uses a static cache with keys based on clientClassName, metastore.uris, and metastore type. For DLF catalogs, all these
  values are identical, causing different DLF catalogs with different dlf.catalog_id configurations to incorrectly share the same HMS client pool.
  This results in the last created catalog's configuration overriding previous ones.

#### Root Cause:
  The cache key construction in CachedClientPool.extractKey() doesn't include DLF-specific configuration differences. Multiple catalogs with different
   dlf.catalog_id values generate identical cache keys, leading to client pool pollution.

#### Solution:
  Add dlf.catalog_id to the cache key by configuring client-pool-cache.keys = "conf:dlf.catalog.id" in
  PaimonAliyunDLFMetaStoreProperties.appendCustomCatalogOptions(). This ensures each DLF catalog with a unique catalog_id gets its own HMS client
  pool.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

