### PR TITLE
[fix](nereids)varchar(-1) and varchar(65533) should be treated as the same data type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/VarcharType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/VarcharType.java
@@ -84,12 +84,12 @@ public class VarcharType extends CharacterType {
             return false;
         }
         VarcharType that = (VarcharType) o;
-        return len == that.len;
+        return len == that.len || (isWildcardVarchar() && that.isWildcardVarchar());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), len);
+        return Objects.hash(super.hashCode(), len == -1 ? MAX_VARCHAR_LENGTH : len);
     }
 
     public boolean isWildcardVarchar() {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/types/DataTypeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/types/DataTypeTest.java
@@ -54,10 +54,18 @@ public class DataTypeTest {
         VarcharType varcharType1 = new VarcharType(32);
         VarcharType varcharType2 = new VarcharType(32);
         VarcharType varcharType3 = new VarcharType(64);
+        VarcharType varcharType4 = new VarcharType(-1);
+        VarcharType varcharType5 = new VarcharType(65533);
         Assertions.assertEquals(varcharType1, varcharType2);
         Assertions.assertEquals(varcharType1.hashCode(), varcharType2.hashCode());
         Assertions.assertNotEquals(varcharType1, varcharType3);
         Assertions.assertNotEquals(varcharType1.hashCode(), varcharType3.hashCode());
+        Assertions.assertEquals(VarcharType.SYSTEM_DEFAULT, VarcharType.MAX_VARCHAR_TYPE);
+        Assertions.assertEquals(VarcharType.SYSTEM_DEFAULT.hashCode(), VarcharType.MAX_VARCHAR_TYPE.hashCode());
+        Assertions.assertEquals(VarcharType.SYSTEM_DEFAULT, varcharType4);
+        Assertions.assertEquals(VarcharType.SYSTEM_DEFAULT.hashCode(), varcharType4.hashCode());
+        Assertions.assertEquals(VarcharType.SYSTEM_DEFAULT, varcharType5);
+        Assertions.assertEquals(VarcharType.SYSTEM_DEFAULT.hashCode(), varcharType5.hashCode());
     }
 
     @Test


### PR DESCRIPTION


### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

