### PR TITLE
[improve](sort) opt heap sort without runtime predicate

### DIFF
--- a/be/src/pipeline/exec/sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/sort_sink_operator.cpp
@@ -45,11 +45,18 @@ Status SortSinkLocalState::open(RuntimeState* state) {
     auto& p = _parent->cast<SortSinkOperatorX>();
 
     RETURN_IF_ERROR(p._vsort_exec_exprs.clone(state, _vsort_exec_exprs));
+    bool with_runtime_predicate = state->get_query_ctx()->has_runtime_predicate(p._node_id);
     switch (p._algorithm) {
     case TSortAlgorithm::HEAP_SORT: {
-        _shared_state->sorter = vectorized::HeapSorter::create_shared(
-                _vsort_exec_exprs, p._limit, p._offset, p._pool, p._is_asc_order, p._nulls_first,
-                p._child->row_desc());
+        if (!with_runtime_predicate && p._limit > 0 && p._limit + p._offset < 1024) {
+            _shared_state->sorter = vectorized::HeapSorter<false>::create_shared(
+                    _vsort_exec_exprs, p._limit, p._offset, p._pool, p._is_asc_order,
+                    p._nulls_first, p._child->row_desc());
+        } else {
+            _shared_state->sorter = vectorized::HeapSorter<true>::create_shared(
+                    _vsort_exec_exprs, p._limit, p._offset, p._pool, p._is_asc_order,
+                    p._nulls_first, p._child->row_desc());
+        }
         break;
     }
     case TSortAlgorithm::TOPN_SORT: {

--- a/be/src/pipeline/exec/sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/sort_sink_operator.cpp
@@ -49,11 +49,11 @@ Status SortSinkLocalState::open(RuntimeState* state) {
     switch (p._algorithm) {
     case TSortAlgorithm::HEAP_SORT: {
         if (!with_runtime_predicate && p._limit > 0 && p._limit + p._offset < 1024) {
-            _shared_state->sorter = vectorized::HeapSorter<false>::create_shared(
+            _shared_state->sorter = vectorized::HeapSorterWithoutRuntimePredicate::create_shared(
                     _vsort_exec_exprs, p._limit, p._offset, p._pool, p._is_asc_order,
                     p._nulls_first, p._child->row_desc());
         } else {
-            _shared_state->sorter = vectorized::HeapSorter<true>::create_shared(
+            _shared_state->sorter = vectorized::HeapSorterWithRuntimePredicate::create_shared(
                     _vsort_exec_exprs, p._limit, p._offset, p._pool, p._is_asc_order,
                     p._nulls_first, p._child->row_desc());
         }

--- a/be/src/vec/common/sort/heap_sorter.h
+++ b/be/src/vec/common/sort/heap_sorter.h
@@ -51,8 +51,8 @@ public:
     }
 
 private:
-    Status _handle_with_runtime_predicate(Block* block);
-    Status _handle_without_runtime_predicate(Block* block);
+    Status _append_block_with_runtime_predicate(Block* block);
+    Status _append_block_without_runtime_predicate(Block* block);
     void _do_filter(HeapSortCursorBlockView& block_view, size_t num_rows);
 
     void prepare_for_read_with_runtime_predicate();

--- a/be/src/vec/common/sort/heap_sorter_util.h
+++ b/be/src/vec/common/sort/heap_sorter_util.h
@@ -1,0 +1,141 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "vec/common/sort/sorter.h"
+
+namespace doris::vectorized {
+#include "common/compile_check_begin.h"
+
+struct HeapSortCursorBlockView {
+public:
+    Block block;
+    ColumnRawPtrs sort_columns;
+    SortDescription& desc;
+
+    HeapSortCursorBlockView(Block&& cur_block, SortDescription& sort_desc)
+            : block(cur_block), desc(sort_desc) {
+        _reset();
+    }
+
+    void filter_block(IColumn::Filter& filter) {
+        Block::filter_block_internal(&block, filter, block.columns());
+        _reset();
+    }
+
+private:
+    void _reset() {
+        sort_columns.clear();
+        auto columns = block.get_columns_and_convert();
+        for (auto& column_desc : desc) {
+            size_t column_number = !column_desc.column_name.empty()
+                                           ? block.get_position_by_name(column_desc.column_name)
+                                           : column_desc.column_number;
+            sort_columns.push_back(columns[column_number].get());
+        }
+    }
+};
+
+using HeapSortCursorBlockSPtr = std::shared_ptr<HeapSortCursorBlockView>;
+
+struct HeapSortCursorImpl {
+public:
+    HeapSortCursorImpl(size_t row_id, HeapSortCursorBlockSPtr block_view)
+            : _row_id(row_id), _block_view(std::move(block_view)) {}
+
+    HeapSortCursorImpl(const HeapSortCursorImpl& other) {
+        _row_id = other._row_id;
+        _block_view = other._block_view;
+    }
+
+    HeapSortCursorImpl(HeapSortCursorImpl&& other) {
+        _row_id = other._row_id;
+        _block_view = other._block_view;
+        other._block_view = nullptr;
+    }
+
+    HeapSortCursorImpl& operator=(HeapSortCursorImpl&& other) {
+        std::swap(_row_id, other._row_id);
+        std::swap(_block_view, other._block_view);
+        return *this;
+    }
+
+    ~HeapSortCursorImpl() = default;
+
+    size_t row_id() const { return _row_id; }
+
+    const ColumnRawPtrs& sort_columns() const { return _block_view->sort_columns; }
+
+    const Block* block() const { return &_block_view->block; }
+
+    const SortDescription& sort_desc() const { return _block_view->desc; }
+
+    bool operator<(const HeapSortCursorImpl& rhs) const {
+        for (size_t i = 0; i < sort_desc().size(); ++i) {
+            int direction = sort_desc()[i].direction;
+            int nulls_direction = sort_desc()[i].nulls_direction;
+            int res = direction * sort_columns()[i]->compare_at(row_id(), rhs.row_id(),
+                                                                *(rhs.sort_columns()[i]),
+                                                                nulls_direction);
+            // ASC: direction == 1. If bigger, res > 0. So we return true.
+            if (res < 0) {
+                return true;
+            }
+            if (res > 0) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+private:
+    size_t _row_id;
+    HeapSortCursorBlockSPtr _block_view;
+};
+
+class SortingHeap {
+    ENABLE_FACTORY_CREATOR(SortingHeap);
+
+public:
+    const HeapSortCursorImpl& top() { return _queue.top(); }
+
+    size_t size() { return _queue.size(); }
+
+    bool empty() { return _queue.empty(); }
+
+    void pop() { _queue.pop(); }
+
+    void replace_top(HeapSortCursorImpl&& top) {
+        _queue.pop();
+        _queue.push(std::move(top));
+    }
+
+    void push(HeapSortCursorImpl&& cursor) { _queue.push(std::move(cursor)); }
+
+    void replace_top_if_less(HeapSortCursorImpl&& val) {
+        if (val < top()) {
+            replace_top(std::move(val));
+        }
+    }
+
+private:
+    std::priority_queue<HeapSortCursorImpl> _queue;
+};
+
+#include "common/compile_check_end.h"
+} // namespace doris::vectorized

--- a/be/src/vec/common/sort/sorter.h
+++ b/be/src/vec/common/sort/sorter.h
@@ -154,6 +154,7 @@ public:
 
 protected:
     Status partial_sort(Block& src_block, Block& dest_block, bool reversed = false);
+    Status _prepare_sort_columns(Block& src_block, Block& dest_block, bool reversed = false);
 
     bool _enable_spill = false;
     SortDescription _sort_description;

--- a/be/test/pipeline/operator/sort_operator_test.cpp
+++ b/be/test/pipeline/operator/sort_operator_test.cpp
@@ -154,7 +154,7 @@ struct SortOperatorTest : public ::testing::Test {
 };
 
 TEST_F(SortOperatorTest, test) {
-    create_operator(TSortAlgorithm::HEAP_SORT, 10, 0);
+    create_operator(TSortAlgorithm::HEAP_SORT, 1025, 0);
 
     {
         vectorized::Block block = ColumnHelper::create_block<DataTypeInt64>({2, 3, 1});
@@ -206,7 +206,7 @@ TEST_F(SortOperatorTest, test_dep) {
         bool eos = false;
         auto st = source->get_block(state.get(), &block, &eos);
         EXPECT_TRUE(st.ok()) << st.msg();
-        EXPECT_FALSE(eos);
+        EXPECT_TRUE(eos);
         EXPECT_EQ(block.rows(), 6);
         std::cout << block.dump_data() << std::endl;
         EXPECT_TRUE(ColumnHelper::block_equal(

--- a/be/test/vec/exec/sort/heap_sorter_test.cpp
+++ b/be/test/vec/exec/sort/heap_sorter_test.cpp
@@ -60,7 +60,7 @@ struct HeapSorterTest : public testing::Test {
     MockRuntimeState _state;
     RuntimeProfile _profile {"test"};
 
-    std::unique_ptr<HeapSorter> sorter;
+    std::unique_ptr<HeapSorter<true>> sorter;
 
     std::unique_ptr<MockRowDescriptor> row_desc;
 
@@ -84,8 +84,8 @@ TEST_F(HeapSorterTest, test_topn_sorter1) {
 
     sort_exec_exprs._sort_tuple_slot_expr_ctxs = MockSlotRef::create_mock_contexts(data_types);
 
-    sorter = HeapSorter::create_unique(sort_exec_exprs, 6, 0, &pool, is_asc_order, nulls_first,
-                                       *row_desc);
+    sorter = HeapSorter<true>::create_unique(sort_exec_exprs, 6, 0, &pool, is_asc_order,
+                                             nulls_first, *row_desc);
 
     sorter->init_profile(&_profile);
 

--- a/be/test/vec/exec/sort/heap_sorter_test.cpp
+++ b/be/test/vec/exec/sort/heap_sorter_test.cpp
@@ -60,7 +60,7 @@ struct HeapSorterTest : public testing::Test {
     MockRuntimeState _state;
     RuntimeProfile _profile {"test"};
 
-    std::unique_ptr<HeapSorter<true>> sorter;
+    std::unique_ptr<HeapSorterWithRuntimePredicate> sorter;
 
     std::unique_ptr<MockRowDescriptor> row_desc;
 
@@ -84,8 +84,8 @@ TEST_F(HeapSorterTest, test_topn_sorter1) {
 
     sort_exec_exprs._sort_tuple_slot_expr_ctxs = MockSlotRef::create_mock_contexts(data_types);
 
-    sorter = HeapSorter<true>::create_unique(sort_exec_exprs, 6, 0, &pool, is_asc_order,
-                                             nulls_first, *row_desc);
+    sorter = HeapSorterWithRuntimePredicate::create_unique(sort_exec_exprs, 6, 0, &pool,
+                                                           is_asc_order, nulls_first, *row_desc);
 
     sorter->init_profile(&_profile);
 

--- a/be/test/vec/exec/sort/sort_test.cpp
+++ b/be/test/vec/exec/sort/sort_test.cpp
@@ -71,8 +71,8 @@ public:
             sorter = TopNSorter::create_unique(sort_exec_exprs, limit, offset, &pool, is_asc_order,
                                                nulls_first, *row_desc, nullptr, nullptr);
         case SortType::HEAP_SORT:
-            sorter = HeapSorter::create_unique(sort_exec_exprs, limit, offset, &pool, is_asc_order,
-                                               nulls_first, *row_desc);
+            sorter = HeapSorter<true>::create_unique(sort_exec_exprs, limit, offset, &pool,
+                                                     is_asc_order, nulls_first, *row_desc);
             break;
         default:
             break;

--- a/be/test/vec/exec/sort/sort_test.cpp
+++ b/be/test/vec/exec/sort/sort_test.cpp
@@ -71,8 +71,8 @@ public:
             sorter = TopNSorter::create_unique(sort_exec_exprs, limit, offset, &pool, is_asc_order,
                                                nulls_first, *row_desc, nullptr, nullptr);
         case SortType::HEAP_SORT:
-            sorter = HeapSorter<true>::create_unique(sort_exec_exprs, limit, offset, &pool,
-                                                     is_asc_order, nulls_first, *row_desc);
+            sorter = HeapSorterWithRuntimePredicate::create_unique(
+                    sort_exec_exprs, limit, offset, &pool, is_asc_order, nulls_first, *row_desc);
             break;
         default:
             break;

--- a/regression-test/data/inverted_index_p0/test_bm25_score.out
+++ b/regression-test/data/inverted_index_p0/test_bm25_score.out
@@ -3,16 +3,16 @@
 702
 
 -- !sql --
-893965910	45.135.0.0	GET /french/history/past_cups/images/past_bu_66_off.gif HTTP/1.0	200	435	0.28830066
-893965908	45.135.0.0	GET /french/history/past_cups/images/past_bu_50_off.gif HTTP/1.0	200	392	0.28830066
-893965906	45.135.0.0	GET /french/history/past_cups/images/past_bu_94_off.gif HTTP/1.0	200	432	0.28830066
-893965906	45.135.0.0	GET /french/history/past_cups/images/past_bu_86_off.gif HTTP/1.0	200	409	0.28830066
-893965905	45.135.0.0	GET /french/history/past_cups/images/past_bu_70_off.gif HTTP/1.0	200	409	0.28830066
-893965905	45.135.0.0	GET /french/history/past_cups/images/past_bu_78_on.gif HTTP/1.0	200	501	0.28830066
-893965904	45.135.0.0	GET /french/history/past_cups/images/past_bu_62_off.gif HTTP/1.0	200	437	0.28830066
-893965903	45.135.0.0	GET /french/history/past_cups/images/past_bu_54_off.gif HTTP/1.0	200	403	0.28830066
-893965902	45.135.0.0	GET /french/history/past_cups/images/past_bu_38_off.gif HTTP/1.0	200	436	0.28830066
-893965901	45.135.0.0	GET /french/history/past_cups/images/past_bu_30_off.gif HTTP/1.0	200	406	0.28830066
+893965901	45.135.0.0	GET /french/history/past_cups/images/past_bu_30_off.gif HTTP/1.0	200	406	0.2883007
+893965902	45.135.0.0	GET /french/history/past_cups/images/past_bu_38_off.gif HTTP/1.0	200	436	0.2883007
+893965903	45.135.0.0	GET /french/history/past_cups/images/past_bu_54_off.gif HTTP/1.0	200	403	0.2883007
+893965904	45.135.0.0	GET /french/history/past_cups/images/past_bu_62_off.gif HTTP/1.0	200	437	0.2883007
+893965905	45.135.0.0	GET /french/history/past_cups/images/past_bu_70_off.gif HTTP/1.0	200	409	0.2883007
+893965905	45.135.0.0	GET /french/history/past_cups/images/past_bu_78_on.gif HTTP/1.0	200	501	0.2883007
+893965906	45.135.0.0	GET /french/history/past_cups/images/past_bu_86_off.gif HTTP/1.0	200	409	0.2883007
+893965906	45.135.0.0	GET /french/history/past_cups/images/past_bu_94_off.gif HTTP/1.0	200	432	0.2883007
+893965908	45.135.0.0	GET /french/history/past_cups/images/past_bu_50_off.gif HTTP/1.0	200	392	0.2883007
+893965910	45.135.0.0	GET /french/history/past_cups/images/past_bu_66_off.gif HTTP/1.0	200	435	0.2883007
 
 -- !sql --
 893966443	30.0.0.0	GET /english/playing/mascot/images/button.03.gif HTTP/1.0	200	893	10.160415

--- a/regression-test/suites/inverted_index_p0/test_bm25_score.groovy
+++ b/regression-test/suites/inverted_index_p0/test_bm25_score.groovy
@@ -89,7 +89,7 @@ suite("test_bm25_score", "p0") {
         }
 
         qt_sql """ select count() from test_bm25_score where request match_any 'button.03.gif'; """
-        qt_sql """ select *, score() as score from test_bm25_score where request match_any 'button.03.gif' order by score limit 10; """
+        order_qt_sql """ select *, score() as score from test_bm25_score where request match_any 'button.03.gif' order by score limit 10; """
         qt_sql """ select *, score() as score from test_bm25_score where request match_all 'button.03.gif' order by score limit 10; """
         qt_sql """ select *, score() as score from test_bm25_score where request match_phrase 'button.03.gif' order by score limit 10; """
 


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
- in sort node, the topn maybe have a runtime predicate, which could filter data in scan. and then get the topn rows.
- When no runtime predicate is pushed down, the previous implementation sorted all input data before maintaining the TopN heap.
- This PR changes the logic to:
  1. Insert incoming rows into the heap until the heap reaches the TopN size.
  2. For subsequent batches, use the current top value in the heap to filter incoming rows before sorted data, avoiding unnecessary operations.
  3. Maintain the heap size by replacing the top when a better row arrives.
- This avoids a full sort and improves performance for TopN queries without runtime predicate pushdown.

```
mysql> SELECT murmur_hash3_32(number) AS n FROM numbers("number" = "20000000") ORDER BY n, n + 1, n + 2 LIMIT 10;
+-------------+
| n           |
+-------------+
| -2147483480 |
| -2147483264 |
| -2147482864 |
| -2147482719 |
| -2147482662 |
| -2147482588 |
| -2147482109 |
| -2147482067 |
| -2147481904 |
| -2147481747 |
+-------------+
10 rows in set (1.83 sec)

mysql> SELECT murmur_hash3_32(number) AS n FROM numbers("number" = "20000000") ORDER BY n, n + 1, n + 2 LIMIT 10;
+-------------+
| n           |
+-------------+
| -2147483480 |
| -2147483264 |
| -2147482864 |
| -2147482719 |
| -2147482662 |
| -2147482588 |
| -2147482109 |
| -2147482067 |
| -2147481904 |
| -2147481747 |
+-------------+
10 rows in set (0.67 sec)

```


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

