### PR TITLE
[opt](ann index) omp_threads_limit working better & minor change for observability

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1581,11 +1581,20 @@ DEFINE_mBool(enable_auto_clone_on_mow_publish_missing_version, "false");
 // The maximum csv line reader output buffer size
 DEFINE_mInt64(max_csv_line_reader_output_buffer_size, "4294967296");
 
-// Maximum number of openmp threads can be used by each doris threads.
-// This configuration controls the parallelism level for OpenMP operations within Doris,
-// helping to prevent resource contention and ensure stable performance when multiple
-// Doris threads are executing OpenMP-accelerated operations simultaneously.
-DEFINE_mInt32(omp_threads_limit, "8");
+// Maximum number of OpenMP threads allowed for concurrent vector index builds.
+// -1 means auto: use 80% of the available CPU cores.
+DEFINE_Int32(omp_threads_limit, "-1");
+DEFINE_Validator(omp_threads_limit, [](const int config) -> bool {
+    CpuInfo::init();
+    int core_cap = config::num_cores > 0 ? config::num_cores : CpuInfo::num_cores();
+    core_cap = std::max(1, core_cap);
+    int limit = config;
+    if (limit < 0) {
+        limit = std::max(1, core_cap * 4 / 5);
+    }
+    omp_threads_limit = std::max(1, std::min(limit, core_cap));
+    return true;
+});
 // The capacity of segment partial column cache, used to cache column readers for each segment.
 DEFINE_mInt32(max_segment_partial_column_cache_size, "100");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1638,7 +1638,8 @@ DECLARE_String(fuzzy_test_type);
 // The maximum csv line reader output buffer size
 DECLARE_mInt64(max_csv_line_reader_output_buffer_size);
 
-// Maximum number of OpenMP threads that can be used by each Doris thread
+// Maximum number of OpenMP threads available for concurrent index builds.
+// -1 means auto: use 80% of detected CPU cores.
 DECLARE_Int32(omp_threads_limit);
 // The capacity of segment partial column cache, used to cache column readers for each segment.
 DECLARE_mInt32(max_segment_partial_column_cache_size);

