### PR TITLE
[fix](parquet) potential bugfix for parquet reader

### DIFF
--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -1016,6 +1016,9 @@ bool ParquetReader::_has_page_index(const std::vector<tparquet::ColumnChunk>& co
 Status ParquetReader::_process_page_index(const tparquet::RowGroup& row_group,
                                           const RowGroupReader::RowGroupIndex& row_group_index,
                                           std::vector<RowRange>& candidate_row_ranges) {
+    // Clear the OffsetIndex from the previous RowGroup.
+    _col_offsets.clear();
+
     if (UNLIKELY(_io_ctx && _io_ctx->should_stop)) {
         return Status::EndOfFile("stop");
     }


### PR DESCRIPTION
### What problem does this PR solve?

The OffsetIndex is defined at the RowGroup and Column Chunk level.
After change RowGroup, we should clear it from last RowGroup

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

