### PR TITLE
[improve](sort) opt heap sort without runtime predicate

### DIFF
--- a/be/src/pipeline/exec/sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/sort_sink_operator.cpp
@@ -49,7 +49,7 @@ Status SortSinkLocalState::open(RuntimeState* state) {
     case TSortAlgorithm::HEAP_SORT: {
         _shared_state->sorter = vectorized::HeapSorter::create_shared(
                 _vsort_exec_exprs, p._limit, p._offset, p._pool, p._is_asc_order, p._nulls_first,
-                p._child->row_desc());
+                p._child->row_desc(), state->get_query_ctx()->has_runtime_predicate(p._node_id));
         break;
     }
     case TSortAlgorithm::TOPN_SORT: {

--- a/be/src/vec/common/sort/heap_sorter.cpp
+++ b/be/src/vec/common/sort/heap_sorter.cpp
@@ -17,23 +17,49 @@
 
 #include "vec/common/sort/heap_sorter.h"
 
+#include "vec/core/sort_block.h"
+
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"
 
 HeapSorter::HeapSorter(VSortExecExprs& vsort_exec_exprs, int64_t limit, int64_t offset,
                        ObjectPool* pool, std::vector<bool>& is_asc_order,
-                       std::vector<bool>& nulls_first, const RowDescriptor& row_desc)
+                       std::vector<bool>& nulls_first, const RowDescriptor& row_desc,
+                       bool have_runtime_predicate)
         : Sorter(vsort_exec_exprs, limit, offset, pool, is_asc_order, nulls_first),
           _heap_size(limit + offset),
