### PR TITLE
[feat](storage) introduce backpressure algorithm to control version number (part I)

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -852,6 +852,11 @@ DEFINE_mInt32(max_tablet_version_num, "2000");
 
 DEFINE_mInt32(time_series_max_tablet_version_num, "20000");
 
+// the max sleep time when meeting high pressure load task
+DEFINE_mInt64(max_load_back_pressure_version_wait_time_ms, "3000");
+// the threshold of rowset number gap that triggers back pressure
+DEFINE_mInt64(load_back_pressure_version_threshold, "80"); // 80%
+
 // Frontend mainly use two thrift sever type: THREAD_POOL, THREADED_SELECTOR. if fe use THREADED_SELECTOR model for thrift server,
 // the thrift_server_type_of_fe should be set THREADED_SELECTOR to make be thrift client to fe constructed with TFramedTransport
 DEFINE_String(thrift_server_type_of_fe, "THREAD_POOL");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -877,6 +877,11 @@ DECLARE_mInt32(max_tablet_version_num);
 
 DECLARE_mInt32(time_series_max_tablet_version_num);
 
+// the max sleep time when meeting high pressure load task
+DECLARE_mInt64(max_load_back_pressure_version_wait_time_ms);
+// the threshold of rowset number gap that triggers back pressure
+DECLARE_mInt64(load_back_pressure_version_threshold);
+
 // Frontend mainly use two thrift sever type: THREAD_POOL, THREADED_SELECTOR. if fe use THREADED_SELECTOR model for thrift server,
 // the thrift_server_type_of_fe should be set THREADED_SELECTOR to make be thrift client to fe constructed with TFramedTransport
 DECLARE_String(thrift_server_type_of_fe);

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -93,6 +93,9 @@ public:
 
     int64_t num_rows_filtered() const;
 
+    void set_tablet_load_rowset_num_info(
+            google::protobuf::RepeatedPtrField<PTabletLoadRowsetInfo>* tablet_info);
+
 protected:
     virtual void _init_profile(RuntimeProfile* profile);
 

--- a/be/src/olap/rowset_builder.h
+++ b/be/src/olap/rowset_builder.h
@@ -126,6 +126,9 @@ public:
 
     Status commit_txn();
 
+    // Cast `BaseTablet` to `Tablet`
+    Tablet* tablet();
+
 private:
     void _init_profile(RuntimeProfile* profile) override;
 
@@ -135,8 +138,6 @@ private:
 
     void _garbage_collection();
 
-    // Cast `BaseTablet` to `Tablet`
-    Tablet* tablet();
     TabletSharedPtr tablet_sptr();
 
     StorageEngine& _engine;

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -50,6 +50,7 @@ class PSuccessSlaveTabletNodeIds;
 class PTabletError;
 class PTabletInfo;
 class PTabletWriterOpenRequest;
+class PTabletWriterOpenResult;
 class PTabletWriterAddBlockRequest;
 class PTabletWriterAddBlockResult;
 class PUniqueId;

--- a/be/src/vec/sink/writer/vtablet_writer.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer.cpp
@@ -45,6 +45,7 @@
 #include <vector>
 
 #include "cloud/config.h"
+#include "common/config.h"
 #include "cpp/sync_point.h"
 #include "util/runtime_profile.h"
 #include "vec/data_types/data_type.h"
