### PR TITLE
[fix](ut) fix BE ut compilation error

### DIFF
--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -112,7 +112,7 @@ add_executable(doris_be_test ${UT_FILES})
 target_link_libraries(doris_be_test ${TEST_LINK_LIBS} 
     -Wl,--whole-archive vector_search_test -Wl,--no-whole-archive)
 set_target_properties(doris_be_test PROPERTIES COMPILE_FLAGS "-fno-access-control")
-
+target_compile_options(doris_be_test PRIVATE -include gtest/gtest.h)
 if (OS_MACOSX AND ARCH_ARM)
     find_program(DSYMUTIL NAMES dsymutil)
     message(STATUS "dsymutil found: ${DSYMUTIL}")


### PR DESCRIPTION
followup #57181
After upgrading gtest to 1.12, need include <gtest/gtest.h>