### PR TITLE
[fix](cn) under k8s env, got physical cpu cores for show backends command

### DIFF
--- a/be/src/util/cgroup_util.cpp
+++ b/be/src/util/cgroup_util.cpp
@@ -317,13 +317,13 @@ int CGroupUtil::get_cgroup_limited_cpu_number(int physical_cores) {
     // For cpuset, child cgroup's cpuset.cpus could not bigger thant parent's cpuset.cpus.
     if (CGroupUtil::cgroupsv2_enable()) {
         std::string cgroupv2_process_path = CGroupUtil::cgroupv2_of_process();
+        std::filesystem::path current_cgroup_path;
         if (cgroupv2_process_path.empty()) {
-            return ret;
+            current_cgroup_path = default_cgroups_mount;
+        } else {
+            current_cgroup_path = (default_cgroups_mount / cgroupv2_process_path);
         }
-        std::filesystem::path current_cgroup_path = (default_cgroups_mount / cgroupv2_process_path);
         ret = get_cgroup_v2_cpu_quota_number(current_cgroup_path, default_cgroups_mount, ret);
-
-        current_cgroup_path = (default_cgroups_mount / cgroupv2_process_path);
         ret = get_cgroup_v2_cpuset_number(current_cgroup_path, default_cgroups_mount, ret);
     } else if (CGroupUtil::cgroupsv1_enable()) {
         // cpu quota, should find first not empty config from current path to top.
@@ -349,7 +349,7 @@ int CGroupUtil::get_cgroup_limited_cpu_number(int physical_cores) {
     return ret;
 }
 
-int CGroupUtil::get_cgroup_v2_cpu_quota_number(std::filesystem::path& current_path,
+int CGroupUtil::get_cgroup_v2_cpu_quota_number(std::filesystem::path current_path,
                                                const std::filesystem::path& default_cg_mout_path,
                                                int cpu_num) {
     int ret = cpu_num;
@@ -369,7 +369,7 @@ int CGroupUtil::get_cgroup_v2_cpu_quota_number(std::filesystem::path& current_pa
     return ret;
 }
 
-int CGroupUtil::get_cgroup_v2_cpuset_number(std::filesystem::path& current_path,
+int CGroupUtil::get_cgroup_v2_cpuset_number(std::filesystem::path current_path,
                                             const std::filesystem::path& default_cg_mout_path,
                                             int cpu_num) {
     int ret = cpu_num;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Under the k8s environment, got physical cpu cores for `show backends` commands, which expect the pod resource.

<img width="1100" height="1026" alt="image" src="https://github.com/user-attachments/assets/9e40efa0-46a7-41c8-ab6a-9223ebeb67a6" />

should be the following value.

<img width="546" height="248" alt="image" src="https://github.com/user-attachments/assets/d185abf4-838a-4351-9fb8-3ae30e6841ba" />


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

