### PR TITLE
[test](nereids)fix prune partitions test case

### DIFF
--- a/regression-test/suites/nereids_rules_p0/partition_prune/one_key_list_part_test.groovy
+++ b/regression-test/suites/nereids_rules_p0/partition_prune/one_key_list_part_test.groovy
@@ -20,6 +20,7 @@ suite("one_key_list_part_test") {
     String dbName = context.config.getDbNameByFile(context.file)
     sql """set partition_pruning_expand_threshold=1000;"""
     sql """SET enable_insert_strict = false;"""
+    sql """set enable_fold_constant_by_be=false;"""
 
     sql """drop table if exists key_1_fixed_list_int_part"""
     sql """create table key_1_fixed_list_int_part (a int, dt datetime, c varchar(100)) duplicate key(a)

--- a/regression-test/suites/nereids_rules_p0/partition_prune/one_key_list_part_update_test.groovy
+++ b/regression-test/suites/nereids_rules_p0/partition_prune/one_key_list_part_update_test.groovy
@@ -20,6 +20,7 @@ suite("one_key_list_part_update_test") {
     String dbName = context.config.getDbNameByFile(context.file)
     sql """set partition_pruning_expand_threshold=1000;"""
     sql """SET enable_insert_strict = false;"""
+    sql """set enable_fold_constant_by_be=false;"""
 
     sql """drop table if exists key_1_fixed_list_int_part_update"""
     sql """create table key_1_fixed_list_int_part_update (a int, dt datetime, c varchar(100)) duplicate key(a)

--- a/regression-test/suites/nereids_rules_p0/partition_prune/one_key_range_part_test.groovy
+++ b/regression-test/suites/nereids_rules_p0/partition_prune/one_key_range_part_test.groovy
@@ -19,6 +19,7 @@ suite("one_key_range_part_test") {
 
     String dbName = context.config.getDbNameByFile(context.file)
     sql """set partition_pruning_expand_threshold=1000;"""
+    sql """set enable_fold_constant_by_be=false;"""
 
     sql """drop table if exists key_1_fixed_range_date_part;"""
     sql """create table key_1_fixed_range_date_part (a int, dt datetime, c varchar(100)) duplicate key(a)

--- a/regression-test/suites/nereids_rules_p0/partition_prune/one_key_range_part_update_test.groovy
+++ b/regression-test/suites/nereids_rules_p0/partition_prune/one_key_range_part_update_test.groovy
@@ -17,8 +17,9 @@
 
 suite("one_key_range_part_update_test") {
 
-    sql """set partition_pruning_expand_threshold=1000;"""
     String dbName = context.config.getDbNameByFile(context.file)
+    sql """set partition_pruning_expand_threshold=1000;"""
+    sql """set enable_fold_constant_by_be=false;"""
 
     sql """drop table if exists key_1_special_fixed_range_date_part_update"""
     sql """create table key_1_special_fixed_range_date_part_update (a int, dt datetime, c varchar(100)) duplicate key(a)


### PR DESCRIPTION
[test](nereids)fix prune partitions test case

The constant folding on the BE (Backend) can affect the partition pruning function on the FE (Frontend). Please disable the corresponding configuration item to test the FE's partition pruning feature.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

