### PR TITLE
[fix](decimal256) fix unstable overflow error when casting decimal256 to float

### DIFF
--- a/be/src/vec/functions/cast/cast_to_basic_number_common.h
+++ b/be/src/vec/functions/cast/cast_to_basic_number_common.h
@@ -328,13 +328,8 @@ struct CastToFloat {
     static inline bool _from_decimalv3(const FromCppT& from, UInt32 from_scale, ToCppT& to,
                                        const typename FromCppT::NativeType& scale_multiplier,
                                        CastParameters& params) {
-        if constexpr (IsDecimal256<FromCppT>) {
-            to = static_cast<ToCppT>(static_cast<long double>(from.value) /
-                                     static_cast<long double>(scale_multiplier));
-        } else {
-            to = static_cast<ToCppT>(static_cast<double>(from.value) /
-                                     static_cast<double>(scale_multiplier));
-        }
+        to = static_cast<ToCppT>(static_cast<double>(from.value) /
+                                 static_cast<double>(scale_multiplier));
         return true;
     }
     // cast from date and datetime to float/double, will not overflow

--- a/be/test/vec/function/cast/cast_to_float_double.cpp
+++ b/be/test/vec/function/cast/cast_to_float_double.cpp
@@ -892,14 +892,8 @@ struct FunctionCastToFloatTest : public FunctionCastTest {
                 auto decimal_num = decimal_ctor(i, 0, FromScale);
                 auto num_str = dt_from.to_string(decimal_num);
                 // auto float_v = static_cast<FloatType>(i);
-                FloatType float_v;
-                if constexpr (IsDecimal256<FromT>) {
-                    float_v = static_cast<long double>(decimal_num.value) /
-                              static_cast<long double>(scale_multiplier);
-                } else {
-                    float_v = static_cast<double>(decimal_num.value) /
-                              static_cast<double>(scale_multiplier);
-                }
+                FloatType float_v = static_cast<double>(decimal_num.value) /
+                                    static_cast<double>(scale_multiplier);
                 if (std::isinf(float_v)) {
                     // std::cout << fmt::format("cast {}({}, {}) value {} to float_v result is inf\n",
                     //                          type_to_string(FromT::PType), FromPrecision, FromScale,
@@ -912,13 +906,8 @@ struct FunctionCastToFloatTest : public FunctionCastTest {
 
                 decimal_num = decimal_ctor(-i, 0, FromScale);
                 num_str = dt_from.to_string(decimal_num);
-                if constexpr (IsDecimal256<FromT>) {
-                    float_v = static_cast<long double>(decimal_num.value) /
-                              static_cast<long double>(scale_multiplier);
-                } else {
-                    float_v = static_cast<double>(decimal_num.value) /
-                              static_cast<double>(scale_multiplier);
-                }
+                float_v = static_cast<double>(decimal_num.value) /
+                          static_cast<double>(scale_multiplier);
                 if (std::isinf(float_v)) {
                     // std::cout << fmt::format("cast {}({}, {}) value {} to float_v result is inf\n",
                     //                          type_to_string(FromT::PType), FromPrecision, FromScale,
@@ -940,27 +929,16 @@ struct FunctionCastToFloatTest : public FunctionCastTest {
             for (const auto& f : fractional_part) {
                 auto decimal_num = decimal_ctor(0, f, FromScale);
                 auto num_str = dt_from.to_string(decimal_num);
-                FloatType float_v;
-                if constexpr (IsDecimal256<FromT>) {
-                    float_v = static_cast<long double>(decimal_num.value) /
-                              static_cast<long double>(scale_multiplier);
-                } else {
-                    float_v = static_cast<double>(decimal_num.value) /
-                              static_cast<double>(scale_multiplier);
-                }
+                FloatType float_v = static_cast<double>(decimal_num.value) /
+                                    static_cast<double>(scale_multiplier);
                 // dbg_str += fmt::format("({}, {})|", dt.to_string(decimal_num), float_v);
                 data_set.push_back({{decimal_num}, float_v});
                 test_data_set.emplace_back(num_str, float_v);
 
                 decimal_num = decimal_ctor(0, -f, FromScale);
                 num_str = dt_from.to_string(decimal_num);
-                if constexpr (IsDecimal256<FromT>) {
-                    float_v = static_cast<long double>(decimal_num.value) /
-                              static_cast<long double>(scale_multiplier);
-                } else {
-                    float_v = static_cast<double>(decimal_num.value) /
-                              static_cast<double>(scale_multiplier);
-                }
+                float_v = static_cast<double>(decimal_num.value) /
+                          static_cast<double>(scale_multiplier);
                 // dbg_str += fmt::format("({}, {})|", dt.to_string(decimal_num), float_v);
                 data_set.push_back({{decimal_num}, float_v});
                 test_data_set.emplace_back(num_str, float_v);
@@ -977,14 +955,8 @@ struct FunctionCastToFloatTest : public FunctionCastTest {
             for (const auto& f : fractional_part) {
                 auto decimal_num = decimal_ctor(i, f, FromScale);
                 auto num_str = dt_from.to_string(decimal_num);
-                FloatType float_v;
-                if constexpr (IsDecimal256<FromT>) {
-                    float_v = static_cast<long double>(decimal_num.value) /
-                              static_cast<long double>(scale_multiplier);
-                } else {
-                    float_v = static_cast<double>(decimal_num.value) /
-                              static_cast<double>(scale_multiplier);
-                }
+                FloatType float_v = static_cast<double>(decimal_num.value) /
+                                    static_cast<double>(scale_multiplier);
                 if (std::isinf(float_v)) {
                     // std::cout << fmt::format("cast {}({}, {}) value {} to float_v result is inf\n",
                     //                          type_to_string(FromT::PType), FromPrecision, FromScale,
@@ -997,13 +969,8 @@ struct FunctionCastToFloatTest : public FunctionCastTest {
 
                 decimal_num = decimal_ctor(-i, -f, FromScale);
                 num_str = dt_from.to_string(decimal_num);
-                if constexpr (IsDecimal256<FromT>) {
-                    float_v = static_cast<long double>(decimal_num.value) /
-                              static_cast<long double>(scale_multiplier);
-                } else {
-                    float_v = static_cast<double>(decimal_num.value) /
-                              static_cast<double>(scale_multiplier);
-                }
+                float_v = static_cast<double>(decimal_num.value) /
+                          static_cast<double>(scale_multiplier);
                 if (std::isinf(float_v)) {
                     // std::cout << fmt::format("cast {}({}, {}) value {} to float_v result is inf\n",
                     //                          type_to_string(FromT::PType), FromPrecision, FromScale,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

When casting `Decimal256` to `float`, sometimes it result in false overflow error:
```
[E-255]Arithmetic overflow when converting value 9999999999999999.999999999999999999999999999999999999999999999999999999999999 from type Decimal(76, 60) to type Float32, src to float is 1e+76, multiplier is 1e+60, div result is 1e+16, result is -nan, result value range: [-3.4028235e+38, 3.4028235e+38]
``` 
Not sure of the root cause for now, maybe related to casting `long double` to `float` type. This PR use `double` instead of  `long double` to avoid this problem temporarily.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

