### PR TITLE
[Fix](warmup) one-time and periodic warm up job should be triggered regardless whether the rowset has been warmed up before

### DIFF
--- a/be/src/cloud/cloud_internal_service.cpp
+++ b/be/src/cloud/cloud_internal_service.cpp
@@ -228,7 +228,7 @@ void CloudInternalServiceImpl::warm_up_rowset(google::protobuf::RpcController* c
             expiration_time = 0;
         }
 
-        if (!tablet->add_rowset_warmup_state(rs_meta, WarmUpState::TRIGGERED_BY_JOB)) {
+        if (!tablet->add_rowset_warmup_state(rs_meta, WarmUpState::TRIGGERED_BY_EVENT_DRIVEN)) {
             LOG(INFO) << "found duplicate warmup task for rowset " << rowset_id.to_string()
                       << ", skip it";
             continue;
@@ -279,8 +279,9 @@ void CloudInternalServiceImpl::warm_up_rowset(google::protobuf::RpcController* c
                     LOG(WARNING) << "download segment failed, tablet_id: " << tablet_id
                                  << " rowset_id: " << rowset_id.to_string() << ", error: " << st;
                 }
-                if (tablet->complete_rowset_segment_warmup(rowset_id, st, 1, 0) ==
-                    WarmUpState::DONE) {
+                if (tablet->complete_rowset_segment_warmup(WarmUpState::TRIGGERED_BY_EVENT_DRIVEN,
+                                                           rowset_id, st, 1,
+                                                           0) == WarmUpState::DONE) {
                     VLOG_DEBUG << "warmup rowset " << version.to_string() << "("
                                << rowset_id.to_string() << ") completed";
                 }
@@ -352,7 +353,8 @@ void CloudInternalServiceImpl::warm_up_rowset(google::protobuf::RpcController* c
                         LOG(WARNING) << "download inverted index failed, tablet_id: " << tablet_id
                                      << " rowset_id: " << rowset_id << ", error: " << st;
                     }
-                    if (tablet->complete_rowset_segment_warmup(rowset_id, st, 0, 1) ==
+                    if (tablet->complete_rowset_segment_warmup(
+                                WarmUpState::TRIGGERED_BY_EVENT_DRIVEN, rowset_id, st, 0, 1) ==
                         WarmUpState::DONE) {
                         VLOG_DEBUG << "warmup rowset " << version.to_string() << "("
                                    << rowset_id.to_string() << ") completed";

--- a/be/src/cloud/cloud_internal_service.cpp
+++ b/be/src/cloud/cloud_internal_service.cpp
@@ -20,6 +20,7 @@
 #include <bthread/countdown_event.h>
 
 #include "cloud/cloud_storage_engine.h"
+#include "cloud/cloud_tablet.h"
 #include "cloud/cloud_tablet_mgr.h"
 #include "cloud/cloud_warm_up_manager.h"
 #include "cloud/config.h"
@@ -228,7 +229,7 @@ void CloudInternalServiceImpl::warm_up_rowset(google::protobuf::RpcController* c
             expiration_time = 0;
         }
 
-        if (!tablet->add_rowset_warmup_state(rs_meta, WarmUpState::TRIGGERED_BY_EVENT_DRIVEN)) {
+        if (!tablet->add_rowset_warmup_state(rs_meta, WarmUpTriggerSource::EVENT_DRIVEN)) {
             LOG(INFO) << "found duplicate warmup task for rowset " << rowset_id.to_string()
                       << ", skip it";
             continue;
@@ -279,9 +280,9 @@ void CloudInternalServiceImpl::warm_up_rowset(google::protobuf::RpcController* c
                     LOG(WARNING) << "download segment failed, tablet_id: " << tablet_id
                                  << " rowset_id: " << rowset_id.to_string() << ", error: " << st;
                 }
-                if (tablet->complete_rowset_segment_warmup(WarmUpState::TRIGGERED_BY_EVENT_DRIVEN,
-                                                           rowset_id, st, 1,
-                                                           0) == WarmUpState::DONE) {
+                if (tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::EVENT_DRIVEN,
+                                                           rowset_id, st, 1, 0)
+                            .trigger_source == WarmUpTriggerSource::EVENT_DRIVEN) {
                     VLOG_DEBUG << "warmup rowset " << version.to_string() << "("
                                << rowset_id.to_string() << ") completed";
                 }
@@ -353,9 +354,9 @@ void CloudInternalServiceImpl::warm_up_rowset(google::protobuf::RpcController* c
                         LOG(WARNING) << "download inverted index failed, tablet_id: " << tablet_id
                                      << " rowset_id: " << rowset_id << ", error: " << st;
                     }
-                    if (tablet->complete_rowset_segment_warmup(
-                                WarmUpState::TRIGGERED_BY_EVENT_DRIVEN, rowset_id, st, 0, 1) ==
-                        WarmUpState::DONE) {
+                    if (tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::EVENT_DRIVEN,
+                                                               rowset_id, st, 0, 1)
+                                .trigger_source == WarmUpTriggerSource::EVENT_DRIVEN) {
                         VLOG_DEBUG << "warmup rowset " << version.to_string() << "("
                                    << rowset_id.to_string() << ") completed";
                     }
@@ -375,7 +376,8 @@ void CloudInternalServiceImpl::warm_up_rowset(google::protobuf::RpcController* c
                 };
                 g_file_cache_event_driven_warm_up_submitted_index_num << 1;
                 g_file_cache_event_driven_warm_up_submitted_index_size << idx_size;
-                tablet->update_rowset_warmup_state_inverted_idx_num(rowset_id, 1);
+                tablet->update_rowset_warmup_state_inverted_idx_num(
+                        WarmUpTriggerSource::EVENT_DRIVEN, rowset_id, 1);
                 if (wait) {
                     wait->add_count();
                 }

--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -1662,24 +1662,25 @@ bool CloudTablet::add_rowset_warmup_state(const RowsetMeta& rowset, WarmUpTrigge
     return add_rowset_warmup_state_unlocked(rowset, source, start_tp);
 }
 
-void CloudTablet::update_rowset_warmup_state_inverted_idx_num(WarmUpTriggerSource source,
+bool CloudTablet::update_rowset_warmup_state_inverted_idx_num(WarmUpTriggerSource source,
                                                               RowsetId rowset_id, int64_t delta) {
     std::lock_guard wlock(_meta_lock);
-    update_rowset_warmup_state_inverted_idx_num_unlocked(source, rowset_id, delta);
+    return update_rowset_warmup_state_inverted_idx_num_unlocked(source, rowset_id, delta);
 }
 
-void CloudTablet::update_rowset_warmup_state_inverted_idx_num_unlocked(WarmUpTriggerSource source,
+bool CloudTablet::update_rowset_warmup_state_inverted_idx_num_unlocked(WarmUpTriggerSource source,
                                                                        RowsetId rowset_id,
                                                                        int64_t delta) {
     auto it = _rowset_warm_up_states.find(rowset_id);
     if (it == _rowset_warm_up_states.end()) {
-        return;
+        return false;
     }
     if (it->second.state.trigger_source != source) {
         // Only the same trigger source can update the state
-        return;
+        return false;
     }
     it->second.num_inverted_idx += delta;
+    return true;
 }
 
 bool CloudTablet::add_rowset_warmup_state_unlocked(const RowsetMeta& rowset,

--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -445,8 +445,8 @@ void CloudTablet::add_rowsets(std::vector<RowsetSharedPtr> to_add, bool version_
                     if (!warm_up_state_updated) {
                         VLOG_DEBUG << "warm up rowset " << rs->version() << "(" << rs->rowset_id()
                                    << ") triggerd by sync rowset";
-                        if (!add_rowset_warmup_state_unlocked(
-                                    *(rs->rowset_meta()), WarmUpState::TRIGGERED_BY_SYNC_ROWSET)) {
+                        if (!add_rowset_warmup_state_unlocked(*(rs->rowset_meta()),
+                                                              WarmUpTriggerSource::SYNC_ROWSET)) {
                             LOG(INFO) << "found duplicate warmup task for rowset "
                                       << rs->rowset_id() << ", skip it";
                             break;
@@ -478,7 +478,7 @@ void CloudTablet::add_rowsets(std::vector<RowsetSharedPtr> to_add, bool version_
                                                         std::chrono::seconds(sleep_time));
                                             }
                                 });
-                                self->complete_rowset_segment_warmup(WarmUpState::TRIGGERED_BY_SYNC_ROWSET, rowset_meta->rowset_id(), st, 1, 0);
+                                self->complete_rowset_segment_warmup(WarmUpTriggerSource::SYNC_ROWSET, rowset_meta->rowset_id(), st, 1, 0);
                                 if (!st) {
                                     LOG_WARNING("add rowset warm up error ").error(st);
                                 }
@@ -510,13 +510,13 @@ void CloudTablet::add_rowsets(std::vector<RowsetSharedPtr> to_add, bool version_
                                                         std::chrono::seconds(sleep_time));
                                                 // clang-format off
                                     });
-                                    self->complete_rowset_segment_warmup(WarmUpState::TRIGGERED_BY_SYNC_ROWSET, rowset_meta->rowset_id(), st, 0, 1);
+                                    self->complete_rowset_segment_warmup(WarmUpTriggerSource::SYNC_ROWSET, rowset_meta->rowset_id(), st, 0, 1);
                                     if (!st) {
                                         LOG_WARNING("add rowset warm up error ").error(st);
                                     }
                                 }},
                         };
-                        self->update_rowset_warmup_state_inverted_idx_num_unlocked(rowset_meta->rowset_id(), 1);
+                        self->update_rowset_warmup_state_inverted_idx_num_unlocked(WarmUpTriggerSource::SYNC_ROWSET, rowset_meta->rowset_id(), 1);
                         _engine.file_cache_block_downloader().submit_download_task(std::move(meta));
                         g_file_cache_cloud_tablet_submitted_index_num << 1;
                         g_file_cache_cloud_tablet_submitted_index_size << idx_size;
@@ -1649,31 +1649,41 @@ Status CloudTablet::check_delete_bitmap_cache(int64_t txn_id,
 WarmUpState CloudTablet::get_rowset_warmup_state(RowsetId rowset_id) {
     std::shared_lock rlock(_meta_lock);
     if (!_rowset_warm_up_states.contains(rowset_id)) {
-        return WarmUpState::NONE;
+        return {.trigger_source = WarmUpTriggerSource::NONE, .progress = WarmUpProgress::NONE};
     }
-    return _rowset_warm_up_states[rowset_id].state;
+    auto& warmup_info = _rowset_warm_up_states[rowset_id];
+    warmup_info.update_state();
+    return warmup_info.state;
 }
 
-bool CloudTablet::add_rowset_warmup_state(const RowsetMeta& rowset, WarmUpState state,
+bool CloudTablet::add_rowset_warmup_state(const RowsetMeta& rowset, WarmUpTriggerSource source,
                                           std::chrono::steady_clock::time_point start_tp) {
     std::lock_guard wlock(_meta_lock);
-    return add_rowset_warmup_state_unlocked(rowset, state, start_tp);
+    return add_rowset_warmup_state_unlocked(rowset, source, start_tp);
 }
 
-void CloudTablet::update_rowset_warmup_state_inverted_idx_num(RowsetId rowset_id, int64_t delta) {
+void CloudTablet::update_rowset_warmup_state_inverted_idx_num(WarmUpTriggerSource source,
+                                                              RowsetId rowset_id, int64_t delta) {
     std::lock_guard wlock(_meta_lock);
-    update_rowset_warmup_state_inverted_idx_num_unlocked(rowset_id, delta);
+    update_rowset_warmup_state_inverted_idx_num_unlocked(source, rowset_id, delta);
 }
 
-void CloudTablet::update_rowset_warmup_state_inverted_idx_num_unlocked(RowsetId rowset_id,
+void CloudTablet::update_rowset_warmup_state_inverted_idx_num_unlocked(WarmUpTriggerSource source,
+                                                                       RowsetId rowset_id,
                                                                        int64_t delta) {
-    if (!_rowset_warm_up_states.contains(rowset_id)) {
+    auto it = _rowset_warm_up_states.find(rowset_id);
+    if (it == _rowset_warm_up_states.end()) {
         return;
     }
-    _rowset_warm_up_states[rowset_id].num_inverted_idx += delta;
+    if (it->second.state.trigger_source != source) {
+        // Only the same trigger source can update the state
+        return;
+    }
+    it->second.num_inverted_idx += delta;
 }
 
-bool CloudTablet::add_rowset_warmup_state_unlocked(const RowsetMeta& rowset, WarmUpState state,
+bool CloudTablet::add_rowset_warmup_state_unlocked(const RowsetMeta& rowset,
+                                                   WarmUpTriggerSource source,
                                                    std::chrono::steady_clock::time_point start_tp) {
     auto rowset_id = rowset.rowset_id();
 
@@ -1683,8 +1693,8 @@ bool CloudTablet::add_rowset_warmup_state_unlocked(const RowsetMeta& rowset, War
 
         // For job-triggered warmup (one-time and periodic warmup), allow it to proceed
         // except when there's already another job-triggered warmup in progress
-        if (state == WarmUpState::TRIGGERED_BY_JOB) {
-            if (existing_state == WarmUpState::TRIGGERED_BY_JOB) {
+        if (source == WarmUpTriggerSource::JOB) {
+            if (existing_state.trigger_source == WarmUpTriggerSource::JOB) {
                 // Same job type already in progress, skip to avoid duplicate warmup
                 return false;
             }
@@ -1695,29 +1705,42 @@ bool CloudTablet::add_rowset_warmup_state_unlocked(const RowsetMeta& rowset, War
         }
     }
 
-    if (state == WarmUpState::TRIGGERED_BY_JOB) {
+    if (source == WarmUpTriggerSource::JOB) {
         g_file_cache_warm_up_rowset_triggered_by_job_num << 1;
-    } else if (state == WarmUpState::TRIGGERED_BY_SYNC_ROWSET) {
+    } else if (source == WarmUpTriggerSource::SYNC_ROWSET) {
         g_file_cache_warm_up_rowset_triggered_by_sync_rowset_num << 1;
-    } else if (state == WarmUpState::TRIGGERED_BY_EVENT_DRIVEN) {
+    } else if (source == WarmUpTriggerSource::EVENT_DRIVEN) {
         g_file_cache_warm_up_rowset_triggered_by_event_driven_num << 1;
     }
     _rowset_warm_up_states[rowset_id] = {
-            .state = state, .num_segments = rowset.num_segments(), .start_tp = start_tp};
+            .state = {.trigger_source = source, .progress = WarmUpProgress::DOING},
+            .num_segments = rowset.num_segments(),
+            .start_tp = start_tp};
     return true;
 }
 
-WarmUpState CloudTablet::complete_rowset_segment_warmup(WarmUpState trigger_source,
+void CloudTablet::RowsetWarmUpInfo::update_state() {
+    if (has_finished()) {
+        g_file_cache_warm_up_rowset_complete_num << 1;
+        auto cost = std::chrono::duration_cast<std::chrono::milliseconds>(
+                            std::chrono::steady_clock::now() - start_tp)
+                            .count();
+        g_file_cache_warm_up_rowset_all_segments_latency << cost;
+        state.progress = WarmUpProgress::DONE;
+    }
+}
+
+WarmUpState CloudTablet::complete_rowset_segment_warmup(WarmUpTriggerSource trigger_source,
                                                         RowsetId rowset_id, Status status,
                                                         int64_t segment_num,
                                                         int64_t inverted_idx_num) {
     std::lock_guard wlock(_meta_lock);
     auto it = _rowset_warm_up_states.find(rowset_id);
     if (it == _rowset_warm_up_states.end()) {
-        return WarmUpState::NONE;
+        return {.trigger_source = WarmUpTriggerSource::NONE, .progress = WarmUpProgress::NONE};
     }
     auto& warmup_info = it->second;
-    if (warmup_info.state != trigger_source) {
+    if (warmup_info.state.trigger_source != trigger_source) {
         // Only the same trigger source can update the state
         return warmup_info.state;
     }
@@ -1735,14 +1758,6 @@ WarmUpState CloudTablet::complete_rowset_segment_warmup(WarmUpState trigger_sour
         }
     }
     warmup_info.done(segment_num, inverted_idx_num);
-    if (_rowset_warm_up_states[rowset_id].has_finished()) {
-        g_file_cache_warm_up_rowset_complete_num << 1;
-        auto cost = std::chrono::duration_cast<std::chrono::milliseconds>(
-                            std::chrono::steady_clock::now() - warmup_info.start_tp)
-                            .count();
-        g_file_cache_warm_up_rowset_all_segments_latency << cost;
-        warmup_info.state = WarmUpState::DONE;
-    }
     return warmup_info.state;
 }
 
@@ -1751,13 +1766,15 @@ bool CloudTablet::is_rowset_warmed_up(const RowsetId& rowset_id) const {
     if (it == _rowset_warm_up_states.end()) {
         return false;
     }
-    return it->second.state == WarmUpState::DONE;
+    return it->second.state.progress == WarmUpProgress::DONE;
 }
 
 void CloudTablet::add_warmed_up_rowset(const RowsetId& rowset_id) {
-    _rowset_warm_up_states[rowset_id] = {.state = WarmUpState::DONE,
-                                         .num_segments = 1,
-                                         .start_tp = std::chrono::steady_clock::now()};
+    _rowset_warm_up_states[rowset_id] = {
+            .state = {.trigger_source = WarmUpTriggerSource::SYNC_ROWSET,
+                      .progress = WarmUpProgress::DONE},
+            .num_segments = 1,
+            .start_tp = std::chrono::steady_clock::now()};
 }
 
 #include "common/compile_check_end.h"

--- a/be/src/cloud/cloud_tablet.h
+++ b/be/src/cloud/cloud_tablet.h
@@ -34,6 +34,10 @@ enum class WarmUpProgress : int { NONE, DOING, DONE };
 struct WarmUpState {
     WarmUpTriggerSource trigger_source {WarmUpTriggerSource::NONE};
     WarmUpProgress progress {WarmUpProgress::NONE};
+
+    bool operator==(const WarmUpState& other) const {
+        return trigger_source == other.trigger_source && progress == other.progress;
+    }
 };
 
 struct SyncRowsetStats {

--- a/be/src/cloud/cloud_tablet.h
+++ b/be/src/cloud/cloud_tablet.h
@@ -330,8 +330,9 @@ public:
             std::chrono::steady_clock::time_point start_tp = std::chrono::steady_clock::now());
     void update_rowset_warmup_state_inverted_idx_num(RowsetId rowset_id, int64_t delta);
     void update_rowset_warmup_state_inverted_idx_num_unlocked(RowsetId rowset_id, int64_t delta);
-    WarmUpState complete_rowset_segment_warmup(RowsetId rowset_id, Status status,
-                                               int64_t segment_num, int64_t inverted_idx_num);
+    WarmUpState complete_rowset_segment_warmup(WarmUpState trigger_source, RowsetId rowset_id,
+                                               Status status, int64_t segment_num,
+                                               int64_t inverted_idx_num);
 
     bool is_rowset_warmed_up(const RowsetId& rowset_id) const;
 

--- a/be/src/cloud/cloud_tablet.h
+++ b/be/src/cloud/cloud_tablet.h
@@ -26,7 +26,15 @@
 namespace doris {
 
 class CloudStorageEngine;
-enum class WarmUpState : int;
+
+enum class WarmUpTriggerSource : int { NONE, SYNC_ROWSET, EVENT_DRIVEN, JOB };
+
+enum class WarmUpProgress : int { NONE, DOING, DONE };
+
+struct WarmUpState {
+    WarmUpTriggerSource trigger_source {WarmUpTriggerSource::NONE};
+    WarmUpProgress progress {WarmUpProgress::NONE};
+};
 
 struct SyncRowsetStats {
     int64_t get_remote_rowsets_num {0};
@@ -326,13 +334,15 @@ public:
     // Add warmup state management
     WarmUpState get_rowset_warmup_state(RowsetId rowset_id);
     bool add_rowset_warmup_state(
-            const RowsetMeta& rowset, WarmUpState state,
+            const RowsetMeta& rowset, WarmUpTriggerSource source,
             std::chrono::steady_clock::time_point start_tp = std::chrono::steady_clock::now());
-    void update_rowset_warmup_state_inverted_idx_num(RowsetId rowset_id, int64_t delta);
-    void update_rowset_warmup_state_inverted_idx_num_unlocked(RowsetId rowset_id, int64_t delta);
-    WarmUpState complete_rowset_segment_warmup(WarmUpState trigger_source, RowsetId rowset_id,
-                                               Status status, int64_t segment_num,
-                                               int64_t inverted_idx_num);
+    void update_rowset_warmup_state_inverted_idx_num(WarmUpTriggerSource source, RowsetId rowset_id,
+                                                     int64_t delta);
+    void update_rowset_warmup_state_inverted_idx_num_unlocked(WarmUpTriggerSource source,
+                                                              RowsetId rowset_id, int64_t delta);
+    WarmUpState complete_rowset_segment_warmup(WarmUpTriggerSource trigger_source,
+                                               RowsetId rowset_id, Status status,
+                                               int64_t segment_num, int64_t inverted_idx_num);
 
     bool is_rowset_warmed_up(const RowsetId& rowset_id) const;
 
@@ -344,8 +354,8 @@ public:
             auto tmp = fmt::format("{}{}", rs->rowset_id().to_string(), rs->version().to_string());
             if (_rowset_warm_up_states.contains(rs->rowset_id())) {
                 tmp += fmt::format(
-                        ", state={}, segments_warmed_up={}/{}, inverted_idx_warmed_up={}/{}",
-                        _rowset_warm_up_states.at(rs->rowset_id()).state,
+                        ", progress={}, segments_warmed_up={}/{}, inverted_idx_warmed_up={}/{}",
+                        _rowset_warm_up_states.at(rs->rowset_id()).state.progress,
                         _rowset_warm_up_states.at(rs->rowset_id()).num_segments_warmed_up,
                         _rowset_warm_up_states.at(rs->rowset_id()).num_segments,
                         _rowset_warm_up_states.at(rs->rowset_id()).num_inverted_idx_warmed_up,
@@ -364,7 +374,7 @@ private:
     Status sync_if_not_running(SyncRowsetStats* stats = nullptr);
 
     bool add_rowset_warmup_state_unlocked(
-            const RowsetMeta& rowset, WarmUpState state,
+            const RowsetMeta& rowset, WarmUpTriggerSource source,
             std::chrono::steady_clock::time_point start_tp = std::chrono::steady_clock::now());
 
     // used by capture_rs_reader_xxx functions
@@ -439,12 +449,15 @@ private:
         void done(int64_t num_segments, int64_t num_inverted_idx) {
             num_segments_warmed_up += num_segments;
             num_inverted_idx_warmed_up += num_inverted_idx;
+            update_state();
         }
 
         bool has_finished() const {
             return (num_segments_warmed_up >= num_segments) &&
                    (num_inverted_idx_warmed_up >= num_inverted_idx);
         }
+
+        void update_state();
     };
     std::unordered_map<RowsetId, RowsetWarmUpInfo> _rowset_warm_up_states;
 

--- a/be/src/cloud/cloud_tablet.h
+++ b/be/src/cloud/cloud_tablet.h
@@ -340,9 +340,9 @@ public:
     bool add_rowset_warmup_state(
             const RowsetMeta& rowset, WarmUpTriggerSource source,
             std::chrono::steady_clock::time_point start_tp = std::chrono::steady_clock::now());
-    void update_rowset_warmup_state_inverted_idx_num(WarmUpTriggerSource source, RowsetId rowset_id,
+    bool update_rowset_warmup_state_inverted_idx_num(WarmUpTriggerSource source, RowsetId rowset_id,
                                                      int64_t delta);
-    void update_rowset_warmup_state_inverted_idx_num_unlocked(WarmUpTriggerSource source,
+    bool update_rowset_warmup_state_inverted_idx_num_unlocked(WarmUpTriggerSource source,
                                                               RowsetId rowset_id, int64_t delta);
     WarmUpState complete_rowset_segment_warmup(WarmUpTriggerSource trigger_source,
                                                RowsetId rowset_id, Status status,

--- a/be/src/cloud/cloud_warm_up_manager.cpp
+++ b/be/src/cloud/cloud_warm_up_manager.cpp
@@ -249,7 +249,8 @@ void CloudWarmUpManager::handle_jobs() {
                                 VLOG_DEBUG << "warmup rowset " << rs->version() << " segment "
                                            << seg_id << " completed";
                                 if (tablet->complete_rowset_segment_warmup(
-                                            rs->rowset_id(), st, 1, 0) == WarmUpState::DONE) {
+                                            WarmUpState::TRIGGERED_BY_JOB, rs->rowset_id(), st, 1,
+                                            0) == WarmUpState::DONE) {
                                     VLOG_DEBUG << "warmup rowset " << rs->version() << " completed";
                                 }
                             });
@@ -290,9 +291,9 @@ void CloudWarmUpManager::handle_jobs() {
                                         VLOG_DEBUG << "warmup rowset " << rs->version()
                                                    << " segment " << seg_id
                                                    << "inverted idx:" << idx_path << " completed";
-                                        if (tablet->complete_rowset_segment_warmup(rs->rowset_id(),
-                                                                                   st, 0, 1) ==
-                                            WarmUpState::DONE) {
+                                        if (tablet->complete_rowset_segment_warmup(
+                                                    WarmUpState::TRIGGERED_BY_JOB, rs->rowset_id(),
+                                                    st, 0, 1) == WarmUpState::DONE) {
                                             VLOG_DEBUG << "warmup rowset " << rs->version()
                                                        << " completed";
                                         }
@@ -311,9 +312,9 @@ void CloudWarmUpManager::handle_jobs() {
                                         VLOG_DEBUG << "warmup rowset " << rs->version()
                                                    << " segment " << seg_id
                                                    << "inverted idx:" << idx_path << " completed";
-                                        if (tablet->complete_rowset_segment_warmup(rs->rowset_id(),
-                                                                                   st, 0, 1) ==
-                                            WarmUpState::DONE) {
+                                        if (tablet->complete_rowset_segment_warmup(
+                                                    WarmUpState::TRIGGERED_BY_JOB, rs->rowset_id(),
+                                                    st, 0, 1) == WarmUpState::DONE) {
                                             VLOG_DEBUG << "warmup rowset " << rs->version()
                                                        << " completed";
                                         }

--- a/be/src/cloud/cloud_warm_up_manager.h
+++ b/be/src/cloud/cloud_warm_up_manager.h
@@ -42,6 +42,7 @@ enum class DownloadType {
 enum class WarmUpState : int {
     NONE,
     TRIGGERED_BY_SYNC_ROWSET,
+    TRIGGERED_BY_EVENT_DRIVEN,
     TRIGGERED_BY_JOB,
     DONE,
 };

--- a/be/src/cloud/cloud_warm_up_manager.h
+++ b/be/src/cloud/cloud_warm_up_manager.h
@@ -39,14 +39,6 @@ enum class DownloadType {
     S3,
 };
 
-enum class WarmUpState : int {
-    NONE,
-    TRIGGERED_BY_SYNC_ROWSET,
-    TRIGGERED_BY_EVENT_DRIVEN,
-    TRIGGERED_BY_JOB,
-    DONE,
-};
-
 struct JobMeta {
     JobMeta() = default;
     JobMeta(const TJobMeta& meta);

--- a/be/test/cloud/cloud_tablet_test.cpp
+++ b/be/test/cloud/cloud_tablet_test.cpp
@@ -95,7 +95,8 @@ TEST_F(CloudTabletWarmUpStateTest, TestAddRowsetWarmupStateTriggeredByJob) {
 
     // Verify the state is correctly set
     WarmUpState state = _tablet->get_rowset_warmup_state(rowset->rowset_id());
-    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    WarmUpState expected_state =
+            WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
     EXPECT_EQ(state, expected_state);
 }
 
@@ -110,7 +111,8 @@ TEST_F(CloudTabletWarmUpStateTest, TestAddRowsetWarmupStateTriggeredBySyncRowset
 
     // Verify the state is correctly set
     WarmUpState state = _tablet->get_rowset_warmup_state(rowset->rowset_id());
-    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DOING};
+    WarmUpState expected_state =
+            WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DOING};
     EXPECT_EQ(state, expected_state);
 }
 
@@ -131,7 +133,8 @@ TEST_F(CloudTabletWarmUpStateTest, TestAddDuplicateRowsetWarmupState) {
 
     // State should remain the original one
     WarmUpState state = _tablet->get_rowset_warmup_state(rowset->rowset_id());
-    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    WarmUpState expected_state =
+            WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
     EXPECT_EQ(state, expected_state);
 }
 
@@ -158,7 +161,8 @@ TEST_F(CloudTabletWarmUpStateTest, TestCompleteRowsetSegmentWarmupPartial) {
     // Complete one segment, should still be in TRIGGERED_BY_EVENT_DRIVEN state
     WarmUpState result1 = _tablet->complete_rowset_segment_warmup(
             WarmUpTriggerSource::EVENT_DRIVEN, rowset->rowset_id(), Status::OK(), 1, 0);
-    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    WarmUpState expected_state =
+            WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
     EXPECT_EQ(result1, expected_state);
 
     // Complete second segment, should still be in TRIGGERED_BY_EVENT_DRIVEN state
@@ -186,7 +190,8 @@ TEST_F(CloudTabletWarmUpStateTest, TestCompleteRowsetSegmentWarmupFull) {
     // Complete first segment
     WarmUpState result1 = _tablet->complete_rowset_segment_warmup(
             WarmUpTriggerSource::SYNC_ROWSET, rowset->rowset_id(), Status::OK(), 1, 0);
-    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DOING};
+    WarmUpState expected_state =
+            WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DOING};
     EXPECT_EQ(result1, expected_state);
 
     // Complete second segment, should transition to DONE state
@@ -219,7 +224,8 @@ TEST_F(CloudTabletWarmUpStateTest, TestCompleteRowsetSegmentWarmupWithInvertedIn
     // Complete one segment file
     WarmUpState result1 = _tablet->complete_rowset_segment_warmup(
             WarmUpTriggerSource::EVENT_DRIVEN, rowset->rowset_id(), Status::OK(), 1, 0);
-    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    WarmUpState expected_state =
+            WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
     EXPECT_EQ(result1, expected_state);
 
     // Complete inverted index file, should still be in TRIGGERED_BY_EVENT_DRIVEN state
@@ -250,7 +256,8 @@ TEST_F(CloudTabletWarmUpStateTest, TestCompleteRowsetSegmentWarmupWithInvertedIn
     // Complete segment file
     WarmUpState result1 = _tablet->complete_rowset_segment_warmup(
             WarmUpTriggerSource::EVENT_DRIVEN, rowset->rowset_id(), Status::OK(), 1, 0);
-    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    WarmUpState expected_state =
+            WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
     EXPECT_EQ(result1, expected_state);
 
     // Complete inverted index file
@@ -279,7 +286,8 @@ TEST_F(CloudTabletWarmUpStateTest, TestCompleteRowsetSegmentWarmupWithError) {
     Status error_status = Status::InternalError("Test error");
     WarmUpState result = _tablet->complete_rowset_segment_warmup(
             WarmUpTriggerSource::EVENT_DRIVEN, rowset->rowset_id(), error_status, 1, 0);
-    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE};
+    WarmUpState expected_state =
+            WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE};
     EXPECT_EQ(result, expected_state);
 
     // Verify final state is DONE even with error
@@ -306,7 +314,8 @@ TEST_F(CloudTabletWarmUpStateTest, TestMultipleRowsetsWarmupState) {
                                                  WarmUpTriggerSource::EVENT_DRIVEN));
 
     // Verify all states
-    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    WarmUpState expected_state =
+            WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
     EXPECT_EQ(_tablet->get_rowset_warmup_state(rowset1->rowset_id()), expected_state);
     expected_state = WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DOING};
     EXPECT_EQ(_tablet->get_rowset_warmup_state(rowset2->rowset_id()), expected_state);
@@ -314,18 +323,18 @@ TEST_F(CloudTabletWarmUpStateTest, TestMultipleRowsetsWarmupState) {
     EXPECT_EQ(_tablet->get_rowset_warmup_state(rowset3->rowset_id()), expected_state);
 
     // Complete rowset1 (2 segments)
-    WarmUpState result = _tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::EVENT_DRIVEN,
-                                                      rowset1->rowset_id(), Status::OK(), 1, 0);
+    WarmUpState result = _tablet->complete_rowset_segment_warmup(
+            WarmUpTriggerSource::EVENT_DRIVEN, rowset1->rowset_id(), Status::OK(), 1, 0);
     expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
     EXPECT_EQ(result, expected_state);
     result = _tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::EVENT_DRIVEN,
-                                                      rowset1->rowset_id(), Status::OK(), 1, 0);
+                                                     rowset1->rowset_id(), Status::OK(), 1, 0);
     expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE};
     EXPECT_EQ(result, expected_state);
 
     // Complete rowset3 (1 segment)
     result = _tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::EVENT_DRIVEN,
-                                                      rowset3->rowset_id(), Status::OK(), 1, 0);
+                                                     rowset3->rowset_id(), Status::OK(), 1, 0);
     expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE};
     EXPECT_EQ(result, expected_state);
 
@@ -350,7 +359,8 @@ TEST_F(CloudTabletWarmUpStateTest, TestWarmupStateWithZeroSegments) {
 
     // State should be immediately ready for completion since there are no segments to warm up
     WarmUpState state = _tablet->get_rowset_warmup_state(rowset->rowset_id());
-    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE};
+    WarmUpState expected_state =
+            WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE};
     EXPECT_EQ(state, expected_state);
 }
 
@@ -368,16 +378,17 @@ TEST_F(CloudTabletWarmUpStateTest, TestConcurrentWarmupStateAccess) {
                                                  WarmUpTriggerSource::SYNC_ROWSET));
 
     // Interleaved completion operations
-    WarmUpState result = _tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::EVENT_DRIVEN,
-                                                      rowset1->rowset_id(), Status::OK(), 1, 0);
-    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    WarmUpState result = _tablet->complete_rowset_segment_warmup(
+            WarmUpTriggerSource::EVENT_DRIVEN, rowset1->rowset_id(), Status::OK(), 1, 0);
+    WarmUpState expected_state =
+            WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
     EXPECT_EQ(result, expected_state);
     result = _tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::SYNC_ROWSET,
-                                                      rowset2->rowset_id(), Status::OK(), 1, 0);
+                                                     rowset2->rowset_id(), Status::OK(), 1, 0);
     expected_state = WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DOING};
     EXPECT_EQ(result, expected_state);
     result = _tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::EVENT_DRIVEN,
-                                                      rowset1->rowset_id(), Status::OK(), 1, 0);
+                                                     rowset1->rowset_id(), Status::OK(), 1, 0);
     expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
     EXPECT_EQ(result, expected_state);
 

--- a/be/test/cloud/cloud_tablet_test.cpp
+++ b/be/test/cloud/cloud_tablet_test.cpp
@@ -80,7 +80,8 @@ TEST_F(CloudTabletWarmUpStateTest, TestGetRowsetWarmupStateNonExistent) {
     auto non_existent_id = _engine.next_rowset_id();
 
     WarmUpState state = _tablet->get_rowset_warmup_state(non_existent_id);
-    EXPECT_EQ(state, WarmUpState {WarmUpTriggerSource::NONE, WarmUpProgress::NONE});
+    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::NONE, WarmUpProgress::NONE};
+    EXPECT_EQ(state, expected_state);
 }
 
 // Test add_rowset_warmup_state with TRIGGERED_BY_EVENT_DRIVEN state
@@ -94,7 +95,8 @@ TEST_F(CloudTabletWarmUpStateTest, TestAddRowsetWarmupStateTriggeredByJob) {
 
     // Verify the state is correctly set
     WarmUpState state = _tablet->get_rowset_warmup_state(rowset->rowset_id());
-    EXPECT_EQ(state, WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING});
+    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    EXPECT_EQ(state, expected_state);
 }
 
 // Test add_rowset_warmup_state with TRIGGERED_BY_SYNC_ROWSET state
@@ -108,7 +110,8 @@ TEST_F(CloudTabletWarmUpStateTest, TestAddRowsetWarmupStateTriggeredBySyncRowset
 
     // Verify the state is correctly set
     WarmUpState state = _tablet->get_rowset_warmup_state(rowset->rowset_id());
-    EXPECT_EQ(state, WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DOING});
+    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DOING};
+    EXPECT_EQ(state, expected_state);
 }
 
 // Test adding duplicate rowset warmup state should fail
@@ -128,7 +131,8 @@ TEST_F(CloudTabletWarmUpStateTest, TestAddDuplicateRowsetWarmupState) {
 
     // State should remain the original one
     WarmUpState state = _tablet->get_rowset_warmup_state(rowset->rowset_id());
-    EXPECT_EQ(state, WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING});
+    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    EXPECT_EQ(state, expected_state);
 }
 
 // Test complete_rowset_segment_warmup for non-existent rowset
@@ -137,7 +141,8 @@ TEST_F(CloudTabletWarmUpStateTest, TestCompleteRowsetSegmentWarmupNonExistent) {
 
     WarmUpState result = _tablet->complete_rowset_segment_warmup(
             WarmUpTriggerSource::SYNC_ROWSET, non_existent_id, Status::OK(), 1, 0);
-    EXPECT_EQ(result, WarmUpState {WarmUpTriggerSource::NONE, WarmUpProgress::NONE});
+    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::NONE, WarmUpProgress::NONE};
+    EXPECT_EQ(result, expected_state);
 }
 
 // Test complete_rowset_segment_warmup with partial completion
@@ -153,17 +158,19 @@ TEST_F(CloudTabletWarmUpStateTest, TestCompleteRowsetSegmentWarmupPartial) {
     // Complete one segment, should still be in TRIGGERED_BY_EVENT_DRIVEN state
     WarmUpState result1 = _tablet->complete_rowset_segment_warmup(
             WarmUpTriggerSource::EVENT_DRIVEN, rowset->rowset_id(), Status::OK(), 1, 0);
-    EXPECT_EQ(result1, WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING});
+    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    EXPECT_EQ(result1, expected_state);
 
     // Complete second segment, should still be in TRIGGERED_BY_EVENT_DRIVEN state
     WarmUpState result2 = _tablet->complete_rowset_segment_warmup(
             WarmUpTriggerSource::EVENT_DRIVEN, rowset->rowset_id(), Status::OK(), 1, 0);
-    EXPECT_EQ(result2, WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING});
+    expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    EXPECT_EQ(result2, expected_state);
 
     // Verify current state is still TRIGGERED_BY_EVENT_DRIVEN
     WarmUpState current_state = _tablet->get_rowset_warmup_state(rowset->rowset_id());
-    EXPECT_EQ(current_state,
-              WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING});
+    expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    EXPECT_EQ(current_state, expected_state);
 }
 
 // Test complete_rowset_segment_warmup with full completion
