### PR TITLE
[improve](glue)Refine Glue region and endpoint initialization

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
@@ -29,6 +29,7 @@ import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.PrintableMap;
 import org.apache.doris.common.util.TimeUtils;
+import org.apache.doris.datasource.property.storage.BrokerProperties;
 import org.apache.doris.datasource.property.storage.StorageProperties;
 import org.apache.doris.fs.FileSystemFactory;
 import org.apache.doris.fs.PersistentFileSystem;
@@ -204,14 +205,15 @@ public class Repository implements Writable, GsonPostProcessable {
             StorageProperties storageProperties = StorageProperties.createPrimary(this.fileSystem.properties);
             this.fileSystem = FileSystemFactory.get(storageProperties);
         } catch (RuntimeException exception) {
-            LOG.warn("Failed to create file system from properties, error msg {}",
+            LOG.warn("File system initialization failed due to incompatible configuration parameters. "
+                            + "The system has reverted to BrokerFileSystem as a fallback. "
+                            + "However, the current configuration is not supported by this version and"
+                            + " cannot be used as is. "
+                            + "Please review the configuration and update it to match the supported parameter"
+                            + " format. Root cause: {}",
                     ExceptionUtils.getRootCause(exception), exception);
-            throw new IllegalStateException(
-                    "Failed to initialize file system due to incompatible configuration with the current version. "
-                            + "This may be caused by a change in property formats or deprecated settings. "
-                            + "Please verify your configuration and ensure it matches the "
-                            + "new version requirements. error msg: "
-                            + ExceptionUtils.getRootCause(exception), exception);
+            BrokerProperties brokerProperties = BrokerProperties.of(this.fileSystem.name, this.fileSystem.properties);
+            this.fileSystem = FileSystemFactory.get(brokerProperties);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/AWSGlueMetaStoreBaseProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/AWSGlueMetaStoreBaseProperties.java
@@ -104,15 +104,22 @@ public class AWSGlueMetaStoreBaseProperties {
 
     private void checkAndInit() {
         buildRules().validate();
-
+        if (StringUtils.isNotBlank(glueRegion) && StringUtils.isNotBlank(glueEndpoint)) {
+            return;
+        }
+        // construct endpoint from region
+        if (StringUtils.isBlank(glueEndpoint) && StringUtils.isNotBlank(glueRegion)) {
+            glueEndpoint = String.format("https://glue.%s.amazonaws.com", glueRegion);
+            return;
+        }
+        // extract region from endpoint
         Matcher matcher = ENDPOINT_PATTERN.matcher(glueEndpoint.toLowerCase());
         if (!matcher.matches()) {
-            throw new IllegalArgumentException("Invalid AWS Glue endpoint: " + glueEndpoint);
+            throw new IllegalArgumentException(String.format(
+                    "Invalid AWS Glue endpoint format: '%s'. Expected format like 'https://glue.<region>.amazonaws"
+                            + ".com'.", glueEndpoint));
         }
-
-        if (StringUtils.isBlank(glueRegion)) {
-            this.glueRegion = extractRegionFromEndpoint(matcher);
-        }
+        this.glueRegion = extractRegionFromEndpoint(matcher);
     }
 
     private String extractRegionFromEndpoint(Matcher matcher) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/AWSGlueMetaStoreBaseProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/AWSGlueMetaStoreBaseProperties.java
@@ -95,7 +95,7 @@ public class AWSGlueMetaStoreBaseProperties {
     private ParamRules buildRules() {
 
         return new ParamRules().requireTogether(new String[]{glueAccessKey, glueSecretKey},
-                "glue.access_key and glue.secret_key must be set together")
+                        "glue.access_key and glue.secret_key must be set together")
                 .requireAtLeastOne(new String[]{glueAccessKey, glueIAMRole},
                         "At least one of glue.access_key or glue.role_arn must be set")
                 .requireAtLeastOne(new String[]{glueEndpoint, glueRegion},
@@ -107,19 +107,18 @@ public class AWSGlueMetaStoreBaseProperties {
         if (StringUtils.isNotBlank(glueRegion) && StringUtils.isNotBlank(glueEndpoint)) {
             return;
         }
-        // construct endpoint from region
         if (StringUtils.isBlank(glueEndpoint) && StringUtils.isNotBlank(glueRegion)) {
-            glueEndpoint = String.format("https://glue.%s.amazonaws.com", glueRegion);
             return;
         }
-        // extract region from endpoint
+        // glue region is not set, try to extract from endpoint
         Matcher matcher = ENDPOINT_PATTERN.matcher(glueEndpoint.toLowerCase());
-        if (!matcher.matches()) {
-            throw new IllegalArgumentException(String.format(
-                    "Invalid AWS Glue endpoint format: '%s'. Expected format like 'https://glue.<region>.amazonaws"
-                            + ".com'.", glueEndpoint));
+        if (matcher.matches()) {
+            this.glueRegion = extractRegionFromEndpoint(matcher);
         }
-        this.glueRegion = extractRegionFromEndpoint(matcher);
+        if (StringUtils.isBlank(glueRegion)) {
+            //follow aws sdk default region
+            glueRegion = "us-east-1";
+        }
     }
 
     private String extractRegionFromEndpoint(Matcher matcher) {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/AWSGlueMetaStoreBasePropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/AWSGlueMetaStoreBasePropertiesTest.java
@@ -100,27 +100,18 @@ public class AWSGlueMetaStoreBasePropertiesTest {
     }
 
     @Test
-    void testInvalidEndpointThrows() {
+    void testInvalidEndpoint() {
         Map<String, String> props = baseValidProps();
         props.put("glue.endpoint", "http://invalid-endpoint.com");
-
-        IllegalArgumentException ex = Assertions.assertThrows(
-                IllegalArgumentException.class,
-                () -> AWSGlueMetaStoreBaseProperties.of(props)
-        );
-        Assertions.assertTrue(ex.getMessage().contains("Invalid AWS Glue endpoint"));
+        Assertions.assertDoesNotThrow(() -> AWSGlueMetaStoreBaseProperties.of(props));
     }
 
     @Test
     void testExtractRegionFailsWhenPatternMatchesButNoRegion() {
         Map<String, String> props = baseValidProps();
         props.put("glue.endpoint", "glue..amazonaws.com"); // malformed
-
-        IllegalArgumentException ex = Assertions.assertThrows(
-                IllegalArgumentException.class,
-                () -> AWSGlueMetaStoreBaseProperties.of(props)
+        Assertions.assertDoesNotThrow(() -> AWSGlueMetaStoreBaseProperties.of(props)
         );
-        Assertions.assertTrue(ex.getMessage().contains("Invalid AWS Glue endpoint"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/AWSGlueMetaStoreBasePropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/AWSGlueMetaStoreBasePropertiesTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.doris.datasource.property.metastore;
 
-import org.apache.doris.common.ExceptionChecker;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -48,17 +46,14 @@ public class AWSGlueMetaStoreBasePropertiesTest {
     void testValidPropertiesWithRegion() {
         Map<String, String> props = baseValidProps();
         props.put("glue.region", "us-east-1");
-        props.remove("glue.endpoint");
-        AWSGlueMetaStoreBaseProperties glueProps = AWSGlueMetaStoreBaseProperties.of(props);
-        Assertions.assertEquals("us-east-1", glueProps.glueRegion);
-        Assertions.assertTrue("https://glue.us-east-1.amazonaws.com".equals(glueProps.glueEndpoint));
         props.put("glue.endpoint", "https://glue.us-east-1.amazonaws.com.cn");
+        AWSGlueMetaStoreBaseProperties glueProps = AWSGlueMetaStoreBaseProperties.of(props);
+        Assertions.assertTrue("https://glue.us-east-1.amazonaws.com.cn".equals(glueProps.glueEndpoint));
+        Assertions.assertEquals("us-east-1", glueProps.glueRegion);
+        props.remove("glue.region");
         glueProps = AWSGlueMetaStoreBaseProperties.of(props);
         Assertions.assertTrue("https://glue.us-east-1.amazonaws.com.cn".equals(glueProps.glueEndpoint));
-        props.remove("glue.region");
-        ExceptionChecker.expectThrowsWithMsg(IllegalArgumentException.class,
-                "Invalid AWS Glue endpoint format: 'https://glue.us-east-1.amazonaws.com.cn'. Expected format like 'https://glue.<region>.amazonaws.com'.",
-                () -> AWSGlueMetaStoreBaseProperties.of(props));
+        Assertions.assertEquals("us-east-1", glueProps.glueRegion);
     }
 
     @Test


### PR DESCRIPTION
### Summary
- Build `glueEndpoint` automatically when only `glueRegion` is provided.
- Extract `glueRegion` from `glueEndpoint` when only endpoint is given.
- Reject unsupported endpoint formats (e.g. `.amazonaws.com.cn`).
- Add clear exception messages for invalid or missing configuration.

### Example
| Input | Output / Exception |
|--------|--------------------|
| `glue.region=us-east-1` | `glue.endpoint=https://glue.us-east-1.amazonaws.com` | 
| `glue.endpoint=https://glue.us-east-1.amazonaws.com` | `glue.region=us-east-1` | 
| `glue.endpoint=https://glue.us-east-1.amazonaws.com.cn` |  `Invalid AWS Glue endpoint format` |
| `glue.endpoint=https://glue.us-east-1.amazonaws.com.cn` `glue.region=us-east-1`  |  `glue.endpoint=https://glue.us-east-1.amazonaws.com.cn` `glue.region=us-east-1` |

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