--- a/be/src/olap/rowset/segment_v2/ann_index/faiss_ann_index.cpp
+++ b/be/src/olap/rowset/segment_v2/ann_index/faiss_ann_index.cpp
@@ -97,11 +97,7 @@ public:
     explicit ScopedThreadName(const std::string& new_name) {
         // POSIX limits thread names to 15 visible chars plus the null terminator.
         char current_name[16] = {0};
-#ifdef __APPLE__
         int ret = pthread_getname_np(pthread_self(), current_name, sizeof(current_name));
-#else
-        int ret = pthread_getname_np(pthread_self(), current_name, sizeof(current_name));
-#endif
         if (ret == 0) {
             _has_previous_name = true;
             _previous_name = current_name;

--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -250,6 +250,7 @@ DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(ann_index_search_cnt, MetricUnit::NOUNIT);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(ann_index_in_memory_cnt, MetricUnit::NOUNIT);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(ann_index_in_memory_rows_cnt, MetricUnit::ROWS);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(ann_index_construction, MetricUnit::NOUNIT);
+DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(ann_index_build_index_threads, MetricUnit::NOUNIT);
 
 const std::string DorisMetrics::_s_registry_name = "doris_be";
 const std::string DorisMetrics::_s_hook_name = "doris_metrics";
@@ -418,6 +419,7 @@ DorisMetrics::DorisMetrics() : _metric_registry(_s_registry_name) {
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, ann_index_in_memory_cnt);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, ann_index_in_memory_rows_cnt);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, ann_index_construction);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, ann_index_build_index_threads);
 }
 
 void DorisMetrics::initialize(bool init_system_metrics, const std::set<std::string>& disk_devices,

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -258,6 +258,7 @@ public:
     IntCounter* ann_index_in_memory_cnt = nullptr;
     IntCounter* ann_index_in_memory_rows_cnt = nullptr;
     IntCounter* ann_index_construction = nullptr;
+    IntCounter* ann_index_build_index_threads = nullptr;
 
     IntGauge* runtime_filter_consumer_num = nullptr;
     IntGauge* runtime_filter_consumer_ready_num = nullptr;


### PR DESCRIPTION
This pull request introduces a new mechanism for managing OpenMP thread usage during concurrent FAISS vector index builds in Doris, improving resource control and stability. It adds a global thread budget guard to ensure that the total number of threads used does not exceed a configurable limit, and provides metrics for monitoring thread usage. Additionally, thread naming is temporarily set for easier debugging during index build phases.

**Resource Management Improvements:**

* Added a global thread budget guard (`ScopedOmpThreadBudget`) to limit total OpenMP threads used by concurrent FAISS index builds, ensuring the number never exceeds the configured `omp_threads_limit`. This replaces previous per-thread static allocation and allows dynamic adjustment based on available resources. (`be/src/olap/rowset/segment_v2/ann_index/faiss_ann_index.cpp`) [[1]](diffhunk://#diff-db0f703076eba6a2e532676979b1bfb928a2ffda3123593779d49b10b143d533R49-R123) [[2]](diffhunk://#diff-db0f703076eba6a2e532676979b1bfb928a2ffda3123593779d49b10b143d533L157-R233) [[3]](diffhunk://#diff-db0f703076eba6a2e532676979b1bfb928a2ffda3123593779d49b10b143d533L172-R258)

* Updated the configuration for `omp_threads_limit` to allow automatic adjustment based on available CPU cores (defaulting to 80% of cores if set to -1), with validation logic to enforce sensible limits. (`be/src/common/config.cpp`, `be/src/common/config.h`) [[1]](diffhunk://#diff-b626e6ab16bc72abf40db76bf5094fcc8ca3c37534c2eb83b63b7805e1b601ffL1584-R1597) [[2]](diffhunk://#diff-46e8c1ada0d43acf8c2965e46e90909089aada1f46531976c10605b837f8da3dL1641-R1642)

**Monitoring and Debugging Enhancements:**

* Added a new metric (`ann_index_build_index_threads`) to monitor the number of threads reserved for index builds, and registered it in the metrics system. (`be/src/util/doris_metrics.cpp`, `be/src/util/doris_metrics.h`) [[1]](diffhunk://#diff-878c2670a099f34646a2d514e473068af8a5c43784e0450555a2e2b79e8f27caR253) [[2]](diffhunk://#diff-878c2670a099f34646a2d514e473068af8a5c43784e0450555a2e2b79e8f27caR422) [[3]](diffhunk://#diff-86758ef39527aa2e06d142689e6b13e5a89872ca7aaffb398d1e491749efbd52R261)

* Introduced a scoped thread renaming utility (`ScopedThreadName`) for FAISS build phases, making them easier to identify in debuggers and logs. (`be/src/olap/rowset/segment_v2/ann_index/faiss_ann_index.cpp`) [[1]](diffhunk://#diff-db0f703076eba6a2e532676979b1bfb928a2ffda3123593779d49b10b143d533R49-R123) [[2]](diffhunk://#diff-db0f703076eba6a2e532676979b1bfb928a2ffda3123593779d49b10b143d533L157-R233) [[3]](diffhunk://#diff-db0f703076eba6a2e532676979b1bfb928a2ffda3123593779d49b10b143d533L172-R258)

**Codebase Maintenance:**

* Added necessary includes for threading, synchronization, and algorithms to support new resource management logic. (`be/src/olap/rowset/segment_v2/ann_index/faiss_ann_index.cpp`)

An illustration of thread name change:
In previous:
![img_v3_02qu_6d47b18b-f7a2-4ad5-a4ad-ff60a849272g](https://github.com/user-attachments/assets/f90ef70e-13ae-49d0-a590-3b1ceeffcd27)
Now we can see faiss_build/train_idx
![img_v3_02qu_1f46db78-bdfd-4e59-a174-7d91fcb8547g](https://github.com/user-attachments/assets/d7e5de95-a1f8-40af-b64d-2dc246869e54)



### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

