### PR TITLE
[Fix](function) Fix wrong nullable of floor/ceil functions

### DIFF
--- a/be/src/vec/functions/function_datetime_floor_ceil.cpp
+++ b/be/src/vec/functions/function_datetime_floor_ceil.cpp
@@ -256,7 +256,7 @@ public:
             }
         }
 
-        if (block.get_by_position(arguments[0]).type->is_nullable()) {
+        if (block.get_by_position(result).type->is_nullable()) {
             block.replace_by_position(
                     result,
                     ColumnNullable::create(std::move(col_to), std::move(result_null_map_column)));

--- a/be/src/vec/functions/function_other_types_to_date.cpp
+++ b/be/src/vec/functions/function_other_types_to_date.cpp
@@ -534,7 +534,7 @@ public:
         }
 
         // Wrap result in nullable column only if input has nullable arguments
-        if (block.get_by_position(arguments[0]).type->is_nullable()) {
+        if (block.get_by_position(result).type->is_nullable()) {
             block.replace_by_position(result,
                                       ColumnNullable::create(std::move(res_column),
                                                              std::move(result_null_map_column)));

--- a/regression-test/suites/correctness_p0/test_time_round.groovy
+++ b/regression-test/suites/correctness_p0/test_time_round.groovy
@@ -396,6 +396,12 @@ suite("test_time_round") {
     testFoldConst("select minute_ceil('2025-09-10 12:34:56.45', 5)")
     testFoldConst("select minute_ceil('2025-09-10 12:34:56.12345', '2025-09-10 12:30:00.678')")
     testFoldConst("select minute_ceil('2025-09-10 12:34:56.9', 10, '2025-09-10 12:30:00.234567')")
+    testFoldConst("""select minute_ceil(CAST('2021-12-31 12:23:34' AS DATETIMEV2(0)),
+                        nullable(CAST('2021-12-31 12:23:34' AS DATETIMEV2(0))));""")
+    testFoldConst("""select minute_ceil(nullable(CAST('2021-12-31 12:23:34' AS DATETIMEV2(0))),
+                        CAST('2021-12-31 12:23:34' AS DATETIMEV2(0)));""")
+    testFoldConst("""select minute_ceil(nullable(CAST('2021-12-31 12:23:34' AS DATETIMEV2(0))),
+                        nullable(CAST('2021-12-31 12:23:34' AS DATETIMEV2(0))));""")
 
     testFoldConst("select minute_floor('2025-09-10 12:34:56')")
     testFoldConst("select minute_floor('2025-09-10 12:34:56', 5)")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

before:
```sql
mysql> select minute_ceil(CAST('2021-12-31 12:23:34' AS DATETIMEV2(0)), nullable(CAST('2021-12-31 12:23:34' AS DATETIMEV2(0))));
ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.3)[INTERNAL_ERROR]Column VectorizedFnCall[minute_ceil](arguments=DateTimeV2(0), VectorizedFnCall[nullable](arguments=DateTimeV2(0),return=Nullable(DateTimeV2(0))),return=Nullable(DateTimeV2(0))) in block is not compatible with its column type :Const(DATETIMEV2), data type :Nullable(DateTimeV2(0)), error: Column type Const(DATETIMEV2) is not compatible with data type Nullable(DateTimeV2(0))
```
now:
```sql
mysql> select minute_ceil(CAST('2021-12-31 12:23:34' AS DATETIMEV2(0)), nullable(CAST('2021-12-31 12:23:34' AS DATETIMEV2(0))));
+-------------------------------------------------------------------------------------------------------------------+
| minute_ceil(CAST('2021-12-31 12:23:34' AS DATETIMEV2(0)), nullable(CAST('2021-12-31 12:23:34' AS DATETIMEV2(0)))) |
+-------------------------------------------------------------------------------------------------------------------+
| 2021-12-31 12:23:34                                                                                               |
+-------------------------------------------------------------------------------------------------------------------+

```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

