### PR TITLE
[fix](nereids) fix copy into fail with no where expression

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CopyFromDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CopyFromDesc.java
@@ -63,6 +63,7 @@ public class CopyFromDesc {
 
     public CopyFromDesc(StageAndPattern stageAndPattern) {
         this.stageAndPattern = stageAndPattern;
+        this.fileFilterExpr = Optional.empty();
     }
 
     public CopyFromDesc(StageAndPattern stageAndPattern, List<NamedExpression> exprList,
@@ -105,7 +106,7 @@ public class CopyFromDesc {
      */
     public void validate(String fullDbName, TableName tableName, boolean useDeleteSign, String fileType)
             throws AnalysisException {
-        if (exprList == null && fileFilterExpr == null && !useDeleteSign) {
+        if (exprList == null && !fileFilterExpr.isPresent() && !useDeleteSign) {
             return;
         }
         this.fileColumns = new ArrayList<>();
@@ -240,7 +241,7 @@ public class CopyFromDesc {
                     exprList.stream().map(expr -> (Expression) expr).collect(Collectors.toList()));
             maxId = maxId > maxFileColumnId ? maxId : maxFileColumnId;
         }
-        if (fileFilterExpr != null) {
+        if (fileFilterExpr.isPresent()) {
             int maxFileColumnId = getMaxFileFilterColumnId(Lists.newArrayList(fileFilterExpr.get()));
             maxId = maxId > maxFileColumnId ? maxId : maxFileColumnId;
         }


### PR DESCRIPTION
### What problem does this PR solve?

introduced by https://github.com/apache/doris/pull/47194

 Copy into with no where expression:
 ```
 copy into customer from @test_tpch('tpch/sf1/customer.csv.split00.gz') properties ('file.compression' = 'gz', 'copy.async' = 'false');
 ```
 
 It will fail:
 ```
 org.apache.doris.common.NereidsException: errCode = 2, detailMessage = Cannot invoke "java.util.Optional.isPresent()" because the return value of "org.apache.doris.nereids.trees.plans.commands.info.
CopyFromDesc.getFileFilterExpr()" is null
        at org.apache.doris.qe.StmtExecutor.executeByNereids(StmtExecutor.java:694) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:535) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.queryRetry(StmtExecutor.java:497) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:482) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.executeQuery(ConnectProcessor.java:358) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:249) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MysqlConnectProcessor.handleQuery(MysqlConnectProcessor.java:233) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MysqlConnectProcessor.dispatch(MysqlConnectProcessor.java:261) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MysqlConnectProcessor.processOnce(MysqlConnectProcessor.java:443) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: org.apache.doris.common.AnalysisException: errCode = 2, detailMessage = Cannot invoke "java.util.Optional.isPresent()" because the return value of "org.apache.doris.nereids.trees.plans.co
mmands.info.CopyFromDesc.getFileFilterExpr()" is null
        ... 13 more
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.Optional.isPresent()" because the return value of "org.apache.doris.nereids.trees.plans.commands.info.CopyFromDesc.getFileFilterEx
pr()" is null
        at org.apache.doris.nereids.trees.plans.commands.info.CopyIntoInfo.doValidate(CopyIntoInfo.java:262) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.info.CopyIntoInfo.validate(CopyIntoInfo.java:195) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.CopyIntoCommand.run(CopyIntoCommand.java:57) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.executeByNereids(StmtExecutor.java:668) ~[doris-fe.jar:1.2-SNAPSHOT]
        ... 12 more

 ```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

