### PR TITLE
[fix](insert) do not generate next id when fe is not master

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.plans.commands.insert;
 
 import org.apache.doris.catalog.DatabaseIf;
+import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.EnvFactory;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.Config;
@@ -77,8 +78,10 @@ public abstract class AbstractInsertExecutor {
             Optional<InsertCommandContext> insertCtx, boolean emptyInsert) {
         this.ctx = ctx;
         this.database = table.getDatabase();
-        this.insertLoadJob = new InsertLoadJob(database.getId(), labelName);
-        ctx.getEnv().getLoadManager().addLoadJob(insertLoadJob);
+        if (Env.getCurrentEnv().isMaster()) {
+            this.insertLoadJob = new InsertLoadJob(database.getId(), labelName);
+            ctx.getEnv().getLoadManager().addLoadJob(insertLoadJob);
+        }
         this.coordinator = EnvFactory.getInstance().createCoordinator(
                 ctx, planner, ctx.getStatsErrorEstimator(), insertLoadJob.getId());
         this.labelName = labelName;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
@@ -132,7 +132,11 @@ public class InsertIntoTableCommand extends Command implements NeedAuditEncrypti
         this.cte = cte;
         this.needNormalizePlan = needNormalizePlan;
         this.branchName = branchName;
-        this.jobId = Env.getCurrentEnv().getNextId();
+        if (Env.getCurrentEnv().isMaster()) {
+            this.jobId = Env.getCurrentEnv().getNextId();
+        } else {
+            this.jobId = -1;
+        }
     }
 
     /**


### PR DESCRIPTION
### What problem does this PR solve?

Do not generate next id when fe is not master:
```
2025-10-13 20:05:06,436 ERROR (mysql-nio-pool-0|121) [BDBJEJournal.write():295] catch ReplicaWriteException when writing to database, will exit. journal id 11
com.sleepycat.je.rep.ReplicaWriteException: (JE 18.3.12) Problem closing transaction 195410. The current state is:REPLICA. The node transitioned to this state at:Mon Oct 13 20:01:33 CST 2025
        at com.sleepycat.je.rep.txn.ReadonlyTxn.disallowReplicaWrite(ReadonlyTxn.java:114) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.rep.txn.ReadonlyTxn.preLogWithoutLock(ReadonlyTxn.java:102) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.dbi.CursorImpl.insertRecordInternal(CursorImpl.java:1371) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.dbi.CursorImpl.insertOrUpdateRecord(CursorImpl.java:1242) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.Cursor.putNoNotify(Cursor.java:2938) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.Cursor.putNotify(Cursor.java:2776) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.Cursor.putNoDups(Cursor.java:2623) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.Cursor.putInternal(Cursor.java:2454) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.Cursor.putInternal(Cursor.java:841) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.Database.put(Database.java:1635) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.Database.put(Database.java:1688) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at org.apache.doris.journal.bdbje.BDBJEJournal.write(BDBJEJournal.java:273) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.persist.EditLog.logEditDirectly(EditLog.java:1553) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.persist.EditLog.logEdit(EditLog.java:1605) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.persist.EditLog.logSaveNextId(EditLog.java:1641) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.MetaIdGenerator.getNextId(MetaIdGenerator.java:50) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.Env.getNextId(Env.java:4914) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand.<init>(InsertIntoTableCommand.java:140) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand.<init>(InsertIntoTableCommand.java:146) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.LogicalPlanBuilder.visitInsertTable(LogicalPlanBuilder.java:1364) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.LogicalPlanBuilderForEncryption.visitCreateScheduledJob(LogicalPlanBuilderForEncryption.java:137) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.LogicalPlanBuilder.visitInsertTable(LogicalPlanBuilder.java:1364) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.LogicalPlanBuilderForEncryption.visitCreateScheduledJob(LogicalPlanBuilderForEncryption.java:137) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.LogicalPlanBuilderForEncryption.visitCreateScheduledJob(LogicalPlanBuilderForEncryption.java:38) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.DorisParser$CreateScheduledJobContext.accept(DorisParser.java:2960) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.LogicalPlanBuilder.visitChildren(LogicalPlanBuilder.java:1127) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.DorisParserBaseVisitor.visitSupportedJobStatementAlias(DorisParserBaseVisitor.java:126) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.DorisParser$SupportedJobStatementAliasContext.accept(DorisParser.java:1526) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.LogicalPlanBuilder.visitChildren(LogicalPlanBuilder.java:1127) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.DorisParserBaseVisitor.visitStatementBaseAlias(DorisParserBaseVisitor.java:42) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.DorisParser$StatementBaseAliasContext.accept(DorisParser.java:820) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.antlr.v4.runtime.tree.AbstractParseTreeVisitor.visit(AbstractParseTreeVisitor.java:18) ~[antlr4-runtime-4.13.1.jar:4.13.1]
        at org.apache.doris.nereids.parser.LogicalPlanBuilder.lambda$visitSingleStatement$1(LogicalPlanBuilder.java:1135) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.ParserUtils.withOrigin(ParserUtils.java:65) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.LogicalPlanBuilder.visitSingleStatement(LogicalPlanBuilder.java:1135) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.parser.LogicalPlanBuilder.visitSingleStatement(LogicalPlanBuilder.java:1093) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.DorisParser$SingleStatementContext.accept(DorisParser.java:652) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.antlr.v4.runtime.tree.AbstractParseTreeVisitor.visit(AbstractParseTreeVisitor.java:18) ~[antlr4-runtime-4.13.1.jar:4.13.1]
        at org.apache.doris.nereids.parser.NereidsParser.parseForEncryption(NereidsParser.java:370) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.NeedAuditEncryption.geneEncryptionSQL(NeedAuditEncryption.java:41) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.AuditLogHelper.logAuditLogImpl(AuditLogHelper.java:416) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.AuditLogHelper.logAuditLog(AuditLogHelper.java:88) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.auditAfterExec(ConnectProcessor.java:174) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.executeQuery(ConnectProcessor.java:337) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:196) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MysqlConnectProcessor.handleQuery(MysqlConnectProcessor.java:231) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MysqlConnectProcessor.dispatch(MysqlConnectProcessor.java:259) ~[doris-fe.jar:1.2-SNAPSHOT]
       at org.apache.doris.qe.MysqlConnectProcessor.processOnce(MysqlConnectProcessor.java:403) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