@@ -179,16 +186,19 @@ TEST_F(CloudTabletWarmUpStateTest, TestCompleteRowsetSegmentWarmupFull) {
     // Complete first segment
     WarmUpState result1 = _tablet->complete_rowset_segment_warmup(
             WarmUpTriggerSource::SYNC_ROWSET, rowset->rowset_id(), Status::OK(), 1, 0);
-    EXPECT_EQ(result1, WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DOING});
+    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DOING};
+    EXPECT_EQ(result1, expected_state);
 
     // Complete second segment, should transition to DONE state
     WarmUpState result2 = _tablet->complete_rowset_segment_warmup(
             WarmUpTriggerSource::SYNC_ROWSET, rowset->rowset_id(), Status::OK(), 1, 0);
-    EXPECT_EQ(result2, WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DONE});
+    expected_state = WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DONE};
+    EXPECT_EQ(result2, expected_state);
 
     // Verify final state is DONE
     WarmUpState final_state = _tablet->get_rowset_warmup_state(rowset->rowset_id());
-    EXPECT_EQ(final_state, WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DONE});
+    expected_state = WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DONE};
+    EXPECT_EQ(final_state, expected_state);
 }
 
 // Test complete_rowset_segment_warmup with inverted index file, partial completion
@@ -209,17 +219,19 @@ TEST_F(CloudTabletWarmUpStateTest, TestCompleteRowsetSegmentWarmupWithInvertedIn
     // Complete one segment file
     WarmUpState result1 = _tablet->complete_rowset_segment_warmup(
             WarmUpTriggerSource::EVENT_DRIVEN, rowset->rowset_id(), Status::OK(), 1, 0);
-    EXPECT_EQ(result1, WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING});
+    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    EXPECT_EQ(result1, expected_state);
 
     // Complete inverted index file, should still be in TRIGGERED_BY_EVENT_DRIVEN state
     WarmUpState result2 = _tablet->complete_rowset_segment_warmup(
             WarmUpTriggerSource::EVENT_DRIVEN, rowset->rowset_id(), Status::OK(), 0, 1);
