### PR TITLE
[fix](iceberg) Fix classloader usage in the Iceberg system table scanner

### DIFF
--- a/fe/be-java-extensions/iceberg-metadata-scanner/src/main/java/org/apache/doris/iceberg/IcebergSysTableJniScanner.java
+++ b/fe/be-java-extensions/iceberg-metadata-scanner/src/main/java/org/apache/doris/iceberg/IcebergSysTableJniScanner.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.iceberg;
 
+import org.apache.doris.common.classloader.ThreadClassLoaderContext;
 import org.apache.doris.common.jni.JniScanner;
 import org.apache.doris.common.jni.vec.ColumnType;
 import org.apache.doris.common.jni.vec.ColumnValue;
@@ -77,19 +78,22 @@ public class IcebergSysTableJniScanner extends JniScanner {
 
     @Override
     public void open() throws IOException {
-        Thread.currentThread().setContextClassLoader(classLoader);
-        nextScanTask();
+        try (ThreadClassLoaderContext ignored = new ThreadClassLoaderContext(classLoader)) {
+            nextScanTask();
+        }
     }
 
     private void nextScanTask() throws IOException {
         Preconditions.checkArgument(scanTasks.hasNext());
         FileScanTask scanTask = scanTasks.next();
         try {
-            preExecutionAuthenticator.execute(() -> {
-                // execute FileScanTask to get rows
-                reader = scanTask.asDataTask().rows().iterator();
-                return null;
-            });
+            try (ThreadClassLoaderContext ignored = new ThreadClassLoaderContext(classLoader)) {
+                preExecutionAuthenticator.execute(() -> {
+                    // execute FileScanTask to get rows
+                    reader = scanTask.asDataTask().rows().iterator();
+                    return null;
+                });
+            }
         } catch (Exception e) {
             this.close();
             String msg = String.format("Failed to open next scan task: %s", scanTask);
@@ -100,31 +104,35 @@ public class IcebergSysTableJniScanner extends JniScanner {
 
     @Override
     protected int getNext() throws IOException {
-        int rows = 0;
-        while (rows < getBatchSize()) {
-            while (!reader.hasNext() && scanTasks.hasNext()) {
-                nextScanTask();
+        try (ThreadClassLoaderContext ignored = new ThreadClassLoaderContext(classLoader)) {
+            int rows = 0;
+            while (rows < getBatchSize()) {
+                while (!reader.hasNext() && scanTasks.hasNext()) {
+                    nextScanTask();
+                }
+                if (!reader.hasNext()) {
+                    break;
+                }
+                StructLike row = reader.next();
+                for (int i = 0; i < fields.size(); i++) {
+                    NestedField field = fields.get(i);
+                    Object value = row.get(i, field.type().typeId().javaClass());
+                    ColumnValue columnValue = new IcebergSysTableColumnValue(value, timezone);
+                    appendData(i, columnValue);
+                }
+                rows++;
             }
-            if (!reader.hasNext()) {
-                break;
-            }
-            StructLike row = reader.next();
-            for (int i = 0; i < fields.size(); i++) {
-                NestedField field = fields.get(i);
-                Object value = row.get(i, field.type().typeId().javaClass());
-                ColumnValue columnValue = new IcebergSysTableColumnValue(value, timezone);
-                appendData(i, columnValue);
-            }
-            rows++;
+            return rows;
         }
-        return rows;
     }
 
     @Override
     public void close() throws IOException {
-        if (reader != null) {
-            // Close the iterator to release resources
-            reader.close();
+        try (ThreadClassLoaderContext ignored = new ThreadClassLoaderContext(classLoader)) {
+            if (reader != null) {
+                // Close the iterator to release resources
+                reader.close();
+            }
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Wrap open/getNext/close/nextScanTask with ThreadClassLoaderContext to keep the
 Iceberg and AWS dependencies on the plugin classloader, preventing reflection f
ailures when execution switches threads.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

