### PR TITLE
[Chore](pipeline)some refactor of pipiline ctx and rf (prework of rec cte)

### DIFF
--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -1997,7 +1997,7 @@ void PipelineFragmentContext::_release_resource() {
     // The memory released by the query end is recorded in the query mem tracker.
     SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_query_ctx->query_mem_tracker());
     auto st = _query_ctx->exec_status();
-    for (auto & _task : _tasks) {
+    for (auto& _task : _tasks) {
         if (!_task.empty()) {
             _call_back(_task.front().first->runtime_state(), &st);
         }

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -143,8 +143,12 @@ PipelineFragmentContext::~PipelineFragmentContext() {
             .tag("query_id", print_id(_query_id))
             .tag("fragment_id", _fragment_id);
     _release_resource();
-    _runtime_state.reset();
-    _query_ctx.reset();
+    {
+        // The memory released by the query end is recorded in the query mem tracker.
+        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_query_ctx->query_mem_tracker());
+        _runtime_state.reset();
+        _query_ctx.reset();
+    }
 }
 
 bool PipelineFragmentContext::is_timeout(timespec now) const {

--- a/be/src/pipeline/pipeline_fragment_context.h
+++ b/be/src/pipeline/pipeline_fragment_context.h
@@ -126,6 +126,10 @@ public:
     std::string get_first_error_msg();
 
 private:
+    void _release_resource();
+
+    Status _build_and_prepare_full_pipeline(ThreadPool* thread_pool);
+
     Status _build_pipelines(ObjectPool* pool, const DescriptorTbl& descs, OperatorPtr* root,
                             PipelinePtr cur_pipe);
     Status _create_tree_helper(ObjectPool* pool, const std::vector<TPlanNode>& tnodes,

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -503,7 +503,7 @@ Status RuntimeState::register_consumer_runtime_filter(
         std::shared_ptr<RuntimeFilterConsumer>* consumer_filter) {
     bool need_merge = desc.has_remote_targets || need_local_merge;
     RuntimeFilterMgr* mgr = need_merge ? global_runtime_filter_mgr() : local_runtime_filter_mgr();
-    return mgr->register_consumer_filter(_query_ctx, desc, node_id, consumer_filter);
+    return mgr->register_consumer_filter(this, desc, node_id, consumer_filter);
 }
 
 bool RuntimeState::is_nereids() const {

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -503,7 +503,7 @@ public:
         _runtime_filter_mgr = runtime_filter_mgr;
     }
 
-    QueryContext* get_query_ctx() { return _query_ctx; }
+    QueryContext* get_query_ctx() const { return _query_ctx; }
 
     [[nodiscard]] bool low_memory_mode() const;
 
@@ -700,6 +700,15 @@ public:
         return VectorSearchUserParams(_query_options.hnsw_ef_search,
                                       _query_options.hnsw_check_relative_distance,
                                       _query_options.hnsw_bounded_queue);
+    }
+
+    void set_force_make_rf_wait_infinite() {
+        _query_options.__set_runtime_filter_wait_infinitely(true);
+    }
+
+    bool runtime_filter_wait_infinitely() const {
+        return _query_options.__isset.runtime_filter_wait_infinitely &&
+               _query_options.runtime_filter_wait_infinitely;
     }
 
 private:

--- a/be/src/runtime_filter/runtime_filter_consumer.h
+++ b/be/src/runtime_filter/runtime_filter_consumer.h
@@ -41,11 +41,11 @@ public:
         APPLIED, // The consumer will switch to this state after the expression is acquired
     };
 
-    static Status create(const QueryContext* query_ctx, const TRuntimeFilterDesc* desc, int node_id,
+    static Status create(const RuntimeState* state, const TRuntimeFilterDesc* desc, int node_id,
                          std::shared_ptr<RuntimeFilterConsumer>* res) {
         *res = std::shared_ptr<RuntimeFilterConsumer>(
-                new RuntimeFilterConsumer(query_ctx, desc, node_id));
-        RETURN_IF_ERROR((*res)->_init_with_desc(desc, &query_ctx->query_options()));
+                new RuntimeFilterConsumer(state, desc, node_id));
+        RETURN_IF_ERROR((*res)->_init_with_desc(desc, &state->query_options()));
         return Status::OK();
     }
 
@@ -86,17 +86,16 @@ public:
     }
 
 private:
