### PR TITLE
branch-3.0 [Fix](JsonFunction) Handle invalid escape sequences in JSON path to prevent crash

### DIFF
--- a/regression-test/suites/query_p0/sql_functions/json_functions/test_json_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/json_functions/test_json_function.groovy
@@ -92,6 +92,9 @@ suite("test_json_function", "arrow_flight_sql") {
     qt_sql """select get_json_string('{"name\\k" : 123}', '\$.name\\\\k')"""
     qt_sql """select get_json_string('{"name\\k" : 123}', '\$.name\\\\\\k')"""
 
+    sql """select json_extract('{"name\\k" : 123}', '\$.name\\\\\\k')"""
+    sql """select json_extract_no_quotes('{"name\\k" : 123}', '\$.name\\\\\\k')"""
+
     qt_json_contains1 """
       SELECT JSON_CONTAINS('{"age": 30, "name": "John", "hobbies": ["reading", "swimming"]}', '{"invalid": "format"}');
     """


### PR DESCRIPTION
The `get_json_token` function, which is used to parse JSON path expressions, could previously throw an unhandled
`boost::escaped_list_error` if the path string contained a malformed or invalid escape sequence (e.g., a trailing backslash).

This unhandled exception would cause the BE process to crash.Only in branch-3.0 and branch-2.1

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

