### PR TITLE
[metrics](ann index) Metrics for in-memory ann index

### DIFF
--- a/be/src/olap/rowset/segment_v2/ann_index/ann_index.cpp
+++ b/be/src/olap/rowset/segment_v2/ann_index/ann_index.cpp
@@ -17,6 +17,7 @@
 
 #include "olap/rowset/segment_v2/ann_index/ann_index.h"
 
+#include "util/doris_metrics.h"
 #include "vec/functions/array/function_array_distance.h"
 
 namespace doris::segment_v2 {
@@ -59,6 +60,14 @@ AnnIndexType string_to_ann_index_type(const std::string& type) {
     } else {
         return AnnIndexType::UNKNOWN;
     }
+}
+
+VectorIndex::VectorIndex() {
+    DorisMetrics::instance()->ann_index_in_memory_cnt->increment(1);
+}
+
+VectorIndex::~VectorIndex() {
+    DorisMetrics::instance()->ann_index_in_memory_cnt->increment(-1);
 }
 
 } // namespace doris::segment_v2

--- a/be/src/olap/rowset/segment_v2/ann_index/ann_index.h
+++ b/be/src/olap/rowset/segment_v2/ann_index/ann_index.h
@@ -74,7 +74,8 @@ AnnIndexType string_to_ann_index_type(const std::string& type);
  */
 class VectorIndex {
 public:
-    virtual ~VectorIndex() = default;
+    VectorIndex();
+    virtual ~VectorIndex();
 
     virtual void train(vectorized::Int64 n, const float* x) = 0;
 

--- a/be/src/olap/rowset/segment_v2/ann_index/faiss_ann_index.h
+++ b/be/src/olap/rowset/segment_v2/ann_index/faiss_ann_index.h
@@ -170,6 +170,8 @@ public:
      */
     FaissVectorIndex();
 
+    ~FaissVectorIndex();
+
     void train(vectorized::Int64 n, const float* x) override;
 
     /**

--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -32,6 +32,7 @@
 
 #include "common/status.h"
 #include "io/fs/local_file_system.h"
+#include "util/metrics.h"
 #include "util/system_metrics.h"
 
 namespace doris {
@@ -244,6 +245,9 @@ DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(ann_index_load_costs_ms, MetricUnit::MILLIS
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(ann_index_load_cnt, MetricUnit::NOUNIT);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(ann_index_search_costs_ms, MetricUnit::MILLISECONDS);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(ann_index_search_cnt, MetricUnit::NOUNIT);
+DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(ann_index_in_memory_cnt, MetricUnit::NOUNIT);
+DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(ann_index_in_memory_rows_cnt, MetricUnit::ROWS);
+DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(ann_index_construction, MetricUnit::NOUNIT);
 
 const std::string DorisMetrics::_s_registry_name = "doris_be";
 const std::string DorisMetrics::_s_hook_name = "doris_metrics";
@@ -407,6 +411,9 @@ DorisMetrics::DorisMetrics() : _metric_registry(_s_registry_name) {
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, ann_index_load_cnt);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, ann_index_search_costs_ms);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, ann_index_search_cnt);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, ann_index_in_memory_cnt);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, ann_index_in_memory_rows_cnt);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, ann_index_construction);
 }
 
 void DorisMetrics::initialize(bool init_system_metrics, const std::set<std::string>& disk_devices,

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -253,6 +253,9 @@ public:
     IntCounter* ann_index_load_cnt = nullptr;
     IntCounter* ann_index_search_costs_ms = nullptr;
     IntCounter* ann_index_search_cnt = nullptr;
+    IntCounter* ann_index_in_memory_cnt = nullptr;
+    IntCounter* ann_index_in_memory_rows_cnt = nullptr;
+    IntCounter* ann_index_construction = nullptr;
 
     IntGauge* runtime_filter_consumer_num = nullptr;
     IntGauge* runtime_filter_consumer_ready_num = nullptr;


### PR DESCRIPTION
### What problem does this PR solve?

This pull request introduces new metrics for monitoring the in-memory state and construction of ANN (Approximate Nearest Neighbor) indexes, and integrates these metrics into the lifecycle of vector indexes. It also ensures that metrics are updated appropriately when indexes are created, destroyed, loaded, or modified.

**Metrics and Monitoring Enhancements:**

* Added three new metrics to `DorisMetrics`: `ann_index_in_memory_cnt`, `ann_index_in_memory_rows_cnt`, and `ann_index_construction`, to track the number of in-memory ANN indexes, the number of rows in memory, and the number of ongoing index constructions, respectively. [[1]](diffhunk://#diff-878c2670a099f34646a2d514e473068af8a5c43784e0450555a2e2b79e8f27caR248-R250) [[2]](diffhunk://#diff-878c2670a099f34646a2d514e473068af8a5c43784e0450555a2e2b79e8f27caR414-R416) [[3]](diffhunk://#diff-86758ef39527aa2e06d142689e6b13e5a89872ca7aaffb398d1e491749efbd52R256-R258)
* Registered the new metrics in the metrics registry and included their prototypes for proper initialization and tracking. [[1]](diffhunk://#diff-878c2670a099f34646a2d514e473068af8a5c43784e0450555a2e2b79e8f27caR414-R416) [[2]](diffhunk://#diff-878c2670a099f34646a2d514e473068af8a5c43784e0450555a2e2b79e8f27caR248-R250)

**Integration with ANN Index Lifecycle:**

* Modified the `VectorIndex` base class to increment and decrement `ann_index_in_memory_cnt` upon construction and destruction, respectively, ensuring accurate tracking of in-memory index objects. [[1]](diffhunk://#diff-b8d71062ef0c17d6d0ddb9690fefa383984d2bfb1ecbde1a34fe88c224e741a7L77-R78) [[2]](diffhunk://#diff-4186cdac2d23477966f836c52ec5f5bc6cc6d9c015ffc0b09616b1fe47eedd57R65-R72)
* Updated `FaissVectorIndex` to:
  - Inherit from the updated `VectorIndex` and override the destructor to decrement `ann_index_in_memory_rows_cnt` based on the number of rows in the index. [[1]](diffhunk://#diff-db0f703076eba6a2e532676979b1bfb928a2ffda3123593779d49b10b143d533L73-R80) [[2]](diffhunk://#diff-65584774f4b13280356d4cfc388080b0ae4215dff6ed79b1c711fae83f2e8cbaR173-R174)
  - Increment `ann_index_in_memory_rows_cnt` when vectors are added or when an index is loaded, and update `ann_index_construction` during index construction. [[1]](diffhunk://#diff-db0f703076eba6a2e532676979b1bfb928a2ffda3123593779d49b10b143d533R173-R176) [[2]](diffhunk://#diff-db0f703076eba6a2e532676979b1bfb928a2ffda3123593779d49b10b143d533R495)

**Codebase Maintenance:**

* Added necessary includes for `doris_metrics.h` and `metrics.h` in relevant files to support the new metrics functionality. [[1]](diffhunk://#diff-4186cdac2d23477966f836c52ec5f5bc6cc6d9c015ffc0b09616b1fe47eedd57R20) [[2]](diffhunk://#diff-db0f703076eba6a2e532676979b1bfb928a2ffda3123593779d49b10b143d533R44) [[3]](diffhunk://#diff-878c2670a099f34646a2d514e473068af8a5c43784e0450555a2e2b79e8f27caR35)

<img width="1104" height="1220" alt="image" src="https://github.com/user-attachments/assets/f1a800fc-0d3a-4f24-b264-0ed5e043fc54" />

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

