### PR TITLE
[fix](olap) Crash caused by out-of-bounds PODArray access

### DIFF
--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -341,7 +341,7 @@ Status VCollectIterator::_topn_next(Block* block) {
                         DCHECK(block->get_by_position(k).type->equals(
                                 *mutable_block.get_datatype_by_position(k)));
                         res = block->get_by_position(k).column->compare_at(
-                                k, last_row_pos, *(mutable_block.get_column_by_position(k)), -1);
+                                j, last_row_pos, *(mutable_block.get_column_by_position(k)), -1);
                         if (res) {
                             break;
                         }


### PR DESCRIPTION
### What problem does this PR solve?

```text
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=136182904088128) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=136182904088128) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=136182904088128, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007fdee8ffb476 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007fdee8fe17f3 in __GI_abort () at ./stdlib/abort.c:79
#5  0x000055cc31fb9bcd in ?? ()
#6  0x000055cc31fadeac in google::LogMessage::SendToLog() ()
#7  0x000055cc31fae538 in google::LogMessage::Flush() ()
#8  0x000055cc31fb2116 in google::LogMessageFatal::~LogMessageFatal() ()
#9  0x000055cc1977f798 in doris::vectorized::PODArray<unsigned int, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul>::operator[] (this=<optimized out>, n=2) at /root/doris/be/src/vec/common/pod_array.h:466
#10 0x000055cc19777580 in doris::vectorized::ColumnStr<unsigned int>::size_at (this=0x7c5eea94dda0, i=2) at /root/doris/be/src/vec/columns/column_string.h:96
#11 doris::vectorized::ColumnStr<unsigned int>::compare_at (this=0x7c5eea94dda0, n=2, m=1, rhs_=...) at /root/doris/be/src/vec/columns/column_string.h:482
#12 0x000055cc2f2f1138 in doris::vectorized::VCollectIterator::_topn_next (this=<optimized out>, block=<optimized out>) at /root/doris/be/src/vec/olap/vcollect_iterator.cpp:343
#13 0x000055cc2f2efa08 in doris::vectorized::VCollectIterator::next (this=0x898f, block=0x6) at /root/doris/be/src/vec/olap/vcollect_iterator.cpp:247
#14 0x000055cc2f28e3ea in doris::vectorized::BlockReader::_direct_next_block (this=0x7dbeed736880, block=<optimized out>, eof=<optimized out>) at /root/doris/be/src/vec/olap/block_reader.cpp:267
#15 0x000055cc2f28778b in doris::vectorized::BlockReader::next_block_with_aggregation (this=0x7dbeed736880, block=<optimized out>, eof=<optimized out>) at /root/doris/be/src/vec/olap/block_reader.cpp:66
#16 0x000055cc2b33300e in doris::vectorized::OlapScanner::_get_block_impl (this=0x7daeee690690, state=<optimized out>, block=0x7daeee6907b8, eof=<optimized out>) at /root/doris/be/src/vec/exec/scan/olap_scanner.cpp:584
#17 0x000055cc2b2c990d in doris::vectorized::Scanner::get_block (this=<optimized out>, state=<optimized out>, block=0x7daeee6907b8, eof=<optimized out>) at /root/doris/be/src/vec/exec/scan/scanner.cpp:116
#18 0x000055cc2b2c8fa0 in doris::vectorized::Scanner::get_block_after_projects (this=0x7daeee690690, state=0x7dcee9e6ec80, block=0x7caee9b74fe0, eos=0x7bdb809a11f0) at /root/doris/be/src/vec/exec/scan/scanner.cpp:82
#19 0x000055cc2b2e51b4 in doris::vectorized::ScannerScheduler::_scanner_scan (ctx=..., scan_task=...) at /root/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:182
#20 0x000055cc2b2ed92c in doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}::operator()() const::{lambda()#1}::operator()() const (this=<optimized out>) at /root/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:96
#21 doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}::operator()() const (this=0x7c0eeec42540)
    at /root/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:95
#22 std::__invoke_impl<bool, doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}&>(std::__invoke_other, doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}&) (__f=...)
    at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:63
#23 std::__invoke_r<bool, doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}&>(doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}&) (__fn=...)
    at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:116
#24 std::_Function_handler<bool (), doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}>::_M_invoke(std::_Any_data const&) (
    __functor=...) at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:292
#25 0x000055cc1dd09d33 in doris::ThreadPool::dispatch_thread (this=0x7d3ee8680f80) at /root/doris/be/src/util/threadpool.cpp:614
#26 0x000055cc1dce6da7 in std::function<void ()>::operator()() const (this=<optimized out>) at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:593
#27 doris::Thread::supervise_thread (arg=<optimized out>) at /root/doris/be/src/util/thread.cpp:460
#28 0x000055cc19364d27 in asan_thread_start(void*) ()
#29 0x00007fdee904dac3 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:442
#30 0x00007fdee90df850 in __closefrom_fallback (from=877593024, dirfd_fallback=<optimized out>) at ../sysdeps/unix/sysv/linux/closefrom_fallback.c:45
#31 0x0000000000000000 in ?? ()
```

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

