### PR TITLE
[enhance](paimon) Intro SessionVariable max_external_split_num to limit the maximum number of file splits when querying external tables 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
@@ -286,7 +286,24 @@ public class PaimonScanNode extends FileQueryScanNode {
         // And for counting the number of selected partitions for this paimon table.
         Map<BinaryRow, Map<String, String>> partitionInfoMaps = new HashMap<>();
         // if applyCountPushdown is true, we can't split the DataSplit
-        long realFileSplitSize = getRealFileSplitSize(applyCountPushdown ? Long.MAX_VALUE : 0);
+        long realFileSplitSize = applyCountPushdown ? Long.MAX_VALUE : getRealFileSplitSize(0);
+
+        long max_external_split_num = sessionVariable.getMaxExternalSplitNum();
+        long total_raw_file_size = dataSplits.stream()
+                .mapToLong(split -> split.rawConvertible()
+                        ? split.convertToRawFiles().get().stream().mapToLong(RawFile::fileSize).sum()
+                        : 0)
+                .sum();
+        if (total_raw_file_size > 0 && realFileSplitSize > 0) {
+            long estimated_split_num = total_raw_file_size / realFileSplitSize;
+            if (estimated_split_num > max_external_split_num) {
+                realFileSplitSize = total_raw_file_size / max_external_split_num;
+                LOG.info("The estimated split num is {} which exceeds the limit {}, "
+                                + "so we adjust the file split size to {}",
+                        estimated_split_num, max_external_split_num, realFileSplitSize);
+            }
+        }
+
         for (DataSplit dataSplit : dataSplits) {
             SplitStat splitStat = new SplitStat();
             splitStat.setRowCount(dataSplit.rowCount());
@@ -376,7 +393,9 @@ public class PaimonScanNode extends FileQueryScanNode {
 
         // We need to set the target size for all splits so that we can calculate the
         // proportion of each split later.
-        splits.forEach(s -> s.setTargetSplitSize(realFileSplitSize));
+        for (Split split : splits) {
+            split.setTargetSplitSize(realFileSplitSize);
+        }
 
         this.selectedPartitionNum = partitionInfoMaps.size();
         return splits;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
@@ -49,6 +49,7 @@ import org.apache.doris.thrift.TPushAggOp;
 import org.apache.doris.thrift.TTableFormatFileDesc;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.paimon.data.BinaryRow;
@@ -289,6 +290,8 @@ public class PaimonScanNode extends FileQueryScanNode {
         long realFileSplitSize = applyCountPushdown ? Long.MAX_VALUE : getRealFileSplitSize(0);
 
         long maxExternalSplitNum = sessionVariable.getMaxExternalSplitNum();
+        Preconditions.checkState(maxExternalSplitNum > 0,
+                "max_external_split_num must be greater than 0, but got: " + maxExternalSplitNum);
         long totalRawFileSize = dataSplits.stream()
                 .mapToLong(split -> split.rawConvertible()
                         ? split.convertToRawFiles().get().stream().mapToLong(RawFile::fileSize).sum()

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
@@ -288,19 +288,19 @@ public class PaimonScanNode extends FileQueryScanNode {
         // if applyCountPushdown is true, we can't split the DataSplit
         long realFileSplitSize = applyCountPushdown ? Long.MAX_VALUE : getRealFileSplitSize(0);
 
-        long max_external_split_num = sessionVariable.getMaxExternalSplitNum();
-        long total_raw_file_size = dataSplits.stream()
+        long maxExternalSplitNum = sessionVariable.getMaxExternalSplitNum();
+        long totalRawFileSize = dataSplits.stream()
                 .mapToLong(split -> split.rawConvertible()
                         ? split.convertToRawFiles().get().stream().mapToLong(RawFile::fileSize).sum()
                         : 0)
                 .sum();
-        if (total_raw_file_size > 0 && realFileSplitSize > 0) {
-            long estimated_split_num = total_raw_file_size / realFileSplitSize;
-            if (estimated_split_num > max_external_split_num) {
-                realFileSplitSize = total_raw_file_size / max_external_split_num;
+        if (totalRawFileSize > 0 && realFileSplitSize > 0) {
+            long estimatedSplitNum = totalRawFileSize / realFileSplitSize;
+            if (estimatedSplitNum > maxExternalSplitNum) {
+                realFileSplitSize = totalRawFileSize / maxExternalSplitNum;
                 LOG.info("The estimated split num is {} which exceeds the limit {}, "
                                 + "so we adjust the file split size to {}",
-                        estimated_split_num, max_external_split_num, realFileSplitSize);
+                        estimatedSplitNum, maxExternalSplitNum, realFileSplitSize);
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -479,6 +479,9 @@ public class SessionVariable implements Serializable, Writable {
     // Split size for ExternalFileScanNode. Default value 0 means use the block size of HDFS/S3.
     public static final String FILE_SPLIT_SIZE = "file_split_size";
 
+    // Maximum number of splits when querying external tables.
+    public static final String MAX_EXTERNAL_SPLIT_NUM = "max_external_split_num";
+
     public static final String NUM_PARTITIONS_IN_BATCH_MODE = "num_partitions_in_batch_mode";
 
     public static final String NUM_FILES_IN_BATCH_MODE = "num_files_in_batch_mode";
@@ -2014,6 +2017,12 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = FILE_SPLIT_SIZE, needForward = true)
     public long fileSplitSize = 0;
+
+    @VariableMgr.VarAttr(name = MAX_EXTERNAL_SPLIT_NUM, needForward = true,
+            description = {"限制查询外部表时的最大split数量，用于控制资源使用和防止过度并行。",
+                    "Limit the maximum number of splits when querying external tables, "
+                            + "used to control resource usage and prevent excessive parallelism."})
+    public int maxExternalSplitNum = 10000;
 
     @VariableMgr.VarAttr(
             name = NUM_PARTITIONS_IN_BATCH_MODE,
@@ -3867,6 +3876,14 @@ public class SessionVariable implements Serializable, Writable {
 
     public void setFileSplitSize(long fileSplitSize) {
         this.fileSplitSize = fileSplitSize;
+    }
+
+    public int getMaxExternalSplitNum() {
+        return maxExternalSplitNum;
+    }
+
+    public void setMaxExternalSplitNum(int maxExternalSplitNum) {
+        this.maxExternalSplitNum = maxExternalSplitNum;
     }
 
     public int getNumPartitionsInBatchMode() {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/source/PaimonScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/source/PaimonScanNodeTest.java
@@ -97,6 +97,7 @@ public class PaimonScanNodeTest {
         // Mock SessionVariable behavior
         Mockito.when(sv.isForceJniScanner()).thenReturn(false);
         Mockito.when(sv.getIgnoreSplitType()).thenReturn("NONE");
+        Mockito.when(sv.getMaxExternalSplitNum()).thenReturn(10000);
 
         // native
         mockNativeReader(spyPaimonScanNode);


### PR DESCRIPTION
### What problem does this PR solve?
This pull request introduces a mechanism to limit the maximum number of file splits when querying external tables, which helps control resource usage and prevent excessive parallelism. 
Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

