### PR TITLE
[Fix](job) fix drop db error and duplicate fragment_id when retry

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -110,7 +110,7 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
     private String tvfType;
     private Map<String, String> originTvfProps;
     @Getter
-    volatile StreamingInsertTask runningStreamTask;
+    StreamingInsertTask runningStreamTask;
     SourceOffsetProvider offsetProvider;
     @Setter
     @Getter

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -324,7 +324,7 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
                     runningStreamTask.getTaskId(), runningStreamTask.getIsCanceled().get());
             runningStreamTask.cancel(true);
             runningStreamTask.closeOrReleaseResources();
-            runningStreamTask = null;
+            // runningStreamTask = null;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -324,7 +324,7 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
                     runningStreamTask.getTaskId(), runningStreamTask.getIsCanceled().get());
             runningStreamTask.cancel(true);
             runningStreamTask.closeOrReleaseResources();
-            // runningStreamTask = null;
+            runningStreamTask = null;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -250,6 +250,7 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
             if (isFinalStatus()) {
                 Env.getCurrentGlobalTransactionMgr().getCallbackFactory().removeCallback(getJobId());
             }
+            log.info("Streaming insert job {} update status to {}", getJobId(), getJobStatus());
         } finally {
             lock.writeLock().unlock();
         }
@@ -315,6 +316,8 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
 
     public void clearRunningStreamTask() {
         if (runningStreamTask != null) {
+            log.info("clear running streaming insert task for job {}, task {} ",
+                    getJobId(), runningStreamTask.getTaskId());
             runningStreamTask.closeOrReleaseResources();
             runningStreamTask = null;
         }
@@ -565,6 +568,9 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         writeLock();
         try {
             ArrayList<Long> taskIds = new ArrayList<>();
+            log.info("prepare to commit streaming insert job {}, running task is {}",
+                    getJobId(),
+                    runningStreamTask == null ? "null" : runningStreamTask.getTaskId());
             taskIds.add(runningStreamTask.getTaskId());
             // todo: Check whether the taskid of runningtask is consistent with the taskid associated with txn
 

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertTask.java
@@ -27,6 +27,7 @@ import org.apache.doris.job.exception.JobException;
 import org.apache.doris.job.extensions.insert.InsertTask;
 import org.apache.doris.job.offset.Offset;
 import org.apache.doris.job.offset.SourceOffsetProvider;
+import org.apache.doris.job.offset.s3.S3Offset;
 import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.glue.LogicalPlanAdapter;
 import org.apache.doris.nereids.parser.NereidsParser;
@@ -130,6 +131,7 @@ public class StreamingInsertTask {
 
         if (isCanceled.get()) {
             log.info("streaming insert task has been canceled, task id is {}", getTaskId());
+            return;
         }
         ctx = InsertTask.makeConnectContext(userIdentity, currentDb);
         ctx.setSessionVariable(jobProperties.getSessionVariable());
@@ -155,7 +157,8 @@ public class StreamingInsertTask {
             log.info("task has been canceled, task id is {}", getTaskId());
             return;
         }
-        log.info("start to run streaming insert task, label {}, offset is {}", labelName, runningOffset.toString());
+        log.info("start to run streaming insert task, label {}, offset is {}, filepath {}",
+                labelName, runningOffset.toString(), ((S3Offset) runningOffset).getFileLists());
         String errMsg = null;
         try {
             taskCommand.run(ctx, stmtExecutor);

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertTask.java
@@ -106,9 +106,10 @@ public class StreamingInsertTask {
                 }
                 this.errMsg = e.getMessage();
                 retryCount++;
-                if (retryCount >= MAX_RETRY) {
+                if (retryCount > MAX_RETRY) {
                     log.error("Task execution failed after {} retries.", MAX_RETRY, e);
                     onFail(e.getMessage());
+                    return;
                 }
                 log.warn("execute streaming task error, job id is {}, task id is {}, retrying {}/{}: {}",
                         jobId, taskId, retryCount, MAX_RETRY, e.getMessage());
@@ -163,10 +164,7 @@ public class StreamingInsertTask {
             } else {
                 errMsg = ctx.getState().getErrorMessage();
             }
-            log.error(
-                    "streaming insert failed with {}, reason {}, to retry",
-                    taskCommand.getLabelName(),
-                    errMsg);
+            throw new JobException(errMsg);
         } catch (Exception e) {
             log.warn("execute insert task error, label is {},offset is {}", taskCommand.getLabelName(),
                     runningOffset.toString(), e);

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingJobSchedulerTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingJobSchedulerTask.java
@@ -122,6 +122,9 @@ public class StreamingJobSchedulerTask extends AbstractTask {
         if (runningTask == null) {
             return null;
         }
+        if (!streamingInsertJob.needScheduleTask()) {
+            return null;
+        }
         TRow trow = new TRow();
         trow.addToColumnValue(new TCell().setStringVal(String.valueOf(runningTask.getTaskId())));
         trow.addToColumnValue(new TCell().setStringVal(String.valueOf(runningTask.getJobId())));

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingJobSchedulerTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingJobSchedulerTask.java
@@ -30,11 +30,13 @@ import org.apache.doris.load.loadv2.LoadJob;
 import org.apache.doris.thrift.TCell;
 import org.apache.doris.thrift.TRow;
 
+import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
 import java.util.List;
 
+@Log4j2
 public class StreamingJobSchedulerTask extends AbstractTask {
     private static final long BACK_OFF_BASIC_TIME_SEC = 10L;
     private static final long MAX_BACK_OFF_TIME_SEC = 60 * 5;
@@ -108,6 +110,7 @@ public class StreamingJobSchedulerTask extends AbstractTask {
 
     @Override
     protected void executeCancelLogic(boolean needWaitCancelComplete) throws Exception {
+        log.info("cancelling streaming insert job scheduler task for job id {}", streamingInsertJob.getJobId());
         if (streamingInsertJob.getRunningStreamTask() != null) {
             streamingInsertJob.getRunningStreamTask().cancel(needWaitCancelComplete);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingJobSchedulerTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingJobSchedulerTask.java
@@ -123,6 +123,7 @@ public class StreamingJobSchedulerTask extends AbstractTask {
             return null;
         }
         if (!streamingInsertJob.needScheduleTask()) {
+            //todo: should list history task
             return null;
         }
         TRow trow = new TRow();

--- a/fe/fe-core/src/main/java/org/apache/doris/job/manager/JobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/manager/JobManager.java
@@ -51,6 +51,7 @@ import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.plans.commands.AlterJobCommand;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.rpc.RpcException;
 
 import com.google.common.collect.Lists;
 import lombok.Getter;
@@ -241,25 +242,25 @@ public class JobManager<T extends AbstractJob<?, C>, C> implements Writable {
     }
 
     private void deleteStremingJob(AbstractJob<?, C> job) throws JobException {
-        boolean isStreamingJob = job.getJobConfig().getExecuteType().equals(JobExecuteType.STREAMING);
-        if (!(Config.isCloudMode() && isStreamingJob)) {
+        if (!(Config.isCloudMode() && job instanceof StreamingInsertJob)) {
             return;
         }
+        StreamingInsertJob streamingJob = (StreamingInsertJob) job;
+        Cloud.DeleteStreamingJobResponse resp = null;
         try {
-            long dbId = Env.getCurrentInternalCatalog().getDbOrDdlException(job.getCurrentDbName()).getId();
             Cloud.DeleteStreamingJobRequest req = Cloud.DeleteStreamingJobRequest.newBuilder()
                     .setCloudUniqueId(Config.cloud_unique_id)
-                    .setDbId(dbId)
+                    .setDbId(streamingJob.getDbId())
                     .setJobId(job.getJobId())
                     .build();
-            Cloud.DeleteStreamingJobResponse resp = MetaServiceProxy.getInstance().deleteStreamingJob(req);
+            resp = MetaServiceProxy.getInstance().deleteStreamingJob(req);
             if (resp.getStatus().getCode() != Cloud.MetaServiceCode.OK) {
-                throw new JobException("deleteJobKey failed for jobId={}, dbId={}, status={}",
-                        job.getJobId(), dbId, resp.getStatus());
+                log.warn("failed to delete streaming job, response: {}", resp);
+                throw new JobException("deleteJobKey failed for jobId=%s, dbId=%s, status=%s",
+                        job.getJobId(), job.getJobId(), resp.getStatus());
             }
-        } catch (Exception e) {
-            throw new JobException("deleteJobKey exception for jobId={}, dbName={}",
-                    job.getJobId(), job.getCurrentDbName(), e);
+        } catch (RpcException e) {
+            log.warn("failed to delete streaming job {}", resp, e);
         }
     }
 

--- a/regression-test/suites/job_p0/streaming_job/test_streaming_insert_job.groovy
+++ b/regression-test/suites/job_p0/streaming_job/test_streaming_insert_job.groovy
@@ -65,7 +65,7 @@ suite("test_streaming_insert_job") {
         Awaitility.await().atMost(300, SECONDS)
                 .pollInterval(1, SECONDS).until(
                 {
-                    def jobSuccendCount = sql """ select SucceedTaskCount from jobs("type"="insert") where Name like '%${jobName}%' and ExecuteType='STREAMING' """
+                    def jobSuccendCount = sql """ select SucceedTaskCount from jobs("type"="insert") where Name = '${jobName}' and ExecuteType='STREAMING' """
                     log.info("jobSuccendCount: " + jobSuccendCount)
                     // check job status and succeed task count larger than 2
                     jobSuccendCount.size() == 1 && '2' <= jobSuccendCount.get(0).get(0)

--- a/regression-test/suites/job_p0/streaming_job/test_streaming_insert_job_drop.groovy
+++ b/regression-test/suites/job_p0/streaming_job/test_streaming_insert_job_drop.groovy
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+import org.awaitility.Awaitility
+
+import static java.util.concurrent.TimeUnit.SECONDS
+
+suite("test_streaming_insert_job_drop") {
+    def tableName = "test_streaming_insert_job_tbl_drop"
+    def jobName = "test_streaming_insert_job_name_drop"
+
+    sql """drop table if exists `${tableName}` force"""
+    sql """
+        DROP JOB IF EXISTS where jobname =  '${jobName}'
+    """
+    def dropDatabase = "test_streaming_insert_job_drop_db"
+    sql """create database if not exists ${dropDatabase}"""
+    sql """use ${dropDatabase}"""
+
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tableName} (
+            `c1` int NULL,
+            `c2` string NULL,
+            `c3` int  NULL,
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`c1`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`c1`) BUCKETS 3
+        PROPERTIES ("replication_allocation" = "tag.location.default: 1");
+    """
+
+    // create streaming job
+    sql """
+       CREATE JOB ${jobName}  
+       PROPERTIES(
+        "s3.max_batch_files" = "1"
+       )
+       ON STREAMING DO INSERT INTO ${tableName} 
+       SELECT * FROM S3
+        (
+            "uri" = "s3://${s3BucketName}/regression/load/data/example_[0-1].csv",
+            "format" = "csv",
+            "provider" = "${getS3Provider()}",
+            "column_separator" = ",",
+            "s3.endpoint" = "${getS3Endpoint()}",
+            "s3.region" = "${getS3Region()}",
+            "s3.access_key" = "${getS3AK()}",
+            "s3.secret_key" = "${getS3SK()}"
+        );
+    """
+    try {
+        Awaitility.await().atMost(300, SECONDS)
+                .pollInterval(1, SECONDS).until(
+                {
+                    def jobSuccendCount = sql """ select SucceedTaskCount from jobs("type"="insert") where Name = '${jobName}' and ExecuteType='STREAMING' """
+                    log.info("jobSuccendCount: " + jobSuccendCount)
+                    // check job status and succeed task count larger than 2
+                    jobSuccendCount.size() == 1 && '2' <= jobSuccendCount.get(0).get(0)
+                }
+        )
+    } catch (Exception ex){
+        def showjob = sql """select * from jobs("type"="insert") where Name='${jobName}'"""
+        def showtask = sql """select * from tasks("type"="insert") where JobName='${jobName}'"""
+        log.info("show job: " + showjob)
+        log.info("show task: " + showtask)
+        throw ex;
+    }
+
+    def jobResult = sql """select * from jobs("type"="insert") where Name='${jobName}'"""
+    log.info("show success job: " + jobResult)
+
+    // drop dataabse
+    sql """drop database ${dropDatabase} force"""
+
+    // drop job
+    sql """
+        DROP JOB IF EXISTS where jobname = '${jobName}'
+    """
+
+    def jobCountRsp = sql """select count(1) from jobs("type"="insert")  where Name ='${jobName}'"""
+    assert jobCountRsp.get(0).get(0) == 0
+}

--- a/regression-test/suites/job_p0/streaming_job/test_streaming_insert_job_task_retry.groovy
+++ b/regression-test/suites/job_p0/streaming_job/test_streaming_insert_job_task_retry.groovy
@@ -1,0 +1,92 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+import org.awaitility.Awaitility
+
+import static java.util.concurrent.TimeUnit.SECONDS
+
+suite("test_streaming_insert_job_task_retry", 'nonConcurrent') {
+    def tableName = "test_streaming_insert_job_tbl_task_retry"
+    def jobName = "test_streaming_insert_job_name_task_retry"
+
+    sql """drop table if exists `${tableName}` force"""
+    sql """
+        DROP JOB IF EXISTS where jobname =  '${jobName}'
+    """
+
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tableName} (
+            `c1` int NULL,
+            `c2` string NULL,
+            `c3` int  NULL,
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`c1`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`c1`) BUCKETS 3
+        PROPERTIES ("replication_allocation" = "tag.location.default: 1");
+    """
+
+    // create streaming job
+    sql """
+       CREATE JOB ${jobName}  
+       PROPERTIES(
+        "session.insert_timeout" = "1",
+        "session.query_timeout" = "1"
+       )
+       ON STREAMING DO INSERT INTO ${tableName} 
+       SELECT c1, c2, sleep(10) FROM S3
+        (
+            "uri" = "s3://${s3BucketName}/regression/load/data/example_[0-1].csv",
+            "format" = "csv",
+            "provider" = "${getS3Provider()}",
+            "column_separator" = ",",
+            "s3.endpoint" = "${getS3Endpoint()}",
+            "s3.region" = "${getS3Region()}",
+            "s3.access_key" = "${getS3AK()}",
+            "s3.secret_key" = "${getS3SK()}"
+        );
+    """
+    try {
+        Awaitility.await().atMost(300, SECONDS)
+                .pollInterval(1, SECONDS).until(
+                {
+                    def jobStatus = sql """ select Status,FailedTaskCount from jobs("type"="insert") where Name = '${jobName}' and ExecuteType='STREAMING' """
+                    log.info("jobStatus: " + jobStatus)
+                    jobStatus.size() == 1 && 'PAUSED' == jobStatus.get(0).get(0) && '1' == jobStatus.get(0).get(1)
+                }
+        )
+    } catch (Exception ex){
+        def showjob = sql """select * from jobs("type"="insert") where Name='${jobName}'"""
+        def showtask = sql """select * from tasks("type"="insert") where JobName='${jobName}'"""
+        log.info("show job: " + showjob)
+        log.info("show task: " + showtask)
+        throw ex;
+    }
+
+    def jobErrorMsg = sql """select ErrorMsg from jobs("type"="insert") where Name='${jobName}'"""
+    log.info("jobErrorMsg: " + jobErrorMsg)
+    assert jobErrorMsg.get(0).get(0).contains("Execute timeout")
+
+    // drop job
+    sql """
+        DROP JOB IF EXISTS where jobname = '${jobName}'
+    """
+
+    def jobCountRsp = sql """select count(1) from jobs("type"="insert")  where Name ='${jobName}'"""
+    assert jobCountRsp.get(0).get(0) == 0
+}


### PR DESCRIPTION
### What problem does this PR solve?
Fixed the following issues:
1. In a cloud environment, if the database has been deleted, attempting to drop a job would result in an error.
2. In a cloud environment, MS offsets were not successfully put, and statistics were inaccurate.
3. When a StreamingTask timed out and retried, a duplicate framement error would be reported.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

