### PR TITLE
[opt](nereids) optimize bs downgrade alg.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulator.java
@@ -303,8 +303,7 @@ public class ChildrenPropertiesRegulator extends PlanVisitor<List<List<PhysicalP
                 int backEndNum = Math.max(1, ConnectContext.get().getEnv().getClusterInfo()
                         .getBackendsNumber(true));
                 int paraNum = Math.max(1, ConnectContext.get().getSessionVariable().getParallelExecInstanceNum());
-                int totalParaNum = Math.min(10, backEndNum * paraNum);
-                return totalBucketNum < totalParaNum;
+                return totalBucketNum < backEndNum * paraNum * 0.8;
             }
         }
     }

--- a/regression-test/data/shape_check/ssb_sf100/shape/q4.3.out
+++ b/regression-test/data/shape_check/ssb_sf100/shape/q4.3.out
@@ -8,7 +8,7 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((lineorder.lo_custkey = customer.c_custkey)) otherCondition=() build RFs:RF3 lo_custkey->[c_custkey]
+----------------hashJoin[INNER_JOIN shuffle] hashCondition=((lineorder.lo_custkey = customer.c_custkey)) otherCondition=() build RFs:RF3 lo_custkey->[c_custkey]
 ------------------PhysicalProject
 --------------------PhysicalOlapScan[customer] apply RFs: RF3
 ------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query15.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query15.out
@@ -8,18 +8,18 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_bill_customer_sk = customer.c_customer_sk)) otherCondition=(OR[substring(ca_zip, 1, 5) IN ('80348', '81792', '83405', '85392', '85460', '85669', '86197', '86475', '88274'),ca_state IN ('CA', 'GA', 'WA'),(catalog_sales.cs_sales_price > 500.00)]) build RFs:RF2 c_customer_sk->[cs_bill_customer_sk]
+----------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_bill_customer_sk = customer.c_customer_sk)) otherCondition=(OR[substring(ca_zip, 1, 5) IN ('80348', '81792', '83405', '85392', '85460', '85669', '86197', '86475', '88274'),ca_state IN ('CA', 'GA', 'WA'),(catalog_sales.cs_sales_price > 500.00)])
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1 RF2
+------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1
 ----------------------PhysicalProject
 ------------------------filter((date_dim.d_qoy = 1) and (date_dim.d_year = 2001))
 --------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF0 c_current_addr_sk->[ca_address_sk]
-----------------------PhysicalProject
-------------------------PhysicalOlapScan[customer_address] apply RFs: RF0
+--------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=()
 ----------------------PhysicalProject
 ------------------------PhysicalOlapScan[customer]
+----------------------PhysicalProject
+------------------------PhysicalOlapScan[customer_address]
 

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query18.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query18.out
@@ -10,7 +10,7 @@ PhysicalResultSink
 --------------hashAgg[LOCAL]
 ----------------PhysicalRepeat
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF5 cs_item_sk->[i_item_sk]
+--------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF5 cs_item_sk->[i_item_sk]
 ----------------------PhysicalProject
 ------------------------PhysicalOlapScan[item] apply RFs: RF5
 ----------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query19.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query19.out
@@ -11,7 +11,7 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=(( not (substring(ca_zip, 1, 5) = substring(s_zip, 1, 5))))
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
 ------------------------PhysicalProject
 --------------------------PhysicalOlapScan[customer_address] apply RFs: RF3
 ------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query24.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query24.out
@@ -11,20 +11,20 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=()
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_zip = customer_address.ca_zip) and (store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF2 ca_zip->[s_zip];RF3 c_customer_sk->[ss_customer_sk]
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_zip = customer_address.ca_zip) and (store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=()
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF1 s_store_sk->[ss_store_sk]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF3
+------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1
 ----------------------------PhysicalProject
 ------------------------------filter((store.s_market_id = 8))
---------------------------------PhysicalOlapScan[store] apply RFs: RF2
+--------------------------------PhysicalOlapScan[store]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=(( not (c_birth_country = upper(ca_country)))) build RFs:RF0 c_current_addr_sk->[ca_address_sk]
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer_address] apply RFs: RF0
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=(( not (c_birth_country = upper(ca_country))))
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[customer]
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[customer_address]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[item]
 ----------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query26.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query26.out
@@ -8,9 +8,7 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 cs_item_sk->[i_item_sk]
-------------------PhysicalProject
---------------------PhysicalOlapScan[item] apply RFs: RF3
+----------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=()
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF2 p_promo_sk->[cs_promo_sk]
 ----------------------PhysicalProject
@@ -28,4 +26,6 @@ PhysicalResultSink
 ----------------------PhysicalProject
 ------------------------filter(OR[(promotion.p_channel_email = 'N'),(promotion.p_channel_event = 'N')])
 --------------------------PhysicalOlapScan[promotion]
+------------------PhysicalProject
+--------------------PhysicalOlapScan[item]
 

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query29.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query29.out
@@ -16,9 +16,7 @@ PhysicalResultSink
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=()
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF5 ss_item_sk->[i_item_sk]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF5
+----------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=()
 ------------------------------PhysicalProject
 --------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_customer_sk = store_returns.sr_customer_sk) and (store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF2 sr_customer_sk->[ss_customer_sk];RF3 sr_item_sk->[ss_item_sk];RF4 sr_ticket_number->[ss_ticket_number]
 ----------------------------------PhysicalProject
@@ -35,6 +33,8 @@ PhysicalResultSink
 --------------------------------------PhysicalProject
 ----------------------------------------filter((d2.d_moy <= 7) and (d2.d_moy >= 4) and (d2.d_year = 1999))
 ------------------------------------------PhysicalOlapScan[date_dim]
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[item]
 --------------------------PhysicalProject
 ----------------------------PhysicalOlapScan[store]
 ------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query30.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query30.out
@@ -7,9 +7,7 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecHash]
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_returns.wr_returning_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 wr_returning_addr_sk->[ca_address_sk]
-----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address] apply RFs: RF1
+--------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_returns.wr_returning_addr_sk = customer_address.ca_address_sk)) otherCondition=()
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_returns.wr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[wr_returned_date_sk]
 --------------------PhysicalProject
@@ -17,6 +15,8 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------------------PhysicalProject
 ----------------------filter((date_dim.d_year = 2002))
 ------------------------PhysicalOlapScan[date_dim]
+----------------PhysicalProject
+------------------PhysicalOlapScan[customer_address]
 --PhysicalResultSink
 ----PhysicalProject
 ------PhysicalLazyMaterialize[materializedSlots:(customer.c_customer_id,ctr1.ctr_total_return) lazySlots:(customer.c_birth_country,customer.c_birth_day,customer.c_birth_month,customer.c_birth_year,customer.c_email_address,customer.c_first_name,customer.c_last_name,customer.c_last_review_date_sk,customer.c_login,customer.c_preferred_cust_flag,customer.c_salutation)]

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query33.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query33.out
@@ -62,7 +62,7 @@ PhysicalResultSink
 ----------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------hashAgg[LOCAL]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 ws_item_sk->[i_item_sk]
+----------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 ws_item_sk->[i_item_sk]
 ------------------------------PhysicalProject
 --------------------------------PhysicalOlapScan[item] apply RFs: RF10 RF11
 ------------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query44.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query44.out
@@ -9,7 +9,7 @@ PhysicalResultSink
 ------------PhysicalProject
 --------------hashJoin[INNER_JOIN broadcast] hashCondition=((asceding.rnk = descending.rnk)) otherCondition=()
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((i2.i_item_sk = descending.item_sk)) otherCondition=() build RFs:RF1 item_sk->[i_item_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((i2.i_item_sk = descending.item_sk)) otherCondition=() build RFs:RF1 item_sk->[i_item_sk]
 --------------------PhysicalProject
 ----------------------PhysicalLazyMaterializeOlapScan[item lazySlots:(i2.i_product_name)] apply RFs: RF1
 --------------------PhysicalProject
@@ -39,7 +39,7 @@ PhysicalResultSink
 ------------------------------------------------------filter((store_sales.ss_store_sk = 146) and ss_addr_sk IS NULL)
 --------------------------------------------------------PhysicalOlapScan[store_sales]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((i1.i_item_sk = asceding.item_sk)) otherCondition=() build RFs:RF0 item_sk->[i_item_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((i1.i_item_sk = asceding.item_sk)) otherCondition=() build RFs:RF0 item_sk->[i_item_sk]
 --------------------PhysicalProject
 ----------------------PhysicalLazyMaterializeOlapScan[item lazySlots:(i1.i_product_name)] apply RFs: RF0
 --------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query45.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query45.out
@@ -11,20 +11,20 @@ PhysicalResultSink
 ----------------filter(OR[substring(ca_zip, 1, 5) IN ('80348', '81792', '83405', '85392', '85460', '85669', '86197', '86475', '88274'),$c$1])
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ws_item_sk]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_bill_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ws_bill_customer_sk]
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_bill_customer_sk = customer.c_customer_sk)) otherCondition=()
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ws_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[web_sales] apply RFs: RF1 RF2 RF3
+------------------------------PhysicalOlapScan[web_sales] apply RFs: RF1 RF3
 ----------------------------PhysicalProject
 ------------------------------filter((date_dim.d_qoy = 2) and (date_dim.d_year = 2000))
 --------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF0 c_current_addr_sk->[ca_address_sk]
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer_address] apply RFs: RF0
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=()
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[customer]
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[customer_address]
 --------------------PhysicalProject
 ----------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=()
 ------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query54.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query54.out
@@ -25,7 +25,7 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_county = store.s_county) and (customer_address.ca_state = store.s_state)) otherCondition=() build RFs:RF4 s_county->[ca_county];RF5 s_state->[ca_state]
 --------------------------------------------PhysicalProject
-----------------------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
+----------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
 ------------------------------------------------PhysicalProject
 --------------------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF3 RF4 RF5
 ------------------------------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query56.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query56.out
