### PR TITLE
[fix](cloud) Fix domain user set default cluster report err

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
@@ -18,7 +18,6 @@
 package org.apache.doris.mysql.privilege;
 
 import org.apache.doris.analysis.ResourceTypeEnum;
-import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.cloud.qe.ComputeGroupException;
 import org.apache.doris.common.AnalysisException;
@@ -386,12 +385,23 @@ public class UserProperty {
             return value;
         }
         // check cluster auth
-        if (!Strings.isNullOrEmpty(value) && !Env.getCurrentEnv().getAccessManager().checkCloudPriv(
-            new UserIdentity(qualifiedUser, "%"), value, PrivPredicate.USAGE, ResourceTypeEnum.CLUSTER)) {
+        // get all users with same name but different host
+        AccessControllerManager am = Env.getCurrentEnv().getAccessManager();
+        List<User> users = am.getAuth()
+                .getUserManager().getUserByName(qualifiedUser);
+        boolean pass = false;
+        for (User user : users) {
+            if (!Strings.isNullOrEmpty(value) && am.checkCloudPriv(
+                    user.getUserIdentity(), value, PrivPredicate.USAGE, ResourceTypeEnum.CLUSTER)) {
+                pass = true;
+            }
+        }
+        if (!pass && !Strings.isNullOrEmpty(value)) {
             throw new ComputeGroupException(String.format("set default compute group failed, "
-                + "user %s has no permission to use compute group '%s', please grant use privilege first ",
+                    + "user %s has no permission to use compute group '%s', please grant use privilege first ",
                 qualifiedUser, value),
                 ComputeGroupException.FailedTypeEnum.CURRENT_USER_NO_AUTH_TO_USE_COMPUTE_GROUP);
+
         }
         // set property "DEFAULT_CLOUD_CLUSTER" = "cluster1"
         if (keyArr.length != 1) {

--- a/regression-test/suites/cloud_p0/auth/test_set_default_cluster.groovy
+++ b/regression-test/suites/cloud_p0/auth/test_set_default_cluster.groovy
@@ -42,10 +42,14 @@ suite("test_default_cluster", "docker") {
         def user1 = "default_user1"
         // admin role
         def user2 = "default_user2"
+        // domain user
+        def user3 = "default_user3@'175.%'"
 
         sql """CREATE USER $user1 IDENTIFIED BY 'Cloud123456' DEFAULT ROLE 'admin'"""
         sql """CREATE USER $user2 IDENTIFIED BY 'Cloud123456'"""
+        sql """CREATE USER $user3 IDENTIFIED BY 'Cloud123456'"""
         sql """GRANT SELECT_PRIV on *.*.* to ${user2}"""
+        sql """GRANT SELECT_PRIV on *.*.* to ${user3}"""
 
         def clusters = sql " SHOW CLUSTERS "
         assertTrue(!clusters.isEmpty())
@@ -91,6 +95,17 @@ suite("test_default_cluster", "docker") {
             sql """set property 'DEFAULT_CLOUD_CLUSTER' = '' """
             def ret = getProperty("default_cloud_cluster")
             assertEquals(ret.Value as String, "")
+        }
+        
+        // user3
+        sql """GRANT USAGE_PRIV ON COMPUTE GROUP $validCluster TO $user3"""  
+        // succ
+        connectInDocker('default_user3', 'Cloud123456') {
+            // user set himself
+            setAndCheckDefaultCluster validCluster
+            // sql """set property 'DEFAULT_CLOUD_CLUSTER' = '' """
+            // def ret = getProperty("default_cloud_cluster")
+            // assertEquals(ret.Value as String, "")
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

When setting up a default cluster on the current cloud, it will check whether the user has cluster permissions. However, this check only checks the entire domain. If you create a user using a partial domain, setting up the default cluster will result in an error. Fix it.


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

