### PR TITLE
[Bug](ip) fixed uint128 constructor in not align address

### DIFF
--- a/be/src/olap/types.h
+++ b/be/src/olap/types.h
@@ -1020,7 +1020,7 @@ struct FieldTypeTraits<FieldType::OLAP_FIELD_TYPE_IPV6>
     }
 
     static std::string to_string(const void* src) {
-        uint128_t value = *reinterpret_cast<const uint128_t*>(src);
+        uint128_t value = unaligned_load<uint128_t>(src);
         IPv6Value ipv6_value(value);
         return ipv6_value.to_string();
     }


### PR DESCRIPTION
### What problem does this PR solve?

ipv6 use uint128 to construct, but the mem access in storage engine in not align address may cause O3
access coredump

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

