### PR TITLE
[Enhancement](grammar) Support omit auto keyword for auto range partition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -3782,6 +3782,10 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
                     }
                 })
                 .collect(ImmutableList.toImmutableList());
+        // support omit 'auto' when have function expression
+        if (partitionList.stream().anyMatch(p -> p instanceof UnboundFunction)) {
+            isAutoPartition = true;
+        }
         return new PartitionTableInfo(
                 isAutoPartition,
                 ctx.RANGE() != null ? "RANGE" : "LIST",

--- a/regression-test/suites/partition_p0/auto_partition/test_auto_partition_behavior.groovy
+++ b/regression-test/suites/partition_p0/auto_partition/test_auto_partition_behavior.groovy
@@ -290,23 +290,37 @@ suite("test_auto_partition_behavior") {
     part_result = sql " show tablets from test_change "
     assertEquals(part_result.size(), 52 * replicaNum)
 
+    sql "drop table if exists not_auto_expr"
+    sql """
+        CREATE TABLE not_auto_expr (
+            `TIME_STAMP` date NOT NULL
+        )
+        partition by range (date_trunc(`TIME_STAMP`, 'day'))()
+        DISTRIBUTED BY HASH(`TIME_STAMP`) BUCKETS 10
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1"
+        );
+    """
+    sql """ insert into not_auto_expr values ("2020-12-12"), ("2020-12-13"), ("2020-12-14"); """
+    part_result = sql " show partitions from not_auto_expr "
+    assertEquals(part_result.size(), 3)
+    def show_result = sql " show create table not_auto_expr "
+    assertTrue(show_result[0][1].contains("AUTO PARTITION BY RANGE"))
 
-
-    // test not auto partition have expr.
+    sql "drop table if exists not_auto_expr_list"
     test {
         sql """
-            CREATE TABLE not_auto_expr (
+            CREATE TABLE not_auto_expr_list (
                 `TIME_STAMP` date NOT NULL
             )
-            partition by range (date_trunc(`TIME_STAMP`, 'day'))()
+            partition by list (date_trunc(`TIME_STAMP`, 'day'))()
             DISTRIBUTED BY HASH(`TIME_STAMP`) BUCKETS 10
             PROPERTIES (
                 "replication_allocation" = "tag.location.default: 1"
             );
         """
-        exception "Non-auto partition table not support partition expr!"
+        exception "auto create partition only support slotRef in list partitions"
     }
-
 
     // test insert empty
     sql "create table if not exists empty_range like test_change"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

when use auto range partition, support omit 'auto' keyword:

```sql
CREATE TABLE not_auto_expr (
    `TIME_STAMP` date NOT NULL
)
partition by range (date_trunc(`TIME_STAMP`, 'day'))()
DISTRIBUTED BY HASH(`TIME_STAMP`) BUCKETS 10
PROPERTIES (
    "replication_allocation" = "tag.location.default: 1"
);
```
--- it's auto range partition

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. https://github.com/apache/doris-website/pull/2992

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