-          _state(MergeSorterState::create_unique(row_desc, offset)) {}
+          _state(MergeSorterState::create_unique(row_desc, offset)),
+          _have_runtime_predicate(have_runtime_predicate) {}
 
 Status HeapSorter::append_block(Block* block) {
     auto tmp_block = std::make_shared<Block>(block->clone_empty());
-    RETURN_IF_ERROR(partial_sort(*block, *tmp_block, true));
-    _queue.push(
-            MergeSortCursor(std::make_shared<MergeSortCursorImpl>(tmp_block, _sort_description)));
-    _queue_row_num += tmp_block->rows();
-    _data_size += tmp_block->allocated_bytes();
+    if (!_have_runtime_predicate && _queue.is_valid() && _queue_row_num >= _heap_size) {
+        RETURN_IF_ERROR(_prepare_sort_columns(*block, *tmp_block, false));
+        if (_materialize_sort_exprs) {
+            block->clear_column_data();
+        } else {
+            tmp_block->swap(*block);
+        }
+        auto tmp_cursor_impl = MergeSortCursorImpl::create_shared(tmp_block, _sort_description);
+        _do_filter(*tmp_cursor_impl, tmp_block->rows());
+
+        // After filtering, sort the remaining rows with reversed description and push that block.
+        auto sorted_block = std::make_shared<Block>(tmp_block->clone_empty());
+        SortDescription rev_desc = _sort_description;
+        for (auto& d : rev_desc) {
+            d.direction *= -1;
+        }
+        sort_block(*tmp_block, *sorted_block, rev_desc, 0 /*limit*/);
+        _queue_row_num += sorted_block->rows();
+        _data_size += sorted_block->allocated_bytes();
+        _queue.push(MergeSortCursor(MergeSortCursorImpl::create_shared(sorted_block, rev_desc)));
+    } else {
+        RETURN_IF_ERROR(partial_sort(*block, *tmp_block, true));
+        _queue_row_num += tmp_block->rows();
+        _data_size += tmp_block->allocated_bytes();
+        _queue.push(
+                MergeSortCursor(MergeSortCursorImpl::create_shared(tmp_block, _sort_description)));
+    }
 
     while (_queue.is_valid() && _queue_row_num > _heap_size) {
         auto [current, current_rows] = _queue.current();
@@ -83,6 +109,21 @@ Field HeapSorter::get_top_value() {
 
 size_t HeapSorter::data_size() const {
     return _data_size;
+}
+
+void HeapSorter::_do_filter(MergeSortCursorImpl& block_cursor, size_t num_rows) {
+    auto [top_cursor, current_rows] = _queue.current();
+    const auto cursor_rid = top_cursor->impl->pos;
+    IColumn::Filter filter(num_rows, 0);
+    std::vector<uint8_t> cmp_res(num_rows, 0);
+
+    for (size_t col_id = 0; col_id < _sort_description.size(); ++col_id) {
+        block_cursor.sort_columns[col_id]->compare_internal(
+                cursor_rid, *top_cursor->impl->sort_columns[col_id],
+                _sort_description[col_id].nulls_direction, _sort_description[col_id].direction,
+                cmp_res, filter.data());
+    }
+    block_cursor.filter_block(filter);
 }
 
 #include "common/compile_check_end.h"

--- a/be/src/vec/common/sort/heap_sorter.h
+++ b/be/src/vec/common/sort/heap_sorter.h
@@ -28,7 +28,7 @@ class HeapSorter final : public Sorter {
 public:
     HeapSorter(VSortExecExprs& vsort_exec_exprs, int64_t limit, int64_t offset, ObjectPool* pool,
                std::vector<bool>& is_asc_order, std::vector<bool>& nulls_first,
-               const RowDescriptor& row_desc);
+               const RowDescriptor& row_desc, bool have_runtime_predicate = true);
 
     ~HeapSorter() override = default;
 
@@ -44,13 +44,14 @@ public:
 
 private:
     Status _prepare_sort_descs(Block* block);
-
+    void _do_filter(MergeSortCursorImpl& block, size_t num_rows);
     size_t _data_size = 0;
     size_t _heap_size = 0;
     size_t _queue_row_num = 0;
     MergeSorterQueue _queue;
     std::unique_ptr<MergeSorterState> _state;
     IColumn::Permutation _reverse_buffer;
+    bool _have_runtime_predicate = true;
 };
 
 #include "common/compile_check_end.h"

--- a/be/src/vec/common/sort/heap_sorter.h
+++ b/be/src/vec/common/sort/heap_sorter.h
@@ -42,6 +42,12 @@ public:
 
     Field get_top_value() override;
 
+    void init_profile(RuntimeProfile* runtime_profile) override {
+        Sorter::init_profile(runtime_profile);
+        _topn_filter_timer = ADD_TIMER(runtime_profile, "TopNFilterTime");
+        _topn_filter_rows_counter = ADD_COUNTER(runtime_profile, "TopNFilterRows", TUnit::UNIT);
+    }
+
 private:
     Status _prepare_sort_descs(Block* block);
     void _do_filter(MergeSortCursorImpl& block, size_t num_rows);
@@ -52,6 +58,8 @@ private:
     std::unique_ptr<MergeSorterState> _state;
     IColumn::Permutation _reverse_buffer;
     bool _have_runtime_predicate = true;
+    RuntimeProfile::Counter* _topn_filter_timer = nullptr;
+    RuntimeProfile::Counter* _topn_filter_rows_counter = nullptr;
 };
 
 #include "common/compile_check_end.h"

--- a/be/src/vec/common/sort/sorter.h
+++ b/be/src/vec/common/sort/sorter.h
@@ -154,7 +154,7 @@ public:
 
 protected:
     Status partial_sort(Block& src_block, Block& dest_block, bool reversed = false);
-
+    Status _prepare_sort_columns(Block& src_block, Block& dest_block, bool reversed = false);
     bool _enable_spill = false;
     SortDescription _sort_description;
     VSortExecExprs& _vsort_exec_exprs;

--- a/be/src/vec/core/sort_cursor.h
+++ b/be/src/vec/core/sort_cursor.h
@@ -75,6 +75,11 @@ struct MergeSortCursorImpl {
         reset();
     }
 
+    void filter_block(IColumn::Filter& filter) {
+        Block::filter_block_internal(block.get(), filter, block->columns());
+        reset();
+    }
+
     /// Set the cursor to the beginning of the new block.
     void reset() {
         sort_columns.clear();


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
- in sort node, the topn maybe have a runtime predicate, which could filter data in scan. and then get the topn rows.
- When no runtime predicate is pushed down, the previous implementation sorted all input data before maintaining the TopN heap.
- This PR changes the logic to:
  1. when incoming rows without runtime predicate, use the current top value in the heap to filter incoming rows before           sorted data, avoiding unnecessary operations.
  2. then sort the left data, and push into heap.
  3. Maintain the heap size by replacing the top.
- This avoids a full sort and improves performance for TopN queries without runtime predicate pushdown.

```
mysql> SELECT murmur_hash3_32(number) AS n FROM numbers("number" = "20000000") ORDER BY n, n + 1, n + 2 LIMIT 10;
+-------------+
| n           |
+-------------+
| -2147483480 |
| -2147483264 |
| -2147482864 |
| -2147482719 |
| -2147482662 |
| -2147482588 |
| -2147482109 |
| -2147482067 |
| -2147481904 |
| -2147481747 |
+-------------+
10 rows in set (1.83 sec)

mysql> SELECT murmur_hash3_32(number) AS n FROM numbers("number" = "20000000") ORDER BY n, n + 1, n + 2 LIMIT 10;
+-------------+
| n           |
+-------------+
| -2147483480 |
| -2147483264 |
| -2147482864 |
| -2147482719 |
| -2147482662 |
| -2147482588 |
| -2147482109 |
| -2147482067 |
| -2147481904 |
| -2147481747 |
+-------------+
10 rows in set (0.67 sec)

```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

