### PR TITLE
[fix](nereids)from_unixtime support decimalv3 literal as its first argument when used in fold constant rule

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
@@ -582,8 +582,10 @@ public class DateTimeExtractAndTransform {
             throw new AnalysisException("Operation from_unixtime of " + second.getValue() + " out of range");
         }
 
+        BigDecimal decimalVal = second.getValue();
+        BigDecimal microSeconds = decimalVal.movePointRight(decimalVal.scale()).setScale(0, RoundingMode.DOWN);
         ZonedDateTime dateTime = LocalDateTime.of(1970, 1, 1, 0, 0, 0)
-                .plusSeconds(second.getValue().longValue())
+                .plus(microSeconds.longValue(), ChronoUnit.MICROS)
                 .atZone(ZoneId.of("UTC+0"))
                 .toOffsetDateTime()
                 .atZoneSameInstant(DateUtils.getTimeZone());
@@ -607,9 +609,10 @@ public class DateTimeExtractAndTransform {
         if (second.getValue().signum() < 0) {
             throw new AnalysisException("Operation from_unixtime of " + second.getValue() + " out of range");
         }
-
+        BigDecimal decimalVal = second.getValue();
+        BigDecimal microSeconds = decimalVal.movePointRight(decimalVal.scale()).setScale(0, RoundingMode.DOWN);
         ZonedDateTime dateTime = LocalDateTime.of(1970, 1, 1, 0, 0, 0)
-                .plusSeconds(second.getValue().longValue())
+                .plus(microSeconds.longValue(), ChronoUnit.MICROS)
                 .atZone(ZoneId.of("UTC+0"))
                 .toOffsetDateTime()
                 .atZoneSameInstant(DateUtils.getTimeZone());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
@@ -576,27 +576,7 @@ public class DateTimeExtractAndTransform {
      */
     @ExecFunction(name = "from_unixtime")
     public static Expression fromUnixTime(DecimalLiteral second, StringLikeLiteral format) {
-        format = (StringLikeLiteral) SupportJavaDateFormatter.translateJavaFormatter(format);
-
-        if (second.getValue().signum() < 0) {
-            throw new AnalysisException("Operation from_unixtime of " + second.getValue() + " out of range");
-        }
-
-        BigDecimal decimalVal = second.getValue();
-        BigDecimal microSeconds = decimalVal.movePointRight(decimalVal.scale()).setScale(0, RoundingMode.DOWN);
-        ZonedDateTime dateTime = LocalDateTime.of(1970, 1, 1, 0, 0, 0)
-                .plus(microSeconds.longValue(), ChronoUnit.MICROS)
-                .atZone(ZoneId.of("UTC+0"))
-                .toOffsetDateTime()
-                .atZoneSameInstant(DateUtils.getTimeZone());
-        DateTimeV2Literal datetime = new DateTimeV2Literal(DateTimeV2Type.of(6), dateTime.getYear(),
-                dateTime.getMonthValue(),
-                dateTime.getDayOfMonth(), dateTime.getHour(), dateTime.getMinute(), dateTime.getSecond(),
-                dateTime.getNano() / 1000);
-        if (datetime.checkRange()) {
-            throw new AnalysisException("Operation from_unixtime of " + second.getValue() + " out of range");
-        }
-        return dateFormat(datetime, format);
+        return fromUnixTime(second.getValue(), format);
     }
 
     /**
@@ -604,13 +584,15 @@ public class DateTimeExtractAndTransform {
      */
     @ExecFunction(name = "from_unixtime")
     public static Expression fromUnixTime(DecimalV3Literal second, StringLikeLiteral format) {
-        format = (StringLikeLiteral) SupportJavaDateFormatter.translateJavaFormatter(format);
+        return fromUnixTime(second.getValue(), format);
+    }
 
-        if (second.getValue().signum() < 0) {
-            throw new AnalysisException("Operation from_unixtime of " + second.getValue() + " out of range");
+    private static Expression fromUnixTime(BigDecimal second, StringLikeLiteral format) {
+        if (second.signum() < 0) {
+            throw new AnalysisException("Operation from_unixtime of " + second + " out of range");
         }
-        BigDecimal decimalVal = second.getValue();
-        BigDecimal microSeconds = decimalVal.movePointRight(decimalVal.scale()).setScale(0, RoundingMode.DOWN);
+        format = (StringLikeLiteral) SupportJavaDateFormatter.translateJavaFormatter(format);
+        BigDecimal microSeconds = second.movePointRight(second.scale()).setScale(0, RoundingMode.DOWN);
         ZonedDateTime dateTime = LocalDateTime.of(1970, 1, 1, 0, 0, 0)
                 .plus(microSeconds.longValue(), ChronoUnit.MICROS)
                 .atZone(ZoneId.of("UTC+0"))
@@ -621,7 +603,7 @@ public class DateTimeExtractAndTransform {
                 dateTime.getDayOfMonth(), dateTime.getHour(), dateTime.getMinute(), dateTime.getSecond(),
                 dateTime.getNano() / 1000);
         if (datetime.checkRange()) {
-            throw new AnalysisException("Operation from_unixtime of " + second.getValue() + " out of range");
+            throw new AnalysisException("Operation from_unixtime of " + second + " out of range");
         }
         return dateFormat(datetime, format);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/DateUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/DateUtils.java
@@ -219,9 +219,12 @@ public class DateUtils {
                         builder.appendValueReduced(ChronoField.YEAR, 2, 2, 1970);
                         length += 2;
                         break;
+                    case 'f':
+                        builder.appendValue(ChronoField.MICRO_OF_SECOND, 6);
+                        length += 6;
+                        break;
                     // TODO(Gabriel): support microseconds in date literal
                     case 'D': // %D Day of the month with English suffix (0th, 1st, 2nd, 3rd, …)
-                    case 'f': // %f Microseconds (000000..999999)
                     case 'U': // %U Week (00..53), where Sunday is the first day of the week
                     case 'u': // %u Week (00..53), where Monday is the first day of the week
                     case 'w': // %w Day of the week (0=Sunday..6=Saturday)

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
@@ -108,6 +108,7 @@ import org.apache.doris.nereids.trees.expressions.literal.DateLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeV2Literal;
 import org.apache.doris.nereids.trees.expressions.literal.DateV2Literal;
+import org.apache.doris.nereids.trees.expressions.literal.DecimalLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DecimalV3Literal;
 import org.apache.doris.nereids.trees.expressions.literal.DoubleLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.FloatLiteral;
@@ -488,6 +489,14 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
         FromUnixtime f = new FromUnixtime(BigIntLiteral.of(123456789L), StringLiteral.of("%y %m %d"));
         rewritten = executor.rewrite(f, context);
         Assertions.assertEquals(new VarcharLiteral("73 11 30"), rewritten);
+
+        f = new FromUnixtime(DecimalLiteral.of(new BigDecimal("1761548288.000000")));
+        rewritten = executor.rewrite(f, context);
+        Assertions.assertEquals(new VarcharLiteral("2025-10-27 14:58:08.000000"), rewritten);
+
+        f = new FromUnixtime(DecimalV3Literal.of(new BigDecimal("1761548288.000000")));
+        rewritten = executor.rewrite(f, context);
+        Assertions.assertEquals(new VarcharLiteral("2025-10-27 14:58:08.000000"), rewritten);
 
         UnixTimestamp ut = new UnixTimestamp(StringLiteral.of("2021-11-11"), StringLiteral.of("%Y-%m-%d"));
         rewritten = executor.rewrite(ut, context);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
@@ -490,13 +490,13 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
         rewritten = executor.rewrite(f, context);
         Assertions.assertEquals(new VarcharLiteral("73 11 30"), rewritten);
 
-        f = new FromUnixtime(DecimalLiteral.of(new BigDecimal("1761548288.000000")));
+        f = new FromUnixtime(DecimalLiteral.of(new BigDecimal("1761548288.100000")));
         rewritten = executor.rewrite(f, context);
-        Assertions.assertEquals(new VarcharLiteral("2025-10-27 14:58:08.000000"), rewritten);
+        Assertions.assertEquals(new VarcharLiteral("2025-10-27 14:58:08.100000"), rewritten);
 
-        f = new FromUnixtime(DecimalV3Literal.of(new BigDecimal("1761548288.000000")));
+        f = new FromUnixtime(DecimalV3Literal.of(new BigDecimal("1761548288.100000")));
         rewritten = executor.rewrite(f, context);
-        Assertions.assertEquals(new VarcharLiteral("2025-10-27 14:58:08.000000"), rewritten);
+        Assertions.assertEquals(new VarcharLiteral("2025-10-27 14:58:08.100000"), rewritten);
 
         UnixTimestamp ut = new UnixTimestamp(StringLiteral.of("2021-11-11"), StringLiteral.of("%Y-%m-%d"));
         rewritten = executor.rewrite(ut, context);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransformTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransformTest.java
@@ -17,8 +17,10 @@
 
 package org.apache.doris.nereids.trees.expressions.functions.executable;
 
+import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.literal.BigIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeV2Literal;
+import org.apache.doris.nereids.trees.expressions.literal.DecimalV3Literal;
 import org.apache.doris.nereids.trees.expressions.literal.SmallIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
@@ -27,6 +29,7 @@ import org.apache.doris.nereids.types.DateTimeV2Type;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 class DateTimeExtractAndTransformTest {
@@ -147,5 +150,20 @@ class DateTimeExtractAndTransformTest {
         Assertions.assertEquals(3, result.getScale());
         result = (DateTimeV2Literal) DateTimeExtractAndTransform.fromMicroSecond(second);
         Assertions.assertEquals(6, result.getScale());
+    }
+
+    @Test
+    public void testFromUnixTimeNegativeThrows() {
+        BigIntLiteral negative = new BigIntLiteral(-1L);
+        Assertions.assertThrows(AnalysisException.class,
+                () -> DateTimeExtractAndTransform.fromUnixTime(negative));
+    }
+
+    @Test
+    public void testFromUnixTimeOutOfRangeThrows() {
+        BigDecimal big = new BigDecimal("253402272000000000");
+        DecimalV3Literal dec = new DecimalV3Literal(big);
+        Assertions.assertThrows(AnalysisException.class,
+                () -> DateTimeExtractAndTransform.fromUnixTime(dec));
     }
 }

--- a/regression-test/suites/nereids_rules_p0/partition_prune/one_key_range_part_test.groovy
+++ b/regression-test/suites/nereids_rules_p0/partition_prune/one_key_range_part_test.groovy
@@ -103,7 +103,7 @@ suite("one_key_range_part_test") {
     }
     explain {
         sql("SELECT a, dt, c FROM key_1_fixed_range_date_part WHERE dt = from_unixtime(unix_timestamp('2023-05-20 12:00:00'));")
-        contains "14/14 (p_min,p_202301,p_202302,p_202303,p_202304,p_202305,p_202306,p_202307,p_202308,p_202309,p_202310,p_202311,p_202312,p_max)"
+        contains "1/14 (p_202305)"
     }
     explain {
         sql("SELECT a, dt, c FROM key_1_fixed_range_date_part WHERE date(dt) = '2023-09-05';")
@@ -234,7 +234,7 @@ suite("one_key_range_part_test") {
     }
     explain {
         sql("SELECT a, dt, c FROM key_1_special_fixed_range_date_part WHERE dt = from_unixtime(unix_timestamp('2023-11-20 12:00:00'));")
-        contains "10/10 (p_min,p_202301,p_202302,p_202304,p_202305,p_202306,p_202309,p_202310,p_202312,p_max)"
+        contains "1/10 (p_202310)"
     }
     explain {
         sql("SELECT a, dt, c FROM key_1_special_fixed_range_date_part WHERE date(dt) = '2023-09-05';")

--- a/regression-test/suites/nereids_rules_p0/partition_prune/one_key_range_part_update_test.groovy
+++ b/regression-test/suites/nereids_rules_p0/partition_prune/one_key_range_part_update_test.groovy
@@ -96,7 +96,7 @@ suite("one_key_range_part_update_test") {
     }
     explain {
         sql("SELECT a, dt, c FROM key_1_special_fixed_range_date_part_update WHERE dt = from_unixtime(unix_timestamp('2023-08-20 12:00:00'));")
-        contains "11/11 (p_min,p_202301,p_202302,p_202304,p_202305,p_202306,p_202308,p_202309,p_202310,p_202312,p_max)"
+        contains "1/11 (p_202308)"
     }
     explain {
         sql("SELECT a, dt, c FROM key_1_special_fixed_range_date_part_update WHERE date(dt) = '2023-08-05';")


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

