### PR TITLE
[refine](datatype) Provide a to_string function for DataTypeSerDe.

### DIFF
--- a/be/src/vec/data_types/data_type_decimal.h
+++ b/be/src/vec/data_types/data_type_decimal.h
@@ -231,7 +231,11 @@ public:
     std::string to_string(const FieldType& value) const;
     using SerDeType = DataTypeDecimalSerDe<T>;
     DataTypeSerDeSPtr get_serde(int nesting_level = 1) const override {
-        return std::make_shared<SerDeType>(precision, scale, nesting_level);
+        if constexpr (T == TYPE_DECIMALV2) {
+            return std::make_shared<SerDeType>(precision, get_format_scale(), nesting_level);
+        } else {
+            return std::make_shared<SerDeType>(precision, scale, nesting_level);
+        }
     };
 
     /// Decimal specific

--- a/be/src/vec/data_types/serde/data_type_array_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_array_serde.cpp
@@ -527,4 +527,23 @@ void DataTypeArraySerDe::write_one_cell_to_binary(const IColumn& src_column,
     }
 }
 
+void DataTypeArraySerDe::to_string(const IColumn& column, size_t row_num,
+                                   BufferWritable& bw) const {
+    const auto& data_column = assert_cast<const ColumnArray&>(column);
+    const auto& offsets = data_column.get_offsets();
+
+    size_t offset = offsets[row_num - 1];
+    size_t next_offset = offsets[row_num];
+
+    const IColumn& nested_column = data_column.get_data();
+    bw.write("[", 1);
+    for (size_t i = offset; i < next_offset; ++i) {
+        if (i != offset) {
+            bw.write(", ", 2);
+        }
+        nested_serde->to_string(nested_column, i, bw);
+    }
+    bw.write("]", 1);
+}
+
 } // namespace doris::vectorized

--- a/be/src/vec/data_types/serde/data_type_array_serde.h
+++ b/be/src/vec/data_types/serde/data_type_array_serde.h
@@ -117,6 +117,8 @@ public:
     void write_one_cell_to_binary(const IColumn& src_column, ColumnString::Chars& chars,
                                   int64_t row_num) const override;
 
+    void to_string(const IColumn& column, size_t row_num, BufferWritable& bw) const override;
+
 private:
     template <bool is_binary_format>
     Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,

--- a/be/src/vec/data_types/serde/data_type_decimal_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_decimal_serde.cpp
@@ -37,6 +37,7 @@
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_decimal.h"
 #include "vec/functions/cast/cast_to_decimal.h"
+#include "vec/functions/cast/cast_to_string.h"
 #include "vec/io/io_helper.h"
 
 namespace doris::vectorized {
@@ -485,6 +486,28 @@ void DataTypeDecimalSerDe<T>::write_one_cell_to_jsonb(const IColumn& column, Jso
     } else {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
                                "write_one_cell_to_jsonb with type " + column.get_name());
+    }
+}
+
+template <PrimitiveType T>
+void DataTypeDecimalSerDe<T>::to_string(const IColumn& column, size_t row_num,
+                                        BufferWritable& bw) const {
+    auto& data = assert_cast<const ColumnDecimal<T>&>(column).get_data();
+    CastToString::push_decimal(data[row_num], scale, bw);
+}
+
+template <PrimitiveType T>
+void DataTypeDecimalSerDe<T>::to_string_batch(const IColumn& column,
+                                              ColumnString& column_to) const {
+    auto& data = assert_cast<const ColumnDecimal<T>&>(column).get_data();
+    const size_t size = column.size();
+    const auto maybe_reserve_size = CastToString::string_length<T>;
+    column_to.get_chars().reserve(size * maybe_reserve_size);
+    column_to.get_offsets().reserve(size);
+    BufferWriter bw(column_to);
+    for (size_t i = 0; i < size; ++i) {
+        CastToString::push_decimal(data[i], scale, bw);
+        bw.commit();
     }
 }
 

