### PR TITLE
[Chore](utils) make Defer allow throw exception

### DIFF
--- a/be/src/util/defer_op.h
+++ b/be/src/util/defer_op.h
@@ -18,6 +18,9 @@
 #pragma once
 
 #include <functional>
+#include <exception> // for std::uncaught_exceptions
+#include "common/logging.h"
+#include <utility>
 
 namespace doris {
 
@@ -29,12 +32,44 @@ namespace doris {
 // for C++11
 // auto op = [] {};
 // Defer<decltype<op>> (op);
+// Defer runs a closure in its destructor. By default destructors must not
+// let exceptions escape during stack unwinding (that would call
+// std::terminate). This implementation tries to strike a balance:
+// - If the destructor is running while there is an active exception
+//   (std::uncaught_exceptions() > 0), we call the closure but catch and
+//   swallow any exception to avoid terminate.
+// - If there is no active exception, we invoke the closure directly and
+//   allow any exception to propagate to the caller. To permit propagation
+//   we declare the destructor noexcept(false).
 template <class T>
 class Defer {
 public:
     Defer(T& closure) : _closure(closure) {}
     Defer(T&& closure) : _closure(std::move(closure)) {}
-    ~Defer() { _closure(); }
+    // Allow throwing when there is no active exception. If we are currently
+    // unwinding (std::uncaught_exceptions() > 0), swallow exceptions from
+    // the closure to prevent std::terminate.
+    ~Defer() noexcept(false) {
+        if (std::uncaught_exceptions() > 0) {
+            try {
+                _closure();
+            } catch (...) {
+                // swallow: cannot safely rethrow during stack unwind
+                // Log the exception for debugging. Try to get std::exception::what()
+                try {
+                    throw;
+                } catch (const std::exception& e) {
+                    LOG(WARNING) << "Exception swallowed in Defer destructor during unwind: "
+                               << e.what();
+                } catch (...) {
+                    LOG(WARNING) << "Unknown exception swallowed in Defer destructor during unwind";
+                }
+            }
+        } else {
+            // No active exception: let any exception escape to caller.
+            _closure();
+        }
+    }
 
 private:
     T _closure;

--- a/be/src/util/defer_op.h
+++ b/be/src/util/defer_op.h
@@ -21,6 +21,7 @@
 #include <utility>
 
 #include "common/logging.h"
+#include "util/stack_util.h"
 
 namespace doris {
 
@@ -60,9 +61,12 @@ public:
                     throw;
                 } catch (const std::exception& e) {
                     LOG(WARNING) << "Exception swallowed in Defer destructor during unwind: "
-                                 << e.what();
+                                 << e.what() << ", stack trace:\n"
+                                 << get_stack_trace();
                 } catch (...) {
-                    LOG(WARNING) << "Unknown exception swallowed in Defer destructor during unwind";
+                    LOG(WARNING) << "Unknown exception swallowed in Defer destructor during unwind"
+                                 << ", stack trace:\n"
+                                 << get_stack_trace();
                 }
             }
         } else {

--- a/be/src/util/defer_op.h
+++ b/be/src/util/defer_op.h
@@ -17,10 +17,10 @@
 
 #pragma once
 
-#include <functional>
-#include <exception> // for std::uncaught_exceptions
-#include "common/logging.h"
+#include <exception>
 #include <utility>
+
+#include "common/logging.h"
 
 namespace doris {
 
@@ -60,7 +60,7 @@ public:
                     throw;
                 } catch (const std::exception& e) {
                     LOG(WARNING) << "Exception swallowed in Defer destructor during unwind: "
-                               << e.what();
+                                 << e.what();
                 } catch (...) {
                     LOG(WARNING) << "Unknown exception swallowed in Defer destructor during unwind";
                 }

--- a/be/test/util/defer_op_test.cpp
+++ b/be/test/util/defer_op_test.cpp
@@ -19,8 +19,6 @@
 
 #include <gtest/gtest.h>
 
-#include "common/logging.h"
-
 namespace doris {
 
 TEST(DeferOpTest, ThrowEscapesWhenNotUnwinding) {

--- a/be/test/util/defer_op_test.cpp
+++ b/be/test/util/defer_op_test.cpp
@@ -1,0 +1,66 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "util/defer_op.h"
+
+#include <gtest/gtest.h>
+
+#include "common/logging.h"
+
+namespace doris {
+
+TEST(DeferOpTest, ThrowEscapesWhenNotUnwinding) {
+    bool threw = false;
+    try {
+        doris::Defer guard([]() { throw std::runtime_error("defer-throws"); });
+        // destructor will run at scope exit and should propagate the exception
+    } catch (const std::runtime_error& e) {
+        threw = true;
+        EXPECT_STREQ(e.what(), "defer-throws");
+    }
+    EXPECT_TRUE(threw);
+}
+
+TEST(DeferOpTest, SwallowDuringUnwind) {
+    // This test ensures that if we're already unwinding, the Defer's exception
+    // does not call std::terminate. To actually run the Defer destructor
+    // during stack unwinding we must create it in a frame that is being
+    // unwound. Creating it inside a catch-handler would be after unwind
+    // completed, so that does not test the intended behavior.
+    bool reached_catch = false;
+
+    auto throwing_func = []() {
+        doris::Defer guard([]() { throw std::runtime_error("inner-defer"); });
+        // throwing here will cause stack unwind while `guard` is destroyed
+        throw std::runtime_error("outer");
+    };
+
+    try {
+        throwing_func();
+    } catch (const std::runtime_error& e) {
+        // We should catch the outer exception here; the inner exception
+        // thrown by the Defer's closure must have been swallowed during
+        // the unwind (otherwise we'd have terminated or a different
+        // exception would propagate).
+        reached_catch = true;
+        EXPECT_STREQ(e.what(), "outer");
+    }
+
+    EXPECT_TRUE(reached_catch);
+}
+
+} // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?
This pull request improves the safety and robustness of the `Defer` utility by enhancing its exception handling during destruction and adds unit tests to verify the new behavior. The main focus is to ensure that exceptions thrown by deferred closures are handled correctly, especially during stack unwinding, to prevent unexpected program termination.

**Enhancements to exception handling in `Defer`:**

* Updated the destructor of the `Defer` class in `defer_op.h` to distinguish between normal destruction and stack unwinding:
  * If an exception is already active (stack unwinding), any exception thrown by the deferred closure is caught and swallowed, with a warning logged instead of calling `std::terminate`.
  * If no exception is active, exceptions from the closure are allowed to propagate. The destructor is now marked `noexcept(false)` to permit this. [[1]](diffhunk://#diff-84aeaa7dcc3d0aefe32d3830f93e34bad19d54bff6cacbab39e39749c4c45133R21-R23) [[2]](diffhunk://#diff-84aeaa7dcc3d0aefe32d3830f93e34bad19d54bff6cacbab39e39749c4c45133R35-R72)

**Testing improvements:**

* Added a new test file `defer_op_test.cpp` with unit tests to verify:
  * That exceptions from the deferred closure propagate when not unwinding.
  * That exceptions are swallowed (and do not cause termination) when the destructor runs during stack unwinding.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

