### PR TITLE
Added bounds check in ColumnVector::insert_indices_from()

### DIFF
--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -283,8 +283,7 @@ void ColumnVector<T>::insert_indices_from(const IColumn& src, const uint32_t* in
     size_t src_size = src_concrete.size();
     if (indices_begin == nullptr || indices_end == nullptr || 
         (indices_begin != indices_end && indices_begin > indices_end)) {
-        throw Exception(ErrorCode::INTERNAL_ERROR,
-                        "Invalid index range: begin={}, end={}",
+        throw Exception(ErrorCode::INTERNAL_ERROR, "Invalid index range: begin={}, end={}",
                         static_cast<const void*>(indices_begin),
                         static_cast<const void*>(indices_end));
     }
@@ -297,11 +296,12 @@ void ColumnVector<T>::insert_indices_from(const IColumn& src, const uint32_t* in
     data.resize(origin_size + new_size);
 
     auto copy = [](const value_type* __restrict src, value_type* __restrict dest,
-                   const uint32_t* __restrict begin, const uint32_t* __restrict end, size_t src_size) {
+                   const uint32_t* __restrict begin, const uint32_t* __restrict end,
+                   size_t src_size) {
         for (const auto* it = begin; it != end; ++it) {
             if (*it >= src_size) {
-                throw Exception(ErrorCode::INTERNAL_ERROR,
-                                "Index {} exceeds source column size {}", *it, src_size);
+                throw Exception(ErrorCode::INTERNAL_ERROR, "Index {} exceeds source column size {}", 
+                                *it, src_size);
             }
             *dest = src[*it];
             ++dest;

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -281,7 +281,8 @@ void ColumnVector<T>::insert_indices_from(const IColumn& src, const uint32_t* in
                                           const uint32_t* indices_end) {
     const auto& src_concrete = static_cast<const ColumnVector<T>&>(src);
     size_t src_size = src_concrete.size();
-    if (indices_begin == nullptr || indices_end == nullptr || indices_begin > indices_end) {
+    if (indices_begin == nullptr || indices_end == nullptr || 
+        (indices_begin != indices_end && indices_begin > indices_end)) {
         throw Exception(ErrorCode::INTERNAL_ERROR,
                         "Invalid index range: begin={}, end={}",
                         static_cast<const void*>(indices_begin),

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -281,7 +281,7 @@ void ColumnVector<T>::insert_indices_from(const IColumn& src, const uint32_t* in
                                           const uint32_t* indices_end) {
     const auto& src_concrete = static_cast<const ColumnVector<T>&>(src);
     size_t src_size = src_concrete.size();
-    if (indices_begin == nullptr || indices_end == nullptr ||
+    if ((indices_begin == nullptr) != (indices_end == nullptr) ||
         (indices_begin != indices_end && indices_begin > indices_end)) {
         throw Exception(ErrorCode::INTERNAL_ERROR, "Invalid index range: begin={}, end={}",
                         static_cast<const void*>(indices_begin),

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -287,7 +287,7 @@ void ColumnVector<T>::insert_indices_from(const IColumn& src, const uint32_t* in
                         static_cast<const void*>(indices_begin),
                         static_cast<const void*>(indices_end));
     }
-                                            
+
     auto origin_size = size();
     auto new_size = indices_end - indices_begin;
     if (new_size == 0) {

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -281,7 +281,7 @@ void ColumnVector<T>::insert_indices_from(const IColumn& src, const uint32_t* in
                                           const uint32_t* indices_end) {
     const auto& src_concrete = static_cast<const ColumnVector<T>&>(src);
     size_t src_size = src_concrete.size();
-    if (indices_begin == nullptr || indices_end == nullptr || 
+    if (indices_begin == nullptr || indices_end == nullptr ||
         (indices_begin != indices_end && indices_begin > indices_end)) {
         throw Exception(ErrorCode::INTERNAL_ERROR, "Invalid index range: begin={}, end={}",
                         static_cast<const void*>(indices_begin),
@@ -300,7 +300,7 @@ void ColumnVector<T>::insert_indices_from(const IColumn& src, const uint32_t* in
                    size_t src_size) {
         for (const auto* it = begin; it != end; ++it) {
             if (*it >= src_size) {
-                throw Exception(ErrorCode::INTERNAL_ERROR, "Index {} exceeds source column size {}", 
+                throw Exception(ErrorCode::INTERNAL_ERROR, "Index {} exceeds source column size {}",
                                 *it, src_size);
             }
             *dest = src[*it];

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -279,19 +279,35 @@ void ColumnVector<T>::insert_range_from(const IColumn& src, size_t start, size_t
 template <PrimitiveType T>
 void ColumnVector<T>::insert_indices_from(const IColumn& src, const uint32_t* indices_begin,
                                           const uint32_t* indices_end) {
+    const auto& src_concrete = static_cast<const ColumnVector<T>&>(src);
+    size_t src_size = src_concrete.size();
+    if (indices_begin == nullptr || indices_end == nullptr || indices_begin > indices_end) {
+        throw Exception(ErrorCode::INTERNAL_ERROR,
+                        "Invalid index range: begin={}, end={}",
+                        static_cast<const void*>(indices_begin),
+                        static_cast<const void*>(indices_end));
+    }
+                                            
     auto origin_size = size();
     auto new_size = indices_end - indices_begin;
+    if (new_size == 0) {
+        return;
+    }
     data.resize(origin_size + new_size);
 
     auto copy = [](const value_type* __restrict src, value_type* __restrict dest,
-                   const uint32_t* __restrict begin, const uint32_t* __restrict end) {
+                   const uint32_t* __restrict begin, const uint32_t* __restrict end, size_t src_size) {
         for (const auto* it = begin; it != end; ++it) {
+            if (*it >= src_size) {
+                throw Exception(ErrorCode::INTERNAL_ERROR,
+                                "Index {} exceeds source column size {}", *it, src_size);
+            }
             *dest = src[*it];
             ++dest;
         }
     };
     copy(reinterpret_cast<const value_type*>(src.get_raw_data().data), data.data() + origin_size,
-         indices_begin, indices_end);
+         indices_begin, indices_end, src_size);
 }
 
 template <PrimitiveType T>

--- a/be/test/vec/core/column_vector_test.cpp
+++ b/be/test/vec/core/column_vector_test.cpp
@@ -57,18 +57,20 @@ TEST(VColumnVectorTest, insert_indices_from_uInt64_crash) {
     // Valid indices (should work)
     uint32_t valid_indices[] = {0, 2, 3};
     dest->insert_indices_from(*src, valid_indices, valid_indices + 3);
-    ASSERT_EQ(dest->size(), 5); // 2 original + 3 inserted
+    ASSERT_EQ(dest->size(), 5);        // 2 original + 3 inserted
     ASSERT_EQ(dest->get_int(2), 10LL); // Check inserted value
 
     // Invalid indices to trigger crash
-    uint32_t invalid_indices[] = {0, 2, 1000000000U, 2000000000U}; // Large indices to hit unmapped memory (src size = 4)
+    uint32_t invalid_indices[] = {
+            0, 2, 1000000000U, 2000000000U}; // Large indices to hit unmapped memory (src size = 4)
     try {
         dest->insert_indices_from(*src, invalid_indices, invalid_indices + 4);
         FAIL() << "Expected Exception for out-of-bounds indices";
     } catch (const Exception& e) {
         ASSERT_EQ(e.code(), ErrorCode::INTERNAL_ERROR);
-        ASSERT_TRUE(std::string(e.to_string()).find("Index 1000000000 exceeds source column size 4") !=
-                    std::string::npos);
+        ASSERT_TRUE(
+                std::string(e.to_string()).find("Index 1000000000 exceeds source column size 4") !=
+                std::string::npos);
     }
 }
 

--- a/be/test/vec/core/column_vector_test.cpp
+++ b/be/test/vec/core/column_vector_test.cpp
@@ -24,6 +24,8 @@
 #include <string>
 
 #include "gtest/gtest_pred_impl.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type_number.h"
 
 namespace doris::vectorized {
 
@@ -36,6 +38,38 @@ TEST(VColumnVectorTest, insert_date_column) {
         column->insert_date_column(reinterpret_cast<char*>(&val), 1);
     }
     ASSERT_EQ(column->size(), rows);
+}
+
+TEST(VColumnVectorTest, insert_indices_from_uInt64_crash) {
+    auto src = ColumnInt64::create();
+    std::vector<int64_t> src_values = {10LL, 20LL, 30LL, 40LL};
+    for (auto v : src_values) {
+        src->insert(Field::create_field<PrimitiveType::TYPE_BIGINT>(v));
+    }
+    ASSERT_EQ(src->size(), 4);
+
+    auto dest = ColumnInt64::create();
+    std::vector<int64_t> dest_values = {1LL, 2LL};
+    for (auto v : dest_values) {
+        dest->insert(Field::create_field<PrimitiveType::TYPE_BIGINT>(v));
+    }
+
+    // Valid indices (should work)
+    uint32_t valid_indices[] = {0, 2, 3};
+    dest->insert_indices_from(*src, valid_indices, valid_indices + 3);
+    ASSERT_EQ(dest->size(), 5); // 2 original + 3 inserted
+    ASSERT_EQ(dest->get_int(2), 10LL); // Check inserted value
+
+    // Invalid indices to trigger crash
+    uint32_t invalid_indices[] = {0, 2, 1000000000U, 2000000000U}; // Large indices to hit unmapped memory (src size = 4)
+    try {
+        dest->insert_indices_from(*src, invalid_indices, invalid_indices + 4);
+        FAIL() << "Expected Exception for out-of-bounds indices";
+    } catch (const Exception& e) {
+        ASSERT_EQ(e.code(), ErrorCode::INTERNAL_ERROR);
+        ASSERT_TRUE(std::string(e.to_string()).find("Index 1000000000 exceeds source column size 4") !=
+                    std::string::npos);
+    }
 }
 
 } // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
Crash similar to Co

(gdb) bt
#0  0x0000555575a42b26 in doris::vectorized::ColumnVector<(doris::PrimitiveType)6>::insert_indices_from(doris::vectorized::IColumn const&, unsigned int const*, unsigned int const*)::{lambda(long const*, long*, unsigned int const*, unsigned int const*)#1}::operator()(long const*, long*, unsigned int const*, unsigned int const*) const (this=0x7fffffffc9df, src=0x7ffff2f73010, dest=0x7ffff2f74048, 
    begin=0x7fffffffcb50, end=0x7fffffffcb60) at /root/doris/be/src/vec/columns/column_vector.cpp:289
#1  0x00005555759d1ae9 in doris::vectorized::ColumnVector<(doris::PrimitiveType)6>::insert_indices_from (this=0x7ffff2fe0bc0, src=..., 
    indices_begin=0x7fffffffcb50, indices_end=0x7fffffffcb60) at /root/doris/be/src/vec/columns/column_vector.cpp:293
#2  0x0000555569dfaff6 in doris::vectorized::VColumnVectorTest_insert_indices_from_uInt64_crash_Test::TestBody (this=0x7ffff31350a0)
    at /root/doris/be/test/vec/core/column_vector_test.cpp:66
#3  0x000055557af8b4d4 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ()
#4  0x000055557af7aad6 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ()
#5  0x000055557af55647 in testing::Test::Run() ()
#6  0x000055557af5632d in testing::TestInfo::Run() ()
#7  0x000055557af56ac0 in testing::TestSuite::Run() ()
#8  0x000055557af6827c in testing::internal::UnitTestImpl::RunAllTests() ()
#9  0x000055557af8d304 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ()
#10 0x000055557af7ccf6 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ()
#11 0x000055557af67e0b in testing::UnitTest::Run() ()
#12 0x000055556903dae3 in RUN_ALL_TESTS () at /var/local/thirdparty/installed/include/gtest/gtest.h:2490
#13 0x00005555690338c0 in main (argc=1, argv=0x7fffffffdc18) at /root/doris/be/test/testutil/run_all_tests.cpp:111
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

