### PR TITLE
[fix](nereids)relase physical plan in Profile.releaseMemory()

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -559,6 +559,9 @@ public class Profile {
     public void releaseMemory() {
         this.executionProfiles.clear();
         this.changedSessionVarCache = "";
+        this.physicalPlan = null;
+        this.rowsProducedMap = null;
+        this.physicalRelations = null;
     }
 
     public boolean shouldStoreToStorage() {


### PR DESCRIPTION
### What problem does this PR solve?
The profile holds a physical plan object. In profile.releaseMemory(), the physicalPlan needs to be set to null to release it, preventing the groupExpression in Memo from failing to be released in a timely manner.
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

