### PR TITLE
[fix](compaction) use rowset meta FS in segcompaction and add RPC client ready check

### DIFF
--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -388,7 +388,7 @@ Status BetaRowsetWriter::_load_noncompacted_segment(segment_v2::SegmentSharedPtr
             .is_doris_table = true,
             .cache_base_path {},
     };
-    auto s = segment_v2::Segment::open(io::global_local_filesystem(), path,
+    auto s = segment_v2::Segment::open(fs, path,
                                        _rowset_meta->tablet_id(), segment_id, rowset_id(),
                                        _context.tablet_schema, reader_options, &segment);
     if (!s.ok()) {

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -388,8 +388,7 @@ Status BetaRowsetWriter::_load_noncompacted_segment(segment_v2::SegmentSharedPtr
             .is_doris_table = true,
             .cache_base_path {},
     };
-    auto s = segment_v2::Segment::open(fs, path,
-                                       _rowset_meta->tablet_id(), segment_id, rowset_id(),
+    auto s = segment_v2::Segment::open(fs, path, _rowset_meta->tablet_id(), segment_id, rowset_id(),
                                        _context.tablet_schema, reader_options, &segment);
     if (!s.ok()) {
         LOG(WARNING) << "failed to open segment. " << path << ":" << s;

--- a/be/src/util/thrift_rpc_helper.cpp
+++ b/be/src/util/thrift_rpc_helper.cpp
@@ -54,7 +54,7 @@ using apache::thrift::transport::TSocket;
 using apache::thrift::transport::TTransport;
 using apache::thrift::transport::TBufferedTransport;
 
-ExecEnv* ThriftRpcHelper::_s_exec_env;
+ExecEnv* ThriftRpcHelper::_s_exec_env = nullptr;
 
 void ThriftRpcHelper::setup(ExecEnv* exec_env) {
     _s_exec_env = exec_env;

--- a/be/src/util/thrift_rpc_helper.h
+++ b/be/src/util/thrift_rpc_helper.h
@@ -47,9 +47,8 @@ public:
     static Status rpc(const std::string& ip, const int32_t port,
                       std::function<void(ClientConnection<T>&)> callback, int timeout_ms);
 
-    ExecEnv* get_exec_env() {
-        return _s_exec_env;
-    }
+    ExecEnv* get_exec_env() { return _s_exec_env; }
+
 private:
     static ExecEnv* _s_exec_env;
 };

--- a/be/src/util/thrift_rpc_helper.h
+++ b/be/src/util/thrift_rpc_helper.h
@@ -47,6 +47,9 @@ public:
     static Status rpc(const std::string& ip, const int32_t port,
                       std::function<void(ClientConnection<T>&)> callback, int timeout_ms);
 
+    ExecEnv* get_exec_env() {
+        return _s_exec_env;
+    }
 private:
     static ExecEnv* _s_exec_env;
 };


### PR DESCRIPTION
1 Segcompaction uses the FS from rowset meta, leveraging the functionality provided by the FS abstraction layer.
2 Add an interface in thrift_rpc_helper to check whether the RPC client is ready, avoiding core dumps when BE has just started but the RPC client is not yet initialized.