@@ -37,7 +37,7 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF7 cs_bill_addr_sk->[ca_address_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF7 cs_bill_addr_sk->[ca_address_sk]
 ----------------------------PhysicalProject
 ------------------------------filter((customer_address.ca_gmt_offset = -6.00))
 --------------------------------PhysicalOlapScan[customer_address] apply RFs: RF7
@@ -61,7 +61,7 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF11 ws_bill_addr_sk->[ca_address_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF11 ws_bill_addr_sk->[ca_address_sk]
 ----------------------------PhysicalProject
 ------------------------------filter((customer_address.ca_gmt_offset = -6.00))
 --------------------------------PhysicalOlapScan[customer_address] apply RFs: RF11

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query58.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query58.out
@@ -11,13 +11,11 @@ PhysicalResultSink
 ----------------PhysicalDistribute[DistributionSpecHash]
 ------------------hashAgg[LOCAL]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF12 ws_item_sk->[i_item_sk]
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[item] apply RFs: RF12 RF13
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF12 i_item_sk->[ws_item_sk]
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF11 d_date_sk->[ws_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[web_sales] apply RFs: RF11
+------------------------------PhysicalOlapScan[web_sales] apply RFs: RF11 RF12
 ----------------------------PhysicalProject
 ------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF10 d_date->[d_date]
 --------------------------------PhysicalProject
@@ -31,6 +29,8 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------filter((date_dim.d_date = '2001-03-24'))
 --------------------------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[item] apply RFs: RF13
 ------------PhysicalProject
 --------------hashJoin[INNER_JOIN colocated] hashCondition=((ss_items.item_id = cs_items.item_id)) otherCondition=((cast(cs_item_rev as DECIMALV3(38, 3)) <= (1.1 * ss_items.ss_item_rev)) and (cast(cs_item_rev as DECIMALV3(38, 3)) >= (0.9 * ss_items.ss_item_rev)) and (cast(ss_item_rev as DECIMALV3(38, 3)) <= (1.1 * cs_items.cs_item_rev)) and (cast(ss_item_rev as DECIMALV3(38, 3)) >= (0.9 * cs_items.cs_item_rev))) build RFs:RF8 item_id->[i_item_id]
 ----------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query6.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query6.out
@@ -10,7 +10,7 @@ PhysicalResultSink
 --------------PhysicalDistribute[DistributionSpecHash]
 ----------------hashAgg[LOCAL]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((a.ca_address_sk = c.c_current_addr_sk)) otherCondition=() build RFs:RF5 c_current_addr_sk->[ca_address_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((a.ca_address_sk = c.c_current_addr_sk)) otherCondition=() build RFs:RF5 c_current_addr_sk->[ca_address_sk]
 ----------------------PhysicalProject
 ------------------------PhysicalOlapScan[customer_address] apply RFs: RF5
 ----------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query60.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query60.out
@@ -61,16 +61,13 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF11 ws_bill_addr_sk->[ca_address_sk]
-----------------------------PhysicalProject
-------------------------------filter((customer_address.ca_gmt_offset = -7.00))
---------------------------------PhysicalOlapScan[customer_address] apply RFs: RF11
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF11 ca_address_sk->[ws_bill_addr_sk]
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 i_item_sk->[ws_item_sk]
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF9 d_date_sk->[ws_sold_date_sk]
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF9 RF10
+--------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF9 RF10 RF11
 ------------------------------------PhysicalProject
 --------------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
 ----------------------------------------PhysicalOlapScan[date_dim]
@@ -80,4 +77,7 @@ PhysicalResultSink
 ----------------------------------PhysicalProject
 ------------------------------------filter((item.i_category = 'Children'))
 --------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((customer_address.ca_gmt_offset = -7.00))
+--------------------------------PhysicalOlapScan[customer_address]
 

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query61.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query61.out
@@ -8,12 +8,12 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecGather]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 ss_item_sk->[i_item_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 ss_item_sk->[i_item_sk]
 ------------------PhysicalProject
 --------------------filter((item.i_category = 'Jewelry'))
 ----------------------PhysicalOlapScan[item] apply RFs: RF10
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF9 c_current_addr_sk->[ca_address_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF9 c_current_addr_sk->[ca_address_sk]
 ----------------------PhysicalProject
 ------------------------filter((customer_address.ca_gmt_offset = -7.00))
 --------------------------PhysicalOlapScan[customer_address] apply RFs: RF9
@@ -42,12 +42,12 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecGather]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF4 ss_item_sk->[i_item_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF4 ss_item_sk->[i_item_sk]
 ------------------PhysicalProject
 --------------------filter((item.i_category = 'Jewelry'))
 ----------------------PhysicalOlapScan[item] apply RFs: RF4
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
 ----------------------PhysicalProject
 ------------------------filter((customer_address.ca_gmt_offset = -7.00))
 --------------------------PhysicalOlapScan[customer_address] apply RFs: RF3

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query64.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query64.out
@@ -13,9 +13,7 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 --------------------PhysicalProject
 ----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=(( not (cd_marital_status = cd_marital_status))) build RFs:RF17 ss_customer_sk->[c_customer_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = ad2.ca_address_sk)) otherCondition=() build RFs:RF16 c_current_addr_sk->[ca_address_sk]
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer_address] apply RFs: RF16
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = ad2.ca_address_sk)) otherCondition=()
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_cdemo_sk = cd2.cd_demo_sk)) otherCondition=()
 --------------------------------PhysicalProject
@@ -30,12 +28,14 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ------------------------------------------PhysicalOlapScan[income_band]
 --------------------------------PhysicalProject
 ----------------------------------PhysicalOlapScan[customer_demographics]
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[customer_address]
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF11 ss_item_sk->[sr_item_sk];RF12 ss_ticket_number->[sr_ticket_number]
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[store_returns] apply RFs: RF11 RF12
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_addr_sk = ad1.ca_address_sk)) otherCondition=() build RFs:RF10 ss_addr_sk->[ca_address_sk]
+------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_addr_sk = ad1.ca_address_sk)) otherCondition=() build RFs:RF10 ss_addr_sk->[ca_address_sk]
 --------------------------------PhysicalProject
 ----------------------------------PhysicalOlapScan[customer_address] apply RFs: RF10
 --------------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query68.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query68.out
@@ -7,7 +7,7 @@ PhysicalResultSink
 --------PhysicalDistribute[DistributionSpecGather]
 ----------PhysicalTopN[LOCAL_SORT]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = current_addr.ca_address_sk)) otherCondition=(( not (ca_city = bought_city))) build RFs:RF5 c_current_addr_sk->[ca_address_sk]
+--------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = current_addr.ca_address_sk)) otherCondition=(( not (ca_city = bought_city))) build RFs:RF5 c_current_addr_sk->[ca_address_sk]
 ----------------PhysicalProject
 ------------------PhysicalOlapScan[customer_address] apply RFs: RF5
 ----------------PhysicalProject
@@ -17,7 +17,7 @@ PhysicalResultSink
 --------------------PhysicalProject
 ----------------------hashAgg[GLOBAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ss_addr_sk->[ca_address_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ss_addr_sk->[ca_address_sk]
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[customer_address] apply RFs: RF3
 ----------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query76.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query76.out
@@ -14,7 +14,7 @@ PhysicalResultSink
 ------------------PhysicalUnion
 --------------------PhysicalDistribute[DistributionSpecExecutionAny]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF0 ss_item_sk->[i_item_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF0 ss_item_sk->[i_item_sk]
 --------------------------PhysicalProject
 ----------------------------PhysicalOlapScan[item] apply RFs: RF0
 --------------------------PhysicalProject
@@ -22,7 +22,7 @@ PhysicalResultSink
 ------------------------------PhysicalOlapScan[store_sales]
 --------------------PhysicalDistribute[DistributionSpecExecutionAny]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 ws_item_sk->[i_item_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 ws_item_sk->[i_item_sk]
 --------------------------PhysicalProject
 ----------------------------PhysicalOlapScan[item] apply RFs: RF1
 --------------------------PhysicalProject
@@ -30,7 +30,7 @@ PhysicalResultSink
 ------------------------------PhysicalOlapScan[web_sales]
 --------------------PhysicalDistribute[DistributionSpecExecutionAny]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 cs_item_sk->[i_item_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 cs_item_sk->[i_item_sk]
 --------------------------PhysicalProject
 ----------------------------PhysicalOlapScan[item] apply RFs: RF2
 --------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query83.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query83.out
@@ -13,13 +13,11 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_returns.sr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF11 sr_item_sk->[i_item_sk]
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[item] apply RFs: RF11 RF12 RF13
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_returns.sr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF11 i_item_sk->[sr_item_sk]
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF10 d_date_sk->[sr_returned_date_sk]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_returns] apply RFs: RF10
+----------------------------------PhysicalOlapScan[store_returns] apply RFs: RF10 RF11
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF9 d_date->[d_date]
 ------------------------------------PhysicalProject
@@ -31,12 +29,14 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------filter(d_date IN ('2001-06-06', '2001-09-02', '2001-11-11'))
 --------------------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[item] apply RFs: RF12 RF13
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((catalog_returns.cr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 cr_item_sk->[i_item_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_returns.cr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 cr_item_sk->[i_item_sk]
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[item] apply RFs: RF7 RF13
 ----------------------------PhysicalProject
@@ -59,7 +59,7 @@ PhysicalResultSink
 ----------------PhysicalDistribute[DistributionSpecHash]
 ------------------hashAgg[LOCAL]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_returns.wr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 wr_item_sk->[i_item_sk]
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_returns.wr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 wr_item_sk->[i_item_sk]
 ------------------------PhysicalProject
 --------------------------PhysicalOlapScan[item] apply RFs: RF3
 ------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query85.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query85.out
@@ -23,14 +23,11 @@ PhysicalResultSink
 ----------------------------------filter(OR[AND[(cd1.cd_marital_status = 'M'),(cd1.cd_education_status = '4 yr Degree')],AND[(cd1.cd_marital_status = 'S'),(cd1.cd_education_status = 'Secondary')],AND[(cd1.cd_marital_status = 'W'),(cd1.cd_education_status = 'Advanced Degree')]] and cd_education_status IN ('4 yr Degree', 'Advanced Degree', 'Secondary') and cd_marital_status IN ('M', 'S', 'W'))
 ------------------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF4
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer_address.ca_address_sk = web_returns.wr_refunded_addr_sk)) otherCondition=(OR[AND[ca_state IN ('DE', 'FL', 'TX'),(web_sales.ws_net_profit >= 100.00),(web_sales.ws_net_profit <= 200.00)],AND[ca_state IN ('ID', 'IN', 'ND'),(web_sales.ws_net_profit >= 150.00)],AND[ca_state IN ('IL', 'MT', 'OH'),(web_sales.ws_net_profit <= 250.00)]]) build RFs:RF3 wr_refunded_addr_sk->[ca_address_sk]
-------------------------------------PhysicalProject
---------------------------------------filter((customer_address.ca_country = 'United States') and ca_state IN ('DE', 'FL', 'ID', 'IL', 'IN', 'MT', 'ND', 'OH', 'TX'))
-----------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF3
+----------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_address.ca_address_sk = web_returns.wr_refunded_addr_sk)) otherCondition=(OR[AND[ca_state IN ('DE', 'FL', 'TX'),(web_sales.ws_net_profit >= 100.00),(web_sales.ws_net_profit <= 200.00)],AND[ca_state IN ('ID', 'IN', 'ND'),(web_sales.ws_net_profit >= 150.00)],AND[ca_state IN ('IL', 'MT', 'OH'),(web_sales.ws_net_profit <= 250.00)]]) build RFs:RF3 ca_address_sk->[wr_refunded_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((web_sales.ws_item_sk = web_returns.wr_item_sk) and (web_sales.ws_order_number = web_returns.wr_order_number)) otherCondition=() build RFs:RF1 ws_item_sk->[wr_item_sk];RF2 ws_order_number->[wr_order_number]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[web_returns] apply RFs: RF1 RF2
+------------------------------------------PhysicalOlapScan[web_returns] apply RFs: RF1 RF2 RF3
 ----------------------------------------PhysicalProject
 ------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ws_sold_date_sk]
 --------------------------------------------PhysicalProject
@@ -39,6 +36,9 @@ PhysicalResultSink
 --------------------------------------------PhysicalProject
 ----------------------------------------------filter((date_dim.d_year = 2000))
 ------------------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------PhysicalProject
+--------------------------------------filter((customer_address.ca_country = 'United States') and ca_state IN ('DE', 'FL', 'ID', 'IL', 'IN', 'MT', 'ND', 'OH', 'TX'))
+----------------------------------------PhysicalOlapScan[customer_address]
 ------------------------PhysicalProject
 --------------------------PhysicalOlapScan[reason]
 --------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query91.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query91.out
@@ -17,7 +17,7 @@ PhysicalResultSink
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF3 RF4
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF2 c_current_addr_sk->[ca_address_sk]
+------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF2 c_current_addr_sk->[ca_address_sk]
 --------------------------------PhysicalProject
 ----------------------------------filter((customer_address.ca_gmt_offset = -6.00))
 ------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF2

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query15.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query15.out
@@ -17,9 +17,9 @@ PhysicalResultSink
 ------------------------filter((date_dim.d_qoy = 1) and (date_dim.d_year = 2001))
 --------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF0 c_current_addr_sk->[ca_address_sk]
+--------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->[c_current_addr_sk]
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[customer_address] apply RFs: RF0
+------------------------PhysicalOlapScan[customer] apply RFs: RF0
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[customer]
+------------------------PhysicalOlapScan[customer_address]
 

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query18.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query18.out
@@ -10,7 +10,7 @@ PhysicalResultSink
 --------------hashAgg[LOCAL]
 ----------------PhysicalRepeat
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF5 cs_item_sk->[i_item_sk]
+--------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF5 cs_item_sk->[i_item_sk]
 ----------------------PhysicalProject
 ------------------------PhysicalOlapScan[item] apply RFs: RF5
 ----------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query19.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query19.out
@@ -11,7 +11,7 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=(( not (substring(ca_zip, 1, 5) = substring(s_zip, 1, 5)))) build RFs:RF4 s_store_sk->[ss_store_sk]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
 ------------------------PhysicalProject
 --------------------------PhysicalOlapScan[customer_address] apply RFs: RF3
 ------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query24.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query24.out
@@ -20,11 +20,11 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------------------filter((store.s_market_id = 8))
 --------------------------------PhysicalOlapScan[store] apply RFs: RF2
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=(( not (c_birth_country = upper(ca_country)))) build RFs:RF0 c_current_addr_sk->[ca_address_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=(( not (c_birth_country = upper(ca_country)))) build RFs:RF0 ca_address_sk->[c_current_addr_sk]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer_address] apply RFs: RF0
+------------------------------PhysicalOlapScan[customer] apply RFs: RF0
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer]
+------------------------------PhysicalOlapScan[customer_address]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[item] apply RFs: RF6
 ----------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query26.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query26.out
@@ -8,9 +8,7 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 cs_item_sk->[i_item_sk]
-------------------PhysicalProject
---------------------PhysicalOlapScan[item] apply RFs: RF3
+----------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[cs_item_sk]
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF2 p_promo_sk->[cs_promo_sk]
 ----------------------PhysicalProject
@@ -18,7 +16,7 @@ PhysicalResultSink
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)) otherCondition=() build RFs:RF0 cd_demo_sk->[cs_bill_cdemo_sk]
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1 RF2
+--------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1 RF2 RF3
 ------------------------------PhysicalProject
 --------------------------------filter((customer_demographics.cd_education_status = 'Unknown') and (customer_demographics.cd_gender = 'M') and (customer_demographics.cd_marital_status = 'S'))
 ----------------------------------PhysicalOlapScan[customer_demographics]
