### PR TITLE
[enhance](mtmv)Base table changes should not cause nested MTMV to schema change status

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRelationManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVRelationManager.java
@@ -287,7 +287,7 @@ public class MTMVRelationManager implements MTMVHookService {
     }
 
     private void processBaseTableChange(BaseTableInfo baseTableInfo, String msgPrefix) {
-        Set<BaseTableInfo> mtmvsByBaseTable = getMtmvsByBaseTable(baseTableInfo);
+        Set<BaseTableInfo> mtmvsByBaseTable = getMtmvsByBaseTableOneLevel(baseTableInfo);
         if (CollectionUtils.isEmpty(mtmvsByBaseTable)) {
             return;
         }

--- a/regression-test/data/mtmv_p0/test_base_alter_col_type_multi_level_mtmv.out
+++ b/regression-test/data/mtmv_p0/test_base_alter_col_type_multi_level_mtmv.out
@@ -9,5 +9,5 @@ test_base_alter_col_type_multi_level_mtmv_mv2	NORMAL	SUCCESS
 test_base_alter_col_type_multi_level_mtmv_mv3	SCHEMA_CHANGE	SUCCESS
 
 -- !add_col_t1_mv4 --
-test_base_alter_col_type_multi_level_mtmv_mv4	SCHEMA_CHANGE	SUCCESS
+test_base_alter_col_type_multi_level_mtmv_mv4	NORMAL	SUCCESS
 

--- a/regression-test/data/mtmv_p0/test_base_drop_col_multi_level_mtmv.out
+++ b/regression-test/data/mtmv_p0/test_base_drop_col_multi_level_mtmv.out
@@ -9,5 +9,5 @@ test_base_drop_col_multi_level_mtmv_mv2	NORMAL	SUCCESS
 test_base_drop_col_multi_level_mtmv_mv3	SCHEMA_CHANGE	SUCCESS
 
 -- !add_col_t1_mv4 --
-test_base_drop_col_multi_level_mtmv_mv4	SCHEMA_CHANGE	SUCCESS
+test_base_drop_col_multi_level_mtmv_mv4	NORMAL	SUCCESS
 

--- a/regression-test/data/mtmv_p0/test_base_drop_multi_level_mtmv.out
+++ b/regression-test/data/mtmv_p0/test_base_drop_multi_level_mtmv.out
@@ -9,5 +9,5 @@ test_base_drop_multi_level_mtmv_mv2	NORMAL	SUCCESS
 test_base_drop_multi_level_mtmv_mv3	SCHEMA_CHANGE	SUCCESS
 
 -- !drop_t1_mv4 --
-test_base_drop_multi_level_mtmv_mv4	SCHEMA_CHANGE	SUCCESS
+test_base_drop_multi_level_mtmv_mv4	NORMAL	SUCCESS
 

--- a/regression-test/data/mtmv_p0/test_base_rename_col_multi_level_mtmv.out
+++ b/regression-test/data/mtmv_p0/test_base_rename_col_multi_level_mtmv.out
@@ -9,5 +9,5 @@ test_base_rename_col_multi_level_mtmv_mv2	NORMAL	SUCCESS
 test_base_rename_col_multi_level_mtmv_mv3	SCHEMA_CHANGE	SUCCESS
 
 -- !add_col_t1_mv4 --
-test_base_rename_col_multi_level_mtmv_mv4	SCHEMA_CHANGE	SUCCESS
+test_base_rename_col_multi_level_mtmv_mv4	NORMAL	SUCCESS
 

--- a/regression-test/data/mtmv_p0/test_base_rename_multi_level_mtmv.out
+++ b/regression-test/data/mtmv_p0/test_base_rename_multi_level_mtmv.out
@@ -9,5 +9,5 @@ test_base_rename_multi_level_mtmv_mv2	NORMAL	SUCCESS
 test_base_rename_multi_level_mtmv_mv3	SCHEMA_CHANGE	SUCCESS
 
 -- !drop_t1_mv4 --
-test_base_rename_multi_level_mtmv_mv4	SCHEMA_CHANGE	SUCCESS
+test_base_rename_multi_level_mtmv_mv4	NORMAL	SUCCESS
 

--- a/regression-test/data/mtmv_p0/test_base_replace_multi_level_mtmv.out
+++ b/regression-test/data/mtmv_p0/test_base_replace_multi_level_mtmv.out
@@ -9,7 +9,7 @@ test_base_replace_multi_level_mtmv_mv2	SCHEMA_CHANGE	SUCCESS
 test_base_replace_multi_level_mtmv_mv3	SCHEMA_CHANGE	SUCCESS
 
 -- !replace_t1_mv4 --
-test_base_replace_multi_level_mtmv_mv4	SCHEMA_CHANGE	SUCCESS
+test_base_replace_multi_level_mtmv_mv4	NORMAL	SUCCESS
 
 -- !refresh_t1_mv1 --
 test_base_replace_multi_level_mtmv_mv1	NORMAL	SUCCESS
@@ -33,5 +33,5 @@ test_base_replace_multi_level_mtmv_mv2	SCHEMA_CHANGE	SUCCESS
 test_base_replace_multi_level_mtmv_mv3	SCHEMA_CHANGE	SUCCESS
 
 -- !replace_t1_mv4 --
-test_base_replace_multi_level_mtmv_mv4	SCHEMA_CHANGE	SUCCESS
+test_base_replace_multi_level_mtmv_mv4	NORMAL	SUCCESS
 

--- a/regression-test/data/mtmv_p0/test_multi_level_mtmv.out
+++ b/regression-test/data/mtmv_p0/test_multi_level_mtmv.out
@@ -26,5 +26,5 @@
 multi_level_mtmv1	SCHEMA_CHANGE	SUCCESS
 
 -- !status2 --
-multi_level_mtmv2	SCHEMA_CHANGE	SUCCESS
+multi_level_mtmv2	NORMAL	SUCCESS
 

--- a/regression-test/suites/mtmv_p0/test_base_alter_col_type_multi_level_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_base_alter_col_type_multi_level_mtmv.groovy
@@ -136,5 +136,5 @@ suite("test_base_alter_col_type_multi_level_mtmv","mtmv") {
     mv_rewrite_success_without_check_chosen(querySql, mvName2)
     mv_not_part_in(querySql, mvName1)
     mv_not_part_in(querySql, mvName3)
-    mv_not_part_in(querySql, mvName4)
+    mv_rewrite_fail(querySql, mvName4)
 }

--- a/regression-test/suites/mtmv_p0/test_base_drop_col_multi_level_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_base_drop_col_multi_level_mtmv.groovy
@@ -137,5 +137,5 @@ suite("test_base_drop_col_multi_level_mtmv","mtmv") {
     mv_rewrite_success_without_check_chosen(querySql, mvName2)
     mv_not_part_in(querySql, mvName1)
     mv_not_part_in(querySql, mvName3)
-    mv_not_part_in(querySql, mvName4)
+    mv_rewrite_fail(querySql, mvName4)
 }

--- a/regression-test/suites/mtmv_p0/test_base_drop_multi_level_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_base_drop_multi_level_mtmv.groovy
@@ -148,5 +148,5 @@ suite("test_base_drop_multi_level_mtmv","mtmv") {
     mv_rewrite_success_without_check_chosen(querySql, mvName2)
     mv_not_part_in(querySql, mvName1)
     mv_not_part_in(querySql, mvName3)
-    mv_not_part_in(querySql, mvName4)
+    mv_rewrite_success_without_check_chosen(querySql, mvName4)
 }

--- a/regression-test/suites/mtmv_p0/test_base_drop_multi_level_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_base_drop_multi_level_mtmv.groovy
@@ -148,5 +148,5 @@ suite("test_base_drop_multi_level_mtmv","mtmv") {
     mv_rewrite_success_without_check_chosen(querySql, mvName2)
     mv_not_part_in(querySql, mvName1)
     mv_not_part_in(querySql, mvName3)
-    mv_rewrite_success_without_check_chosen(querySql, mvName4)
+    mv_rewrite_fail(querySql, mvName4)
 }

--- a/regression-test/suites/mtmv_p0/test_base_rename_col_multi_level_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_base_rename_col_multi_level_mtmv.groovy
@@ -136,5 +136,5 @@ suite("test_base_rename_col_multi_level_mtmv","mtmv") {
     mv_rewrite_success_without_check_chosen(querySql, mvName2)
     mv_not_part_in(querySql, mvName1)
     mv_not_part_in(querySql, mvName3)
-    mv_not_part_in(querySql, mvName4)
+    mv_rewrite_fail(querySql, mvName4)
 }

--- a/regression-test/suites/mtmv_p0/test_base_rename_multi_level_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_base_rename_multi_level_mtmv.groovy
@@ -137,5 +137,5 @@ suite("test_base_rename_multi_level_mtmv","mtmv") {
     mv_rewrite_success_without_check_chosen(querySql, mvName2)
     mv_not_part_in(querySql, mvName1)
     mv_not_part_in(querySql, mvName3)
-    mv_not_part_in(querySql, mvName4)
+    mv_rewrite_fail(querySql, mvName4)
 }

--- a/regression-test/suites/mtmv_p0/test_base_replace_multi_level_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_base_replace_multi_level_mtmv.groovy
@@ -135,7 +135,7 @@ suite("test_base_replace_multi_level_mtmv","mtmv") {
     mv_not_part_in(querySql, mvName2)
     mv_not_part_in(querySql, mvName1)
     mv_not_part_in(querySql, mvName3)
-    mv_not_part_in(querySql, mvName4)
+    mv_rewrite_fail(querySql, mvName4)
 
     sql """
             REFRESH MATERIALIZED VIEW ${mvName1} auto


### PR DESCRIPTION
### What problem does this PR solve?

t1 => mv1 => mv2

if t1 schema change

status of mv1 should is schema change

status of mv2 should is normal

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

