### PR TITLE
[opt](partition) process auto partition name when its length exceeds 50

### DIFF
--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -249,8 +249,8 @@ private:
             res_s += '_';
         }
         for (int i = 0; i < s.length(); i++) {
-            char ch = s[i];
-            if (std::isalnum(ch)) {
+            char16_t ch = s[i];
+            if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9')) {
                 res_s += ch;
             } else {
                 int unicodeValue = _get_code_point_at(s, i);
@@ -307,9 +307,9 @@ private:
 
             // check the name of length
             int len = res_p.size();
-            if (len > 50) [[unlikely]] {
-                return Status::InvalidArgument(
-                        "The list partition name cannot exceed 50 characters");
+            if (len > 50) {
+                res_p = std::format("{}_{:08x}", res_p.substr(0, 50), to_hash_code(res_p));
+                len = res_p.size();
             }
             curr_len += len;
             res_data.resize(curr_len);
@@ -400,6 +400,14 @@ private:
         }
         block.get_by_position(result).column = std::move(res);
         return Status::OK();
+    }
+
+    int32_t to_hash_code(const std::string& str) const {
+        int32_t h = 0;
+        for (uint8_t c : str) {
+            h = 31 * h + c;
+        }
+        return h;
     }
 };
 

--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -403,11 +403,11 @@ private:
     }
 
     int32_t to_hash_code(const std::string& str) const {
-        int32_t h = 0;
+        uint64_t h = 0;
         for (uint8_t c : str) {
-            h = 31 * h + c;
+            h = (h * 31U + c) & 0xFFFFFFFFU;
         }
-        return h;
+        return static_cast<int32_t>(h);
     }
 };
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/PartitionExprUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/PartitionExprUtil.java
@@ -45,6 +45,7 @@ public class PartitionExprUtil {
     public static final String DATETIME_NAME_FORMATTER = "%04d%02d%02d%02d%02d%02d";
     private static final Logger LOG = LogManager.getLogger(PartitionExprUtil.class);
     private static final PartitionExprUtil partitionExprUtil = new PartitionExprUtil();
+    private static final int MAX_PARTITION_NAME_LENGTH = 50;
 
     public static FunctionIntervalInfo getFunctionIntervalInfo(ArrayList<Expr> partitionExprs,
             PartitionType partitionType) throws AnalysisException {
@@ -176,8 +177,9 @@ public class PartitionExprUtil {
                 partitionKeyDesc = PartitionKeyDesc.createIn(listValues);
                 partitionName += getFormatPartitionValue(filterStr);
                 if (hasStringType) {
-                    if (partitionName.length() > 50) {
-                        throw new AnalysisException("Partition name's length is over limit of 50. abort to create.");
+                    if (partitionName.length() > MAX_PARTITION_NAME_LENGTH) {
+                        partitionName = partitionName.substring(0, MAX_PARTITION_NAME_LENGTH)
+                                + "_" + Integer.toHexString(partitionName.hashCode());
                     }
                 }
             } else {

--- a/regression-test/data/nereids_function_p0/scalar_function/A.out
+++ b/regression-test/data/nereids_function_p0/scalar_function/A.out
@@ -509,6 +509,12 @@ p4023ffe5257e7cworld111112e2e2e2e20
 -- !sql_auto_partition_name_list_literal_mixed --
 plist4X11X
 
+-- !sql_auto_partition_name_list_literal_mixed --
+p4f60597d20hello214023ffe5257e7cworld111112e2e2e2e_14dcd01b
+
+-- !sql_auto_partition_name_list_literal_mixed --
+pthis5fis5fa5fvery5flong5ftenant5fgroup5fname5ftha_45266af1
+
 -- !sql_auto_partition_name_list_literal_null --
 pXXX
 

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_ctas_to_doris.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_ctas_to_doris.groovy
@@ -76,14 +76,13 @@ suite("test_hive_ctas_to_doris", "p0,external,hive,external_docker,external_dock
                 sql """ create table internal.${db_name}.${hive_tb}_4 (id,str2,str3,str1) auto partition by list (str1)() properties("replication_num" = "1") as select id, str1, str2, str3 from ${catalog}.${db_name}.${hive_tb} """
                 assertTrue(false)
             } catch (Exception ex) {
-                assertTrue(ex.getMessage().contains("Partition name's length is over limit of 50"))
+                assertTrue(ex.getMessage().contains("Insert has filtered data in strict mode"))
             }
 
-            try {
-                sql """ create table internal.${db_name}.${hive_tb}_5 (id,str1,str3,str2) auto partition by list (str2)() properties("replication_num" = "1") as select id, str1, str2, str3 from ${catalog}.${db_name}.${hive_tb} """
-                assertTrue(false)
-            } catch (Exception ex) {
-                assertTrue(ex.getMessage().contains("Partition name's length is over limit of 50"))
+            sql """ create table internal.${db_name}.${hive_tb}_5 (id,str1,str3,str2) auto partition by list (str2)() properties("replication_num" = "1") as select id, str1, str2, str3 from ${catalog}.${db_name}.${hive_tb} """
+            def results = sql"""show partitions from internal.${db_name}.${hive_tb}_5"""
+            for (def result : results) {
+                assertTrue(result[1].length() <= 62)
             }
 
             try {

--- a/regression-test/suites/nereids_function_p0/scalar_function/A.groovy
+++ b/regression-test/suites/nereids_function_p0/scalar_function/A.groovy
@@ -87,6 +87,9 @@ suite("nereids_scalar_fn_A") {
 	qt_sql_auto_partition_name_list_literal_mixed "select auto_partition_name('list', '-hello')"
 	qt_sql_auto_partition_name_list_literal_mixed "select auto_partition_name('list', '@#￥%~|world11111....')"
 	qt_sql_auto_partition_name_list_literal_mixed "select auto_partition_name('list', 'list', null, true, null)"
+	qt_sql_auto_partition_name_list_literal_mixed "select auto_partition_name('list', '你好 hello!@#￥%~|world11111.... 世界');"
+	qt_sql_auto_partition_name_list_literal_mixed "select auto_partition_name('list', 'this_is_a_very_long_tenant_group_name_that_will_cause_partition_name_to_exceed_fifty_characters');"
+
 	qt_sql_auto_partition_name_list_literal_null "select auto_partition_name('list', null, null, null);"
 	qt_sql_auto_partition_name_range_literal_notnull "select auto_partition_name('range', 'day', '2022-12-12 19:20:30')"
 	qt_sql_auto_partition_name_range_literal_notnull "select auto_partition_name('range', 'month', '2022-12-12 19:20:30')"
@@ -152,9 +155,5 @@ suite("nereids_scalar_fn_A") {
 	test{
 		sql """select auto_partition_name('range', 'years', 'hello');"""
 		exception "range auto_partition_name must accept year|month|day|hour|minute|second for 2nd argument"
-	}
-	test{
-		sql "select auto_partition_name('list', '你好', 'hello!@#￥%~|world11111....', '世界')"
-		exception "The list partition name cannot exceed 50 characters"
 	}
 }

--- a/regression-test/suites/partition_p0/auto_partition/test_auto_partition_behavior.groovy
+++ b/regression-test/suites/partition_p0/auto_partition/test_auto_partition_behavior.groovy
@@ -225,12 +225,11 @@ suite("test_auto_partition_behavior") {
             "replication_num" = "1"
         );
     """
-    test{
-        sql """insert into `long_value` values ("jwklefjklwehrnkjlwbfjkwhefkjhwjkefhkjwehfkjwehfkjwehfkjbvkwebconqkcqnocdmowqmosqmojwnqknrviuwbnclkmwkj");"""
-        def exception_str = isGroupCommitMode() ? "s length is over limit of 50." : "Partition name's length is over limit of 50."
-        exception exception_str
-    }
 
+    sql """insert into `long_value` values ("jwklefjklwehrnkjlwbfjkwhefkjhwjkefhkjwehfkjwehfkjwehfkjbvkwebconqkcqnocdmowqmosqmojwnqknrviuwbnclkmwkj");"""
+    def maxPartitionNameRes = sql "show partitions from long_value"
+    def maxPartitionName = maxPartitionNameRes[0][1]
+    assertTrue(maxPartitionName.length() <= 62, "actual length:" + maxPartitionName.length())
 
 
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Before, when meet a auto partition name exceeds 50, doris will throw
```text
errCode = 2, detailMessage = Partition name's length is over limit of 50. abort to create.
```
This pr replace the exception throwing with truncating and hashing to re-construct the partition name. For example
`this_is_a_very_long_tenant_group_name_that_will_cause_partition_name_to_exceed_fifty_characters` will be constructed to `pthis5fis5fa5fvery5flong5ftenant5fgroup5fname5ftha_45266af1`

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

