### PR TITLE
[fix](nereids) fix copy into fail when enable debug log

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CopyIntoInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CopyIntoInfo.java
@@ -214,8 +214,10 @@ public class CopyIntoInfo {
                 copyIntoProperties.getFileTypeIgnoreCompression());
         if (LOG.isDebugEnabled()) {
             LOG.debug("copy into params. sql: {}, fileColumns: {}, columnMappingList: {}, filter: {}",
-                    copyFromDesc.getFileColumns().toString(), copyFromDesc.getColumnMappingList().toString(),
-                    copyFromDesc.getFileFilterExpr().toString());
+                    originStmt,
+                    String.valueOf(copyFromDesc.getFileColumns()),
+                    String.valueOf(copyFromDesc.getColumnMappingList()),
+                    String.valueOf(copyFromDesc.getFileFilterExpr()));
         }
 
         List<String> nameParts = Lists.newArrayList();


### PR DESCRIPTION
### What problem does this PR solve?

Introduced by https://github.com/apache/doris/pull/47194.

Fix copy into fail when enable debug log:
```
Cannot invoke "Object.toString()" because the return value of "org.apache.doris.nereids.trees.plans.commands.info.CopyFromDesc.getFileColumns()" is null
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

