### PR TITLE
[Chore](errmsg) refine error message of str_to_date

### DIFF
--- a/be/src/vec/functions/function_other_types_to_date.cpp
+++ b/be/src/vec/functions/function_other_types_to_date.cpp
@@ -259,7 +259,8 @@ private:
         auto& ts_val = *reinterpret_cast<DateValueType*>(&res[index]);
         if (!ts_val.from_date_format_str(r_raw_str, r_str_size, l_raw_str, l_str_size))
                 [[unlikely]] {
-            throw_invalid_string("str_to_date", std::string_view(l_raw_str, l_str_size));
+            throw_invalid_strings("str_to_date", std::string_view(l_raw_str, l_str_size),
+                                  std::string_view(r_raw_str, r_str_size));
         }
         if constexpr (std::is_same_v<DateValueType, VecDateTimeValue>) {
             if (context->get_return_type()->get_primitive_type() ==

--- a/regression-test/suites/correctness/test_str_to_date.groovy
+++ b/regression-test/suites/correctness/test_str_to_date.groovy
@@ -97,4 +97,8 @@ suite("test_str_to_date") {
         """
         exception "is invalid"
     }
+    test {
+        sql "SELECT str_to_date('2022-09-18 00:00:59','%Y-%m-%d %H:%M:%S')"
+        exception "%Y-%m-%d %H:%M:%S is invalid"
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

before:
```sql
mysql> select * from (SELECT str_to_date('2022-09-18 00:00:59','%Y-%m-%d %H:%M:%S') AS `time`) t;
ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[INVALID_ARGUMENT]Operation str_to_date of 2022-09-18 00:00:59 is invalid
```

now:
```sql
mysql> SELECT str_to_date('2022-09-18 00:00:59','%Y-%m-%d %H:%M:%S') AS `time`;
ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[INVALID_ARGUMENT]Operation str_to_date of 2022-09-18 00:00:59, %Y-%m-%d %H:%M:%S is invalid
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

