### PR TITLE
[Fix](cloud) Fix cloud compile err

### DIFF
--- a/cloud/src/recycler/azure_obj_client.cpp
+++ b/cloud/src/recycler/azure_obj_client.cpp
@@ -314,4 +314,9 @@ ObjectStorageResponse AzureObjClient::check_versioning(const std::string& bucket
     return {0};
 }
 
+ObjectStorageResponse AzureObjClient::abort_multipart_upload(ObjectStoragePathRef path,
+                                                             const std::string& upload_id) {
+    return {0};
+}
+
 } // namespace doris::cloud

--- a/cloud/src/recycler/azure_obj_client.cpp
+++ b/cloud/src/recycler/azure_obj_client.cpp
@@ -316,7 +316,10 @@ ObjectStorageResponse AzureObjClient::check_versioning(const std::string& bucket
 
 ObjectStorageResponse AzureObjClient::abort_multipart_upload(ObjectStoragePathRef path,
                                                              const std::string& upload_id) {
-    return {0};
+    LOG_WARNING("abort_multipart_upload not implemented")
+            .tag("path", path.bucket + "/" + path.key)
+            .tag("upload_id", upload_id);
+    return {-1};
 }
 
 } // namespace doris::cloud

--- a/cloud/src/recycler/azure_obj_client.h
+++ b/cloud/src/recycler/azure_obj_client.h
@@ -52,6 +52,9 @@ public:
 
     ObjectStorageResponse check_versioning(const std::string& bucket) override;
 
+    ObjectStorageResponse abort_multipart_upload(ObjectStoragePathRef path,
+                                                 const std::string& upload_id) override;
+
 private:
     std::shared_ptr<Azure::Storage::Blobs::BlobContainerClient> client_;
 };


### PR DESCRIPTION
### What problem does this PR solve?
Fix cloud compile err, due to https://github.com/apache/doris/pull/56628
```
/mnt/disk2/doris/apache_doris/cloud/src/recycler/azure_obj_client.h:29:7: error: abstract class is marked 'final' [-Werror,-Wabstract-final-class]
   29 | class AzureObjClient final : public ObjStorageClient {
      |       ^
/mnt/disk2/doris/apache_doris/cloud/src/recycler/obj_storage_client.h:106:35: note: unimplemented pure virtual method 'abort_multipart_upload' in 'AzureObjClient'
  106 |     virtual ObjectStorageResponse abort_multipart_upload(ObjectStoragePathRef path,
      |                                   ^
```



Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

