### PR TITLE
[fix](nereids)set RuntimeFilterInfo only on BE which is merge node

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/distribute/worker/BackendWorker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/distribute/worker/BackendWorker.java
@@ -45,7 +45,7 @@ public class BackendWorker implements DistributedPlanWorker {
 
     @Override
     public String brpcAddress() {
-        return backend.getHost() + brpcPort();
+        return backend.getHost() + ":" + brpcPort();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/RuntimeFiltersThriftBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/RuntimeFiltersThriftBuilder.java
@@ -65,7 +65,7 @@ public class RuntimeFiltersThriftBuilder {
         return mergeInstance == instance;
     }
 
-    public void setRuntimeFilterThriftParams(TRuntimeFilterParams runtimeFilterParams) {
+    public void populateRuntimeFilterParams(TRuntimeFilterParams runtimeFilterParams) {
         for (RuntimeFilter rf : runtimeFilters) {
             List<RuntimeFilterTarget> targets = ridToTargets.get(rf.getFilterId());
             if (targets == null) {
@@ -89,8 +89,7 @@ public class RuntimeFiltersThriftBuilder {
                 }
 
                 runtimeFilterParams.putToRidToTargetParamv2(
-                        rf.getFilterId().asInt(), new ArrayList<>(targetToParams.values())
-                );
+                        rf.getFilterId().asInt(), new ArrayList<>(targetToParams.values()));
             }
         }
         for (Map.Entry<RuntimeFilterId, Integer> entry : ridToBuilderNum.entrySet()) {
@@ -122,15 +121,14 @@ public class RuntimeFiltersThriftBuilder {
             PlanFragment fragment = plan.getFragmentJob().getFragment();
             // Transform <fragment, runtimeFilterId> to <runtimeFilterId, fragment>
             for (RuntimeFilterId rid : fragment.getTargetRuntimeFilterIds()) {
-                List<RuntimeFilterTarget> targetFragments =
-                        ridToTargetParam.computeIfAbsent(rid, k -> new ArrayList<>());
+                List<RuntimeFilterTarget> targetFragments = ridToTargetParam.computeIfAbsent(rid,
+                        k -> new ArrayList<>());
                 for (AssignedJob instanceJob : plan.getInstanceJobs()) {
                     BackendWorker backendWorker = (BackendWorker) instanceJob.getAssignedWorker();
                     Backend backend = backendWorker.getBackend();
                     targetFragments.add(new RuntimeFilterTarget(
                             fragment.getFragmentId().asInt(),
-                            new TNetworkAddress(backend.getHost(), backend.getBrpcPort())
-                    ));
+                            new TNetworkAddress(backend.getHost(), backend.getBrpcPort())));
                 }
             }
 
@@ -146,8 +144,7 @@ public class RuntimeFiltersThriftBuilder {
         }
         return new RuntimeFiltersThriftBuilder(
                 mergeAddress, runtimeFilters, mergeInstance,
-                broadcastRuntimeFilterIds, ridToTargetParam, ridToBuilderNum
-        );
+                broadcastRuntimeFilterIds, ridToTargetParam, ridToBuilderNum);
     }
 
     public static class RuntimeFilterTarget {

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -442,6 +442,7 @@ struct TRuntimeFilterParams {
   // Runtime filter merge instance address. Used if this filter has a remote target
   1: optional Types.TNetworkAddress runtime_filter_merge_addr
 
+  // keep 2/3/4/5 unset if BE is not used for merge 
   // deprecated
   2: optional map<i32, list<TRuntimeFilterTargetParams>> rid_to_target_param
 


### PR DESCRIPTION
### What problem does this PR solve?
set RuntimeFilterInfo only on BE which is merge node.
note: RuntimeFilterInfo only contains runtime-filter merge information, not runtime filter descriptor
In the previous pull request #56978, we moved the runtime info (which records how runtime filters are merged) from the instance level to the Backend (BE) level. In a multi-BE environment, when a runtime filter needs to be merged, the BE does not perform the merge using the mergeInstance specified by the Runtime Filter descriptor. Instead, it selects a BE that has the RuntimeInfo set to perform the merge. This causes BEs that should not be responsible for merging to wait for other nodes to send local runtime filters, resulting in a timeout.
 
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