@@ -28,4 +26,6 @@ PhysicalResultSink
 ----------------------PhysicalProject
 ------------------------filter(OR[(promotion.p_channel_email = 'N'),(promotion.p_channel_event = 'N')])
 --------------------------PhysicalOlapScan[promotion]
+------------------PhysicalProject
+--------------------PhysicalOlapScan[item]
 

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query29.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query29.out
@@ -16,25 +16,25 @@ PhysicalResultSink
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=() build RFs:RF6 s_store_sk->[ss_store_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF5 ss_item_sk->[i_item_sk]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item] apply RFs: RF5
+----------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((item.i_item_sk = store_sales.ss_item_sk)) otherCondition=() build RFs:RF5 i_item_sk->[sr_item_sk,ss_item_sk]
 ------------------------------PhysicalProject
 --------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_customer_sk = store_returns.sr_customer_sk) and (store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF2 sr_customer_sk->[ss_customer_sk];RF3 sr_item_sk->[ss_item_sk];RF4 sr_ticket_number->[ss_ticket_number]
 ----------------------------------PhysicalProject
 ------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk]
 --------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2 RF3 RF4 RF6
+----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2 RF3 RF4 RF5 RF6
 --------------------------------------PhysicalProject
 ----------------------------------------filter((d1.d_moy = 4) and (d1.d_year = 1999))
 ------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
 ------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[sr_returned_date_sk]
 --------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF0
+----------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF0 RF5
 --------------------------------------PhysicalProject
 ----------------------------------------filter((d2.d_moy <= 7) and (d2.d_moy >= 4) and (d2.d_year = 1999))
 ------------------------------------------PhysicalOlapScan[date_dim]
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[item]
 --------------------------PhysicalProject
 ----------------------------PhysicalOlapScan[store]
 ------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query30.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query30.out
@@ -7,16 +7,16 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute[DistributionSpecHash]
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_returns.wr_returning_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 wr_returning_addr_sk->[ca_address_sk]
-----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address] apply RFs: RF1
+--------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_returns.wr_returning_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->[wr_returning_addr_sk]
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_returns.wr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[wr_returned_date_sk]
 --------------------PhysicalProject
-----------------------PhysicalOlapScan[web_returns] apply RFs: RF0
+----------------------PhysicalOlapScan[web_returns] apply RFs: RF0 RF1
 --------------------PhysicalProject
 ----------------------filter((date_dim.d_year = 2002))
 ------------------------PhysicalOlapScan[date_dim]
+----------------PhysicalProject
+------------------PhysicalOlapScan[customer_address]
 --PhysicalResultSink
 ----PhysicalProject
 ------PhysicalLazyMaterialize[materializedSlots:(customer.c_customer_id,ctr1.ctr_total_return) lazySlots:(customer.c_birth_country,customer.c_birth_day,customer.c_birth_month,customer.c_birth_year,customer.c_email_address,customer.c_first_name,customer.c_last_name,customer.c_last_review_date_sk,customer.c_login,customer.c_preferred_cust_flag,customer.c_salutation)]

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query33.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query33.out
@@ -62,7 +62,7 @@ PhysicalResultSink
 ----------------------PhysicalDistribute[DistributionSpecHash]
 ------------------------hashAgg[LOCAL]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 ws_item_sk->[i_item_sk]
+----------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 ws_item_sk->[i_item_sk]
 ------------------------------PhysicalProject
 --------------------------------PhysicalOlapScan[item] apply RFs: RF10 RF11
 ------------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query44.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query44.out
@@ -9,7 +9,7 @@ PhysicalResultSink
 ------------PhysicalProject
 --------------hashJoin[INNER_JOIN broadcast] hashCondition=((asceding.rnk = descending.rnk)) otherCondition=()
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((i2.i_item_sk = descending.item_sk)) otherCondition=() build RFs:RF1 item_sk->[i_item_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((i2.i_item_sk = descending.item_sk)) otherCondition=() build RFs:RF1 item_sk->[i_item_sk]
 --------------------PhysicalProject
 ----------------------PhysicalLazyMaterializeOlapScan[item lazySlots:(i2.i_product_name)] apply RFs: RF1
 --------------------PhysicalProject
@@ -39,7 +39,7 @@ PhysicalResultSink
 ------------------------------------------------------filter((store_sales.ss_store_sk = 146) and ss_addr_sk IS NULL)
 --------------------------------------------------------PhysicalOlapScan[store_sales]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((i1.i_item_sk = asceding.item_sk)) otherCondition=() build RFs:RF0 item_sk->[i_item_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((i1.i_item_sk = asceding.item_sk)) otherCondition=() build RFs:RF0 item_sk->[i_item_sk]
 --------------------PhysicalProject
 ----------------------PhysicalLazyMaterializeOlapScan[item lazySlots:(i1.i_product_name)] apply RFs: RF0
 --------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query45.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query45.out
@@ -20,11 +20,11 @@ PhysicalResultSink
 ------------------------------filter((date_dim.d_qoy = 2) and (date_dim.d_year = 2000))
 --------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF0 c_current_addr_sk->[ca_address_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->[c_current_addr_sk]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer_address] apply RFs: RF0
+------------------------------PhysicalOlapScan[customer] apply RFs: RF0
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer]
+------------------------------PhysicalOlapScan[customer_address]
 --------------------PhysicalProject
 ----------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((item.i_item_id = item.i_item_id)) otherCondition=()
 ------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query54.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query54.out
@@ -25,7 +25,7 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_county = store.s_county) and (customer_address.ca_state = store.s_state)) otherCondition=() build RFs:RF4 s_county->[ca_county];RF5 s_state->[ca_state]
 --------------------------------------------PhysicalProject
-----------------------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
+----------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
 ------------------------------------------------PhysicalProject
 --------------------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF3 RF4 RF5
 ------------------------------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query56.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query56.out
