### PR TITLE
[fix](hash bucketing) add bitmap type in zlib_crc32

### DIFF
--- a/be/src/runtime/raw_value.h
+++ b/be/src/runtime/raw_value.h
@@ -54,6 +54,7 @@ inline uint32_t RawValue::zlib_crc32(const void* v, size_t len, const PrimitiveT
 
     switch (type) {
     case TYPE_VARCHAR:
+    case TYPE_BITMAP:
     case TYPE_HLL:
     case TYPE_STRING:
     case TYPE_CHAR: {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #56878 

Related PR: #xxx

Problem Summary:

When `RawValue::zlib_crc32` calculates hash values, there is no bitmap type, which causes all the hash values corresponding to the bitmap columns to return 0. Therefore, all data is distributed to bucket 0.

Adding the bitmap type to `RawValue::zlib_crc32` will solve this problem:

```sql
-- 创建测试表
CREATE TABLE test_bitmap2 (
    id INT,
    bmp BITMAP
) DISTRIBUTED BY HASH(bmp) BUCKETS 2 PROPERTIES ("replication_num" = "1");
-- 插入测试数据
INSERT INTO test_bitmap2 VALUES
(1, bitmap_from_string('1,2,3')),
(2, bitmap_from_string('4,5,6')),
(3, bitmap_from_string('7,8,9')),
(4, bitmap_from_string('10,11,12')),
(5, bitmap_from_string('13,14,15')),
(6, bitmap_from_string('16,17,18'));
-- 查看分布情况
mysql> SHOW DATA SKEW FROM test_bitmap2;
+---------------+-----------+-------------+-------------+----------------------------------------------------+---------+
| PartitionName | BucketIdx | AvgRowCount | AvgDataSize | Graph                                              | Percent |
+---------------+-----------+-------------+-------------+----------------------------------------------------+---------+
| test_bitmap2  | 0         | 3           | 440         | >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> | 50.06 % |
| test_bitmap2  | 1         | 3           | 439         | >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>  | 49.94 % |
+---------------+-----------+-------------+-------------+----------------------------------------------------+---------+
2 rows in set (0.00 sec)
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

