### PR TITLE
[refine](cast) Check whether the input type in cast matches the one in the FE plan.

### DIFF
--- a/be/src/vec/functions/cast/function_cast.cpp
+++ b/be/src/vec/functions/cast/function_cast.cpp
@@ -338,7 +338,8 @@ protected:
                 wrapper_function(context, block, arguments, result, input_rows_count, nullptr));
 
         // check output column
-        RETURN_IF_ERROR(res.type->check_column(*res.column));
+        RETURN_IF_ERROR(block.get_by_position(result).type->check_column(
+                *block.get_by_position(result).column));
 
         return Status::OK();
     }


### PR DESCRIPTION
### What problem does this PR solve?

1. When executing cast, check the column and type of both input and output.
2. PreparedFunctionCast will not be constructed repeatedly during execution; it will be saved during open.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

