### PR TITLE
[OPT](S3) init aws ClientConfiguration  when starting BE

### DIFF
--- a/be/src/pipeline/exec/result_file_sink_operator.cpp
+++ b/be/src/pipeline/exec/result_file_sink_operator.cpp
@@ -109,6 +109,12 @@ Status ResultFileSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo& i
     return Status::OK();
 }
 
+Status ResultFileSinkLocalState::open(RuntimeState* state) {
+    SCOPED_TIMER(exec_time_counter());
+    SCOPED_TIMER(_open_timer);
+    return Base::open(state);
+}
+
 Status ResultFileSinkLocalState::close(RuntimeState* state, Status exec_status) {
     if (Base::_closed) {
         return Status::OK();

--- a/be/src/pipeline/exec/result_file_sink_operator.h
+++ b/be/src/pipeline/exec/result_file_sink_operator.h
@@ -37,6 +37,7 @@ public:
     ~ResultFileSinkLocalState() override;
 
     Status init(RuntimeState* state, LocalSinkStateInfo& info) override;
+    Status open(RuntimeState* state) override;
     Status close(RuntimeState* state, Status exec_status) override;
 
     [[nodiscard]] int sender_id() const { return _sender_id; }

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -408,6 +408,11 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
 
     // Make aws-sdk-cpp InitAPI and ShutdownAPI called in the same thread
     S3ClientFactory::instance();
+    LOG(INFO) << "Begin exec S3ClientFactory::getClientConfiguration().";
+    // This will take a long time, indirectly causing slow S3 writing during the first execution
+    // after BE restart
+    S3ClientFactory::getClientConfiguration();
+    LOG(INFO) << "Exec S3ClientFactory::getClientConfiguration() done.";
     return Status::OK();
 }
 

--- a/be/src/vec/sink/writer/vfile_result_writer.cpp
+++ b/be/src/vec/sink/writer/vfile_result_writer.cpp
@@ -458,8 +458,10 @@ Status VFileResultWriter::close(Status exec_status) {
         if (_written_rows_counter) {
             COUNTER_SET(_written_rows_counter, _written_rows);
             SCOPED_TIMER(_writer_close_timer);
+            st = _close_file_writer(true);
+        } else {
+            st = _close_file_writer(true);
         }
-        st = _close_file_writer(true);
     }
     return st;
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
When calling `S3ClientFactory::getClientConfiguration`, it may cost too much long time.
```
E20250916 00:43:33.577644 3174497 aws_logger.h:50] [CurlHttpClient] Curl returned error code 28 - Timeout was reached
E20250916 00:43:33.577708 3174497 aws_logger.h:50] [EC2MetadataClient] Http request to retrieve credentials failed
W20250916 00:43:33.577716 3174497 aws_logger.h:53] [EC2MetadataClient] Request failed, now waiting 0 ms before attempting again.
E20250916 00:43:34.577911 3174497 aws_logger.h:50] [CurlHttpClient] Curl returned error code 28 - Timeout was reached
E20250916 00:43:34.577973 3174497 aws_logger.h:50] [EC2MetadataClient] Http request to retrieve credentials failed
E20250916 00:43:34.577984 3174497 aws_logger.h:50] [EC2MetadataClient] Can not retrieve resource from http://169.254.169.254/latest/api/token
E20250916 00:43:35.578131 3174497 aws_logger.h:50] [CurlHttpClient] Curl returned error code 28 - Timeout was reached
E20250916 00:43:35.578181 3174497 aws_logger.h:50] [EC2MetadataClient] Http request to retrieve credentials failed
W20250916 00:43:35.578188 3174497 aws_logger.h:53] [EC2MetadataClient] Request failed, now waiting 0 ms before attempting again.
E20250916 00:43:36.578377 3174497 aws_logger.h:50] [CurlHttpClient] Curl returned error code 28 - Timeout was reached
E20250916 00:43:36.578429 3174497 aws_logger.h:50] [EC2MetadataClient] Http request to retrieve credentials failed
E20250916 00:43:36.578439 3174497 aws_logger.h:50] [EC2MetadataClient] Can not retrieve resource from http://169.254.169.254/latest/meta-data/iam/security-credentials
E20250916 00:43:37.578578 3174497 aws_logger.h:50] [CurlHttpClient] Curl returned error code 28 - Timeout was reached
E20250916 00:43:37.578635 3174497 aws_logger.h:50] [EC2MetadataClient] Http request to retrieve credentials failed
W20250916 00:43:37.578644 3174497 aws_logger.h:53] [EC2MetadataClient] Request failed, now waiting 0 ms before attempting again.
E20250916 00:43:38.578836 3174497 aws_logger.h:50] [CurlHttpClient] Curl returned error code 28 - Timeout was reached
E20250916 00:43:38.578886 3174497 aws_logger.h:50] [EC2MetadataClient] Http request to retrieve credentials failed
E20250916 00:43:38.578897 3174497 aws_logger.h:50] [EC2MetadataClient] Can not retrieve resource from http://169.254.169.254/latest/meta-data/placement/availability-zone
```
In this PR, Exec `getClientConfiguration` in `ExecEnv::_init`.
In the same time, fix the bug that `OpenTime` of `RESULT_FILE_SINK_OPERATOR` is always 0 and fix the bug of inaccurate `FileWriterCloseTime` in `VFileResultWriter`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