@@ -100,6 +101,8 @@ bvar::PerSecond<bvar::Adder<int64_t>> g_sink_write_bytes_per_second("sink_throug
 bvar::Adder<int64_t> g_sink_write_rows;
 bvar::PerSecond<bvar::Adder<int64_t>> g_sink_write_rows_per_second("sink_throughput_row",
                                                                    &g_sink_write_rows, 60);
+bvar::Adder<int64_t> g_sink_load_back_pressure_version_time_ms(
+        "load_back_pressure_version_time_ms");
 
 Status IndexChannel::init(RuntimeState* state, const std::vector<TTabletWithPartition>& tablets,
                           bool incremental) {
@@ -806,6 +809,15 @@ int VNodeChannel::try_send_and_fetch_status(RuntimeState* state,
         return 0;
     }
 
+    auto load_back_pressure_version_wait_time_ms = _load_back_pressure_version_wait_time_ms.load();
+    if (UNLIKELY(load_back_pressure_version_wait_time_ms > 0)) {
+        std::this_thread::sleep_for(
+                std::chrono::milliseconds(load_back_pressure_version_wait_time_ms));
+        _load_back_pressure_version_block_ms.fetch_add(
+                load_back_pressure_version_wait_time_ms); // already in milliseconds
+        _load_back_pressure_version_wait_time_ms = 0;
+    }
+
     // set closure for sending block.
     if (!_send_block_callback->try_set_in_flight()) {
         // There is packet in flight, skip.
@@ -837,6 +849,45 @@ void VNodeChannel::_cancel_with_msg(const std::string& msg) {
         }
     }
     _cancelled = true;
+}
+
+void VNodeChannel::_refresh_back_pressure_version_wait_time(
+        const ::google::protobuf::RepeatedPtrField<::doris::PTabletLoadRowsetInfo>&
+                tablet_load_infos) {
+    int64_t max_rowset_num_gap = 0;
+    // if any one tablet is under high load pressure, we would make the whole procedure
+    // sleep to prevent the corresponding BE return -235
+    std::for_each(
+            tablet_load_infos.begin(), tablet_load_infos.end(),
+            [&max_rowset_num_gap](auto& load_info) {
+                int64_t cur_rowset_num = load_info.current_rowset_nums();
+                int64_t high_load_point = load_info.max_config_rowset_nums() *
+                                          (config::load_back_pressure_version_threshold / 100);
+                DCHECK(cur_rowset_num > high_load_point);
+                max_rowset_num_gap = std::max(max_rowset_num_gap, cur_rowset_num - high_load_point);
+            });
+    // to slow down the high load pressure
+    // we would use the rowset num gap to calculate one sleep time
+    // for example:
+    // if the max tablet version is 2000, there are 3 BE
+    // A: ====================  1800
+    // B: ===================   1700
+    // C: ==================    1600
+    //    ==================    1600
+    //                      ^
+    //                      the high load point
+    // then then max gap is 1800 - (max tablet version * config::load_back_pressure_version_threshold / 100) = 200,
+    // we would make the whole send procesure sleep
+    // 1200ms for compaction to be done toe reduce the high pressure
+    auto max_time = config::max_load_back_pressure_version_wait_time_ms;
+    if (UNLIKELY(max_rowset_num_gap > 0)) {
+        _load_back_pressure_version_wait_time_ms.store(
+                std::min(max_rowset_num_gap + 1000, max_time));
+        LOG(INFO) << "try to back pressure version, wait time(ms): "
+                  << _load_back_pressure_version_wait_time_ms
+                  << ", load id: " << print_id(_parent->_load_id)
+                  << ", max_rowset_num_gap: " << max_rowset_num_gap;
+    }
 }
 
 void VNodeChannel::try_send_pending_block(RuntimeState* state) {
@@ -1006,6 +1057,7 @@ void VNodeChannel::_add_block_success_callback(const PTabletWriterAddBlockResult
     SCOPED_ATTACH_TASK(_state);
     Status status(Status::create(result.status()));
     if (status.ok()) {
+        _refresh_back_pressure_version_wait_time(result.tablet_load_rowset_num_infos());
         // if has error tablet, handle them first
         for (const auto& error : result.tablet_errors()) {
             _index_channel->mark_as_failed(this, "tablet error: " + error.msg(), error.tablet_id());
@@ -1534,6 +1586,7 @@ Status VTabletWriter::_init(RuntimeState* state, RuntimeProfile* profile) {
     _max_wait_exec_timer = ADD_TIMER(profile, "MaxWaitExecTime");
     _add_batch_number = ADD_COUNTER(profile, "NumberBatchAdded", TUnit::UNIT);
     _num_node_channels = ADD_COUNTER(profile, "NumberNodeChannels", TUnit::UNIT);
+    _load_back_pressure_version_time_ms = ADD_TIMER(profile, "LoadBackPressureVersionTimeMs");
 
 #ifdef DEBUG
     // check: tablet ids should be unique
@@ -1868,6 +1921,10 @@ Status VTabletWriter::close(Status exec_status) {
             COUNTER_SET(_max_wait_exec_timer, writer_stats.max_wait_exec_time_ns);
             COUNTER_SET(_add_batch_number, writer_stats.total_add_batch_num);
             COUNTER_SET(_num_node_channels, writer_stats.num_node_channels);
+            COUNTER_SET(_load_back_pressure_version_time_ms,
+                        writer_stats.load_back_pressure_version_time_ms);
+            g_sink_load_back_pressure_version_time_ms
+                    << writer_stats.load_back_pressure_version_time_ms;
 
             // _number_input_rows don't contain num_rows_load_filtered and num_rows_load_unselected in scan node
             int64_t num_rows_load_total = _number_input_rows + _state->num_rows_load_filtered() +

--- a/regression-test/suites/fault_injection_p0/test_load_back_pressure_version.groovy
+++ b/regression-test/suites/fault_injection_p0/test_load_back_pressure_version.groovy
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_load_back_pressure_version", "nonConcurrent") {
+    sql """ set enable_memtable_on_sink_node=false """
+    def testTable = "test_load_back_pressure_version"
+    sql """ DROP TABLE IF EXISTS ${testTable}"""
+
+    sql """
+        CREATE TABLE IF NOT EXISTS `${testTable}` (
+          `id` BIGINT NOT NULL,
+          `value` int(11) NOT NULL
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`id`)
+        COMMENT "OLAP"
+        DISTRIBUTED BY HASH(`id`) BUCKETS 1
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1"
+        )
+    """
+
+    try {
+        set_be_param("load_back_pressure_version_threshold", "0")
+        sql "insert into ${testTable} values(1,1)"
+        def res = sql "select * from ${testTable}"
+        logger.info("res: " + res.size())
+        assertTrue(res.size() == 1)
+    } finally {
+        set_be_param("load_back_pressure_version_threshold", "80")
+        sql """ set enable_memtable_on_sink_node=true """
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

#### background
`-235` error (too_many_version) may happened when high concurrent load and compaction cannot keep up, this will cause load fail until version number reduce to below max_tablet_version_num. 

#### solution
This PR implements a backpressure algorithm to control version number by slow down load speed when version number exceed the threshold.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

