### PR TITLE
[improvement](storage) Release unused memory earlier, rather than leaving it to the memory pool for guaranteed release

### DIFF
--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -515,8 +515,8 @@ void MemTable::_aggregate() {
                 if (!temp_row_in_blocks.empty()) {
                     // The rows from the previous batch of _row_in_blocks have been merged into temp_row_in_blocks,
                     // now call finalize to write the aggregation results into _output_mutable_block.
-                                        _finalize_one_row<is_final>(temp_row_in_blocks.back().get(), block_data,
-                                                                    row_pos)
+                    _finalize_one_row<is_final>(temp_row_in_blocks.back().get(), block_data,
+                                                row_pos)
                 }
                 temp_row_in_blocks.push_back(cur_row_ptr);
                 row_pos++;

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -481,7 +481,7 @@ void MemTable::_clear_row_agg(RowInBlock* row) {
         row->remove_init_agg();
     }
 }
-// only in to_block the is_final will be true, in other cases, it will be false
+// only in `to_block` the `is_final` flag will be true, in other cases, it will be false
 template <bool is_final, bool has_skip_bitmap_col>
 void MemTable::_aggregate() {
     SCOPED_RAW_TIMER(&_stat.agg_ns);

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -507,16 +507,15 @@ void MemTable::_aggregate() {
                 _stat.merged_rows++;
                 _aggregate_two_row_in_block<has_skip_bitmap_col>(mutable_block, cur_row, prev_row);
                 // Clean up aggregation state of the merged row to avoid memory leak
-                if constexpr (!is_final) {
+                if (cur_row) {
                     _clear_row_agg(cur_row);
                 }
             } else {
                 prev_row = cur_row;
                 if (!temp_row_in_blocks.empty()) {
-                    // 上一批_row_in_blocks中的row合并到了temp_row_in_blocks，调用
-                    // finalize将聚合结果写入到_output_mutable_block中
-                    _finalize_one_row<is_final>(temp_row_in_blocks.back().get(), block_data,
-                                                row_pos);
+                    // The rows from the previous batch of _row_in_blocks have been merged into temp_row_in_blocks,
+                    // now call finalize to write the aggregation results into _output_mutable_block.
+                    _finalize_one_row<is_final>(temp_row_in_blocks.back().get(), block_data, row_pos);
                 }
                 temp_row_in_blocks.push_back(cur_row_ptr);
                 row_pos++;

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -515,7 +515,8 @@ void MemTable::_aggregate() {
                 if (!temp_row_in_blocks.empty()) {
                     // The rows from the previous batch of _row_in_blocks have been merged into temp_row_in_blocks,
                     // now call finalize to write the aggregation results into _output_mutable_block.
-                    _finalize_one_row<is_final>(temp_row_in_blocks.back().get(), block_data, row_pos);
+                                        _finalize_one_row<is_final>(temp_row_in_blocks.back().get(), block_data,
+                                                                    row_pos)
                 }
                 temp_row_in_blocks.push_back(cur_row_ptr);
                 row_pos++;

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -516,7 +516,7 @@ void MemTable::_aggregate() {
                     // The rows from the previous batch of _row_in_blocks have been merged into temp_row_in_blocks,
                     // now call finalize to write the aggregation results into _output_mutable_block.
                     _finalize_one_row<is_final>(temp_row_in_blocks.back().get(), block_data,
-                                                row_pos)
+                                                row_pos);
                 }
                 temp_row_in_blocks.push_back(cur_row_ptr);
                 row_pos++;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

when aggregate, the `cur_row` is useless, so we should call `_clear_row_agg` to release it, rather than leaving it to the memory pool for guaranteed release

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

