### PR TITLE
[fix](ubsan) fix ub error of uninitialized variable

### DIFF
--- a/be/src/pipeline/exec/result_sink_operator.h
+++ b/be/src/pipeline/exec/result_sink_operator.h
@@ -47,8 +47,8 @@ struct ResultFileOptions {
     std::vector<TParquetSchema> parquet_schemas;
     TParquetCompressionType::type parquet_commpression_type;
     TParquetVersion::type parquet_version;
-    bool parquert_disable_dictionary;
-    bool enable_int96_timestamps;
+    bool parquert_disable_dictionary = false;
+    bool enable_int96_timestamps = false;
     //note: use outfile with parquet format, have deprecated 9:schema and 10:file_properties
     //But in order to consider the compatibility when upgrading, so add a bool to check
     //Now the code version is 1.1.2, so when the version is after 1.2, could remove this code.


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
The `bool` value should be initialized, otherwise it will cause crash when enabling UBSAN

```
be/src/vec/sink/writer/vfile_result_writer.cpp:139:71: runtime error: load of value 190, which is not a valid value for type 'bool'
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

