### PR TITLE
[chore](function) Add a range limit to the second parameter of format_round.

### DIFF
--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -3291,9 +3291,10 @@ struct FormatRoundDoubleImpl {
         // when scale is above 38, we will go here
         for (size_t i = 0; i < input_rows_count; i++) {
             int32_t decimal_places = arg_column_data_2[index_check_const<is_const>(i)];
-            if (decimal_places < 0) {
+            if (decimal_places < 0 || decimal_places > 1024) {
                 return Status::InvalidArgument(
-                        "The second argument is {}, it can not be less than 0.", decimal_places);
+                        "The second argument is {}, it should be in range [0, 1024].",
+                        decimal_places);
             }
             // round to `decimal_places` decimal places
             double value = MathFunctions::my_double_round(data_column->get_element(i),
@@ -3325,9 +3326,10 @@ struct FormatRoundInt64Impl {
                 assert_cast<const ColumnInt32*>(decimal_places_col_ptr.get())->get_data();
         for (size_t i = 0; i < input_rows_count; i++) {
             int32_t decimal_places = arg_column_data_2[index_check_const<is_const>(i)];
-            if (decimal_places < 0) {
+            if (decimal_places < 0 || decimal_places > 1024) {
                 return Status::InvalidArgument(
-                        "The second argument is {}, it can not be less than 0.", decimal_places);
+                        "The second argument is {}, it should be in range [0, 1024].",
+                        decimal_places);
             }
             Int64 value = data_column->get_element(i);
             StringRef str =
@@ -3356,9 +3358,10 @@ struct FormatRoundInt128Impl {
         // see https://github.com/apache/doris/blob/788abf2d7c3c7c2d57487a9608e889e7662d5fb2/be/src/vec/data_types/data_type_number_base.cpp#L124
         for (size_t i = 0; i < input_rows_count; i++) {
             int32_t decimal_places = arg_column_data_2[index_check_const<is_const>(i)];
-            if (decimal_places < 0) {
+            if (decimal_places < 0 || decimal_places > 1024) {
                 return Status::InvalidArgument(
-                        "The second argument is {}, it can not be less than 0.", decimal_places);
+                        "The second argument is {}, it should be in range [0, 1024].",
+                        decimal_places);
             }
             Int128 value = data_column->get_element(i);
             StringRef str =
@@ -3385,9 +3388,9 @@ struct FormatRoundDecimalImpl {
         if (auto* decimalv2_column = check_and_get_column<ColumnDecimal128V2>(*col_ptr)) {
             for (size_t i = 0; i < input_rows_count; i++) {
                 int32_t decimal_places = arg_column_data_2[index_check_const<is_const>(i)];
-                if (decimal_places < 0) {
+                if (decimal_places < 0 || decimal_places > 1024) {
                     return Status::InvalidArgument(
-                            "The second argument is {}, it can not be less than 0.",
+                            "The second argument is {}, it should be in range [0, 1024].",
                             decimal_places);
                 }
                 const Decimal128V2& dec128 = decimalv2_column->get_element(i);
@@ -3405,9 +3408,9 @@ struct FormatRoundDecimalImpl {
             const UInt32 scale = decimal32_column->get_scale();
             for (size_t i = 0; i < input_rows_count; i++) {
                 int32_t decimal_places = arg_column_data_2[index_check_const<is_const>(i)];
-                if (decimal_places < 0) {
+                if (decimal_places < 0 || decimal_places > 1024) {
                     return Status::InvalidArgument(
-                            "The second argument is {}, it can not be less than 0.",
+                            "The second argument is {}, it should be in range [0, 1024].",
                             decimal_places);
                 }
                 const Int32& frac_part = decimal32_column->get_fractional_part(i);
@@ -3423,9 +3426,9 @@ struct FormatRoundDecimalImpl {
             const UInt32 scale = decimal64_column->get_scale();
             for (size_t i = 0; i < input_rows_count; i++) {
                 int32_t decimal_places = arg_column_data_2[index_check_const<is_const>(i)];
-                if (decimal_places < 0) {
+                if (decimal_places < 0 || decimal_places > 1024) {
                     return Status::InvalidArgument(
-                            "The second argument is {}, it can not be less than 0.",
+                            "The second argument is {}, it should be in range [0, 1024].",
                             decimal_places);
                 }
                 const Int64& frac_part = decimal64_column->get_fractional_part(i);
@@ -3441,9 +3444,9 @@ struct FormatRoundDecimalImpl {
             const UInt32 scale = decimal128_column->get_scale();
             for (size_t i = 0; i < input_rows_count; i++) {
                 int32_t decimal_places = arg_column_data_2[index_check_const<is_const>(i)];
-                if (decimal_places < 0) {
+                if (decimal_places < 0 || decimal_places > 1024) {
                     return Status::InvalidArgument(
-                            "The second argument is {}, it can not be less than 0.",
+                            "The second argument is {}, it should be in range [0, 1024].",
                             decimal_places);
                 }
                 const Int128& frac_part = decimal128_column->get_fractional_part(i);

--- a/regression-test/suites/query_p0/sql_functions/math_functions/test_format_round.groovy
+++ b/regression-test/suites/query_p0/sql_functions/math_functions/test_format_round.groovy
@@ -59,7 +59,12 @@ suite("test_format_round", "p0") {
 
     test {
         sql """select format_round(1234567.8910, -1) """
-        exception "it can not be less than 0"
+        exception "it should be in range [0, 1024]"
+    }
+
+    test {
+        sql """select format_round(1234567.8910, 1025) """
+        exception "it should be in range [0, 1024]"
     }
 
     order_qt_format_round_14 """ SELECT format_round(9876.54321, 0) AS result; """


### PR DESCRIPTION
### What problem does this PR solve?
https://github.com/apache/doris-website/pull/2873

before
```
mysql> SELECT format_round(-0.01, 2147483647) AS result;
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INTERNAL_ERROR]basic_string::_M_replace_aux
```
now
```
mysql> SELECT format_round(-0.01, 2147483647) AS result;
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]The second argument is 2147483647, it should be in range [0, 1024].
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

