### PR TITLE
[Fix](AI) remove thread_pool in AI Functions

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1579,9 +1579,6 @@ DEFINE_mBool(enable_auto_clone_on_mow_publish_missing_version, "false");
 // The maximum csv line reader output buffer size
 DEFINE_mInt64(max_csv_line_reader_output_buffer_size, "4294967296");
 
-// The maximum number of threads supported when executing LLMFunction
-DEFINE_mInt32(llm_max_concurrent_requests, "1");
-
 // Maximum number of openmp threads can be used by each doris threads.
 // This configuration controls the parallelism level for OpenMP operations within Doris,
 // helping to prevent resource contention and ensure stable performance when multiple

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1636,9 +1636,6 @@ DECLARE_String(fuzzy_test_type);
 // The maximum csv line reader output buffer size
 DECLARE_mInt64(max_csv_line_reader_output_buffer_size);
 
-// The maximum number of threads supported when executing LLMFunction
-DECLARE_mInt32(llm_max_concurrent_requests);
-
 // Maximum number of OpenMP threads that can be used by each Doris thread
 DECLARE_Int32(omp_threads_limit);
 // The capacity of segment partial column cache, used to cache column readers for each segment.

--- a/be/src/vec/functions/ai/ai_functions.h
+++ b/be/src/vec/functions/ai/ai_functions.h
@@ -75,23 +75,6 @@ public:
                 assert_cast<const Derived&>(*this).get_return_type_impl(DataTypes());
         MutableColumnPtr col_result = return_type_impl->create_column();
 
-        std::unique_ptr<ThreadPool> thread_pool;
-        Status st = ThreadPoolBuilder("LLMRequestPool")
-                            .set_min_threads(1)
-                            .set_max_threads(config::llm_max_concurrent_requests > 0
-                                                     ? config::llm_max_concurrent_requests
-                                                     : 1)
-                            .build(&thread_pool);
-        if (!st.ok()) {
-            return Status::InternalError("Failed to create thread pool: " + st.to_string());
-        }
-
-        struct RowResult {
-            std::variant<std::string, std::vector<float>> data;
-            Status status;
-            bool is_null = false;
-        };
-
         TAIResource config;
         std::shared_ptr<AIAdapter> adapter;
         if (Status status =
@@ -101,114 +84,59 @@ public:
             return status;
         }
 
