### PR TITLE
[fix](inverted index) fix boolean query for NOT operator

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index/query_v2/boolean_query/boolean_weight.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index/query_v2/boolean_query/boolean_weight.h
@@ -88,7 +88,8 @@ public:
             if (max_doc == 0) {
                 return make_empty();
             }
-            auto match_all = std::make_shared<MatchAllDocsScorer>(max_doc, composite_reader->readers());
+            auto match_all =
+                    std::make_shared<MatchAllDocsScorer>(max_doc, composite_reader->readers());
             if (_sub_weights.empty()) {
                 return match_all;
             }

--- a/be/src/olap/rowset/segment_v2/inverted_index/query_v2/intersection_scorer.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index/query_v2/intersection_scorer.h
@@ -25,6 +25,25 @@ namespace doris::segment_v2::inverted_index::query_v2 {
 
 ScorerPtr intersection_scorer_build(std::vector<ScorerPtr>& scorers);
 
+class AndNotScorer final : public Scorer {
+public:
+    AndNotScorer(ScorerPtr include, std::vector<ScorerPtr> excludes);
+    ~AndNotScorer() override = default;
+
+    uint32_t advance() override;
+    uint32_t seek(uint32_t target) override;
+    uint32_t doc() const override;
+    uint32_t size_hint() const override;
+
+    float score() override;
+
+private:
+    uint32_t _align(uint32_t candidate);
+
+    ScorerPtr _include;
+    std::vector<ScorerPtr> _excludes;
+};
+
 template <typename PivotScorerPtr>
 class IntersectionScorer final : public Scorer {
 public:

--- a/be/src/olap/rowset/segment_v2/inverted_index/query_v2/match_all_docs_scorer.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index/query_v2/match_all_docs_scorer.h
@@ -21,14 +21,13 @@
 #include <vector>
 
 #include "CLucene.h" // IWYU pragma: keep
-#include "CLucene/index/IndexReader.h"
 #include "olap/rowset/segment_v2/inverted_index/query_v2/scorer.h"
 
 namespace doris::segment_v2::inverted_index::query_v2 {
 
-class MatchAllScorer : public Scorer {
+class MatchAllDocsScorer : public Scorer {
 public:
-    MatchAllScorer(uint32_t max_doc, std::vector<lucene::index::IndexReader*> readers)
+    MatchAllDocsScorer(uint32_t max_doc, std::vector<lucene::index::IndexReader*> readers)
             : _max_doc(max_doc), _readers(std::move(readers)) {
         if (_max_doc == 0) {
             _doc = TERMINATED;
@@ -36,7 +35,7 @@ public:
             _doc = _next_live_doc(0);
         }
     }
-    ~MatchAllScorer() override = default;
+    ~MatchAllDocsScorer() override = default;
 
     uint32_t advance() override {
         if (_doc == TERMINATED) {

--- a/be/src/olap/rowset/segment_v2/inverted_index/query_v2/match_all_scorer.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index/query_v2/match_all_scorer.h
@@ -1,0 +1,100 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "CLucene.h" // IWYU pragma: keep
+#include "CLucene/index/IndexReader.h"
+
+#include <utility>
+#include <vector>
+
+#include "olap/rowset/segment_v2/inverted_index/query_v2/scorer.h"
+
+namespace doris::segment_v2::inverted_index::query_v2 {
+
+class MatchAllScorer : public Scorer {
+public:
+    MatchAllScorer(uint32_t max_doc, std::vector<lucene::index::IndexReader*> readers)
+            : _max_doc(max_doc), _readers(std::move(readers)) {
+        if (_max_doc == 0) {
+            _doc = TERMINATED;
+        } else {
+            _doc = _next_live_doc(0);
+        }
+    }
+    ~MatchAllScorer() override = default;
+
+    uint32_t advance() override {
+        if (_doc == TERMINATED) {
+            return TERMINATED;
+        }
+        uint32_t candidate = _doc + 1;
+        if (candidate >= _max_doc) {
+            _doc = TERMINATED;
+            return TERMINATED;
+        }
+        _doc = _next_live_doc(candidate);
+        return _doc;
+    }
+
+    uint32_t seek(uint32_t target) override {
+        if (_doc == TERMINATED) {
+            return TERMINATED;
+        }
+        if (target <= _doc) {
+            return _doc;
+        }
+        if (target >= _max_doc) {
+            _doc = TERMINATED;
+            return TERMINATED;
+        }
+        _doc = _next_live_doc(target);
+        return _doc;
+    }
+
+    uint32_t doc() const override { return _doc; }
+
+    uint32_t size_hint() const override { return _max_doc; }
+
+    float score() override { return 1.0F; }
+
+private:
+    [[nodiscard]] uint32_t _next_live_doc(uint32_t start) const {
+        for (uint32_t doc = start; doc < _max_doc; ++doc) {
+            if (_is_live(doc)) {
+                return doc;
+            }
+        }
+        return TERMINATED;
+    }
+
+    [[nodiscard]] bool _is_live(uint32_t doc) const {
+        for (auto* reader : _readers) {
+            if (reader != nullptr && reader->isDeleted(static_cast<int32_t>(doc))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    uint32_t _max_doc;
+    std::vector<lucene::index::IndexReader*> _readers;
+    uint32_t _doc = TERMINATED;
+};
+
+} // namespace doris::segment_v2::inverted_index::query_v2

--- a/be/src/olap/rowset/segment_v2/inverted_index/query_v2/match_all_scorer.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index/query_v2/match_all_scorer.h
@@ -17,12 +17,11 @@
 
 #pragma once
 
-#include "CLucene.h" // IWYU pragma: keep
-#include "CLucene/index/IndexReader.h"
-
 #include <utility>
 #include <vector>
 
+#include "CLucene.h" // IWYU pragma: keep
+#include "CLucene/index/IndexReader.h"
 #include "olap/rowset/segment_v2/inverted_index/query_v2/scorer.h"
 
 namespace doris::segment_v2::inverted_index::query_v2 {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #55721

Problem Summary:
This PR implements support for NOT operations in the boolean query system for inverted index queries. The changes add proper handling of negation operations that were previously missing or incomplete.

Adds MatchAllDocsScorer class to handle matching all documents in an index
Implements AndNotScorer for excluding documents based on exclusion criteria
Updates BooleanWeight to properly handle NOT operations and combinations with AND/OR
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

