### PR TITLE
 [fix](github) force use text diff for .out files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,6 @@
 *.thrift text eol=lf
 *.proto text eol=lf
 *.conf text eol=lf
-*.out text eol=lf -diff
+*.out text eol=lf diff
 *.groovy -linguist-detectable
 regression-test/ export-ignore


### PR DESCRIPTION
when executing `git diff`, treat .out file as text file