--- a/be/src/vec/data_types/serde/data_type_decimal_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_decimal_serde.cpp
@@ -492,7 +492,8 @@ void DataTypeDecimalSerDe<T>::write_one_cell_to_jsonb(const IColumn& column, Jso
 template <PrimitiveType T>
 void DataTypeDecimalSerDe<T>::to_string(const IColumn& column, size_t row_num,
                                         BufferWritable& bw) const {
-    auto& data = assert_cast<const ColumnDecimal<T>&>(column).get_data();
+    auto& data =
+            assert_cast<const ColumnDecimal<T>&, TypeCheckOnRelease::DISABLE>(column).get_data();
     CastToString::push_decimal(data[row_num], scale, bw);
 }
 

--- a/be/src/vec/data_types/serde/data_type_decimal_serde.h
+++ b/be/src/vec/data_types/serde/data_type_decimal_serde.h
@@ -128,6 +128,10 @@ public:
     void write_one_cell_to_binary(const IColumn& src_column, ColumnString::Chars& chars,
                                   int64_t row_num) const override;
 
+    void to_string(const IColumn& column, size_t row_num, BufferWritable& bw) const override;
+
+    void to_string_batch(const IColumn& column, ColumnString& column_to) const override;
+
 private:
     template <bool is_binary_format>
     Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,

--- a/be/src/vec/data_types/serde/data_type_jsonb_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_jsonb_serde.cpp
@@ -332,7 +332,7 @@ void DataTypeJsonbSerDe::write_one_cell_to_binary(const IColumn& src_column,
 
 void DataTypeJsonbSerDe::to_string(const IColumn& column, size_t row_num,
                                    BufferWritable& bw) const {
-    const auto& col = assert_cast<const ColumnString&>(column);
+    const auto& col = assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(column);
     const auto& data_ref = col.get_data_at(row_num);
     if (data_ref.size > 0) {
         std::string str = JsonbToJson::jsonb_to_json_string(data_ref.data, data_ref.size);

--- a/be/src/vec/data_types/serde/data_type_jsonb_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_jsonb_serde.cpp
@@ -329,5 +329,17 @@ void DataTypeJsonbSerDe::write_one_cell_to_binary(const IColumn& src_column,
            sizeof(size_t));
     memcpy(chars.data() + old_size + sizeof(uint8_t) + sizeof(size_t), data_ref.data, data_size);
 }
+
+void DataTypeJsonbSerDe::to_string(const IColumn& column, size_t row_num,
+                                   BufferWritable& bw) const {
+    const auto& col = assert_cast<const ColumnString&>(column);
+    const auto& data_ref = col.get_data_at(row_num);
+    if (data_ref.size > 0) {
+        std::string str = JsonbToJson::jsonb_to_json_string(data_ref.data, data_ref.size);
+        bw.write(str.c_str(), str.size());
+    } else {
+        bw.write("NULL", 4);
+    }
+}
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/data_types/serde/data_type_jsonb_serde.h
+++ b/be/src/vec/data_types/serde/data_type_jsonb_serde.h
@@ -80,6 +80,8 @@ public:
     void write_one_cell_to_binary(const IColumn& src_column, ColumnString::Chars& chars,
                                   int64_t row_num) const override;
 
+    void to_string(const IColumn& column, size_t row_num, BufferWritable& bw) const override;
+
 private:
     template <bool is_binary_format>
     Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,

--- a/be/src/vec/data_types/serde/data_type_map_serde.h
+++ b/be/src/vec/data_types/serde/data_type_map_serde.h
@@ -110,6 +110,8 @@ public:
         return {key_serde, value_serde};
     }
 
+    void to_string(const IColumn& column, size_t row_num, BufferWritable& bw) const override;
+
 private:
     template <bool is_binary_format>
     Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,

--- a/be/src/vec/data_types/serde/data_type_nullable_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_nullable_serde.cpp
@@ -425,7 +425,7 @@ void DataTypeNullableSerDe::write_one_cell_to_binary(const IColumn& src_column,
 
 void DataTypeNullableSerDe::to_string(const IColumn& column, size_t row_num,
                                       BufferWritable& bw) const {
-    const auto& col_null = assert_cast<const ColumnNullable&>(column);
+    const auto& col_null = assert_cast<const ColumnNullable&, TypeCheckOnRelease::DISABLE>(column);
     if (col_null.is_null_at(row_num)) {
         bw.write("NULL", 4);
     } else {

--- a/be/src/vec/data_types/serde/data_type_nullable_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_nullable_serde.cpp
@@ -423,6 +423,16 @@ void DataTypeNullableSerDe::write_one_cell_to_binary(const IColumn& src_column,
     }
 }
 
+void DataTypeNullableSerDe::to_string(const IColumn& column, size_t row_num,
+                                      BufferWritable& bw) const {
+    const auto& col_null = assert_cast<const ColumnNullable&>(column);
+    if (col_null.is_null_at(row_num)) {
+        bw.write("NULL", 4);
+    } else {
+        nested_serde->to_string(col_null.get_nested_column(), row_num, bw);
+    }
+}
+
 // In non-strict mode, from string will handle errors by inserting a null value.
 Status DataTypeNullableSerDe::from_string(StringRef& str, IColumn& column,
                                           const FormatOptions& options) const {

--- a/be/src/vec/data_types/serde/data_type_nullable_serde.h
+++ b/be/src/vec/data_types/serde/data_type_nullable_serde.h
@@ -114,6 +114,8 @@ public:
 
     const DataTypeSerDeSPtr& get_nested_serde() const { return nested_serde; }
 
+    void to_string(const IColumn& column, size_t row_num, BufferWritable& bw) const override;
+
 private:
     template <bool is_binary_format>
     Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,

--- a/be/src/vec/data_types/serde/data_type_number_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_number_serde.cpp
@@ -770,6 +770,54 @@ void DataTypeNumberSerDe<T>::write_one_cell_to_binary(const IColumn& src_column,
     memcpy(chars.data() + old_size + sizeof(uint8_t), data_ref.data, data_ref.size);
 }
 
+template <PrimitiveType T>
+void value_to_string(const typename PrimitiveTypeTraits<T>::ColumnItemType value,
+                     BufferWritable& bw, int scale) {
+    if constexpr (T == TYPE_BOOLEAN || T == TYPE_TINYINT || T == TYPE_SMALLINT || T == TYPE_INT ||
+                  T == TYPE_BIGINT || T == TYPE_LARGEINT || T == TYPE_FLOAT || T == TYPE_DOUBLE) {
+        CastToString::push_number(value, bw);
+    } else if constexpr (T == TYPE_DATE || T == TYPE_DATETIME) {
+        VecDateTimeValue dt = binary_cast<Int64, VecDateTimeValue>(value);
+        CastToString::push_date_or_datetime(dt, bw);
+    } else if constexpr (T == TYPE_DATEV2) {
+        DateV2Value<doris::DateV2ValueType> dt =
+                binary_cast<UInt32, DateV2Value<doris::DateV2ValueType>>(value);
+        CastToString::push_datev2(dt, bw);
+    } else if constexpr (T == TYPE_DATETIMEV2) {
+        DateV2Value<doris::DateTimeV2ValueType> dt =
+                binary_cast<UInt64, DateV2Value<doris::DateTimeV2ValueType>>(value);
+        CastToString::push_datetimev2(dt, scale, bw);
+    } else if constexpr (T == TYPE_TIME || T == TYPE_TIMEV2) {
+        CastToString::push_time(value, scale, bw);
+    } else if constexpr (T == TYPE_IPV4 || T == TYPE_IPV6) {
+        CastToString::push_ip(value, bw);
+    } else {
+        static_assert(std::is_same_v<decltype(T), void>, "non-exhaustive visitor!");
+    }
+}
+
+template <PrimitiveType T>
+void DataTypeNumberSerDe<T>::to_string(const IColumn& column, size_t row_num,
+                                       BufferWritable& bw) const {
+    auto& data = assert_cast<const ColumnType&>(column).get_data();
+    value_to_string<T>(data[row_num], bw, get_scale());
+}
+
+template <PrimitiveType T>
+void DataTypeNumberSerDe<T>::to_string_batch(const IColumn& column, ColumnString& column_to) const {
+    auto& data = assert_cast<const ColumnType&>(column).get_data();
+    const size_t size = column.size();
+    const auto maybe_reserve_size = CastToString::string_length<T>;
+    column_to.get_chars().reserve(size * maybe_reserve_size);
+    column_to.get_offsets().reserve(size);
+    BufferWriter bw(column_to);
+    const auto scale = get_scale();
+    for (size_t i = 0; i < size; ++i) {
+        value_to_string<T>(data[i], bw, scale);
+        bw.commit();
+    }
+}
+
 /// Explicit template instantiations - to avoid code bloat in headers.
 template class DataTypeNumberSerDe<TYPE_BOOLEAN>;
 template class DataTypeNumberSerDe<TYPE_TINYINT>;

--- a/be/src/vec/data_types/serde/data_type_number_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_number_serde.cpp
@@ -799,7 +799,7 @@ void value_to_string(const typename PrimitiveTypeTraits<T>::ColumnItemType value
 template <PrimitiveType T>
 void DataTypeNumberSerDe<T>::to_string(const IColumn& column, size_t row_num,
                                        BufferWritable& bw) const {
-    auto& data = assert_cast<const ColumnType&>(column).get_data();
+    auto& data = assert_cast<const ColumnType&, TypeCheckOnRelease::DISABLE>(column).get_data();
     value_to_string<T>(data[row_num], bw, get_scale());
 }
 

--- a/be/src/vec/data_types/serde/data_type_number_serde.h
+++ b/be/src/vec/data_types/serde/data_type_number_serde.h
@@ -129,7 +129,9 @@ public:
 
     void write_one_cell_to_binary(const IColumn& src_column, ColumnString::Chars& chars,
                                   int64_t row_num) const override;
+    void to_string(const IColumn& column, size_t row_num, BufferWritable& bw) const override;
 
+    void to_string_batch(const IColumn& column, ColumnString& column_to) const override;
     // will override in DateTime and Time
     virtual int get_scale() const { return 0; }
 

--- a/be/src/vec/data_types/serde/data_type_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_serde.cpp
@@ -116,6 +116,21 @@ Status DataTypeSerDe::deserialize_column_from_jsonb_vector(ColumnNullable& colum
     return Status::OK();
 }
 
+void DataTypeSerDe::to_string_batch(const IColumn& column, ColumnString& column_to) const {
+    const auto size = column.size();
+    column_to.reserve(size);
+    VectorBufferWriter write_buffer(column_to);
+    for (size_t i = 0; i < size; ++i) {
+        to_string(column, i, write_buffer);
+        write_buffer.commit();
+    }
+}
+
+void DataTypeSerDe::to_string(const IColumn& column, size_t row_num, BufferWritable& bw) const {
+    throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
+                           "Data type {} to_string_batch not implement.", get_name());
+}
+
 const std::string DataTypeSerDe::NULL_IN_COMPLEX_TYPE = "null";
 const std::string DataTypeSerDe::NULL_IN_CSV_FOR_ORDINARY_TYPE = "\\N";
 

--- a/be/src/vec/data_types/serde/data_type_serde.h
+++ b/be/src/vec/data_types/serde/data_type_serde.h
@@ -241,6 +241,10 @@ public:
 
     Status default_from_string(StringRef& str, IColumn& column) const;
 
+    virtual void to_string_batch(const IColumn& column, ColumnString& column_to) const;
+
+    virtual void to_string(const IColumn& column, size_t row_num, BufferWritable& bw) const;
+
     // All types can override this function
     // When this function is called, column should be of the corresponding type
     // everytime call this, should insert new cell to the end of column

--- a/be/src/vec/data_types/serde/data_type_string_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_string_serde.cpp
@@ -430,7 +430,9 @@ void DataTypeStringSerDeBase<ColumnType>::to_string(const IColumn& column, size_
     if (_nesting_level > 1) {
         bw.write('"');
     }
-    const auto& value = assert_cast<const ColumnType&>(column).get_data_at(row_num);
+    const auto& value =
+            assert_cast<const ColumnType&, TypeCheckOnRelease::DISABLE>(column).get_data_at(
+                    row_num);
     bw.write(value.data, value.size);
     if (_nesting_level > 1) {
         bw.write('"');

--- a/be/src/vec/data_types/serde/data_type_string_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_string_serde.cpp
@@ -425,6 +425,19 @@ Status DataTypeStringSerDeBase<ColumnType>::deserialize_column_from_jsonb_vector
 }
 
 template <typename ColumnType>
+void DataTypeStringSerDeBase<ColumnType>::to_string(const IColumn& column, size_t row_num,
+                                                    BufferWritable& bw) const {
+    if (_nesting_level > 1) {
+        bw.write('"');
+    }
+    const auto& value = assert_cast<const ColumnType&>(column).get_data_at(row_num);
+    bw.write(value.data, value.size);
+    if (_nesting_level > 1) {
+        bw.write('"');
+    }
+}
+
+template <typename ColumnType>
 Status DataTypeStringSerDeBase<ColumnType>::from_string(StringRef& str, IColumn& column,
                                                         const FormatOptions& options) const {
     auto slice = str.to_slice();

--- a/be/src/vec/data_types/serde/data_type_string_serde.h
+++ b/be/src/vec/data_types/serde/data_type_string_serde.h
@@ -233,6 +233,8 @@ public:
                data_size);
     }
 
+    void to_string(const IColumn& column, size_t row_num, BufferWritable& bw) const override;
+
 private:
     template <bool is_binary_format>
     Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,

--- a/be/src/vec/data_types/serde/data_type_struct_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_struct_serde.cpp
@@ -656,5 +656,18 @@ Status DataTypeStructSerDe::from_string_strict_mode(StringRef& str, IColumn& col
     return _from_string<true>(str, column, options);
 }
 
+void DataTypeStructSerDe::to_string(const IColumn& column, size_t row_num,
+                                    BufferWritable& bw) const {
+    const auto& struct_column = assert_cast<const ColumnStruct&>(column);
+    bw.write("{", 1);
+    for (size_t idx = 0; idx < elem_serdes_ptrs.size(); idx++) {
+        if (idx != 0) {
+            bw.write(", ", 2);
+        }
+        elem_serdes_ptrs[idx]->to_string(struct_column.get_column(idx), row_num, bw);
+    }
+    bw.write("}", 1);
+}
+
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/data_types/serde/data_type_struct_serde.h
+++ b/be/src/vec/data_types/serde/data_type_struct_serde.h
@@ -113,6 +113,8 @@ public:
 
     DataTypeSerDeSPtrs get_nested_serdes() const override { return elem_serdes_ptrs; }
 
+    void to_string(const IColumn& column, size_t row_num, BufferWritable& bw) const override;
+
 private:
     template <bool is_binary_format>
     Status _write_column_to_mysql(const IColumn& column, bool return_object_data_as_binary,

--- a/be/src/vec/data_types/serde/data_type_variant_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_variant_serde.cpp
@@ -162,6 +162,12 @@ Status DataTypeVariantSerDe::write_column_to_arrow(const IColumn& column, const 
     return Status::OK();
 }
 
+void DataTypeVariantSerDe::to_string(const IColumn& column, size_t row_num,
+                                     BufferWritable& bw) const {
+    const auto& var = assert_cast<const ColumnVariant&>(column);
+    var.serialize_one_row_to_string(row_num, bw);
+}
+
 Status DataTypeVariantSerDe::write_column_to_orc(const std::string& timezone, const IColumn& column,
                                                  const NullMap* null_map,
                                                  orc::ColumnVectorBatch* orc_col_batch,

--- a/be/src/vec/data_types/serde/data_type_variant_serde.h
+++ b/be/src/vec/data_types/serde/data_type_variant_serde.h
@@ -83,6 +83,7 @@ public:
     Status write_column_to_orc(const std::string& timezone, const IColumn& column,
                                const NullMap* null_map, orc::ColumnVectorBatch* orc_col_batch,
                                int64_t start, int64_t end, vectorized::Arena& arena) const override;
+    void to_string(const IColumn& column, size_t row_num, BufferWritable& bw) const override;
 
 private:
     template <bool is_binary_format>

--- a/be/src/vec/functions/cast/cast_to_string.h
+++ b/be/src/vec/functions/cast/cast_to_string.h
@@ -40,26 +40,45 @@ struct CastToString {
     static inline void push_number(const SRC& from, ColumnString::Chars& chars);
 
     template <class SRC>
+    static inline void push_number(const SRC& from, BufferWritable& bw);
+
+    template <class SRC>
     static inline std::string from_decimal(const SRC& from, UInt32 scale);
+
+    template <class SRC>
+    static inline void push_decimal(const SRC& from, UInt32 scale, BufferWritable& bw);
 
     static inline std::string from_date_or_datetime(const VecDateTimeValue& from);
 
     static inline void push_date_or_datetime(const VecDateTimeValue& from,
                                              ColumnString::Chars& chars);
+    static inline void push_date_or_datetime(const VecDateTimeValue& from, BufferWritable& bw);
 
     static inline std::string from_datev2(const DateV2Value<DateV2ValueType>& from);
     static inline void push_datev2(const DateV2Value<DateV2ValueType>& from,
                                    ColumnString::Chars& chars);
+    static inline void push_datev2(const DateV2Value<DateV2ValueType>& from, BufferWritable& bw);
 
     static inline std::string from_datetimev2(const DateV2Value<DateTimeV2ValueType>& from,
                                               UInt32 scale);
     static inline void push_datetimev2(const DateV2Value<DateTimeV2ValueType>& from, UInt32 scale,
                                        ColumnString::Chars& chars);
 
+    static inline void push_datetimev2(const DateV2Value<DateTimeV2ValueType>& from, UInt32 scale,
+                                       BufferWritable& bw);
+
     template <class SRC>
     static inline std::string from_ip(const SRC& from);
 
+    template <class SRC>
+    static inline void push_ip(const SRC& from, BufferWritable& bw);
+
     static inline std::string from_time(const TimeValue::TimeType& from, UInt32 scale);
+
+    static inline void push_time(const TimeValue::TimeType& from, UInt32 scale, BufferWritable& bw);
+
+    template <PrimitiveType T>
+    static constexpr size_t string_length = 1;
 
 private:
     // refer to: https://en.cppreference.com/w/cpp/types/numeric_limits/max_digits10.html
@@ -99,6 +118,49 @@ private:
     }
 };
 
+template <>
+constexpr size_t CastToString::string_length<TYPE_BOOLEAN> = 1;
+template <>
+constexpr size_t CastToString::string_length<TYPE_TINYINT> = 4;
+template <>
+constexpr size_t CastToString::string_length<TYPE_SMALLINT> = 6;
+template <>
+constexpr size_t CastToString::string_length<TYPE_INT> = 11;
+template <>
+constexpr size_t CastToString::string_length<TYPE_BIGINT> = 20;
+template <>
+constexpr size_t CastToString::string_length<TYPE_LARGEINT> = 40;
+template <>
+constexpr size_t CastToString::string_length<TYPE_FLOAT> = MAX_FLOAT_STR_LENGTH;
+template <>
+constexpr size_t CastToString::string_length<TYPE_DOUBLE> = MAX_DOUBLE_STR_LENGTH;
+template <>
+constexpr size_t CastToString::string_length<TYPE_DECIMAL32> = 14;
+template <>
+constexpr size_t CastToString::string_length<TYPE_DECIMAL64> = 24;
+template <>
+constexpr size_t CastToString::string_length<TYPE_DECIMALV2> = 24;
+template <>
+constexpr size_t CastToString::string_length<TYPE_DECIMAL128I> = 39;
+template <>
+constexpr size_t CastToString::string_length<TYPE_DECIMAL256> = 78;
+template <>
+constexpr size_t CastToString::string_length<TYPE_DATE> = sizeof("YYYY-MM-DD") - 1;
+template <>
+constexpr size_t CastToString::string_length<TYPE_DATETIME> = sizeof("YYYY-MM-DD HH:MM:SS") - 1;
+template <>
+constexpr size_t CastToString::string_length<TYPE_DATEV2> = sizeof("YYYY-MM-DD") - 1;
+template <>
+constexpr size_t CastToString::string_length<TYPE_DATETIMEV2> =
+        sizeof("YYYY-MM-DD HH:MM:SS.ssssss") - 1;
+template <>
+constexpr size_t CastToString::string_length<TYPE_TIMEV2> = sizeof("-838:59:59.999999") - 1;
+template <>
+constexpr size_t CastToString::string_length<TYPE_IPV4> = sizeof("255.255 .255.255") - 1;
+template <>
+constexpr size_t CastToString::string_length<TYPE_IPV6> =
+        sizeof("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff") - 1;
+
 // BOOLEAN
 template <>
 inline std::string CastToString::from_number(const UInt8& num) {
@@ -110,6 +172,12 @@ template <>
 inline void CastToString::push_number(const UInt8& num, ColumnString::Chars& chars) {
     auto f = fmt::format_int(num);
     chars.insert(f.data(), f.data() + f.size());
+}
+
+template <>
+inline void CastToString::push_number(const UInt8& num, BufferWritable& bw) {
+    auto f = fmt::format_int(num);
+    bw.write(f.data(), f.size());
 }
 
 // TINYINT
@@ -125,6 +193,12 @@ inline void CastToString::push_number(const Int8& num, ColumnString::Chars& char
     chars.insert(f.data(), f.data() + f.size());
 }
 
+template <>
+inline void CastToString::push_number(const Int8& num, BufferWritable& bw) {
+    auto f = fmt::format_int(num);
+    bw.write(f.data(), f.size());
+}
+
 // SMALLINT
 template <>
 inline std::string CastToString::from_number(const Int16& num) {
@@ -136,6 +210,12 @@ template <>
 inline void CastToString::push_number(const Int16& num, ColumnString::Chars& chars) {
     auto f = fmt::format_int(num);
     chars.insert(f.data(), f.data() + f.size());
+}
+
+template <>
+inline void CastToString::push_number(const Int16& num, BufferWritable& bw) {
+    auto f = fmt::format_int(num);
+    bw.write(f.data(), f.size());
 }
 
 // INT
@@ -151,6 +231,12 @@ inline void CastToString::push_number(const Int32& num, ColumnString::Chars& cha
     chars.insert(f.data(), f.data() + f.size());
 }
 
+template <>
+inline void CastToString::push_number(const Int32& num, BufferWritable& bw) {
+    auto f = fmt::format_int(num);
+    bw.write(f.data(), f.size());
+}
+
 // BIGINT
 template <>
 inline std::string CastToString::from_number(const Int64& num) {
@@ -162,6 +248,12 @@ template <>
 inline void CastToString::push_number(const Int64& num, ColumnString::Chars& chars) {
     auto f = fmt::format_int(num);
     chars.insert(f.data(), f.data() + f.size());
+}
+
+template <>
+inline void CastToString::push_number(const Int64& num, BufferWritable& bw) {
+    auto f = fmt::format_int(num);
+    bw.write(f.data(), f.size());
 }
 
 // LARGEINT
@@ -177,6 +269,13 @@ inline void CastToString::push_number(const Int128& num, ColumnString::Chars& ch
     fmt::memory_buffer buffer;
     fmt::format_to(buffer, "{}", num);
     chars.insert(buffer.data(), buffer.data() + buffer.size());
+}
+
+template <>
+inline void CastToString::push_number(const Int128& num, BufferWritable& bw) {
+    fmt::memory_buffer buffer;
+    fmt::format_to(buffer, "{}", num);
+    bw.write(buffer.data(), buffer.size());
 }
 
 // FLOAT
@@ -201,6 +300,13 @@ inline void CastToString::push_number(const Float32& num, ColumnString::Chars& c
     chars.insert(buf, buf + len);
 }
 
+template <>
+inline void CastToString::push_number(const Float32& num, BufferWritable& bw) {
+    char buf[MAX_FLOAT_STR_LENGTH + 2];
+    int len = _fast_to_buffer(num, buf);
+    bw.write(buf, len);
+}
+
 // DOUBLE
 template <>
 inline std::string CastToString::from_number(const Float64& num) {
@@ -216,10 +322,23 @@ inline void CastToString::push_number(const Float64& num, ColumnString::Chars& c
     chars.insert(buf, buf + len);
 }
 
+template <>
+inline void CastToString::push_number(const Float64& num, BufferWritable& bw) {
+    char buf[MAX_DOUBLE_STR_LENGTH + 2];
+    int len = _fast_to_buffer(num, buf);
+    bw.write(buf, len);
+}
+
 // DECIMAL32
 template <>
 inline std::string CastToString::from_decimal(const Decimal32& from, UInt32 scale) {
     return from.to_string(scale);
+}
+
+template <>
+inline void CastToString::push_decimal(const Decimal32& from, UInt32 scale, BufferWritable& bw) {
+    std::string str = from.to_string(scale);
+    bw.write(str.data(), str.size());
 }
 
 // DECIMAL64
@@ -228,10 +347,22 @@ inline std::string CastToString::from_decimal(const Decimal64& from, UInt32 scal
     return from.to_string(scale);
 }
 
+template <>
+inline void CastToString::push_decimal(const Decimal64& from, UInt32 scale, BufferWritable& bw) {
+    std::string str = from.to_string(scale);
+    bw.write(str.data(), str.size());
+}
+
 // DECIMAL128
 template <>
 inline std::string CastToString::from_decimal(const Decimal128V3& from, UInt32 scale) {
     return from.to_string(scale);
+}
+
+template <>
+inline void CastToString::push_decimal(const Decimal128V3& from, UInt32 scale, BufferWritable& bw) {
+    std::string str = from.to_string(scale);
+    bw.write(str.data(), str.size());
 }
 
 // DECIMAL256
@@ -240,12 +371,25 @@ inline std::string CastToString::from_decimal(const Decimal256& from, UInt32 sca
     return from.to_string(scale);
 }
 
+template <>
+inline void CastToString::push_decimal(const Decimal256& from, UInt32 scale, BufferWritable& bw) {
+    std::string str = from.to_string(scale);
+    bw.write(str.data(), str.size());
+}
+
 // DECIMALV2
 template <>
 inline std::string CastToString::from_decimal(const Decimal128V2& from, UInt32 scale) {
     auto value = (DecimalV2Value)from;
     auto str = value.to_string(scale);
     return str;
+}
+
+template <>
+inline void CastToString::push_decimal(const Decimal128V2& from, UInt32 scale, BufferWritable& bw) {
+    auto value = (DecimalV2Value)from;
+    std::string str = value.to_string(scale);
+    bw.write(str.data(), str.size());
 }
 
 // DATEV1 DATETIMEV1
@@ -264,6 +408,13 @@ inline void CastToString::push_date_or_datetime(const VecDateTimeValue& from,
     chars.insert(buf, pos - 1);
 }
 
+inline void CastToString::push_date_or_datetime(const VecDateTimeValue& from, BufferWritable& bw) {
+    char buf[64];
+    char* pos = from.to_string(buf);
+    // DateTime to_string the end is /0
+    bw.write(buf, pos - buf - 1);
+}
+
 // DATEV2
 inline std::string CastToString::from_datev2(const DateV2Value<DateV2ValueType>& from) {
     char buf[64];
@@ -278,6 +429,14 @@ inline void CastToString::push_datev2(const DateV2Value<DateV2ValueType>& from,
     char* pos = from.to_string(buf);
     // DateTime to_string the end is /0
     chars.insert(buf, pos - 1);
+}
+
+inline void CastToString::push_datev2(const DateV2Value<DateV2ValueType>& from,
+                                      BufferWritable& bw) {
+    char buf[64];
+    char* pos = from.to_string(buf);
+    // DateTime to_string the end is /0
+    bw.write(buf, pos - buf - 1);
 }
 
 // DATETIMEV2
@@ -297,11 +456,26 @@ inline void CastToString::push_datetimev2(const DateV2Value<DateTimeV2ValueType>
     chars.insert(buf, pos - 1);
 }
 
+inline void CastToString::push_datetimev2(const DateV2Value<DateTimeV2ValueType>& from,
+                                          UInt32 scale, BufferWritable& bw) {
+    char buf[64];
+    char* pos = from.to_string(buf, scale);
+    // DateTime to_string the end is /0
+    bw.write(buf, pos - buf - 1);
+}
+
 // IPv4
 template <>
 inline std::string CastToString::from_ip(const IPv4& from) {
     auto value = IPv4Value(from);
     return value.to_string();
+}
+
+template <>
+inline void CastToString::push_ip(const IPv4& from, BufferWritable& bw) {
+    auto value = IPv4Value(from);
+    std::string str = value.to_string();
+    bw.write(str.data(), str.size());
 }
 
 //IPv6
@@ -312,9 +486,22 @@ inline std::string CastToString::from_ip(const IPv6& from) {
     return value.to_string();
 }
 
+template <>
+inline void CastToString::push_ip(const IPv6& from, BufferWritable& bw) {
+    auto value = IPv6Value(from);
+    std::string str = value.to_string();
+    bw.write(str.data(), str.size());
+}
+
 // Time
 inline std::string CastToString::from_time(const TimeValue::TimeType& from, UInt32 scale) {
     return timev2_to_buffer_from_double(from, scale);
+}
+
+inline void CastToString::push_time(const TimeValue::TimeType& from, UInt32 scale,
+                                    BufferWritable& bw) {
+    std::string str = timev2_to_buffer_from_double(from, scale);
+    bw.write(str.data(), str.size());
 }
 
 class CastToStringFunction {
@@ -328,7 +515,8 @@ public:
         const IColumn& col_from = *col_with_type_and_name.column;
 
         auto col_to = ColumnString::create();
-        type.to_string_batch(col_from, *col_to);
+
+        type.get_serde()->to_string_batch(col_from, *col_to);
 
         block.replace_by_position(result, std::move(col_to));
         return Status::OK();

--- a/be/test/vec/function/cast/cast_to_string.cpp
+++ b/be/test/vec/function/cast/cast_to_string.cpp
@@ -22,6 +22,10 @@
 
 #include "cast_test.h"
 #include "util/to_string.h"
+#include "vec/columns/column_map.h"
+#include "vec/data_types/data_type_map.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_string.h"
 
 namespace doris::vectorized {
 using namespace ut_type;
@@ -336,5 +340,24 @@ TEST_F(FunctionCastToStringTest, from_double) {
         int len = CastToString::from_number(value_pair.first, buffer);
         EXPECT_EQ(std::string(buffer, len), std::string(value_pair.second));
     }
+}
+
+TEST_F(FunctionCastToStringTest, from_map) {
+    auto map_type = std::make_shared<DataTypeMap>(
+            std::make_shared<DataTypeNullable>(std::make_shared<DataTypeString>()),
+            std::make_shared<DataTypeNullable>(std::make_shared<DataTypeString>()));
+
+    auto serde = map_type->get_serde();
+
+    auto key_column = ColumnHelper::create_nullable_column<DataTypeString>({"123", "456"}, {0, 1});
+    auto value_column =
+            ColumnHelper::create_nullable_column<DataTypeString>({"abc", "def"}, {1, 0});
+    auto offset_column = ColumnArray::ColumnOffsets::create();
+    offset_column->insert_value(2);
+    auto column = ColumnMap::create(key_column, value_column, std::move(offset_column));
+    // {"123":null,"456":"def"}
+    ColumnString tmp_col;
+    serde->to_string_batch(*column, tmp_col);
+    EXPECT_EQ(tmp_col.get_data_at(0).to_string(), "{\"123\":NULL, NULL:\"def\"}");
 }
 } // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?

Previously, we only had the to_string function in DataType, but in fact, it is DataTypeSerDe that actually needs the to_string function.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

