### PR TITLE
[fix](job) fix streaming job repeated load after FE master change in cloud mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -81,6 +81,7 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
     private final long dbId;
     private StreamingJobStatistic jobStatistic = new StreamingJobStatistic();
     @Getter
+    @Setter
     @SerializedName("fr")
     protected FailureReason failureReason;
     @Getter
@@ -458,7 +459,7 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         succeedTaskCount.incrementAndGet();
     }
 
-    public void replayOnCloudMode() throws UserException {
+    public void replayOnCloudMode() throws JobException {
         Cloud.GetStreamingTaskCommitAttachRequest.Builder builder =
                 Cloud.GetStreamingTaskCommitAttachRequest.newBuilder();
         builder.setCloudUniqueId(Config.cloud_unique_id);
@@ -474,12 +475,12 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
                     log.warn("not found streaming job progress, response: {}", response);
                     return;
                 } else {
-                    throw new UserException(response.getStatus().getMsg());
+                    throw new JobException(response.getStatus().getMsg());
                 }
             }
         } catch (RpcException e) {
             log.info("failed to get streaming task commit attach {}", e);
-            throw new UserException(e.getMessage());
+            throw new JobException(e.getMessage());
         }
 
         StreamingTaskTxnCommitAttachment commitAttach =


### PR DESCRIPTION
### What problem does this PR solve?

Fix streaming job offset will be incorrect after FE master change causing repeated load in cloud mode.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