-    EXPECT_EQ(result2, WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING});
+    expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    EXPECT_EQ(result2, expected_state);
 
     // Verify current state is still TRIGGERED_BY_EVENT_DRIVEN
     WarmUpState current_state = _tablet->get_rowset_warmup_state(rowset->rowset_id());
-    EXPECT_EQ(current_state,
-              WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING});
+    expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    EXPECT_EQ(current_state, expected_state);
 }
 
 // Test complete_rowset_segment_warmup with inverted index file, full completion
@@ -238,16 +250,19 @@ TEST_F(CloudTabletWarmUpStateTest, TestCompleteRowsetSegmentWarmupWithInvertedIn
     // Complete segment file
     WarmUpState result1 = _tablet->complete_rowset_segment_warmup(
             WarmUpTriggerSource::EVENT_DRIVEN, rowset->rowset_id(), Status::OK(), 1, 0);
-    EXPECT_EQ(result1, WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING});
+    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    EXPECT_EQ(result1, expected_state);
 
     // Complete inverted index file
     WarmUpState result2 = _tablet->complete_rowset_segment_warmup(
             WarmUpTriggerSource::EVENT_DRIVEN, rowset->rowset_id(), Status::OK(), 0, 1);
-    EXPECT_EQ(result2, WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE});
+    expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE};
+    EXPECT_EQ(result2, expected_state);
 
     // Verify final state is DONE
     WarmUpState final_state = _tablet->get_rowset_warmup_state(rowset->rowset_id());
