### PR TITLE
[function](mask) mask_last/first second parameter can be non-const

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/MaskFirstN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/MaskFirstN.java
@@ -18,7 +18,6 @@
 package org.apache.doris.nereids.trees.expressions.functions.scalar;
 
 import org.apache.doris.catalog.FunctionSignature;
-import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
 import org.apache.doris.nereids.trees.expressions.functions.PropagateNullable;
@@ -66,13 +65,6 @@ public class MaskFirstN extends ScalarFunction implements ExplicitlyCastableSign
     public MaskFirstN withChildren(List<Expression> children) {
         Preconditions.checkArgument(!children.isEmpty());
         return new MaskFirstN(getFunctionParams(children));
-    }
-
-    @Override
-    public void checkLegalityAfterRewrite() {
-        if (arity() == 2 && !child(1).isLiteral()) {
-            throw new AnalysisException("mask_first_n must accept literal for 2nd argument");
-        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/MaskLastN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/MaskLastN.java
@@ -18,7 +18,6 @@
 package org.apache.doris.nereids.trees.expressions.functions.scalar;
 
 import org.apache.doris.catalog.FunctionSignature;
-import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
 import org.apache.doris.nereids.trees.expressions.functions.PropagateNullable;
@@ -66,13 +65,6 @@ public class MaskLastN extends ScalarFunction implements ExplicitlyCastableSigna
     public MaskLastN withChildren(List<Expression> children) {
         Preconditions.checkArgument(!children.isEmpty());
         return new MaskLastN(getFunctionParams(children));
-    }
-
-    @Override
-    public void checkLegalityAfterRewrite() {
-        if (arity() == 2 && !child(1).isLiteral()) {
-            throw new AnalysisException("mask_last_n must accept literal for 2nd argument");
-        }
     }
 
     @Override

--- a/regression-test/data/correctness_p0/test_mask_function.out
+++ b/regression-test/data/correctness_p0/test_mask_function.out
@@ -24,36 +24,36 @@ Meimei Han	Xxxxxx Xxx	*xxxxx *xx	*##### *##
 13556780000	nnnnnnnnnnn	nnnnnnnnnnn	@@@@@@@@@@@
 
 -- !select_mask_first_n --
-Jack Hawk	Xxxx Xxxx	Xxxk Hawk	Xxxx Xxxx
-Sam Smith	Xxx Xxxxx	Xxx Smith	Xxx Xxxxx
-Tom Cruise	Xxx Xxxxxx	Xxx Cruise	Xxx Xxxxxx
-Bruce Willis	Xxxxx Xxxxxx	Xxxce Willis	Xxxxx Xxxxxx
-Ming Li	Xxxx Xx	Xxxg Li	Xxxx Xx
-Meimei Han	Xxxxxx Xxx	Xxxmei Han	Xxxxxx Xxx
+Jack Hawk	Xack Hawk	Xxxx Xxxx	Xxxk Hawk	Xxxx Xxxx
+Sam Smith	Xxm Smith	Xxx Xxxxx	Xxx Smith	Xxx Xxxxx
+Tom Cruise	Xxx Cruise	Xxx Xxxxxx	Xxx Cruise	Xxx Xxxxxx
+Bruce Willis	Xxxxe Willis	Xxxxx Xxxxxx	Xxxce Willis	Xxxxx Xxxxxx
+Ming Li	Xxxx Li	Xxxx Xx	Xxxg Li	Xxxx Xx
+Meimei Han	Xxxxxx Han	Xxxxxx Xxx	Xxxmei Han	Xxxxxx Xxx
 
 -- !select_mask_first_n_nullable --
-18112349876	nnnnnnnnnnn	nnn12349876	nnnnnnnnnnn
-\N	\N	\N	\N
-18212349876	nnnnnnnnnnn	nnn12349876	nnnnnnnnnnn
-\N	\N	\N	\N
-19943216789	nnnnnnnnnnn	nnn43216789	nnnnnnnnnnn
-13556780000	nnnnnnnnnnn	nnn56780000	nnnnnnnnnnn
+18112349876	n8112349876	nnnnnnnnnnn	nnn12349876	nnnnnnnnnnn
+\N	\N	\N	\N	\N
+18212349876	nnn12349876	nnnnnnnnnnn	nnn12349876	nnnnnnnnnnn
+\N	\N	\N	\N	\N
+19943216789	nnnnn216789	nnnnnnnnnnn	nnn43216789	nnnnnnnnnnn
+13556780000	nnnnnn80000	nnnnnnnnnnn	nnn56780000	nnnnnnnnnnn
 
 -- !select_mask_last_n --
-Jack Hawk	Xxxx Xxxx	Jack Hxxx	Xxxx Xxxx
-Sam Smith	Xxx Xxxxx	Sam Smxxx	Xxx Xxxxx
-Tom Cruise	Xxx Xxxxxx	Tom Cruxxx	Xxx Xxxxxx
-Bruce Willis	Xxxxx Xxxxxx	Bruce Wilxxx	Xxxxx Xxxxxx
-Ming Li	Xxxx Xx	Ming Xx	Xxxx Xx
-Meimei Han	Xxxxxx Xxx	Meimei Xxx	Xxxxxx Xxx
+Jack Hawk	Jack Hawx	Xxxx Xxxx	Jack Hxxx	Xxxx Xxxx
+Sam Smith	Sam Smixx	Xxx Xxxxx	Sam Smxxx	Xxx Xxxxx
+Tom Cruise	Tom Cruxxx	Xxx Xxxxxx	Tom Cruxxx	Xxx Xxxxxx
+Bruce Willis	Bruce Wixxxx	Xxxxx Xxxxxx	Bruce Wilxxx	Xxxxx Xxxxxx
+Ming Li	Mixx Xx	Xxxx Xx	Ming Xx	Xxxx Xx
+Meimei Han	Meimxx Xxx	Xxxxxx Xxx	Meimei Xxx	Xxxxxx Xxx
 
 -- !select_mask_last_n_nullable --
-18112349876	nnnnnnnnnnn	18112349nnn	nnnnnnnnnnn
-\N	\N	\N	\N
-18212349876	nnnnnnnnnnn	18212349nnn	nnnnnnnnnnn
-\N	\N	\N	\N
-19943216789	nnnnnnnnnnn	19943216nnn	nnnnnnnnnnn
-13556780000	nnnnnnnnnnn	13556780nnn	nnnnnnnnnnn
+18112349876	1811234987n	nnnnnnnnnnn	18112349nnn	nnnnnnnnnnn
+\N	\N	\N	\N	\N
+18212349876	18212349nnn	nnnnnnnnnnn	18212349nnn	nnnnnnnnnnn
+\N	\N	\N	\N	\N
+19943216789	199432nnnnn	nnnnnnnnnnn	19943216nnn	nnnnnnnnnnn
+13556780000	13556nnnnnn	nnnnnnnnnnn	13556780nnn	nnnnnnnnnnn
 
 -- !select_digital_masking --
 138****5678

--- a/regression-test/suites/correctness_p0/test_mask_function.groovy
+++ b/regression-test/suites/correctness_p0/test_mask_function.groovy
@@ -57,19 +57,19 @@ suite("test_mask_function") {
     """
 
     qt_select_mask_first_n """
-        select name, mask_first_n(name), mask_first_n(name, 3), mask_first_n(name, 100) from table_mask_test order by id;
+        select name, mask_first_n(name,id), mask_first_n(name), mask_first_n(name, 3), mask_first_n(name, 100) from table_mask_test order by id;
     """
 
     qt_select_mask_first_n_nullable """
-        select phone, mask_first_n(phone), mask_first_n(phone, 3), mask_first_n(phone, 100) from table_mask_test order by id;
+        select phone, mask_first_n(phone,id), mask_first_n(phone), mask_first_n(phone, 3), mask_first_n(phone, 100) from table_mask_test order by id;
     """
 
     qt_select_mask_last_n """
-        select name, mask_last_n(name), mask_last_n(name, 3), mask_last_n(name, 100) from table_mask_test order by id;
+        select name, mask_last_n(name,id), mask_last_n(name), mask_last_n(name, 3), mask_last_n(name, 100) from table_mask_test order by id;
     """
 
     qt_select_mask_last_n_nullable """
-        select phone, mask_last_n(phone), mask_last_n(phone, 3), mask_last_n(phone, 100) from table_mask_test order by id;
+        select phone, mask_last_n(phone,id), mask_last_n(phone), mask_last_n(phone, 3), mask_last_n(phone, 100) from table_mask_test order by id;
     """
 
     qt_select_digital_masking """
@@ -108,14 +108,6 @@ suite("test_mask_function") {
     test {
         sql """ select mask_first_n("12345", -100); """
         exception "function mask_first_n only accept non-negative input for 2nd argument but got -100"
-    }
-    test {
-        sql """ select mask_last_n("12345", id) from table_mask_test; """
-        exception "mask_last_n must accept literal for 2nd argument"
-    }
-    test {
-        sql """ select mask_first_n("12345", id) from table_mask_test; """
-        exception "mask_first_n must accept literal for 2nd argument"
     }
 
     test {


### PR DESCRIPTION
### What problem does this PR solve?
before
```
mysql> select mask_last_n('123',number) from numbers("number" = "5");
ERROR 1105 (HY000): errCode = 2, detailMessage = mask_last_n must accept literal for 2nd argument
```
now
```
mysql> select mask_last_n('123',number) from numbers("number" = "5");
+---------------------------+
| mask_last_n('123',number) |
+---------------------------+
| 123                       |
| 12n                       |
| 1nn                       |
| nnn                       |
| nnn                       |
+---------------------------+
```

https://github.com/apache/doris-website/pull/2983

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

