### PR TITLE
[refactor](compress) Unify the decompressin error msg

### DIFF
--- a/be/src/exec/decompressor.cpp
+++ b/be/src/exec/decompressor.cpp
@@ -221,10 +221,10 @@ Status GzipDecompressor::decompress(uint8_t* input, uint32_t input_len, size_t* 
             // reset _z_strm to continue decoding a subsequent gzip stream
             ret = inflateReset(&_z_strm);
             if (ret != Z_OK) {
-                return Status::InternalError("Failed to inflateReset. return code: {}", ret);
+                return Status::InternalError("Failed to do gzip decompress. return code: {}", ret);
             }
         } else if (ret != Z_OK) {
-            return Status::InternalError("Failed to inflate. return code: {}", ret);
+            return Status::InternalError("Failed to do gzip decompress. return code: {}", ret);
         } else {
             // here ret must be Z_OK.
             // we continue if avail_out and avail_in > 0.
@@ -549,7 +549,7 @@ Status Lz4BlockDecompressor::decompress(uint8_t* input, uint32_t input_len,
                     reinterpret_cast<const char*>(input_ptr), reinterpret_cast<char*>(output_ptr),
                     compressed_small_block_len, remaining_output_len);
             if (decompressed_small_block_len < 0) {
-                return Status::InvalidArgument("fail to do LZ4 decompress, error = {}",
+                return Status::InvalidArgument("Failed to Lz4Block decompress, error = {}",
                                                LZ4F_getErrorName(decompressed_small_block_len));
             }
             input_ptr += compressed_small_block_len;

--- a/be/src/exec/decompressor.cpp
+++ b/be/src/exec/decompressor.cpp
@@ -282,14 +282,12 @@ Status Bzip2Decompressor::decompress(uint8_t* input, uint32_t input_len, size_t*
             *stream_end = true;
             ret = BZ2_bzDecompressEnd(&_bz_strm);
             if (ret != BZ_OK) {
-                return Status::InternalError(
-                        "Failed to do bz2 decompress. status code: {}", ret);
+                return Status::InternalError("Failed to do bz2 decompress. status code: {}", ret);
             }
 
             ret = BZ2_bzDecompressInit(&_bz_strm, 0, 0);
             if (ret != BZ_OK) {
-                return Status::InternalError(
-                        "Failed to do bz2 decompress. status code: {}", ret);
+                return Status::InternalError("Failed to do bz2 decompress. status code: {}", ret);
             }
         } else if (ret != BZ_OK) {
             return Status::InternalError("Failed to bz2 decompress. status code: {}", ret);

--- a/be/src/exec/decompressor.cpp
+++ b/be/src/exec/decompressor.cpp
@@ -221,10 +221,18 @@ Status GzipDecompressor::decompress(uint8_t* input, uint32_t input_len, size_t* 
             // reset _z_strm to continue decoding a subsequent gzip stream
             ret = inflateReset(&_z_strm);
             if (ret != Z_OK) {
-                return Status::InternalError("Failed to do gzip decompress. return code: {}", ret);
+                if (_is_deflate) {
+                    return Status::InternalError("Failed to do deflate decompress. return code: {}", ret);
+                } else {
+                    return Status::InternalError("Failed to do gzip decompress. return code: {}", ret);
+                }
             }
         } else if (ret != Z_OK) {
-            return Status::InternalError("Failed to do gzip decompress. return code: {}", ret);
+            if (_is_deflate) {
+                return Status::InternalError("Failed to do deflate decompress. return code: {}", ret);
+            } else {
+                return Status::InternalError("Failed to do gzip decompress. return code: {}", ret);
+            }
         } else {
             // here ret must be Z_OK.
             // we continue if avail_out and avail_in > 0.

--- a/be/src/exec/decompressor.cpp
+++ b/be/src/exec/decompressor.cpp
@@ -222,14 +222,17 @@ Status GzipDecompressor::decompress(uint8_t* input, uint32_t input_len, size_t* 
             ret = inflateReset(&_z_strm);
             if (ret != Z_OK) {
                 if (_is_deflate) {
-                    return Status::InternalError("Failed to do deflate decompress. return code: {}", ret);
+                    return Status::InternalError("Failed to do deflate decompress. return code: {}",
+                                                 ret);
                 } else {
-                    return Status::InternalError("Failed to do gzip decompress. return code: {}", ret);
+                    return Status::InternalError("Failed to do gzip decompress. return code: {}",
+                                                 ret);
                 }
             }
         } else if (ret != Z_OK) {
             if (_is_deflate) {
-                return Status::InternalError("Failed to do deflate decompress. return code: {}", ret);
+                return Status::InternalError("Failed to do deflate decompress. return code: {}",
+                                             ret);
             } else {
                 return Status::InternalError("Failed to do gzip decompress. return code: {}", ret);
             }


### PR DESCRIPTION
### What problem does this PR solve?

Unify the error messages in decompression methods to be  "Failed to do xxxx decompress".

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

