### PR TITLE
[fix](function) Incorrect input rows in json_extract_string

### DIFF
--- a/be/src/vec/functions/function_jsonb.cpp
+++ b/be/src/vec/functions/function_jsonb.cpp
@@ -828,7 +828,7 @@ public:
             const std::vector<const ColumnString*>& rdata_columns, // here we can support more paths
             const std::vector<bool>& path_const, ColumnString::Chars& res_data,
             ColumnString::Offsets& res_offsets, NullMap& null_map, bool& is_invalid_json_path) {
-        size_t input_rows_count = json_data_const ? rdata_columns.size() : loffsets.size();
+        size_t input_rows_count = null_map.size();
         res_offsets.resize(input_rows_count);
 
         auto writer = std::make_unique<JsonbWriter>();


### PR DESCRIPTION
### What problem does this PR solve?

Test sql:
```sql
SELECT
    ARRAY_EXCEPT(
        ARRAY_MAP(
            i -> JSON_EXTRACT_STRING(
                CAST('[{"a":"a\\nb"},{"a":"c"},{"b":2}]' AS JSON),
                REPLACE('$[*].a', '*', i)
            ),
            ARRAY_RANGE(
                JSON_LENGTH(
                    CAST('[{"a":"a\\nb"},{"a":"c"},{"b":2}]' AS JSON)
                )
            )
        ),
        [NULL]
    );
```
Coredump:
```text
 *** SIGABRT unknown detail explain (@0x3f80005e289) received by PID 385673 (TID 390392 OR 0x7f54ba19e700) from PID 385673; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris-2.1/be/src/common/signal_handler.h:421
 1# 0x00007F63B47505B0 in /lib64/libc.so.6
 2# __GI_raise in /lib64/libc.so.6
 3# __GI_abort in /lib64/libc.so.6
 4# 0x00005614C87F796D in /root/doris-2.1/be/output/lib/doris_be
 5# google::LogMessage::SendToLog() in /root/doris-2.1/be/output/lib/doris_be
 6# google::LogMessage::Flush() in /root/doris-2.1/be/output/lib/doris_be
 7# google::LogMessageFatal::~LogMessageFatal() in /root/doris-2.1/be/output/lib/doris_be
 8# doris::vectorized::ColumnStr<unsigned int>::get_data_at(unsigned long) const in /root/doris-2.1/be/output/lib/doris_be
 9# void doris::vectorized::OpenSetImpl<(doris::vectorized::SetOperation)1, doris::vectorized::ColumnStr<unsigned int> >::apply<true>(doris::vectorized::ColumnArrayExecutionData const&, unsigned long, unsigned long, doris::vectorized::ColumnArrayMutableData&, unsigned long*) at /root/doris-2.1/be/src/vec/functions/array/function_array_set.h:111
10# bool doris::vectorized::ArraySetImpl<(doris::vectorized::SetOperation)1>::_execute_internal<false, true, doris::vectorized::ColumnStr<unsigned int> >(doris::vectorized::ColumnArrayMutableData&, doris::vectorized::ColumnArrayExecutionData const&, doris::vectorized::ColumnArrayExecutionData const&) at /root/doris-2.1/be/src/vec/functions/array/function_array_set.h:200
11# bool doris::vectorized::ArraySetImpl<(doris::vectorized::SetOperation)1>::_execute_internal<false, true, doris::vectorized::ColumnVector<unsigned long>, doris::vectorized::ColumnStr<unsigned int> >(doris::vectorized::ColumnArrayMutableData&, doris::vectorized::ColumnArrayExecutionData const&, doris::vectorized::ColumnArrayExecutionData const&) at /root/doris-2.1/be/src/vec/functions/array/function_array_set.h:214
12# bool doris::vectorized::ArraySetImpl<(doris::vectorized::SetOperation)1>::_execute_internal<false, true, doris::vectorized::ColumnVector<unsigned int>, doris::vectorized::ColumnVector<unsigned long>, doris::vectorized::ColumnStr<unsigned int> >(doris::vectorized::ColumnArrayMutableData&, doris::vectorized::ColumnArrayExecutionData const&, doris::vectorized::ColumnArrayExecutionData const&) at /root/doris-2.1/be/src/vec/functions/array/function_array_set.h:214
13# bool doris::vectorized::ArraySetImpl<(doris::vectorized::SetOperation)1>::_execute_internal<false, true, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<unsigned int>, doris::vectorized::ColumnVector<unsigned long>, doris::vectorized::ColumnStr<unsigned int> >(doris::vectorized::ColumnArrayMutableData&, doris::vectorized::ColumnArrayExecutionData const&, doris::vectorized::ColumnArrayExecutionData const&) at /root/doris-2.1/be/src/vec/functions/array/function_array_set.h:214
14# bool doris::vectorized::ArraySetImpl<(doris::vectorized::SetOperation)1>::_execute_internal<false, true, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<unsigned int>, doris::vectorized::ColumnVector<unsigned long>, doris::vectorized::ColumnStr<unsigned int> >(doris::vectorized::ColumnArrayMutableData&, doris::vectorized::ColumnArrayExecutionData const&, doris::vectorized::ColumnArrayExecutionData const&) at /root/doris-2.1/be/src/vec/functions/array/function_array_set.h:214
15# bool doris::vectorized::ArraySetImpl<(doris::vectorized::SetOperation)1>::_execute_internal<false, true, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<wide::integer<256ul, int> > >, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<unsigned int>, doris::vectorized::ColumnVector<unsigned long>, doris::vectorized::ColumnStr<unsigned int> >(doris::vectorized::ColumnArrayMutableData&, doris::vectorized::ColumnArrayExecutionData const&, doris::vectorized::ColumnArrayExecutionData const&) at /root/doris-2.1/be/src/vec/functions/array/function_array_set.h:214
16# bool doris::vectorized::ArraySetImpl<(doris::vectorized::SetOperation)1>::_execute_internal<false, true, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<__int128> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<wide::integer<256ul, int> > >, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<unsigned int>, doris::vectorized::ColumnVector<unsigned long>, doris::vectorized::ColumnStr<unsigned int> >(doris::vectorized::ColumnArrayMutableData&, doris::vectorized::ColumnArrayExecutionData const&, doris::vectorized::ColumnArrayExecutionData const&) at /root/doris-2.1/be/src/vec/functions/array/function_array_set.h:214
17# bool doris::vectorized::ArraySetImpl<(doris::vectorized::SetOperation)1>::_execute_internal<false, true, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal128V3>, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<__int128> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<wide::integer<256ul, int> > >, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<unsigned int>, doris::vectorized::ColumnVector<unsigned long>, doris::vectorized::ColumnStr<unsigned int> >(doris::vectorized::ColumnArrayMutableData&, doris::vectorized::ColumnArrayExecutionData const&, doris::vectorized::ColumnArrayExecutionData const&) at /root/doris-2.1/be/src/vec/functions/array/function_array_set.h:214
18# bool doris::vectorized::ArraySetImpl<(doris::vectorized::SetOperation)1>::_execute_internal<false, true, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<long> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal128V3>, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<__int128> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<wide::integer<256ul, int> > >, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<unsigned int>, doris::vectorized::ColumnVector<unsigned long>, doris::vectorized::ColumnStr<unsigned int> >(doris::vectorized::ColumnArrayMutableData&, doris::vectorized::ColumnArrayExecutionData const&, doris::vectorized::ColumnArrayExecutionData const&) at /root/doris-2.1/be/src/vec/functions/array/function_array_set.h:214
19# bool doris::vectorized::ArraySetImpl<(doris::vectorized::SetOperation)1>::_execute_internal<false, true, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<int> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<long> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal128V3>, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<__int128> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<wide::integer<256ul, int> > >, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<unsigned int>, doris::vectorized::ColumnVector<unsigned long>, doris::vectorized::ColumnStr<unsigned int> >(doris::vectorized::ColumnArrayMutableData&, doris::vectorized::ColumnArrayExecutionData const&, doris::vectorized::ColumnArrayExecutionData const&) at /root/doris-2.1/be/src/vec/functions/array/function_array_set.h:214
20# bool doris::vectorized::ArraySetImpl<(doris::vectorized::SetOperation)1>::_execute_internal<false, true, doris::vectorized::ColumnVector<double>, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<int> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<long> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal128V3>, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<__int128> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<wide::integer<256ul, int> > >, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<unsigned int>, doris::vectorized::ColumnVector<unsigned long>, doris::vectorized::ColumnStr<unsigned int> >(doris::vectorized::ColumnArrayMutableData&, doris::vectorized::ColumnArrayExecutionData const&, doris::vectorized::ColumnArrayExecutionData const&) at /root/doris-2.1/be/src/vec/functions/array/function_array_set.h:214
21# bool doris::vectorized::ArraySetImpl<(doris::vectorized::SetOperation)1>::_execute_internal<false, true, doris::vectorized::ColumnVector<float>, doris::vectorized::ColumnVector<double>, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<int> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<long> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal128V3>, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<__int128> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<wide::integer<256ul, int> > >, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<unsigned int>, doris::vectorized::ColumnVector<unsigned long>, doris::vectorized::ColumnStr<unsigned int> >(doris::vectorized::ColumnArrayMutableData&, doris::vectorized::ColumnArrayExecutionData const&, doris::vectorized::ColumnArrayExecutionData const&) at /root/doris-2.1/be/src/vec/functions/array/function_array_set.h:214
22# bool doris::vectorized::ArraySetImpl<(doris::vectorized::SetOperation)1>::_execute_internal<false, true, doris::vectorized::ColumnVector<__int128>, doris::vectorized::ColumnVector<float>, doris::vectorized::ColumnVector<double>, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<int> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<long> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal128V3>, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<__int128> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<wide::integer<256ul, int> > >, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<unsigned int>, doris::vectorized::ColumnVector<unsigned long>, doris::vectorized::ColumnStr<unsigned int> >(doris::vectorized::ColumnArrayMutableData&, doris::vectorized::ColumnArrayExecutionData const&, doris::vectorized::ColumnArrayExecutionData const&) at /root/doris-2.1/be/src/vec/functions/array/function_array_set.h:214
23# bool doris::vectorized::ArraySetImpl<(doris::vectorized::SetOperation)1>::_execute_internal<false, true, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<__int128>, doris::vectorized::ColumnVector<float>, doris::vectorized::ColumnVector<double>, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<int> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<long> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal128V3>, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<__int128> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<wide::integer<256ul, int> > >, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<unsigned int>, doris::vectorized::ColumnVector<unsigned long>, doris::vectorized::ColumnStr<unsigned int> >(doris::vectorized::ColumnArrayMutableData&, doris::vectorized::ColumnArrayExecutionData const&, doris::vectorized::ColumnArrayExecutionData const&) at /root/doris-2.1/be/src/vec/functions/array/function_array_set.h:214
24# bool doris::vectorized::ArraySetImpl<(doris::vectorized::SetOperation)1>::_execute_internal<false, true, doris::vectorized::ColumnVector<int>, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<__int128>, doris::vectorized::ColumnVector<float>, doris::vectorized::ColumnVector<double>, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<int> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<long> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal128V3>, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<__int128> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<wide::integer<256ul, int> > >, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<unsigned int>, doris::vectorized::ColumnVector<unsigned long>, doris::vectorized::ColumnStr<unsigned int> >(doris::vectorized::ColumnArrayMutableData&, doris::vectorized::ColumnArrayExecutionData const&, doris::vectorized::ColumnArrayExecutionData const&) at /root/doris-2.1/be/src/vec/functions/array/function_array_set.h:214
25# bool doris::vectorized::ArraySetImpl<(doris::vectorized::SetOperation)1>::_execute_internal<false, true, doris::vectorized::ColumnVector<short>, doris::vectorized::ColumnVector<int>, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<__int128>, doris::vectorized::ColumnVector<float>, doris::vectorized::ColumnVector<double>, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<int> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<long> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal128V3>, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<__int128> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<wide::integer<256ul, int> > >, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<unsigned int>, doris::vectorized::ColumnVector<unsigned long>, doris::vectorized::ColumnStr<unsigned int> >(doris::vectorized::ColumnArrayMutableData&, doris::vectorized::ColumnArrayExecutionData const&, doris::vectorized::ColumnArrayExecutionData const&) at /root/doris-2.1/be/src/vec/functions/array/function_array_set.h:214
26# bool doris::vectorized::ArraySetImpl<(doris::vectorized::SetOperation)1>::_execute_internal<false, true, doris::vectorized::ColumnVector<signed char>, doris::vectorized::ColumnVector<short>, doris::vectorized::ColumnVector<int>, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<__int128>, doris::vectorized::ColumnVector<float>, doris::vectorized::ColumnVector<double>, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<int> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<long> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal128V3>, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<__int128> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<wide::integer<256ul, int> > >, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<unsigned int>, doris::vectorized::ColumnVector<unsigned long>, doris::vectorized::ColumnStr<unsigned int> >(doris::vectorized::ColumnArrayMutableData&, doris::vectorized::ColumnArrayExecutionData const&, doris::vectorized::ColumnArrayExecutionData const&) at /root/doris-2.1/be/src/vec/functions/array/function_array_set.h:214
27# bool doris::vectorized::ArraySetImpl<(doris::vectorized::SetOperation)1>::_execute_internal<false, true, doris::vectorized::ColumnVector<unsigned char>, doris::vectorized::ColumnVector<signed char>, doris::vectorized::ColumnVector<short>, doris::vectorized::ColumnVector<int>, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<__int128>, doris::vectorized::ColumnVector<float>, doris::vectorized::ColumnVector<double>, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<int> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<long> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal128V3>, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<__int128> >, doris::vectorized::ColumnDecimal<doris::vectorized::Decimal<wide::integer<256ul, int> > >, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<long>, doris::vectorized::ColumnVector<unsigned int>, doris::vectorized::ColumnVector<unsigned long>, doris::vectorized::ColumnStr<unsigned int> >(doris::vectorized::ColumnArrayMutableData&, doris::vectorized::ColumnArrayExecutionData const&, doris::vectorized::ColumnArrayExecutionData const&) at /root/doris-2.1/be/src/vec/functions/array/function_array_set.h:214
28# doris::vectorized::ArraySetImpl<(doris::vectorized::SetOperation)1>::execute(COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>&, doris::vectorized::ColumnArrayExecutionData const&, doris::vectorized::ColumnArrayExecutionData const&, bool, bool) at /root/doris-2.1/be/src/vec/functions/array/function_array_set.h:156
29# doris::vectorized::FunctionArrayBinary<doris::vectorized::ArraySetImpl<(doris::vectorized::SetOperation)1>, doris::vectorized::NameArrayExcept>::execute_impl(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long) const at /root/doris-2.1/be/src/vec/functions/array/function_array_binary.h:65
30# doris::vectorized::DefaultExecutable::execute_impl(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long) const at /root/doris-2.1/be/src/vec/functions/function.h:470
31# doris::vectorized::PreparedFunctionImpl::_execute_skipped_constant_deal(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) const at /root/doris-2.1/be/src/vec/functions/function.cpp:121
32# doris::vectorized::PreparedFunctionImpl::execute_without_low_cardinality_columns(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) const at /root/doris-2.1/be/src/vec/functions/function.cpp:245
33# doris::vectorized::PreparedFunctionImpl::default_implementation_for_nulls(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool, bool*) const at /root/doris-2.1/be/src/vec/functions/function.cpp:218
34# doris::vectorized::PreparedFunctionImpl::_execute_skipped_constant_deal(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) const at /root/doris-2.1/be/src/vec/functions/function.cpp:112
35# doris::vectorized::PreparedFunctionImpl::execute_without_low_cardinality_columns(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) const at /root/doris-2.1/be/src/vec/functions/function.cpp:245
36# doris::vectorized::PreparedFunctionImpl::execute(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) const at /root/doris-2.1/be/src/vec/functions/function.cpp:251
37# doris::vectorized::IFunctionBase::execute(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) const at /root/doris-2.1/be/src/vec/functions/function.h:195
38# doris::vectorized::VectorizedFnCall::_do_execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*, std::vector<unsigned long, std::allocator<unsigned long> >&) at /root/doris-2.1/be/src/vec/exprs/vectorized_fn_call.cpp:182
39# doris::vectorized::VectorizedFnCall::execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*) at /root/doris-2.1/be/src/vec/exprs/vectorized_fn_call.cpp:197
40# doris::vectorized::VExprContext::execute(doris::vectorized::Block*, int*) at /root/doris-2.1/be/src/vec/exprs/vexpr_context.cpp:54
41# doris::pipeline::UnionSourceOperatorX::get_next_const(doris::RuntimeState*, doris::vectorized::Block*) at /root/doris-2.1/be/src/pipeline/exec/union_source_operator.cpp:233
42# doris::pipeline::UnionSourceOperatorX::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /root/doris-2.1/be/src/pipeline/exec/union_source_operator.cpp:193
43# doris::pipeline::OperatorXBase::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /root/doris-2.1/be/src/pipeline/pipeline_x/operator.cpp:292
44# doris::pipeline::PipelineXTask::execute(bool*) at /root/doris-2.1/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:353
45# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /root/doris-2.1/be/src/pipeline/task_scheduler.cpp:347
46# doris::pipeline::TaskScheduler::start()::$_0::operator()() const at /root/doris-2.1/be/src/pipeline/task_scheduler.cpp:218
47# void std::__invoke_impl<void, doris::pipeline::TaskScheduler::start()::$_0&>(std::__invoke_other, doris::pipeline::TaskScheduler::start()::$_0&) at /mnt/disk6/common/ldb_toolchain_robin/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61
48# std::enable_if<is_invocable_r_v<void, doris::pipeline::TaskScheduler::start()::$_0&>, void>::type std::__invoke_r<void, doris::pipeline::TaskScheduler::start()::$_0&>(doris::pipeline::TaskScheduler::start()::$_0&) at /mnt/disk6/common/ldb_toolchain_robin/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:117
49# std::_Function_handler<void (), doris::pipeline::TaskScheduler::start()::$_0>::_M_invoke(std::_Any_data const&) at /mnt/disk6/common/ldb_toolchain_robin/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290
50# std::function<void ()>::operator()() const at /mnt/disk6/common/ldb_toolchain_robin/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:591
51# doris::FunctionRunnable::run() at /root/doris-2.1/be/src/util/threadpool.cpp:48
52# doris::ThreadPool::dispatch_thread() at /root/doris-2.1/be/src/util/threadpool.cpp:544
53# void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /mnt/disk6/common/ldb_toolchain_robin/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:74
54# std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /mnt/disk6/common/ldb_toolchain_robin/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:96
55# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) at /mnt/disk6/common/ldb_toolchain_robin/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/functional:506
56# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() at /mnt/disk6/common/ldb_toolchain_robin/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/functional:591
57# void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) at /mnt/disk6/common/ldb_toolchain_robin/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61
58# std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) at /mnt/disk6/common/ldb_toolchain_robin/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:117
59# std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) at /mnt/disk6/common/ldb_toolchain_robin/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290
60# std::function<void ()>::operator()() const at /mnt/disk6/common/ldb_toolchain_robin/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:591
61# doris::Thread::supervise_thread(void*) at /root/doris-2.1/be/src/util/thread.cpp:498
62# asan_thread_start(void*) in /root/doris-2.1/be/output/lib/doris_be
63# start_thread in /lib64/libpthread.so.0
64# __GI___clone in /lib64/libc.so.6
```

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

