### PR TITLE
[fix](test) Reduce cache cleanup interval to fix flaky test

### DIFF
--- a/regression-test/suites/cloud_p0/cache/multi_cluster/warm_up/cluster/test_warm_up_cluster_periodic_add_new_be.groovy
+++ b/regression-test/suites/cloud_p0/cache/multi_cluster/warm_up/cluster/test_warm_up_cluster_periodic_add_new_be.groovy
@@ -23,6 +23,7 @@ suite('test_warm_up_cluster_periodic_add_new_be', 'docker') {
     options.feConfigs += [
         'cloud_cluster_check_interval_second=1',
         'fetch_cluster_cache_hotspot_interval_ms=1000',
+        'rehash_tablet_after_be_dead_seconds=1',
     ]
     options.beConfigs += [
         'file_cache_enter_disk_resource_limit_mode_percent=99',


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

When a new BE node is added, tablet locations are rehashed.
The old tablet location cache can persist while a new one is warmed up.
This creates a temporary duplicated cache copies, making tests flaky.

This change shortens the cache cleanup interval,
ensuring the stale cache is evicted faster to resolve the issue.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

