### PR TITLE
[metrics](warmup) add bvar for skipped warmup rowsets

### DIFF
--- a/be/src/cloud/cloud_warm_up_manager.cpp
+++ b/be/src/cloud/cloud_warm_up_manager.cpp
@@ -42,6 +42,8 @@
 namespace doris {
 #include "common/compile_check_begin.h"
 
+bvar::Adder<uint64_t> g_file_cache_event_driven_warm_up_skipped_rowset_num(
+        "file_cache_event_driven_warm_up_skipped_rowset_num");
 bvar::Adder<uint64_t> g_file_cache_event_driven_warm_up_requested_segment_size(
         "file_cache_event_driven_warm_up_requested_segment_size");
 bvar::Adder<uint64_t> g_file_cache_event_driven_warm_up_requested_segment_num(
@@ -554,6 +556,7 @@ void CloudWarmUpManager::warm_up_rowset(RowsetMeta& rs_meta, int64_t sync_wait_t
     if (replicas.empty()) {
         VLOG_DEBUG << "There is no need to warmup tablet=" << rs_meta.tablet_id()
                    << ", skipping rowset=" << rs_meta.rowset_id().to_string();
+        g_file_cache_event_driven_warm_up_skipped_rowset_num << 1;
         return;
     }
     Status st = _do_warm_up_rowset(rs_meta, replicas, sync_wait_timeout_ms, !cache_hit);


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Adds the bvar `file_cache_event_driven_warm_up_skipped_rowset_num` to the source cluster Backend to improve observability of the cache warmup process.

During event-driven warmup, rowsets can be skipped if the Backend fails to find the tablet's replica location information from a `TGetTabletReplicaInfosRequest`.

This new metric makes it possible to monitor and alert on these events, which helps in diagnosing incomplete cache warmups.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