-    EXPECT_EQ(final_state, WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE});
+    expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE};
+    EXPECT_EQ(final_state, expected_state);
 }
 
 // Test complete_rowset_segment_warmup with error status
@@ -264,11 +279,13 @@ TEST_F(CloudTabletWarmUpStateTest, TestCompleteRowsetSegmentWarmupWithError) {
     Status error_status = Status::InternalError("Test error");
     WarmUpState result = _tablet->complete_rowset_segment_warmup(
             WarmUpTriggerSource::EVENT_DRIVEN, rowset->rowset_id(), error_status, 1, 0);
-    EXPECT_EQ(result, WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE});
+    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE};
+    EXPECT_EQ(result, expected_state);
 
     // Verify final state is DONE even with error
     WarmUpState final_state = _tablet->get_rowset_warmup_state(rowset->rowset_id());
-    EXPECT_EQ(final_state, WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE});
+    expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE};
+    EXPECT_EQ(final_state, expected_state);
 }
 
 // Test multiple rowsets warmup state management
@@ -289,32 +306,36 @@ TEST_F(CloudTabletWarmUpStateTest, TestMultipleRowsetsWarmupState) {
                                                  WarmUpTriggerSource::EVENT_DRIVEN));
 
     // Verify all states
-    EXPECT_EQ(_tablet->get_rowset_warmup_state(rowset1->rowset_id()),
-              WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING});
-    EXPECT_EQ(_tablet->get_rowset_warmup_state(rowset2->rowset_id()),
-              WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DOING});
-    EXPECT_EQ(_tablet->get_rowset_warmup_state(rowset3->rowset_id()),
-              WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING});
+    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    EXPECT_EQ(_tablet->get_rowset_warmup_state(rowset1->rowset_id()), expected_state);
+    expected_state = WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DOING};
+    EXPECT_EQ(_tablet->get_rowset_warmup_state(rowset2->rowset_id()), expected_state);
+    expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    EXPECT_EQ(_tablet->get_rowset_warmup_state(rowset3->rowset_id()), expected_state);
 
     // Complete rowset1 (2 segments)
