### PR TITLE
[fix](schema-change) Fix distribution columns with varchar type could not increase length

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/ModifyColumnOp.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/ModifyColumnOp.java
@@ -110,10 +110,6 @@ public class ModifyColumnOp extends AlterTableOp {
                     columnDef.setIsKey(originalColumn.isKey());
                 }
                 schemaColumns = olapTable.getFullSchema();
-                if (olapTable.getPartitionColumnNames().contains(colName.toLowerCase())
-                        || olapTable.getDistributionColumnNames().contains(colName.toLowerCase())) {
-                    throw new AnalysisException("Can not modify partition or distribution column : " + colName);
-                }
                 long baseIndexId = olapTable.getBaseIndexId();
                 for (Map.Entry<Long, MaterializedIndexMeta> entry : olapTable.getVisibleIndexIdToMeta().entrySet()) {
                     long indexId = entry.getKey();

--- a/regression-test/suites/partition_p0/auto_partition/test_col_data_type_boundary.groovy
+++ b/regression-test/suites/partition_p0/auto_partition/test_col_data_type_boundary.groovy
@@ -71,7 +71,7 @@ suite("test_col_data_type_boundary") {
         if (isClusterKeyEnabled()) {
             assertTrue(e.getMessage().contains("Can not modify "))
         } else {
-            assertTrue(e.getMessage().contains("Can not modify partition or distribution column"))
+            assertTrue(e.getMessage().contains("Can not modify partition column"))
         }
     }
 
@@ -104,7 +104,7 @@ suite("test_col_data_type_boundary") {
         if (isClusterKeyEnabled()) {
             assertTrue(e.getMessage().contains("Can not modify "))
         } else {
-            assertTrue(e.getMessage().contains("Can not modify partition or distribution column"))
+            assertTrue(e.getMessage().contains("Can not modify partition column"))
         }
     }
 
@@ -137,7 +137,7 @@ suite("test_col_data_type_boundary") {
         if (isClusterKeyEnabled()) {
             assertTrue(e.getMessage().contains("Can not modify "))
         } else {
-            assertTrue(e.getMessage().contains("Can not modify partition or distribution column"))
+            assertTrue(e.getMessage().contains("Can not modify partition column"))
         }
     }
 
@@ -170,7 +170,7 @@ suite("test_col_data_type_boundary") {
         if (isClusterKeyEnabled()) {
             assertTrue(e.getMessage().contains("Can not modify "))
         } else {
-            assertTrue(e.getMessage().contains("Can not modify partition or distribution column"))
+            assertTrue(e.getMessage().contains("Can not modify partition column"))
         }
     }
 
@@ -246,7 +246,7 @@ suite("test_col_data_type_boundary") {
         if (isClusterKeyEnabled()) {
             assertTrue(e.getMessage().contains("Can not modify "))
         } else {
-            assertTrue(e.getMessage().contains("Can not modify partition or distribution column"))
+            assertTrue(e.getMessage().contains("Can not modify partition column"))
         }
     }
 
@@ -274,7 +274,7 @@ suite("test_col_data_type_boundary") {
         if (isClusterKeyEnabled()) {
             assertTrue(e.getMessage().contains("Can not modify "))
         } else {
-            assertTrue(e.getMessage().contains("Can not modify partition or distribution column"))
+            assertTrue(e.getMessage().contains("Can not modify partition column"))
         }
     }
 
@@ -303,7 +303,7 @@ suite("test_col_data_type_boundary") {
         if (isClusterKeyEnabled()) {
             assertTrue(e.getMessage().contains("Can not modify "))
         } else {
-            assertTrue(e.getMessage().contains("Can not modify partition or distribution column"))
+            assertTrue(e.getMessage().contains("Can not modify partition column"))
         }
     }
 
@@ -332,7 +332,7 @@ suite("test_col_data_type_boundary") {
         if (isClusterKeyEnabled()) {
             assertTrue(e.getMessage().contains("Can not modify "))
         } else {
-            assertTrue(e.getMessage().contains("Can not modify partition or distribution column"))
+            assertTrue(e.getMessage().contains("Can not modify partition column"))
         }
     }
 
@@ -360,7 +360,7 @@ suite("test_col_data_type_boundary") {
         if (isClusterKeyEnabled()) {
             assertTrue(e.getMessage().contains("Can not modify "))
         } else {
-            assertTrue(e.getMessage().contains("Can not modify partition or distribution column"))
+            assertTrue(e.getMessage().contains("Can not modify partition column"))
         }
     }
 
@@ -388,7 +388,7 @@ suite("test_col_data_type_boundary") {
         if (isClusterKeyEnabled()) {
             assertTrue(e.getMessage().contains("Can not modify "))
         } else {
-            assertTrue(e.getMessage().contains("Can not modify partition or distribution column"))
+            assertTrue(e.getMessage().contains("Can not modify partition column"))
         }
     }
 

--- a/regression-test/suites/partition_p0/dynamic_partition/test_dynamic_partition_mod_distribution_key.groovy
+++ b/regression-test/suites/partition_p0/dynamic_partition/test_dynamic_partition_mod_distribution_key.groovy
@@ -49,6 +49,7 @@ suite("test_dynamic_partition_mod_distribution_key") {
         """
 
         sql """ alter table ${tableName} modify column k1 comment 'new_comment_for_k1' """
+        sql """ alter table ${tableName} modify column k2 varchar(255) """
 
         sql """ ADMIN SET FRONTEND CONFIG ('dynamic_partition_check_interval_seconds' = '1') """
         sql """ alter table ${tableName} set('dynamic_partition.end'='5') """

--- a/regression-test/suites/schema_change_p0/test_alter_table_modify_column.groovy
+++ b/regression-test/suites/schema_change_p0/test_alter_table_modify_column.groovy
@@ -180,7 +180,7 @@ suite("test_alter_table_modify_column") {
     test {
         sql """alter table ${dupTableName} modify COLUMN siteid BIGINT key DEFAULT '10' first;"""
         // check exception message contains
-        exception "Can not modify partition or distribution column : siteid"
+        exception "Can not modify distribution column"
     }
 
     sql """alter table ${dupTableName} modify COLUMN username VARCHAR(32) key DEFAULT 'test' first;"""

--- a/regression-test/suites/schema_change_p0/test_schema_change_agg.groovy
+++ b/regression-test/suites/schema_change_p0/test_schema_change_agg.groovy
@@ -198,14 +198,14 @@ suite("test_schema_change_agg", "p0") {
     //partition col
     test {
         sql "alter table ${tableName3} modify column siteid varchar DEFAULT '10'"
-        exception "Can not modify partition or distribution column : siteid"
+        exception "Can not modify partition column[siteid]."
     }
 
     //distribution key
 
     test {
         sql "alter table ${tableName3} modify column citycode smallint  comment 'citycode'"
-        exception "Can not modify partition or distribution column : citycode"
+        exception "Can not modify distribution column[citycode]. index[${tableName3}]"
     }
 
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Varchar type distribution column should be enabled to increase length through light schema change. Nereids' alter command does not support this behavior.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