-    RuntimeFilterConsumer(const QueryContext* query_ctx, const TRuntimeFilterDesc* desc,
-                          int node_id)
+    RuntimeFilterConsumer(const RuntimeState* state, const TRuntimeFilterDesc* desc, int node_id)
             : RuntimeFilter(desc),
               _probe_expr(desc->planId_to_target_expr.find(node_id)->second),
               _registration_time(MonotonicMillis()),
               _rf_state(State::NOT_READY) {
         // If bitmap filter is not applied, it will cause the query result to be incorrect
-        bool wait_infinitely = query_ctx->runtime_filter_wait_infinitely() ||
+        bool wait_infinitely = state->runtime_filter_wait_infinitely() ||
                                _runtime_filter_type == RuntimeFilterType::BITMAP_FILTER;
-        _rf_wait_time_ms = wait_infinitely ? query_ctx->execution_timeout() * 1000
-                                           : query_ctx->runtime_filter_wait_time_ms();
+        _rf_wait_time_ms = wait_infinitely ? state->get_query_ctx()->execution_timeout() * 1000
+                                           : state->get_query_ctx()->runtime_filter_wait_time_ms();
         DorisMetrics::instance()->runtime_filter_consumer_num->increment(1);
     }
 

--- a/be/src/runtime_filter/runtime_filter_mgr.cpp
+++ b/be/src/runtime_filter/runtime_filter_mgr.cpp
@@ -62,13 +62,13 @@ std::vector<std::shared_ptr<RuntimeFilterConsumer>> RuntimeFilterMgr::get_consum
 }
 
 Status RuntimeFilterMgr::register_consumer_filter(
-        const QueryContext* query_ctx, const TRuntimeFilterDesc& desc, int node_id,
+        const RuntimeState* state, const TRuntimeFilterDesc& desc, int node_id,
         std::shared_ptr<RuntimeFilterConsumer>* consumer) {
     SCOPED_CONSUME_MEM_TRACKER(_tracker.get());
     int32_t key = desc.filter_id;
 
     std::lock_guard<std::mutex> l(_lock);
-    RETURN_IF_ERROR(RuntimeFilterConsumer::create(query_ctx, &desc, node_id, consumer));
+    RETURN_IF_ERROR(RuntimeFilterConsumer::create(state, &desc, node_id, consumer));
     _consumer_map[key].push_back(*consumer);
     return Status::OK();
 }

--- a/be/src/runtime_filter/runtime_filter_mgr.h
+++ b/be/src/runtime_filter/runtime_filter_mgr.h
@@ -83,7 +83,7 @@ public:
 
     // get/set consumer
     std::vector<std::shared_ptr<RuntimeFilterConsumer>> get_consume_filters(int filter_id);
-    Status register_consumer_filter(const QueryContext* query_ctx, const TRuntimeFilterDesc& desc,
+    Status register_consumer_filter(const RuntimeState* state, const TRuntimeFilterDesc& desc,
                                     int node_id,
                                     std::shared_ptr<RuntimeFilterConsumer>* consumer_filter);
 

--- a/be/test/runtime_filter/runtime_filter_consumer_test.cpp
+++ b/be/test/runtime_filter/runtime_filter_consumer_test.cpp
@@ -31,7 +31,7 @@ public:
     void test_signal_aquire(TRuntimeFilterDesc desc) {
         std::shared_ptr<RuntimeFilterConsumer> consumer;
         FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
-                RuntimeFilterConsumer::create(_query_ctx.get(), &desc, 0, &consumer));
+                RuntimeFilterConsumer::create(_runtime_states[0].get(), &desc, 0, &consumer));
 
         std::shared_ptr<RuntimeFilterProducer> producer;
         FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