-    EXPECT_EQ(_tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::EVENT_DRIVEN,
-                                                      rowset1->rowset_id(), Status::OK(), 1, 0),
-              WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING});
-    EXPECT_EQ(_tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::EVENT_DRIVEN,
-                                                      rowset1->rowset_id(), Status::OK(), 1, 0),
-              WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE});
+    WarmUpState result = _tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::EVENT_DRIVEN,
+                                                      rowset1->rowset_id(), Status::OK(), 1, 0);
+    expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    EXPECT_EQ(result, expected_state);
+    result = _tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::EVENT_DRIVEN,
+                                                      rowset1->rowset_id(), Status::OK(), 1, 0);
+    expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE};
+    EXPECT_EQ(result, expected_state);
 
     // Complete rowset3 (1 segment)
-    EXPECT_EQ(_tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::EVENT_DRIVEN,
-                                                      rowset3->rowset_id(), Status::OK(), 1, 0),
-              WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE});
+    result = _tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::EVENT_DRIVEN,
+                                                      rowset3->rowset_id(), Status::OK(), 1, 0);
+    expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE};
+    EXPECT_EQ(result, expected_state);
 
     // Verify states after completion
-    EXPECT_EQ(_tablet->get_rowset_warmup_state(rowset1->rowset_id()),
-              WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE});
-    EXPECT_EQ(_tablet->get_rowset_warmup_state(rowset2->rowset_id()),
-              WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DOING});
-    EXPECT_EQ(_tablet->get_rowset_warmup_state(rowset3->rowset_id()), WarmUpState::DONE);
+    expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE};
+    EXPECT_EQ(_tablet->get_rowset_warmup_state(rowset1->rowset_id()), expected_state);
+    expected_state = WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DOING};
+    EXPECT_EQ(_tablet->get_rowset_warmup_state(rowset2->rowset_id()), expected_state);
+    expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE};
+    EXPECT_EQ(_tablet->get_rowset_warmup_state(rowset3->rowset_id()), expected_state);
 }
 
 // Test warmup state with zero segments (edge case)
