### PR TITLE
[opt](nereids) print slotReference in explain verbose

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotDescriptor.java
@@ -151,7 +151,7 @@ public class SlotDescriptor {
     public void setColumn(Column column) {
         this.column = column;
         this.type = column.getType();
-        this.caption = normalizeCaption(column.getName());
+        this.caption = column.getName();
     }
 
     public void setSrcColumn(Column column) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotDescriptor.java
@@ -42,6 +42,9 @@ public class SlotDescriptor {
     private Type type;
     private Column column;  // underlying column, if there is one
 
+    // used in explain verbose, caption is column name or alias name
+    private String caption;
+
     // for SlotRef.toSql() in the absence of a path
     private String label;
     // for variant column's sub column lables
@@ -148,6 +151,7 @@ public class SlotDescriptor {
     public void setColumn(Column column) {
         this.column = column;
         this.type = column.getType();
+        this.caption = column.getName();
     }
 
     public void setSrcColumn(Column column) {
@@ -338,8 +342,12 @@ public class SlotDescriptor {
         return tSlotDescriptor;
     }
 
+    public void setCaption(String caption) {
+        this.caption = caption;
+    }
+
     public String debugString() {
-        String colStr = (column == null ? "null" : column.getName());
+        String colStr = (column == null ? caption : column.getName());
         String typeStr = (type == null ? "null" : type.toString());
         String parentTupleId = (parent == null) ? "null" : parent.getId().toString();
         return MoreObjects.toStringHelper(this).add("id", id.asInt()).add("parent", parentTupleId).add("col", colStr)
@@ -358,7 +366,7 @@ public class SlotDescriptor {
         return new StringBuilder()
                 .append(prefix).append("SlotDescriptor{")
                 .append("id=").append(id)
-                .append(", col=").append(column == null ? "null" : column.getName())
+                .append(", col=").append(column == null ? caption : column.getName())
                 .append(", colUniqueId=").append(column == null ? "null" : column.getUniqueId())
                 .append(", type=").append(type == null ? "null" : type.toSql())
                 .append(", nullable=").append(isNullable)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PlanTranslatorContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PlanTranslatorContext.java
@@ -298,7 +298,11 @@ public class PlanTranslatorContext {
         SlotDescriptor slotDescriptor = this.addSlotDesc(tupleDesc);
         // Only the SlotDesc that in the tuple generated for scan node would have corresponding column.
         Optional<Column> column = slotReference.getOriginalColumn();
-        column.ifPresent(slotDescriptor::setColumn);
+        if (column.isPresent()) {
+            slotDescriptor.setColumn(column.get());
+        } else {
+            slotDescriptor.setCaption(slotReference.toString());
+        }
         slotDescriptor.setType(slotReference.getDataType().toCatalogDataType());
         slotDescriptor.setIsMaterialized(true);
         SlotRef slotRef;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PlanTranslatorContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PlanTranslatorContext.java
@@ -301,7 +301,7 @@ public class PlanTranslatorContext {
         if (column.isPresent()) {
             slotDescriptor.setColumn(column.get());
         } else {
-            slotDescriptor.setCaption(slotReference.toString());
+            slotDescriptor.setCaptionAndNormalize(slotReference.toString());
         }
         slotDescriptor.setType(slotReference.getDataType().toCatalogDataType());
         slotDescriptor.setIsMaterialized(true);

--- a/regression-test/suites/nereids_p0/datatype/test_date_implicit_cast.groovy
+++ b/regression-test/suites/nereids_p0/datatype/test_date_implicit_cast.groovy
@@ -38,7 +38,7 @@ suite("test_date_implicit_cast") {
         if (value.contains("col=k1, colUniqueId=0, type=datetimev2(4)")) {
             contain0 = true;
         }
-        if (value.contains("col=null, colUniqueId=null, type=text")) {
+        if (value.contains("col=if(k1='2020-1#1, colUniqueId=null, type=text")) {
             contain1 = true;
         }
     }
@@ -50,7 +50,7 @@ suite("test_date_implicit_cast") {
         if (value.contains("col=k1, colUniqueId=0, type=datetimev2(4)")) {
             contain0 = true;
         }
-        if (value.contains("col=null, colUniqueId=null, type=datetimev2(4)")) {
+        if (value.contains("col=if(k1='2020-1#1, colUniqueId=null, type=datetimev2(4)")) {
             contain1 = true;
         }
     }
@@ -61,7 +61,7 @@ suite("test_date_implicit_cast") {
         if (value.contains("col=k1, colUniqueId=0, type=datetimev2(4)")) {
             contain0 = true;
         }
-        if (value.contains("col=null, colUniqueId=null, type=text")) {
+        if (value.contains("col=if(k1='2020-1#1, colUniqueId=null, type=text")) {
             contain1 = true;
         }
     }
@@ -80,7 +80,7 @@ suite("test_date_implicit_cast") {
         if (value.contains("col=k1, colUniqueId=0, type=datetimev2(6)")) {
             contain0 = true;
         }
-        if (value.contains("col=null, colUniqueId=null, type=text")) {
+        if (value.contains("col=if(k1='2020-1#1, colUniqueId=null, type=text")) {
             contain1 = true;
         }
     }

--- a/regression-test/suites/nereids_syntax_p0/explain.groovy
+++ b/regression-test/suites/nereids_syntax_p0/explain.groovy
@@ -62,7 +62,7 @@ suite("explain") {
             when 1>1 then cast(1 as float)
             else 0.0 end;
             """
-        contains "SlotDescriptor{id=0, col=null, colUniqueId=null, type=double, nullable=false, isAutoIncrement=false, subColPath=null, virtualColumn=null}"
+        contains "SlotDescriptor{id=0, col=case when 1=1#1, colUniqueId=null, type=double, nullable=false, isAutoIncrement=false, subColPath=null, virtualColumn=null}"
     }
 
     def explainStr = sql("select sum(if(lo_tax=1,lo_tax,0)) from lineorder where false").toString()

--- a/regression-test/suites/query_p0/explain/explain_alias.groovy
+++ b/regression-test/suites/query_p0/explain/explain_alias.groovy
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("explain_alias") {
+    sql """
+    create table t (
+        a int,
+        b int,
+        c int
+    ) distributed by hash(a)
+    properties (
+        'replication_num' = '1'
+    );
+
+    insert into t values (1, 10, 100), (2, 20, 200), (3, 30, 300);
+
+    """
+
+    explain {
+        sql """
+            verbose 
+            select sum(a) as mysum from t;
+        """
+        contains "col=mysum"
+
+        /**
+        even SlotDescriptor.column is null, the col in explain is not null
+        | Tuples:                                                                                                                                                        |
+        | TupleDescriptor{id=0, tbl=t}                                                                                                                                   |
+        |   SlotDescriptor{id=0, col=a, colUniqueId=0, type=int, nullable=true, isAutoIncrement=false, subColPath=null, virtualColumn=null}                              |
+        |                                                                                                                                                                |
+        | TupleDescriptor{id=1, tbl=t}                                                                                                                                   |
+        |   SlotDescriptor{id=3, col=a, colUniqueId=0, type=int, nullable=true, isAutoIncrement=false, subColPath=null, virtualColumn=null}                              |
+        |                                                                                                                                                                |
+        | TupleDescriptor{id=2, tbl=null}                                                                                                                                |
+        |   SlotDescriptor{id=4, col=partial_sum(a)#4, colUniqueId=null, type=varchar(65533), nullable=true, isAutoIncrement=false, subColPath=null, virtualColumn=null} |
+        |                                                                                                                                                                |
+        | TupleDescriptor{id=3, tbl=null}                                                                                                                                |
+        |   SlotDescriptor{id=5, col=mysum#3, colUniqueId=null, type=bigint, nullable=true, isAutoIncrement=false, subColPath=null, virtualColumn=null}         
+        */
+
+}

--- a/regression-test/suites/query_p0/explain/explain_alias.groovy
+++ b/regression-test/suites/query_p0/explain/explain_alias.groovy
@@ -36,7 +36,7 @@ suite("explain_alias") {
             select sum(a) as mysum from t;
         """
         contains "col=mysum"
-
+    }
         /**
         even SlotDescriptor.column is null, the col in explain is not null
         | Tuples:                                                                                                                                                        |


### PR DESCRIPTION
### What problem does this PR solve?
In the result of explain verbose, most of columns of SlotDescriptors are null. It is not easy to trace column in TupleDescriptor table. In this pr, we add caption for SlotDescriptor. if column is null, the caption is its corresponding slotreference.toString().

for example : "select sum(a) as mysum from t;"
we have "SlotDescriptor{id=5, col=mysum#3, ..."

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

