### PR TITLE
[fix](file writer) fix value of s3 bytes written bvar incorrect

### DIFF
--- a/be/src/io/fs/s3_file_writer.cpp
+++ b/be/src/io/fs/s3_file_writer.cpp
@@ -480,6 +480,7 @@ void S3FileWriter::_put_object(UploadFileBuffer& buf) {
               << " size=" << _bytes_appended << " time=" << timer.elapsed_time_milliseconds()
               << "ms";
     s3_file_created_total << 1;
+    s3_bytes_written_total << buf.get_size();
 }
 
 std::string S3FileWriter::_dump_completed_part() const {

--- a/regression-test/suites/load_p0/stream_load/test_s3_bytes_written_metrics.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_s3_bytes_written_metrics.groovy
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_s3_bytes_written_metrics", "p0") {
+    if (!context.config.isCloudMode()) {
+        return
+    }
+
+    def tableName = "test_s3_bytes_written_metrics"
+    def getBrpcMetrics = {ip, port, name ->
+        def url = "http://${ip}:${port}/brpc_metrics"
+        def metrics = new URL(url).text
+        def matcher = metrics =~ ~"${name}\\s+(\\d+)"
+        if (matcher.find()) {
+            def ret = matcher[0][1] as long
+            logger.info("getBrpcMetrics, ${url}, name:${name}, value:${ret}")
+            return ret
+        } else {
+            throw new RuntimeException("${name} not found for ${ip}:${port}")
+        }
+    }
+
+    def getTotalS3BytesWritten = {
+        def backends = sql """SHOW BACKENDS"""
+        def totalBytes = 0L
+        for (def backend : backends) {
+            def ip = backend[1]
+            def httpPort = backend[5]
+            def bytes = getBrpcMetrics(ip, httpPort, "s3_file_writer_bytes_written")
+            totalBytes += bytes
+        }
+        return totalBytes
+    }
+
+    def initialBytes = getTotalS3BytesWritten()
+    logger.info("before load s3_file_writer_bytes_written: ${initialBytes}")
+
+    sql """ DROP TABLE IF EXISTS ${tableName} """
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tableName} (
+            `k1` int(20) NULL,
+            `k2` string NULL,
+            `v1` date  NULL,
+            `v2` string  NULL,
+            `v3` datetime  NULL,
+            `v4` string  NULL
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`k1`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+        PROPERTIES ("replication_allocation" = "tag.location.default: 1");
+    """
+
+    streamLoad {
+        table "${tableName}"
+        set 'column_separator', ','
+
+        file "empty_field_as_null.csv"
+    }
+
+    def afterLoadBytes = getTotalS3BytesWritten()
+    def loadBytes = afterLoadBytes - initialBytes
+    logger.info("after load s3_file_writer_bytes_written: ${afterLoadBytes}, written: ${loadBytes}")
+    assertTrue(loadBytes > 0, "s3_file_writer_bytes_written should increase")
+}
+


### PR DESCRIPTION
### What problem does this PR solve?

Upload small files efficiently using single PUT Object instead of multipart upload, but it missing record s3 bytes written bvar.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

