### PR TITLE
[chore](recycler) Support storage vault for recycler test

### DIFF
--- a/cloud/CMakeLists.txt
+++ b/cloud/CMakeLists.txt
@@ -343,6 +343,11 @@ if(BUILD_AZURE STREQUAL "ON")
     add_definitions(-DUSE_AZURE)
 endif()
 
+message(STATUS "enable vault: ${ENABLE_VAULT}")
+if(ENABLE_VAULT STREQUAL "ON")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_STORAGE_VAULT_FOR_TEST")
+endif()
+
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(ASAN_LIBS -static-libasan)
     set(LSAN_LIBS -static-liblsan)

--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -137,6 +137,7 @@ CONF_String(test_s3_endpoint, "");
 CONF_String(test_s3_region, "");
 CONF_String(test_s3_bucket, "");
 CONF_String(test_s3_prefix, "");
+CONF_String(test_s3_provider, "");
 
 CONF_String(test_hdfs_prefix, "");
 CONF_String(test_hdfs_fs_name, "");

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -544,7 +544,7 @@ InstanceRecycler::~InstanceRecycler() = default;
 
 int InstanceRecycler::init_obj_store_accessors() {
     for (const auto& obj_info : instance_info_.obj_info()) {
-#ifdef UNIT_TEST
+#if defined(UNIT_TEST) && !defined(USE_STORAGE_VAULT_FOR_TEST)
         auto accessor = std::make_shared<MockAccessor>();
 #else
         auto s3_conf = S3Conf::from_obj_store_info(obj_info);
@@ -4543,7 +4543,7 @@ int InstanceRecycler::recycle_copy_jobs() {
 int InstanceRecycler::init_copy_job_accessor(const std::string& stage_id,
                                              const StagePB::StageType& stage_type,
                                              std::shared_ptr<StorageVaultAccessor>* accessor) {
-#ifdef UNIT_TEST
+#if defined(UNIT_TEST) && !defined(USE_STORAGE_VAULT_FOR_TEST)
     // In unit test, external use the same accessor as the internal stage
     auto it = accessor_map_.find(stage_id);
     if (it != accessor_map_.end()) {

--- a/cloud/test/recycler_test.cpp
+++ b/cloud/test/recycler_test.cpp
@@ -60,6 +60,9 @@ std::string instance_id = "instance_id_recycle_test";
 int64_t current_time = 0;
 static constexpr int64_t db_id = 1000;
 static RecyclerMetricsContext ctx;
+static std::string recycler_s3_path = "recycler_test_s3";
+static doris::cloud::ObjectStoreInfoPB_Provider provider =
+        ObjectStoreInfoPB_Provider::ObjectStoreInfoPB_Provider_S3;
 
 std::vector<std::string> index_v2_file_path = {
         "data/1753202639945/0200000000001a5c92f4e7d9j8f2b4c8a3e6f8b1c9d2e5f8_0.idx",
@@ -103,6 +106,23 @@ std::vector<std::string> index_v1_file_path = {
 
 doris::cloud::RecyclerThreadPoolGroup thread_group;
 
+ObjectStoreInfoPB_Provider parser_provider(const std::string& provider_str) {
+    if (provider_str.empty()) {
+        return ObjectStoreInfoPB_Provider::ObjectStoreInfoPB_Provider_S3;
+    }
+    if (provider_str == "S3" || provider_str == "OSS" || provider_str == "COS" ||
+        provider_str == "OBS" || provider_str == "BOS") {
+        return ObjectStoreInfoPB_Provider::ObjectStoreInfoPB_Provider_S3;
+    } else if (provider_str == "GCP") {
+        return ObjectStoreInfoPB_Provider::ObjectStoreInfoPB_Provider_GCP;
+    } else if (provider_str == "AZURE") {
+        return ObjectStoreInfoPB_Provider::ObjectStoreInfoPB_Provider_AZURE;
+    } else {
+        LOG_WARNING("unknown provider {}, use S3 as default", provider_str);
+        return ObjectStoreInfoPB_Provider::ObjectStoreInfoPB_Provider_S3;
+    }
+}
+
 int main(int argc, char** argv) {
     auto conf_file = "doris_cloud.conf";
     if (!cloud::config::init(conf_file, true)) {
@@ -113,6 +133,17 @@ int main(int argc, char** argv) {
         std::cerr << "failed to init glog" << std::endl;
         return -1;
     }
+
+#ifdef USE_STORAGE_VAULT_FOR_TEST
+    if (!config::test_s3_provider.empty()) {
+        provider = parser_provider(config::test_s3_provider);
+        LOG(INFO) << "use test s3 config, bucket=" << config::test_s3_bucket
+                  << ", prefix=" << recycler_s3_path << ", provider=" << provider;
+    } else {
+        std::cerr << "lack of s3 config, please set test_s3_ak/sk/bucket in conf file" << std::endl;
+        return -1;
+    }
+#endif
 
     using namespace std::chrono;
     current_time = duration_cast<seconds>(system_clock::now().time_since_epoch()).count();
@@ -1024,8 +1055,8 @@ static int create_instance(const std::string& internal_stage_id,
                            const std::string& external_stage_id, InstanceInfoPB& instance_info) {
     // create internal stage
     {
-        std::string s3_prefix = "internal_prefix";
-        std::string stage_prefix = fmt::format("{}/stage/root/{}/", s3_prefix, internal_stage_id);
+        std::string stage_prefix =
+                fmt::format("{}/stage/root/{}/", recycler_s3_path, internal_stage_id);
         ObjectStoreInfoPB object_info;
         object_info.set_id(internal_stage_id); // test use accessor_map_ in recycle
 
@@ -1195,7 +1226,8 @@ TEST(RecyclerTest, recycle_empty) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("recycle_empty");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/recycle_empty");
 
     InstanceRecycler recycler(txn_kv, instance, thread_group,
                               std::make_shared<TxnLazyCommitter>(txn_kv));
@@ -1218,7 +1250,8 @@ TEST(RecyclerTest, recycle_rowsets) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("recycle_rowsets");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/recycle_rowsets");
 
     config::instance_recycler_worker_pool_size = 1;
 
@@ -1300,7 +1333,8 @@ TEST(RecyclerTest, recycle_rowsets_with_data_ref_count) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("recycle_rowsets_with_data_ref_count");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/recycle_rowsets_with_data_ref_count");
 
     config::instance_recycler_worker_pool_size = 1;
 
@@ -1381,7 +1415,8 @@ TEST(RecyclerTest, bench_recycle_rowsets) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("recycle_rowsets");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/recycle_rowsets");
 
     config::instance_recycler_worker_pool_size = 10;
     config::recycle_task_threshold_seconds = 0;
@@ -1464,7 +1499,8 @@ TEST(RecyclerTest, recycle_tmp_rowsets) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("recycle_tmp_rowsets");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/recycle_tmp_rowsets");
 
     int insert_no_inverted_index = 0;
     int insert_inverted_index = 0;
@@ -1556,7 +1592,8 @@ TEST(RecyclerTest, recycle_tmp_rowsets_partial_update) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("recycle_tmp_rowsets_partial_update");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/recycle_tmp_rowsets_partial_update");
 
     InstanceRecycler recycler(txn_kv, instance, thread_group,
                               std::make_shared<TxnLazyCommitter>(txn_kv));
@@ -1625,7 +1662,8 @@ TEST(RecyclerTest, recycle_tablet) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("recycle_tablet");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/recycle_tablet");
 
     InstanceRecycler recycler(txn_kv, instance, thread_group,
                               std::make_shared<TxnLazyCommitter>(txn_kv));
@@ -1708,6 +1746,7 @@ TEST(RecyclerTest, recycle_tablet) {
 TEST(RecyclerTest, recycle_indexes) {
     config::retention_seconds = 0;
     auto txn_kv = std::make_shared<MemTxnKv>();
+    std::string prefix = recycler_s3_path + "/recycle_indexes";
     ASSERT_EQ(txn_kv->init(), 0);
 
     InstanceInfoPB instance;
@@ -1719,7 +1758,8 @@ TEST(RecyclerTest, recycle_indexes) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("recycle_indexes");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(prefix);
 
     InstanceRecycler recycler(txn_kv, instance, thread_group,
                               std::make_shared<TxnLazyCommitter>(txn_kv));
@@ -1739,9 +1779,10 @@ TEST(RecyclerTest, recycle_indexes) {
 
     constexpr int table_id = 10000, index_id = 10001, partition_id = 10002;
     auto accessor = recycler.accessor_map_.begin()->second;
+    accessor->delete_directory(recycler_s3_path);
     int64_t tablet_id_base = 10100;
     int64_t txn_id_base = 114115;
-    for (int i = 0; i < 100; ++i) {
+    for (int i = 0; i < 20; ++i) {
         int64_t tablet_id = tablet_id_base + i;
         create_tablet(txn_kv.get(), table_id, index_id, partition_id, tablet_id);
         for (int j = 0; j < 10; ++j) {
@@ -1763,7 +1804,7 @@ TEST(RecyclerTest, recycle_indexes) {
 
     ASSERT_EQ(create_partition_version_kv(txn_kv.get(), table_id, partition_id), 0);
     create_recycle_index(txn_kv.get(), table_id, index_id);
-    for (int i = 0; i < 100; ++i) {
+    for (int i = 0; i < 20; ++i) {
         int64_t tablet_id = tablet_id_base + i;
         check_delete_bitmap_keys_size(txn_kv.get(), tablet_id, 10);
     }
@@ -1773,7 +1814,7 @@ TEST(RecyclerTest, recycle_indexes) {
 
     // check rowset does not exist on s3
     std::unique_ptr<ListIterator> list_iter;
-    ASSERT_EQ(0, accessor->list_directory("data/", &list_iter));
+    ASSERT_EQ(0, accessor->list_directory(prefix, &list_iter));
     ASSERT_FALSE(list_iter->has_next()) << [&]() -> std::string {
         std::string out;
         while (list_iter->has_next()) {
@@ -1858,7 +1899,8 @@ TEST(RecyclerTest, recycle_partitions) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("recycle_partitions");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/recycle_partitions");
 
     InstanceRecycler recycler(txn_kv, instance, thread_group,
                               std::make_shared<TxnLazyCommitter>(txn_kv));
@@ -2071,7 +2113,8 @@ TEST(RecyclerTest, recycle_restore_jobs) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("recycle_restore_jobs");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/recycle_restore_jobs");
 
     InstanceRecycler recycler(txn_kv, instance, thread_group,
                               std::make_shared<TxnLazyCommitter>(txn_kv));
@@ -2863,7 +2906,7 @@ TEST(RecyclerTest, recycle_stage) {
     ASSERT_NE(txn_kv.get(), nullptr);
     ASSERT_EQ(txn_kv->init(), 0);
 
-    std::string stage_prefix = "prefix/stage/bob/bc9fff5e-5f91-4168-8eaa-0afd6667f7ef";
+    std::string stage_prefix = recycler_s3_path + "/stage/bob/bc9fff5e-5f91-4168-8eaa-0afd6667f7ef";
     ObjectStoreInfoPB object_info;
     object_info.set_id("obj_id");
     InstanceInfoPB instance;
@@ -3114,7 +3157,8 @@ TEST(RecyclerTest, multi_recycler) {
         obj_info->set_endpoint(config::test_s3_endpoint);
         obj_info->set_region(config::test_s3_region);
         obj_info->set_bucket(config::test_s3_bucket);
-        obj_info->set_prefix("multi_recycler_test");
+        obj_info->set_provider(provider);
+        obj_info->set_prefix(recycler_s3_path + "/multi_recycler_test");
         InstanceKeyInfo key_info {std::to_string(i)};
         std::string key;
         instance_key(key_info, &key);
@@ -3232,7 +3276,8 @@ TEST(CheckerTest, DISABLED_abnormal_inverted_check) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("CheckerTest");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/DISABLED_abnormal_inverted_check");
 
     auto sp = SyncPoint::get_instance();
     SyncPoint::CallbackGuard guard;
@@ -3377,7 +3422,8 @@ TEST(CheckerTest, normal_check_index_file_v2) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("CheckerTest");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/normal_check_index_file_v2");
 
     InstanceChecker checker(txn_kv, instance_id);
     ASSERT_EQ(checker.init(instance), 0);
@@ -3429,7 +3475,8 @@ TEST(CheckerTest, normal_inverted_check_index_file_v2) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("CheckerTest");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/normal_inverted_check_index_file_v2");
 
     InstanceChecker checker(txn_kv, instance_id);
     ASSERT_EQ(checker.init(instance), 0);
@@ -3481,7 +3528,8 @@ TEST(CheckerTest, abnormal_check_index_file_v1) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("CheckerTest");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/abnormal_check_index_file_v1");
 
     InstanceChecker checker(txn_kv, instance_id);
     ASSERT_EQ(checker.init(instance), 0);
@@ -3544,7 +3592,8 @@ TEST(CheckerTest, abnormal_inverted_check_index_file_v1) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("CheckerTest");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/abnormal_inverted_check_index_file_v1");
 
     InstanceChecker checker(txn_kv, instance_id);
     ASSERT_EQ(checker.init(instance), 0);
@@ -3628,7 +3677,8 @@ TEST(CheckerTest, abnormal_inverted_check_index_file_v2) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("CheckerTest");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/abnormal_inverted_check_index_file_v2");
 
     InstanceChecker checker(txn_kv, instance_id);
     ASSERT_EQ(checker.init(instance), 0);
@@ -3713,7 +3763,8 @@ TEST(CheckerTest, abnormal_check_index_file_v2) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("CheckerTest");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/abnormal_check_index_file_v2");
 
     InstanceChecker checker(txn_kv, instance_id);
     ASSERT_EQ(checker.init(instance), 0);
@@ -5052,7 +5103,8 @@ TEST(CheckerTest, version_key_check_normal) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("version_key_check_normal");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/version_key_check_normal");
 
     InstanceChecker checker(txn_kv, instance_id);
     ASSERT_EQ(checker.init(instance), 0);
@@ -5095,7 +5147,8 @@ TEST(CheckerTest, version_key_check_abnormal) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("version_key_check_normal");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/version_key_check_normal");
 
     InstanceChecker checker(txn_kv, instance_id);
     ASSERT_EQ(checker.init(instance), 0);
@@ -5143,7 +5196,8 @@ TEST(RecyclerTest, delete_rowset_data) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("recycle_tmp_rowsets");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/recycle_tmp_rowsets");
 
     std::vector<doris::TabletSchemaCloudPB> schemas;
     for (int i = 0; i < 5; ++i) {
@@ -5182,7 +5236,7 @@ TEST(RecyclerTest, delete_rowset_data) {
     }
     {
         InstanceInfoPB tmp_instance;
-        std::string resource_id = "recycle_tmp_rowsets";
+        std::string resource_id = recycler_s3_path + "/recycle_tmp_rowsets";
         tmp_instance.set_instance_id(instance_id);
         auto tmp_obj_info = tmp_instance.add_obj_info();
         tmp_obj_info->set_id(resource_id);
@@ -5191,6 +5245,7 @@ TEST(RecyclerTest, delete_rowset_data) {
         tmp_obj_info->set_endpoint(config::test_s3_endpoint);
         tmp_obj_info->set_region(config::test_s3_region);
         tmp_obj_info->set_bucket(config::test_s3_bucket);
+        obj_info->set_provider(provider);
         tmp_obj_info->set_prefix(resource_id);
 
         InstanceRecycler recycler(txn_kv, tmp_instance, thread_group,
@@ -5250,7 +5305,8 @@ TEST(RecyclerTest, delete_rowset_data_without_inverted_index_storage_format) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("recycle_tmp_rowsets");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/recycle_tmp_rowsets");
 
     std::vector<doris::TabletSchemaCloudPB> schemas;
     for (int i = 0; i < 5; ++i) {
@@ -5289,7 +5345,7 @@ TEST(RecyclerTest, delete_rowset_data_without_inverted_index_storage_format) {
     }
     {
         InstanceInfoPB tmp_instance;
-        std::string resource_id = "recycle_tmp_rowsets";
+        std::string resource_id = recycler_s3_path + "/recycle_tmp_rowsets";
         tmp_instance.set_instance_id(instance_id);
         auto tmp_obj_info = tmp_instance.add_obj_info();
         tmp_obj_info->set_id(resource_id);
@@ -5298,6 +5354,7 @@ TEST(RecyclerTest, delete_rowset_data_without_inverted_index_storage_format) {
         tmp_obj_info->set_endpoint(config::test_s3_endpoint);
         tmp_obj_info->set_region(config::test_s3_region);
         tmp_obj_info->set_bucket(config::test_s3_bucket);
+        obj_info->set_provider(provider);
         tmp_obj_info->set_prefix(resource_id);
 
         InstanceRecycler recycler(txn_kv, tmp_instance, thread_group,
@@ -5402,7 +5459,7 @@ TEST(RecyclerTest, init_vault_accessor_failed_test) {
         hdfs_build_conf.set_fs_name("fs_name");
         hdfs_build_conf.set_user("root");
         HdfsVaultInfo hdfs_info;
-        hdfs_info.set_prefix("root_path");
+        hdfs_info.set_prefix(recycler_s3_path + "/root_path");
         hdfs_info.mutable_build_conf()->MergeFrom(hdfs_build_conf);
         vault.mutable_hdfs_info()->MergeFrom(hdfs_info);
         vault.set_name("test_failed_hdfs_vault_1");
@@ -5450,7 +5507,7 @@ TEST(RecyclerTest, init_vault_accessor_failed_test) {
         hdfs_build_conf.set_fs_name("fs_name");
         hdfs_build_conf.set_user("root");
         HdfsVaultInfo hdfs_info;
-        hdfs_info.set_prefix("root_path");
+        hdfs_info.set_prefix(recycler_s3_path + "/root_path");
         hdfs_info.mutable_build_conf()->MergeFrom(hdfs_build_conf);
         vault.mutable_hdfs_info()->MergeFrom(hdfs_info);
         vault.set_name("test_success_hdfs_vault");
@@ -5535,7 +5592,7 @@ TEST(RecyclerTest, recycle_tablet_without_resource_id) {
         hdfs_build_conf.set_fs_name("fs_name");
         hdfs_build_conf.set_user("root");
         HdfsVaultInfo hdfs_info;
-        hdfs_info.set_prefix("root_path");
+        hdfs_info.set_prefix(recycler_s3_path + "/root_path");
         hdfs_info.mutable_build_conf()->MergeFrom(hdfs_build_conf);
         vault.mutable_hdfs_info()->MergeFrom(hdfs_info);
         vault.set_name("test_success_hdfs_vault");
@@ -5618,7 +5675,7 @@ TEST(RecyclerTest, recycle_tablet_with_wrong_resource_id) {
         hdfs_build_conf.set_fs_name("fs_name");
         hdfs_build_conf.set_user("root");
         HdfsVaultInfo hdfs_info;
-        hdfs_info.set_prefix("root_path");
+        hdfs_info.set_prefix(recycler_s3_path + "/root_path");
         hdfs_info.mutable_build_conf()->MergeFrom(hdfs_build_conf);
         vault.mutable_hdfs_info()->MergeFrom(hdfs_info);
         vault.set_name("test_success_hdfs_vault");
@@ -5751,7 +5808,7 @@ TEST(RecyclerTest, recycler_storage_vault_white_list_test) {
         hdfs_build_conf.set_fs_name("fs_name");
         hdfs_build_conf.set_user("root");
         HdfsVaultInfo hdfs_info;
-        hdfs_info.set_prefix("root_path");
+        hdfs_info.set_prefix(recycler_s3_path + "/root_path");
         hdfs_info.mutable_build_conf()->MergeFrom(hdfs_build_conf);
         vault.mutable_hdfs_info()->MergeFrom(hdfs_info);
         vault.set_name("hdfs_1");
@@ -5768,7 +5825,7 @@ TEST(RecyclerTest, recycler_storage_vault_white_list_test) {
         hdfs_build_conf.set_fs_name("fs_name");
         hdfs_build_conf.set_user("root");
         HdfsVaultInfo hdfs_info;
-        hdfs_info.set_prefix("root_path");
+        hdfs_info.set_prefix(recycler_s3_path + "/root_path");
         hdfs_info.mutable_build_conf()->MergeFrom(hdfs_build_conf);
         vault.mutable_hdfs_info()->MergeFrom(hdfs_info);
         vault.set_name("hdfs_2");
@@ -5848,7 +5905,8 @@ TEST(RecyclerTest, delete_tmp_rowset_data_with_idx_v1) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("delete_tmp_rowset_data_with_idx_v1");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/delete_tmp_rowset_data_with_idx_v1");
 
     doris::TabletSchemaCloudPB schema;
     schema.set_schema_version(1);
@@ -5928,7 +5986,8 @@ TEST(RecyclerTest, delete_tmp_rowset_data_with_idx_v2) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("delete_tmp_rowset_data_with_idx_v2");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/delete_tmp_rowset_data_with_idx_v2");
 
     doris::TabletSchemaCloudPB schema;
     schema.set_schema_version(1);
@@ -6007,7 +6066,8 @@ TEST(RecyclerTest, delete_tmp_rowset_without_resource_id) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("delete_tmp_rowset_data_with_idx_v2");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/delete_tmp_rowset_data_with_idx_v2");
 
     doris::TabletSchemaCloudPB schema;
     schema.set_schema_version(1);
@@ -6768,7 +6828,8 @@ TEST(RecyclerTest, recycle_restore_job_complete_state) {
     obj_info->set_endpoint(config::test_s3_endpoint);
     obj_info->set_region(config::test_s3_region);
     obj_info->set_bucket(config::test_s3_bucket);
-    obj_info->set_prefix("recycle_restore_job_transaction");
+    obj_info->set_provider(provider);
+    obj_info->set_prefix(recycler_s3_path + "/recycle_restore_job_transaction");
 
     InstanceRecycler recycler(txn_kv, instance, thread_group,
                               std::make_shared<TxnLazyCommitter>(txn_kv));

--- a/run-cloud-ut.sh
+++ b/run-cloud-ut.sh
@@ -52,6 +52,7 @@ Usage: $0 <options>
                         a <binary_name> is the name of a cpp file without '.cpp' suffix.
                         e.g. binary_name of xxx_test.cpp is xxx_test
      --fdb              run with a specific fdb connection string, e.g fdb_cluster0:cluster0@192.168.1.100:4500
+     --vault             run with storage vault, test_s3_ak, test_s3_sk, ... must be set
      -j                 build parallel
      -h                 print this help message
 
@@ -64,6 +65,7 @@ Usage: $0 <options>
     $0 --run --filter=recycler_test:FooTest.*-FooTest.Bar                       runs everything in test suite FooTest except FooTest.Bar in recycler_test.cpp
     $0 --run --filter=recycler_test:FooTest.*:BarTest.*-FooTest.Bar:BarTest.Foo runs everything in test suite FooTest except FooTest.Bar and everything in test suite BarTest except BarTest.Foo in recycler_test.cpp
     $0 --run --fdb=fdb_cluster0:cluster0@192.168.1.100:4500                     run with specific fdb
+    $0 --run --vault                                                            run with storage vault
     $0 --run --coverage                                                         run with coverage report
     $0 --clean                                                                  clean and build tests
     $0 --clean --run                                                            clean, build and run all tests
@@ -71,7 +73,7 @@ Usage: $0 <options>
     exit 1
 }
 
-if ! OPTS=$(getopt -n "$0" -o vhj:f: -l run,clean,filter:,fdb:,coverage -- "$@"); then
+if ! OPTS=$(getopt -n "$0" -o vhj:f: -l run,clean,filter:,fdb:,coverage,vault -- "$@"); then
     usage
 fi
 
@@ -87,6 +89,7 @@ FILTER=""
 FDB=""
 ENABLE_CLANG_COVERAGE=OFF
 BUILD_AZURE="ON"
+ENABLE_VAULT=OFF
 
 echo "===================== filter: ${FILTER}"
 if [[ $# != 1 ]]; then
@@ -102,6 +105,10 @@ if [[ $# != 1 ]]; then
             ;;
         --coverage)
             ENABLE_CLANG_COVERAGE="ON"
+            shift
+            ;;
+        --vault)
+            ENABLE_VAULT="ON"
             shift
             ;;
         --fdb)
@@ -137,6 +144,7 @@ echo "Get params:
     CLEAN               -- ${CLEAN}
     FILTER              -- ${FILTER}
     COVERAGE            -- ${ENABLE_CLANG_COVERAGE}
+    VAULT               -- ${ENABLE_VAULT}
     FDB                 -- ${FDB}
 "
 echo "Build Doris Cloud UT"
@@ -194,6 +202,7 @@ find . -name "*.gcda" -exec rm {} \;
     -DENABLE_CLANG_COVERAGE="${ENABLE_CLANG_COVERAGE}" \
     "${CMAKE_USE_CCACHE}" \
     -DBUILD_AZURE="${BUILD_AZURE}" \
+    -DENABLE_VAULT="${ENABLE_VAULT}" \
     "${DORIS_HOME}/cloud/"
 "${BUILD_SYSTEM}" -j "${PARALLEL}"
 "${BUILD_SYSTEM}" install


### PR DESCRIPTION
### What problem does this PR solve?

This PR adds storage vault support to recycler tests.

- The `run-cloud-ut` script now accepts the `--vault` option, which initializes vault as the storage backend by `doris_cloud.conf` config file
- If don't use it, accessor will be mocked

Only test scripts and configs are affected; production code is unchanged.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

