### PR TITLE
[Fix](date) Fix the issue that the ceil func of date ignores ms

### DIFF
--- a/be/src/vec/functions/function_datetime_floor_ceil.cpp
+++ b/be/src/vec/functions/function_datetime_floor_ceil.cpp
@@ -449,37 +449,35 @@ private:
             if constexpr (Flag::Unit == YEAR) {
                 diff = ts_arg.year();
                 part = (ts_arg.month() - 1) | (ts_arg.day() - 1) | ts_arg.hour() | ts_arg.minute() |
-                       ts_arg.second();
+                       ts_arg.second() | ts_arg.microsecond();
             }
             if constexpr (Flag::Unit == QUARTER) {
                 // only ceil cannot be optimized then reach here.
                 diff = ts_arg.year() * 4 + ts_arg.quarter() - 1;
                 part = (ts_arg.month() - 1) % 3 | (ts_arg.day() - 1) | ts_arg.hour() |
-                       ts_arg.minute() | ts_arg.second();
+                       ts_arg.minute() | ts_arg.second() | ts_arg.microsecond();
             }
             if constexpr (Flag::Unit == MONTH) {
                 diff = ts_arg.year() * 12 + ts_arg.month() - 1;
-                part = (ts_arg.day() - 1) | ts_arg.hour() | ts_arg.minute() | ts_arg.second();
+                part = (ts_arg.day() - 1) | ts_arg.hour() | ts_arg.minute() | ts_arg.second() |
+                       ts_arg.microsecond();
             }
             if constexpr (Flag::Unit == DAY) {
                 diff = ts_arg.daynr();
-                part = ts_arg.hour() | ts_arg.minute() | ts_arg.second();
+                part = ts_arg.hour() | ts_arg.minute() | ts_arg.second() | ts_arg.microsecond();
             }
             if constexpr (Flag::Unit == HOUR) {
                 diff = ts_arg.daynr() * 24 + ts_arg.hour();
-                part = ts_arg.minute() | ts_arg.second();
+                part = ts_arg.minute() | ts_arg.second() | ts_arg.microsecond();
             }
             if constexpr (Flag::Unit == MINUTE) {
                 diff = ts_arg.daynr() * 24L * 60 + ts_arg.hour() * 60 + ts_arg.minute();
-                part = ts_arg.second();
+                part = ts_arg.second() | ts_arg.microsecond();
             }
             if constexpr (Flag::Unit == SECOND) {
                 diff = ts_arg.daynr() * 24L * 60 * 60 + ts_arg.hour() * 60L * 60 +
                        ts_arg.minute() * 60L + ts_arg.second();
-                part = false;
-                if constexpr (std::is_same_v<DateValueType, DateV2Value<DateTimeV2ValueType>>) {
-                    part = ts_arg.microsecond();
-                }
+                part = ts_arg.microsecond();
             }
 
             if constexpr (Flag::Type == CEIL) {

--- a/be/src/vec/runtime/vdatetime_value.h
+++ b/be/src/vec/runtime/vdatetime_value.h
@@ -508,6 +508,7 @@ public:
     uint8_t hour() const { return _hour; }
     uint8_t minute() const { return _minute; }
     uint16_t second() const { return _second; }
+    uint8_t microsecond() const { return 0; }
 
     int64_t time_part_to_seconds() const {
         return _hour * SECOND_PER_HOUR + _minute * SECOND_PER_MINUTE + _second;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/TimeRoundSeries.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/TimeRoundSeries.java
@@ -105,6 +105,7 @@ public class TimeRoundSeries {
                 return null;
             }
         }
+        trivialPart = (trivialPart == 0 ? dt.getMicroSecond() - start.getMicroSecond() : trivialPart);
         if (getCeil) {
             diff = diff + (trivialPart > 0 ? 1 : 0);
         } else {

--- a/regression-test/data/query_p0/sql_functions/datetime_functions/test_date_floor_ceil.out
+++ b/regression-test/data/query_p0/sql_functions/datetime_functions/test_date_floor_ceil.out
@@ -470,3 +470,87 @@
 -- !three_param_91 --
 2024-01-01T00:00
 
+-- !second_ceil_ms_test_1 --
+2001-01-01T12:00:01
+
+-- !second_ceil_ms_test_2 --
+2001-01-01T12:00:20
+
+-- !second_ceil_ms_test_3 --
+2001-01-01T12:00:01
+
+-- !second_ceil_ms_test_4 --
+2001-01-01T12:00:20
+
+-- !minute_ceil_ms_test_1 --
+2001-01-01T12:01
+
+-- !minute_ceil_ms_test_2 --
+2001-01-01T12:20
+
+-- !minute_ceil_ms_test_3 --
+2001-01-01T12:01
+
+-- !minute_ceil_ms_test_4 --
+2001-01-01T12:20
+
+-- !hour_ceil_ms_test_1 --
+2001-01-01T13:00
+
+-- !hour_ceil_ms_test_2 --
+2001-01-02T00:00
+
+-- !hour_ceil_ms_test_3 --
+2001-01-01T13:00
+
+-- !hour_ceil_ms_test_4 --
+2001-01-02T00:00
+
+-- !day_ceil_ms_test_1 --
+2001-01-02T00:00
+
+-- !day_ceil_ms_test_2 --
+2001-01-02T00:00
+
+-- !day_ceil_ms_test_3 --
+2001-01-02T00:00
+
+-- !day_ceil_ms_test_4 --
+2001-01-02T00:00
+
+-- !month_ceil_ms_test_1 --
+2001-02-01T00:00
+
+-- !month_ceil_ms_test_2 --
+2001-02-01T00:00
+
+-- !month_ceil_ms_test_3 --
+2001-01-04T00:00
+
+-- !month_ceil_ms_test_4 --
+2001-01-04T00:00
+
+-- !quarter_ceil_ms_test_1 --
+2001-04-01T00:00
+
+-- !quarter_ceil_ms_test_2 --
+2001-04-01T00:00
+
+-- !quarter_ceil_ms_test_3 --
+2001-01-04T00:00
+
+-- !quarter_ceil_ms_test_4 --
+2001-01-04T00:00
+
+-- !year_ceil_ms_test_1 --
+2002-01-01T00:00
+
+-- !year_ceil_ms_test_2 --
+2011-01-01T00:00
+
+-- !year_ceil_ms_test_3 --
+2002-01-01T00:00
+
+-- !year_ceil_ms_test_4 --
+2010-01-01T00:00
+

--- a/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_floor_ceil.groovy
+++ b/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_floor_ceil.groovy
@@ -213,4 +213,74 @@ suite("test_date_floor_ceil") {
     qt_three_param_89 """ select quarter_ceil('0001-01-01 00:00:00', 1, '0001-01-01 00:00:00'); """
     qt_three_param_90 """ select quarter_floor('2023-06-30 23:59:59', 2, '2022-01-01 00:00:00'); """
     qt_three_param_91 """ select quarter_ceil('2023-07-01 00:00:01', 2, '2022-01-01 00:00:00'); """
+
+    qt_second_ceil_ms_test_1"""SELECT SECOND_CEIL('2001-01-01 12:00:00.000001');"""
+    qt_second_ceil_ms_test_2"""SELECT SECOND_CEIL('2001-01-01 12:00:00.000001', 20);"""
+    qt_second_ceil_ms_test_3"""SELECT SECOND_CEIL('2001-01-01 12:00:00.000001', '1970-01-01');"""
+    qt_second_ceil_ms_test_4"""SELECT SECOND_CEIL('2001-01-01 12:00:00.000001', 20, '1970-01-01');"""
+
+    qt_minute_ceil_ms_test_1"""SELECT MINUTE_CEIL('2001-01-01 12:00:00.000001');"""
+    qt_minute_ceil_ms_test_2"""SELECT MINUTE_CEIL('2001-01-01 12:00:00.000001', 20);"""
+    qt_minute_ceil_ms_test_3"""SELECT MINUTE_CEIL('2001-01-01 12:00:00.000001', '1970-01-01');"""
+    qt_minute_ceil_ms_test_4"""SELECT MINUTE_CEIL('2001-01-01 12:00:00.000001', 20, '1970-01-01');"""
+
+    qt_hour_ceil_ms_test_1"""SELECT HOUR_CEIL('2001-01-01 12:00:00.000001');"""
+    qt_hour_ceil_ms_test_2"""SELECT HOUR_CEIL('2001-01-01 12:00:00.000001', 12);"""
+    qt_hour_ceil_ms_test_3"""SELECT HOUR_CEIL('2001-01-01 12:00:00.000001', '1970-01-01');"""
+    qt_hour_ceil_ms_test_4"""SELECT HOUR_CEIL('2001-01-01 12:00:00.000001', 12, '1970-01-01');"""
+
+    qt_day_ceil_ms_test_1"""SELECT DAY_CEIL('2001-01-01 0:00:00.000001');"""
+    qt_day_ceil_ms_test_2"""SELECT DAY_CEIL('2001-01-01 0:00:00.000001', 1);"""
+    qt_day_ceil_ms_test_3"""SELECT DAY_CEIL('2001-01-01 0:00:00.000001', '1145-01-04');"""
+    qt_day_ceil_ms_test_4"""SELECT DAY_CEIL('2001-01-01 0:00:00.000001', 1, '1145-01-04');"""
+
+    qt_month_ceil_ms_test_1"""SELECT MONTH_CEIL('2001-01-01 0:00:00.000001');"""
+    qt_month_ceil_ms_test_2"""SELECT MONTH_CEIL('2001-01-01 0:00:00.000001', 1);"""
+    qt_month_ceil_ms_test_3"""SELECT MONTH_CEIL('2001-01-01 0:00:00.000001', '1145-01-04');"""
+    qt_month_ceil_ms_test_4"""SELECT MONTH_CEIL('2001-01-01 0:00:00.000001', 1, '1145-01-04');"""
+
+    qt_quarter_ceil_ms_test_1"""SELECT QUARTER_CEIL('2001-01-01 0:00:00.000001');"""
+    qt_quarter_ceil_ms_test_2"""SELECT QUARTER_CEIL('2001-01-01 0:00:00.000001', 1);"""
+    qt_quarter_ceil_ms_test_3"""SELECT QUARTER_CEIL('2001-01-01 0:00:00.000001', '1145-01-04');"""
+    qt_quarter_ceil_ms_test_4"""SELECT QUARTER_CEIL('2001-01-01 0:00:00.000001', 1, '1145-01-04');"""
+
+    qt_year_ceil_ms_test_1"""SELECT YEAR_CEIL('2001-01-01 0:00:00.000001');"""
+    qt_year_ceil_ms_test_2"""SELECT YEAR_CEIL('2001-01-01 0:00:00.000001', 10);"""
+    qt_year_ceil_ms_test_3"""SELECT YEAR_CEIL('2001-01-01 0:00:00.000001', '1970-01-01');"""
+    qt_year_ceil_ms_test_4"""SELECT YEAR_CEIL('2001-01-01 0:00:00.000001', 10, '1970-01-01');"""
+
+    testFoldConst("SELECT SECOND_CEIL('2001-01-01 12:00:00.000001');");
+    testFoldConst("SELECT SECOND_CEIL('2001-01-01 12:00:00.000001', 20);");
+    testFoldConst("SELECT SECOND_CEIL('2001-01-01 12:00:00.000001', '1970-01-01');");
+    testFoldConst("SELECT SECOND_CEIL('2001-01-01 12:00:00.000001', 20, '1970-01-01');");
+    
+    testFoldConst("SELECT MINUTE_CEIL('2001-01-01 12:00:00.000001');");
+    testFoldConst("SELECT MINUTE_CEIL('2001-01-01 12:00:00.000001', 20);");
+    testFoldConst("SELECT MINUTE_CEIL('2001-01-01 12:00:00.000001', '1970-01-01');");
+    testFoldConst("SELECT MINUTE_CEIL('2001-01-01 12:00:00.000001', 20, '1970-01-01');");
+    
+    testFoldConst("SELECT HOUR_CEIL('2001-01-01 12:00:00.000001');");
+    testFoldConst("SELECT HOUR_CEIL('2001-01-01 12:00:00.000001', 12);");
+    testFoldConst("SELECT HOUR_CEIL('2001-01-01 12:00:00.000001', '1970-01-01');");
+    testFoldConst("SELECT HOUR_CEIL('2001-01-01 12:00:00.000001', 12, '1970-01-01');");
+    
+    testFoldConst("SELECT DAY_CEIL('2001-01-01 0:00:00.000001');");
+    testFoldConst("SELECT DAY_CEIL('2001-01-01 0:00:00.000001', 1);");
+    testFoldConst("SELECT DAY_CEIL('2001-01-01 0:00:00.000001', '1145-01-04');");
+    testFoldConst("SELECT DAY_CEIL('2001-01-01 0:00:00.000001', 1, '1145-01-04');");
+    
+    testFoldConst("SELECT MONTH_CEIL('2001-01-01 0:00:00.000001');");
+    testFoldConst("SELECT MONTH_CEIL('2001-01-01 0:00:00.000001', 1);");
+    testFoldConst("SELECT MONTH_CEIL('2001-01-01 0:00:00.000001', '1145-01-04');");
+    testFoldConst("SELECT MONTH_CEIL('2001-01-01 0:00:00.000001', 1, '1145-01-04');");
+    
+    testFoldConst("SELECT QUARTER_CEIL('2001-01-01 0:00:00.000001');");
+    testFoldConst("SELECT QUARTER_CEIL('2001-01-01 0:00:00.000001', 1);");
+    testFoldConst("SELECT QUARTER_CEIL('2001-01-01 0:00:00.000001', '1145-01-04');");
+    testFoldConst("SELECT QUARTER_CEIL('2001-01-01 0:00:00.000001', 1, '1145-01-04');");
+    
+    testFoldConst("SELECT YEAR_CEIL('2001-01-01 0:00:00.000001');");
+    testFoldConst("SELECT YEAR_CEIL('2001-01-01 0:00:00.000001', 10);");
+    testFoldConst("SELECT YEAR_CEIL('2001-01-01 0:00:00.000001', '1970-01-01');");
+    testFoldConst("SELECT YEAR_CEIL('2001-01-01 0:00:00.000001', 10, '1970-01-01');");
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

The ceil function in the date will ignore the input millisecond values which leading to incorrect results like:
```text
mysql> SELECT HOUR_CEIL('2001-01-01 12:00:00.000001');
+-----------------------------------------+
| HOUR_CEIL('2001-01-01 12:00:00.000001') |
+-----------------------------------------+
| 2001-01-01 12:00:00.000000              |
+-----------------------------------------+
```

After fix:
```text
mysql> SELECT HOUR_CEIL('2001-01-01 12:00:00.000001');
+-----------------------------------------+
| HOUR_CEIL('2001-01-01 12:00:00.000001') |
+-----------------------------------------+
| 2001-01-01 13:00:00.000000              |
+-----------------------------------------+
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