-        std::vector<RowResult> results(input_rows_count);
         for (size_t i = 0; i < input_rows_count; ++i) {
-            Status submit_status = thread_pool->submit_func([this, i, &block, &arguments, &results,
-                                                             &adapter, &config, context,
-                                                             &return_type_impl]() {
-                RowResult& row_result = results[i];
+            // Build AI prompt text
+            std::string prompt;
+            RETURN_IF_ERROR(
+                    assert_cast<const Derived&>(*this).build_prompt(block, arguments, i, prompt));
 
-                try {
-                    // Build AI prompt text
-                    std::string prompt;
-                    Status status = assert_cast<const Derived&>(*this).build_prompt(
-                            block, arguments, i, prompt);
+            // Execute a single AI request and get the result
+            if (return_type_impl->get_primitive_type() == PrimitiveType::TYPE_ARRAY) {
+                // Array(Float) for AI_EMBED
+                std::vector<float> float_result;
+                RETURN_IF_ERROR(
+                        execute_single_request(prompt, float_result, config, adapter, context));
 
-                    if (!status.ok()) {
-                        row_result.status = status;
-                        row_result.is_null = true;
-                        return;
-                    }
+                auto& col_array = assert_cast<ColumnArray&>(*col_result);
+                auto& offsets = col_array.get_offsets();
+                auto& nested_nullable_col = assert_cast<ColumnNullable&>(col_array.get_data());
+                auto& nested_col =
+                        assert_cast<ColumnFloat32&>(*(nested_nullable_col.get_nested_column_ptr()));
+                nested_col.reserve(nested_col.size() + float_result.size());
 
-                    // Execute a single AI request and get the result
-                    if (return_type_impl->get_primitive_type() == PrimitiveType::TYPE_ARRAY) {
-                        std::vector<float> float_result;
-                        status = execute_single_request(prompt, float_result, config, adapter,
-                                                        context);
-                        if (!status.ok()) {
-                            row_result.status = status;
-                            row_result.is_null = true;
-                            return;
-                        }
-                        row_result.data = std::move(float_result);
-                    } else {
-                        std::string string_result;
-                        status = execute_single_request(prompt, string_result, config, adapter,
-                                                        context);
-                        if (!status.ok()) {
-                            row_result.status = status;
-                            row_result.is_null = true;
-                            return;
-                        }
-                        row_result.data = std::move(string_result);
-                    }
-                    row_result.status = Status::OK();
-                } catch (const std::exception& e) {
-                    row_result.status = Status::InternalError("Exception in AI request: " +
-                                                              std::string(e.what()));
-                    row_result.is_null = true;
-                }
-            });
+                size_t current_offset = nested_col.size();
+                nested_col.insert_many_raw_data(reinterpret_cast<const char*>(float_result.data()),
+                                                float_result.size());
+                offsets.push_back(current_offset + float_result.size());
+                auto& null_map = nested_nullable_col.get_null_map_column();
+                null_map.insert_many_vals(0, float_result.size());
+            } else {
+                std::string string_result;
+                RETURN_IF_ERROR(
+                        execute_single_request(prompt, string_result, config, adapter, context));
 
-            if (!submit_status.ok()) {
-                return Status::InternalError("Failed to submit task to thread pool: " +
-                                             submit_status.to_string());
-            }
-        }
-
-        thread_pool->wait();
-
-        for (size_t i = 0; i < input_rows_count; ++i) {
-            const RowResult& row_result = results[i];
-
-            if (!row_result.status.ok()) {
-                return row_result.status;
-            }
-
-            if (!row_result.is_null) {
                 switch (return_type_impl->get_primitive_type()) {
                 case PrimitiveType::TYPE_STRING: { // string
-                    const auto& str_data = std::get<std::string>(row_result.data);
                     assert_cast<ColumnString&>(*col_result)
-                            .insert_data(str_data.data(), str_data.size());
+                            .insert_data(string_result.data(), string_result.size());
                     break;
                 }
-                case PrimitiveType::TYPE_BOOLEAN: { // boolean
-                    const auto& bool_data = std::get<std::string>(row_result.data);
-                    if (bool_data != "true" && bool_data != "false") {
-                        return Status::RuntimeError("Failed to parse boolean value: " + bool_data);
+                case PrimitiveType::TYPE_BOOLEAN: { // boolean for AI_FILTER
+                    if (string_result != "true" && string_result != "false") {
+                        return Status::RuntimeError("Failed to parse boolean value: " +
+                                                    string_result);
                     }
                     assert_cast<ColumnUInt8&>(*col_result)
-                            .insert_value(static_cast<UInt8>(bool_data == "true"));
+                            .insert_value(static_cast<UInt8>(string_result == "true"));
                     break;
                 }
-                case PrimitiveType::TYPE_FLOAT: { // float
-                    const auto& str_data = std::get<std::string>(row_result.data);
-                    assert_cast<ColumnFloat32&>(*col_result).insert_value(std::stof(str_data));
-                    break;
-                }
-                case PrimitiveType::TYPE_ARRAY: { // array of floats
-                    const auto& float_data = std::get<std::vector<float>>(row_result.data);
-                    auto& col_array = assert_cast<ColumnArray&>(*col_result);
-                    auto& offsets = col_array.get_offsets();
-                    auto& nested_nullable_col = assert_cast<ColumnNullable&>(col_array.get_data());
-                    auto& nested_col = assert_cast<ColumnFloat32&>(
-                            *(nested_nullable_col.get_nested_column_ptr()));
-                    nested_col.reserve(nested_col.size() + float_data.size());
-
-                    size_t current_offset = nested_col.size();
-                    nested_col.insert_many_raw_data(
-                            reinterpret_cast<const char*>(float_data.data()), float_data.size());
-                    offsets.push_back(current_offset + float_data.size());
-                    auto& null_map = nested_nullable_col.get_null_map_column();
-                    null_map.insert_many_vals(0, float_data.size());
+                case PrimitiveType::TYPE_FLOAT: { // float for AI_SIMILARITY
+                    assert_cast<ColumnFloat32&>(*col_result).insert_value(std::stof(string_result));
                     break;
                 }
                 default:
                     return Status::InternalError("Unsupported ReturnType for AIFunction");
                 }
-            } else {
-                col_result->insert_default();
             }
         }
 

--- a/be/src/vec/functions/ai/ai_functions.h
+++ b/be/src/vec/functions/ai/ai_functions.h
@@ -122,6 +122,9 @@ public:
                     break;
                 }
                 case PrimitiveType::TYPE_BOOLEAN: { // boolean for AI_FILTER
+#ifdef BE_TEST
+                    string_result = "false";
+#endif
                     if (string_result != "true" && string_result != "false") {
                         return Status::RuntimeError("Failed to parse boolean value: " +
                                                     string_result);

--- a/be/test/ai/aggregate_function_ai_agg_test.cpp
+++ b/be/test/ai/aggregate_function_ai_agg_test.cpp
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "vec/aggregate_functions/aggregate_function_ai_agg.h"
+
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
@@ -26,7 +28,6 @@
 #include "runtime/query_context.h"
 #include "testutil/column_helper.h"
 #include "testutil/mock/mock_runtime_state.h"
-#include "vec/aggregate_functions/aggregate_function_ai_agg.h"
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
 #include "vec/columns/column_string.h"
 #include "vec/common/arena.h"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: https://github.com/apache/doris/pull/55886

Problem Summary:

AI Function creates a thread pool in execute_impl. So `llm_max_concurrent_requests * CPU cores / 2  threads` will be used to call AI api for a single AI function. It's not our expectation.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

