### PR TITLE
[fix](compile)fix thrift checkstyle compile error

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -172,7 +172,7 @@ under the License.
                         <linkXRef>false</linkXRef>
                         <includeTestSourceDirectory>true</includeTestSourceDirectory>
                         <excludes>
-                            **/apache/doris/thrift/*,
+                            **/apache/doris/thrift/**/*,
                             **/apache/parquet/**/*
                         </excludes>
                     </configuration>


### PR DESCRIPTION
```text
...
[ERROR] doris/fe/fe-common/src/main/java/org/apache/doris/thrift/schema/external/TNestedField.java:258:9: 'block' child has incorrect indentation level 8, expected level should be 16. [Indentation]
[ERROR] doris/fe/fe-common/src/main/java/org/apache/doris/thrift/schema/external/TNestedField.java:259:9: 'block' child has incorrect indentation level 8, expected level should be 16. [Indentation]
[ERROR] doris/fe/fe-common/src/main/java/org/apache/doris/thrift/schema/external/TNestedField.java:260:7: 'case' child has incorrect indentation level 6, expected level should be 12. [Indentation]
[ERROR] doris/fe/fe-common/src/main/java/org/apache/doris/thrift/schema/external/TNestedField.java:261:9: 'block' child has incorrect indentation level 8, expected level should be 16. [Indentation]
...
```

