### PR TITLE
[Fix]Fix drop index and build index running same time

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -3333,7 +3333,8 @@ public class SchemaChangeHandler extends AlterHandler {
                     && indexChangeJob.getDbId() == dbId
                     && indexChangeJob.getTableId() == tableId
                     && indexChangeJob.getPartitionName().equals(partitionName)
-                    && indexChangeJob.hasSameAlterInvertedIndex(isDrop, alterIndexes)
+                    && ((Config.isNotCloudMode() && indexChangeJob.hasSameAlterInvertedIndex(isDrop, alterIndexes))
+                    || Config.isCloudMode())
                     && !indexChangeJob.isDone()) {
                 // if JobState is done (CANCELLED or FINISHED), also allow user to create job again
                 return true;


### PR DESCRIPTION
### What problem does this PR solve?
Disable drop and build index operation running at same time in Cloud mode, this is to prevent unexpected situations from happening.

when execute drop index when build index is running,  error could happens.
```
mysql> BUILD INDEX ON v2_table_build_index1858;
Query OK, 0 rows affected (0.02 sec)

mysql> drop index idx1 on v2_table_build_index1858;
ERROR 1105 (HY000): errCode = 2, detailMessage = partition v2_table_build_index1858 has been built specified index. please check your build stmt.
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

