### PR TITLE
ui: remove unused dependencies

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -30,17 +30,14 @@
     "@ant-design/icons": "^4.1.0",
     "@umijs/hooks": "^1.9.3",
     "antd": "^4.5.4",
-    "axios": "^0.19.2",
     "classnames": "^2.2.6",
     "i18next": "^19.7.0",
     "i18next-browser-languagedetector": "^6.0.1",
     "json-bigint": "^1.0.0",
     "lodash-decorators": "^6.0.1",
-    "path-to-regexp": "^2.2.0",
     "react": "^16.13.1",
     "react-codemirror2": "^7.1.0",
     "react-dom": "^16.13.1",
-    "react-draggable": "4.4.6",
     "react-i18next": "^11.7.2",
     "react-resizable": "^1.10.1",
     "react-router": "^5.2.0",
@@ -79,8 +76,5 @@
     "webpack-cli": "^3.3.3",
     "webpack-dev-server": "^3.7.1",
     "webpack-merge": "^4.2.1"
-  },
-  "resolutions": {
-    "react-draggable": "4.4.6"
   }
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -38,6 +38,7 @@
     "react": "^16.13.1",
     "react-codemirror2": "^7.1.0",
     "react-dom": "^16.13.1",
+    "react-draggable": "4.4.6",
     "react-i18next": "^11.7.2",
     "react-resizable": "^1.10.1",
     "react-router": "^5.2.0",
@@ -76,5 +77,8 @@
     "webpack-cli": "^3.3.3",
     "webpack-dev-server": "^3.7.1",
     "webpack-merge": "^4.2.1"
+  },
+  "resolutions": {
+    "react-draggable": "4.4.6"
   }
 }


### PR DESCRIPTION
removes 2 unused dependencies (`axios` and `path-to-regexp`)