### PR TITLE
[feat](paimon)expose paimon cachingcatalog metrics in doris

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalog.java
@@ -181,6 +181,7 @@ public class PaimonExternalCatalog extends ExternalCatalog {
     }
 
     public Catalog getOriginCatalog() {
+        makeSureInitialized();
         return catalog;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalog.java
@@ -180,6 +180,10 @@ public class PaimonExternalCatalog extends ExternalCatalog {
         }
     }
 
+    public Catalog getOriginCatalog() {
+        return catalog;
+    }
+
     public Map<String, String> getPaimonOptionsMap() {
         makeSureInitialized();
         return paimonProperties.getCatalogOptionsMap();

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
@@ -117,7 +117,6 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hudi.common.table.timeline.HoodieInstant;

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
@@ -66,6 +66,8 @@ import org.apache.doris.datasource.iceberg.IcebergExternalCatalog;
 import org.apache.doris.datasource.iceberg.IcebergMetadataCache;
 import org.apache.doris.datasource.maxcompute.MaxComputeExternalCatalog;
 import org.apache.doris.datasource.mvcc.MvccUtil;
+import org.apache.doris.datasource.paimon.PaimonExternalCatalog;
+import org.apache.doris.datasource.paimon.PaimonMetadataCache;
 import org.apache.doris.job.common.JobType;
 import org.apache.doris.job.extensions.mtmv.MTMVJob;
 import org.apache.doris.job.task.AbstractTask;
@@ -115,18 +117,23 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.paimon.catalog.CachingCatalog;
+import org.apache.paimon.catalog.CachingCatalog.CacheSizes;
+import org.apache.paimon.catalog.Catalog;
 import org.apache.thrift.TException;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1522,6 +1529,27 @@ public class MetadataGenerator {
                 // 3. iceberg cache
                 IcebergMetadataCache icebergCache = mgr.getIcebergMetadataCache();
                 fillBatch(dataBatch, icebergCache.getCacheStats(), catalogIf.getName());
+            } else if (catalogIf instanceof PaimonExternalCatalog) {
+                PaimonExternalCatalog paimonExternalCatalog = (PaimonExternalCatalog) catalogIf;
+                PaimonMetadataCache paimonMetadataCache = mgr.getPaimonMetadataCache();
+                Catalog paimonCatalog = paimonExternalCatalog.getOriginCatalog();
+                Map<String, Map<String, String>> paimonCacheStats = new HashMap<>(paimonMetadataCache.getCacheStats());
+
+                if (paimonCatalog instanceof CachingCatalog) {
+                    CachingCatalog cachingCatalog = (CachingCatalog) paimonCatalog;
+                    CacheSizes cacheSizes = cachingCatalog.estimatedCacheSizes();
+
+                    Map<String, String> stats = new HashMap<>();
+                    stats.put("database_cache_size", String.valueOf(cacheSizes.databaseCacheSize()));
+                    stats.put("table_cache_size", String.valueOf(cacheSizes.tableCacheSize()));
+                    stats.put("manifest_cache_size", String.valueOf(cacheSizes.manifestCacheSize()));
+                    stats.put("manifest_cache_bytes", String.valueOf(cacheSizes.manifestCacheBytes()));
+                    stats.put("partition_cache_size", String.valueOf(cacheSizes.partitionCacheSize()));
+
+                    paimonCacheStats.put("paimon_origin_cache_catalog", stats);
+                }
+
+                fillBatch(dataBatch, paimonCacheStats, catalogIf.getName());
             }
         }
         result.setDataBatch(dataBatch);


### PR DESCRIPTION
### What problem does this PR solve?
  Currently, Apache Doris caches Paimon Catalog snapshots using Caffeine, and users can query basic cache statistics (e.g., eviction count, hit ratio) via the `catalog_meta_cache_statistics` system table. However, this does not include detailed metrics from Paimon's native CachingCatalog, which was introduced in [Apache Paimon PR #3829](https://github.com/apache/paimon/pull/3829) to expose cache statistics for compute engines like Doris. These metrics provide valuable insights into Paimon's internal caching performance, such as partition cache size, database/table cache sizes, manifest cache size, and manifest cache bytes.

  Without these metrics, users lack visibility into Paimon's origin catalog caching behavior, making it harder to monitor and optimize query performance in Doris-Paimon integrations.

