### PR TITLE
[Chore](exchange) add some check about eos with exhcnage source

### DIFF
--- a/be/src/pipeline/exec/exchange_source_operator.cpp
+++ b/be/src/pipeline/exec/exchange_source_operator.cpp
@@ -186,7 +186,7 @@ Status ExchangeSourceOperatorX::get_block(RuntimeState* state, vectorized::Block
             }
         }
         // Merge actually also handles the limit, but handling the limit one more time will not cause correctness issues
-        if (local_state.num_rows_returned() + block->rows() < _limit) {
+        if (_limit == -1 || local_state.num_rows_returned() + block->rows() < _limit) {
             local_state.add_num_rows_returned(block->rows());
         } else {
             *eos = true;

--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -88,7 +88,12 @@ Status VDataStreamRecvr::SenderQueue::get_batch(Block* block, bool* eos) {
         }
 
         if (_block_queue.empty()) {
-            DCHECK_EQ(_num_remaining_senders, 0);
+            if (_num_remaining_senders != 0) {
+                return Status::InternalError(
+                        "Data queue is empty but there are still remaining senders. "
+                        "_num_remaining_senders: {}",
+                        _num_remaining_senders);
+            }
             *eos = true;
             return Status::OK();
         }

--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -176,10 +176,9 @@ Status VDataStreamRecvr::SenderQueue::add_block(std::unique_ptr<PBlock> pblock, 
         auto iter = _packet_seq_map.find(be_number);
         if (iter != _packet_seq_map.end()) {
             if (iter->second >= packet_seq) {
-                LOG(WARNING) << fmt::format(
+                return Status::InternalError(
                         "packet already exist [cur_packet_id= {} receive_packet_id={}]",
                         iter->second, packet_seq);
-                return Status::OK();
             }
             iter->second = packet_seq;
         } else {

--- a/be/src/vec/runtime/vdata_stream_recvr.h
+++ b/be/src/vec/runtime/vdata_stream_recvr.h
@@ -272,6 +272,10 @@ protected:
                 SCOPED_RAW_TIMER(&_deserialize_time);
                 _block = Block::create_unique();
                 RETURN_IF_ERROR_OR_CATCH_EXCEPTION(_block->deserialize(*_pblock));
+                if (_block->rows() == 0) {
+                    return Status::InternalError("Deserialize block rows is 0, block: {}",
+                                                 _block->dump_structure());
+                }
             }
             block.swap(_block);
             _block.reset();

--- a/be/src/vec/runtime/vdata_stream_recvr.h
+++ b/be/src/vec/runtime/vdata_stream_recvr.h
@@ -272,10 +272,6 @@ protected:
                 SCOPED_RAW_TIMER(&_deserialize_time);
                 _block = Block::create_unique();
                 RETURN_IF_ERROR_OR_CATCH_EXCEPTION(_block->deserialize(*_pblock));
-                if (_block->rows() == 0) {
-                    return Status::InternalError("Deserialize block rows is 0, block: {}",
-                                                 _block->dump_structure());
-                }
             }
             block.swap(_block);
             _block.reset();


### PR DESCRIPTION
### What problem does this PR solve?

This pull request introduces improvements to the handling of data limits and error detection in the data exchange and streaming components. The main changes ensure correct behavior when limits are unset and add better error reporting for unexpected sender states.

**Improvements to limit handling:**

* Updated the condition in `ExchangeSourceOperatorX::get_block` (in `exchange_source_operator.cpp`) to correctly handle cases when `_limit` is unset (`-1`), ensuring that the row limit logic only applies when a limit is set.

**Robustness and error detection:**

* Enhanced `VDataStreamRecvr::SenderQueue::get_batch` (in `vdata_stream_recvr.cpp`) to return an internal error status if the data queue is empty but there are still remaining senders, improving error detection and debugging.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

