### PR TITLE
[log](load) log error when failed to put stream_load_record

### DIFF
--- a/be/src/http/action/http_stream.cpp
+++ b/be/src/http/action/http_stream.cpp
@@ -400,6 +400,9 @@ void HttpStreamAction::_save_stream_load_record(std::shared_ptr<StreamLoadContex
         if (st.ok()) {
             LOG(INFO) << "put stream_load_record rocksdb successfully. label: " << ctx->label
                       << ", key: " << key;
+        } else {
+            LOG(WARNING) << "put stream_load_record rocksdb failed. label: " << ctx->label
+                         << ", key: " << key << ", err: " << st;
         }
     } else {
         LOG(WARNING) << "put stream_load_record rocksdb failed. stream_load_recorder is null.";

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -835,6 +835,9 @@ void StreamLoadAction::_save_stream_load_record(std::shared_ptr<StreamLoadContex
         if (st.ok()) {
             LOG(INFO) << "put stream_load_record rocksdb successfully. label: " << ctx->label
                       << ", key: " << key;
+        } else {
+            LOG(WARNING) << "put stream_load_record rocksdb failed. label: " << ctx->label
+                         << ", key: " << key << ", err: " << st;
         }
     } else {
         LOG(WARNING) << "put stream_load_record rocksdb failed. stream_load_recorder is null.";


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Print a warning log when failed to put stream_load_record into rocksdb.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

