### PR TITLE
[chore](cloud) Add optional code dir enterprise/

### DIFF
--- a/cloud/CMakeLists.txt
+++ b/cloud/CMakeLists.txt
@@ -281,11 +281,6 @@ set(WL_START_GROUP "-Wl,--start-group")
 set(WL_END_GROUP "-Wl,--end-group")
 
 # Set Doris libraries
-set(DORIS_LINK_LIBS
-    ${WL_START_GROUP}
-    ${WL_END_GROUP}
-)
-
 if ((ARCH_AMD64 OR ARCH_AARCH64) AND OS_LINUX)
     add_library(hadoop_hdfs STATIC IMPORTED)
     set_target_properties(hadoop_hdfs PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/hadoop_hdfs/native/libhdfs.a)
@@ -318,17 +313,7 @@ message(STATUS "DORIS_DEPENDENCIES is ${DORIS_DEPENDENCIES}")
 
 # Add all external dependencies. They should come after the project's libs.
 # static link gcc's lib
-set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS}
-    ${WL_START_GROUP}
-    CloudGen
-    Common
-    MetaService
-    MetaStore
-    ResourceManager
-    Recycler
-    RateLimiter
-    Snapshot
-    ${WL_END_GROUP}
+set(DORIS_LINK_LIBS
     CommonCPP
     ${DORIS_DEPENDENCIES}
     -static-libstdc++
@@ -390,15 +375,6 @@ set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS}
 if(BUILD_CHECK_META STREQUAL "ON")
     set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS} -lmysqlclient)
 endif ()
-
-# Set libraries for test
-set (TEST_LINK_LIBS ${DORIS_LINK_LIBS}
-    ${WL_START_GROUP}
-    gmock
-    gtest
-    gtest_main
-    ${WL_END_GROUP}
-)
 
 # Only build static libs
 set(BUILD_SHARED_LIBS OFF)
@@ -481,6 +457,21 @@ add_definitions(-DGLOG_CUSTOM_PREFIX_SUPPORT)
 
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lfdb_c -L${THIRDPARTY_DIR}/lib")
 
+set(DORIS_CLOUD_LIBS
+    CloudGen
+    Common
+    MetaService
+    MetaStore
+    ResourceManager
+    Recycler
+    RateLimiter
+    Snapshot
+)
+
+if (EXISTS ${SRC_DIR}/enterprise/CMakeLists.txt)
+    add_subdirectory(${SRC_DIR}/enterprise)
+endif()
+
 add_subdirectory(${SRC_DIR}/common)
 add_subdirectory(${SRC_DIR}/gen-cpp)
 add_subdirectory(${SRC_DIR}/meta-service)
@@ -489,6 +480,22 @@ add_subdirectory(${SRC_DIR}/recycler)
 add_subdirectory(${SRC_DIR}/rate-limiter)
 add_subdirectory(${SRC_DIR}/resource-manager)
 add_subdirectory(${SRC_DIR}/snapshot)
+
+# Set libraries for doris_cloud
+set(DORIS_LINK_LIBS
+    ${WL_START_GROUP}
+    ${DORIS_CLOUD_LIBS}
+    ${WL_END_GROUP}
+    ${DORIS_LINK_LIBS})
+
+# Set libraries for test
+set (TEST_LINK_LIBS ${DORIS_LINK_LIBS}
+    ${WL_START_GROUP}
+    gmock
+    gtest
+    gtest_main
+    ${WL_END_GROUP}
+)
 
 if (${MAKE_TEST} STREQUAL "ON")
     add_subdirectory(${TEST_DIR})

--- a/cloud/test/CMakeLists.txt
+++ b/cloud/test/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/enterprise/CMakeLists.txt)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/enterprise)
+endif()
+
 # where to put generated libraries
 set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/test")
 


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Usage:

Place the code files in the `enterprise/` directory and add a `CMakeLists.txt` file. In the `CMakeLists.txt`, define a library and configure its include directories using `target_include_directories`. Finally, expose the library to the parent scope with the following command:

```
set(DORIS_CLOUD_LIBS ${DORIS_CLOUD_DIR} ${library} PARENT_SCOPE)
```

The CMake build system will automatically add this library as a dependency for doris_cloud. This library will be grouped with other libraries to prevent dependency issues.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

