### PR TITLE
[chore](typo)Fix typos in thrift

### DIFF
--- a/be/src/pipeline/exec/result_sink_operator.cpp
+++ b/be/src/pipeline/exec/result_sink_operator.cpp
@@ -56,17 +56,14 @@ Status ResultSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo& info)
         _sender = _parent->cast<ResultSinkOperatorX>()._sender;
     } else {
         std::shared_ptr<arrow::Schema> arrow_schema;
-        if (p._sink_type == TResultSinkType::ARROW_FLIGHT_PROTOCOL ||
-            p._sink_type == TResultSinkType::ARROW_FLIGHT_PROTOCAL) {
+        if (p._sink_type == TResultSinkType::ARROW_FLIGHT_PROTOCOL) {
             RETURN_IF_ERROR(get_arrow_schema_from_expr_ctxs(_output_vexpr_ctxs, &arrow_schema,
                                                             state->timezone()));
         }
         VLOG_DEBUG << "create sender in INIT with instance id " << fragment_instance_id;
         RETURN_IF_ERROR(state->exec_env()->result_mgr()->create_sender(
                 fragment_instance_id, p._result_sink_buffer_size_rows, &_sender, state,
-                p._sink_type == TResultSinkType::ARROW_FLIGHT_PROTOCOL ||
-                        p._sink_type == TResultSinkType::ARROW_FLIGHT_PROTOCAL,
-                arrow_schema));
+                p._sink_type == TResultSinkType::ARROW_FLIGHT_PROTOCOL, arrow_schema));
     }
     _sender->set_dependency(fragment_instance_id, _dependency->shared_from_this());
     return Status::OK();