@@ -37,7 +37,7 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF7 cs_bill_addr_sk->[ca_address_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF7 cs_bill_addr_sk->[ca_address_sk]
 ----------------------------PhysicalProject
 ------------------------------filter((customer_address.ca_gmt_offset = -6.00))
 --------------------------------PhysicalOlapScan[customer_address] apply RFs: RF7
@@ -61,7 +61,7 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF11 ws_bill_addr_sk->[ca_address_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF11 ws_bill_addr_sk->[ca_address_sk]
 ----------------------------PhysicalProject
 ------------------------------filter((customer_address.ca_gmt_offset = -6.00))
 --------------------------------PhysicalOlapScan[customer_address] apply RFs: RF11

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query58.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query58.out
@@ -11,13 +11,11 @@ PhysicalResultSink
 ----------------PhysicalDistribute[DistributionSpecHash]
 ------------------hashAgg[LOCAL]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF12 ws_item_sk->[i_item_sk]
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[item] apply RFs: RF12 RF13
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF12 i_item_sk->[ws_item_sk]
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF11 d_date_sk->[ws_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[web_sales] apply RFs: RF11
+------------------------------PhysicalOlapScan[web_sales] apply RFs: RF11 RF12
 ----------------------------PhysicalProject
 ------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF10 d_date->[d_date]
 --------------------------------PhysicalProject
@@ -31,6 +29,8 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------filter((date_dim.d_date = '2001-03-24'))
 --------------------------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[item] apply RFs: RF13
 ------------PhysicalProject
 --------------hashJoin[INNER_JOIN colocated] hashCondition=((ss_items.item_id = cs_items.item_id)) otherCondition=((cast(cs_item_rev as DECIMALV3(38, 3)) <= (1.1 * ss_items.ss_item_rev)) and (cast(cs_item_rev as DECIMALV3(38, 3)) >= (0.9 * ss_items.ss_item_rev)) and (cast(ss_item_rev as DECIMALV3(38, 3)) <= (1.1 * cs_items.cs_item_rev)) and (cast(ss_item_rev as DECIMALV3(38, 3)) >= (0.9 * cs_items.cs_item_rev))) build RFs:RF8 item_id->[i_item_id]
 ----------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query6.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query6.out
@@ -10,7 +10,7 @@ PhysicalResultSink
 --------------PhysicalDistribute[DistributionSpecHash]
 ----------------hashAgg[LOCAL]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((a.ca_address_sk = c.c_current_addr_sk)) otherCondition=() build RFs:RF5 c_current_addr_sk->[ca_address_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((a.ca_address_sk = c.c_current_addr_sk)) otherCondition=() build RFs:RF5 c_current_addr_sk->[ca_address_sk]
 ----------------------PhysicalProject
 ------------------------PhysicalOlapScan[customer_address] apply RFs: RF5
 ----------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query60.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query60.out
@@ -61,16 +61,13 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF11 ws_bill_addr_sk->[ca_address_sk]
-----------------------------PhysicalProject
-------------------------------filter((customer_address.ca_gmt_offset = -7.00))
---------------------------------PhysicalOlapScan[customer_address] apply RFs: RF11
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF11 ca_address_sk->[ws_bill_addr_sk]
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 i_item_sk->[ws_item_sk]
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF9 d_date_sk->[ws_sold_date_sk]
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF9 RF10
+--------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF9 RF10 RF11
 ------------------------------------PhysicalProject
 --------------------------------------filter((date_dim.d_moy = 8) and (date_dim.d_year = 2000))
 ----------------------------------------PhysicalOlapScan[date_dim]
@@ -80,4 +77,7 @@ PhysicalResultSink
 ----------------------------------PhysicalProject
 ------------------------------------filter((item.i_category = 'Children'))
 --------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalProject
+------------------------------filter((customer_address.ca_gmt_offset = -7.00))
+--------------------------------PhysicalOlapScan[customer_address]
 

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query61.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query61.out
@@ -8,12 +8,12 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecGather]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 ss_item_sk->[i_item_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF10 ss_item_sk->[i_item_sk]
 ------------------PhysicalProject
 --------------------filter((item.i_category = 'Jewelry'))
 ----------------------PhysicalOlapScan[item] apply RFs: RF10
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF9 c_current_addr_sk->[ca_address_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF9 c_current_addr_sk->[ca_address_sk]
 ----------------------PhysicalProject
 ------------------------filter((customer_address.ca_gmt_offset = -7.00))
 --------------------------PhysicalOlapScan[customer_address] apply RFs: RF9
@@ -42,12 +42,12 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecGather]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF4 ss_item_sk->[i_item_sk]
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF4 ss_item_sk->[i_item_sk]
 ------------------PhysicalProject
 --------------------filter((item.i_category = 'Jewelry'))
 ----------------------PhysicalOlapScan[item] apply RFs: RF4
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
 ----------------------PhysicalProject
 ------------------------filter((customer_address.ca_gmt_offset = -7.00))
 --------------------------PhysicalOlapScan[customer_address] apply RFs: RF3

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query64.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query64.out
@@ -13,15 +13,13 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 --------------------PhysicalProject
 ----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=(( not (cd_marital_status = cd_marital_status))) build RFs:RF17 ss_customer_sk->[c_customer_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = ad2.ca_address_sk)) otherCondition=() build RFs:RF16 c_current_addr_sk->[ca_address_sk]
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer_address] apply RFs: RF16
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = ad2.ca_address_sk)) otherCondition=() build RFs:RF16 ca_address_sk->[c_current_addr_sk]
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_cdemo_sk = cd2.cd_demo_sk)) otherCondition=() build RFs:RF15 cd_demo_sk->[c_current_cdemo_sk]
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_hdemo_sk = hd2.hd_demo_sk)) otherCondition=() build RFs:RF14 hd_demo_sk->[c_current_hdemo_sk]
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[customer] apply RFs: RF14 RF15 RF17 RF18 RF19
+--------------------------------------PhysicalOlapScan[customer] apply RFs: RF14 RF15 RF16 RF17 RF18 RF19
 ------------------------------------PhysicalProject
 --------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((hd2.hd_income_band_sk = ib2.ib_income_band_sk)) otherCondition=() build RFs:RF13 ib_income_band_sk->[hd_income_band_sk]
 ----------------------------------------PhysicalProject
@@ -30,12 +28,14 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ------------------------------------------PhysicalOlapScan[income_band]
 --------------------------------PhysicalProject
 ----------------------------------PhysicalOlapScan[customer_demographics]
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[customer_address]
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF11 ss_item_sk->[sr_item_sk];RF12 ss_ticket_number->[sr_ticket_number]
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[store_returns] apply RFs: RF11 RF12
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_addr_sk = ad1.ca_address_sk)) otherCondition=() build RFs:RF10 ss_addr_sk->[ca_address_sk]
+------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_addr_sk = ad1.ca_address_sk)) otherCondition=() build RFs:RF10 ss_addr_sk->[ca_address_sk]
 --------------------------------PhysicalProject
 ----------------------------------PhysicalOlapScan[customer_address] apply RFs: RF10
 --------------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query68.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query68.out
@@ -7,7 +7,7 @@ PhysicalResultSink
 --------PhysicalDistribute[DistributionSpecGather]
 ----------PhysicalTopN[LOCAL_SORT]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = current_addr.ca_address_sk)) otherCondition=(( not (ca_city = bought_city))) build RFs:RF5 c_current_addr_sk->[ca_address_sk]
+--------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = current_addr.ca_address_sk)) otherCondition=(( not (ca_city = bought_city))) build RFs:RF5 c_current_addr_sk->[ca_address_sk]
 ----------------PhysicalProject
 ------------------PhysicalOlapScan[customer_address] apply RFs: RF5
 ----------------PhysicalProject
