### PR TITLE
[chore](jsonb) Remove unused code from ObjectVal

### DIFF
--- a/be/src/util/jsonb_document.cpp
+++ b/be/src/util/jsonb_document.cpp
@@ -66,9 +66,9 @@ JsonbFindResult JsonbValue::findValue(JsonbPath& path) const {
                         continue;
                     }
 
-                    pval = pval->unpack<ObjectVal>()->find(path.get_leg_from_leg_vector(i)->leg_ptr,
-                                                           path.get_leg_from_leg_vector(i)->leg_len,
-                                                           nullptr);
+                    pval = pval->unpack<ObjectVal>()->find(
+                            path.get_leg_from_leg_vector(i)->leg_ptr,
+                            path.get_leg_from_leg_vector(i)->leg_len);
 
                     if (pval) {
                         results.emplace_back(pval);

--- a/be/src/util/jsonb_document.h
+++ b/be/src/util/jsonb_document.h
@@ -1253,10 +1253,9 @@ inline bool JsonbValue::contains(JsonbValue* rhs) const {
         if (rhs->isObject()) {
             const auto* obj_value1 = unpack<ObjectVal>();
             const auto* obj_value2 = rhs->unpack<ObjectVal>();
-
-            for (auto it : *obj_value2) {
-                JsonbValue* value = obj_value1->find(it.getKeyStr(), it.klen());
-                if (value == nullptr || !value->contains(it.value())) {
+            for (auto it = obj_value2->begin(); it != obj_value2->end(); ++it) {
+                JsonbValue* value = obj_value1->find(it->getKeyStr(), it->klen());
+                if (value == nullptr || !value->contains(it->value())) {
                     return false;
                 }
             }

--- a/be/src/util/jsonb_document.h
+++ b/be/src/util/jsonb_document.h
@@ -903,52 +903,26 @@ struct ObjectVal : public ContainerVal {
     using iterator = JsonbFwdIteratorT<pointer, ObjectVal>;
     using const_iterator = JsonbFwdIteratorT<const_pointer, ObjectVal>;
 
-    const_iterator search(const char* key, hDictFind handler = nullptr) const {
-        return const_cast<ObjectVal*>(this)->search(key, handler);
+    const_iterator search(const char* key) const {
+        return const_cast<ObjectVal*>(this)->search(key);
     }
 
-    const_iterator search(const char* key, unsigned int klen, hDictFind handler = nullptr) const {
-        return const_cast<ObjectVal*>(this)->search(key, klen, handler);
+    const_iterator search(const char* key, unsigned int klen) const {
+        return const_cast<ObjectVal*>(this)->search(key, klen);
     }
 
-    const_iterator search(int key_id) const { return const_cast<ObjectVal*>(this)->search(key_id); }
-    iterator search(const char* key, hDictFind handler = nullptr) {
+    iterator search(const char* key) {
         if (!key) {
             return end();
         }
-        return search(key, (unsigned int)strlen(key), handler);
+        return search(key, (unsigned int)strlen(key));
     }
 
-    iterator search(const char* key, unsigned int klen, hDictFind handler = nullptr) {
+    iterator search(const char* key, unsigned int klen) {
         if (!key || !klen) {
             return end();
         }
-
-        int key_id = -1;
-        if (handler && (key_id = handler(key, klen)) >= 0) {
-            return search(key_id);
-        }
         return internalSearch(key, klen);
-    }
-
-    iterator search(int key_id) {
-        if (key_id < 0 || key_id > JsonbKeyValue::sMaxKeyId) {
-            return end();
-        }
-
-        const char* pch = payload;
-        const char* fence = payload + size;
-
-        while (pch < fence) {
-            auto* pkey = (JsonbKeyValue*)(pch);
-            if (!pkey->klen() && key_id == pkey->getKeyId()) {
-                return iterator(pkey);
-            }
-            pch += pkey->numPackedBytes();
-        }
-
-        assert(pch == fence);
-        return end();
     }
 
     // Get number of elements in object
@@ -968,54 +942,23 @@ struct ObjectVal : public ContainerVal {
         return num;
     }
 
-    JsonbKeyValue* getJsonbKeyValue(unsigned int i) const {
-        const char* pch = payload;
-        const char* fence = payload + size;
+    JsonbValue* find(const char* key) const { return const_cast<ObjectVal*>(this)->find(key); }
 
-        unsigned int num = 0;
-        while (pch < fence) {
-            auto* pkey = (JsonbKeyValue*)(pch);
-            if (num == i) {
-                return pkey;
-            }
-            ++num;
-            pch += pkey->numPackedBytes();
-        }
-
-        assert(pch == fence);
-
-        return nullptr;
+    JsonbValue* find(const char* key, unsigned int klen) const {
+        return const_cast<ObjectVal*>(this)->find(key, klen);
     }
-
-    JsonbValue* find(const char* key, hDictFind handler = nullptr) const {
-        return const_cast<ObjectVal*>(this)->find(key, handler);
-    }
-
-    JsonbValue* find(const char* key, unsigned int klen, hDictFind handler = nullptr) const {
-        return const_cast<ObjectVal*>(this)->find(key, klen, handler);
-    }
-    JsonbValue* find(int key_id) const { return const_cast<ObjectVal*>(this)->find(key_id); }
 
     // find the JSONB value by a key string (null terminated)
-    JsonbValue* find(const char* key, hDictFind handler = nullptr) {
+    JsonbValue* find(const char* key) {
         if (!key) {
             return nullptr;
         }
-        return find(key, (unsigned int)strlen(key), handler);
+        return find(key, (unsigned int)strlen(key));
     }
 
     // find the JSONB value by a key string (with length)
-    JsonbValue* find(const char* key, unsigned int klen, hDictFind handler = nullptr) {
-        iterator kv = search(key, klen, handler);
-        if (end() == kv) {
-            return nullptr;
-        }
-        return kv->value();
-    }
-
-    // find the JSONB value by a key dictionary ID
-    JsonbValue* find(int key_id) {
-        iterator kv = search(key_id);
+    JsonbValue* find(const char* key, unsigned int klen) {
+        iterator kv = search(key, klen);
         if (end() == kv) {
             return nullptr;
         }
@@ -1310,10 +1253,10 @@ inline bool JsonbValue::contains(JsonbValue* rhs) const {
         if (rhs->isObject()) {
             const auto* obj_value1 = unpack<ObjectVal>();
             const auto* obj_value2 = rhs->unpack<ObjectVal>();
-            for (int i = 0; i < obj_value2->numElem(); ++i) {
-                JsonbKeyValue* key = obj_value2->getJsonbKeyValue(i);
-                JsonbValue* value = obj_value1->find(key->getKeyStr(), key->klen());
-                if (value == nullptr || !value->contains(key->value())) {
+
+            for (auto it : *obj_value2) {
+                JsonbValue* value = obj_value1->find(it.getKeyStr(), it.klen());
+                if (value == nullptr || !value->contains(it.value())) {
                     return false;
                 }
             }

--- a/be/test/vec/jsonb/jsonb_document_test.cpp
+++ b/be/test/vec/jsonb/jsonb_document_test.cpp
@@ -213,4 +213,49 @@ TEST_F(JsonbDocumentTest, writer) {
             R"("key_decimal256":3402823669209384634633746074317.68211454})");
     ASSERT_EQ(json_string, expected_string);
 }
+
+TEST_F(JsonbDocumentTest, forobject) {
+    JsonbWriter writer;
+    writer.writeStartObject();
+
+    writer.writeKey("key_null");
+    writer.writeNull();
+
+    writer.writeKey("key_true");
+    writer.writeBool(true);
+
+    writer.writeKey("key_false");
+    writer.writeBool(false);
+
+    writer.writeKey("key_int");
+    writer.writeInt(12345);
+
+    // writer array
+
+    writer.writeKey("key_array");
+    writer.writeStartArray();
+    writer.writeInt(1);
+    writer.writeStartString();
+    writer.writeString("array string");
+    writer.writeEndString();
+    writer.writeEndArray();
+
+    writer.writeEndObject();
+
+    JsonbDocument* doc = writer.getDocument();
+    auto* root = doc->getValue();
+    std::cout << JsonbToJson {}.to_json_string(root) << std::endl;
+    EXPECT_EQ(
+            JsonbToJson {}.to_json_string(root),
+            R"({"key_null":null,"key_true":true,"key_false":false,"key_int":12345,"key_array":[1,"array string"]})");
+
+    // object
+    const auto* root_obj = root->unpack<ObjectVal>();
+    EXPECT_EQ(root_obj->numElem(), 5);
+    std::cout << "numElem: " << root_obj->numElem() << std::endl;
+    for (auto it = root_obj->begin(); it != root_obj->end(); ++it) {
+        std::cout << "key: " << std::string(it->getKeyStr(), it->klen()) << std::endl;
+    }
+}
+
 } // namespace doris

--- a/be/test/vec/jsonb/jsonb_document_test.cpp
+++ b/be/test/vec/jsonb/jsonb_document_test.cpp
@@ -256,6 +256,27 @@ TEST_F(JsonbDocumentTest, forobject) {
     for (auto it = root_obj->begin(); it != root_obj->end(); ++it) {
         std::cout << "key: " << std::string(it->getKeyStr(), it->klen()) << std::endl;
     }
+
+    {
+        std::string key = "key_null";
+        {
+            auto val = root_obj->search(key.data(), key.size());
+            EXPECT_TRUE(val != root_obj->end());
+        }
+        {
+            auto val = root_obj->search(key.c_str());
+            EXPECT_TRUE(val != root_obj->end());
+        }
+
+        {
+            auto* val = root_obj->find(key.data(), key.size());
+            EXPECT_TRUE(val != nullptr);
+        }
+        {
+            auto* val = root_obj->find(key.c_str());
+            EXPECT_TRUE(val != nullptr);
+        }
+    }
 }
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

In jsonb ObjectVal, the hDictFind handler is useless and does not accelerate search.
Additionally, the getJsonbKeyValue function has been removed, since random access is not required for JSON objects (the standard specifies that a JSON object is an unordered collection).

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

