### PR TITLE
[feat](nereids) Add fold constant for nullif function

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
@@ -64,7 +64,6 @@ import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
 import org.apache.doris.nereids.trees.expressions.functions.PropagateNullLiteral;
 import org.apache.doris.nereids.trees.expressions.functions.PropagateNullable;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
-import org.apache.doris.nereids.trees.expressions.functions.generator.TableGeneratingFunction;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Array;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.ConnectionId;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.CurrentCatalog;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
@@ -74,6 +74,7 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.Date;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.EncryptKeyRef;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.If;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.LastQueryId;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.NullIf;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Nvl;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Password;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.SessionUser;
@@ -186,6 +187,7 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
                 matches(SessionUser.class, this::visitSessionUser),
                 matches(LastQueryId.class, this::visitLastQueryId),
                 matches(Nvl.class, this::visitNvl),
+                matches(NullIf.class, this::visitNullIf),
                 matches(Match.class, this::visitMatch)
         );
     }
@@ -551,9 +553,6 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
 
     @Override
     public Expression visitBoundFunction(BoundFunction boundFunction, ExpressionRewriteContext context) {
-        if (!boundFunction.foldable()) {
-            return boundFunction;
-        }
         boundFunction = rewriteChildren(boundFunction, context);
         Optional<Expression> checkedExpr = preProcess(boundFunction);
         if (checkedExpr.isPresent()) {
@@ -735,18 +734,39 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
     public Expression visitNvl(Nvl nvl, ExpressionRewriteContext context) {
         Nvl originNvl = nvl;
         nvl = rewriteChildren(nvl, context);
+        Expression first = nvl.left();
+        Expression second = nvl.right();
+        Expression result = nvl;
+        if (first.equals(second) || second.isNullLiteral() || (first.isLiteral() && !first.isNullLiteral())) {
+            result = first;
+        } else if (first.isNullLiteral()) {
+            result = second;
+        }
+        return TypeCoercionUtils.ensureSameResultType(originNvl, result, context);
+    }
 
-        for (Expression expr : nvl.children()) {
-            if (expr.isLiteral()) {
-                if (!expr.isNullLiteral()) {
-                    return TypeCoercionUtils.ensureSameResultType(originNvl, expr, context);
-                }
-            } else {
-                return TypeCoercionUtils.ensureSameResultType(originNvl, nvl, context);
+    @Override
+    public Expression visitNullIf(NullIf nullIf, ExpressionRewriteContext context) {
+        NullIf originNullIf = nullIf;
+        nullIf = rewriteChildren(nullIf, context);
+        Expression first = nullIf.left();
+        Expression second = nullIf.right();
+        Expression result = nullIf;
+        // if first is null, then first = second will be null
+        if (first.isNullLiteral() || second.isNullLiteral()) {
+            result = first;
+        } else if (first.equals(second)) {
+            // even if first is null, then first = second will be null, then result is first, so the result is also null
+            result = new NullLiteral(originNullIf.getDataType());
+        } else if (first.isLiteral() && second.isLiteral()) {
+            Expression isEqual = visitEqualTo(new EqualTo(first, second), context);
+            if (isEqual.equals(BooleanLiteral.TRUE)) {
+                result = new NullLiteral(originNullIf.getDataType());
+            } else if (isEqual.equals(BooleanLiteral.FALSE) || isEqual.isNullLiteral()) {
+                result = first;
             }
         }
-        // all nulls
-        return TypeCoercionUtils.ensureSameResultType(originNvl, nvl.child(0), context);
+        return TypeCoercionUtils.ensureSameResultType(originNullIf, result, context);
     }
 
     private <E extends Expression> E rewriteChildren(E expr, ExpressionRewriteContext context) {
@@ -787,7 +807,7 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
     }
 
     private Optional<Expression> preProcess(Expression expression) {
-        if (expression instanceof AggregateFunction || expression instanceof TableGeneratingFunction) {
+        if (!expression.foldable()) {
             return Optional.of(expression);
         }
         if (ExpressionUtils.hasNullLiteral(expression.getArguments())

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ExpressionEvaluator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ExpressionEvaluator.java
@@ -19,7 +19,6 @@ package org.apache.doris.nereids.trees.expressions;
 
 import org.apache.doris.nereids.exceptions.NotSupportedException;
 import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
-import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
 import org.apache.doris.nereids.trees.expressions.functions.executable.DateTimeAcquire;
 import org.apache.doris.nereids.trees.expressions.functions.executable.DateTimeArithmetic;
 import org.apache.doris.nereids.trees.expressions.functions.executable.DateTimeExtractAndTransform;
@@ -56,7 +55,7 @@ public enum ExpressionEvaluator {
      * Evaluate the value of the expression.
      */
     public Expression eval(Expression expression) {
-        if (!(expression.isConstant() || expression.foldable()) || expression instanceof AggregateFunction) {
+        if (!(expression.isConstant() || expression.foldable())) {
             return expression;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/AggregateFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/AggregateFunction.java
@@ -123,6 +123,11 @@ public abstract class AggregateFunction extends BoundFunction implements Expects
     }
 
     @Override
+    public boolean foldable() {
+        return false;
+    }
+
+    @Override
     public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
         return visitor.visitAggregateFunction(this, context);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/generator/TableGeneratingFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/generator/TableGeneratingFunction.java
@@ -52,4 +52,9 @@ public abstract class TableGeneratingFunction extends BoundFunction implements C
     protected GeneratorFunctionParams getFunctionParams(List<Expression> arguments) {
         return new GeneratorFunctionParams(this, getName(), arguments, isInferred());
     }
+
+    @Override
+    public boolean foldable() {
+        return false;
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
@@ -1482,7 +1482,8 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
 
         assertRewriteExpression("nvl(NULL, 1)", "1");
         assertRewriteExpression("nvl(NULL, NULL)", "NULL");
-        assertRewriteAfterTypeCoercion("nvl(IA, NULL)", "ifnull(IA, NULL)");
+        assertRewriteAfterTypeCoercion("nvl(IA, NULL)", "IA");
+        assertRewriteAfterTypeCoercion("nvl(IA, IA)", "IA");
         assertRewriteAfterTypeCoercion("nvl(IA, 1)", "ifnull(IA, 1)");
 
         Expression foldNvl = executor.rewrite(
@@ -1490,6 +1491,33 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
                 context
         );
         Assertions.assertEquals(new DateTimeV2Literal(DateTimeV2Type.of(6), "2025-04-17"), foldNvl);
+    }
+
+    @Test
+    void testFoldNullIf() {
+        executor = new ExpressionRuleExecutor(ImmutableList.of(
+                bottomUp(
+                        FoldConstantRule.INSTANCE
+                )
+        ));
+        assertRewriteAfterTypeCoercion("nullif(a, b)", "nullif(a, b)");
+        assertRewriteAfterTypeCoercion("nullif(a, a)", "null");
+        assertRewriteAfterTypeCoercion("nullif(a, null)", "a");
+        assertRewriteAfterTypeCoercion("nullif(null, a)", "null");
+        assertRewriteAfterTypeCoercion("nullif(1, 1)", "null");
+        assertRewriteAfterTypeCoercion("nullif(1, 2)", "1");
+    }
+
+    @Test
+    void testNonFoldable() {
+        executor = new ExpressionRuleExecutor(ImmutableList.of(
+                bottomUp(
+                        FoldConstantRule.INSTANCE
+                )
+        ));
+        assertRewriteAfterTypeCoercion("random(0, 1)", "random(0, 1)");
+        assertRewriteAfterTypeCoercion("sum(1 + 2)", "sum(3)");
+        assertRewriteAfterTypeCoercion("explode([1, 2, 3])", "explode([1, 2, 3])");
     }
 
     private void assertRewriteExpression(String actualExpression, String expectedExpression) {

--- a/regression-test/suites/external_table_p0/jdbc/test_mysql_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_mysql_jdbc_catalog.groovy
@@ -394,18 +394,18 @@ suite("test_mysql_jdbc_catalog", "p0,external,mysql,external_docker,external_doc
             contains "QUERY: SELECT `timestamp0` FROM `doris_test`.`dt` WHERE (`timestamp0` > '2022-01-01 00:00:00')"
         }
         explain {
-            sql ("select k6, k8 from test1 where nvl(k6, null) = 1;")
+            sql ("select k6, k8 from test1 where nvl(k6, 1) = 1;")
 
-            contains "QUERY: SELECT `k6`, `k8` FROM `doris_test`.`test1` WHERE ((ifnull(`k6`, NULL) = 1))"
+            contains "QUERY: SELECT `k6`, `k8` FROM `doris_test`.`test1` WHERE ((ifnull(`k6`, 1) = 1))"
         }
         explain {
-            sql ("select k6, k8 from test1 where nvl(nvl(k6, null),null) = 1;")
+            sql ("select k6, k8 from test1 where nvl(nvl(k6, 1), 1) = 1;")
 
-            contains "QUERY: SELECT `k6`, `k8` FROM `doris_test`.`test1` WHERE ((ifnull(ifnull(`k6`, NULL), NULL) = 1))"
+            contains "QUERY: SELECT `k6`, `k8` FROM `doris_test`.`test1` WHERE ((ifnull(`k6`, 1) = 1))"
         }
         sql """ set enable_ext_func_pred_pushdown = "false"; """
         explain {
-            sql ("select k6, k8 from test1 where nvl(k6, null) = 1 and k8 = 1;")
+            sql ("select k6, k8 from test1 where nvl(k6, 1) = 1 and k8 = 1;")
 
             contains "QUERY: SELECT `k6`, `k8` FROM `doris_test`.`test1` WHERE ((`k8` = 1))"
         }


### PR DESCRIPTION
1. Add fold constant for nullif function;
2. Opt fold nvl:   `nvl(a, a)`  => `a`,  `nvl(a, null)` => `a`;
3. Make AggregateFunction and TableGeneratingFunction to non-foldable.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