@@ -17,7 +17,7 @@ PhysicalResultSink
 --------------------PhysicalProject
 ----------------------hashAgg[GLOBAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ss_addr_sk->[ca_address_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ss_addr_sk->[ca_address_sk]
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[customer_address] apply RFs: RF3
 ----------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query76.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query76.out
@@ -14,7 +14,7 @@ PhysicalResultSink
 ------------------PhysicalUnion
 --------------------PhysicalDistribute[DistributionSpecExecutionAny]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF0 ss_item_sk->[i_item_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF0 ss_item_sk->[i_item_sk]
 --------------------------PhysicalProject
 ----------------------------PhysicalOlapScan[item] apply RFs: RF0
 --------------------------PhysicalProject
@@ -22,7 +22,7 @@ PhysicalResultSink
 ------------------------------PhysicalOlapScan[store_sales]
 --------------------PhysicalDistribute[DistributionSpecExecutionAny]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 ws_item_sk->[i_item_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 ws_item_sk->[i_item_sk]
 --------------------------PhysicalProject
 ----------------------------PhysicalOlapScan[item] apply RFs: RF1
 --------------------------PhysicalProject
@@ -30,7 +30,7 @@ PhysicalResultSink
 ------------------------------PhysicalOlapScan[web_sales]
 --------------------PhysicalDistribute[DistributionSpecExecutionAny]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 cs_item_sk->[i_item_sk]
+------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 cs_item_sk->[i_item_sk]
 --------------------------PhysicalProject
 ----------------------------PhysicalOlapScan[item] apply RFs: RF2
 --------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query83.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query83.out
@@ -13,13 +13,11 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_returns.sr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF11 sr_item_sk->[i_item_sk]
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[item] apply RFs: RF11 RF12 RF13
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_returns.sr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF11 i_item_sk->[sr_item_sk]
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_returns.sr_returned_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF10 d_date_sk->[sr_returned_date_sk]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_returns] apply RFs: RF10
+----------------------------------PhysicalOlapScan[store_returns] apply RFs: RF10 RF11
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((date_dim.d_date = date_dim.d_date)) otherCondition=() build RFs:RF9 d_date->[d_date]
 ------------------------------------PhysicalProject
@@ -31,12 +29,14 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------filter(d_date IN ('2001-06-06', '2001-09-02', '2001-11-11'))
 --------------------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[item] apply RFs: RF12 RF13
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((catalog_returns.cr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 cr_item_sk->[i_item_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((catalog_returns.cr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 cr_item_sk->[i_item_sk]
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[item] apply RFs: RF7 RF13
 ----------------------------PhysicalProject
@@ -59,7 +59,7 @@ PhysicalResultSink
 ----------------PhysicalDistribute[DistributionSpecHash]
 ------------------hashAgg[LOCAL]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_returns.wr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 wr_item_sk->[i_item_sk]
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_returns.wr_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 wr_item_sk->[i_item_sk]
 ------------------------PhysicalProject
 --------------------------PhysicalOlapScan[item] apply RFs: RF3
 ------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query85.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query85.out
@@ -23,14 +23,11 @@ PhysicalResultSink
 ----------------------------------filter(OR[AND[(cd1.cd_marital_status = 'M'),(cd1.cd_education_status = '4 yr Degree')],AND[(cd1.cd_marital_status = 'S'),(cd1.cd_education_status = 'Secondary')],AND[(cd1.cd_marital_status = 'W'),(cd1.cd_education_status = 'Advanced Degree')]] and cd_education_status IN ('4 yr Degree', 'Advanced Degree', 'Secondary') and cd_marital_status IN ('M', 'S', 'W'))
 ------------------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF4
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer_address.ca_address_sk = web_returns.wr_refunded_addr_sk)) otherCondition=(OR[AND[ca_state IN ('DE', 'FL', 'TX'),(web_sales.ws_net_profit >= 100.00),(web_sales.ws_net_profit <= 200.00)],AND[ca_state IN ('ID', 'IN', 'ND'),(web_sales.ws_net_profit >= 150.00)],AND[ca_state IN ('IL', 'MT', 'OH'),(web_sales.ws_net_profit <= 250.00)]]) build RFs:RF3 wr_refunded_addr_sk->[ca_address_sk]
-------------------------------------PhysicalProject
---------------------------------------filter((customer_address.ca_country = 'United States') and ca_state IN ('DE', 'FL', 'ID', 'IL', 'IN', 'MT', 'ND', 'OH', 'TX'))
-----------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF3
+----------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_address.ca_address_sk = web_returns.wr_refunded_addr_sk)) otherCondition=(OR[AND[ca_state IN ('DE', 'FL', 'TX'),(web_sales.ws_net_profit >= 100.00),(web_sales.ws_net_profit <= 200.00)],AND[ca_state IN ('ID', 'IN', 'ND'),(web_sales.ws_net_profit >= 150.00)],AND[ca_state IN ('IL', 'MT', 'OH'),(web_sales.ws_net_profit <= 250.00)]]) build RFs:RF3 ca_address_sk->[wr_refunded_addr_sk]
 ------------------------------------PhysicalProject
 --------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((web_sales.ws_item_sk = web_returns.wr_item_sk) and (web_sales.ws_order_number = web_returns.wr_order_number)) otherCondition=() build RFs:RF1 ws_item_sk->[wr_item_sk];RF2 ws_order_number->[wr_order_number]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[web_returns] apply RFs: RF1 RF2 RF8
+------------------------------------------PhysicalOlapScan[web_returns] apply RFs: RF1 RF2 RF3 RF8
 ----------------------------------------PhysicalProject
 ------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ws_sold_date_sk]
 --------------------------------------------PhysicalProject
@@ -39,6 +36,9 @@ PhysicalResultSink
 --------------------------------------------PhysicalProject
 ----------------------------------------------filter((date_dim.d_year = 2000))
 ------------------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------PhysicalProject
+--------------------------------------filter((customer_address.ca_country = 'United States') and ca_state IN ('DE', 'FL', 'ID', 'IL', 'IN', 'MT', 'ND', 'OH', 'TX'))
+----------------------------------------PhysicalOlapScan[customer_address]
 ------------------------PhysicalProject
 --------------------------PhysicalOlapScan[reason]
 --------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query91.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query91.out
@@ -17,7 +17,7 @@ PhysicalResultSink
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF3 RF4 RF5
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF2 c_current_addr_sk->[ca_address_sk]
+------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF2 c_current_addr_sk->[ca_address_sk]
 --------------------------------PhysicalProject
 ----------------------------------filter((customer_address.ca_gmt_offset = -6.00))
 ------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF2

--- a/regression-test/data/shape_check/tpcds_sf1000/bs_downgrade_shape/query13.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/bs_downgrade_shape/query13.out
@@ -7,7 +7,7 @@ PhysicalResultSink
 --------PhysicalProject
 ----------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=() build RFs:RF4 s_store_sk->[ss_store_sk]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=(OR[AND[ca_state IN ('IL', 'TN', 'TX'),(store_sales.ss_net_profit >= 100.00),(store_sales.ss_net_profit <= 200.00)],AND[ca_state IN ('ID', 'OH', 'WY'),(store_sales.ss_net_profit >= 150.00)],AND[ca_state IN ('IA', 'MS', 'SC'),(store_sales.ss_net_profit <= 250.00)]]) build RFs:RF3 ss_addr_sk->[ca_address_sk]
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=(OR[AND[ca_state IN ('IL', 'TN', 'TX'),(store_sales.ss_net_profit >= 100.00),(store_sales.ss_net_profit <= 200.00)],AND[ca_state IN ('ID', 'OH', 'WY'),(store_sales.ss_net_profit >= 150.00)],AND[ca_state IN ('IA', 'MS', 'SC'),(store_sales.ss_net_profit <= 250.00)]]) build RFs:RF3 ss_addr_sk->[ca_address_sk]
 ----------------PhysicalProject
 ------------------filter((customer_address.ca_country = 'United States') and ca_state IN ('IA', 'ID', 'IL', 'MS', 'OH', 'SC', 'TN', 'TX', 'WY'))
 --------------------PhysicalOlapScan[customer_address] apply RFs: RF3

--- a/regression-test/data/shape_check/tpcds_sf1000/bs_downgrade_shape/query19.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/bs_downgrade_shape/query19.out
@@ -9,7 +9,7 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=(( not (substring(ca_zip, 1, 5) = substring(s_zip, 1, 5)))) build RFs:RF4 c_current_addr_sk->[ca_address_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=(( not (substring(ca_zip, 1, 5) = substring(s_zip, 1, 5)))) build RFs:RF4 c_current_addr_sk->[ca_address_sk]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[customer_address] apply RFs: RF4
 --------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/bs_downgrade_shape/query44.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/bs_downgrade_shape/query44.out
@@ -9,7 +9,7 @@ PhysicalResultSink
 ------------PhysicalProject
 --------------hashJoin[INNER_JOIN broadcast] hashCondition=((asceding.rnk = descending.rnk)) otherCondition=()
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((i2.i_item_sk = descending.item_sk)) otherCondition=() build RFs:RF1 item_sk->[i_item_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((i2.i_item_sk = descending.item_sk)) otherCondition=() build RFs:RF1 item_sk->[i_item_sk]
 --------------------PhysicalProject
 ----------------------PhysicalLazyMaterializeOlapScan[item lazySlots:(i2.i_product_name)] apply RFs: RF1
 --------------------PhysicalProject
@@ -39,7 +39,7 @@ PhysicalResultSink
 ------------------------------------------------------filter((store_sales.ss_store_sk = 4) and ss_hdemo_sk IS NULL)
 --------------------------------------------------------PhysicalOlapScan[store_sales]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((i1.i_item_sk = asceding.item_sk)) otherCondition=() build RFs:RF0 item_sk->[i_item_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((i1.i_item_sk = asceding.item_sk)) otherCondition=() build RFs:RF0 item_sk->[i_item_sk]
 --------------------PhysicalProject
 ----------------------PhysicalLazyMaterializeOlapScan[item lazySlots:(i1.i_product_name)] apply RFs: RF0
 --------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/bs_downgrade_shape/query54.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/bs_downgrade_shape/query54.out
@@ -25,7 +25,7 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_county = store.s_county) and (customer_address.ca_state = store.s_state)) otherCondition=() build RFs:RF4 s_county->[ca_county];RF5 s_state->[ca_state]
 --------------------------------------------PhysicalProject
-----------------------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
+----------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
 ------------------------------------------------PhysicalProject
 --------------------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF3 RF4 RF5
 ------------------------------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/bs_downgrade_shape/query56.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/bs_downgrade_shape/query56.out
@@ -61,7 +61,7 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF11 ws_bill_addr_sk->[ca_address_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF11 ws_bill_addr_sk->[ca_address_sk]
 ----------------------------PhysicalProject
 ------------------------------filter((customer_address.ca_gmt_offset = -6.00))
 --------------------------------PhysicalOlapScan[customer_address] apply RFs: RF11

--- a/regression-test/data/shape_check/tpcds_sf1000/bs_downgrade_shape/query6.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/bs_downgrade_shape/query6.out
@@ -10,7 +10,7 @@ PhysicalResultSink
 --------------PhysicalDistribute[DistributionSpecHash]
 ----------------hashAgg[LOCAL]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((a.ca_address_sk = c.c_current_addr_sk)) otherCondition=() build RFs:RF5 c_current_addr_sk->[ca_address_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((a.ca_address_sk = c.c_current_addr_sk)) otherCondition=() build RFs:RF5 c_current_addr_sk->[ca_address_sk]
 ----------------------PhysicalProject
 ------------------------PhysicalOlapScan[customer_address] apply RFs: RF5
 ----------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/bs_downgrade_shape/query61.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/bs_downgrade_shape/query61.out
@@ -8,7 +8,7 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecGather]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF10 c_current_addr_sk->[ca_address_sk]
+----------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF10 c_current_addr_sk->[ca_address_sk]
 ------------------PhysicalProject
 --------------------filter((customer_address.ca_gmt_offset = -7.00))
 ----------------------PhysicalOlapScan[customer_address] apply RFs: RF10

--- a/regression-test/data/shape_check/tpcds_sf1000/bs_downgrade_shape/query68.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/bs_downgrade_shape/query68.out
@@ -7,7 +7,7 @@ PhysicalResultSink
 --------PhysicalDistribute[DistributionSpecGather]
 ----------PhysicalTopN[LOCAL_SORT]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = current_addr.ca_address_sk)) otherCondition=(( not (ca_city = bought_city))) build RFs:RF5 c_current_addr_sk->[ca_address_sk]
+--------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = current_addr.ca_address_sk)) otherCondition=(( not (ca_city = bought_city))) build RFs:RF5 c_current_addr_sk->[ca_address_sk]
 ----------------PhysicalProject
 ------------------PhysicalOlapScan[customer_address] apply RFs: RF5
 ----------------PhysicalProject
@@ -17,7 +17,7 @@ PhysicalResultSink
 --------------------PhysicalProject
 ----------------------hashAgg[GLOBAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ss_addr_sk->[ca_address_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ss_addr_sk->[ca_address_sk]
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[customer_address] apply RFs: RF3
 ----------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/bs_downgrade_shape/query91.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/bs_downgrade_shape/query91.out
@@ -17,7 +17,7 @@ PhysicalResultSink
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF3 RF4 RF5
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF2 c_current_addr_sk->[ca_address_sk]
+------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF2 c_current_addr_sk->[ca_address_sk]
 --------------------------------PhysicalProject
 ----------------------------------filter((customer_address.ca_gmt_offset = -7.00))
 ------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF2

--- a/regression-test/data/shape_check/tpcds_sf1000/hint/query19.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/hint/query19.out
@@ -11,7 +11,7 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=(( not (substring(ca_zip, 1, 5) = substring(s_zip, 1, 5)))) build RFs:RF4 s_store_sk->[ss_store_sk]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
 ------------------------PhysicalProject
 --------------------------PhysicalOlapScan[customer_address] apply RFs: RF3
 ------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/hint/query44.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/hint/query44.out
@@ -9,7 +9,7 @@ PhysicalResultSink
 ------------PhysicalProject
 --------------hashJoin[INNER_JOIN broadcast] hashCondition=((asceding.rnk = descending.rnk)) otherCondition=()
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((i1.i_item_sk = asceding.item_sk)) otherCondition=() build RFs:RF1 item_sk->[i_item_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((i1.i_item_sk = asceding.item_sk)) otherCondition=() build RFs:RF1 item_sk->[i_item_sk]
 --------------------PhysicalProject
 ----------------------PhysicalLazyMaterializeOlapScan[item lazySlots:(i1.i_product_name)] apply RFs: RF1
 --------------------PhysicalProject
@@ -39,7 +39,7 @@ PhysicalResultSink
 ------------------------------------------------------filter((store_sales.ss_store_sk = 4) and ss_hdemo_sk IS NULL)
 --------------------------------------------------------PhysicalOlapScan[store_sales]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((i2.i_item_sk = descending.item_sk)) otherCondition=() build RFs:RF0 item_sk->[i_item_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((i2.i_item_sk = descending.item_sk)) otherCondition=() build RFs:RF0 item_sk->[i_item_sk]
 --------------------PhysicalProject
 ----------------------PhysicalLazyMaterializeOlapScan[item lazySlots:(i2.i_product_name)] apply RFs: RF0
 --------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/hint/query54.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/hint/query54.out
@@ -25,7 +25,7 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_county = store.s_county) and (customer_address.ca_state = store.s_state)) otherCondition=() build RFs:RF4 s_county->[ca_county];RF5 s_state->[ca_state]
 --------------------------------------------PhysicalProject
-----------------------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
+----------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
 ------------------------------------------------PhysicalProject
 --------------------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF3 RF4 RF5
 ------------------------------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/hint/query56.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/hint/query56.out
@@ -61,7 +61,7 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF11 ws_bill_addr_sk->[ca_address_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF11 ws_bill_addr_sk->[ca_address_sk]
 ----------------------------PhysicalProject
 ------------------------------filter((customer_address.ca_gmt_offset = -6.00))
 --------------------------------PhysicalOlapScan[customer_address] apply RFs: RF11

--- a/regression-test/data/shape_check/tpcds_sf1000/hint/query6.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/hint/query6.out
@@ -10,7 +10,7 @@ PhysicalResultSink
 --------------PhysicalDistribute[DistributionSpecHash]
 ----------------hashAgg[LOCAL]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((a.ca_address_sk = c.c_current_addr_sk)) otherCondition=() build RFs:RF5 c_current_addr_sk->[ca_address_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((a.ca_address_sk = c.c_current_addr_sk)) otherCondition=() build RFs:RF5 c_current_addr_sk->[ca_address_sk]
 ----------------------PhysicalProject
 ------------------------PhysicalOlapScan[customer_address] apply RFs: RF5
 ----------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/hint/query61.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/hint/query61.out
@@ -9,7 +9,7 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecGather]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF10 c_current_addr_sk->[ca_address_sk]
+------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF10 c_current_addr_sk->[ca_address_sk]
 --------------------PhysicalProject
 ----------------------filter((customer_address.ca_gmt_offset = -7.00))
 ------------------------PhysicalOlapScan[customer_address] apply RFs: RF10

--- a/regression-test/data/shape_check/tpcds_sf1000/hint/query68.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/hint/query68.out
@@ -7,7 +7,7 @@ PhysicalResultSink
 --------PhysicalDistribute[DistributionSpecGather]
 ----------PhysicalTopN[LOCAL_SORT]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = current_addr.ca_address_sk)) otherCondition=(( not (ca_city = bought_city))) build RFs:RF5 c_current_addr_sk->[ca_address_sk]
+--------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = current_addr.ca_address_sk)) otherCondition=(( not (ca_city = bought_city))) build RFs:RF5 c_current_addr_sk->[ca_address_sk]
 ----------------PhysicalProject
 ------------------PhysicalOlapScan[customer_address] apply RFs: RF5
 ----------------PhysicalProject
