### PR TITLE
[improvement](load & cache) Set disable_file_cache to true for load data into disposable LRU queue 

### DIFF
--- a/be/src/vec/exec/scan/file_scanner.cpp
+++ b/be/src/vec/exec/scan/file_scanner.cpp
@@ -170,6 +170,7 @@ Status FileScanner::init(RuntimeState* state, const VExprContextSPtrs& conjuncts
     RETURN_IF_ERROR(_init_io_ctx());
     _io_ctx->file_cache_stats = _file_cache_statistics.get();
     _io_ctx->file_reader_stats = _file_reader_stats.get();
+    _io_ctx->is_disposable = _state->query_options().disable_file_cache;
 
     if (_is_load) {
         _src_row_desc.reset(new RowDescriptor(_state->desc_tbl(),

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
@@ -103,8 +103,15 @@ public class NereidsCoordinator extends Coordinator {
         super(context, planner, statsErrorEstimator);
 
         this.coordinatorContext = CoordinatorContext.buildForSql(planner, this);
-        this.coordinatorContext.setJobProcessor(buildJobProcessor(coordinatorContext, jobId));
         this.needEnqueue = true;
+
+        DataSink dataSink = coordinatorContext.dataSink;
+        // output to mysql or to file
+        if ((dataSink instanceof ResultSink || dataSink instanceof ResultFileSink)) {
+            setForQuery();
+        } else {
+            setForInsert();
+        }
 
         Preconditions.checkState(!planner.getFragments().isEmpty()
                 && coordinatorContext.instanceNum.get() > 0, "Fragment and Instance can not be empty˚");
@@ -120,6 +127,8 @@ public class NereidsCoordinator extends Coordinator {
                 this, jobId, queryId, fragments, distributedPlans, scanNodes,
                 descTable, timezone, loadZeroTolerance, enableProfile
         );
+        // same reason in `setForInsert`
+        this.coordinatorContext.queryOptions.setDisableFileCache(true);
         this.needEnqueue = false;
 
         Preconditions.checkState(!fragments.isEmpty()
@@ -528,13 +537,18 @@ public class NereidsCoordinator extends Coordinator {
         return false;
     }
 
-    private JobProcessor buildJobProcessor(CoordinatorContext coordinatorContext, long jobId) {
-        DataSink dataSink = coordinatorContext.dataSink;
-        if ((dataSink instanceof ResultSink || dataSink instanceof ResultFileSink)) {
-            return QueryProcessor.build(coordinatorContext);
-        } else {
-            return new LoadProcessor(coordinatorContext, jobId);
-        }
+    private void setForInsert() {
+        // insert statement has jobId == -1
+        JobProcessor jobProc = new LoadProcessor(this.coordinatorContext, -1L);
+        this.coordinatorContext.setJobProcessor(jobProc);
+        // Set this field to true to avoid data entering the normal cache LRU queue
+        // see detail reasons in DORIS-22597
+        this.coordinatorContext.queryOptions.setDisableFileCache(true);
+    }
+
+    private void setForQuery() {
+        JobProcessor jobProc = QueryProcessor.build(this.coordinatorContext);
+        this.coordinatorContext.setJobProcessor(jobProc);
     }
 
     @Override


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Like the S3 TVF load, we cache the customer data read from S3 into the normal LRU queue, which disrupts the historical cache and causes severe fluctuations in cache hit rates. Now, we set disable_file_cache to true so that during the import phase, the queried data enters the lowest-level disposable LRU queue.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