- `partition_cache_size`: Number of cached partitions.
- `database_cache_size`: Number of cached databases.
- `table_cache_size`: Number of cached tables.
- `manifest_cache_bytes`: Total bytes of cached manifests.
- `manifest_cache_size`: Number of cached manifests.

  These are exposed under the cache name paimon_origin_cache_catalog for Paimon catalogs. The implementation collects metrics from Paimon's CachingCatalog instance during catalog operations and registers them with Doris's internal metrics system.

#### Example
Before this PR, querying the system table for a Paimon catalog (paimon_dev_copy) only shows Caffeine snapshot cache stats:
```
mysql> SELECT * FROM catalog_meta_cache_statistics WHERE CATALOG_NAME = 'paimon_dev_copy';
+-----------------+-----------------------------+----------------------+----------------+
| CATALOG_NAME    | CACHE_NAME                  | METRIC_NAME          | METRIC_VALUE   |
+-----------------+-----------------------------+----------------------+----------------+
| paimon_dev_copy | paimon_snapshot_cache       | eviction_count       | 0              |
| paimon_dev_copy | paimon_snapshot_cache       | hit_ratio            | 0.5            |
| paimon_dev_copy | paimon_snapshot_cache       | average_load_penalty | 2.0682061665E9 |
| paimon_dev_copy | paimon_snapshot_cache       | estimated_size       | 1              |
| paimon_dev_copy | paimon_snapshot_cache       | hit_count            | 4              |
| paimon_dev_copy | paimon_snapshot_cache       | read_count           | 8              |
+-----------------+-----------------------------+----------------------+----------------+
```
After this PR, the table includes Paimon's origin cache metrics for both catalogs (paimon_dev_copy and paimon_dev):
```
mysql> SELECT * FROM catalog_meta_cache_statistics;
+-----------------+-----------------------------+----------------------+----------------+
| CATALOG_NAME    | CACHE_NAME                  | METRIC_NAME          | METRIC_VALUE   |
+-----------------+-----------------------------+----------------------+----------------+
| paimon_dev_copy | paimon_snapshot_cache       | eviction_count       | 0              |
| paimon_dev_copy | paimon_snapshot_cache       | hit_ratio            | 0.5            |
| paimon_dev_copy | paimon_snapshot_cache       | average_load_penalty | 2.0682061665E9 |
| paimon_dev_copy | paimon_snapshot_cache       | estimated_size       | 1              |
| paimon_dev_copy | paimon_snapshot_cache       | hit_count            | 4              |
| paimon_dev_copy | paimon_snapshot_cache       | read_count           | 8              |
| paimon_dev_copy | paimon_origin_cache_catalog | partition_cache_size | 0              |
| paimon_dev_copy | paimon_origin_cache_catalog | database_cache_size  | 0              |
| paimon_dev_copy | paimon_origin_cache_catalog | table_cache_size     | 0              |
| paimon_dev_copy | paimon_origin_cache_catalog | manifest_cache_bytes | 0              |
| paimon_dev_copy | paimon_origin_cache_catalog | manifest_cache_size  | 0              |
| paimon_dev      | paimon_snapshot_cache       | eviction_count       | 0              |
| paimon_dev      | paimon_snapshot_cache       | hit_ratio            | 0.5            |
| paimon_dev      | paimon_snapshot_cache       | average_load_penalty | 2.0682061665E9 |
| paimon_dev      | paimon_snapshot_cache       | estimated_size       | 1              |
| paimon_dev      | paimon_snapshot_cache       | hit_count            | 4              |
| paimon_dev      | paimon_snapshot_cache       | read_count           | 8              |
| paimon_dev      | paimon_origin_cache_catalog | partition_cache_size | 0              |
| paimon_dev      | paimon_origin_cache_catalog | database_cache_size  | 0              |
| paimon_dev      | paimon_origin_cache_catalog | table_cache_size     | 3              |
| paimon_dev      | paimon_origin_cache_catalog | manifest_cache_bytes | 332680         |
| paimon_dev      | paimon_origin_cache_catalog | manifest_cache_size  | 5              |
+-----------------+-----------------------------+----------------------+----------------+
```
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