@@ -17,7 +17,7 @@ PhysicalResultSink
 --------------------PhysicalProject
 ----------------------hashAgg[GLOBAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ss_addr_sk->[ca_address_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ss_addr_sk->[ca_address_sk]
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[customer_address] apply RFs: RF3
 ----------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/hint/query76.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/hint/query76.out
@@ -18,14 +18,13 @@ PhysicalResultSink
 ------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF3
 --------------------------PhysicalProject
 ----------------------------PhysicalOlapScan[item]
---------------------PhysicalDistribute[DistributionSpecExecutionAny]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 ws_item_sk->[i_item_sk]
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[item] apply RFs: RF1
---------------------------PhysicalProject
-----------------------------filter(ws_promo_sk IS NULL)
-------------------------------PhysicalOlapScan[web_sales] apply RFs: RF3
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 ws_item_sk->[i_item_sk]
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[item] apply RFs: RF1
+------------------------PhysicalProject
+--------------------------filter(ws_promo_sk IS NULL)
+----------------------------PhysicalOlapScan[web_sales] apply RFs: RF3
 --------------------PhysicalDistribute[DistributionSpecExecutionAny]
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[cs_item_sk]

--- a/regression-test/data/shape_check/tpcds_sf1000/hint/query85.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/hint/query85.out
@@ -20,7 +20,7 @@ PhysicalResultSink
 ------------------------------filter(cd_education_status IN ('Advanced Degree', 'College', 'Primary') and cd_marital_status IN ('D', 'S', 'U'))
 --------------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5 RF6 RF7
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer_address.ca_address_sk = web_returns.wr_refunded_addr_sk)) otherCondition=(OR[AND[ca_state IN ('IA', 'NC', 'TX'),(web_sales.ws_net_profit >= 100.00),(web_sales.ws_net_profit <= 200.00)],AND[ca_state IN ('GA', 'WI', 'WV'),(web_sales.ws_net_profit >= 150.00)],AND[ca_state IN ('KY', 'OK', 'VA'),(web_sales.ws_net_profit <= 250.00)]]) build RFs:RF4 wr_refunded_addr_sk->[ca_address_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = web_returns.wr_refunded_addr_sk)) otherCondition=(OR[AND[ca_state IN ('IA', 'NC', 'TX'),(web_sales.ws_net_profit >= 100.00),(web_sales.ws_net_profit <= 200.00)],AND[ca_state IN ('GA', 'WI', 'WV'),(web_sales.ws_net_profit >= 150.00)],AND[ca_state IN ('KY', 'OK', 'VA'),(web_sales.ws_net_profit <= 250.00)]]) build RFs:RF4 wr_refunded_addr_sk->[ca_address_sk]
 --------------------------------PhysicalProject
 ----------------------------------filter((customer_address.ca_country = 'United States') and ca_state IN ('GA', 'IA', 'KY', 'NC', 'OK', 'TX', 'VA', 'WI', 'WV'))
 ------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF4

--- a/regression-test/data/shape_check/tpcds_sf1000/hint/query91.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/hint/query91.out
@@ -17,7 +17,7 @@ PhysicalResultSink
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF3 RF4 RF5
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF2 c_current_addr_sk->[ca_address_sk]
+------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF2 c_current_addr_sk->[ca_address_sk]
 --------------------------------PhysicalProject
 ----------------------------------filter((customer_address.ca_gmt_offset = -7.00))
 ------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF2

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query13.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query13.out
@@ -7,7 +7,7 @@ PhysicalResultSink
 --------PhysicalProject
 ----------hashJoin[INNER_JOIN broadcast] hashCondition=((store.s_store_sk = store_sales.ss_store_sk)) otherCondition=() build RFs:RF4 s_store_sk->[ss_store_sk]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=(OR[AND[ca_state IN ('IL', 'TN', 'TX'),(store_sales.ss_net_profit >= 100.00),(store_sales.ss_net_profit <= 200.00)],AND[ca_state IN ('ID', 'OH', 'WY'),(store_sales.ss_net_profit >= 150.00)],AND[ca_state IN ('IA', 'MS', 'SC'),(store_sales.ss_net_profit <= 250.00)]]) build RFs:RF3 ss_addr_sk->[ca_address_sk]
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=(OR[AND[ca_state IN ('IL', 'TN', 'TX'),(store_sales.ss_net_profit >= 100.00),(store_sales.ss_net_profit <= 200.00)],AND[ca_state IN ('ID', 'OH', 'WY'),(store_sales.ss_net_profit >= 150.00)],AND[ca_state IN ('IA', 'MS', 'SC'),(store_sales.ss_net_profit <= 250.00)]]) build RFs:RF3 ss_addr_sk->[ca_address_sk]
 ----------------PhysicalProject
 ------------------filter((customer_address.ca_country = 'United States') and ca_state IN ('IA', 'ID', 'IL', 'MS', 'OH', 'SC', 'TN', 'TX', 'WY'))
 --------------------PhysicalOlapScan[customer_address] apply RFs: RF3

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query19.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query19.out
@@ -9,7 +9,7 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=(( not (substring(ca_zip, 1, 5) = substring(s_zip, 1, 5)))) build RFs:RF4 c_current_addr_sk->[ca_address_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=(( not (substring(ca_zip, 1, 5) = substring(s_zip, 1, 5)))) build RFs:RF4 c_current_addr_sk->[ca_address_sk]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[customer_address] apply RFs: RF4
 --------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query24.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query24.out
@@ -20,11 +20,11 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------------------------------filter((store.s_market_id = 5))
 --------------------------------PhysicalOlapScan[store] apply RFs: RF2
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=(( not (c_birth_country = upper(ca_country)))) build RFs:RF0 c_current_addr_sk->[ca_address_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=(( not (c_birth_country = upper(ca_country)))) build RFs:RF0 ca_address_sk->[c_current_addr_sk]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer_address] apply RFs: RF0
+------------------------------PhysicalOlapScan[customer] apply RFs: RF0
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer]
+------------------------------PhysicalOlapScan[customer_address]
 --------------------PhysicalProject
 ----------------------PhysicalOlapScan[item] apply RFs: RF6
 ----------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query44.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query44.out
@@ -9,7 +9,7 @@ PhysicalResultSink
 ------------PhysicalProject
 --------------hashJoin[INNER_JOIN broadcast] hashCondition=((asceding.rnk = descending.rnk)) otherCondition=()
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((i2.i_item_sk = descending.item_sk)) otherCondition=() build RFs:RF1 item_sk->[i_item_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((i2.i_item_sk = descending.item_sk)) otherCondition=() build RFs:RF1 item_sk->[i_item_sk]
 --------------------PhysicalProject
 ----------------------PhysicalLazyMaterializeOlapScan[item lazySlots:(i2.i_product_name)] apply RFs: RF1
 --------------------PhysicalProject
@@ -39,7 +39,7 @@ PhysicalResultSink
 ------------------------------------------------------filter((store_sales.ss_store_sk = 4) and ss_hdemo_sk IS NULL)
 --------------------------------------------------------PhysicalOlapScan[store_sales]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((i1.i_item_sk = asceding.item_sk)) otherCondition=() build RFs:RF0 item_sk->[i_item_sk]
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((i1.i_item_sk = asceding.item_sk)) otherCondition=() build RFs:RF0 item_sk->[i_item_sk]
 --------------------PhysicalProject
 ----------------------PhysicalLazyMaterializeOlapScan[item lazySlots:(i1.i_product_name)] apply RFs: RF0
 --------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query46.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query46.out
@@ -5,19 +5,15 @@ PhysicalResultSink
 ----PhysicalDistribute[DistributionSpecGather]
 ------PhysicalTopN[LOCAL_SORT]
 --------PhysicalProject
-----------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = current_addr.ca_address_sk)) otherCondition=(( not (ca_city = bought_city))) build RFs:RF5 c_current_addr_sk->[ca_address_sk]
-------------PhysicalProject
---------------PhysicalOlapScan[customer_address] apply RFs: RF5
+----------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = current_addr.ca_address_sk)) otherCondition=(( not (ca_city = bought_city))) build RFs:RF5 ca_address_sk->[c_current_addr_sk]
 ------------PhysicalProject
 --------------hashJoin[INNER_JOIN shuffle] hashCondition=((dn.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF4 ss_customer_sk->[c_customer_sk]
 ----------------PhysicalProject
-------------------PhysicalOlapScan[customer] apply RFs: RF4
+------------------PhysicalOlapScan[customer] apply RFs: RF4 RF5
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ss_addr_sk->[ca_address_sk]
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[customer_address] apply RFs: RF3
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[ss_addr_sk]
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_hdemo_sk = household_demographics.hd_demo_sk)) otherCondition=() build RFs:RF2 hd_demo_sk->[ss_hdemo_sk]
 ----------------------------PhysicalProject
@@ -25,7 +21,7 @@ PhysicalResultSink
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF0 s_store_sk->[ss_store_sk]
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2
+--------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1 RF2 RF3
 ------------------------------------PhysicalProject
 --------------------------------------filter(s_city IN ('Fairview', 'Midway'))
 ----------------------------------------PhysicalOlapScan[store]
@@ -35,4 +31,8 @@ PhysicalResultSink
 ----------------------------PhysicalProject
 ------------------------------filter(OR[(household_demographics.hd_dep_count = 8),(household_demographics.hd_vehicle_count = 0)])
 --------------------------------PhysicalOlapScan[household_demographics]
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[customer_address]
+------------PhysicalProject
+--------------PhysicalOlapScan[customer_address]
 

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query54.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query54.out
@@ -25,7 +25,7 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_county = store.s_county) and (customer_address.ca_state = store.s_state)) otherCondition=() build RFs:RF4 s_county->[ca_county];RF5 s_state->[ca_state]
 --------------------------------------------PhysicalProject
-----------------------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
+----------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
 ------------------------------------------------PhysicalProject
 --------------------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF3 RF4 RF5
 ------------------------------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query56.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query56.out
