### PR TITLE
branch-2.7: [fix] Fix storage policy persistence problem with partition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RangePartitionInfo.java
@@ -25,6 +25,7 @@ import org.apache.doris.analysis.RangePartitionDesc;
 import org.apache.doris.analysis.SinglePartitionDesc;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.util.PrintableMap;
 import org.apache.doris.common.util.RangeUtils;
 
 import com.google.common.base.Preconditions;
@@ -37,6 +38,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -295,8 +297,18 @@ public class RangePartitionInfo extends PartitionInfo {
             // print all partitions' range is fixed range, even if some of them is created by less than range
             sb.append("PARTITION ").append(partitionName).append(" VALUES [");
             sb.append(range.lowerEndpoint().toSql());
-            sb.append(", ").append(range.upperEndpoint().toSql()).append(")");
+            sb.append(", ").append(range.upperEndpoint().toSql()).append("]");
 
+            Map<String, String> properties = new HashMap<>();
+            Optional.ofNullable(this.idToStoragePolicy.get(entry.getKey()))
+                    .filter(p -> !p.isEmpty())
+                    .ifPresent(p -> properties.put("storage_policy", p));
+
+            if (!properties.isEmpty()) {
+                sb.append(", (");
+                sb.append(new PrintableMap<>(properties, "=", true, false));
+                sb.append(")");
+            }
             if (partitionId != null) {
                 partitionId.add(entry.getKey());
                 break;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Before this fix, storage policy information for partitions was neither displayed nor persisted. With this change, the information is now persisted and can be viewed using the SHOW CREATE TABLE statement, as demonstrated below:

Related PR: #xxx

Problem Summary:

```
CREATE RESOURCE IF NOT EXISTS "resource_name"
        PROPERTIES(
            "type"="s3",
            "s3.endpoint" = "http://s3_enpoint",
            "s3.region" = "s3_region",
            "s3.root.path" = "path/to/root",
            "s3.access_key" = "s3_ak",
            "s3.secret_key" = "s3_sk",
            "s3.connection.maximum" = "50",
            "s3.connection.request.timeout" = "3000",
            "s3.connection.timeout" = "1000",
            "s3.bucket" = "s3_bucket_name",
            "s3_validity_check" = "false"
        );
CREATE STORAGE POLICY testPolicy
PROPERTIES(
  "storage_resource" = "resource_name",
  "cooldown_ttl" = "1d"
);

create database test;
use test;

CREATE TABLE IF NOT EXISTS lineitem1 (
            L_ORDERKEY    INTEGER NOT NULL,
            L_PARTKEY     INTEGER NOT NULL,
            L_SUPPKEY     INTEGER NOT NULL,
            L_LINENUMBER  INTEGER NOT NULL,
            L_QUANTITY    DECIMAL(15,2) NOT NULL,
            L_EXTENDEDPRICE  DECIMAL(15,2) NOT NULL,
            L_DISCOUNT    DECIMAL(15,2) NOT NULL,
            L_TAX         DECIMAL(15,2) NOT NULL,
            L_RETURNFLAG  CHAR(1) NOT NULL,
            L_LINESTATUS  CHAR(1) NOT NULL,
            L_SHIPDATE    DATEV2 NOT NULL,
            L_COMMITDATE  DATEV2 NOT NULL,
            L_RECEIPTDATE DATEV2 NOT NULL,
            L_SHIPINSTRUCT CHAR(25) NOT NULL,
            L_SHIPMODE     CHAR(10) NOT NULL,
            L_COMMENT      VARCHAR(44) NOT NULL
            )
            DUPLICATE KEY(L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_LINENUMBER)
            PARTITION BY RANGE(`L_SHIPDATE`)
            (
                PARTITION `p202301` VALUES LESS THAN ("2017-02-01") ("storage_policy" = "testPolicy"),
                PARTITION `p202302` VALUES LESS THAN ("2017-03-01")
            )
            DISTRIBUTED BY HASH(L_ORDERKEY) BUCKETS 3
            PROPERTIES (
            "replication_num" = "1"
            );

SHOW CREATE TABLE lineitem1;
```
<img width="1101" height="707" alt="image" src="https://github.com/user-attachments/assets/10578ce5-5f82-4194-a348-facdb508273d" />

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

