### PR TITLE
[Opt](storage) Add pre decoder for BinaryPlainPageV2 and BinaryDictPage

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1634,6 +1634,8 @@ DEFINE_Validator(binary_plain_encoding_default_impl, [](const std::string& confi
 
 DEFINE_mBool(integer_type_default_use_plain_encoding, "true");
 
+DEFINE_mBool(enable_fuzzy_storage_encoding, "false");
+
 // clang-format off
 #ifdef BE_TEST
 // test s3
@@ -2087,8 +2089,10 @@ Status set_fuzzy_configs() {
             ((distribution(*generator) % 2) == 0) ? "true" : "false";
     fuzzy_field_and_value["max_segment_partial_column_cache_size"] =
             ((distribution(*generator) % 2) == 0) ? "5" : "10";
-    fuzzy_field_and_value["binary_plain_encoding_default_impl"] =
-            ((distribution(*generator) % 2) == 0) ? "v1" : "v2";
+    if (config::enable_fuzzy_storage_encoding) {
+        fuzzy_field_and_value["binary_plain_encoding_default_impl"] =
+                ((distribution(*generator) % 2) == 0) ? "v1" : "v2";
+    }
 
     std::uniform_int_distribution<int64_t> distribution2(-2, 10);
     fuzzy_field_and_value["segments_key_bounds_truncation_threshold"] =

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1627,7 +1627,7 @@ DEFINE_Validator(aws_credentials_provider_version, [](const std::string& config)
     return config == "v1" || config == "v2";
 });
 
-DEFINE_mString(binary_plain_encoding_default_impl, "v2");
+DEFINE_mString(binary_plain_encoding_default_impl, "v1");
 DEFINE_Validator(binary_plain_encoding_default_impl, [](const std::string& config) -> bool {
     return config == "v1" || config == "v2";
 });

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1627,7 +1627,7 @@ DEFINE_Validator(aws_credentials_provider_version, [](const std::string& config)
     return config == "v1" || config == "v2";
 });
 
-DEFINE_mString(binary_plain_encoding_default_impl, "v1");
+DEFINE_mString(binary_plain_encoding_default_impl, "v2");
 DEFINE_Validator(binary_plain_encoding_default_impl, [](const std::string& config) -> bool {
     return config == "v1" || config == "v2";
 });

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1674,6 +1674,8 @@ DECLARE_mString(binary_plain_encoding_default_impl);
 
 DECLARE_mBool(integer_type_default_use_plain_encoding);
 
+DECLARE_mBool(enable_fuzzy_storage_encoding);
+
 #ifdef BE_TEST
 // test s3
 DECLARE_String(test_s3_resource);

--- a/be/src/olap/rowset/segment_v2/binary_dict_page_pre_decoder.h
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page_pre_decoder.h
@@ -1,0 +1,128 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "olap/page_cache.h"
+#include "olap/rowset/segment_v2/binary_dict_page.h"
+#include "olap/rowset/segment_v2/binary_plain_page_v2_pre_decoder.h"
+#include "olap/rowset/segment_v2/bitshuffle_page_pre_decoder.h"
+#include "olap/rowset/segment_v2/encoding_info.h"
+#include "util/coding.h"
+
+namespace doris {
+namespace segment_v2 {
+
+/**
+ * @brief Pre-decoder for BinaryDictPage data pages
+ *
+ * BinaryDictPage data pages can have different encoding types:
+ * 1. DICT_ENCODING: header(4 bytes) + bitshuffle encoded codeword page
+ * 2. PLAIN_ENCODING_V2: header(4 bytes) + BinaryPlainPageV2 encoded data
+ * 3. PLAIN_ENCODING: header(4 bytes) + BinaryPlainPage encoded data (no pre-decode needed)
+ *
+ * This pre-decoder reads the encoding type from the first 4 bytes, strips the header,
+ * dispatches to the appropriate pre-decoder (BitShufflePagePreDecoder or
+ * BinaryPlainPageV2PreDecoder), and then restores the header.
+ */
+struct BinaryDictPagePreDecoder : public DataPagePreDecoder {
+    /**
+     * @brief Decode BinaryDictPage data page
+     *
+     * @param page unique_ptr to hold page data, may be replaced by decoded data
+     * @param page_slice data to decode, will be updated if decoding happens
+     * @param size_of_tail including size of footer and null map
+     * @param _use_cache whether to use page cache
+     * @param page_type the type of page
+     * @param file_path file path for error reporting
+     * @return Status
+     */
+    Status decode(std::unique_ptr<DataPage>* page, Slice* page_slice, size_t size_of_tail,
+                  bool _use_cache, segment_v2::PageTypePB page_type,
+                  const std::string& file_path) override {
+        // Validate minimum size (at least 4 bytes for encoding type)
+        if (page_slice->size < BINARY_DICT_PAGE_HEADER_SIZE) {
+            return Status::Corruption(
+                    "Invalid BinaryDictPage size: {}, expected at least {} in file: {}",
+                    page_slice->size, BINARY_DICT_PAGE_HEADER_SIZE, file_path);
+        }
+
+        // Read encoding type from first 4 bytes
+        auto encoding_type =
+                static_cast<EncodingTypePB>(decode_fixed32_le((const uint8_t*)page_slice->data));
+
+        // For PLAIN_ENCODING, no pre-decoding needed
+        if (encoding_type == PLAIN_ENCODING) {
+            return Status::OK();
+        }
+
+        // For other encoding types, we need to:
+        // 1. Strip the 4-byte header
+        // 2. Apply the appropriate pre-decoder
+        // 3. Restore the 4-byte header in the decoded result
+
+        Slice data_without_header(page_slice->data + BINARY_DICT_PAGE_HEADER_SIZE,
+                                  page_slice->size - BINARY_DICT_PAGE_HEADER_SIZE);
+
+        std::unique_ptr<DataPage> decoded_page_inner;
+        Status status;
+
+        switch (encoding_type) {
+        case DICT_ENCODING: {
+            // Use BitShufflePagePreDecoder (without USED_IN_DICT_ENCODING)
+            BitShufflePagePreDecoder bitshuffle_decoder;
+            status = bitshuffle_decoder.decode(&decoded_page_inner, &data_without_header,
+                                               size_of_tail, _use_cache, page_type, file_path);
+            break;
+        }
+        case PLAIN_ENCODING_V2: {
+            // Use BinaryPlainPageV2PreDecoder
+            BinaryPlainPageV2PreDecoder v2_decoder;
+            status = v2_decoder.decode(&decoded_page_inner, &data_without_header, size_of_tail,
+                                       _use_cache, page_type, file_path);
+            break;
+        }
+        default:
+            // Unknown encoding type, no pre-decoding needed
+            return Status::OK();
+        }
+
+        RETURN_IF_ERROR(status);
+
+        // Allocate new page with space for 4-byte header
+        Slice final_slice;
+        final_slice.size = BINARY_DICT_PAGE_HEADER_SIZE + data_without_header.size;
+        std::unique_ptr<DataPage> final_page =
+                std::make_unique<DataPage>(final_slice.size, _use_cache, page_type);
+        final_slice.data = final_page->data();
+
+        // Copy header
+        memcpy(final_slice.data, page_slice->data, BINARY_DICT_PAGE_HEADER_SIZE);
+
+        // Copy decoded data
+        memcpy(final_slice.data + BINARY_DICT_PAGE_HEADER_SIZE, data_without_header.data,
+               data_without_header.size);
+
+        *page_slice = final_slice;
+        *page = std::move(final_page);
+
+        return Status::OK();
+    }
+};
+
+} // namespace segment_v2
+} // namespace doris

--- a/be/src/olap/rowset/segment_v2/binary_plain_page_v2_pre_decoder.h
+++ b/be/src/olap/rowset/segment_v2/binary_plain_page_v2_pre_decoder.h
@@ -53,9 +53,8 @@ struct BinaryPlainPageV2PreDecoder : public DataPagePreDecoder {
                   bool _use_cache, segment_v2::PageTypePB page_type) override {
         // Validate input
         if (page_slice->size < sizeof(uint32_t) + size_of_tail) {
-            return Status::Corruption(
-                    "Invalid page size: {}, expected at least {}", page_slice->size,
-                    sizeof(uint32_t) + size_of_tail);
+            return Status::Corruption("Invalid page size: {}, expected at least {}",
+                                      page_slice->size, sizeof(uint32_t) + size_of_tail);
         }
 
         // Calculate data portion (excluding tail)

--- a/be/src/olap/rowset/segment_v2/binary_plain_page_v2_pre_decoder.h
+++ b/be/src/olap/rowset/segment_v2/binary_plain_page_v2_pre_decoder.h
@@ -137,12 +137,12 @@ struct BinaryPlainPageV2PreDecoder : public DataPagePreDecoder {
 
         // Step 2: Write offsets array
         for (uint32_t offset : offsets) {
-            put_fixed32_le(reinterpret_cast<uint8_t*>(output), offset);
+            encode_fixed32_le(reinterpret_cast<uint8_t*>(output), offset);
             output += sizeof(uint32_t);
         }
 
         // Step 3: Write num_elems
-        put_fixed32_le(reinterpret_cast<uint8_t*>(output), num_elems);
+        encode_fixed32_le(reinterpret_cast<uint8_t*>(output), num_elems);
         output += sizeof(uint32_t);
 
         // Step 4: Copy tail (footer and null map)

--- a/be/src/olap/rowset/segment_v2/binary_plain_page_v2_pre_decoder.h
+++ b/be/src/olap/rowset/segment_v2/binary_plain_page_v2_pre_decoder.h
@@ -1,0 +1,163 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "olap/page_cache.h"
+#include "olap/rowset/segment_v2/encoding_info.h"
+#include "util/coding.h"
+
+namespace doris {
+namespace segment_v2 {
+
+/**
+ * @brief Pre-decoder for BinaryPlainPageV2
+ *
+ * Converts BinaryPlainPageV2 format (varint-encoded lengths) to BinaryPlainPage format
+ * (offset array) to enable O(1) seeking without scanning the entire page.
+ *
+ * V2 format (input):
+ *   Data: |length1(varuint)|binary1|length2(varuint)|binary2|...
+ *   Trailer: num_elems (32-bit)
+ *
+ * V1 format (output):
+ *   Data: |binary1|binary2|...
+ *   Trailer: |offset1(32-bit)|offset2(32-bit)|...| num_elems (32-bit)
+ */
+struct BinaryPlainPageV2PreDecoder : public DataPagePreDecoder {
+    /**
+     * @brief Decode BinaryPlainPageV2 data to BinaryPlainPage format
+     *
+     * @param page unique_ptr to hold page data, will be replaced by decoded data
+     * @param page_slice data to decode, will be updated to point to decoded data
+     * @param size_of_tail including size of footer and null map
+     * @param _use_cache whether to use page cache
+     * @param page_type the type of page
+     * @return Status
+     */
+    Status decode(std::unique_ptr<DataPage>* page, Slice* page_slice, size_t size_of_tail,
+                  bool _use_cache, segment_v2::PageTypePB page_type) override {
+        // Validate input
+        if (page_slice->size < sizeof(uint32_t) + size_of_tail) {
+            return Status::Corruption(
+                    "Invalid page size: {}, expected at least {}", page_slice->size,
+                    sizeof(uint32_t) + size_of_tail);
+        }
+
+        // Calculate data portion (excluding tail)
+        Slice data(page_slice->data, page_slice->size - size_of_tail);
+
+        // Read num_elems from the last 4 bytes of data portion
+        if (data.size < sizeof(uint32_t)) {
+            return Status::Corruption("Data too small to contain num_elems");
+        }
+
+        uint32_t num_elems = decode_fixed32_le(
+                reinterpret_cast<const uint8_t*>(&data[data.size - sizeof(uint32_t)]));
+
+        // Calculate required size for V1 format
+        // V1 format: binary_data + offsets_array + num_elems + tail
+        // We need to parse V2 to calculate the total binary data size
+        const uint8_t* ptr = reinterpret_cast<const uint8_t*>(data.data);
+        const uint8_t* limit = ptr + data.size - sizeof(uint32_t);
+
+        std::vector<uint32_t> offsets;
+        offsets.reserve(num_elems);
+
+        uint32_t current_offset = 0;
+        for (uint32_t i = 0; i < num_elems; i++) {
+            if (ptr >= limit) {
+                return Status::Corruption(
+                        "Unexpected end of data while parsing BinaryPlainPageV2PreDecoder");
+            }
+
+            // Decode varuint length
+            uint32_t length;
+            const uint8_t* data_start = decode_varint32_ptr(ptr, limit, &length);
+            if (data_start == nullptr) {
+                return Status::Corruption(
+                        "Failed to decode varuint in BinaryPlainPageV2PreDecoder");
+            }
+
+            // Store offset for this element
+            offsets.push_back(current_offset);
+            current_offset += length;
+
+            // Move to next entry
+            ptr = data_start + length;
+
+            if (ptr > limit) {
+                return Status::Corruption(
+                        "Data extends beyond page in BinaryPlainPageV2PreDecoder");
+            }
+        }
+
+        // Calculate size for V1 format
+        size_t binary_data_size = current_offset;
+        size_t offsets_size = num_elems * sizeof(uint32_t);
+        size_t v1_data_size = binary_data_size + offsets_size + sizeof(uint32_t);
+        size_t total_size = v1_data_size + size_of_tail;
+
+        // Allocate new page
+        Slice decoded_slice;
+        decoded_slice.size = total_size;
+        std::unique_ptr<DataPage> decoded_page =
+                std::make_unique<DataPage>(decoded_slice.size, _use_cache, page_type);
+        decoded_slice.data = decoded_page->data();
+
+        // Write V1 format data
+        char* output = decoded_slice.data;
+
+        // Step 1: Write binary data (without varint prefixes)
+        ptr = reinterpret_cast<const uint8_t*>(data.data);
+        for (uint32_t i = 0; i < num_elems; i++) {
+            uint32_t length;
+            const uint8_t* data_start = decode_varint32_ptr(ptr, limit, &length);
+
+            // Copy binary data
+            memcpy(output, data_start, length);
+            output += length;
+
+            // Move to next entry
+            ptr = data_start + length;
+        }
+
+        // Step 2: Write offsets array
+        for (uint32_t offset : offsets) {
+            put_fixed32_le(reinterpret_cast<uint8_t*>(output), offset);
+            output += sizeof(uint32_t);
+        }
+
+        // Step 3: Write num_elems
+        put_fixed32_le(reinterpret_cast<uint8_t*>(output), num_elems);
+        output += sizeof(uint32_t);
+
+        // Step 4: Copy tail (footer and null map)
+        if (size_of_tail > 0) {
+            memcpy(output, page_slice->data + page_slice->size - size_of_tail, size_of_tail);
+        }
+
+        // Update output parameters
+        *page_slice = decoded_slice;
+        *page = std::move(decoded_page);
+
+        return Status::OK();
+    }
+};
+
+} // namespace segment_v2
+} // namespace doris

--- a/be/src/olap/rowset/segment_v2/bitshuffle_page_pre_decoder.h
+++ b/be/src/olap/rowset/segment_v2/bitshuffle_page_pre_decoder.h
@@ -73,10 +73,9 @@ struct BitShufflePagePreDecoder : public DataPagePreDecoder {
 
         memcpy(decoded_slice.data, data.data, BITSHUFFLE_PAGE_HEADER_SIZE);
 
-        auto bytes = bitshuffle::decompress_lz4(
-                &data.data[BITSHUFFLE_PAGE_HEADER_SIZE],
-                decoded_slice.data + BITSHUFFLE_PAGE_HEADER_SIZE,
-                num_element_after_padding, size_of_element, 0);
+        auto bytes = bitshuffle::decompress_lz4(&data.data[BITSHUFFLE_PAGE_HEADER_SIZE],
+                                                decoded_slice.data + BITSHUFFLE_PAGE_HEADER_SIZE,
+                                                num_element_after_padding, size_of_element, 0);
         if (bytes < 0) [[unlikely]] {
             // Ideally, this should not happen.
             warn_with_bitshuffle_error(bytes);

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -182,7 +182,7 @@ public:
     // read a page from file into a page handle
     Status read_page(const ColumnIteratorOptions& iter_opts, const PagePointer& pp,
                      PageHandle* handle, Slice* page_body, PageFooterPB* footer,
-                     BlockCompressionCodec* codec) const;
+                     BlockCompressionCodec* codec, bool is_dict_page = false) const;
 
     bool is_nullable() const { return _meta_is_nullable; }
 

--- a/be/src/olap/rowset/segment_v2/encoding_info.cpp
+++ b/be/src/olap/rowset/segment_v2/encoding_info.cpp
@@ -30,6 +30,7 @@
 #include "olap/rowset/segment_v2/binary_dict_page.h"
 #include "olap/rowset/segment_v2/binary_plain_page.h"
 #include "olap/rowset/segment_v2/binary_plain_page_v2.h"
+#include "olap/rowset/segment_v2/binary_plain_page_v2_pre_decoder.h"
 #include "olap/rowset/segment_v2/binary_prefix_page.h"
 #include "olap/rowset/segment_v2/bitshuffle_page.h"
 #include "olap/rowset/segment_v2/bitshuffle_page_pre_decoder.h"
@@ -417,6 +418,12 @@ EncodingInfo::EncodingInfo(TraitsClass traits)
         _data_page_pre_decoder = std::make_unique<BitShufflePagePreDecoder<false>>();
     } else if (_encoding == DICT_ENCODING) {
         _data_page_pre_decoder = std::make_unique<BitShufflePagePreDecoder<true>>();
+    } else if (_encoding == PLAIN_ENCODING_V2) {
+        // Only binary types (Slice) need the predecoder for PLAIN_ENCODING_V2
+        // to convert varint-encoded lengths to offset array format
+        if (field_is_slice_type(_type)) {
+            _data_page_pre_decoder = std::make_unique<BinaryPlainPageV2PreDecoder>();
+        }
     }
 }
 

--- a/be/src/olap/rowset/segment_v2/encoding_info.cpp
+++ b/be/src/olap/rowset/segment_v2/encoding_info.cpp
@@ -421,7 +421,7 @@ EncodingInfo::EncodingInfo(TraitsClass traits)
     } else if (_encoding == PLAIN_ENCODING_V2) {
         // Only binary types (Slice) need the predecoder for PLAIN_ENCODING_V2
         // to convert varint-encoded lengths to offset array format
-        if (field_is_slice_type(_type)) {
+        if constexpr (std::is_same_v<typename TraitsClass::CppType, Slice>) {
             _data_page_pre_decoder = std::make_unique<BinaryPlainPageV2PreDecoder>();
         }
     }

--- a/be/src/olap/rowset/segment_v2/encoding_info.cpp
+++ b/be/src/olap/rowset/segment_v2/encoding_info.cpp
@@ -28,6 +28,7 @@
 #include "common/config.h"
 #include "olap/olap_common.h"
 #include "olap/rowset/segment_v2/binary_dict_page.h"
+#include "olap/rowset/segment_v2/binary_dict_page_pre_decoder.h"
 #include "olap/rowset/segment_v2/binary_plain_page.h"
 #include "olap/rowset/segment_v2/binary_plain_page_v2.h"
 #include "olap/rowset/segment_v2/binary_plain_page_v2_pre_decoder.h"
@@ -415,9 +416,9 @@ EncodingInfo::EncodingInfo(TraitsClass traits)
           _type(TraitsClass::type),
           _encoding(TraitsClass::encoding) {
     if (_encoding == BIT_SHUFFLE) {
-        _data_page_pre_decoder = std::make_unique<BitShufflePagePreDecoder<false>>();
+        _data_page_pre_decoder = std::make_unique<BitShufflePagePreDecoder>();
     } else if (_encoding == DICT_ENCODING) {
-        _data_page_pre_decoder = std::make_unique<BitShufflePagePreDecoder<true>>();
+        _data_page_pre_decoder = std::make_unique<BinaryDictPagePreDecoder>();
     } else if (_encoding == PLAIN_ENCODING_V2) {
         // Only binary types (Slice) need the predecoder for PLAIN_ENCODING_V2
         // to convert varint-encoded lengths to offset array format

--- a/be/src/olap/rowset/segment_v2/encoding_info.h
+++ b/be/src/olap/rowset/segment_v2/encoding_info.h
@@ -45,7 +45,7 @@ class DataPagePreDecoder {
 public:
     virtual Status decode(std::unique_ptr<DataPage>* page, Slice* page_slice, size_t size_of_tail,
                           bool _use_cache, segment_v2::PageTypePB page_type,
-                          const std::string& file_path) = 0;
+                          const std::string& file_path, size_t size_of_prefix = 0) = 0;
     virtual ~DataPagePreDecoder() = default;
 };
 

--- a/be/src/olap/rowset/segment_v2/encoding_info.h
+++ b/be/src/olap/rowset/segment_v2/encoding_info.h
@@ -44,7 +44,8 @@ enum EncodingTypePB : int;
 class DataPagePreDecoder {
 public:
     virtual Status decode(std::unique_ptr<DataPage>* page, Slice* page_slice, size_t size_of_tail,
-                          bool _use_cache, segment_v2::PageTypePB page_type) = 0;
+                          bool _use_cache, segment_v2::PageTypePB page_type,
+                          const std::string& file_path) = 0;
     virtual ~DataPagePreDecoder() = default;
 };
 

--- a/be/src/olap/rowset/segment_v2/encoding_info.h
+++ b/be/src/olap/rowset/segment_v2/encoding_info.h
@@ -127,6 +127,7 @@ struct TypeEncodingTraits {};
 template <FieldType field_type, EncodingTypePB encoding_type>
 struct EncodingTraits : TypeEncodingTraits<field_type, encoding_type,
                                            typename CppTypeTraits<field_type>::CppType> {
+    using CppType = typename CppTypeTraits<field_type>::CppType;
     static const FieldType type = field_type;
     static const EncodingTypePB encoding = encoding_type;
 };

--- a/be/src/olap/rowset/segment_v2/page_io.cpp
+++ b/be/src/olap/rowset/segment_v2/page_io.cpp
@@ -230,7 +230,7 @@ Status PageIO::read_and_decompress_page_(const PageReadOptions& opts, PageHandle
         if (pre_decoder) {
             RETURN_IF_ERROR(pre_decoder->decode(
                     &page, &page_slice, footer->data_page_footer().nullmap_size() + footer_size + 4,
-                    opts.use_page_cache, opts.type));
+                    opts.use_page_cache, opts.type, opts.file_reader->path().native()));
         }
     }
 

