### PR TITLE
[fix](inverted index) remove shadow prefix when matching index columns in schema change

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Index.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Index.java
@@ -283,7 +283,9 @@ public class Index implements Writable {
         if (schema != null) {
             for (String columnName : columns) {
                 for (Column column : schema) {
-                    if (columnName.equalsIgnoreCase(column.getName())) {
+                    // Remove shadow prefix when comparing to handle schema change scenarios
+                    if (columnName.equalsIgnoreCase(
+                            Column.removeNamePrefix(column.getName()))) {
                         columnUniqueIds.add(column.getUniqueId());
                     }
                 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

test_index_ddl_fault_injection.groovy
Fixes an issue where index columns fail to match during schema change operations due to shadow column prefix mismatch.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