@@ -329,7 +350,8 @@ TEST_F(CloudTabletWarmUpStateTest, TestWarmupStateWithZeroSegments) {
 
     // State should be immediately ready for completion since there are no segments to warm up
     WarmUpState state = _tablet->get_rowset_warmup_state(rowset->rowset_id());
-    EXPECT_EQ(state, WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE});
+    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DONE};
+    EXPECT_EQ(state, expected_state);
 }
 
 // Test concurrent access to warmup state (basic thread safety verification)
@@ -346,21 +368,24 @@ TEST_F(CloudTabletWarmUpStateTest, TestConcurrentWarmupStateAccess) {
                                                  WarmUpTriggerSource::SYNC_ROWSET));
 
     // Interleaved completion operations
-    EXPECT_EQ(_tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::EVENT_DRIVEN,
-                                                      rowset1->rowset_id(), Status::OK(), 1, 0),
-              WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING});
-    EXPECT_EQ(_tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::SYNC_ROWSET,
-                                                      rowset2->rowset_id(), Status::OK(), 1, 0),
-              WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DOING});
-    EXPECT_EQ(_tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::EVENT_DRIVEN,
-                                                      rowset1->rowset_id(), Status::OK(), 1, 0),
-              WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING});
+    WarmUpState result = _tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::EVENT_DRIVEN,
+                                                      rowset1->rowset_id(), Status::OK(), 1, 0);
+    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    EXPECT_EQ(result, expected_state);
+    result = _tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::SYNC_ROWSET,
+                                                      rowset2->rowset_id(), Status::OK(), 1, 0);
+    expected_state = WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DOING};
+    EXPECT_EQ(result, expected_state);
+    result = _tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::EVENT_DRIVEN,
+                                                      rowset1->rowset_id(), Status::OK(), 1, 0);
+    expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    EXPECT_EQ(result, expected_state);
 
     // Check states are maintained correctly
