### PR TITLE
[Fix](job) fix streaming job block when fe restart

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -90,6 +90,7 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
     private final long dbId;
     private StreamingJobStatistic jobStatistic = new StreamingJobStatistic();
     @Getter
+    @Setter
     @SerializedName("fr")
     protected FailureReason failureReason;
     @Getter

--- a/fe/fe-core/src/main/java/org/apache/doris/job/offset/s3/S3SourceOffsetProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/offset/s3/S3SourceOffsetProvider.java
@@ -174,10 +174,10 @@ public class S3SourceOffsetProvider implements SourceOffsetProvider {
 
     @Override
     public boolean hasMoreDataToConsume() {
-        if (currentOffset == null) {
-            return true;
-        }
-        if (currentOffset.endFile.compareTo(maxEndFile) < 0) {
+        if (currentOffset != null
+                && currentOffset.endFile != null
+                && maxEndFile != null
+                && currentOffset.endFile.compareTo(maxEndFile) < 0) {
             return true;
         }
         return false;

--- a/fe/fe-core/src/main/java/org/apache/doris/job/offset/s3/S3SourceOffsetProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/offset/s3/S3SourceOffsetProvider.java
@@ -174,10 +174,11 @@ public class S3SourceOffsetProvider implements SourceOffsetProvider {
 
     @Override
     public boolean hasMoreDataToConsume() {
-        if (currentOffset != null
-                && currentOffset.endFile != null
-                && maxEndFile != null
-                && currentOffset.endFile.compareTo(maxEndFile) < 0) {
+        if (currentOffset == null || currentOffset.endFile == null) {
+            return true;
+        }
+
+        if (maxEndFile != null && currentOffset.endFile.compareTo(maxEndFile) < 0) {
             return true;
         }
         return false;

--- a/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/StreamingTaskScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/StreamingTaskScheduler.java
@@ -20,6 +20,7 @@ package org.apache.doris.job.scheduler;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.CustomThreadFactory;
+import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.common.util.MasterDaemon;
 import org.apache.doris.job.common.FailureReason;
 import org.apache.doris.job.common.JobStatus;
@@ -96,6 +97,9 @@ public class StreamingTaskScheduler extends MasterDaemon {
     }
 
     private void scheduleOneTask(StreamingInsertTask task) {
+        if (DebugPointUtil.isEnable("StreamingJob.scheduleTask.exception")) {
+            throw new RuntimeException("debug point StreamingJob.scheduleTask.exception");
+        }
         StreamingInsertJob job = (StreamingInsertJob) Env.getCurrentEnv().getJobManager().getJob(task.getJobId());
         if (job == null) {
             log.warn("Job not found, job id: {}", task.getJobId());

--- a/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/StreamingTaskScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/StreamingTaskScheduler.java
@@ -78,10 +78,11 @@ public class StreamingTaskScheduler extends MasterDaemon {
             threadPool.execute(() -> {
                 try {
                     scheduleOneTask(task);
-                }catch (Exception e){
+                } catch (Exception e) {
                     log.warn("Failed to schedule task, task id {}, job id {}",
                             task.getTaskId(), task.getJobId(), e);
-                    StreamingInsertJob job = (StreamingInsertJob) Env.getCurrentEnv().getJobManager().getJob(task.getJobId());
+                    StreamingInsertJob job =
+                            (StreamingInsertJob) Env.getCurrentEnv().getJobManager().getJob(task.getJobId());
                     job.setFailureReason(new FailureReason(e.getMessage()));
                     try {
                         job.updateJobStatus(JobStatus.PAUSED);

--- a/regression-test/suites/job_p0/streaming_job/test_streaming_job_schedule_task_error.groovy
+++ b/regression-test/suites/job_p0/streaming_job/test_streaming_job_schedule_task_error.groovy
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+import org.awaitility.Awaitility
+
+import static java.util.concurrent.TimeUnit.SECONDS
+
+suite("test_streaming_job_schedule_task_error", 'nonConcurrent') {
+    def tableName = "test_streaming_job_schedule_task_error_tbl"
+    def jobName = "test_streaming_job_schedule_task_error_job"
+
+    sql """drop table if exists `${tableName}` force"""
+    sql """
+        DROP JOB IF EXISTS where jobname =  '${jobName}'
+    """
+
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tableName} (
+            `c1` int NULL,
+            `c2` string NULL,
+            `c3` int  NULL,
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`c1`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`c1`) BUCKETS 3
+        PROPERTIES ("replication_allocation" = "tag.location.default: 1");
+    """
+
+    GetDebugPoint().enableDebugPointForAllFEs('StreamingJob.scheduleTask.exception')
+    try {
+        // create streaming job
+        sql """
+           CREATE JOB ${jobName}  
+           ON STREAMING DO INSERT INTO ${tableName} 
+           SELECT * FROM S3
+            (
+                "uri" = "s3://${s3BucketName}/regression/load/data/example_[0-1].csv",
+                "format" = "csv",
+                "provider" = "${getS3Provider()}",
+                "column_separator" = ",",
+                "s3.endpoint" = "${getS3Endpoint()}",
+                "s3.region" = "${getS3Region()}",
+                "s3.access_key" = "${getS3AK()}",
+                "s3.secret_key" = "${getS3SK()}"
+            );
+        """
+        try {
+            Awaitility.await().atMost(300, SECONDS)
+                    .pollInterval(1, SECONDS).until(
+                    {
+                        def jobRes = sql """ select Status, errorMsg from jobs("type"="insert") where Name = '${jobName}' and ExecuteType='STREAMING' """
+                        // check job status and succeed task count larger than 2
+                        log.info("jobRes: " + jobRes)
+                        jobRes.size() == 1 && 'PAUSED'.equals(jobRes.get(0).get(0))
+                    }
+            )
+        } catch (Exception ex){
+            def showjob = sql """select * from jobs("type"="insert") where Name='${jobName}'"""
+            def showtask = sql """select * from tasks("type"="insert") where JobName='${jobName}'"""
+            log.info("show job: " + showjob)
+            log.info("show task: " + showtask)
+            throw ex;chixu
+        }
+
+        def errorMsg = sql """select ErrorMsg from jobs("type"="insert") where Name='${jobName}'"""
+        assert errorMsg.get(0).get(0).contains("StreamingJob.scheduleTask.exception")
+
+        sql """
+        DROP JOB IF EXISTS where jobname =  '${jobName}'
+        """
+
+        def jobCountRsp = sql """select count(1) from jobs("type"="insert")  where Name ='${jobName}'"""
+        assert jobCountRsp.get(0).get(0) == 0
+
+    } finally {
+        GetDebugPoint().disableDebugPointForAllFEs('StreamingJob.scheduleTask.exception')
+    }
+
+}


### PR DESCRIPTION
### What problem does this PR solve?

Before：
If an exception occurs while scheduling a stream insert, neither the job nor the task status will be updated, and the task will become stuck.

After:
When an exception occurs, the job is paused and an error message is displayed.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