--- a/be/src/olap/rowset/segment_v2/page_io.h
+++ b/be/src/olap/rowset/segment_v2/page_io.h
@@ -72,6 +72,10 @@ struct PageReadOptions {
 
     const io::IOContext io_ctx;
 
+    // for dict page, we need to use encoding_info based on footer->dict_page_footer().encoding()
+    // to get its pre_decoder
+    bool is_dict_page {false};
+
     void sanity_check() const {
         CHECK_NOTNULL(file_reader);
         CHECK_NOTNULL(stats);
@@ -89,6 +93,7 @@ struct PageReadOptions {
         type = old.type;
         encoding_info = old.encoding_info;
         pre_decode = old.pre_decode;
+        is_dict_page = old.is_dict_page;
     }
 };
 

--- a/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
@@ -93,7 +93,7 @@ public:
     // Decode bitshuffle encoded page
     Status decode_bitshuffle_page(Slice& page_slice, std::unique_ptr<DataPage>& decoded_page) {
         segment_v2::BitShufflePagePreDecoder<true> pre_decoder;
-        return pre_decoder.decode(&decoded_page, &page_slice, 0, false, PageTypePB::DATA_PAGE);
+        return pre_decoder.decode(&decoded_page, &page_slice, 0, false, PageTypePB::DATA_PAGE, "");
     }
 
     // Create and setup a BinaryDictPageBuilder with data

--- a/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
@@ -27,10 +27,10 @@
 #include "common/config.h"
 #include "common/logging.h"
 #include "olap/olap_common.h"
+#include "olap/rowset/segment_v2/binary_dict_page_pre_decoder.h"
 #include "olap/rowset/segment_v2/binary_plain_page.h"
 #include "olap/rowset/segment_v2/binary_plain_page_v2.h"
 #include "olap/rowset/segment_v2/binary_plain_page_v2_pre_decoder.h"
-#include "olap/rowset/segment_v2/bitshuffle_page_pre_decoder.h"
 #include "olap/rowset/segment_v2/page_builder.h"
 #include "olap/rowset/segment_v2/page_decoder.h"
 #include "olap/types.h"
@@ -67,8 +67,21 @@ public:
     }
 
     // Create dict page decoder based on encoding type