-    EXPECT_EQ(_tablet->get_rowset_warmup_state(rowset1->rowset_id()),
-              WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING});
-    EXPECT_EQ(_tablet->get_rowset_warmup_state(rowset2->rowset_id()),
-              WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DOING});
+    expected_state = WarmUpState {WarmUpTriggerSource::EVENT_DRIVEN, WarmUpProgress::DOING};
+    EXPECT_EQ(_tablet->get_rowset_warmup_state(rowset1->rowset_id()), expected_state);
+    expected_state = WarmUpState {WarmUpTriggerSource::SYNC_ROWSET, WarmUpProgress::DOING};
+    EXPECT_EQ(_tablet->get_rowset_warmup_state(rowset2->rowset_id()), expected_state);
 }
 
 // Test only when the trigger source matches can the state be updated
@@ -375,14 +400,17 @@ TEST_F(CloudTabletWarmUpStateTest, TestCompleteRowsetSegmentWarmupTriggerSource)
     // Attempt to complete with a different trigger source, should not update state
     WarmUpState result = _tablet->complete_rowset_segment_warmup(
             WarmUpTriggerSource::SYNC_ROWSET, rowset->rowset_id(), Status::OK(), 1, 0);
-    EXPECT_EQ(result, WarmUpTriggerSource::JOB);
+    WarmUpState expected_state = WarmUpState {WarmUpTriggerSource::JOB, WarmUpProgress::DOING};
+    EXPECT_EQ(result, expected_state);
     result = _tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::EVENT_DRIVEN,
                                                      rowset->rowset_id(), Status::OK(), 1, 0);
-    EXPECT_EQ(result, WarmUpState {WarmUpTriggerSource::JOB, WarmUpProgress::DOING});
+    expected_state = WarmUpState {WarmUpTriggerSource::JOB, WarmUpProgress::DOING};
+    EXPECT_EQ(result, expected_state);
 
     // Now complete with the correct trigger source
     result = _tablet->complete_rowset_segment_warmup(WarmUpTriggerSource::JOB, rowset->rowset_id(),
                                                      Status::OK(), 1, 0);
-    EXPECT_EQ(result, WarmUpState {WarmUpTriggerSource::JOB, WarmUpProgress::DONE});
+    expected_state = WarmUpState {WarmUpTriggerSource::JOB, WarmUpProgress::DONE};
+    EXPECT_EQ(result, expected_state);
 }
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?


Related PR: https://github.com/apache/doris/pull/54611

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

