### PR TITLE
[chore](compile) fix macos compile be failed

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -166,7 +166,7 @@ void Daemon::tcmalloc_gc_thread() {
             }
         }
 
-        int release_rate_index = memory_pressure / 10;
+        int release_rate_index = static_cast<int>(memory_pressure / 10);
         double release_rate = 1.0;
         if (release_rate_index >= sizeof(release_rates) / sizeof(release_rates[0])) {
             release_rate = 2000.0;

--- a/be/src/io/cache/block_file_cache_factory.cpp
+++ b/be/src/io/cache/block_file_cache_factory.cpp
@@ -31,7 +31,9 @@
 #endif
 
 #include <algorithm>
+#if !defined(__APPLE__)
 #include <execution>
+#endif
 #include <ostream>
 #include <utility>
 
@@ -159,7 +161,11 @@ FileCacheFactory::get_query_context_holders(const TUniqueId& query_id) {
 std::string FileCacheFactory::clear_file_caches(bool sync) {
     std::vector<std::string> results(_caches.size());
 
+#if defined(__APPLE__)
+    std::for_each(_caches.begin(), _caches.end(), [&](const auto& cache) {
+#else
     std::for_each(std::execution::par, _caches.begin(), _caches.end(), [&](const auto& cache) {
+#endif
         size_t index = &cache - &_caches[0];
         results[index] =
                 sync ? cache->clear_file_cache_directly() : cache->clear_file_cache_async();

--- a/be/src/util/disk_info_mac.cpp
+++ b/be/src/util/disk_info_mac.cpp
@@ -74,7 +74,7 @@ void DiskInfo::get_device_names() {
             auto it = major_to_disk_id.find(major(dev));
             int disk_id;
             if (it == major_to_disk_id.end()) {
-                disk_id = _s_disks.size();
+                disk_id = static_cast<int>(_s_disks.size());
                 major_to_disk_id[major(dev)] = disk_id;
 
                 std::string name = "disk" + std::to_string(disk_id);

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -54,7 +54,7 @@ public:
 #if !defined(__APPLE__) || !defined(_POSIX_C_SOURCE)
         return getpagesize();
 #else
-        return vm_page_size;
+        return static_cast<int>(vm_page_size);
 #endif
     }
 


### PR DESCRIPTION
  1. Follow PR #55634: Fix implicit type conversion warnings on macOS
     - Added `static_cast<int>()` for `vm_page_size`, `memory_pressure/10`, and `_s_disks.size()`
     - These warnings only appear on macOS due to platform-specific type differences (`vm_size_t` vs `int`)

  2. Follow PR #55259: Fix `std::execution::par` compatibility on macOS
     - Added conditional compilation for `std::execution::par` which is not available in macOS libc++
     - Preserves parallel execution on Linux while maintaining compatibility on macO