### PR TITLE
[fix](mysql) optimize some error handling logic

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -6242,12 +6242,7 @@ public class Env {
 
     // Switch catalog of this session
     public void changeCatalog(ConnectContext ctx, String catalogName) throws DdlException {
-        CatalogIf catalogIf = catalogMgr.getCatalog(catalogName);
-        if (catalogIf == null) {
-            throw new DdlException(ErrorCode.ERR_UNKNOWN_CATALOG.formatErrorMsg(catalogName),
-                    ErrorCode.ERR_UNKNOWN_CATALOG);
-        }
-
+        CatalogIf catalogIf = catalogMgr.getCatalogOrDdlException(catalogName);
         String currentDB = ctx.getDatabase();
         if (StringUtils.isNotEmpty(currentDB)) {
             // When dropped the current catalog in current context, the current catalog will be null.

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
@@ -234,6 +234,7 @@ public class MysqlProto {
                 dbName = dbNames[1];
             } else if (dbNames.length > 2) {
                 context.getState().setError(ErrorCode.ERR_BAD_DB_ERROR, "Only one dot can be in the name: " + db);
+                sendResponsePacket(context);
                 return false;
             }
 
@@ -252,27 +253,11 @@ public class MysqlProto {
                 }
             }
 
-            String dbFullName = dbName;
-
-            // check catalog and db exists
-            if (catalogName != null) {
-                CatalogIf catalogIf = context.getEnv().getCatalogMgr().getCatalog(catalogName);
-                if (catalogIf == null) {
-                    context.getState()
-                            .setError(ErrorCode.ERR_BAD_DB_ERROR, ErrorCode.ERR_BAD_DB_ERROR.formatErrorMsg(db));
-                    return false;
-                }
-                if (catalogIf.getDbNullable(dbFullName) == null) {
-                    context.getState()
-                            .setError(ErrorCode.ERR_BAD_DB_ERROR, ErrorCode.ERR_BAD_DB_ERROR.formatErrorMsg(db));
-                    return false;
-                }
-            }
             try {
                 if (catalogName != null) {
                     context.getEnv().changeCatalog(context, catalogName);
                 }
-                Env.getCurrentEnv().changeDb(context, dbFullName);
+                Env.getCurrentEnv().changeDb(context, dbName);
             } catch (DdlException e) {
                 context.getState().setError(e.getMysqlErrorCode(), e.getMessage());
                 sendResponsePacket(context);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -144,20 +144,6 @@ public abstract class ConnectProcessor {
             }
         }
 
-        // check catalog and db exists
-        if (catalogName != null) {
-            CatalogIf catalogIf = ctx.getEnv().getCatalogMgr().getCatalog(catalogName);
-            if (catalogIf == null) {
-                ctx.getState().setError(ErrorCode.ERR_BAD_DB_ERROR,
-                        ErrorCode.ERR_BAD_DB_ERROR.formatErrorMsg(catalogName + "." + dbName));
-                return;
-            }
-            if (catalogIf.getDbNullable(dbName) == null) {
-                ctx.getState().setError(ErrorCode.ERR_BAD_DB_ERROR,
-                        ErrorCode.ERR_BAD_DB_ERROR.formatErrorMsg(catalogName + "." + dbName));
-                return;
-            }
-        }
         try {
             if (catalogName != null) {
                 ctx.getEnv().changeCatalog(ctx, catalogName);
@@ -170,7 +156,6 @@ public abstract class ConnectProcessor {
             ctx.getState().setError(ErrorCode.ERR_INTERNAL_ERROR, Util.getRootCauseMessage(t));
             return;
         }
-
         ctx.getState().setOk();
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

1. Simplify `change catalog/db` and `init db` logic. No need to check existence twice.
2. Fix bug that missing `sendResponsePacket(context);` if name is invalid

Before:
```
mysql -h [127.0.0.1](http://127.0.0.1/) -P 9033 -uroot -D iceberg2.da
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading authorization packet', system error: 2
```

After
```
mysql -h [127.0.0.1](http://127.0.0.1/) -P 9033 -uroot -D iceberg2.da
ERROR 5086 (42000): errCode = 2, detailMessage = Unknown catalog 'iceberg2'
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

