### PR TITLE
[fix](function)Precision loss in RADIANS function

### DIFF
--- a/be/src/vec/functions/math.cpp
+++ b/be/src/vec/functions/math.cpp
@@ -317,8 +317,8 @@ struct RadiansImpl {
     static constexpr PrimitiveType ResultType = ResultOfUnaryFunc<A>::ResultType;
 
     static inline typename PrimitiveTypeTraits<ResultType>::ColumnItemType apply(A a) {
-        return static_cast<typename PrimitiveTypeTraits<ResultType>::ColumnItemType>(
-                a * PiImpl::value / 180.0);
+        return static_cast<typename PrimitiveTypeTraits<ResultType>::ColumnItemType>(a / 180.0 *
+                                                                                     PiImpl::value);
     }
 };
 

--- a/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_numeric_arithmatic.groovy
+++ b/regression-test/suites/nereids_p0/expression/fold_constant/fold_constant_numeric_arithmatic.groovy
@@ -476,6 +476,7 @@ suite("fold_constant_numeric_arithmatic") {
     testFoldConst("SELECT RADIANS(90) AS radians_case_2") //radians(90) = π/2
     testFoldConst("SELECT RADIANS(45) AS radians_case_3") //radians(45)
     testFoldConst("SELECT radians(0), radians(180), radians(360), radians(45)")
+    testFoldConst("SELECT RADIANS(1e308)")
 
 //Round function cases
     testFoldConst("SELECT ROUND(3.4) AS round_case_1")


### PR DESCRIPTION
### What problem does this PR solve?


```
mysql> set debug_skip_fold_constant = true;
Query OK, 0 rows affected (0.01 sec)

mysql> select RADIANS(1e308);
+----------------+
| RADIANS(1e308) |
+----------------+
|       Infinity |
+----------------+

now

mysql> select RADIANS(1e308);
+------------------------+
| RADIANS(1e308)         |
+------------------------+
| 1.745329251994329e+306 |
+------------------------+
```
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

