### PR TITLE
[fix](cloud-ut)fix bvar kv test count error

### DIFF
--- a/cloud/test/rpc_kv_bvar_test.cpp
+++ b/cloud/test/rpc_kv_bvar_test.cpp
@@ -524,7 +524,7 @@ void clear_memkv_count_bytes(MemTxnKv* memkv) {
     memkv->get_bytes_ = memkv->put_bytes_ = memkv->del_bytes_ = 0;
 }
 
-// RAII guard to setup and cleanup notify_refresh_instance syncpoint
+// setup and cleanup notify_refresh_instance syncpoint
 class NotifyRefreshSyncpointGuard {
 public:
     NotifyRefreshSyncpointGuard() {

--- a/cloud/test/rpc_kv_bvar_test.cpp
+++ b/cloud/test/rpc_kv_bvar_test.cpp
@@ -57,15 +57,6 @@ int main(int argc, char** argv) {
 
     ::testing::InitGoogleTest(&argc, argv);
 
-    // Setup syncpoint to disable notify_refresh_instance for all tests
-    // This MUST be done before any test runs to prevent race conditions
-    auto* sp = doris::SyncPoint::get_instance();
-    sp->enable_processing();
-    sp->set_call_back("notify_refresh_instance_return", [](auto&& args) {
-        auto* pred = doris::try_any_cast<bool*>(args.back());
-        *pred = true;
-    });
-
     return RUN_ALL_TESTS();
 }
 


### PR DESCRIPTION
`async_notify_refresh_instance` maybe execute after `clear_memkv_count_bytes`, it would cause test error