@@ -59,7 +59,7 @@ TEST_F(RuntimeFilterConsumerTest, basic) {
     std::shared_ptr<RuntimeFilterConsumer> consumer;
     auto desc = TRuntimeFilterDescBuilder().add_planId_to_target_expr(0).build();
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
-            RuntimeFilterConsumer::create(_query_ctx.get(), &desc, 0, &consumer));
+            RuntimeFilterConsumer::create(_runtime_states[1].get(), &desc, 0, &consumer));
 
     std::shared_ptr<RuntimeFilterConsumer> registed_consumer;
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(_runtime_states[1]->register_consumer_runtime_filter(
@@ -116,7 +116,7 @@ TEST_F(RuntimeFilterConsumerTest, timeout_aquire) {
     std::shared_ptr<RuntimeFilterConsumer> consumer;
     auto desc = TRuntimeFilterDescBuilder().add_planId_to_target_expr(0).build();
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
-            RuntimeFilterConsumer::create(_query_ctx.get(), &desc, 0, &consumer));
+            RuntimeFilterConsumer::create(_runtime_states[1].get(), &desc, 0, &consumer));
 
     std::shared_ptr<RuntimeFilterProducer> producer;
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
@@ -141,7 +141,7 @@ TEST_F(RuntimeFilterConsumerTest, wait_infinity) {
     const_cast<TQueryOptions&>(_query_ctx->_query_options)
             .__set_runtime_filter_wait_infinitely(true);
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
-            RuntimeFilterConsumer::create(_query_ctx.get(), &desc, 0, &consumer));
+            RuntimeFilterConsumer::create(_runtime_states[1].get(), &desc, 0, &consumer));
 
     std::shared_ptr<RuntimeFilterConsumer> registed_consumer;
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(_runtime_states[1]->register_consumer_runtime_filter(
@@ -152,7 +152,7 @@ TEST_F(RuntimeFilterConsumerTest, aquire_disabled) {
     std::shared_ptr<RuntimeFilterConsumer> consumer;
     auto desc = TRuntimeFilterDescBuilder().add_planId_to_target_expr(0).build();
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
-            RuntimeFilterConsumer::create(_query_ctx.get(), &desc, 0, &consumer));
+            RuntimeFilterConsumer::create(_runtime_states[1].get(), &desc, 0, &consumer));
 
     std::shared_ptr<RuntimeFilterProducer> producer;
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
@@ -174,7 +174,7 @@ TEST_F(RuntimeFilterConsumerTest, bitmap_filter) {
     std::shared_ptr<RuntimeFilterConsumer> consumer;
 
     {
-        auto st = RuntimeFilterConsumer::create(_query_ctx.get(), &desc, 0, &consumer);
+        auto st = RuntimeFilterConsumer::create(_runtime_states[1].get(), &desc, 0, &consumer);
         ASSERT_FALSE(st.ok());
     }
     desc.__set_src_expr(
@@ -195,13 +195,13 @@ TEST_F(RuntimeFilterConsumerTest, bitmap_filter) {
                     .build());
 
     {
-        auto st = RuntimeFilterConsumer::create(_query_ctx.get(), &desc, 0, &consumer);
+        auto st = RuntimeFilterConsumer::create(_runtime_states[1].get(), &desc, 0, &consumer);
         ASSERT_FALSE(st.ok());
     }
     {
         desc.__set_has_local_targets(false);
         desc.__set_has_remote_targets(true);
-        auto st = RuntimeFilterConsumer::create(_query_ctx.get(), &desc, 0, &consumer);
+        auto st = RuntimeFilterConsumer::create(_runtime_states[1].get(), &desc, 0, &consumer);
         ASSERT_FALSE(st.ok());
         desc.__set_has_local_targets(true);
         desc.__set_has_remote_targets(false);
@@ -209,7 +209,7 @@ TEST_F(RuntimeFilterConsumerTest, bitmap_filter) {
 
     desc.__set_bitmap_target_expr(TRuntimeFilterDescBuilder::get_default_expr());
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
-            RuntimeFilterConsumer::create(_query_ctx.get(), &desc, 0, &consumer));
+            RuntimeFilterConsumer::create(_runtime_states[1].get(), &desc, 0, &consumer));
 }
 
 TEST_F(RuntimeFilterConsumerTest, aquire_signal_at_same_time) {
@@ -217,7 +217,7 @@ TEST_F(RuntimeFilterConsumerTest, aquire_signal_at_same_time) {
         std::shared_ptr<RuntimeFilterConsumer> consumer;
         auto desc = TRuntimeFilterDescBuilder().add_planId_to_target_expr(0).build();
         FAIL_IF_ERROR_OR_CATCH_EXCEPTION(
-                RuntimeFilterConsumer::create(_query_ctx.get(), &desc, 0, &consumer));
+                RuntimeFilterConsumer::create(_runtime_states[1].get(), &desc, 0, &consumer));
 
         std::shared_ptr<RuntimeFilterProducer> producer;
         FAIL_IF_ERROR_OR_CATCH_EXCEPTION(

--- a/be/test/runtime_filter/runtime_filter_mgr_test.cpp
+++ b/be/test/runtime_filter/runtime_filter_mgr_test.cpp
@@ -65,7 +65,7 @@ TEST_F(RuntimeFilterMgrTest, TestRuntimeFilterMgr) {
         EXPECT_TRUE(global_runtime_filter_mgr->get_consume_filters(filter_id).empty());
         std::shared_ptr<RuntimeFilterConsumer> consumer_filter;
         EXPECT_TRUE(global_runtime_filter_mgr
-                            ->register_consumer_filter(ctx.get(), desc, 0, &consumer_filter)
+                            ->register_consumer_filter(&state, desc, 0, &consumer_filter)
                             .ok());
         EXPECT_FALSE(global_runtime_filter_mgr->get_consume_filters(filter_id).empty());
     }


### PR DESCRIPTION
### What problem does this PR solve?
part of #57358
This pull request refactors and improves the pipeline fragment context and runtime filter consumer logic in the backend system. The main changes focus on better resource management and more robust runtime filter handling by passing `RuntimeState` instead of `QueryContext` where appropriate. This ensures that runtime filter consumers have more accurate context and options, and also improves thread safety and encapsulation.

Key changes include:

**Pipeline resource management and preparation:**
- Introduced a new `_release_resource()` method in `PipelineFragmentContext` to encapsulate resource cleanup logic, improving maintainability and ensuring all relevant resources are properly released. The destructor now calls this method instead of duplicating cleanup code. [[1]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617L145-L161) [[2]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617R1994-R2014)
- Refactored pipeline preparation by moving the full pipeline build and preparation logic into a new `_build_and_prepare_full_pipeline()` method, simplifying the `prepare()` method and making the codebase easier to follow. [[1]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617R241-R288) [[2]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617L325-R358) [[3]](diffhunk://#diff-c606eba62cda49d906e1cdd2566a8c8f6c6344c2503a75cc4cd3213e69796ab2R129-R132)
- Added initialization of `_closed_tasks` to zero in `_build_pipeline_tasks()` for proper task state tracking.
- Added locking with `_task_mutex` in `debug_string()` and `_release_resource()` to improve thread safety when accessing or modifying `_tasks`. [[1]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617R1918) [[2]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617R1994-R2014)

**Runtime filter consumer and manager refactoring:**
- Changed the interface for registering and creating runtime filter consumers to use `RuntimeState` instead of `QueryContext`. This provides richer context and allows runtime filter consumers to access query options directly. [[1]](diffhunk://#diff-1e9d839e1befa1609458c0381610e56fa959060366f89c70a4f8ea471583d500L506-R506) [[2]](diffhunk://#diff-efeb89760ec70cdad5ae9c6169e213b9efa84fccb6ede73f626bf6583bd82333L506-R506) [[3]](diffhunk://#diff-e9fec5553f7a236ca6d86f1828ce169ffea3aeebfa231aaeeea77050105997b9L44-R48) [[4]](diffhunk://#diff-e9fec5553f7a236ca6d86f1828ce169ffea3aeebfa231aaeeea77050105997b9L89-R98) [[5]](diffhunk://#diff-5354bacdeccbd2d6f61cee8d8206e6853f7505f353bfd33d556e05aba0a4db7fL65-R71) [[6]](diffhunk://#diff-8d3b5fadacc9da8da3387768a6c5caf841a85e1bdbc5f02227735fd4e03255ecL86-R86)
- Updated `RuntimeFilterConsumer` to use `RuntimeState` for initialization and waiting logic, ensuring correct timeout and wait behavior based on query options. [[1]](diffhunk://#diff-e9fec5553f7a236ca6d86f1828ce169ffea3aeebfa231aaeeea77050105997b9L44-R48) [[2]](diffhunk://#diff-e9fec5553f7a236ca6d86f1828ce169ffea3aeebfa231aaeeea77050105997b9L89-R98)
- Added helper methods in `RuntimeState` to set and get the `runtime_filter_wait_infinitely` option, improving encapsulation and making option handling more robust.

**Test updates:**
- Updated all relevant tests to use `RuntimeState` instead of `QueryContext` when creating or registering runtime filter consumers, ensuring tests match the new interfaces. [[1]](diffhunk://#diff-6f1cb3a7f5d1662512c380f36e284d527c2bb1681b13e3a3a1d3fada67640067L34-R34) [[2]](diffhunk://#diff-6f1cb3a7f5d1662512c380f36e284d527c2bb1681b13e3a3a1d3fada67640067L62-R62) [[3]](diffhunk://#diff-6f1cb3a7f5d1662512c380f36e284d527c2bb1681b13e3a3a1d3fada67640067L119-R119) [[4]](diffhunk://#diff-6f1cb3a7f5d1662512c380f36e284d527c2bb1681b13e3a3a1d3fada67640067L144-R144) [[5]](diffhunk://#diff-6f1cb3a7f5d1662512c380f36e284d527c2bb1681b13e3a3a1d3fada67640067L155-R155) [[6]](diffhunk://#diff-6f1cb3a7f5d1662512c380f36e284d527c2bb1681b13e3a3a1d3fada67640067L177-R177) [[7]](diffhunk://#diff-6f1cb3a7f5d1662512c380f36e284d527c2bb1681b13e3a3a1d3fada67640067L198-R220) [[8]](diffhunk://#diff-a777cd53e7b401b384cbf992123362fb97e262108e72245a4226280d20669e84L68-R68)

These changes collectively improve the maintainability, correctness, and thread safety of the pipeline and runtime filter subsystems.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

