### PR TITLE
[Enhancement](length) Support alias OCTET_LENGTH for function LENGTH

### DIFF
--- a/be/src/vec/functions/function_string.cpp
+++ b/be/src/vec/functions/function_string.cpp
@@ -1455,6 +1455,7 @@ void register_function_string(SimpleFunctionFactory& factory) {
     factory.register_alias(FunctionStringDigestMulti<SM3Sum>::name, "sm3");
     factory.register_alias(FunctionStringDigestSHA1::name, "sha");
     factory.register_alias(FunctionStringLocatePos::name, "position");
+    factory.register_alias(FunctionStringLength::name, "octet_length");
 }
 
 } // namespace doris::vectorized

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinScalarFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinScalarFunctions.java
@@ -828,7 +828,7 @@ public class BuiltinScalarFunctions implements FunctionHelper {
             scalar(Lcm.class, "lcm"),
             scalar(Least.class, "least"),
             scalar(Left.class, "left", "strleft"),
-            scalar(Length.class, "length"),
+            scalar(Length.class, "length", "octet_length"),
             scalar(Crc32.class, "crc32"),
             scalar(Crc32Internal.class, "crc32_internal"),
             scalar(Like.class, "like"),

--- a/regression-test/suites/nereids_function_p0/scalar_function/L.groovy
+++ b/regression-test/suites/nereids_function_p0/scalar_function/L.groovy
@@ -73,6 +73,18 @@ suite("nereids_scalar_fn_L") {
 	qt_sql_length_Varchar_notnull "select length(kvchrs1) from fn_test_not_nullable order by kvchrs1"
 	qt_sql_length_String "select length(kstr) from fn_test order by kstr"
 	qt_sql_length_String_notnull "select length(kstr) from fn_test_not_nullable order by kstr"
+	def length_str = sql """select length(kvchrs1) from fn_test order by kvchrs1"""
+	def octet_length_str = sql """select octet_length(kvchrs1) from fn_test order by kvchrs1"""
+	assertEquals(length_str, octet_length_str)
+	length_str = sql """select length(kvchrs1) from fn_test_not_nullable order by kvchrs1"""
+	octet_length_str = sql """select length(kvchrs1) from fn_test_not_nullable order by kvchrs1"""
+	assertEquals(length_str, octet_length_str)
+	length_str = sql """select length(kstr) from fn_test order by kstr"""
+	octet_length_str = sql """select octet_length(kstr) from fn_test order by kstr"""
+	assertEquals(length_str, octet_length_str)
+	length_str = sql """select length(kstr) from fn_test_not_nullable order by kstr"""
+	octet_length_str = sql """select octet_length(kstr) from fn_test_not_nullable order by kstr"""
+	assertEquals(length_str, octet_length_str)
 	qt_sql_like_Varchar_Varchar "select like(kvchrs1, kvchrs2) from fn_test order by kvchrs1"
 	qt_sql_like_Varchar_Varchar_not_null "select like(kvchrs1, kvchrs2) from fn_test_not_nullable order by kvchrs1"
 	qt_sql_ln_Double "select ln(kdbl) from fn_test order by kdbl"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

An alias for `LENGTH`(see [OCTET_LENGTH in MySQL](https://dev.mysql.com/doc/refman/8.4/en/string-functions.html#function_octet-length): [OCTET_LENGTH()](https://dev.mysql.com/doc/refman/8.4/en/string-functions.html#function_octet-length) is a synonym for [LENGTH()](https://dev.mysql.com/doc/refman/8.4/en/string-functions.html#function_length).)

```text
mysql> SELECT OCTET_LENGTH('abc');
+---------------------+
| OCTET_LENGTH('abc') |
+---------------------+
|                   3 |
+---------------------+

mysql> SELECT OCTET_LENGTH('你好');
+------------------------+
| OCTET_LENGTH('你好')   |
+------------------------+
|                      6 |
+------------------------+
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No. 
    - [ ] Yes. 

- Does this need documentation?
    - [x] No. There is already an explanation of the alias `OCTET_LENGTH` in `LENGTH`'s document.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

