### PR TITLE
[fix](es) Handle object type in Elasticsearch mapping when table is empty

### DIFF
--- a/docker/thirdparties/docker-compose/elasticsearch/scripts/es_init.sh
+++ b/docker/thirdparties/docker-compose/elasticsearch/scripts/es_init.sh
@@ -130,6 +130,8 @@ curl "http://${ES_7_HOST}:9200/test2_20220808" -H "Content-Type:application/json
 curl "http://${ES_7_HOST}:9200/test2_20220809" -H "Content-Type:application/json" -X PUT -d '@/mnt/scripts/index/es7_test2.json'
 # create index test3_20231005
 curl "http://${ES_7_HOST}:9200/test3_20231005" -H "Content-Type:application/json" -X PUT -d '@/mnt/scripts/index/es7_test3.json'
+# create index test_object for object type testing (empty table)
+curl "http://${ES_7_HOST}:9200/test_object" -H "Content-Type:application/json" -X PUT -d '@/mnt/scripts/index/es7_test_object.json'
 # put data for tese1
 curl "http://${ES_7_HOST}:9200/test1/_doc/1" -H "Content-Type:application/json" -X POST -d '@/mnt/scripts/data/data1.json'
 curl "http://${ES_7_HOST}:9200/test1/_doc/2" -H "Content-Type:application/json" -X POST -d '@/mnt/scripts/data/data2.json'

--- a/docker/thirdparties/docker-compose/elasticsearch/scripts/index/es7_test_object.json
+++ b/docker/thirdparties/docker-compose/elasticsearch/scripts/index/es7_test_object.json
@@ -1,0 +1,16 @@
+{
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
+  "mappings": {
+    "properties": {
+      "id": {
+        "type": "integer"
+      },
+      "user_info": {
+        "type": "object"
+      }
+    }
+  }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/es/EsUtil.java
@@ -300,6 +300,8 @@ public class EsUtil {
                 case "constant_keyword":
                     type = ScalarType.createStringType();
                     break;
+                // When ES table is empty, object fields still have explicit "type": "object" in mapping
+                case "object":
                 case "nested":
                     type = Type.JSONB;
                     break;

--- a/regression-test/data/external_table_p0/es/test_es_query.out
+++ b/regression-test/data/external_table_p0/es/test_es_query.out
@@ -608,6 +608,12 @@ string_ignore_above_10	text_ignore_above_10
 4444
 4444
 
+-- !sql_7_39 --
+id	int	Yes	true	\N	
+user_info	json	Yes	true	\N	
+
+-- !sql_7_40 --
+
 -- !sql_7_50 --
 value1	value2
 
@@ -1414,6 +1420,12 @@ string_ignore_above_10	text_ignore_above_10
 3333
 4444
 4444
+
+-- !sql_7_39 --
+id	int	Yes	true	\N	
+user_info	json	Yes	true	\N	
+
+-- !sql_7_40 --
 
 -- !sql_7_50 --
 value1	value2

--- a/regression-test/suites/external_table_p0/es/test_es_query.groovy
+++ b/regression-test/suites/external_table_p0/es/test_es_query.groovy
@@ -344,6 +344,8 @@ suite("test_es_query", "p0,external,es,external_docker,external_docker_es") {
             order_qt_sql_7_36 """select test1, test2 from test1 where test2 like 'text%';"""
             order_qt_sql_7_37 """select test9 from test1;"""
             order_qt_sql_7_38 """select test9 from test2;"""
+            order_qt_sql_7_39 """desc test_object;"""
+            order_qt_sql_7_40 """select * from test_object;"""
 
             List<List<String>> tables7N = sql """show tables"""
             boolean notContainHide7 = true


### PR DESCRIPTION
### What problem does this PR solve?

This PR fixes an issue with Elasticsearch external tables when the table is empty but contains object type fields. In such cases, the Elasticsearch mapping still explicitly shows `"type": "object"` for object fields, but Doris was not handling this type correctly, leading to type mapping failures.

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

