### PR TITLE
[fix](nereids) make alter add correct partition properties  

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/PartitionDefinition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/PartitionDefinition.java
@@ -129,6 +129,8 @@ public abstract class PartitionDefinition {
             }
 
             Map<String, String> mergedMap = Maps.newHashMap();
+            // validate should not change partitionDesc properties
+            Map<String, String> oldProperties = this.properties == null ? null : Maps.newHashMap(this.properties);
             // Should putAll `otherProperties` before `this.properties`,
             // because the priority of partition is higher than table
             if (otherProperties != null) {
@@ -173,6 +175,7 @@ public abstract class PartitionDefinition {
                     }
                 }
             }
+            this.properties = oldProperties; // recover properties
         } catch (Exception e) {
             throw new AnalysisException(e.getMessage(), e.getCause());
         }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #55967


Problem Summary:
When using alter table add partition without specifying the properties keyword to add properties, the default table properties will be used instead of the specified properties.
### Release note
None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

