### PR TITLE
[refine](function) In the function, check whether the size of the arguments' column equals the input rows count.

### DIFF
--- a/be/src/vec/exprs/vliteral.cpp
+++ b/be/src/vec/exprs/vliteral.cpp
@@ -52,7 +52,7 @@ Status VLiteral::prepare(RuntimeState* state, const RowDescriptor& desc, VExprCo
 Status VLiteral::execute(VExprContext* context, vectorized::Block* block, int* result_column_id) {
     // Literal expr should return least one row.
     // sometimes we just use a VLiteral without open or prepare. so can't check it at this moment
-    size_t row_size = std::max(block->rows(), _column_ptr->size());
+    size_t row_size = block->rows();
     *result_column_id = VExpr::insert_param(block, {_column_ptr, _data_type, _expr_name}, row_size);
     return Status::OK();
 }

--- a/be/src/vec/functions/function.h
+++ b/be/src/vec/functions/function.h
@@ -187,6 +187,14 @@ public:
 
     Status execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                    uint32_t result, size_t input_rows_count, bool dry_run = false) const {
+        for (const auto& arg : arguments) {
+            if (block.get_by_position(arg).column->size() != input_rows_count) {
+                return Status::InternalError(
+                        "Function {} got argument column of invalid size. "
+                        "input_rows_count {}, column {}",
+                        get_name(), input_rows_count, block.get_by_position(arg).column->size());
+            }
+        }
         try {
             return prepare(context, block, arguments, result)
                     ->execute(context, block, arguments, result, input_rows_count, dry_run);

--- a/be/src/vec/functions/function.h
+++ b/be/src/vec/functions/function.h
@@ -188,8 +188,7 @@ public:
     Status execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                    uint32_t result, size_t input_rows_count, bool dry_run = false) const {
         for (const auto& arg : arguments) {
-            if (input_rows_count != 0 &&
-                block.get_by_position(arg).column->size() != input_rows_count) {
+            if (block.get_by_position(arg).column->size() != input_rows_count) {
                 return Status::InternalError(
                         "Function {} got argument column of invalid size. "
                         "input_rows_count {}, column {}",

--- a/be/src/vec/functions/function.h
+++ b/be/src/vec/functions/function.h
@@ -191,8 +191,9 @@ public:
             if (block.get_by_position(arg).column->size() != input_rows_count) {
                 return Status::InternalError(
                         "Function {} got argument column of invalid size. "
-                        "input_rows_count {}, column {}",
-                        get_name(), input_rows_count, block.get_by_position(arg).column->size());
+                        "input_rows_count {}, column {} , column name {}",
+                        get_name(), input_rows_count, block.get_by_position(arg).column->size(),
+                        block.get_by_position(arg).name);
             }
         }
         try {

--- a/be/src/vec/functions/function.h
+++ b/be/src/vec/functions/function.h
@@ -188,7 +188,8 @@ public:
     Status execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                    uint32_t result, size_t input_rows_count, bool dry_run = false) const {
         for (const auto& arg : arguments) {
-            if (block.get_by_position(arg).column->size() != input_rows_count) {
+            if (input_rows_count != 0 &&
+                block.get_by_position(arg).column->size() != input_rows_count) {
                 return Status::InternalError(
                         "Function {} got argument column of invalid size. "
                         "input_rows_count {}, column {}",

--- a/be/test/vec/function/function_throw_exception_test.cpp
+++ b/be/test/vec/function/function_throw_exception_test.cpp
@@ -132,7 +132,7 @@ TEST(FunctionThrowExceptionTest, input_rows_count_not_match) {
     EXPECT_EQ(st.code(), ErrorCode::INTERNAL_ERROR);
     EXPECT_EQ(st.msg(),
               "Function mock_function_input_rows_count_not_match got argument column of invalid "
-              "size. input_rows_count 1, column 3");
+              "size. input_rows_count 1, column 3 , column name column");
 }
 
 } // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?

Copilot said: In some incorrect usages, the size of
In some incorrect usages, the size of the column in the arguments may not equal the number of input rows. This is incorrect usage, but we must ensure it does not cause a crash (core dump) and instead returns an explicit error.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