-    std::unique_ptr<PageDecoder> create_dict_page_decoder(Slice& dict_slice,
-                                                          EncodingTypePB encoding_type) {
+    // The decoded_page parameter is passed by reference to ensure the decoded data's lifetime
+    // is managed by the caller, preventing the data from being freed prematurely
+    std::unique_ptr<PageDecoder> create_dict_page_decoder(
+            Slice& dict_slice, EncodingTypePB encoding_type,
+            std::unique_ptr<DataPage>& decoded_page) {
+        // Apply pre-decode for BinaryPlainPageV2
+        if (encoding_type == PLAIN_ENCODING_V2) {
+            BinaryPlainPageV2PreDecoder pre_decoder;
+            Status status = pre_decoder.decode(&decoded_page, &dict_slice, 0, false,
+                                               PageTypePB::DATA_PAGE, "");
+            if (!status.ok()) {
+                return nullptr;
+            }
+        }
+
         PageDecoderOptions dict_decoder_options;
         std::unique_ptr<PageDecoder> dict_page_decoder;
 
@@ -76,13 +89,6 @@ public:
             dict_page_decoder.reset(new BinaryPlainPageDecoder<FieldType::OLAP_FIELD_TYPE_VARCHAR>(
                     dict_slice, dict_decoder_options));
         } else if (encoding_type == PLAIN_ENCODING_V2) {
-            // Apply pre-decode for BinaryPlainPageV2
-            std::unique_ptr<DataPage> decoded_page;
-            Status status = apply_pre_decode_v2(dict_slice, decoded_page);
-            if (!status.ok()) {
-                return nullptr;
-            }
-
             dict_page_decoder.reset(
                     new BinaryPlainPageV2Decoder<FieldType::OLAP_FIELD_TYPE_VARCHAR>(
                             dict_slice, dict_decoder_options));
@@ -98,15 +104,10 @@ public:
         return dict_page_decoder;
     }
 
-    // Decode bitshuffle encoded page
-    Status decode_bitshuffle_page(Slice& page_slice, std::unique_ptr<DataPage>& decoded_page) {
-        segment_v2::BitShufflePagePreDecoder<true> pre_decoder;
-        return pre_decoder.decode(&decoded_page, &page_slice, 0, false, PageTypePB::DATA_PAGE, "");
-    }
-
-    // Apply pre-decode step for BinaryPlainPageV2 encoded page
-    Status apply_pre_decode_v2(Slice& page_slice, std::unique_ptr<DataPage>& decoded_page) {
-        BinaryPlainPageV2PreDecoder pre_decoder;
+    // Apply pre-decode for BinaryDictPage data pages
+    // This method handles all encoding types (bitshuffle, plain V1, plain V2)
+    Status apply_pre_decode(Slice& page_slice, std::unique_ptr<DataPage>& decoded_page) {
+        BinaryDictPagePreDecoder pre_decoder;
         return pre_decoder.decode(&decoded_page, &page_slice, 0, false, PageTypePB::DATA_PAGE, "");
     }
 
@@ -209,8 +210,11 @@ public:
         EXPECT_TRUE(status.ok());
 
         // Create dict decoder
+        // decoded_dict_page must outlive dict_page_decoder since it holds the decoded data
         Slice dict_page_slice = dict_slice.slice();
-        auto dict_page_decoder = create_dict_page_decoder(dict_page_slice, dict_encoding_type);
+        std::unique_ptr<DataPage> decoded_dict_page;
+        auto dict_page_decoder =
+                create_dict_page_decoder(dict_page_slice, dict_encoding_type, decoded_dict_page);
         ASSERT_NE(nullptr, dict_page_decoder) << "Failed to create dict page decoder";
         EXPECT_EQ(slices.size(), dict_page_decoder->count());
 
@@ -224,7 +228,7 @@ public:
 
         Slice page_slice = s.slice();
         std::unique_ptr<DataPage> decoded_page;
-        status = decode_bitshuffle_page(page_slice, decoded_page);
+        status = apply_pre_decode(page_slice, decoded_page);
         EXPECT_TRUE(status.ok());
 
         BinaryDictPageDecoder page_decoder(page_slice, decoder_options);
@@ -350,7 +354,9 @@ public:
         size_t dict_entries = 0;
         if (dict_slice.slice().size > 0) {
             Slice temp_dict_slice = dict_slice.slice();
-            auto temp_decoder = create_dict_page_decoder(temp_dict_slice, dict_encoding_type);
+            std::unique_ptr<DataPage> temp_decoded_page;
+            auto temp_decoder =
+                    create_dict_page_decoder(temp_dict_slice, dict_encoding_type, temp_decoded_page);
             if (temp_decoder) {
                 dict_entries = temp_decoder->count();
             }
@@ -368,8 +374,11 @@ public:
                 << "Should have fallback pages (dict entries < total entries)";
 
         // Create dict decoder for dictionary page
+        // decoded_dict_page must outlive dict_page_decoder since it holds the decoded data
         Slice dict_page_slice = dict_slice.slice();
-        auto dict_page_decoder = create_dict_page_decoder(dict_page_slice, dict_encoding_type);
+        std::unique_ptr<DataPage> decoded_dict_page;
+        auto dict_page_decoder =
+                create_dict_page_decoder(dict_page_slice, dict_encoding_type, decoded_dict_page);
         ASSERT_NE(nullptr, dict_page_decoder) << "Failed to create dict page decoder";
 
         // Get dict word info
@@ -383,10 +392,10 @@ public:
             PageDecoderOptions decoder_options;
             Slice page_slice = results[page_idx].slice();
 
-            // First, decode bitshuffle for all pages (similar to test_by_small_data_size)
+            // First, apply pre-decode for all pages (handles bitshuffle, plain V1, plain V2)
             std::unique_ptr<DataPage> decoded_page;
-            status = decode_bitshuffle_page(page_slice, decoded_page);
-            EXPECT_TRUE(status.ok()) << "Failed to decode bitshuffle for page " << page_idx;
+            status = apply_pre_decode(page_slice, decoded_page);
+            EXPECT_TRUE(status.ok()) << "Failed to apply pre-decode for page " << page_idx;
 
             // Create BinaryDictPageDecoder and check encoding type
             BinaryDictPageDecoder page_decoder(page_slice, decoder_options);
@@ -452,11 +461,11 @@ public:
             PageDecoderOptions decoder_options;
             Slice page_slice = results[page_idx].slice();
 
-            // Decode bitshuffle
+            // Apply pre-decode
             std::unique_ptr<DataPage> decoded_page;
-            status = decode_bitshuffle_page(page_slice, decoded_page);
+            status = apply_pre_decode(page_slice, decoded_page);
             EXPECT_TRUE(status.ok())
-                    << "Failed to decode bitshuffle for page " << page_idx << " in seek test";
+                    << "Failed to apply pre-decode for page " << page_idx << " in seek test";
 
             // Create decoder
             BinaryDictPageDecoder page_decoder(page_slice, decoder_options);
@@ -503,10 +512,10 @@ public:
             PageDecoderOptions decoder_options;
             Slice page_slice = results[page_idx].slice();
 
-            // Decode bitshuffle
+            // Apply pre-decode
             std::unique_ptr<DataPage> decoded_page;
-            status = decode_bitshuffle_page(page_slice, decoded_page);
-            EXPECT_TRUE(status.ok()) << "Failed to decode bitshuffle for page " << page_idx
+            status = apply_pre_decode(page_slice, decoded_page);
+            EXPECT_TRUE(status.ok()) << "Failed to apply pre-decode for page " << page_idx
                                      << " in read_by_rowids test";
 
             // Create decoder
@@ -671,7 +680,9 @@ TEST_F(BinaryDictPageTest, TestConfigAffectsDictionaryPageEncoding) {
         // First apply pre-decode for BinaryPlainPageV2
         Slice dict_page_slice = dict_slice.slice();
         std::unique_ptr<DataPage> decoded_page;
-        status = apply_pre_decode_v2(dict_page_slice, decoded_page);
+        BinaryPlainPageV2PreDecoder pre_decoder;
+        status = pre_decoder.decode(&decoded_page, &dict_page_slice, 0, false,
+                                    PageTypePB::DATA_PAGE, "");
         EXPECT_TRUE(status.ok());
 
         PageDecoderOptions dict_decoder_options;

--- a/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
@@ -301,7 +301,7 @@ public:
         // Use smaller page sizes to ensure we trigger fallback scenario
         // where dictionary gets full and we switch to plain encoding
         options.data_page_size = 64 * 1024; // 64KB data page
-        options.dict_page_size = 32 * 1024; // 32KB dict page to trigger fallback
+        options.dict_page_size = 1024;      // 1KB dict page to trigger fallback
 
         PageBuilder* builder_ptr = nullptr;
         Status ret0 = BinaryDictPageBuilder::create(&builder_ptr, options);

--- a/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
@@ -69,9 +69,9 @@ public:
     // Create dict page decoder based on encoding type
     // The decoded_page parameter is passed by reference to ensure the decoded data's lifetime
     // is managed by the caller, preventing the data from being freed prematurely
-    std::unique_ptr<PageDecoder> create_dict_page_decoder(
-            Slice& dict_slice, EncodingTypePB encoding_type,
-            std::unique_ptr<DataPage>& decoded_page) {
+    std::unique_ptr<PageDecoder> create_dict_page_decoder(Slice& dict_slice,
+                                                          EncodingTypePB encoding_type,
+                                                          std::unique_ptr<DataPage>& decoded_page) {
         // Apply pre-decode for BinaryPlainPageV2
         if (encoding_type == PLAIN_ENCODING_V2) {
             BinaryPlainPageV2PreDecoder pre_decoder;
@@ -355,8 +355,8 @@ public:
         if (dict_slice.slice().size > 0) {
             Slice temp_dict_slice = dict_slice.slice();
             std::unique_ptr<DataPage> temp_decoded_page;
-            auto temp_decoder =
-                    create_dict_page_decoder(temp_dict_slice, dict_encoding_type, temp_decoded_page);
+            auto temp_decoder = create_dict_page_decoder(temp_dict_slice, dict_encoding_type,
+                                                         temp_decoded_page);
             if (temp_decoder) {
                 dict_entries = temp_decoder->count();
             }

--- a/be/test/olap/rowset/segment_v2/bitshuffle_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/bitshuffle_page_test.cpp
@@ -77,8 +77,9 @@ public:
 
         segment_v2::BitShufflePagePreDecoder pre_decoder;
         Slice page_slice = s.slice();
-        std::unique_ptr<char[]> auto_release;
-        pre_decoder.decode(&auto_release, &page_slice, 0);
+        std::unique_ptr<DataPage> decoded_page;
+        pre_decoder.decode(&decoded_page, &page_slice, 0, false, segment_v2::PageTypePB::DATA_PAGE,
+                           "");
         PageDecoderType page_decoder(page_slice, decoder_options);
         status = page_decoder.init();
         EXPECT_TRUE(status.ok());
@@ -136,8 +137,9 @@ public:
 
         segment_v2::BitShufflePagePreDecoder pre_decoder;
         Slice page_slice = s.slice();
-        std::unique_ptr<char[]> auto_release;
-        pre_decoder.decode(&auto_release, &page_slice, 0);
+        std::unique_ptr<DataPage> decoded_page;
+        pre_decoder.decode(&decoded_page, &page_slice, 0, false, segment_v2::PageTypePB::DATA_PAGE,
+                           "");
         PageDecoderType page_decoder(page_slice, decoder_options);
         status = page_decoder.init();
         EXPECT_TRUE(status.ok());

--- a/be/test/olap/rowset/segment_v2/bitshuffle_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/bitshuffle_page_test.cpp
@@ -75,7 +75,7 @@ public:
         Status status = page_decoder_.init();
         EXPECT_FALSE(status.ok());
 
-        segment_v2::BitShufflePagePreDecoder<false> pre_decoder;
+        segment_v2::BitShufflePagePreDecoder pre_decoder;
         Slice page_slice = s.slice();
         std::unique_ptr<char[]> auto_release;
         pre_decoder.decode(&auto_release, &page_slice, 0);
@@ -134,7 +134,7 @@ public:
         Status status = page_decoder_.init();
         EXPECT_FALSE(status.ok());
 
-        segment_v2::BitShufflePagePreDecoder<false> pre_decoder;
+        segment_v2::BitShufflePagePreDecoder pre_decoder;
         Slice page_slice = s.slice();
         std::unique_ptr<char[]> auto_release;
         pre_decoder.decode(&auto_release, &page_slice, 0);

--- a/regression-test/pipeline/cloud_p0/conf/be_custom.conf
+++ b/regression-test/pipeline/cloud_p0/conf/be_custom.conf
@@ -52,3 +52,5 @@ enable_prefill_all_dbm_agg_cache_after_compaction=true
 
 enable_batch_get_delete_bitmap=true
 get_delete_bitmap_bytes_threshold=10
+
+enable_fuzzy_storage_encoding=true

--- a/regression-test/pipeline/external/conf/be.conf
+++ b/regression-test/pipeline/external/conf/be.conf
@@ -72,3 +72,5 @@ crash_in_memory_tracker_inaccurate = true
 # So feature has bug, so by default is false, only open it in pipeline to observe
 enable_parquet_page_index=true
 enable_graceful_exit_check=true
+
+enable_fuzzy_storage_encoding=true

--- a/regression-test/pipeline/nonConcurrent/conf/be.conf
+++ b/regression-test/pipeline/nonConcurrent/conf/be.conf
@@ -89,3 +89,4 @@ large_cumu_compaction_task_min_thread_num=3
 enable_parquet_page_index=true
 enable_graceful_exit_check=true
 
+enable_fuzzy_storage_encoding=true

--- a/regression-test/pipeline/p0/conf/be.conf
+++ b/regression-test/pipeline/p0/conf/be.conf
@@ -91,3 +91,5 @@ enable_graceful_exit_check=true
 
 enable_prefill_all_dbm_agg_cache_after_compaction=true
 enable_fetch_rowsets_from_peer_replicas = true
+
+enable_fuzzy_storage_encoding=true

--- a/regression-test/pipeline/p1/conf/be.conf
+++ b/regression-test/pipeline/p1/conf/be.conf
@@ -76,3 +76,5 @@ enable_parquet_page_index=true
 enable_graceful_exit_check=true
 
 enable_prefill_all_dbm_agg_cache_after_compaction=true
+
+enable_fuzzy_storage_encoding=true


### PR DESCRIPTION
### What problem does this PR solve?

  Summary

  This PR implements pre-decoders for BinaryPlainPageV2 and BinaryDictPage formats to enable O(1) random access seeking by converting page data at read time. The main improvements include:

  - ✨ New BinaryPlainPageV2PreDecoder: Converts varint-encoded V2 format to offset-array V1 format for faster seeking
  - ✨ New BinaryDictPagePreDecoder: Pre-decodes dictionary pages for efficient random access
  - 🔧 Encoding Configuration: Adds enable_fuzzy_storage_encoding flag to control fuzzy encoding testing
  - 🐛 Bug Fixes: Fixed issues in FileColumnIterator::_read_dict_data and dictionary page handling
  - 🧪 Comprehensive Tests: Added unit tests covering all encoding types and pre-decoder scenarios
  - ⚡ Performance Optimization: Reduced redundant memcpy operations in pre-decoder pipeline

  Technical Details

  Pre-Decoder Design

  BinaryPlainPageV2PreDecoder (be/src/olap/rowset/segment_v2/binary_plain_page_v2_pre_decoder.h:41)
  - Converts V2 format (varint lengths) → V1 format (offset array)
  - Enables O(1) seeking without scanning entire page
  - Reduces memory copy overhead

  BinaryDictPagePreDecoder (be/src/olap/rowset/segment_v2/binary_dict_page_pre_decoder.h)
  - Pre-decodes dictionary-encoded binary pages
  - Integrates with existing page cache infrastructure

  Configuration Changes

  - Added enable_fuzzy_storage_encoding config flag (be/src/common/config.h:1677)
  - Default: Uses V1 format for stability and compatibility
  - V2 format remains available for fuzzy testing when enabled

  Files Changed

  - Core Implementation: binary_plain_page_v2_pre_decoder.h, binary_dict_page_pre_decoder.h
  - Integration: encoding_info.cpp, column_reader.cpp, page_io.cpp
  - Tests: encoding_info_test.cpp, binary_plain_page_v2_test.cpp, binary_dict_page_test.cpp
  - Config: config.h, config.cpp, regression test configs

  Test Plan

  - Unit tests for BinaryPlainPageV2PreDecoder with all data types
  - Unit tests for BinaryDictPagePreDecoder
  - EncodingInfo tests covering all type × encoding combinations
  - Fixed existing binary page tests
  - Regression tests with both V1 and V2 formats

  Impact

  - Performance: Improves random access performance for binary columns
  - Compatibility: No breaking changes; V1 format used by default
  - Risk: Low - pre-decoding is transparent to upper layers

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

