### PR TITLE
[refine](json type) DataTypeJsonbSerDe no longer inherits from DataTypeStringSerDe.

### DIFF
--- a/be/src/vec/data_types/serde/data_type_jsonb_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_jsonb_serde.cpp
@@ -30,6 +30,7 @@
 #include "common/status.h"
 #include "exprs/json_functions.h"
 #include "runtime/jsonb_value.h"
+#include "runtime/primitive_type.h"
 #include "util/jsonb_parser_simd.h"
 namespace doris {
 namespace vectorized {
@@ -350,6 +351,12 @@ void DataTypeJsonbSerDe::write_one_cell_to_jsonb(const IColumn& column, JsonbWri
     result.writeStartBinary();
     result.writeBinary(reinterpret_cast<const char*>(data_ref.data), data_ref.size);
     result.writeEndBinary();
+}
+
+void DataTypeJsonbSerDe::read_one_cell_from_jsonb(IColumn& column, const JsonbValue* arg) const {
+    DCHECK(arg->isBinary());
+    const auto* blob = arg->unpack<JsonbBinaryVal>();
+    assert_cast<ColumnString&>(column).insert_data(blob->getBlob(), blob->getBlobLen());
 }
 
 } // namespace vectorized

--- a/be/src/vec/data_types/serde/data_type_jsonb_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_jsonb_serde.cpp
@@ -341,5 +341,16 @@ void DataTypeJsonbSerDe::to_string(const IColumn& column, size_t row_num,
         bw.write("NULL", 4);
     }
 }
+
+void DataTypeJsonbSerDe::write_one_cell_to_jsonb(const IColumn& column, JsonbWriter& result,
+                                                 Arena& mem_pool, int32_t col_id,
+                                                 int64_t row_num) const {
+    result.writeKey(cast_set<JsonbKeyValue::keyid_type>(col_id));
+    const auto& data_ref = column.get_data_at(row_num);
+    result.writeStartBinary();
+    result.writeBinary(reinterpret_cast<const char*>(data_ref.data), data_ref.size);
+    result.writeEndBinary();
+}
+
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/data_types/serde/data_type_jsonb_serde.h
+++ b/be/src/vec/data_types/serde/data_type_jsonb_serde.h
@@ -85,10 +85,7 @@ public:
     void write_one_cell_to_jsonb(const IColumn& column, JsonbWriter& result, Arena& mem_pool,
                                  int32_t col_id, int64_t row_num) const override;
 
-    void read_one_cell_from_jsonb(IColumn& column, const JsonbValue* arg) const override {
-        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "Method read_one_cell_from_jsonb is not supported for jsonb serde");
-    }
+    void read_one_cell_from_jsonb(IColumn& column, const JsonbValue* arg) const override;
 
     Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
                                   int64_t end, const cctz::time_zone& ctz) const override {

--- a/be/src/vec/data_types/serde/data_type_jsonb_serde.h
+++ b/be/src/vec/data_types/serde/data_type_jsonb_serde.h
@@ -83,10 +83,7 @@ public:
     void to_string(const IColumn& column, size_t row_num, BufferWritable& bw) const override;
 
     void write_one_cell_to_jsonb(const IColumn& column, JsonbWriter& result, Arena& mem_pool,
-                                 int32_t col_id, int64_t row_num) const override {
-        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
-                               "Method write_one_cell_to_jsonb is not supported for jsonb serde");
-    }
+                                 int32_t col_id, int64_t row_num) const override;
 
     void read_one_cell_from_jsonb(IColumn& column, const JsonbValue* arg) const override {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,

--- a/be/src/vec/data_types/serde/data_type_jsonb_serde.h
+++ b/be/src/vec/data_types/serde/data_type_jsonb_serde.h
@@ -32,9 +32,9 @@ class JsonbOutStream;
 namespace vectorized {
 class Arena;
 
-class DataTypeJsonbSerDe : public DataTypeStringSerDe {
+class DataTypeJsonbSerDe : public DataTypeSerDe {
 public:
-    DataTypeJsonbSerDe(int nesting_level = 1) : DataTypeStringSerDe(nesting_level) {};
+    DataTypeJsonbSerDe(int nesting_level = 1) : DataTypeSerDe(nesting_level) {};
 
     std::string get_name() const override { return "JSONB"; }
 
@@ -81,6 +81,23 @@ public:
                                   int64_t row_num) const override;
 
     void to_string(const IColumn& column, size_t row_num, BufferWritable& bw) const override;
+
+    void write_one_cell_to_jsonb(const IColumn& column, JsonbWriter& result, Arena& mem_pool,
+                                 int32_t col_id, int64_t row_num) const override {
+        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
+                               "Method write_one_cell_to_jsonb is not supported for jsonb serde");
+    }
+
+    void read_one_cell_from_jsonb(IColumn& column, const JsonbValue* arg) const override {
+        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
+                               "Method read_one_cell_from_jsonb is not supported for jsonb serde");
+    }
+
+    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
+                                  int64_t end, const cctz::time_zone& ctz) const override {
+        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
+                               "Method read_column_from_arrow is not supported for jsonb serde");
+    }
 
 private:
     template <bool is_binary_format>

--- a/be/test/vec/data_types/serde/data_type_jsonb_serde_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_jsonb_serde_test.cpp
@@ -74,8 +74,7 @@ protected:
 
 TEST_F(DataTypeJsonbSerDeTest, serdes) {
     auto test_func = [](const auto& serde, const auto& source_column) {
-        using SerdeType = decltype(serde);
-        using ColumnType = typename std::remove_reference<SerdeType>::type::ColumnStrType;
+        using ColumnType = ColumnString;
 
         auto row_count = source_column->size();
         auto option = DataTypeSerDe::FormatOptions();


### PR DESCRIPTION
### What problem does this PR solve?

Previously, our DataTypeJsonbSerDe inherited from DataTypeStringSerDe, while DataType did not inherit from it.
```C++
class DataTypeJsonb final : public IDataType {
```
Now, we have removed the inheritance relationship to make the behavior more explicit.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