@@ -61,7 +61,7 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF11 ws_bill_addr_sk->[ca_address_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF11 ws_bill_addr_sk->[ca_address_sk]
 ----------------------------PhysicalProject
 ------------------------------filter((customer_address.ca_gmt_offset = -6.00))
 --------------------------------PhysicalOlapScan[customer_address] apply RFs: RF11

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query6.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query6.out
@@ -10,7 +10,7 @@ PhysicalResultSink
 --------------PhysicalDistribute[DistributionSpecHash]
 ----------------hashAgg[LOCAL]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((a.ca_address_sk = c.c_current_addr_sk)) otherCondition=() build RFs:RF5 c_current_addr_sk->[ca_address_sk]
+--------------------hashJoin[INNER_JOIN broadcast] hashCondition=((a.ca_address_sk = c.c_current_addr_sk)) otherCondition=() build RFs:RF5 c_current_addr_sk->[ca_address_sk]
 ----------------------PhysicalProject
 ------------------------PhysicalOlapScan[customer_address] apply RFs: RF5
 ----------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query61.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query61.out
@@ -8,7 +8,7 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecGather]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF10 c_current_addr_sk->[ca_address_sk]
+----------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF10 c_current_addr_sk->[ca_address_sk]
 ------------------PhysicalProject
 --------------------filter((customer_address.ca_gmt_offset = -7.00))
 ----------------------PhysicalOlapScan[customer_address] apply RFs: RF10

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query64.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query64.out
@@ -7,86 +7,85 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 --------PhysicalDistribute[DistributionSpecHash]
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF19 i_item_sk->[cr_item_sk,cs_item_sk,sr_item_sk,ss_item_sk]
+--------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_first_shipto_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF19 d_date_sk->[c_first_shipto_date_sk]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN broadcast] hashCondition=((hd2.hd_income_band_sk = ib2.ib_income_band_sk)) otherCondition=() build RFs:RF18 ib_income_band_sk->[hd_income_band_sk]
+------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=(( not (cd_marital_status = cd_marital_status))) build RFs:RF18 ss_customer_sk->[c_customer_sk]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((hd1.hd_income_band_sk = ib1.ib_income_band_sk)) otherCondition=() build RFs:RF17 ib_income_band_sk->[hd_income_band_sk]
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = ad2.ca_address_sk)) otherCondition=() build RFs:RF17 ca_address_sk->[c_current_addr_sk]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_addr_sk = ad2.ca_address_sk)) otherCondition=() build RFs:RF16 ca_address_sk->[c_current_addr_sk]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_cdemo_sk = cd2.cd_demo_sk)) otherCondition=() build RFs:RF16 cd_demo_sk->[c_current_cdemo_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_addr_sk = ad1.ca_address_sk)) otherCondition=() build RFs:RF15 ca_address_sk->[ss_addr_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_first_sales_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF15 d_date_sk->[c_first_sales_date_sk]
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_hdemo_sk = hd2.hd_demo_sk)) otherCondition=() build RFs:RF14 hd_demo_sk->[c_current_hdemo_sk]
 ------------------------------------PhysicalProject
---------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_hdemo_sk = hd1.hd_demo_sk)) otherCondition=() build RFs:RF13 hd_demo_sk->[ss_hdemo_sk]
-----------------------------------------PhysicalProject
-------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF12 p_promo_sk->[ss_promo_sk]
---------------------------------------------PhysicalProject
-----------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_current_cdemo_sk = cd2.cd_demo_sk)) otherCondition=(( not (cd_marital_status = cd_marital_status))) build RFs:RF11 cd_demo_sk->[c_current_cdemo_sk]
-------------------------------------------------PhysicalProject
---------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_cdemo_sk = cd1.cd_demo_sk)) otherCondition=() build RFs:RF10 cd_demo_sk->[ss_cdemo_sk]
-----------------------------------------------------PhysicalProject
-------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_first_shipto_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF9 d_date_sk->[c_first_shipto_date_sk]
---------------------------------------------------------PhysicalProject
-----------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_first_sales_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF8 d_date_sk->[c_first_sales_date_sk]
-------------------------------------------------------------PhysicalProject
---------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_customer_sk = customer.c_customer_sk)) otherCondition=() build RFs:RF7 c_customer_sk->[ss_customer_sk]
-----------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF6 s_store_sk->[ss_store_sk]
---------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = d1.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ss_sold_date_sk]
-------------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF3 sr_item_sk->[cr_item_sk,cs_item_sk,ss_item_sk];RF4 sr_ticket_number->[ss_ticket_number]
-----------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = cs_ui.cs_item_sk)) otherCondition=() build RFs:RF2 cs_item_sk->[ss_item_sk]
---------------------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3 RF4 RF5 RF6 RF7 RF10 RF12 RF13 RF15 RF19
---------------------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------------------filter((sale > (2 * refund)))
-------------------------------------------------------------------------------------hashAgg[GLOBAL]
---------------------------------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------------------------------------------------------------------hashAgg[LOCAL]
-------------------------------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=() build RFs:RF0 cr_item_sk->[cs_item_sk];RF1 cr_order_number->[cs_order_number]
-----------------------------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1 RF3 RF19
-----------------------------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF3 RF19
-----------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------PhysicalOlapScan[store_returns] apply RFs: RF19
-------------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------------filter(d_year IN (1999, 2000))
-----------------------------------------------------------------------------PhysicalOlapScan[date_dim]
---------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------PhysicalOlapScan[store]
-----------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------PhysicalOlapScan[customer] apply RFs: RF8 RF9 RF11 RF14 RF16
-------------------------------------------------------------PhysicalProject
---------------------------------------------------------------PhysicalOlapScan[date_dim]
---------------------------------------------------------PhysicalProject
-----------------------------------------------------------PhysicalOlapScan[date_dim]
-----------------------------------------------------PhysicalProject
-------------------------------------------------------PhysicalOlapScan[customer_demographics]
-------------------------------------------------PhysicalProject
---------------------------------------------------PhysicalOlapScan[customer_demographics]
---------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[promotion]
-----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[household_demographics] apply RFs: RF17
+--------------------------------------PhysicalOlapScan[customer] apply RFs: RF14 RF15 RF16 RF17 RF18 RF19
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[household_demographics] apply RFs: RF18
+--------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((hd2.hd_income_band_sk = ib2.ib_income_band_sk)) otherCondition=() build RFs:RF13 ib_income_band_sk->[hd_income_band_sk]
+----------------------------------------PhysicalProject
+------------------------------------------PhysicalOlapScan[household_demographics] apply RFs: RF13
+----------------------------------------PhysicalProject
+------------------------------------------PhysicalOlapScan[income_band]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer_address]
+----------------------------------PhysicalOlapScan[date_dim]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer_address]
+------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[income_band]
+--------------------------PhysicalOlapScan[customer_address]
 --------------------PhysicalProject
-----------------------PhysicalOlapScan[income_band]
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_addr_sk = ad1.ca_address_sk)) otherCondition=() build RFs:RF12 ca_address_sk->[ss_addr_sk]
+------------------------PhysicalProject
+--------------------------hashJoin[INNER_JOIN colocated] hashCondition=((store_sales.ss_item_sk = store_returns.sr_item_sk) and (store_sales.ss_ticket_number = store_returns.sr_ticket_number)) otherCondition=() build RFs:RF10 ss_item_sk->[sr_item_sk];RF11 ss_ticket_number->[sr_ticket_number]
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[store_returns] apply RFs: RF10 RF11
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_promo_sk = promotion.p_promo_sk)) otherCondition=() build RFs:RF9 p_promo_sk->[ss_promo_sk]
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_cdemo_sk = cd1.cd_demo_sk)) otherCondition=() build RFs:RF8 cd_demo_sk->[ss_cdemo_sk]
+------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF7 i_item_sk->[cr_item_sk,cs_item_sk,ss_item_sk]
+--------------------------------------PhysicalProject
+----------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF6 s_store_sk->[ss_store_sk]
+------------------------------------------PhysicalProject
+--------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((hd1.hd_income_band_sk = ib1.ib_income_band_sk)) otherCondition=() build RFs:RF5 ib_income_band_sk->[hd_income_band_sk]
+----------------------------------------------PhysicalProject
+------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_hdemo_sk = hd1.hd_demo_sk)) otherCondition=() build RFs:RF4 hd_demo_sk->[ss_hdemo_sk]
+--------------------------------------------------PhysicalProject
+----------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_item_sk = cs_ui.cs_item_sk)) otherCondition=() build RFs:RF3 cs_item_sk->[ss_item_sk]
+------------------------------------------------------PhysicalProject
+--------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = d1.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
+----------------------------------------------------------PhysicalProject
+------------------------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3 RF4 RF6 RF7 RF8 RF9 RF12
+----------------------------------------------------------PhysicalProject
+------------------------------------------------------------filter(d_year IN (1999, 2000))
+--------------------------------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------------------------PhysicalProject
+--------------------------------------------------------filter((sale > (2 * refund)))
+----------------------------------------------------------hashAgg[GLOBAL]
+------------------------------------------------------------PhysicalDistribute[DistributionSpecHash]
+--------------------------------------------------------------hashAgg[LOCAL]
+----------------------------------------------------------------PhysicalProject
+------------------------------------------------------------------hashJoin[INNER_JOIN colocated] hashCondition=((catalog_sales.cs_item_sk = catalog_returns.cr_item_sk) and (catalog_sales.cs_order_number = catalog_returns.cr_order_number)) otherCondition=() build RFs:RF0 cr_item_sk->[cs_item_sk];RF1 cr_order_number->[cs_order_number]
+--------------------------------------------------------------------PhysicalProject
+----------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1 RF7
+--------------------------------------------------------------------PhysicalProject
+----------------------------------------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF7
+--------------------------------------------------PhysicalProject
+----------------------------------------------------PhysicalOlapScan[household_demographics] apply RFs: RF5
+----------------------------------------------PhysicalProject
+------------------------------------------------PhysicalOlapScan[income_band]
+------------------------------------------PhysicalProject
+--------------------------------------------PhysicalOlapScan[store]
+--------------------------------------PhysicalProject
+----------------------------------------filter((item.i_current_price <= 58.00) and (item.i_current_price >= 49.00) and i_color IN ('blush', 'lace', 'lawn', 'misty', 'orange', 'pink'))
+------------------------------------------PhysicalOlapScan[item]
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[customer_demographics]
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[promotion]
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[customer_address]
 ----------------PhysicalProject
-------------------filter((item.i_current_price <= 58.00) and (item.i_current_price >= 49.00) and i_color IN ('blush', 'lace', 'lawn', 'misty', 'orange', 'pink'))
---------------------PhysicalOlapScan[item]
+------------------PhysicalOlapScan[date_dim]
 --PhysicalResultSink
 ----PhysicalQuickSort[MERGE_SORT]
 ------PhysicalDistribute[DistributionSpecGather]

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query68.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query68.out
@@ -7,7 +7,7 @@ PhysicalResultSink
 --------PhysicalDistribute[DistributionSpecGather]
 ----------PhysicalTopN[LOCAL_SORT]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer.c_current_addr_sk = current_addr.ca_address_sk)) otherCondition=(( not (ca_city = bought_city))) build RFs:RF5 c_current_addr_sk->[ca_address_sk]
+--------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer.c_current_addr_sk = current_addr.ca_address_sk)) otherCondition=(( not (ca_city = bought_city))) build RFs:RF5 c_current_addr_sk->[ca_address_sk]
 ----------------PhysicalProject
 ------------------PhysicalOlapScan[customer_address] apply RFs: RF5
 ----------------PhysicalProject
