### PR TITLE
[fix](function) fix convert_tz function fe time_zone range problem

### DIFF
--- a/regression-test/suites/correctness/test_timev2_fold.groovy
+++ b/regression-test/suites/correctness/test_timev2_fold.groovy
@@ -30,6 +30,14 @@ suite("test_timev2_fold") {
     qt_select13 """
         select CONVERT_TZ('9999-12-31 23:59:59.999999', 'Pacific/Galapagos', 'Pacific/GalapaGoS');
     """
+    test {
+        sql "select convert_tz('2020-05-01 12:00:00', '+08:00', '+15:00');"
+        exception "Operation convert_tz invalid timezone: +15:00"
+    }
+    test {
+        sql "select convert_tz('2020-05-01 12:00:00', '-13:00', '+12:00');"
+        exception "Operation convert_tz invalid timezone: -13:00"
+    }
     // FE + BE
     sql """ set enable_fold_constant_by_be=true """
     qt_select20 """


### PR DESCRIPTION
### What problem does this PR solve?

fe result is not the same as convert_tz when time zone over the range 
BE：
mysql> select CONVERT_TZ('2019-08-01 13:21:03', '+08:00', '+18:00');
ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[INVALID_ARGUMENT][E33] Operation convert_tz invalid timezone: +18:00 
FE：

mysql> select CONVERT_TZ('2019-08-01 13:21:03', '+08:00', '+18:00');
+-------------------------------------------------------+
| CONVERT_TZ('2019-08-01 13:21:03', '+08:00', '+18:00') |
+-------------------------------------------------------+
| 2019-08-01 23:21:03                                   |
+-------------------------------------------------------+ 
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

