### PR TITLE
[Enhancement](llm) support longcat for ai resources

### DIFF
--- a/be/src/vec/functions/ai/ai_adapter.h
+++ b/be/src/vec/functions/ai/ai_adapter.h
@@ -691,6 +691,24 @@ protected:
     bool supports_dimension_param(const std::string& model_name) const override { return false; }
 };
 
+class LongCatAdapter : public OpenAIAdapter {
+public:
+    Status build_embedding_request(const std::vector<std::string>& inputs,
+                                   std::string& request_body) const override {
+        return Status::NotSupported("{} does not support the Embed feature.",
+                                    _config.provider_type);
+    }
+
+    Status parse_embedding_response(const std::string& response_body,
+                                    std::vector<std::vector<float>>& results) const override {
+        return Status::NotSupported("{} does not support the Embed feature.",
+                                    _config.provider_type);
+    }
+
+protected:
+    bool supports_dimension_param(const std::string& model_name) const override { return false; }
+};
+
 // Gemini's embedding format is different from VoyageAI, so it requires a separate adapter
 class GeminiAdapter : public AIAdapter {
 public:
@@ -1064,6 +1082,7 @@ public:
                             {"ZHIPU", []() { return std::make_shared<ZhipuAdapter>(); }},
                             {"QWEN", []() { return std::make_shared<QwenAdapter>(); }},
                             {"BAICHUAN", []() { return std::make_shared<BaichuanAdapter>(); }},
+                            {"LONGCAT", []() { return std::make_shared<LongCatAdapter>(); }},
                             {"ANTHROPIC", []() { return std::make_shared<AnthropicAdapter>(); }},
                             {"GEMINI", []() { return std::make_shared<GeminiAdapter>(); }},
                             {"VOYAGEAI", []() { return std::make_shared<VoyageAIAdapter>(); }},

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AIProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AIProperties.java
@@ -55,7 +55,7 @@ public class AIProperties extends BaseProperties {
     public static final List<String> REQUIRED_FIELDS = Arrays.asList(ENDPOINT, PROVIDER_TYPE, MODEL_NAME);
     public static final List<String> PROVIDERS
             = Arrays.asList("OPENAI", "LOCAL", "GEMINI", "DEEPSEEK", "ANTHROPIC",
-            "MOONSHOT", "QWEN", "MINIMAX", "ZHIPU", "BAICHUAN", "VOYAGEAI");
+            "MOONSHOT", "QWEN", "MINIMAX", "ZHIPU", "BAICHUAN", "VOYAGEAI", "LONGCAT");
 
     public static void requiredAIProperties(Map<String, String> properties) throws DdlException {
         // Check required field


### PR DESCRIPTION
### What problem does this PR solve?

This PR enables AI Resource to directly support LongCat. To configure LongCat as AI Resource, follow this example.
```sql
CREATE RESOURCE 'longcat_example'
PROPERTIES (    
    'type' = 'ai',    
    'ai.provider_type' = 'longcat',    
    'ai.endpoint' = 'https://api.longcat.chat/openai/v1/chat/completions',    
    'ai.model_name' = 'LongCat-Flash-Chat',    
    'ai.api_key' = 'ak_xxx'
);
```
LongCat API doc: https://longcat.chat/platform/docs/zh/

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

