### PR TITLE
[Fix](job) add thread num config for streaming task exec

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1976,6 +1976,11 @@ public class Config extends ConfigBase {
                     + " greater than 0, otherwise it defaults to 3." })
     public static int job_dictionary_task_consumer_thread_num = 3;
 
+    @ConfField(masterOnly = true, description = {"用于执行 Streaming 任务的线程数,值应该大于0，否则默认为10",
+            "The number of threads used to consume Streaming Tasks, "
+                    + "the value should be greater than 0, if it is <=0, default is 10."})
+    public static int job_streaming_task_exec_thread_num = 10;
+
     @ConfField(masterOnly = true, description = {"最大的 Streaming 作业数量,值应该大于0，否则默认为1024",
             "The maximum number of Streaming jobs, "
                     + "the value should be greater than 0, if it is <=0, default is 1024."})

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1977,7 +1977,7 @@ public class Config extends ConfigBase {
     public static int job_dictionary_task_consumer_thread_num = 3;
 
     @ConfField(masterOnly = true, description = {"用于执行 Streaming 任务的线程数,值应该大于0，否则默认为10",
-            "The number of threads used to consume Streaming Tasks, "
+            "The number of threads used to execute Streaming Tasks, "
                     + "the value should be greater than 0, if it is <=0, default is 10."})
     public static int job_streaming_task_exec_thread_num = 10;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/StreamingTaskScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/StreamingTaskScheduler.java
@@ -41,8 +41,8 @@ import java.util.concurrent.TimeUnit;
 @Log4j2
 public class StreamingTaskScheduler extends MasterDaemon {
     private final ThreadPoolExecutor threadPool = new ThreadPoolExecutor(
-                    0,
-                    Config.max_streaming_job_num,
+                    Config.job_streaming_task_exec_thread_num,
+                    Config.job_streaming_task_exec_thread_num,
                     60,
                     TimeUnit.SECONDS,
                     new ArrayBlockingQueue<>(Config.max_streaming_job_num),
@@ -120,9 +120,11 @@ public class StreamingTaskScheduler extends MasterDaemon {
         log.info("prepare to schedule task, task id: {}, job id: {}", task.getTaskId(), task.getJobId());
         job.setLastScheduleTaskTimestamp(System.currentTimeMillis());
         Env.getCurrentEnv().getJobManager().getStreamingTaskManager().addRunningTask(task);
-
+        long start = System.currentTimeMillis();
         try {
             task.execute();
+            log.info("Finished executing task, task id: {}, job id: {}, cost {}ms",
+                    task.getTaskId(), task.getJobId(), System.currentTimeMillis() - start);
         } catch (Exception e) {
             log.error("Failed to execute task, task id: {}, job id: {}", task.getTaskId(), task.getJobId(), e);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/StreamingTaskScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/StreamingTaskScheduler.java
@@ -43,7 +43,7 @@ public class StreamingTaskScheduler extends MasterDaemon {
     private final ThreadPoolExecutor threadPool = new ThreadPoolExecutor(
                     Config.job_streaming_task_exec_thread_num,
                     Config.job_streaming_task_exec_thread_num,
-                    60,
+                    0,
                     TimeUnit.SECONDS,
                     new ArrayBlockingQueue<>(Config.max_streaming_job_num),
                     new CustomThreadFactory("streaming-task-execute"),


### PR DESCRIPTION
### What problem does this PR solve?

Add thread num config for streaming task exec
Currently, coreSize=0. New threads are created only when the task exceeds the queue length.
If the queue is not full, only one thread will execute.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

