### PR TITLE
[feat](ObjectStorage)Relax endpoint validation for private object storage

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/AbstractS3CompatibleProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/AbstractS3CompatibleProperties.java
@@ -19,6 +19,7 @@ package org.apache.doris.datasource.property.storage;
 
 import org.apache.doris.common.UserException;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -138,10 +139,13 @@ public abstract class AbstractS3CompatibleProperties extends StorageProperties i
             throw new IllegalArgumentException("Both the access key and the secret key must be set.");
         }
         if (StringUtils.isBlank(getRegion())) {
-            throw new IllegalArgumentException("Region must be set.");
+            throw new IllegalArgumentException("Region is not set. If you are using a standard endpoint, the region "
+                    + "will be detected automatically. Otherwise, please specify it explicitly."
+            );
         }
-        if (isEndpointCheckRequired() && StringUtils.isBlank(getEndpoint())) {
-            throw new IllegalArgumentException("Endpoint must be set.");
+        if (StringUtils.isBlank(getEndpoint())) {
+            throw new IllegalArgumentException("Endpoint is not set. Please specify it explicitly."
+            );
         }
     }
 
@@ -254,12 +258,11 @@ public abstract class AbstractS3CompatibleProperties extends StorageProperties i
     private void appendS3HdfsProperties(Configuration hadoopStorageConfig) {
         hadoopStorageConfig.set("fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
         hadoopStorageConfig.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
-        if (StringUtils.isNotBlank(getEndpoint())) {
-            hadoopStorageConfig.set("fs.s3a.endpoint", getEndpoint());
-        }
-        if (StringUtils.isNotBlank(getRegion())) {
-            hadoopStorageConfig.set("fs.s3a.endpoint.region", getRegion());
-        }
+        // use google assert not null
+        Preconditions.checkNotNull(getEndpoint(), "endpoint is null");
+        hadoopStorageConfig.set("fs.s3a.endpoint", getEndpoint());
+        Preconditions.checkNotNull(getRegion(), "region is null");
+        hadoopStorageConfig.set("fs.s3a.endpoint.region", getRegion());
         hadoopStorageConfig.set("fs.s3.impl.disable.cache", "true");
         hadoopStorageConfig.set("fs.s3a.impl.disable.cache", "true");
         if (StringUtils.isNotBlank(getAccessKey())) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/AbstractS3CompatibleProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/AbstractS3CompatibleProperties.java
@@ -137,9 +137,16 @@ public abstract class AbstractS3CompatibleProperties extends StorageProperties i
         if (StringUtils.isBlank(getAccessKey()) != StringUtils.isBlank(getSecretKey())) {
             throw new IllegalArgumentException("Both the access key and the secret key must be set.");
         }
-        if (StringUtils.isBlank(getRegion()) || StringUtils.isBlank(getEndpoint())) {
-            throw new IllegalArgumentException("Endpoint and region must be set.");
+        if (StringUtils.isBlank(getRegion())) {
+            throw new IllegalArgumentException("Region must be set.");
         }
+        if (isEndpointCheckRequired() && StringUtils.isBlank(getEndpoint())) {
+            throw new IllegalArgumentException("Endpoint must be set.");
+        }
+    }
+
+    boolean isEndpointCheckRequired() {
+        return true;
     }
 
     /**
@@ -247,8 +254,12 @@ public abstract class AbstractS3CompatibleProperties extends StorageProperties i
     private void appendS3HdfsProperties(Configuration hadoopStorageConfig) {
         hadoopStorageConfig.set("fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
         hadoopStorageConfig.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
-        hadoopStorageConfig.set("fs.s3a.endpoint", getEndpoint());
-        hadoopStorageConfig.set("fs.s3a.endpoint.region", getRegion());
+        if (StringUtils.isNotBlank(getEndpoint())) {
+            hadoopStorageConfig.set("fs.s3a.endpoint", getEndpoint());
+        }
+        if (StringUtils.isNotBlank(getRegion())) {
+            hadoopStorageConfig.set("fs.s3a.endpoint.region", getRegion());
+        }
         hadoopStorageConfig.set("fs.s3.impl.disable.cache", "true");
         hadoopStorageConfig.set("fs.s3a.impl.disable.cache", "true");
         if (StringUtils.isNotBlank(getAccessKey())) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/AbstractS3CompatibleProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/AbstractS3CompatibleProperties.java
@@ -131,14 +131,14 @@ public abstract class AbstractS3CompatibleProperties extends StorageProperties i
     public void initNormalizeAndCheckProps() {
         super.initNormalizeAndCheckProps();
         setEndpointIfPossible();
-        if (!isValidEndpoint(getEndpoint())) {
-            throw new IllegalArgumentException("Invalid endpoint: " + getEndpoint());
-        }
         setRegionIfPossible();
         //Allow anonymous access if both access_key and secret_key are empty
         //But not recommended for production use.
         if (StringUtils.isBlank(getAccessKey()) != StringUtils.isBlank(getSecretKey())) {
             throw new IllegalArgumentException("Both the access key and the secret key must be set.");
+        }
+        if (StringUtils.isBlank(getRegion()) || StringUtils.isBlank(getEndpoint())) {
+            throw new IllegalArgumentException("Endpoint and region must be set.");
         }
     }
 
@@ -216,23 +216,6 @@ public abstract class AbstractS3CompatibleProperties extends StorageProperties i
     }
 
     protected abstract Set<Pattern> endpointPatterns();
-
-    private boolean isValidEndpoint(String endpoint) {
-        if (StringUtils.isBlank(endpoint)) {
-            // Endpoint is not required, so we consider it valid if empty.
-            return true;
-        }
-        if (endpointPatterns().isEmpty()) {
-            return true;
-        }
-        for (Pattern pattern : endpointPatterns()) {
-            Matcher matcher = pattern.matcher(endpoint.toLowerCase());
-            if (matcher.matches()) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     // This method should be overridden by subclasses to provide a default endpoint based on the region.
     // Because for aws s3, only region is needed, the endpoint can be constructed from the region.

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
@@ -142,7 +142,7 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
      * - s3.cn-hangzhou.aliyuncs.com              => region = cn-hangzhou
      * <p>
      * https://help.aliyun.com/zh/dlf/dlf-1-0/developer-reference/api-datalake-2020-07-10-endpoint
-     * - detalake.cn-hangzhou.aliyuncs.com          => region = cn-hangzhou
+     * - datalake.cn-hangzhou.aliyuncs.com          => region = cn-hangzhou
      */
     public static final Set<Pattern> ENDPOINT_PATTERN = ImmutableSet.of(STANDARD_ENDPOINT_PATTERN,
             Pattern.compile("(?:https?://)?([a-z]{2}-[a-z0-9-]+)\\.oss-dls\\.aliyuncs\\.com"),

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
@@ -123,6 +123,9 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
     @Getter
     protected String forceParsingByStandardUrl = "false";
 
+    private static final Pattern STANDARD_ENDPOINT_PATTERN = Pattern
+            .compile("^(?:https?://)?(?:s3\\.)?oss-([a-z0-9-]+?)(?:-internal)?\\.aliyuncs\\.com$");
+
     /**
      * Pattern to extract the region from an Alibaba Cloud OSS endpoint.
      * <p>
@@ -141,8 +144,7 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
      * https://help.aliyun.com/zh/dlf/dlf-1-0/developer-reference/api-datalake-2020-07-10-endpoint
      * - detalake.cn-hangzhou.aliyuncs.com          => region = cn-hangzhou
      */
-    public static final Set<Pattern> ENDPOINT_PATTERN = ImmutableSet.of(Pattern
-                    .compile("^(?:https?://)?(?:s3\\.)?oss-([a-z0-9-]+?)(?:-internal)?\\.aliyuncs\\.com$"),
+    public static final Set<Pattern> ENDPOINT_PATTERN = ImmutableSet.of(STANDARD_ENDPOINT_PATTERN,
             Pattern.compile("(?:https?://)?([a-z]{2}-[a-z0-9-]+)\\.oss-dls\\.aliyuncs\\.com"),
             Pattern.compile("^(?:https?://)?dlf(?:-vpc)?\\.([a-z0-9-]+)\\.aliyuncs\\.com(?:/.*)?$"),
             Pattern.compile("^(?:https?://)?datalake(?:-vpc)?\\.([a-z0-9-]+)\\.aliyuncs\\.com(?:/.*)?$"));
@@ -247,7 +249,7 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
     @Override
     public void initNormalizeAndCheckProps() {
         super.initNormalizeAndCheckProps();
-        if (endpoint.contains("dlf") || endpoint.contains("oss-dls")) {
+        if (StringUtils.isBlank(endpoint) || !STANDARD_ENDPOINT_PATTERN.matcher(endpoint).matches()) {
             this.endpoint = getOssEndpoint(region, BooleanUtils.toBoolean(dlfAccessPublic));
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/S3Properties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/S3Properties.java
@@ -213,6 +213,11 @@ public class S3Properties extends AbstractS3CompatibleProperties {
         convertGlueToS3EndpointIfNeeded();
     }
 
+    @Override
+    boolean isEndpointCheckRequired() {
+        return false;
+    }
+
     /**
      * Guess if the storage properties is for this storage type.
      * Subclass should override this method to provide the correct implementation.

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/IcebergS3TablesMetaStorePropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/IcebergS3TablesMetaStorePropertiesTest.java
@@ -41,12 +41,8 @@ public class IcebergS3TablesMetaStorePropertiesTest {
                 "s3.access_key", "AK",
                 "s3.secret_key", "SK",
                 "s3.endpoint", "https://s3.us-west-2.amazonaws.com");
-        IcebergS3TablesMetaStoreProperties failedProperties = (IcebergS3TablesMetaStoreProperties) MetastoreProperties.create(baseProps);
-        Assertions.assertEquals("s3tables", failedProperties.getIcebergCatalogType());
-        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
-            failedProperties.initializeCatalog("iceberg_catalog", StorageProperties.createAll(baseProps));
-        });
-        Assertions.assertTrue(exception.getMessage().contains("region must not be blank or empty."));
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> MetastoreProperties.create(baseProps));
+        Assertions.assertTrue(exception.getMessage().contains("Region must be set."));
         Map<String, String> allProps = ImmutableMap.<String, String>builder()
                 .putAll(baseProps)
                 .putAll(s3Props)

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/IcebergS3TablesMetaStorePropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/IcebergS3TablesMetaStorePropertiesTest.java
@@ -42,7 +42,7 @@ public class IcebergS3TablesMetaStorePropertiesTest {
                 "s3.secret_key", "SK",
                 "s3.endpoint", "https://s3.us-west-2.amazonaws.com");
         RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> MetastoreProperties.create(baseProps));
-        Assertions.assertTrue(exception.getMessage().contains("Region must be set."));
+        Assertions.assertTrue(exception.getMessage().contains("Region is not set."));
         Map<String, String> allProps = ImmutableMap.<String, String>builder()
                 .putAll(baseProps)
                 .putAll(s3Props)

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/COSPropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/COSPropertiesTest.java
@@ -53,7 +53,7 @@ public class COSPropertiesTest {
         origProps.put("cos.use_path_style", "true");
         origProps.put(StorageProperties.FS_COS_SUPPORT, "true");
         origProps.put("test_non_storage_param", "6000");
-        Assertions.assertThrowsExactly(IllegalArgumentException.class, () -> StorageProperties.createAll(origProps), "Invalid endpoint format: https://cos.example.com");
+        Assertions.assertDoesNotThrow(() -> StorageProperties.createAll(origProps));
         origProps.put("cos.endpoint", "cos.ap-beijing-1.myqcloud.com");
         COSProperties cosProperties = (COSProperties) StorageProperties.createAll(origProps).get(0);
         Map<String, String> cosConfig = cosProperties.getMatchedProperties();
@@ -151,7 +151,7 @@ public class COSPropertiesTest {
         origProps.put("cos.endpoint", "cos.ap-beijing.myqcloud.com");
         origProps.put("cos.secret_key", "myCOSSecretKey");
         Assertions.assertThrows(IllegalArgumentException.class, () -> StorageProperties.createPrimary(origProps),
-                 "Please set access_key and secret_key or omit both for anonymous access to public bucket.");
+                "Please set access_key and secret_key or omit both for anonymous access to public bucket.");
     }
 
     @Test
@@ -159,7 +159,7 @@ public class COSPropertiesTest {
         origProps.put("cos.endpoint", "cos.ap-beijing.myqcloud.com");
         origProps.put("cos.access_key", "myCOSAccessKey");
         Assertions.assertThrows(IllegalArgumentException.class, () -> StorageProperties.createPrimary(origProps),
-                 "Both the access key and the secret key must be set.");
+                "Both the access key and the secret key must be set.");
         origProps.remove("cos.access_key");
         Assertions.assertDoesNotThrow(() -> StorageProperties.createPrimary(origProps));
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OBSPropertyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OBSPropertyTest.java
@@ -39,7 +39,7 @@ public class OBSPropertyTest {
         origProps.put("obs.secret_key", "myOBSSecretKey");
         origProps.put(StorageProperties.FS_OBS_SUPPORT, "true");
         ExceptionChecker.expectThrowsWithMsg(IllegalArgumentException.class,
-                "Invalid endpoint: https://obs.example.com", () -> StorageProperties.createAll(origProps));
+                "Region must be set.", () -> StorageProperties.createAll(origProps));
 
         // Test creation without additional properties
         origProps = new HashMap<>();

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OBSPropertyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OBSPropertyTest.java
@@ -39,7 +39,7 @@ public class OBSPropertyTest {
         origProps.put("obs.secret_key", "myOBSSecretKey");
         origProps.put(StorageProperties.FS_OBS_SUPPORT, "true");
         ExceptionChecker.expectThrowsWithMsg(IllegalArgumentException.class,
-                "Region must be set.", () -> StorageProperties.createAll(origProps));
+                "Region is not set. If you are using a standard endpoint, the region will be detected automatically. Otherwise, please specify it explicitly.", () -> StorageProperties.createAll(origProps));
 
         // Test creation without additional properties
         origProps = new HashMap<>();

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSPropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSPropertiesTest.java
@@ -183,6 +183,32 @@ public class OSSPropertiesTest {
     }
 
     @Test
+    public void testDlfPropertiesEndpoint() {
+        Map<String, String> origProps = new HashMap<>();
+        origProps.put("type", "iceberg");
+        origProps.put("warehouse", "oss://bucket/hive-dlf-oss-warehouse/iceberg/dlf-oss/");
+        origProps.put("dlf.region", "cn-beijing");
+        origProps.put("dlf.endpoint", "datalake-vpc.cn-beijing.aliyuncs.com");
+        origProps.put("dlf.uid", "12345");
+        origProps.put("dlf.catalog.id", "p2_regression_case");
+        origProps.put("dlf.access_key", "ACCESS_KEY");
+        origProps.put("dlf.secret_key", "SECERT_KET");
+        origProps.put("dlf.access.public", "true");
+        OSSProperties ossProperties = OSSProperties.of(origProps);
+        Assertions.assertEquals("oss-cn-beijing.aliyuncs.com", ossProperties.getEndpoint());
+        origProps.remove("dlf.access.public");
+        ossProperties = OSSProperties.of(origProps);
+        Assertions.assertEquals("oss-cn-beijing-internal.aliyuncs.com", ossProperties.getEndpoint());
+        origProps.put("oss.endpoint", "dlf.cn-beijing.aliyuncs.com");
+        ossProperties = OSSProperties.of(origProps);
+        Assertions.assertEquals("oss-cn-beijing-internal.aliyuncs.com", ossProperties.getEndpoint());
+        origProps.put("oss.endpoint", "dlf-vpc.cn-beijing.aliyuncs.com");
+        ossProperties = OSSProperties.of(origProps);
+        Assertions.assertEquals("oss-cn-beijing-internal.aliyuncs.com", ossProperties.getEndpoint());
+    }
+
+
+    @Test
     public void testNotEndpoint() throws UserException {
         Map<String, String> origProps = new HashMap<>();
         origProps.put("uri", "oss://examplebucket-1250000000/test/file.txt");

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSPropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSPropertiesTest.java
@@ -43,7 +43,7 @@ public class OSSPropertiesTest {
         origProps.put(StorageProperties.FS_OSS_SUPPORT, "true");
         Map<String, String> finalOrigProps = origProps;
         ExceptionChecker.expectThrowsWithMsg(IllegalArgumentException.class,
-                "Region must be set.", () -> StorageProperties.createPrimary(finalOrigProps));
+                "Region is not set. If you are using a standard endpoint, the region will be detected automatically. Otherwise, please specify it explicitly.", () -> StorageProperties.createPrimary(finalOrigProps));
         origProps.put("oss.endpoint", "oss-cn-shenzhen-finance-1-internal.aliyuncs.com");
         Map<String, String> finalOrigProps1 = origProps;
         OSSProperties ossProperties = (OSSProperties) StorageProperties.createPrimary(finalOrigProps1);
@@ -145,7 +145,7 @@ public class OSSPropertiesTest {
         ossNoEndpointProps.put("oss.region", "cn-hangzhou");
         origProps.put("uri", "s3://examplebucket-1250000000/test/file.txt");
         // oss support without endpoint
-        ExceptionChecker.expectThrowsWithMsg(IllegalArgumentException.class, "Endpoint must be set.", () -> StorageProperties.createPrimary(ossNoEndpointProps));
+        ExceptionChecker.expectThrowsWithMsg(IllegalArgumentException.class, "Endpoint is not set. Please specify it explicitly.", () -> StorageProperties.createPrimary(ossNoEndpointProps));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSPropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSPropertiesTest.java
@@ -43,7 +43,7 @@ public class OSSPropertiesTest {
         origProps.put(StorageProperties.FS_OSS_SUPPORT, "true");
         Map<String, String> finalOrigProps = origProps;
         ExceptionChecker.expectThrowsWithMsg(IllegalArgumentException.class,
-                "Invalid endpoint: https://oss.aliyuncs.com", () -> StorageProperties.createPrimary(finalOrigProps));
+                "Region must be set.", () -> StorageProperties.createPrimary(finalOrigProps));
         origProps.put("oss.endpoint", "oss-cn-shenzhen-finance-1-internal.aliyuncs.com");
         Map<String, String> finalOrigProps1 = origProps;
         OSSProperties ossProperties = (OSSProperties) StorageProperties.createPrimary(finalOrigProps1);
@@ -145,7 +145,7 @@ public class OSSPropertiesTest {
         ossNoEndpointProps.put("oss.region", "cn-hangzhou");
         origProps.put("uri", "s3://examplebucket-1250000000/test/file.txt");
         // oss support without endpoint
-        ExceptionChecker.expectThrowsNoException(() -> StorageProperties.createPrimary(ossNoEndpointProps));
+        ExceptionChecker.expectThrowsWithMsg(IllegalArgumentException.class, "Endpoint must be set.", () -> StorageProperties.createPrimary(ossNoEndpointProps));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/S3PropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/S3PropertiesTest.java
@@ -200,7 +200,7 @@ public class S3PropertiesTest {
         s3EndpointProps.put("oss.region", "cn-hangzhou");
         origProps.put("uri", "s3://examplebucket-1250000000/test/file.txt");
         // not support
-        ExceptionChecker.expectThrowsNoException(() -> StorageProperties.createPrimary(s3EndpointProps));
+        ExceptionChecker.expectThrowsWithMsg(IllegalArgumentException.class, "Endpoint must be set.", () -> StorageProperties.createPrimary(s3EndpointProps));
     }
 
     @Test
@@ -310,7 +310,7 @@ public class S3PropertiesTest {
         String invalidEndpoint1 = "s3.amazonaws.com";
         origProps.put("s3.endpoint", invalidEndpoint1);
         ExceptionChecker.expectThrowsWithMsg(IllegalArgumentException.class,
-                "Endpoint and region must be set.", () -> StorageProperties.createPrimary(origProps));
+                "Region must be set.", () -> StorageProperties.createPrimary(origProps));
         origProps.put("s3.region", "us-west-2");
         Assertions.assertDoesNotThrow(() -> StorageProperties.createPrimary(origProps));
         // Fails because it contains 'amazonaws.com' but doesn't match the strict S3 endpoint pattern (invalid subdomain).

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/S3PropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/S3PropertiesTest.java
@@ -59,8 +59,7 @@ public class S3PropertiesTest {
         origProps.put("s3.secret_key", "myS3SecretKey");
         origProps.put("s3.region", "us-west-1");
         origProps.put(StorageProperties.FS_S3_SUPPORT, "true");
-        ExceptionChecker.expectThrowsWithMsg(IllegalArgumentException.class,
-                "Invalid endpoint: https://cos.example.com", () -> StorageProperties.createAll(origProps));
+        Assertions.assertDoesNotThrow(() -> StorageProperties.createAll(origProps));
         origProps = new HashMap<>();
         origProps.put("s3.endpoint", "s3-fips.dualstack.us-east-2.amazonaws.com");
         origProps.put(StorageProperties.FS_S3_SUPPORT, "true");
@@ -120,7 +119,6 @@ public class S3PropertiesTest {
 
     @Test
     public void testToNativeS3Configuration() throws UserException {
-        origProps.put("s3.endpoint", "https://cos.example.com");
         origProps.put("s3.access_key", "myS3AccessKey");
         origProps.put("s3.secret_key", "myS3SecretKey");
         origProps.put("s3.region", "us-west-1");
@@ -129,11 +127,6 @@ public class S3PropertiesTest {
         origProps.put("s3.connection.maximum", "88");
         origProps.put("s3.connection.timeout", "6000");
         origProps.put("test_non_storage_param", "6000");
-
-        ExceptionChecker.expectThrowsWithMsg(IllegalArgumentException.class,
-                "Invalid endpoint: https://cos.example.com", () -> {
-                    StorageProperties.createAll(origProps).get(1);
-                });
         origProps.put("s3.endpoint", "s3.us-west-1.amazonaws.com");
         S3Properties s3Properties = (S3Properties) StorageProperties.createAll(origProps).get(0);
         Map<String, String> s3Props = s3Properties.getBackendConfigProperties();
@@ -230,7 +223,7 @@ public class S3PropertiesTest {
 
     @Test
     public void testGetAwsCredentialsProviderWithIamRoleAndExternalId(@Mocked StsClientBuilder mockBuilder,
-            @Mocked StsClient mockStsClient, @Mocked InstanceProfileCredentialsProvider mockInstanceCreds) {
+                                                                      @Mocked StsClient mockStsClient, @Mocked InstanceProfileCredentialsProvider mockInstanceCreds) {
 
         new Expectations() {
             {
@@ -317,21 +310,16 @@ public class S3PropertiesTest {
         String invalidEndpoint1 = "s3.amazonaws.com";
         origProps.put("s3.endpoint", invalidEndpoint1);
         ExceptionChecker.expectThrowsWithMsg(IllegalArgumentException.class,
-                "Invalid endpoint: s3.amazonaws.com", () -> StorageProperties.createPrimary(origProps));
-
+                "Endpoint and region must be set.", () -> StorageProperties.createPrimary(origProps));
+        origProps.put("s3.region", "us-west-2");
+        Assertions.assertDoesNotThrow(() -> StorageProperties.createPrimary(origProps));
         // Fails because it contains 'amazonaws.com' but doesn't match the strict S3 endpoint pattern (invalid subdomain).
         String invalidEndpoint2 = "my-s3-service.amazonaws.com";
         origProps.put("s3.endpoint", invalidEndpoint2);
-        ExceptionChecker.expectThrowsWithMsg(IllegalArgumentException.class,
-                "Invalid endpoint: my-s3-service.amazonaws.com",
-                () -> StorageProperties.createPrimary(origProps));
-
-        // Fails because it contains 'amazonaws.com' but doesn't match the strict S3 endpoint pattern (invalid TLD).
+        Assertions.assertDoesNotThrow(() -> StorageProperties.createPrimary(origProps));
         String invalidEndpoint3 = "http://s3.us-west-2.amazonaws.com.cn";
         origProps.put("s3.endpoint", invalidEndpoint3);
-        ExceptionChecker.expectThrowsWithMsg(IllegalArgumentException.class,
-                "Invalid endpoint: http://s3.us-west-2.amazonaws.com.cn",
-                () -> StorageProperties.createPrimary(origProps));
+        Assertions.assertDoesNotThrow(() -> StorageProperties.createPrimary(origProps));
     }
 
     @Test

--- a/regression-test/suites/load_p0/broker_load/test_domain_connection_and_ak_sk_correction.groovy
+++ b/regression-test/suites/load_p0/broker_load/test_domain_connection_and_ak_sk_correction.groovy
@@ -102,7 +102,7 @@ suite("test_domain_connection_and_ak_sk_correction",  "load_p0") {
         assertTrue(false. "The endpoint is wrong, so the connection test should fale")
     } catch (Exception e) {
         logger.info("the second sql exception result is {}", e.getMessage())
-        assertTrue(e.getMessage().contains("Invalid endpoint"), e.getMessage())
+        assertTrue(e.getMessage().contains("Failed to access object storage"), e.getMessage())
     }
 
     sql """ DROP TABLE IF EXISTS ${tableName} FORCE"""


### PR DESCRIPTION
…

### 
Support private deployments by removing strict endpoint checks. If the endpoint is non-standard, region cannot be inferred automatically, so users must provide the region explicitly.


### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