@@ -79,8 +76,6 @@ Status ResultSinkLocalState::open(RuntimeState* state) {
     auto& p = _parent->cast<ResultSinkOperatorX>();
     // create writer based on sink type
     switch (p._sink_type) {
-    case TResultSinkType::MYSQL_PROTOCAL:
-        [[fallthrough]];
     case TResultSinkType::MYSQL_PROTOCOL: {
         if (state->mysql_row_binary_format()) {
             _writer.reset(new (std::nothrow) vectorized::VMysqlResultWriter<true>(
@@ -91,8 +86,6 @@ Status ResultSinkLocalState::open(RuntimeState* state) {
         }
         break;
     }
-    case TResultSinkType::ARROW_FLIGHT_PROTOCAL:
-        [[fallthrough]];
     case TResultSinkType::ARROW_FLIGHT_PROTOCOL: {
         _writer.reset(new (std::nothrow) vectorized::VArrowFlightResultWriter(
                 _sender, _output_vexpr_ctxs, custom_profile()));
@@ -111,12 +104,10 @@ ResultSinkOperatorX::ResultSinkOperatorX(int operator_id, const RowDescriptor& r
                                          const TResultSink& sink)
         : DataSinkOperatorX(operator_id, std::numeric_limits<int>::max(),
                             std::numeric_limits<int>::max()),
-          _sink_type(!sink.__isset.type || (sink.type == TResultSinkType::MYSQL_PROTOCOL ||
-                                            sink.type == TResultSinkType::MYSQL_PROTOCAL)
+          _sink_type(!sink.__isset.type || sink.type == TResultSinkType::MYSQL_PROTOCOL
                              ? TResultSinkType::MYSQL_PROTOCOL
                              : sink.type),
-          _result_sink_buffer_size_rows((_sink_type == TResultSinkType::ARROW_FLIGHT_PROTOCOL ||
-                                         _sink_type == TResultSinkType::ARROW_FLIGHT_PROTOCAL)
+          _result_sink_buffer_size_rows(_sink_type == TResultSinkType::ARROW_FLIGHT_PROTOCOL
                                                 ? config::arrow_flight_result_sink_buffer_size_rows
                                                 : RESULT_SINK_BUFFER_SIZE),
           _row_desc(row_desc),
@@ -141,17 +132,14 @@ Status ResultSinkOperatorX::prepare(RuntimeState* state) {
 
     if (state->query_options().enable_parallel_result_sink) {
         std::shared_ptr<arrow::Schema> arrow_schema;
-        if (_sink_type == TResultSinkType::ARROW_FLIGHT_PROTOCOL ||
-            _sink_type == TResultSinkType::ARROW_FLIGHT_PROTOCAL) {
+        if (_sink_type == TResultSinkType::ARROW_FLIGHT_PROTOCOL) {
             RETURN_IF_ERROR(get_arrow_schema_from_expr_ctxs(_output_vexpr_ctxs, &arrow_schema,
                                                             state->timezone()));
         }
         VLOG_DEBUG << "create sender in prepare with query id " << state->query_id();
         RETURN_IF_ERROR(state->exec_env()->result_mgr()->create_sender(
                 state->query_id(), _result_sink_buffer_size_rows, &_sender, state,
-                _sink_type == TResultSinkType::ARROW_FLIGHT_PROTOCOL ||
-                        _sink_type == TResultSinkType::ARROW_FLIGHT_PROTOCAL,
-                arrow_schema));
+                _sink_type == TResultSinkType::ARROW_FLIGHT_PROTOCOL, arrow_schema));
     }
     return vectorized::VExpr::open(_output_vexpr_ctxs, state);
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlChannel.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlChannel.java
@@ -114,7 +114,7 @@ public class MysqlChannel implements BytesChannel {
         this.remoteIp = "";
         this.conn = connection;
 
-        // if proxy protocal is enabled, the remote address will be got from proxy protocal header
+        // if proxy protocol is enabled, the remote address will be got from proxy protocol header
         // and overwrite the original remote address.
         if (connection.getPeerAddress() instanceof InetSocketAddress) {
             InetSocketAddress address = (InetSocketAddress) connection.getPeerAddress();
@@ -638,7 +638,7 @@ public class MysqlChannel implements BytesChannel {
         }
     }
 
-    // for proxy protocal only
+    // for proxy protocol only
     public void setRemoteAddr(String ip, int port) {
         this.remoteIp = ip;
         this.remoteHostPortString = NetUtils.getHostPortInAccessibleFormat(ip, port);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanFragment.java
@@ -157,7 +157,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     protected boolean hasColocatePlanNode = false;
     protected final Supplier<Boolean> hasBucketShuffleJoin;
 
-    private TResultSinkType resultSinkType = TResultSinkType.MYSQL_PROTOCAL;
+    private TResultSinkType resultSinkType = TResultSinkType.MYSQL_PROTOCOL;
 
     public Optional<NereidsSpecifyInstances<ScanSource>> specifyInstances = Optional.empty();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ResultSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ResultSink.java
@@ -34,7 +34,7 @@ public class ResultSink extends DataSink {
     // Two phase fetch option
     private TFetchOption fetchOption;
 
-    private TResultSinkType resultSinkType = TResultSinkType.MYSQL_PROTOCAL;
+    private TResultSinkType resultSinkType = TResultSinkType.MYSQL_PROTOCOL;
 
     public ResultSink(PlanNodeId exchNodeId) {
         this.exchNodeId = exchNodeId;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -240,7 +240,7 @@ public class ConnectContext {
     private String workloadGroupName = "";
     private boolean isGroupCommit;
 
-    private TResultSinkType resultSinkType = TResultSinkType.MYSQL_PROTOCAL;
+    private TResultSinkType resultSinkType = TResultSinkType.MYSQL_PROTOCOL;
 
     private Map<String, Set<String>> dbToTempTableNamesMap = new HashMap<>();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/sessions/FlightSqlConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/sessions/FlightSqlConnectContext.java
@@ -41,7 +41,7 @@ public class FlightSqlConnectContext extends ConnectContext {
         this.peerIdentity = peerIdentity;
         mysqlChannel = null; // Use of MysqlChannel is not expected
         flightSqlChannel = new FlightSqlChannel();
-        setResultSinkType(TResultSinkType.ARROW_FLIGHT_PROTOCAL);
+        setResultSinkType(TResultSinkType.ARROW_FLIGHT_PROTOCOL);
         init();
     }
 

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -45,9 +45,11 @@ enum TDataSinkType {
 }
 
 enum TResultSinkType {
-    MYSQL_PROTOCAL = 0,
-    ARROW_FLIGHT_PROTOCAL = 1,
+    MYSQL_PROTOCAL = 0,  // deprecated, use MYSQL_PROTOCOL
+    ARROW_FLIGHT_PROTOCAL = 1,  // deprecated, use ARROW_FLIGHT_PROTOCOL
     FILE = 2,    // deprecated, should not be used any more. FileResultSink is covered by TRESULT_FILE_SINK for concurrent purpose.
+    MYSQL_PROTOCOL = 3,
+    ARROW_FLIGHT_PROTOCOL = 4,
 }
 
 enum TParquetCompressionType {

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -45,11 +45,9 @@ enum TDataSinkType {
 }
 
 enum TResultSinkType {
-    MYSQL_PROTOCAL = 0,  // deprecated, use MYSQL_PROTOCOL
-    ARROW_FLIGHT_PROTOCAL = 1,  // deprecated, use ARROW_FLIGHT_PROTOCOL
+    MYSQL_PROTOCOL = 0,
+    ARROW_FLIGHT_PROTOCOL = 1,
     FILE = 2,    // deprecated, should not be used any more. FileResultSink is covered by TRESULT_FILE_SINK for concurrent purpose.
-    MYSQL_PROTOCOL = 3,
-    ARROW_FLIGHT_PROTOCOL = 4,
 }
 
 enum TParquetCompressionType {

--- a/regression-test/suites/nereids_tpch_p0/tpch/push_topn_to_agg.groovy
+++ b/regression-test/suites/nereids_tpch_p0/tpch/push_topn_to_agg.groovy
@@ -124,7 +124,7 @@ suite("push_topn_to_agg") {
 |   HAS_COLO_PLAN_NODE: false                                                    |
 |                                                                                |
 |   VRESULT SINK                                                                 |
-|      MYSQL_PROTOCAL                                                            |
+|      MYSQL_PROTOCOL                                                            |
 |                                                                                |
 |   4:VEXCHANGE                                                                  |
 |      offset: 0                                                                 |

--- a/samples/datalake/lakesoul/README.md
+++ b/samples/datalake/lakesoul/README.md
@@ -101,7 +101,7 @@ mysql> explain verbose select * from customer_from_spark where c_nationkey < 3;
 |   HAS_COLO_PLAN_NODE: false                                                                                                                                          |
 |                                                                                                                                                                      |
 |   VRESULT SINK                                                                                                                                                       |
-|      MYSQL_PROTOCAL                                                                                                                                                  |
+|      MYSQL_PROTOCOL                                                                                                                                                  |
 |                                                                                                                                                                      |
 |   1:VEXCHANGE                                                                                                                                                        |
 |      offset: 0                                                                                                                                                       |


### PR DESCRIPTION
In Thrift, fields are distinguished by IDs rather than names, so modifying field names does not break compatibility.