### PR TITLE
[fix](hdfs)Fix be coredump  in HDFS reader during profile collection.

### DIFF
--- a/be/src/io/fs/hdfs_file_reader.cpp
+++ b/be/src/io/fs/hdfs_file_reader.cpp
@@ -119,6 +119,7 @@ Status HdfsFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_r
                                     const IOContext* io_ctx) {
     auto st = do_read_at_impl(offset, result, bytes_read, io_ctx);
     if (!st.ok()) {
+        _handle = nullptr;
         _accessor.destroy();
     }
     return st;
@@ -129,6 +130,11 @@ Status HdfsFileReader::do_read_at_impl(size_t offset, Slice result, size_t* byte
                                        const IOContext* /*io_ctx*/) {
     if (closed()) [[unlikely]] {
         return Status::InternalError("read closed file: {}", _path.native());
+    }
+
+    if (_handle == nullptr) [[unlikely]] {
+        return Status::InternalError("cached hdfs file handle has been destroyed: {}",
+                                     _path.native());
     }
 
     if (offset > _handle->file_size()) {
@@ -245,6 +251,10 @@ Status HdfsFileReader::do_read_at_impl(size_t offset, Slice result, size_t* byte
 void HdfsFileReader::_collect_profile_before_close() {
     if (_profile != nullptr && is_hdfs(_fs_name)) {
 #ifdef USE_HADOOP_HDFS
+        if (_handle == nullptr) [[unlikely]] {
+            return;
+        }
+
         struct hdfsReadStatistics* hdfs_statistics = nullptr;
         auto r = hdfsFileGetReadStatistics(_handle->file(), &hdfs_statistics);
         if (r != 0) {


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #54926
Issue Number: close #55747

Problem Summary:
PR #54926 destroyed the corresponding hdfs handle cache when HDFS read failed, but HDFS reader still held such a dangling pointer, which led to issue #55747


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

