### PR TITLE
[Fix](brpc) Fix wrong usage of brpc call_id

### DIFF
--- a/be/src/util/brpc_closure.h
+++ b/be/src/util/brpc_closure.h
@@ -36,6 +36,7 @@ public:
     using ResponseType = Response;
     DummyBrpcCallback() {
         cntl_ = std::make_shared<brpc::Controller>();
+        call_id_ = cntl_->call_id();
         response_ = std::make_shared<Response>();
     }
 
@@ -43,8 +44,11 @@ public:
 
     virtual void call() {}
 
-    virtual void join() { brpc::Join(cntl_->call_id()); }
+    virtual void join() { brpc::Join(call_id_); }
 
+    // according to brpc doc, we MUST save the call_id before rpc done. use this id to join.
+    // if a rpc is already done then we get the id and join, it's wrong.
+    brpc::CallId call_id_;
     // controller has to be the same lifecycle with the closure, because brpc may use
     // it in any stage of the rpc.
     std::shared_ptr<brpc::Controller> cntl_;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

According to [brpc doc](https://brpc.apache.org/docs/client/basics/#wait-for-completion-of-rpc), 

> Calling Join(controller->call_id()) after completion of RPC is wrong, do save call_id before RPC, otherwise the controller may be deleted by done at any time.

now fixed it.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

