### PR TITLE
[fix](export) avoid throw npe when export task has illegal url

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/BrokerMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/BrokerMgr.java
@@ -167,13 +167,16 @@ public class BrokerMgr {
     }
 
     public FsBroker getBroker(String brokerName, String host) throws AnalysisException {
+        if (brokerName == null) {
+            throw new AnalysisException("Unknown broker name(" + brokerName + ")");
+        }
         if (brokerName.equalsIgnoreCase(BrokerDesc.MULTI_LOAD_BROKER)) {
             return new FsBroker("127.0.0.1", 0);
         }
         lock.lock();
         try {
             ArrayListMultimap<String, FsBroker> brokerAddsMap = brokersMap.get(brokerName);
-            if (brokerAddsMap == null || brokerAddsMap.size() == 0) {
+            if (brokerAddsMap == null || brokerAddsMap.isEmpty()) {
                 throw new AnalysisException("Unknown broker name(" + brokerName + ")");
             }
             List<FsBroker> brokers = brokerAddsMap.get(host);

--- a/regression-test/suites/export_p0/test_export_table_with_label_retry.groovy
+++ b/regression-test/suites/export_p0/test_export_table_with_label_retry.groovy
@@ -157,6 +157,9 @@ suite("test_export_table_with_label_retry", "p0") {
         """
         waiting_export_expect_failed.call(label)
 
+        def res = sql_return_maparray(""" show export where label = "${label}" """)
+        assertTrue(res[0].get("ErrorMsg").toString().contains("Unknown broker name(null)"))
+
         // exec right export with same label again
         sql """
             EXPORT TABLE ${table_export_name} TO "file://${outFilePath}/"


### PR DESCRIPTION
### What problem does this PR solve?

avoid throw npe when export task has illegal url:
```sql
-- illegal url: file://xxx,  should be file:///xxx
EXPORT TABLE tbl to 'file://xxxx' PROPERTIES(
  "label" = "label_cce1b8f0-3ec0-47d4-8dbf-5b5c2386d71e12112a1",
  "format" = "csv",
  "column_separator"=","
);
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

