### PR TITLE
[feature](agg) Add a knob to shuffled streaming agg

### DIFF
--- a/be/src/pipeline/exec/aggregation_sink_operator.h
+++ b/be/src/pipeline/exec/aggregation_sink_operator.h
@@ -155,11 +155,12 @@ public:
 
     Status sink(RuntimeState* state, vectorized::Block* in_block, bool eos) override;
 
-    DataDistribution required_data_distribution() const override {
+    DataDistribution required_data_distribution(RuntimeState* state) const override {
         if (_partition_exprs.empty()) {
             return _needs_finalize
                            ? DataDistribution(ExchangeType::NOOP)
-                           : DataSinkOperatorX<AggSinkLocalState>::required_data_distribution();
+                           : DataSinkOperatorX<AggSinkLocalState>::required_data_distribution(
+                                     state);
         }
         return _is_colocate && _require_bucket_distribution && !_followed_by_shuffled_operator
                        ? DataDistribution(ExchangeType::BUCKET_HASH_SHUFFLE, _partition_exprs)

--- a/be/src/pipeline/exec/analytic_sink_operator.h
+++ b/be/src/pipeline/exec/analytic_sink_operator.h
@@ -201,7 +201,7 @@ public:
     Status prepare(RuntimeState* state) override;
 
     Status sink(RuntimeState* state, vectorized::Block* in_block, bool eos) override;
-    DataDistribution required_data_distribution() const override {
+    DataDistribution required_data_distribution(RuntimeState* /*state*/) const override {
         if (_partition_by_eq_expr_ctxs.empty()) {
             return {ExchangeType::PASSTHROUGH};
         } else {

--- a/be/src/pipeline/exec/assert_num_rows_operator.h
+++ b/be/src/pipeline/exec/assert_num_rows_operator.h
@@ -47,7 +47,7 @@ public:
 
     [[nodiscard]] bool is_source() const override { return false; }
 
-    DataDistribution required_data_distribution() const override {
+    DataDistribution required_data_distribution(RuntimeState* /*state*/) const override {
         return {ExchangeType::PASSTHROUGH};
     }
 

--- a/be/src/pipeline/exec/distinct_streaming_aggregation_operator.h
+++ b/be/src/pipeline/exec/distinct_streaming_aggregation_operator.h
@@ -111,7 +111,7 @@ public:
     Status push(RuntimeState* state, vectorized::Block* input_block, bool eos) const override;
     bool need_more_input_data(RuntimeState* state) const override;
 
-    DataDistribution required_data_distribution() const override {
+    DataDistribution required_data_distribution(RuntimeState* state) const override {
         if (_needs_finalize && _probe_expr_ctxs.empty()) {
             return {ExchangeType::NOOP};
         }
@@ -120,7 +120,7 @@ public:
                            ? DataDistribution(ExchangeType::BUCKET_HASH_SHUFFLE, _partition_exprs)
                            : DataDistribution(ExchangeType::HASH_SHUFFLE, _partition_exprs);
         }
-        return StatefulOperatorX<DistinctStreamingAggLocalState>::required_data_distribution();
+        return StatefulOperatorX<DistinctStreamingAggLocalState>::required_data_distribution(state);
     }
 
     bool require_data_distribution() const override { return _is_colocate; }

--- a/be/src/pipeline/exec/exchange_source_operator.h
+++ b/be/src/pipeline/exec/exchange_source_operator.h
@@ -93,7 +93,7 @@ public:
     [[nodiscard]] int num_senders() const { return _num_senders; }
     [[nodiscard]] bool is_merging() const { return _is_merging; }
 
-    DataDistribution required_data_distribution() const override {
+    DataDistribution required_data_distribution(RuntimeState* /*state*/) const override {
         if (OperatorX<ExchangeLocalState>::is_serial_operator()) {
             return {ExchangeType::NOOP};
         }

--- a/be/src/pipeline/exec/hashjoin_build_sink.h
+++ b/be/src/pipeline/exec/hashjoin_build_sink.h
@@ -126,7 +126,7 @@ public:
                                               ._should_build_hash_table;
     }
 
-    DataDistribution required_data_distribution() const override {
+    DataDistribution required_data_distribution(RuntimeState* /*state*/) const override {
         if (_join_op == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN) {
             return {ExchangeType::NOOP};
         } else if (_is_broadcast_join) {

--- a/be/src/pipeline/exec/hashjoin_probe_operator.h
+++ b/be/src/pipeline/exec/hashjoin_probe_operator.h
@@ -130,7 +130,7 @@ public:
                 bool* eos) const override;
 
     bool need_more_input_data(RuntimeState* state) const override;
-    DataDistribution required_data_distribution() const override {
+    DataDistribution required_data_distribution(RuntimeState* /*state*/) const override {
         if (_join_op == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN) {
             return {ExchangeType::NOOP};
         }

--- a/be/src/pipeline/exec/nested_loop_join_build_operator.h
+++ b/be/src/pipeline/exec/nested_loop_join_build_operator.h
@@ -67,7 +67,7 @@ public:
 
     Status sink(RuntimeState* state, vectorized::Block* in_block, bool eos) override;
 
-    DataDistribution required_data_distribution() const override {
+    DataDistribution required_data_distribution(RuntimeState* /*state*/) const override {
         if (_join_op == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN) {
             return {ExchangeType::NOOP};
         }

--- a/be/src/pipeline/exec/nested_loop_join_probe_operator.h
+++ b/be/src/pipeline/exec/nested_loop_join_probe_operator.h
@@ -213,7 +213,7 @@ public:
         return _old_version_flag ? _row_descriptor : *_intermediate_row_desc;
     }
 
-    DataDistribution required_data_distribution() const override {
+    DataDistribution required_data_distribution(RuntimeState* /*state*/) const override {
         if (_join_op == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN ||
             _join_op == TJoinOp::RIGHT_OUTER_JOIN || _join_op == TJoinOp::RIGHT_ANTI_JOIN ||
             _join_op == TJoinOp::RIGHT_SEMI_JOIN || _join_op == TJoinOp::FULL_OUTER_JOIN) {

--- a/be/src/pipeline/exec/operator.cpp
+++ b/be/src/pipeline/exec/operator.cpp
@@ -135,14 +135,14 @@ Status PipelineXSinkLocalState<SharedStateArg>::terminate(RuntimeState* state) {
     return Status::OK();
 }
 
-DataDistribution OperatorBase::required_data_distribution() const {
+DataDistribution OperatorBase::required_data_distribution(RuntimeState* /*state*/) const {
     return _child && _child->is_serial_operator() && !is_source()
                    ? DataDistribution(ExchangeType::PASSTHROUGH)
                    : DataDistribution(ExchangeType::NOOP);
 }
 
-bool OperatorBase::require_shuffled_data_distribution() const {
-    return Pipeline::is_hash_exchange(required_data_distribution().distribution_type);
+bool OperatorBase::require_shuffled_data_distribution(RuntimeState* state) const {
+    return Pipeline::is_hash_exchange(required_data_distribution(state).distribution_type);
 }
 
 const RowDescriptor& OperatorBase::row_desc() const {

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -617,9 +617,7 @@ public:
         return Status::InternalError("init() is only implemented in local exchange!");
     }
 
-    Status prepare(RuntimeState* state) override {
-        return Status::OK();
-    }
+    Status prepare(RuntimeState* state) override { return Status::OK(); }
     Status terminate(RuntimeState* state) override;
     [[nodiscard]] bool is_finished(RuntimeState* state) const {
         auto result = state->get_sink_local_state_result();
@@ -641,9 +639,7 @@ public:
         return state->get_sink_local_state()->is_blockable();
     }
 
-    [[nodiscard]] bool is_spillable() const {
-        return _spillable;
-    }
+    [[nodiscard]] bool is_spillable() const { return _spillable; }
 
     template <class TARGET>
     TARGET& cast() {
@@ -671,9 +667,7 @@ public:
     [[nodiscard]] virtual std::string debug_string(RuntimeState* state,
                                                    int indentation_level) const;
 
-    [[nodiscard]] bool is_sink() const override {
-        return true;
-    }
+    [[nodiscard]] bool is_sink() const override { return true; }
 
     static Status close(RuntimeState* state, Status exec_status) {
         auto result = state->get_sink_local_state_result();
@@ -683,33 +677,19 @@ public:
         return result.value()->close(state, exec_status);
     }
 
-    [[nodiscard]] int operator_id() const {
-        return _operator_id;
-    }
+    [[nodiscard]] int operator_id() const { return _operator_id; }
 
-    [[nodiscard]] const std::vector<int>& dests_id() const {
-        return _dests_id;
-    }
+    [[nodiscard]] const std::vector<int>& dests_id() const { return _dests_id; }
 
-    [[nodiscard]] int nereids_id() const {
-        return _nereids_id;
-    }
+    [[nodiscard]] int nereids_id() const { return _nereids_id; }
 
-    [[nodiscard]] int node_id() const override {
-        return _node_id;
-    }
+    [[nodiscard]] int node_id() const override { return _node_id; }
 
-    [[nodiscard]] std::string get_name() const override {
-        return _name;
-    }
+    [[nodiscard]] std::string get_name() const override { return _name; }
 
-    virtual bool should_dry_run(RuntimeState* state) {
-        return false;
-    }
+    virtual bool should_dry_run(RuntimeState* state) { return false; }
 
-    [[nodiscard]] virtual bool count_down_destination() {
-        return true;
-    }
+    [[nodiscard]] virtual bool count_down_destination() { return true; }
 
 protected:
     template <typename Writer, typename Parent>
@@ -897,12 +877,8 @@ public:
     [[noreturn]] virtual const std::vector<TRuntimeFilterDesc>& runtime_filter_descs() {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR, _op_name);
     }
-    [[nodiscard]] std::string get_name() const override {
-        return _op_name;
-    }
-    [[nodiscard]] virtual bool need_more_input_data(RuntimeState* state) const {
-        return true;
-    }
+    [[nodiscard]] std::string get_name() const override { return _op_name; }
+    [[nodiscard]] virtual bool need_more_input_data(RuntimeState* state) const { return true; }
     bool is_blockable(RuntimeState* state) const override {
         return state->get_sink_local_state()->is_blockable() || _blockable;
     }
@@ -965,33 +941,17 @@ public:
         return reinterpret_cast<const TARGET&>(*this);
     }
 
-    [[nodiscard]] OperatorPtr get_child() {
-        return _child;
-    }
+    [[nodiscard]] OperatorPtr get_child() { return _child; }
 
-    [[nodiscard]] vectorized::VExprContextSPtrs& conjuncts() {
-        return _conjuncts;
-    }
-    [[nodiscard]] vectorized::VExprContextSPtrs& projections() {
-        return _projections;
-    }
-    [[nodiscard]] virtual RowDescriptor& row_descriptor() {
-        return _row_descriptor;
-    }
+    [[nodiscard]] vectorized::VExprContextSPtrs& conjuncts() { return _conjuncts; }
+    [[nodiscard]] vectorized::VExprContextSPtrs& projections() { return _projections; }
+    [[nodiscard]] virtual RowDescriptor& row_descriptor() { return _row_descriptor; }
 
-    [[nodiscard]] int operator_id() const {
-        return _operator_id;
-    }
-    [[nodiscard]] int node_id() const override {
-        return _node_id;
-    }
-    [[nodiscard]] int nereids_id() const {
-        return _nereids_id;
-    }
+    [[nodiscard]] int operator_id() const { return _operator_id; }
+    [[nodiscard]] int node_id() const override { return _node_id; }
+    [[nodiscard]] int nereids_id() const { return _nereids_id; }
 
-    [[nodiscard]] int64_t limit() const {
-        return _limit;
-    }
+    [[nodiscard]] int64_t limit() const { return _limit; }
 
     [[nodiscard]] const RowDescriptor& row_desc() const override {
         return _output_row_descriptor ? *_output_row_descriptor : _row_descriptor;
@@ -1001,9 +961,7 @@ public:
         return _output_row_descriptor.get();
     }
 
-    bool has_output_row_desc() const {
-        return _output_row_descriptor != nullptr;
-    }
+    bool has_output_row_desc() const { return _output_row_descriptor != nullptr; }
 
     [[nodiscard]] virtual Status get_block_after_projects(RuntimeState* state,
                                                           vectorized::Block* block, bool* eos);
@@ -1011,17 +969,11 @@ public:
     /// Only use in vectorized exec engine try to do projections to trans _row_desc -> _output_row_desc
     Status do_projections(RuntimeState* state, vectorized::Block* origin_block,
                           vectorized::Block* output_block) const;
-    void set_parallel_tasks(int parallel_tasks) {
-        _parallel_tasks = parallel_tasks;
-    }
-    int parallel_tasks() const {
-        return _parallel_tasks;
-    }
+    void set_parallel_tasks(int parallel_tasks) { _parallel_tasks = parallel_tasks; }
+    int parallel_tasks() const { return _parallel_tasks; }
 
     // To keep compatibility with older FE
-    void set_serial_operator() {
-        _is_serial_operator = true;
-    }
+    void set_serial_operator() { _is_serial_operator = true; }
 
     virtual void reset_reserve_mem_size(RuntimeState* state) {}
 
@@ -1163,9 +1115,7 @@ public:
                                       bool* eos) const = 0;
     [[nodiscard]] virtual Status push(RuntimeState* state, vectorized::Block* input_block,
                                       bool eos) const = 0;
-    bool need_more_input_data(RuntimeState* state) const override {
-        return true;
-    }
+    bool need_more_input_data(RuntimeState* state) const override { return true; }
 };
 
 template <typename Writer, typename Parent>

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -151,8 +151,9 @@ public:
         _followed_by_shuffled_operator = followed_by_shuffled_operator;
     }
     [[nodiscard]] virtual bool is_shuffled_operator() const { return false; }
-    [[nodiscard]] virtual DataDistribution required_data_distribution() const;
-    [[nodiscard]] virtual bool require_shuffled_data_distribution() const;
+    [[nodiscard]] virtual DataDistribution required_data_distribution(
+            RuntimeState* /*state*/) const;
+    [[nodiscard]] virtual bool require_shuffled_data_distribution(RuntimeState* /*state*/) const;
 
 protected:
     OperatorPtr _child = nullptr;
@@ -616,7 +617,9 @@ public:
         return Status::InternalError("init() is only implemented in local exchange!");
     }
 
-    Status prepare(RuntimeState* state) override { return Status::OK(); }
+    Status prepare(RuntimeState* state) override {
+        return Status::OK();
+    }
     Status terminate(RuntimeState* state) override;
     [[nodiscard]] bool is_finished(RuntimeState* state) const {
         auto result = state->get_sink_local_state_result();
@@ -638,7 +641,9 @@ public:
         return state->get_sink_local_state()->is_blockable();
     }
 
-    [[nodiscard]] bool is_spillable() const { return _spillable; }
+    [[nodiscard]] bool is_spillable() const {
+        return _spillable;
+    }
 
     template <class TARGET>
     TARGET& cast() {
@@ -666,7 +671,9 @@ public:
     [[nodiscard]] virtual std::string debug_string(RuntimeState* state,
                                                    int indentation_level) const;
 
-    [[nodiscard]] bool is_sink() const override { return true; }
+    [[nodiscard]] bool is_sink() const override {
+        return true;
+    }
 
     static Status close(RuntimeState* state, Status exec_status) {
         auto result = state->get_sink_local_state_result();
@@ -676,19 +683,33 @@ public:
         return result.value()->close(state, exec_status);
     }
 
-    [[nodiscard]] int operator_id() const { return _operator_id; }
+    [[nodiscard]] int operator_id() const {
+        return _operator_id;
+    }
 
-    [[nodiscard]] const std::vector<int>& dests_id() const { return _dests_id; }
+    [[nodiscard]] const std::vector<int>& dests_id() const {
+        return _dests_id;
+    }
 
-    [[nodiscard]] int nereids_id() const { return _nereids_id; }
+    [[nodiscard]] int nereids_id() const {
+        return _nereids_id;
+    }
 
-    [[nodiscard]] int node_id() const override { return _node_id; }
+    [[nodiscard]] int node_id() const override {
+        return _node_id;
+    }
 
-    [[nodiscard]] std::string get_name() const override { return _name; }
+    [[nodiscard]] std::string get_name() const override {
+        return _name;
+    }
 
-    virtual bool should_dry_run(RuntimeState* state) { return false; }
+    virtual bool should_dry_run(RuntimeState* state) {
+        return false;
+    }
 
-    [[nodiscard]] virtual bool count_down_destination() { return true; }
+    [[nodiscard]] virtual bool count_down_destination() {
+        return true;
+    }
 
 protected:
     template <typename Writer, typename Parent>
@@ -876,8 +897,12 @@ public:
     [[noreturn]] virtual const std::vector<TRuntimeFilterDesc>& runtime_filter_descs() {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR, _op_name);
     }
-    [[nodiscard]] std::string get_name() const override { return _op_name; }
-    [[nodiscard]] virtual bool need_more_input_data(RuntimeState* state) const { return true; }
+    [[nodiscard]] std::string get_name() const override {
+        return _op_name;
+    }
+    [[nodiscard]] virtual bool need_more_input_data(RuntimeState* state) const {
+        return true;
+    }
     bool is_blockable(RuntimeState* state) const override {
         return state->get_sink_local_state()->is_blockable() || _blockable;
     }
@@ -940,17 +965,33 @@ public:
         return reinterpret_cast<const TARGET&>(*this);
     }
 
-    [[nodiscard]] OperatorPtr get_child() { return _child; }
+    [[nodiscard]] OperatorPtr get_child() {
+        return _child;
+    }
 
-    [[nodiscard]] vectorized::VExprContextSPtrs& conjuncts() { return _conjuncts; }
-    [[nodiscard]] vectorized::VExprContextSPtrs& projections() { return _projections; }
-    [[nodiscard]] virtual RowDescriptor& row_descriptor() { return _row_descriptor; }
+    [[nodiscard]] vectorized::VExprContextSPtrs& conjuncts() {
+        return _conjuncts;
+    }
+    [[nodiscard]] vectorized::VExprContextSPtrs& projections() {
+        return _projections;
+    }
+    [[nodiscard]] virtual RowDescriptor& row_descriptor() {
+        return _row_descriptor;
+    }
 
-    [[nodiscard]] int operator_id() const { return _operator_id; }
-    [[nodiscard]] int node_id() const override { return _node_id; }
-    [[nodiscard]] int nereids_id() const { return _nereids_id; }
+    [[nodiscard]] int operator_id() const {
+        return _operator_id;
+    }
+    [[nodiscard]] int node_id() const override {
+        return _node_id;
+    }
+    [[nodiscard]] int nereids_id() const {
+        return _nereids_id;
+    }
 
-    [[nodiscard]] int64_t limit() const { return _limit; }
+    [[nodiscard]] int64_t limit() const {
+        return _limit;
+    }
 
     [[nodiscard]] const RowDescriptor& row_desc() const override {
         return _output_row_descriptor ? *_output_row_descriptor : _row_descriptor;
@@ -960,7 +1001,9 @@ public:
         return _output_row_descriptor.get();
     }
 
-    bool has_output_row_desc() const { return _output_row_descriptor != nullptr; }
+    bool has_output_row_desc() const {
+        return _output_row_descriptor != nullptr;
+    }
 
     [[nodiscard]] virtual Status get_block_after_projects(RuntimeState* state,
                                                           vectorized::Block* block, bool* eos);
@@ -968,11 +1011,17 @@ public:
     /// Only use in vectorized exec engine try to do projections to trans _row_desc -> _output_row_desc
     Status do_projections(RuntimeState* state, vectorized::Block* origin_block,
                           vectorized::Block* output_block) const;
-    void set_parallel_tasks(int parallel_tasks) { _parallel_tasks = parallel_tasks; }
-    int parallel_tasks() const { return _parallel_tasks; }
+    void set_parallel_tasks(int parallel_tasks) {
+        _parallel_tasks = parallel_tasks;
+    }
+    int parallel_tasks() const {
+        return _parallel_tasks;
+    }
 
     // To keep compatibility with older FE
-    void set_serial_operator() { _is_serial_operator = true; }
+    void set_serial_operator() {
+        _is_serial_operator = true;
+    }
 
     virtual void reset_reserve_mem_size(RuntimeState* state) {}
 
@@ -1114,7 +1163,9 @@ public:
                                       bool* eos) const = 0;
     [[nodiscard]] virtual Status push(RuntimeState* state, vectorized::Block* input_block,
                                       bool eos) const = 0;
-    bool need_more_input_data(RuntimeState* state) const override { return true; }
+    bool need_more_input_data(RuntimeState* state) const override {
+        return true;
+    }
 };
 
 template <typename Writer, typename Parent>

--- a/be/src/pipeline/exec/partition_sort_sink_operator.h
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.h
@@ -94,7 +94,7 @@ public:
 
     Status prepare(RuntimeState* state) override;
     Status sink(RuntimeState* state, vectorized::Block* in_block, bool eos) override;
-    DataDistribution required_data_distribution() const override {
+    DataDistribution required_data_distribution(RuntimeState* /*state*/) const override {
         if (_topn_phase == TPartTopNPhase::TWO_PHASE_GLOBAL) {
             return DataDistribution(ExchangeType::HASH_SHUFFLE, _distribute_exprs);
         }

--- a/be/src/pipeline/exec/partitioned_aggregation_sink_operator.h
+++ b/be/src/pipeline/exec/partitioned_aggregation_sink_operator.h
@@ -116,8 +116,8 @@ public:
 
     Status sink(RuntimeState* state, vectorized::Block* in_block, bool eos) override;
 
-    DataDistribution required_data_distribution() const override {
-        return _agg_sink_operator->required_data_distribution();
+    DataDistribution required_data_distribution(RuntimeState* state) const override {
+        return _agg_sink_operator->required_data_distribution(state);
     }
 
     bool require_data_distribution() const override {

--- a/be/src/pipeline/exec/partitioned_hash_join_probe_operator.h
+++ b/be/src/pipeline/exec/partitioned_hash_join_probe_operator.h
@@ -137,7 +137,7 @@ public:
                 bool* eos) const override;
 
     bool need_more_input_data(RuntimeState* state) const override;
-    DataDistribution required_data_distribution() const override {
+    DataDistribution required_data_distribution(RuntimeState* /*state*/) const override {
         if (_join_op == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN) {
             return {ExchangeType::NOOP};
         }

--- a/be/src/pipeline/exec/partitioned_hash_join_sink_operator.h
+++ b/be/src/pipeline/exec/partitioned_hash_join_sink_operator.h
@@ -118,7 +118,7 @@ public:
 
     size_t get_reserve_mem_size(RuntimeState* state, bool eos) override;
 
-    DataDistribution required_data_distribution() const override {
+    DataDistribution required_data_distribution(RuntimeState* /*state*/) const override {
         if (_join_op == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN) {
             return {ExchangeType::NOOP};
         }

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -374,7 +374,7 @@ public:
 
     TPushAggOp::type get_push_down_agg_type() { return _push_down_agg_type; }
 
-    DataDistribution required_data_distribution() const override {
+    DataDistribution required_data_distribution(RuntimeState* /*state*/) const override {
         if (OperatorX<LocalStateType>::is_serial_operator()) {
             // `is_serial_operator()` returns true means we ignore the distribution.
             return {ExchangeType::NOOP};

--- a/be/src/pipeline/exec/set_probe_sink_operator.h
+++ b/be/src/pipeline/exec/set_probe_sink_operator.h
@@ -102,7 +102,7 @@ public:
     Status prepare(RuntimeState* state) override;
 
     Status sink(RuntimeState* state, vectorized::Block* in_block, bool eos) override;
-    DataDistribution required_data_distribution() const override {
+    DataDistribution required_data_distribution(RuntimeState* /*state*/) const override {
         return _is_colocate ? DataDistribution(ExchangeType::BUCKET_HASH_SHUFFLE, _partition_exprs)
                             : DataDistribution(ExchangeType::HASH_SHUFFLE, _partition_exprs);
     }

--- a/be/src/pipeline/exec/set_sink_operator.h
+++ b/be/src/pipeline/exec/set_sink_operator.h
@@ -109,7 +109,7 @@ public:
     Status prepare(RuntimeState* state) override;
 
     Status sink(RuntimeState* state, vectorized::Block* in_block, bool eos) override;
-    DataDistribution required_data_distribution() const override {
+    DataDistribution required_data_distribution(RuntimeState* /*state*/) const override {
         return _is_colocate ? DataDistribution(ExchangeType::BUCKET_HASH_SHUFFLE, _partition_exprs)
                             : DataDistribution(ExchangeType::HASH_SHUFFLE, _partition_exprs);
     }

--- a/be/src/pipeline/exec/sort_sink_operator.h
+++ b/be/src/pipeline/exec/sort_sink_operator.h
@@ -77,7 +77,7 @@ public:
 
     Status prepare(RuntimeState* state) override;
     Status sink(RuntimeState* state, vectorized::Block* in_block, bool eos) override;
-    DataDistribution required_data_distribution() const override {
+    DataDistribution required_data_distribution(RuntimeState* /*state*/) const override {
         if (_is_analytic_sort) {
             return _is_colocate && _require_bucket_distribution && !_followed_by_shuffled_operator
                            ? DataDistribution(ExchangeType::BUCKET_HASH_SHUFFLE, _partition_exprs)

--- a/be/src/pipeline/exec/spill_sort_sink_operator.h
+++ b/be/src/pipeline/exec/spill_sort_sink_operator.h
@@ -76,8 +76,8 @@ public:
 
     Status prepare(RuntimeState* state) override;
     Status sink(RuntimeState* state, vectorized::Block* in_block, bool eos) override;
-    DataDistribution required_data_distribution() const override {
-        return _sort_sink_operator->required_data_distribution();
+    DataDistribution required_data_distribution(RuntimeState* state) const override {
+        return _sort_sink_operator->required_data_distribution(state);
     }
     bool require_data_distribution() const override {
         return _sort_sink_operator->require_data_distribution();

--- a/be/src/pipeline/exec/streaming_aggregation_operator.cpp
+++ b/be/src/pipeline/exec/streaming_aggregation_operator.cpp
@@ -25,6 +25,7 @@
 #include "common/cast_set.h"
 #include "common/compiler_util.h" // IWYU pragma: keep
 #include "pipeline/exec/operator.h"
+#include "vec/aggregate_functions/aggregate_function_simple_factory.h"
 #include "vec/exprs/vectorized_agg_fn.h"
 #include "vec/exprs/vslot_ref.h"
 
@@ -610,7 +611,8 @@ void StreamingAggLocalState::_emplace_into_hash_table(vectorized::AggregateDataP
 }
 
 StreamingAggOperatorX::StreamingAggOperatorX(ObjectPool* pool, int operator_id,
-                                             const TPlanNode& tnode, const DescriptorTbl& descs)
+                                             const TPlanNode& tnode, const DescriptorTbl& descs,
+                                             bool require_bucket_distribution)
         : StatefulOperatorX<StreamingAggLocalState>(pool, tnode, operator_id, descs),
           _intermediate_tuple_id(tnode.agg_node.intermediate_tuple_id),
           _output_tuple_id(tnode.agg_node.output_tuple_id),
@@ -618,7 +620,21 @@ StreamingAggOperatorX::StreamingAggOperatorX(ObjectPool* pool, int operator_id,
           _is_merge(false),
           _is_first_phase(tnode.agg_node.__isset.is_first_phase && tnode.agg_node.is_first_phase),
           _have_conjuncts(tnode.__isset.vconjunct && !tnode.vconjunct.nodes.empty()),
-          _agg_fn_output_row_descriptor(descs, tnode.row_tuples, tnode.nullable_tuples) {}
+          _agg_fn_output_row_descriptor(descs, tnode.row_tuples, tnode.nullable_tuples),
+          _partition_exprs(
+                  tnode.__isset.distribute_expr_lists &&
+                                  (require_bucket_distribution ||
+                                   std::any_of(
+                                           tnode.agg_node.aggregate_functions.begin(),
+                                           tnode.agg_node.aggregate_functions.end(),
+                                           [](const TExpr& texpr) -> bool {
+                                               return texpr.nodes[0]
+                                                       .fn.name.function_name.starts_with(
+                                                               vectorized::
+                                                                       DISTINCT_FUNCTION_PREFIX);
+                                           }))
+                          ? tnode.distribute_expr_lists[0]
+                          : tnode.agg_node.grouping_exprs) {}
 
 Status StreamingAggOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(StatefulOperatorX<StreamingAggLocalState>::init(tnode, state));

--- a/be/src/pipeline/exec/streaming_aggregation_operator.h
+++ b/be/src/pipeline/exec/streaming_aggregation_operator.h
@@ -136,7 +136,7 @@ private:
 class StreamingAggOperatorX MOCK_REMOVE(final) : public StatefulOperatorX<StreamingAggLocalState> {
 public:
     StreamingAggOperatorX(ObjectPool* pool, int operator_id, const TPlanNode& tnode,
-                          const DescriptorTbl& descs);
+                          const DescriptorTbl& descs, bool require_bucket_distribution);
 #ifdef BE_TEST
     StreamingAggOperatorX() : _is_first_phase {false} {}
 #endif
@@ -149,6 +149,19 @@ public:
     bool need_more_input_data(RuntimeState* state) const override;
     void set_low_memory_mode(RuntimeState* state) override {
         _spill_streaming_agg_mem_limit = 1024 * 1024;
+    }
+    DataDistribution required_data_distribution(RuntimeState* state) const override {
+        if (!state->get_query_ctx()->should_be_shuffled_agg(
+                    StatefulOperatorX<StreamingAggLocalState>::node_id())) {
+            return StatefulOperatorX<StreamingAggLocalState>::required_data_distribution(state);
+        }
+        if (_partition_exprs.empty()) {
+            return _needs_finalize
+                           ? DataDistribution(ExchangeType::NOOP)
+                           : StatefulOperatorX<StreamingAggLocalState>::required_data_distribution(
+                                     state);
+        }
+        return DataDistribution(ExchangeType::HASH_SHUFFLE, _partition_exprs);
     }
 
 private:
@@ -184,6 +197,7 @@ private:
     std::vector<size_t> _make_nullable_keys;
     bool _have_conjuncts;
     RowDescriptor _agg_fn_output_row_descriptor;
+    const std::vector<TExpr> _partition_exprs;
 };
 
 } // namespace pipeline

--- a/be/src/pipeline/exec/table_function_operator.h
+++ b/be/src/pipeline/exec/table_function_operator.h
@@ -96,7 +96,7 @@ public:
         return !local_state._child_block->rows() && !local_state._child_eos;
     }
 
-    DataDistribution required_data_distribution() const override {
+    DataDistribution required_data_distribution(RuntimeState* /*state*/) const override {
         return {ExchangeType::PASSTHROUGH};
     }
 

--- a/be/src/pipeline/exec/union_sink_operator.h
+++ b/be/src/pipeline/exec/union_sink_operator.h
@@ -99,11 +99,11 @@ public:
         }
     }
 
-    bool require_shuffled_data_distribution() const override {
+    bool require_shuffled_data_distribution(RuntimeState* /*state*/) const override {
         return _followed_by_shuffled_operator;
     }
 
-    DataDistribution required_data_distribution() const override {
+    DataDistribution required_data_distribution(RuntimeState* /*state*/) const override {
         if (_child->is_serial_operator() && _followed_by_shuffled_operator) {
             return DataDistribution(ExchangeType::HASH_SHUFFLE, _distribute_exprs);
         }

--- a/be/src/pipeline/exec/union_source_operator.h
+++ b/be/src/pipeline/exec/union_source_operator.h
@@ -102,7 +102,7 @@ public:
         return Status::OK();
     }
     [[nodiscard]] int get_child_count() const { return _child_size; }
-    bool require_shuffled_data_distribution() const override {
+    bool require_shuffled_data_distribution(RuntimeState* /*state*/) const override {
         return _followed_by_shuffled_operator;
     }
 

--- a/be/src/pipeline/pipeline.h
+++ b/be/src/pipeline/pipeline.h
@@ -83,8 +83,8 @@ public:
 
     bool need_to_local_exchange(const DataDistribution target_data_distribution,
                                 const int idx) const;
-    void init_data_distribution() {
-        set_data_distribution(_operators.front()->required_data_distribution());
+    void init_data_distribution(RuntimeState* state) {
+        set_data_distribution(_operators.front()->required_data_distribution(state));
     }
     void set_data_distribution(const DataDistribution& data_distribution) {
         _data_distribution = data_distribution;

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -187,6 +187,12 @@ public:
         return _query_options.__isset.enable_force_spill && _query_options.enable_force_spill;
     }
     const TQueryOptions& query_options() const { return _query_options; }
+    bool should_be_shuffled_agg(int node_id) const {
+        return _query_options.__isset.shuffled_agg_ids &&
+               std::any_of(_query_options.shuffled_agg_ids.begin(),
+                           _query_options.shuffled_agg_ids.end(),
+                           [&](const int id) -> bool { return id == node_id; });
+    }
 
     // global runtime filter mgr, the runtime filter have remote target or
     // need local merge should regist here. before publish() or push_to_remote()

--- a/be/test/pipeline/operator/hashjoin_probe_operator_test.cpp
+++ b/be/test/pipeline/operator/hashjoin_probe_operator_test.cpp
@@ -206,11 +206,13 @@ public:
         ASSERT_FALSE(probe_operator->is_shuffled_operator());
         std::cout << "sink distribution: "
                   << get_exchange_type_name(
-                             sink_operator->required_data_distribution().distribution_type)
+                             sink_operator->required_data_distribution(_helper.runtime_state.get())
+                                     .distribution_type)
                   << std::endl;
         std::cout << "probe distribution: "
                   << get_exchange_type_name(
-                             probe_operator->required_data_distribution().distribution_type)
+                             probe_operator->required_data_distribution(_helper.runtime_state.get())
+                                     .distribution_type)
                   << std::endl;
 
         LocalStateInfo info {.parent_profile = _helper.runtime_profile.get(),

--- a/be/test/pipeline/operator/spill_sort_sink_operator_test.cpp
+++ b/be/test/pipeline/operator/spill_sort_sink_operator_test.cpp
@@ -75,8 +75,9 @@ TEST_F(SpillSortSinkOperatorTest, Basic) {
     ASSERT_EQ(sink_operator->get_reserve_mem_size(_helper.runtime_state.get(), false), 0);
     ASSERT_EQ(sink_operator->get_reserve_mem_size(_helper.runtime_state.get(), true), 0);
 
-    auto data_distribution = sink_operator->required_data_distribution();
-    auto inner_data_distribution = sink_operator->_sort_sink_operator->required_data_distribution();
+    auto data_distribution = sink_operator->required_data_distribution(_helper.runtime_state.get());
+    auto inner_data_distribution = sink_operator->_sort_sink_operator->required_data_distribution(
+            _helper.runtime_state.get());
     ASSERT_EQ(data_distribution.distribution_type, inner_data_distribution.distribution_type);
 
     ASSERT_EQ(sink_operator->require_data_distribution(),

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -409,6 +409,7 @@ struct TQueryOptions {
   174: optional i64 merge_read_slice_size = 8388608;
 
   175: optional bool enable_fuzzy_blockable_task = false;
+  176: optional list<i32> shuffled_agg_ids;
 
   // For cloud, to control if the content would be written into file cache
   // In write path, to control if the content would be written into file cache.


### PR DESCRIPTION
### What problem does this PR solve?

Add a knob to control whether data fed into a streaming aggregation should be shuffled at first.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

