### PR TITLE
[Opt](storage) Opt BinaryPlainPageV2

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1625,6 +1625,8 @@ DEFINE_Validator(binary_plain_encoding_default_impl, [](const std::string& confi
     return config == "v1" || config == "v2";
 });
 
+DEFINE_mBool(enable_fuzzy_storage_encoding, "false");
+
 // clang-format off
 #ifdef BE_TEST
 // test s3
@@ -2078,8 +2080,10 @@ Status set_fuzzy_configs() {
             ((distribution(*generator) % 2) == 0) ? "true" : "false";
     fuzzy_field_and_value["max_segment_partial_column_cache_size"] =
             ((distribution(*generator) % 2) == 0) ? "5" : "10";
-    fuzzy_field_and_value["binary_plain_encoding_default_impl"] =
-            ((distribution(*generator) % 2) == 0) ? "v1" : "v2";
+    if (config::enable_fuzzy_storage_encoding) {
+        fuzzy_field_and_value["binary_plain_encoding_default_impl"] =
+                ((distribution(*generator) % 2) == 0) ? "v1" : "v2";
+    }
 
     std::uniform_int_distribution<int64_t> distribution2(-2, 10);
     fuzzy_field_and_value["segments_key_bounds_truncation_threshold"] =

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1665,6 +1665,8 @@ DECLARE_mString(aws_credentials_provider_version);
 
 DECLARE_mString(binary_plain_encoding_default_impl);
 
+DECLARE_mBool(enable_fuzzy_storage_encoding);
+
 #ifdef BE_TEST
 // test s3
 DECLARE_String(test_s3_resource);

--- a/be/src/olap/rowset/segment_v2/binary_plain_page_v2.h
+++ b/be/src/olap/rowset/segment_v2/binary_plain_page_v2.h
@@ -228,8 +228,8 @@ public:
         }
 
         // Decode trailer (last 8 bytes: lengths_offset and num_elems)
-        uint32_t lengths_offset = decode_fixed32_le(
-                (const uint8_t*)&_data[_data.get_size() - 2 * sizeof(uint32_t)]);
+        uint32_t lengths_offset =
+                decode_fixed32_le((const uint8_t*)&_data[_data.get_size() - 2 * sizeof(uint32_t)]);
         _num_elems = decode_fixed32_le((const uint8_t*)&_data[_data.get_size() - sizeof(uint32_t)]);
 
         // Decode lengths using ForDecoder