@@ -17,7 +17,7 @@ PhysicalResultSink
 --------------------PhysicalProject
 ----------------------hashAgg[GLOBAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ss_addr_sk->[ca_address_sk]
+--------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((store_sales.ss_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ss_addr_sk->[ca_address_sk]
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[customer_address] apply RFs: RF3
 ----------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query76.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query76.out
@@ -18,14 +18,13 @@ PhysicalResultSink
 ------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF3
 --------------------------PhysicalProject
 ----------------------------PhysicalOlapScan[item]
---------------------PhysicalDistribute[DistributionSpecExecutionAny]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 ws_item_sk->[i_item_sk]
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[item] apply RFs: RF1
---------------------------PhysicalProject
-----------------------------filter(ws_promo_sk IS NULL)
-------------------------------PhysicalOlapScan[web_sales] apply RFs: RF3
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((web_sales.ws_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 ws_item_sk->[i_item_sk]
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[item] apply RFs: RF1
+------------------------PhysicalProject
+--------------------------filter(ws_promo_sk IS NULL)
+----------------------------PhysicalOlapScan[web_sales] apply RFs: RF3
 --------------------PhysicalDistribute[DistributionSpecExecutionAny]
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[cs_item_sk]

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query85.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query85.out
@@ -18,7 +18,7 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_web_page_sk = web_page.wp_web_page_sk)) otherCondition=() build RFs:RF5 wp_web_page_sk->[ws_web_page_sk]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer_address.ca_address_sk = web_returns.wr_refunded_addr_sk)) otherCondition=(OR[AND[ca_state IN ('IA', 'NC', 'TX'),(web_sales.ws_net_profit >= 100.00),(web_sales.ws_net_profit <= 200.00)],AND[ca_state IN ('GA', 'WI', 'WV'),(web_sales.ws_net_profit >= 150.00)],AND[ca_state IN ('KY', 'OK', 'VA'),(web_sales.ws_net_profit <= 250.00)]]) build RFs:RF4 wr_refunded_addr_sk->[ca_address_sk]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_address_sk = web_returns.wr_refunded_addr_sk)) otherCondition=(OR[AND[ca_state IN ('IA', 'NC', 'TX'),(web_sales.ws_net_profit >= 100.00),(web_sales.ws_net_profit <= 200.00)],AND[ca_state IN ('GA', 'WI', 'WV'),(web_sales.ws_net_profit >= 150.00)],AND[ca_state IN ('KY', 'OK', 'VA'),(web_sales.ws_net_profit <= 250.00)]]) build RFs:RF4 wr_refunded_addr_sk->[ca_address_sk]
 --------------------------------PhysicalProject
 ----------------------------------filter((customer_address.ca_country = 'United States') and ca_state IN ('GA', 'IA', 'KY', 'NC', 'OK', 'TX', 'VA', 'WI', 'WV'))
 ------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF4

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query91.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query91.out
@@ -17,7 +17,7 @@ PhysicalResultSink
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF3 RF4 RF5
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF2 c_current_addr_sk->[ca_address_sk]
+------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_address.ca_address_sk = customer.c_current_addr_sk)) otherCondition=() build RFs:RF2 c_current_addr_sk->[ca_address_sk]
 --------------------------------PhysicalProject
 ----------------------------------filter((customer_address.ca_gmt_offset = -7.00))
 ------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF2

--- a/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query54.out
+++ b/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query54.out
@@ -23,7 +23,7 @@ PhysicalResultSink
 ----------------------------------------PhysicalProject
 ------------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->[c_current_addr_sk]
 --------------------------------------------PhysicalProject
-----------------------------------------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((my_customers.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk]
+----------------------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((my_customers.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->[ss_customer_sk]
 ------------------------------------------------PhysicalProject
 --------------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF7
 ------------------------------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query72.out
+++ b/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query72.out
@@ -12,15 +12,15 @@ PhysicalResultSink
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_hdemo_sk = household_demographics.hd_demo_sk)) otherCondition=() build RFs:RF6 hd_demo_sk->[cs_bill_hdemo_sk]
 ----------------------PhysicalProject
-------------------------hashJoin[LEFT_OUTER_JOIN bucketShuffle] hashCondition=((catalog_returns.cr_item_sk = catalog_sales.cs_item_sk) and (catalog_returns.cr_order_number = catalog_sales.cs_order_number)) otherCondition=()
+------------------------hashJoin[LEFT_OUTER_JOIN broadcast] hashCondition=((catalog_sales.cs_promo_sk = promotion.p_promo_sk)) otherCondition=()
 --------------------------PhysicalProject
-----------------------------hashJoin[LEFT_OUTER_JOIN broadcast] hashCondition=((catalog_sales.cs_promo_sk = promotion.p_promo_sk)) otherCondition=()
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_ship_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_ship_date_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_ship_date_sk = d3.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[cs_ship_date_sk]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[inv_date_sk]
 ----------------------------------PhysicalProject
-------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((inventory.inv_date_sk = d2.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[inv_date_sk]
+------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)) otherCondition=() build RFs:RF3 cd_demo_sk->[cs_bill_cdemo_sk]
 --------------------------------------PhysicalProject
-----------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)) otherCondition=() build RFs:RF3 cd_demo_sk->[cs_bill_cdemo_sk]
+----------------------------------------hashJoin[LEFT_OUTER_JOIN shuffle] hashCondition=((catalog_returns.cr_item_sk = catalog_sales.cs_item_sk) and (catalog_returns.cr_order_number = catalog_sales.cs_order_number)) otherCondition=()
 ------------------------------------------PhysicalProject
 --------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[cs_item_sk,inv_item_sk]
 ----------------------------------------------PhysicalProject
@@ -35,16 +35,16 @@ PhysicalResultSink
 ----------------------------------------------PhysicalProject
 ------------------------------------------------PhysicalOlapScan[item]
 ------------------------------------------PhysicalProject
---------------------------------------------filter((customer_demographics.cd_marital_status = 'D'))
-----------------------------------------------PhysicalOlapScan[customer_demographics]
+--------------------------------------------PhysicalOlapScan[catalog_returns]
 --------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[date_dim] apply RFs: RF7
+----------------------------------------filter((customer_demographics.cd_marital_status = 'D'))
+------------------------------------------PhysicalOlapScan[customer_demographics]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------PhysicalOlapScan[date_dim] apply RFs: RF7
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[promotion]
+--------------------------------PhysicalOlapScan[date_dim]
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_returns]
+----------------------------PhysicalOlapScan[promotion]
 ----------------------PhysicalProject
 ------------------------filter((household_demographics.hd_buy_potential = '1001-5000'))
 --------------------------PhysicalOlapScan[household_demographics]

--- a/regression-test/data/shape_check/tpch_sf1000/hint/q15.out
+++ b/regression-test/data/shape_check/tpch_sf1000/hint/q15.out
@@ -7,7 +7,7 @@ PhysicalResultSink
 --------PhysicalProject
 ----------hashJoin[INNER_JOIN broadcast] hashCondition=((revenue0.total_revenue = max(total_revenue))) otherCondition=()
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((supplier.s_suppkey = revenue0.supplier_no)) otherCondition=()
+--------------hashJoin[INNER_JOIN shuffleBucket] hashCondition=((supplier.s_suppkey = revenue0.supplier_no)) otherCondition=()
 ----------------PhysicalProject
 ------------------PhysicalOlapScan[supplier]
 ----------------PhysicalProject

--- a/regression-test/data/shape_check/tpch_sf1000/hint/q8.out
+++ b/regression-test/data/shape_check/tpch_sf1000/hint/q8.out
@@ -11,7 +11,7 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((supplier.s_nationkey = n2.n_nationkey)) otherCondition=()
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((supplier.s_suppkey = lineitem.l_suppkey)) otherCondition=()
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((supplier.s_suppkey = lineitem.l_suppkey)) otherCondition=()
 ------------------------PhysicalProject
 --------------------------PhysicalOlapScan[supplier]
 ------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpch_sf1000/rf_prune/q15.out
+++ b/regression-test/data/shape_check/tpch_sf1000/rf_prune/q15.out
@@ -7,9 +7,7 @@ PhysicalResultSink
 --------PhysicalProject
 ----------hashJoin[INNER_JOIN broadcast] hashCondition=((revenue0.total_revenue = max(total_revenue))) otherCondition=()
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((supplier.s_suppkey = revenue0.supplier_no)) otherCondition=() build RFs:RF0 supplier_no->[s_suppkey]
-----------------PhysicalProject
-------------------PhysicalOlapScan[supplier] apply RFs: RF0
+--------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((supplier.s_suppkey = revenue0.supplier_no)) otherCondition=()
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
@@ -17,6 +15,8 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------filter((lineitem.l_shipdate < '1996-04-01') and (lineitem.l_shipdate >= '1996-01-01'))
 ----------------------------PhysicalOlapScan[lineitem]
+----------------PhysicalProject
+------------------PhysicalOlapScan[supplier]
 ------------hashAgg[GLOBAL]
 --------------PhysicalDistribute[DistributionSpecGather]
 ----------------hashAgg[LOCAL]

--- a/regression-test/data/shape_check/tpch_sf1000/rf_prune/q8.out
+++ b/regression-test/data/shape_check/tpch_sf1000/rf_prune/q8.out
@@ -11,7 +11,7 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((supplier.s_nationkey = n2.n_nationkey)) otherCondition=()
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((supplier.s_suppkey = lineitem.l_suppkey)) otherCondition=() build RFs:RF5 l_suppkey->[s_suppkey]
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((supplier.s_suppkey = lineitem.l_suppkey)) otherCondition=() build RFs:RF5 l_suppkey->[s_suppkey]
 ------------------------PhysicalProject
 --------------------------PhysicalOlapScan[supplier] apply RFs: RF5
 ------------------------PhysicalProject

--- a/regression-test/data/shape_check/tpch_sf1000/shape/q15.out
+++ b/regression-test/data/shape_check/tpch_sf1000/shape/q15.out
@@ -7,16 +7,16 @@ PhysicalResultSink
 --------PhysicalProject
 ----------hashJoin[INNER_JOIN broadcast] hashCondition=((revenue0.total_revenue = max(total_revenue))) otherCondition=()
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((supplier.s_suppkey = revenue0.supplier_no)) otherCondition=() build RFs:RF0 supplier_no->[s_suppkey]
-----------------PhysicalProject
-------------------PhysicalOlapScan[supplier] apply RFs: RF0
+--------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((supplier.s_suppkey = revenue0.supplier_no)) otherCondition=() build RFs:RF0 s_suppkey->[l_suppkey]
 ----------------PhysicalProject
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
 --------------------------filter((lineitem.l_shipdate < '1996-04-01') and (lineitem.l_shipdate >= '1996-01-01'))
-----------------------------PhysicalOlapScan[lineitem]
+----------------------------PhysicalOlapScan[lineitem] apply RFs: RF0
+----------------PhysicalProject
+------------------PhysicalOlapScan[supplier]
 ------------hashAgg[GLOBAL]
 --------------PhysicalDistribute[DistributionSpecGather]
 ----------------hashAgg[LOCAL]

--- a/regression-test/data/shape_check/tpch_sf1000/shape/q8.out
+++ b/regression-test/data/shape_check/tpch_sf1000/shape/q8.out
@@ -11,7 +11,7 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN broadcast] hashCondition=((supplier.s_nationkey = n2.n_nationkey)) otherCondition=() build RFs:RF6 n_nationkey->[s_nationkey]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((supplier.s_suppkey = lineitem.l_suppkey)) otherCondition=() build RFs:RF5 l_suppkey->[s_suppkey]
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((supplier.s_suppkey = lineitem.l_suppkey)) otherCondition=() build RFs:RF5 l_suppkey->[s_suppkey]
 ------------------------PhysicalProject
 --------------------------PhysicalOlapScan[supplier] apply RFs: RF5 RF6
 ------------------------PhysicalProject


### PR DESCRIPTION
### What problem does this PR solve?
PR#36784: Bucket shuffle join shall be disabled if the number of scan instances for the left table of the join is less than 10.
The value "10" should not be hardcoded here; instead, it should be calculated based on the cluster size. This PR will replace the fixed value "10" with a dynamic value equal to 0.8 times the maximum concurrency of the cluster.
 
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

