### PR TITLE
[chore](build) Add feature list to version info

### DIFF
--- a/be/src/common/version_internal.cpp
+++ b/be/src/common/version_internal.cpp
@@ -56,6 +56,9 @@ const char* doris_build_time() {
 const char* doris_build_info() {
     return DORIS_BUILD_INFO;
 }
+const std::string doris_feature_list() {
+    return std::string(DORIS_FEATURE_LIST);
+}
 
 } // namespace version
 

--- a/be/src/common/version_internal.h
+++ b/be/src/common/version_internal.h
@@ -16,6 +16,7 @@
 // under the License.
 
 #pragma once
+#include <string>
 
 namespace doris {
 namespace version {
@@ -32,6 +33,7 @@ extern const char* doris_build_hash();
 extern const char* doris_build_short_hash();
 extern const char* doris_build_time();
 extern const char* doris_build_info();
+extern const std::string doris_feature_list();
 
 } // namespace version
 

--- a/be/src/util/debug_util.cpp
+++ b/be/src/util/debug_util.cpp
@@ -22,6 +22,7 @@
 #include <gen_cpp/PlanNodes_types.h>
 #include <stdint.h>
 
+#include <cstring>
 #include <iomanip>
 #include <map>
 #include <sstream> // IWYU pragma: keep
@@ -46,6 +47,7 @@ std::string print_plan_node_type(const TPlanNodeType::type& type) {
 
 std::string get_build_version(bool compact) {
     std::stringstream ss;
+    // clang-format off
     ss << version::doris_build_version()
 #if defined(__x86_64__) || defined(_M_X64)
 #ifdef __AVX2__
@@ -74,7 +76,9 @@ std::string get_build_version(bool compact) {
        << " with BLSAN"
 #endif
 #endif
+       << (version::doris_feature_list().empty() ? "" : " features: " + version::doris_feature_list())
        << " (build " << version::doris_build_hash() << ")";
+    // clang-format on
 
     if (!compact) {
         ss << std::endl

--- a/build.sh
+++ b/build.sh
@@ -509,18 +509,12 @@ echo "Get params:
 "
 
 FEAT=()
-if [[ -n "${WITH_TDE_DIR}" ]]; then
-    FEAT+=("TDE")
-fi
-if [[ "${ENABLE_HDFS_STORAGE_VAULT:-OFF}" == "ON" ]]; then
-    FEAT+=("HDFS_STORAGE_VAULT")
-fi
-if [[ ${BUILD_UI} -eq 1 ]]; then
-    FEAT+=("WEBUI")
-fi
-if [[ "${BUILD_AZURE}" == "ON" ]]; then
-    FEAT+=("AZURE_BLOB,AZURE_STORAGE_VAULT")
-fi
+FEAT+=($([[ -n "${WITH_TDE_DIR}" ]] && echo "+TDE" || echo "-TDE"))
+FEAT+=($([[ "${ENABLE_HDFS_STORAGE_VAULT:-OFF}" == "ON" ]] && echo "+HDFS_STORAGE_VAULT" || echo "-HDFS_STORAGE_VAULT"))
+FEAT+=($([[ ${BUILD_UI} -eq 1 ]] && echo "+UI" || echo "-UI"))
+FEAT+=($([[ "${BUILD_AZURE}" == "ON" ]] && echo "+AZURE_BLOB,+AZURE_STORAGE_VAULT" || echo "-AZURE_BLOB,-AZURE_STORAGE_VAULT"))
+FEAT+=($([[ ${BUILD_HIVE_UDF} -eq 1 ]] && echo "+HIVE_UDF" || echo "-HIVE_UDF"))
+FEAT+=($([[ ${BUILD_BE_JAVA_EXTENSIONS} -eq 1 ]] && echo "+BE_JAVA_EXTENSIONS" || echo "-BE_JAVA_EXTENSIONS"))
 
 export DORIS_FEATURE_LIST=$(IFS=','; echo "${FEAT[*]}")
 echo "Feature List: ${DORIS_FEATURE_LIST}"

--- a/build.sh
+++ b/build.sh
@@ -508,6 +508,23 @@ echo "Get params:
     WITH_TDE_DIR                        -- ${WITH_TDE_DIR}
 "
 
+FEAT=()
+if [[ -n "${WITH_TDE_DIR}" ]]; then
+    FEAT+=("TDE")
+fi
+if [[ "${ENABLE_HDFS_STORAGE_VAULT:-OFF}" == "ON" ]]; then
+    FEAT+=("HDFS_STORAGE_VAULT")
+fi
+if [[ ${BUILD_UI} -eq 1 ]]; then
+    FEAT+=("WEBUI")
+fi
+if [[ "${BUILD_AZURE}" == "ON" ]]; then
+    FEAT+=("AZURE_BLOB,AZURE_STORAGE_VAULT")
+fi
+
+export DORIS_FEATURE_LIST=$(IFS=','; echo "${FEAT[*]}")
+echo "Feature List: ${DORIS_FEATURE_LIST}"
+
 # Clean and build generated code
 if [[ "${CLEAN}" -eq 1 ]]; then
     clean_gensrc

--- a/cloud/src/main.cpp
+++ b/cloud/src/main.cpp
@@ -136,15 +136,17 @@ static void help() {
 
 static std::string build_info() {
     std::stringstream ss;
+// clang-format off
 #if defined(NDEBUG)
     ss << "version:{" DORIS_CLOUD_BUILD_VERSION "-release}"
 #else
     ss << "version:{" DORIS_CLOUD_BUILD_VERSION "-debug}"
 #endif
-       << " code_version:{commit=" DORIS_CLOUD_BUILD_HASH " time=" DORIS_CLOUD_BUILD_VERSION_TIME
-          "}"
+       << " code_version:{commit=" DORIS_CLOUD_BUILD_HASH " time=" DORIS_CLOUD_BUILD_VERSION_TIME "}"
+       << " features:{" DORIS_CLOUD_FEATURE_LIST "}"
        << " build_info:{initiator=" DORIS_CLOUD_BUILD_INITIATOR " build_at=" DORIS_CLOUD_BUILD_TIME
           " build_on=" DORIS_CLOUD_BUILD_OS_VERSION "}\n";
+    // clang-format on
     return ss.str();
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
@@ -432,6 +432,11 @@ public class DorisFE {
         LOG.info("Build hash: {}", Version.DORIS_BUILD_HASH);
         LOG.info("Java compile version: {}", Version.DORIS_JAVA_COMPILE_VERSION);
 
+        if (!Version.DORIS_FEATURE_LIST.isEmpty()) {
+            LogUtils.stdout("Features: " + Version.DORIS_FEATURE_LIST);
+            LOG.info("Features: {}", Version.DORIS_FEATURE_LIST);
+        }
+
         if (Config.isCloudMode()) {
             LogUtils.stdout("Run FE in the cloud mode, cloud_unique_id: " + Config.cloud_unique_id
                     + ", meta_service_endpoint: " + Config.meta_service_endpoint);

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/HardwareInfoController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/HardwareInfoController.java
@@ -69,6 +69,7 @@ public class HardwareInfoController {
         map.put("Git", Version.DORIS_BUILD_HASH);
         map.put("BuildInfo", Version.DORIS_BUILD_INFO);
         map.put("BuildTime", Version.DORIS_BUILD_TIME);
+        map.put("Features", Version.DORIS_FEATURE_LIST);
         content.put("VersionInfo", map);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
@@ -91,7 +91,8 @@ public final class GlobalVariable {
     @VariableMgr.VarAttr(name = VERSION_COMMENT, flag = VariableMgr.READ_ONLY)
     public static String versionComment = Version.DORIS_BUILD_VERSION_PREFIX + " version "
             + Version.DORIS_BUILD_VERSION + "-" + Version.DORIS_BUILD_SHORT_HASH
-            + (Config.isCloudMode() ? " (Cloud Mode)" : "");
+            + (Config.isCloudMode() ? " (Cloud Mode)" : "")
+            + (Version.DORIS_FEATURE_LIST.isEmpty() ? "" : " features: " + Version.DORIS_FEATURE_LIST);
 
     @VariableMgr.VarAttr(name = VERSION)
     public static String version = MysqlHandshakePacket.DEFAULT_SERVER_VERSION;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/GlobalVariable.java
@@ -91,8 +91,7 @@ public final class GlobalVariable {
     @VariableMgr.VarAttr(name = VERSION_COMMENT, flag = VariableMgr.READ_ONLY)
     public static String versionComment = Version.DORIS_BUILD_VERSION_PREFIX + " version "
             + Version.DORIS_BUILD_VERSION + "-" + Version.DORIS_BUILD_SHORT_HASH
-            + (Config.isCloudMode() ? " (Cloud Mode)" : "")
-            + (Version.DORIS_FEATURE_LIST.isEmpty() ? "" : " features: " + Version.DORIS_FEATURE_LIST);
+            + (Config.isCloudMode() ? " (Cloud Mode)" : "");
 
     @VariableMgr.VarAttr(name = VERSION)
     public static String version = MysqlHandshakePacket.DEFAULT_SERVER_VERSION;

--- a/gensrc/script/gen_build_version.sh
+++ b/gensrc/script/gen_build_version.sh
@@ -42,6 +42,7 @@ if [[ -n "${build_version_rc_version}" ]]; then
     build_version+="-${build_version_rc_version}"
 fi
 
+doris_feature_list="${DORIS_FEATURE_LIST-""}"
 # This version is used to check FeMetaVersion is not changed during release
 build_fe_meta_version=0
 unset LANG
@@ -134,6 +135,7 @@ public class Version {
   public static final int DORIS_BUILD_VERSION_PATCH = ${build_version_patch};
   public static final int DORIS_BUILD_VERSION_HOTFIX = ${build_version_hotfix};
   public static final String DORIS_BUILD_VERSION_RC_VERSION = "${build_version_rc_version}";
+  public static final String DORIS_FEATURE_LIST = "${doris_feature_list}";
 
   public static final String DORIS_BUILD_VERSION = "${build_version}";
   public static final String DORIS_BUILD_HASH = "${build_hash}";
@@ -149,6 +151,7 @@ public class Version {
     System.out.println("doris_build_version_minor: " + DORIS_BUILD_VERSION_MINOR);
     System.out.println("doris_build_version_patch: " + DORIS_BUILD_VERSION_PATCH);
     System.out.println("doris_build_version_rc_version: " + DORIS_BUILD_VERSION_RC_VERSION);
+    System.out.println("doris_feature_list: " + DORIS_FEATURE_LIST);
 
     System.out.println("doris_build_version: " + DORIS_BUILD_VERSION);
     System.out.println("doris_build_hash: " + DORIS_BUILD_HASH);
@@ -202,6 +205,7 @@ namespace doris {
 #define DORIS_BUILD_SHORT_HASH          "${build_short_hash}"
 #define DORIS_BUILD_TIME                "${build_time}"
 #define DORIS_BUILD_INFO                "${build_info}"
+#define DORIS_FEATURE_LIST              "${doris_feature_list}"
 
 } // namespace doris
 
@@ -263,6 +267,7 @@ namespace doris::cloud {
 #define DORIS_CLOUD_BUILD_VERSION_PATCH       ${build_version_patch}
 #define DORIS_CLOUD_BUILD_VERSION_HOTFIX      ${build_version_hotfix}
 #define DORIS_CLOUD_BUILD_VERSION_RC_VERSION  R"(${build_version_rc_version})"
+#define DORIS_CLOUD_FEATURE_LIST              R"(${doris_feature_list})"
 
 #define DORIS_CLOUD_BUILD_VERSION             R"(${build_version})"
 #define DORIS_CLOUD_BUILD_HASH                R"(${build_hash})"


### PR DESCRIPTION
```
$ fe/bin/start_fe.sh --version
RuntimeLogger 2025-09-29 16:13:34,388 INFO (main|29) [DorisFE.printVersion():437] Features: -TDE,-HDFS_STORAGE_VAULT,-WEBUI,+AZURE_BLOB,+AZURE_STORAGE_VAULT,+HIVE_UDF,+BE_JAVA_EXTENSIONS

$ be/bin/start_be.sh --version
gavin-0.0.0(AVX2) DEBUG with ASAN features: -TDE,-HDFS_STORAGE_VAULT,-WEBUI,+AZURE_BLOB,+AZURE_STORAGE_VAULT,+HIVE_UDF,+BE_JAVA_EXTENSIONS (build git://VM-10-11-centos@8a6af620d7801375bfbd05c93c95ac573bd295ed)

$ ms/bin/start.sh --version
version:{gavin-0.0.0-debug} code_version:{commit=8a6af620d7801375bfbd05c93c95ac573bd295ed time=2025-09-29 11:53:14 +0800} features:{-TDE,-HDFS_STORAGE_VAULT,-WEBUI,+AZURE_BLOB,+AZURE_STORAGE_VAULT,+HIVE_UDF,+BE_JAVA_EXTENSIONS} build_info:{initiator=gavinchou@VM-10-11-centos build_at=2025-09-29 11:53:14 +0800 build_on=NAME="TencentOS Server" VERSION="3.1 (Final)" }
```


<img width="1918" height="455" alt="image" src="https://github.com/user-attachments/assets/38629a6b-1e88-4565-845e-85208bc2f2e0" />
<img width="883" height="417" alt="image" src="https://github.com/user-attachments/assets/6fab7d63-4ecf-4b01-bd5a-0f93989a1823" />
