### PR TITLE
[chore](code)Remove unnecessary accurate code and reduce template parameters

### DIFF
--- a/be/src/vec/core/accurate_comparison.h
+++ b/be/src/vec/core/accurate_comparison.h
@@ -20,330 +20,109 @@
 
 #pragma once
 
-#include <cmath>
-#include <limits>
-
 #include "common/compare.h"
 #include "runtime/primitive_type.h"
-#include "util/binary_cast.hpp"
-#include "vec/common/nan_utils.h"
 #include "vec/common/string_ref.h"
-#include "vec/common/uint128.h"
-#include "vec/core/decomposed_float.h"
-#include "vec/core/extended_types.h"
 #include "vec/core/types.h"
-#include "vec/runtime/vdatetime_value.h"
-/** Perceptually-correct number comparisons.
-  * Example: Int8(-1) != UInt8(255)
-*/
-
-namespace accurate {
-
-/** Cases:
-    1) Safe conversion (in case of default C++ operators)
-        a) int vs any int
-        b) uint vs any uint
-        c) float vs any float
-    2) int vs uint
-        a) sizeof(int) <= sizeof(uint). Accurate comparison with MAX_INT thresholds
-        b) sizeof(int)  > sizeof(uint). Casting to int
-    3) integral_type vs floating_type
-        a) sizeof(integral_type) <= 4. Comparison via casting arguments to Float64
-        b) sizeof(integral_type) == 8. Accurate comparison. Consider 3 sets of intervals:
-            1) interval between adjacent floats less or equal 1
-            2) interval between adjacent floats greater then 2
-            3) float is outside [MIN_INT64; MAX_INT64]
-*/
-
-// Case 1. Is pair of floats or pair of ints or pair of uints
-template <typename A, typename B>
-constexpr bool is_safe_conversion =
-        (std::is_floating_point_v<A> && std::is_floating_point_v<B>) ||
-        (IsIntegralV<A> && IsIntegralV<B> && !(IsSignedV<A> ^ IsSignedV<B>)) ||
-        (std::is_same_v<A, doris::vectorized::Int128> &&
-         std::is_same_v<B, doris::vectorized::Int128>) ||
-        (IsIntegralV<A> && std::is_same_v<B, doris::vectorized::Int128>) ||
-        (std::is_same_v<A, doris::vectorized::Int128> && IsIntegralV<B>);
-template <typename A, typename B>
-using bool_if_safe_conversion = std::enable_if_t<is_safe_conversion<A, B>, bool>;
-template <typename A, typename B>
-using bool_if_not_safe_conversion = std::enable_if_t<!is_safe_conversion<A, B>, bool>;
-
-/* Final realizations */
-
-template <typename A, typename B>
-bool lessOp(A a, B b) {
-    if constexpr (std::is_same_v<A, B>) {
-        return a < b;
-    }
-
-    /// float vs float
-    if constexpr (std::is_floating_point_v<A> && std::is_floating_point_v<B>) {
-        return a < b;
-    }
-
-    /// anything vs NaN
-    if (is_nan(a) || is_nan(b)) {
-        return false;
-    }
-
-    /// int vs int
-    if constexpr (IsIntegralV<A> && IsIntegralV<B>) {
-        /// same signedness
-        if constexpr (IsSignedV<A> == IsSignedV<B>) {
-            return a < b;
-        }
-
-        /// different signedness
-
-        if constexpr (IsSignedV<A> && !IsSignedV<B>) {
-            return a < 0 || static_cast<std::make_unsigned_t<A>>(a) < b;
-        }
-
-        if constexpr (!IsSignedV<A> && IsSignedV<B>) {
-            return b >= 0 && a < static_cast<std::make_unsigned_t<B>>(b);
-        }
-    }
-
-    /// int vs float
-    if constexpr (IsIntegralV<A> && std::is_floating_point_v<B>) {
-        if constexpr (sizeof(A) <= 4) {
-            return static_cast<double>(a) < static_cast<double>(b);
-        }
-
-        return DecomposedFloat<B>(b).greater(a);
-    }
-
-    if constexpr (std::is_floating_point_v<A> && IsIntegralV<B>) {
-        if constexpr (sizeof(B) <= 4) {
-            return static_cast<double>(a) < static_cast<double>(b);
-        }
-
-        return DecomposedFloat<A>(a).less(b);
-    }
-
-    static_assert(IsIntegralV<A> || std::is_floating_point_v<A>);
-    static_assert(IsIntegralV<B> || std::is_floating_point_v<B>);
-    __builtin_unreachable();
-}
-
-template <typename A, typename B>
-bool greaterOp(A a, B b) {
-    return lessOp(b, a);
-}
-
-template <typename A, typename B>
-inline bool_if_not_safe_conversion<A, B> greaterOrEqualsOp(A a, B b) {
-    if (is_nan(a) || is_nan(b)) {
-        return false;
-    }
-
-    return !lessOp(a, b);
-}
-
-template <typename A, typename B>
-inline bool_if_safe_conversion<A, B> greaterOrEqualsOp(A a, B b) {
-    return a >= b;
-}
-
-template <typename A, typename B>
-inline bool_if_not_safe_conversion<A, B> lessOrEqualsOp(A a, B b) {
-    if (is_nan(a) || is_nan(b)) {
-        return false;
-    }
-
-    return !lessOp(b, a);
-}
-
-template <typename A, typename B>
-inline bool_if_safe_conversion<A, B> lessOrEqualsOp(A a, B b) {
-    return a <= b;
-}
-
-template <typename A, typename B>
-bool equalsOp(A a, B b) {
-    if constexpr (std::is_same_v<A, B>) {
-        return a == b;
-    }
-
-    /// float vs float
-    if constexpr (std::is_floating_point_v<A> && std::is_floating_point_v<B>) {
-        return a == b;
-    }
-
-    /// anything vs NaN
-    if (is_nan(a) || is_nan(b)) {
-        return false;
-    }
-
-    /// int vs int
-    if constexpr (IsIntegralV<A> && IsIntegralV<B>) {
-        /// same signedness
-        if constexpr (IsSignedV<A> == IsSignedV<B>) {
-            return a == b;
-        }
-
-        /// different signedness
-
-        if constexpr (IsSignedV<A> && !IsSignedV<B>) {
-            return a >= 0 && static_cast<std::make_unsigned_t<A>>(a) == b;
-        }
-
-        if constexpr (!IsSignedV<A> && IsSignedV<B>) {
-            return b >= 0 && a == static_cast<std::make_unsigned_t<B>>(b);
-        }
-    }
-
-    /// int vs float
-    if constexpr (IsIntegralV<A> && std::is_floating_point_v<B>) {
-        if constexpr (sizeof(A) <= 4) {
-            return static_cast<double>(a) == static_cast<double>(b);
-        }
-
-        return DecomposedFloat<B>(b).equals(a);
-    }
-
-    if constexpr (std::is_floating_point_v<A> && IsIntegralV<B>) {
-        if constexpr (sizeof(B) <= 4) {
-            return static_cast<double>(a) == static_cast<double>(b);
-        }
-
-        return DecomposedFloat<A>(a).equals(b);
-    }
-
-    /// e.g comparing UUID with integer.
-    return false;
-}
-
-template <typename A, typename B>
-bool notEqualsOp(A a, B b) {
-    return !equalsOp(a, b);
-}
-} // namespace accurate
-
 namespace doris::vectorized {
 
-template <PrimitiveType A, PrimitiveType B>
+template <PrimitiveType PT>
+using CompareType =
+        std::conditional_t<PT == TYPE_BOOLEAN, typename PrimitiveTypeTraits<PT>::ColumnItemType,
+                           typename PrimitiveTypeTraits<PT>::CppNativeType>;
+
+template <PrimitiveType PT>
 struct EqualsOp {
     /// An operation that gives the same result, if arguments are passed in reverse order.
-    using SymmetricOp = EqualsOp<B, A>;
-    using NativeTypeA =
-            std::conditional_t<A == TYPE_BOOLEAN, typename PrimitiveTypeTraits<A>::ColumnItemType,
-                               typename PrimitiveTypeTraits<A>::CppNativeType>;
-    using NativeTypeB =
-            std::conditional_t<B == TYPE_BOOLEAN, typename PrimitiveTypeTraits<B>::ColumnItemType,
-                               typename PrimitiveTypeTraits<B>::CppNativeType>;
-    static UInt8 apply(NativeTypeA a, NativeTypeB b) { return Compare::equal(a, b); }
+    using SymmetricOp = EqualsOp<PT>;
+    using NativeType = CompareType<PT>;
+
+    static UInt8 apply(NativeType a, NativeType b) { return Compare::equal(a, b); }
 };
 
 template <>
-struct EqualsOp<TYPE_DECIMALV2, TYPE_DECIMALV2> {
+struct EqualsOp<TYPE_DECIMALV2> {
     static UInt8 apply(const Int128& a, const Int128& b) { return a == b; }
 };
 
 template <>
-struct EqualsOp<TYPE_STRING, TYPE_STRING> {
+struct EqualsOp<TYPE_STRING> {
     static UInt8 apply(const StringRef& a, const StringRef& b) { return a == b; }
 };
 
-template <PrimitiveType A, PrimitiveType B>
+template <PrimitiveType PT>
 struct NotEqualsOp {
-    using SymmetricOp = NotEqualsOp<B, A>;
-    using NativeTypeA =
-            std::conditional_t<A == TYPE_BOOLEAN, typename PrimitiveTypeTraits<A>::ColumnItemType,
-                               typename PrimitiveTypeTraits<A>::CppNativeType>;
-    using NativeTypeB =
-            std::conditional_t<B == TYPE_BOOLEAN, typename PrimitiveTypeTraits<B>::ColumnItemType,
-                               typename PrimitiveTypeTraits<B>::CppNativeType>;
-    static UInt8 apply(NativeTypeA a, NativeTypeB b) { return Compare::not_equal(a, b); }
+    using SymmetricOp = NotEqualsOp<PT>;
+    using NativeType = CompareType<PT>;
+    static UInt8 apply(NativeType a, NativeType b) { return Compare::not_equal(a, b); }
 };
 
 template <>
-struct NotEqualsOp<TYPE_DECIMALV2, TYPE_DECIMALV2> {
+struct NotEqualsOp<TYPE_DECIMALV2> {
     static UInt8 apply(const DecimalV2Value& a, const DecimalV2Value& b) { return a != b; }
 };
 
-template <PrimitiveType A, PrimitiveType B>
+template <PrimitiveType PT>
 struct GreaterOp;
 
-template <PrimitiveType A, PrimitiveType B>
+template <PrimitiveType PT>
 struct LessOp {
-    using SymmetricOp = GreaterOp<B, A>;
-    using NativeTypeA =
-            std::conditional_t<A == TYPE_BOOLEAN, typename PrimitiveTypeTraits<A>::ColumnItemType,
-                               typename PrimitiveTypeTraits<A>::CppNativeType>;
-    using NativeTypeB =
-            std::conditional_t<B == TYPE_BOOLEAN, typename PrimitiveTypeTraits<B>::ColumnItemType,
-                               typename PrimitiveTypeTraits<B>::CppNativeType>;
-    static UInt8 apply(NativeTypeA a, NativeTypeB b) { return Compare::less(a, b); }
+    using SymmetricOp = GreaterOp<PT>;
+    using NativeType = CompareType<PT>;
+    static UInt8 apply(NativeType a, NativeType b) { return Compare::less(a, b); }
 };
 
 template <>
-struct LessOp<TYPE_DECIMALV2, TYPE_DECIMALV2> {
+struct LessOp<TYPE_DECIMALV2> {
     static UInt8 apply(Int128 a, Int128 b) { return a < b; }
 };
 
 template <>
-struct LessOp<TYPE_STRING, TYPE_STRING> {
+struct LessOp<TYPE_STRING> {
     static UInt8 apply(StringRef a, StringRef b) { return a < b; }
 };
 
-template <PrimitiveType A, PrimitiveType B>
+template <PrimitiveType PT>
 struct GreaterOp {
-    using SymmetricOp = LessOp<B, A>;
-    using NativeTypeA =
-            std::conditional_t<A == TYPE_BOOLEAN, typename PrimitiveTypeTraits<A>::ColumnItemType,
-                               typename PrimitiveTypeTraits<A>::CppNativeType>;
-    using NativeTypeB =
-            std::conditional_t<B == TYPE_BOOLEAN, typename PrimitiveTypeTraits<B>::ColumnItemType,
-                               typename PrimitiveTypeTraits<B>::CppNativeType>;
-    static UInt8 apply(NativeTypeA a, NativeTypeB b) { return Compare::greater(a, b); }
+    using SymmetricOp = LessOp<PT>;
+    using NativeType = CompareType<PT>;
+    static UInt8 apply(NativeType a, NativeType b) { return Compare::greater(a, b); }
 };
 
 template <>
-struct GreaterOp<TYPE_DECIMALV2, TYPE_DECIMALV2> {
+struct GreaterOp<TYPE_DECIMALV2> {
     static UInt8 apply(Int128 a, Int128 b) { return a > b; }
 };
 
 template <>
-struct GreaterOp<TYPE_STRING, TYPE_STRING> {
+struct GreaterOp<TYPE_STRING> {
     static UInt8 apply(StringRef a, StringRef b) { return a > b; }
 };
 
-template <PrimitiveType A, PrimitiveType B>
+template <PrimitiveType PT>
 struct GreaterOrEqualsOp;
 
-template <PrimitiveType A, PrimitiveType B>
+template <PrimitiveType PT>
 struct LessOrEqualsOp {
-    using SymmetricOp = GreaterOrEqualsOp<B, A>;
-    using NativeTypeA =
-            std::conditional_t<A == TYPE_BOOLEAN, typename PrimitiveTypeTraits<A>::ColumnItemType,
-                               typename PrimitiveTypeTraits<A>::CppNativeType>;
-    using NativeTypeB =
-            std::conditional_t<B == TYPE_BOOLEAN, typename PrimitiveTypeTraits<B>::ColumnItemType,
-                               typename PrimitiveTypeTraits<B>::CppNativeType>;
-    static UInt8 apply(NativeTypeA a, NativeTypeB b) { return Compare::less_equal(a, b); }
+    using SymmetricOp = GreaterOrEqualsOp<PT>;
+    using NativeType = CompareType<PT>;
+    static UInt8 apply(NativeType a, NativeType b) { return Compare::less_equal(a, b); }
 };
 
 template <>
-struct LessOrEqualsOp<TYPE_DECIMALV2, TYPE_DECIMALV2> {
+struct LessOrEqualsOp<TYPE_DECIMALV2> {
     static UInt8 apply(DecimalV2Value a, DecimalV2Value b) { return a <= b; }
 };
 
-template <PrimitiveType A, PrimitiveType B>
+template <PrimitiveType PT>
 struct GreaterOrEqualsOp {
-    using SymmetricOp = LessOrEqualsOp<B, A>;
-    using NativeTypeA =
-            std::conditional_t<A == TYPE_BOOLEAN, typename PrimitiveTypeTraits<A>::ColumnItemType,
-                               typename PrimitiveTypeTraits<A>::CppNativeType>;
-    using NativeTypeB =
-            std::conditional_t<B == TYPE_BOOLEAN, typename PrimitiveTypeTraits<B>::ColumnItemType,
-                               typename PrimitiveTypeTraits<B>::CppNativeType>;
-    static UInt8 apply(NativeTypeA a, NativeTypeB b) { return Compare::greater_equal(a, b); }
+    using SymmetricOp = LessOrEqualsOp<PT>;
+    using NativeType = CompareType<PT>;
+    static UInt8 apply(NativeType a, NativeType b) { return Compare::greater_equal(a, b); }
 };
 
 template <>
-struct GreaterOrEqualsOp<TYPE_DECIMALV2, TYPE_DECIMALV2> {
+struct GreaterOrEqualsOp<TYPE_DECIMALV2> {
     static UInt8 apply(DecimalV2Value a, DecimalV2Value b) { return a >= b; }
 };
 

--- a/be/src/vec/core/decimal_comparison.h
+++ b/be/src/vec/core/decimal_comparison.h
@@ -71,14 +71,13 @@ struct DecCompareInt {
 };
 
 ///
-template <PrimitiveType A, PrimitiveType B,
-          template <PrimitiveType, PrimitiveType> typename Operation, bool _check_overflow = true,
-          bool _actual = is_decimal(A) || is_decimal(B)>
+template <PrimitiveType A, PrimitiveType B, template <PrimitiveType> typename Operation,
+          bool _check_overflow = true, bool _actual = is_decimal(A) || is_decimal(B)>
 class DecimalComparison {
 public:
     static constexpr PrimitiveType CompareIntPType = DecCompareInt<A, B>::Type;
     using CompareInt = typename PrimitiveTypeTraits<CompareIntPType>::CppNativeType;
-    using Op = Operation<CompareIntPType, CompareIntPType>;
+    using Op = Operation<CompareIntPType>;
     using ColVecA = typename PrimitiveTypeTraits<A>::ColumnType;
     using ColVecB = typename PrimitiveTypeTraits<B>::ColumnType;
     using ArrayA = typename ColVecA::Container;

--- a/be/test/vec/core/accurate_comparison_test.cpp
+++ b/be/test/vec/core/accurate_comparison_test.cpp
@@ -17,58 +17,23 @@
 
 #include "vec/core/accurate_comparison.h"
 
-#include <gtest/gtest-message.h>
-#include <gtest/gtest-test-part.h>
-
-#include <string>
-
-#include "gtest/gtest_pred_impl.h"
-#include "runtime/primitive_type.h"
+#include <gtest/gtest.h>
 
 namespace doris::vectorized {
 TEST(VAccurateComparison, TestsOP) {
-    ASSERT_TRUE(accurate::equalsOp(static_cast<Float32>(123), static_cast<UInt64>(123)));
-    ASSERT_TRUE(accurate::lessOp(static_cast<Float32>(123), static_cast<UInt64>(124)));
-    ASSERT_TRUE(accurate::lessOp(static_cast<Float32>(-1), static_cast<UInt64>(1)));
-    ASSERT_TRUE(accurate::lessOp(static_cast<Int64>(-1), static_cast<UInt64>(1)));
-    ASSERT_TRUE(!accurate::equalsOp(static_cast<Int64>(-1), static_cast<UInt64>(-1)));
-    ASSERT_TRUE(accurate::equalsOp(-0., 0));
-    ASSERT_TRUE(accurate::lessOp(-0., 1));
-    ASSERT_TRUE(accurate::lessOp(-0.5, 1));
-    ASSERT_TRUE(accurate::lessOp(0.5, 1));
-    ASSERT_TRUE(accurate::equalsOp(1.0, 1));
-    ASSERT_TRUE(accurate::greaterOp(1.1, 1));
-    ASSERT_TRUE(accurate::greaterOp(11.1, 1));
-    ASSERT_TRUE(accurate::greaterOp(11.1, 11));
-    ASSERT_TRUE(accurate::lessOp(-11.1, 11));
-    ASSERT_TRUE(accurate::lessOp(-11.1, -11));
-    ASSERT_TRUE(accurate::lessOp(-1.1, -1));
-    ASSERT_TRUE(accurate::greaterOp(-1.1, -2));
-    ASSERT_TRUE(accurate::greaterOp(1000., 100));
-    ASSERT_TRUE(accurate::greaterOp(-100., -1000));
-    ASSERT_TRUE(accurate::lessOp(100., 1000));
-    ASSERT_TRUE(accurate::lessOp(-1000., -100));
-
-    ASSERT_TRUE(accurate::lessOp(-std::numeric_limits<Float64>::infinity(), 0));
-    ASSERT_TRUE(accurate::lessOp(-std::numeric_limits<Float64>::infinity(), 1000));
-    ASSERT_TRUE(accurate::lessOp(-std::numeric_limits<Float64>::infinity(), -1000));
-    ASSERT_TRUE(accurate::greaterOp(std::numeric_limits<Float64>::infinity(), 0));
-    ASSERT_TRUE(accurate::greaterOp(std::numeric_limits<Float64>::infinity(), 1000));
-    ASSERT_TRUE(accurate::greaterOp(std::numeric_limits<Float64>::infinity(), -1000));
-
-    ASSERT_TRUE(accurate::lessOp(1, 1e100));
-    ASSERT_TRUE(accurate::lessOp(-1, 1e100));
-    ASSERT_TRUE(accurate::lessOp(-1e100, 1));
-    ASSERT_TRUE(accurate::lessOp(-1e100, -1));
-
-    ASSERT_TRUE(accurate::equalsOp(static_cast<UInt64>(9223372036854775808ULL),
-                                   static_cast<Float64>(9223372036854775808ULL)));
-    ASSERT_TRUE(accurate::equalsOp(static_cast<UInt64>(9223372036854775808ULL),
-                                   static_cast<Float32>(9223372036854775808ULL)));
-    ASSERT_TRUE(accurate::lessOp(static_cast<UInt8>(255), 300));
-    ASSERT_TRUE(accurate::lessOp(static_cast<UInt8>(255), static_cast<Int16>(300)));
-    ASSERT_TRUE(accurate::notEqualsOp(static_cast<UInt8>(255), 44));
-    ASSERT_TRUE(accurate::notEqualsOp(static_cast<UInt8>(255), static_cast<Int16>(44)));
+    EXPECT_TRUE((EqualsOp<TYPE_INT>::apply(1, 1)));
+    EXPECT_FALSE((EqualsOp<TYPE_INT>::apply(1, 2)));
+    EXPECT_TRUE((NotEqualsOp<TYPE_INT>::apply(1, 2)));
+    EXPECT_FALSE((NotEqualsOp<TYPE_INT>::apply(1, 1)));
+    EXPECT_TRUE((LessOp<TYPE_INT>::apply(1, 2)));
+    EXPECT_FALSE((LessOp<TYPE_INT>::apply(2, 1)));
+    EXPECT_TRUE((GreaterOp<TYPE_INT>::apply(2, 1)));
+    EXPECT_FALSE((GreaterOp<TYPE_INT>::apply(1, 2)));
+    EXPECT_TRUE((LessOrEqualsOp<TYPE_INT>::apply(1, 2)));
+    EXPECT_TRUE((LessOrEqualsOp<TYPE_INT>::apply(1, 1)));
+    EXPECT_FALSE((LessOrEqualsOp<TYPE_INT>::apply(2, 1)));
+    EXPECT_TRUE((GreaterOrEqualsOp<TYPE_INT>::apply(2, 1)));
+    EXPECT_TRUE((GreaterOrEqualsOp<TYPE_INT>::apply(1, 1)));
 }
 
 } // namespace doris::vectorized

--- a/regression-test/data/correctness/test_compare_float.out
+++ b/regression-test/data/correctness/test_compare_float.out
@@ -5,7 +5,6 @@
 3	114514.0
 4	Infinity
 5	-Infinity
-6	-0.0
 7	0.0
 8	NaN
 9	NaN
@@ -13,7 +12,6 @@
 -- !sql1 --
 5	-Infinity
 2	-123.0
-6	-0.0
 7	0.0
 1	123.0
 3	114514.0
@@ -24,7 +22,6 @@
 -- !sql2 --
 -Infinity	true
 -123.0	true
--0.0	true
 0.0	true
 123.0	true
 114514.0	true
@@ -35,7 +32,6 @@ NaN	false
 -- !sql3 --
 -Infinity	true
 -123.0	true
--0.0	true
 0.0	true
 123.0	true
 114514.0	true
@@ -46,7 +42,6 @@ NaN	true
 -- !sql4 --
 -Infinity	false
 -123.0	false
--0.0	false
 0.0	false
 123.0	false
 114514.0	false
@@ -57,7 +52,6 @@ NaN	false
 -- !sql5 --
 -Infinity	false
 -123.0	false
--0.0	false
 0.0	false
 123.0	false
 114514.0	false
@@ -68,7 +62,6 @@ NaN	true
 -- !sql6 --
 -Infinity	false
 -123.0	false
--0.0	false
 0.0	false
 123.0	false
 114514.0	false
@@ -79,7 +72,6 @@ NaN	true
 -- !sql7 --
 -Infinity	true
 -123.0	true
--0.0	true
 0.0	true
 123.0	true
 114514.0	true

--- a/regression-test/suites/correctness/test_compare_float.groovy
+++ b/regression-test/suites/correctness/test_compare_float.groovy
@@ -37,7 +37,7 @@ suite("test_compare_float") {
 
 
     sql """
-        insert into sort_float values(1,'123'),(2,'-123'),(3,'114514'),(4,'+inf'),(5,'-inf'),(6,'-0'),(7,'+0'),(8,'Nan'),(9,'Nan');
+        insert into sort_float values(1,'123'),(2,'-123'),(3,'114514'),(4,'+inf'),(5,'-inf'),(7,'+0'),(8,'Nan'),(9,'Nan');
     """
 
     qt_sql """


### PR DESCRIPTION
### What problem does this PR solve?

In the past, the two sides of our comparison operator templates were different types, but in fact, they were the same type internally. Here, the unnecessary template has been removed.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