@@ -237,7 +237,8 @@ public:
         _lengths.reserve(_num_elems);
 
         if (_num_elems > 0) {
-            const uint8_t* lengths_data = reinterpret_cast<const uint8_t*>(_data.data) + lengths_offset;
+            const uint8_t* lengths_data =
+                    reinterpret_cast<const uint8_t*>(_data.data) + lengths_offset;
             size_t lengths_size = _data.get_size() - lengths_offset - 2 * sizeof(uint32_t);
 
             ForDecoder<uint32_t> decoder(lengths_data, lengths_size);

--- a/regression-test/pipeline/cloud_p0/conf/be_custom.conf
+++ b/regression-test/pipeline/cloud_p0/conf/be_custom.conf
@@ -53,4 +53,4 @@ enable_prefill_all_dbm_agg_cache_after_compaction=true
 enable_batch_get_delete_bitmap=true
 get_delete_bitmap_bytes_threshold=10
 
-binary_plain_encoding_default_impl=true
+binary_plain_encoding_default_impl=v2

--- a/regression-test/pipeline/cloud_p0/conf/be_custom.conf
+++ b/regression-test/pipeline/cloud_p0/conf/be_custom.conf
@@ -52,3 +52,5 @@ enable_prefill_all_dbm_agg_cache_after_compaction=true
 
 enable_batch_get_delete_bitmap=true
 get_delete_bitmap_bytes_threshold=10
+
+binary_plain_encoding_default_impl=true

--- a/regression-test/pipeline/nonConcurrent/conf/be.conf
+++ b/regression-test/pipeline/nonConcurrent/conf/be.conf
@@ -89,4 +89,4 @@ large_cumu_compaction_task_min_thread_num=3
 enable_parquet_page_index=true
 enable_graceful_exit_check=true
 
-binary_plain_encoding_default_impl=true
+binary_plain_encoding_default_impl=v2

--- a/regression-test/pipeline/nonConcurrent/conf/be.conf
+++ b/regression-test/pipeline/nonConcurrent/conf/be.conf
@@ -89,3 +89,4 @@ large_cumu_compaction_task_min_thread_num=3
 enable_parquet_page_index=true
 enable_graceful_exit_check=true
 
+binary_plain_encoding_default_impl=true

--- a/regression-test/pipeline/p0/conf/be.conf
+++ b/regression-test/pipeline/p0/conf/be.conf
@@ -90,3 +90,5 @@ enable_parquet_page_index=true
 enable_graceful_exit_check=true
 
 enable_prefill_all_dbm_agg_cache_after_compaction=true
+
+binary_plain_encoding_default_impl=true

--- a/regression-test/pipeline/p0/conf/be.conf
+++ b/regression-test/pipeline/p0/conf/be.conf
@@ -91,4 +91,4 @@ enable_graceful_exit_check=true
 
 enable_prefill_all_dbm_agg_cache_after_compaction=true
 
-binary_plain_encoding_default_impl=true
+binary_plain_encoding_default_impl=v2

--- a/regression-test/pipeline/p1/conf/be.conf
+++ b/regression-test/pipeline/p1/conf/be.conf
@@ -77,4 +77,4 @@ enable_graceful_exit_check=true
 
 enable_prefill_all_dbm_agg_cache_after_compaction=true
 
-binary_plain_encoding_default_impl=true
+binary_plain_encoding_default_impl=v2

--- a/regression-test/pipeline/p1/conf/be.conf
+++ b/regression-test/pipeline/p1/conf/be.conf
@@ -76,3 +76,5 @@ enable_parquet_page_index=true
 enable_graceful_exit_check=true
 
 enable_prefill_all_dbm_agg_cache_after_compaction=true
+
+binary_plain_encoding_default_impl=true

--- a/regression-test/pipeline/performance/clickbench/conf/be_custom.conf
+++ b/regression-test/pipeline/performance/clickbench/conf/be_custom.conf
@@ -20,4 +20,4 @@ disable_storage_page_cache=false
 disable_chunk_allocator=false
 enable_simdjson_reader = true
 
-binary_plain_encoding_default_impl=true
+binary_plain_encoding_default_impl=v2

--- a/regression-test/pipeline/performance/clickbench/conf/be_custom.conf
+++ b/regression-test/pipeline/performance/clickbench/conf/be_custom.conf
@@ -19,3 +19,5 @@ disable_auto_compaction=true
 disable_storage_page_cache=false
 disable_chunk_allocator=false
 enable_simdjson_reader = true
+
+binary_plain_encoding_default_impl=true

--- a/regression-test/pipeline/performance/conf/be_custom.conf
+++ b/regression-test/pipeline/performance/conf/be_custom.conf
@@ -25,3 +25,5 @@ streaming_load_max_mb=102400
 # So feature has bug, so by default is false, only open it in pipeline to observe
 enable_parquet_page_index=true
 enable_graceful_exit_check=true
+
+binary_plain_encoding_default_impl=true

--- a/regression-test/pipeline/performance/conf/be_custom.conf
+++ b/regression-test/pipeline/performance/conf/be_custom.conf
@@ -26,4 +26,4 @@ streaming_load_max_mb=102400
 enable_parquet_page_index=true
 enable_graceful_exit_check=true
 
-binary_plain_encoding_default_impl=true
+binary_plain_encoding_default_impl=v2

--- a/regression-test/pipeline/vault_p0/conf/be_custom.conf
+++ b/regression-test/pipeline/vault_p0/conf/be_custom.conf
@@ -40,4 +40,4 @@ crash_in_memory_tracker_inaccurate = true
 enable_table_size_correctness_check=true
 enable_brpc_connection_check=true
 
-binary_plain_encoding_default_impl=true
+binary_plain_encoding_default_impl=v2

--- a/regression-test/pipeline/vault_p0/conf/be_custom.conf
+++ b/regression-test/pipeline/vault_p0/conf/be_custom.conf
@@ -39,3 +39,5 @@ pipeline_task_leakage_detect_period_sec=1
 crash_in_memory_tracker_inaccurate = true
 enable_table_size_correctness_check=true
 enable_brpc_connection_check=true
+
+binary_plain_encoding_default_impl=true


### PR DESCRIPTION
### What problem does this PR solve?

change the storage format of BinaryPlainPageV2 from:
```
|length1(varuint32)|binary1||length2(varuint32)|binary2|...
```

to 
```
|binary1|binary2|binary3|... + frame of reference encoded(size1|size2|size3|...)
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

