### PR TITLE
[fix](DecimalV2)keep the original precision and scale in get_data_type_with_default_argument

### DIFF
--- a/be/src/vec/data_types/data_type_decimal.cpp
+++ b/be/src/vec/data_types/data_type_decimal.cpp
@@ -55,10 +55,20 @@ namespace doris::vectorized {
 DataTypePtr get_data_type_with_default_argument(DataTypePtr type) {
     auto transform = [&](DataTypePtr t) -> DataTypePtr {
         if (t->get_primitive_type() == PrimitiveType::TYPE_DECIMALV2) {
-            auto res = DataTypeFactory::instance().create_data_type(
-                    TYPE_DECIMALV2, t->is_nullable(), BeConsts::MAX_DECIMALV2_PRECISION,
-                    BeConsts::MAX_DECIMALV2_SCALE);
+            auto not_nullable_t = remove_nullable(t);
+            const auto* real_type_t = assert_cast<const DataTypeDecimalV2*>(not_nullable_t.get());
+            // should keep the original precision and scale
+            DataTypePtr res = std::make_shared<DataTypeDecimalV2>(
+                    BeConsts::MAX_DECIMALV2_PRECISION, BeConsts::MAX_DECIMALV2_SCALE,
+                    real_type_t->get_original_precision(), real_type_t->get_original_scale());
+
+            // keep nullable property
+            if (t->is_nullable()) {
+                res = make_nullable(res);
+            }
+
             DCHECK_EQ(res->get_scale(), BeConsts::MAX_DECIMALV2_SCALE);
+
             return res;
         } else if (t->get_primitive_type() == PrimitiveType::TYPE_BINARY ||
                    t->get_primitive_type() == PrimitiveType::TYPE_LAMBDA_FUNCTION) {

--- a/regression-test/suites/datatype_p0/decimalv2/test_decimalv2_rqg.groovy
+++ b/regression-test/suites/datatype_p0/decimalv2/test_decimalv2_rqg.groovy
@@ -56,8 +56,4 @@ suite("test_decimalv2_rqg") {
     sql """
         SELECT CEIL(ARG0,CAST(-1 AS INT)) FROM (SELECT TEMPDATA . data, TABLE0.ARG0 FROM TEMPDATA CROSS JOIN (SELECT data AS ARG0 FROM DECIMALV2_10_0_DATA_NOT_EMPTY_NOT_NULLABLE ) AS TABLE0) t ;
     """
-
-
-
-    sql """ADMIN SET FRONTEND CONFIG ('disable_decimalv2' = 'true')"""
 }

--- a/regression-test/suites/datatype_p0/decimalv2/test_decimalv2_rqg.groovy
+++ b/regression-test/suites/datatype_p0/decimalv2/test_decimalv2_rqg.groovy
@@ -1,0 +1,63 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_decimalv2_rqg") {
+
+
+    sql """ADMIN SET FRONTEND CONFIG ('disable_decimalv2' = 'false')"""
+
+    sql """
+        CREATE TABLE IF NOT EXISTS TEMPDATA(id INT, data INT) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ('replication_num' = '1');
+    """
+    sql """
+        INSERT INTO TEMPDATA values(1, 1);
+    """
+
+    sql """CREATE TABLE IF NOT EXISTS DECIMALV2_10_0_DATA_NOT_EMPTY_NOT_NULLABLE(id INT, data DECIMALV2(10,0)  NOT NULL) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ('replication_num' = '1');"""
+
+    sql """
+    INSERT INTO DECIMALV2_10_0_DATA_NOT_EMPTY_NOT_NULLABLE values (0, 1234567890);"""
+    sql """
+    INSERT INTO DECIMALV2_10_0_DATA_NOT_EMPTY_NOT_NULLABLE values (1, 9999999999);"""
+    sql """
+    INSERT INTO DECIMALV2_10_0_DATA_NOT_EMPTY_NOT_NULLABLE values (2, 1000000000);"""
+    sql """
+    INSERT INTO DECIMALV2_10_0_DATA_NOT_EMPTY_NOT_NULLABLE values (3, 1111111111);"""
+    sql """
+    INSERT INTO DECIMALV2_10_0_DATA_NOT_EMPTY_NOT_NULLABLE values (4, -1234567890);"""
+    sql """
+    INSERT INTO DECIMALV2_10_0_DATA_NOT_EMPTY_NOT_NULLABLE values (5, -9999999999);"""
+    sql """
+    INSERT INTO DECIMALV2_10_0_DATA_NOT_EMPTY_NOT_NULLABLE values (6, -1000000000);"""
+    sql """
+    INSERT INTO DECIMALV2_10_0_DATA_NOT_EMPTY_NOT_NULLABLE values (7, -1111111111);"""
+    sql """
+    INSERT INTO DECIMALV2_10_0_DATA_NOT_EMPTY_NOT_NULLABLE values (8, 1);"""
+    sql """
+    INSERT INTO DECIMALV2_10_0_DATA_NOT_EMPTY_NOT_NULLABLE values (9, 0);"""
+    sql """
+    INSERT INTO DECIMALV2_10_0_DATA_NOT_EMPTY_NOT_NULLABLE values (10, -1);"""
+
+
+    sql """
+        SELECT CEIL(ARG0,CAST(-1 AS INT)) FROM (SELECT TEMPDATA . data, TABLE0.ARG0 FROM TEMPDATA CROSS JOIN (SELECT data AS ARG0 FROM DECIMALV2_10_0_DATA_NOT_EMPTY_NOT_NULLABLE ) AS TABLE0) t ;
+    """
+
+
+
+    sql """ADMIN SET FRONTEND CONFIG ('disable_decimalv2' = 'true')"""
+}


### PR DESCRIPTION
### What problem does this PR solve?

In the past, the get_data_type_with_default_argument function would set the original precision and scale to 27,9, but this will cause problems with some codes that rely on original precision and scale. Here, the original precision and scale will be maintained.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

