### PR TITLE
[enhancement](parquet)Optimize the performance of parquet reader when decode RLE_DICTIONARY encoding

### DIFF
--- a/be/src/vec/exec/format/parquet/decoder.cpp
+++ b/be/src/vec/exec/format/parquet/decoder.cpp
@@ -63,12 +63,22 @@ Status Decoder::get_decoder(tparquet::Type::type type, tparquet::Encoding::type 
             decoder.reset(new ByteArrayDictDecoder());
             break;
         case tparquet::Type::INT32:
+            decoder.reset(new FixLengthDictDecoder<tparquet::Type::INT32>());
+            break;
         case tparquet::Type::INT64:
+            decoder.reset(new FixLengthDictDecoder<tparquet::Type::INT64>());
+            break;
         case tparquet::Type::INT96:
+            decoder.reset(new FixLengthDictDecoder<tparquet::Type::INT96>());
+            break;
         case tparquet::Type::FLOAT:
+            decoder.reset(new FixLengthDictDecoder<tparquet::Type::FLOAT>());
+            break;
         case tparquet::Type::DOUBLE:
+            decoder.reset(new FixLengthDictDecoder<tparquet::Type::DOUBLE>());
+            break;
         case tparquet::Type::FIXED_LEN_BYTE_ARRAY:
-            decoder.reset(new FixLengthDictDecoder());
+            decoder.reset(new FixLengthDictDecoder<tparquet::Type::FIXED_LEN_BYTE_ARRAY>());
             break;
         default:
             return Status::InternalError("Unsupported type {}(encoding={}) in parquet decoder",

--- a/be/src/vec/exec/format/parquet/fix_length_dict_decoder.hpp
+++ b/be/src/vec/exec/format/parquet/fix_length_dict_decoder.hpp
@@ -26,41 +26,41 @@
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"
 
+template <tparquet::Type::type type>
+struct PhysicalTypeTraits {};
+
+template <>
+struct PhysicalTypeTraits<tparquet::Type::INT32> {
+    using CppType = int32_t;
+};
+
+template <>
+struct PhysicalTypeTraits<tparquet::Type::INT64> {
+    using CppType = int64_t;
+};
+
+template <>
+struct PhysicalTypeTraits<tparquet::Type::INT96> {
+    using CppType = ParquetInt96;
+};
+
+template <>
+struct PhysicalTypeTraits<tparquet::Type::FLOAT> {
+    using CppType = float;
+};
+
+template <>
+struct PhysicalTypeTraits<tparquet::Type::DOUBLE> {
+    using CppType = double;
+};
+
+template <>
+struct PhysicalTypeTraits<tparquet::Type::FIXED_LEN_BYTE_ARRAY> {
+    using CppType = Slice;
+};
+
 template <tparquet::Type::type PhysicalType>
 class FixLengthDictDecoder final : public BaseDictDecoder {
-    template <tparquet::Type::type type>
-    struct PhysicalTypeTraits {};
-
-    template <>
-    struct PhysicalTypeTraits<tparquet::Type::INT32> {
-        using CppType = int32_t;
-    };
-
-    template <>
-    struct PhysicalTypeTraits<tparquet::Type::INT64> {
-        using CppType = int64_t;
-    };
-
-    template <>
-    struct PhysicalTypeTraits<tparquet::Type::INT96> {
-        using CppType = ParquetInt96;
-    };
-
-    template <>
-    struct PhysicalTypeTraits<tparquet::Type::FLOAT> {
-        using CppType = float;
-    };
-
-    template <>
-    struct PhysicalTypeTraits<tparquet::Type::DOUBLE> {
-        using CppType = double;
-    };
-
-    template <>
-    struct PhysicalTypeTraits<tparquet::Type::FIXED_LEN_BYTE_ARRAY> {
-        using CppType = Slice;
-    };
-
 public:
     using cppType = PhysicalTypeTraits<PhysicalType>::CppType;
     FixLengthDictDecoder() = default;

--- a/be/test/vec/exec/format/parquet/fix_length_dict_decoder_test.cpp
+++ b/be/test/vec/exec/format/parquet/fix_length_dict_decoder_test.cpp
@@ -44,7 +44,7 @@ protected:
         ASSERT_TRUE(_decoder.set_dict(dict_data, dict_data_size, dict_size).ok());
     }
 
-    FixLengthDictDecoder _decoder;
+    FixLengthDictDecoder<tparquet::Type::FIXED_LEN_BYTE_ARRAY> _decoder;
     size_t _type_length;
 };
 
@@ -200,7 +200,7 @@ TEST_F(FixLengthDictDecoderTest, test_decode_with_filter_and_null) {
 
 // Test empty dictionary case
 TEST_F(FixLengthDictDecoderTest, test_empty_dict) {
-    FixLengthDictDecoder empty_decoder;
+    FixLengthDictDecoder<tparquet::Type::INT32> empty_decoder;
     empty_decoder.set_type_length(sizeof(int32_t));
 
     auto dict_data = make_unique_buffer<uint8_t>(0);


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
When parsing RLE_DICTIONARY encoding, the parquet reader uniformly uses memcpy. However, for INT32, INT64, etc., direct assignment is faster than memcpy.

In Parquet dictionary encoding, the actual data is not stored contiguously, resulting in very small memcpy sizes. When analyzing the implementation of `memcpy`, we can see that for such small sizes, `__builtin_memcpy` is used instead. The implementation of `__builtin_memcpy` essentially behaves like a series of simple assignments. You can observe the corresponding assembly code here: https://godbolt.org/z/r9Ma1ozvd.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

