### PR TITLE
[opt](nereids) when we check if there is a target for runtime filter, we should use ctx.probeSlot not ctx.probeExpr

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPushDownVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPushDownVisitor.java
@@ -269,11 +269,7 @@ public class RuntimeFilterPushDownVisitor extends PlanVisitor<Boolean, PushDownC
         probExprList.add(ctx.probeExpr);
         Pair<PhysicalRelation, Slot> srcPair = ctx.rfContext.getAliasTransferMap().get(ctx.srcExpr);
         PhysicalRelation srcNode = (srcPair == null) ? null : srcPair.first;
-        Expression probe = ctx.probeExpr;
-        if (ctx.probeExpr instanceof Cast) {
-            probe = ctx.probeExpr.child(0);
-        }
-        Pair<PhysicalRelation, Slot> targetPair = ctx.rfContext.getAliasTransferMap().get(probe);
+        Pair<PhysicalRelation, Slot> targetPair = ctx.rfContext.getAliasTransferMap().get(ctx.probeSlot);
         if (targetPair == null) {
             /* cases for "targetPair is null"
              when probeExpr is output slot of setOperator, targetPair is null

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPushDownVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPushDownVisitor.java
@@ -269,7 +269,11 @@ public class RuntimeFilterPushDownVisitor extends PlanVisitor<Boolean, PushDownC
         probExprList.add(ctx.probeExpr);
         Pair<PhysicalRelation, Slot> srcPair = ctx.rfContext.getAliasTransferMap().get(ctx.srcExpr);
         PhysicalRelation srcNode = (srcPair == null) ? null : srcPair.first;
-        Pair<PhysicalRelation, Slot> targetPair = ctx.rfContext.getAliasTransferMap().get(ctx.probeExpr);
+        Expression probe = ctx.probeExpr;
+        if (ctx.probeExpr instanceof Cast) {
+            probe = ctx.probeExpr.child(0);
+        }
+        Pair<PhysicalRelation, Slot> targetPair = ctx.rfContext.getAliasTransferMap().get(probe);
         if (targetPair == null) {
             /* cases for "targetPair is null"
              when probeExpr is output slot of setOperator, targetPair is null

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalNestedLoopJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalNestedLoopJoin.java
@@ -230,7 +230,13 @@ public class PhysicalNestedLoopJoin<
         } else {
             otherJoinConjuncts.forEach(expr -> builder.append(expr.shapeInfo()));
         }
-
+        if (!runtimeFilters.isEmpty()) {
+            builder.append(" build RFs:").append(runtimeFilters.stream()
+                    .map(rf -> rf.shapeInfo()).collect(Collectors.joining(";")));
+        }
+        if (!runtimeFiltersV2.isEmpty()) {
+            builder.append(" RFV2: ").append(runtimeFiltersV2);
+        }
         return builder.toString();
     }
 

--- a/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query2.out
+++ b/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query2.out
@@ -21,18 +21,18 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ------PhysicalDistribute[DistributionSpecGather]
 --------PhysicalQuickSort[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF2 d_week_seq->[d_week_seq]
+------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF3 d_week_seq->[d_week_seq]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 53))) otherCondition=()
+----------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 53))) otherCondition=() build RFs:RF2 expr_cast(d_week_seq1 as BIGINT)->[(cast(d_week_seq as BIGINT) - 53)]
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN shuffle] hashCondition=((date_dim.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF1 d_week_seq->[d_week_seq]
 ----------------------PhysicalProject
-------------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF1
+------------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF1 RF2
 ----------------------PhysicalProject
 ------------------------filter((date_dim.d_year = 1999))
 --------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
---------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF2
+--------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF3
 --------------PhysicalProject
 ----------------filter((date_dim.d_year = 1998))
 ------------------PhysicalOlapScan[date_dim]

--- a/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query2.out
+++ b/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query2.out
@@ -21,18 +21,18 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ------PhysicalDistribute[DistributionSpecGather]
 --------PhysicalQuickSort[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF2 d_week_seq->[d_week_seq]
+------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF3 d_week_seq->[d_week_seq]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 53))) otherCondition=()
+----------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 53))) otherCondition=() build RFs:RF2 expr_cast(d_week_seq1 as BIGINT)->[(cast(d_week_seq as BIGINT) - 53)]
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN shuffle] hashCondition=((date_dim.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF1 d_week_seq->[d_week_seq]
 ----------------------PhysicalProject
-------------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF1
+------------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF1 RF2
 ----------------------PhysicalProject
 ------------------------filter((date_dim.d_year = 1999))
 --------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
---------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF2
+--------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF3
 --------------PhysicalProject
 ----------------filter((date_dim.d_year = 1998))
 ------------------PhysicalOlapScan[date_dim]

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query2.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query2.out
@@ -21,11 +21,11 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ------PhysicalDistribute[DistributionSpecGather]
 --------PhysicalQuickSort[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN broadcast] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 53))) otherCondition=()
+------------hashJoin[INNER_JOIN broadcast] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 53))) otherCondition=() build RFs:RF3 expr_(cast(d_week_seq2 as BIGINT) - 53)->[cast(d_week_seq as BIGINT)]
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN shuffle] hashCondition=((date_dim.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF2 d_week_seq->[d_week_seq]
 ------------------PhysicalProject
---------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF2
+--------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF2 RF3
 ------------------PhysicalProject
 --------------------filter((date_dim.d_year = 1998))
 ----------------------PhysicalOlapScan[date_dim]

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query59.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query59.out
@@ -16,13 +16,13 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------PhysicalDistribute[DistributionSpecGather]
 --------PhysicalTopN[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 52)) and (y.s_store_id1 = x.s_store_id2)) otherCondition=() build RFs:RF5 s_store_id2->[s_store_id]
+------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 52)) and (y.s_store_id1 = x.s_store_id2)) otherCondition=() build RFs:RF5 s_store_id2->[s_store_id];RF6 expr_(cast(d_week_seq2 as BIGINT) - 52)->[cast(d_week_seq as BIGINT)]
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN broadcast] hashCondition=((d.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF4 d_week_seq->[d_week_seq]
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN shuffle] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF3 s_store_sk->[ss_store_sk]
 ----------------------PhysicalProject
-------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF4
+------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF4 RF6
 ----------------------PhysicalProject
 ------------------------PhysicalOlapScan[store] apply RFs: RF5
 ------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query2.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query2.out
@@ -21,11 +21,11 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ------PhysicalDistribute[DistributionSpecGather]
 --------PhysicalQuickSort[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN broadcast] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 53))) otherCondition=()
+------------hashJoin[INNER_JOIN broadcast] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 53))) otherCondition=() build RFs:RF3 expr_(cast(d_week_seq2 as BIGINT) - 53)->[cast(d_week_seq as BIGINT)]
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN shuffle] hashCondition=((date_dim.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF2 d_week_seq->[d_week_seq]
 ------------------PhysicalProject
---------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF2
+--------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF2 RF3
 ------------------PhysicalProject
 --------------------filter((date_dim.d_year = 1998))
 ----------------------PhysicalOlapScan[date_dim]

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query59.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query59.out
@@ -16,13 +16,13 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------PhysicalDistribute[DistributionSpecGather]
 --------PhysicalTopN[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 52)) and (y.s_store_id1 = x.s_store_id2)) otherCondition=() build RFs:RF5 s_store_id2->[s_store_id]
+------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 52)) and (y.s_store_id1 = x.s_store_id2)) otherCondition=() build RFs:RF5 s_store_id2->[s_store_id];RF6 expr_(cast(d_week_seq2 as BIGINT) - 52)->[cast(d_week_seq as BIGINT)]
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN broadcast] hashCondition=((d.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF4 d_week_seq->[d_week_seq]
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN shuffle] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF3 s_store_sk->[ss_store_sk]
 ----------------------PhysicalProject
-------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF4
+------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF4 RF6
 ----------------------PhysicalProject
 ------------------------PhysicalOlapScan[store] apply RFs: RF5
 ------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf1000/hint/query2.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/hint/query2.out
@@ -21,11 +21,11 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ------PhysicalDistribute[DistributionSpecGather]
 --------PhysicalQuickSort[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 53))) otherCondition=()
+------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 53))) otherCondition=() build RFs:RF3 expr_(cast(d_week_seq2 as BIGINT) - 53)->[cast(d_week_seq as BIGINT)]
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN shuffle] hashCondition=((date_dim.d_week_seq = y.d_week_seq1)) otherCondition=() build RFs:RF2 d_week_seq->[d_week_seq]
 ------------------PhysicalProject
---------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF2
+--------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF2 RF3
 ------------------PhysicalProject
 --------------------filter((date_dim.d_year = 1998))
 ----------------------PhysicalOlapScan[date_dim]

--- a/regression-test/data/shape_check/tpcds_sf1000/hint/query59.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/hint/query59.out
@@ -16,13 +16,13 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------PhysicalDistribute[DistributionSpecGather]
 --------PhysicalTopN[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 52)) and (y.s_store_id1 = x.s_store_id2)) otherCondition=() build RFs:RF5 s_store_id2->[s_store_id]
+------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 52)) and (y.s_store_id1 = x.s_store_id2)) otherCondition=() build RFs:RF5 s_store_id2->[s_store_id];RF6 expr_(cast(d_week_seq2 as BIGINT) - 52)->[cast(d_week_seq as BIGINT)]
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN broadcast] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF4 s_store_sk->[ss_store_sk]
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN shuffle] hashCondition=((d.d_week_seq = y.d_week_seq1)) otherCondition=() build RFs:RF3 d_week_seq->[d_week_seq]
 ----------------------PhysicalProject
-------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF4
+------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF4 RF6
 ----------------------PhysicalProject
 ------------------------filter((d.d_month_seq <= 1206) and (d.d_month_seq >= 1195))
 --------------------------PhysicalOlapScan[date_dim(d)]

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query2.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query2.out
@@ -21,11 +21,11 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ------PhysicalDistribute[DistributionSpecGather]
 --------PhysicalQuickSort[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN broadcast] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 53))) otherCondition=()
+------------hashJoin[INNER_JOIN broadcast] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 53))) otherCondition=() build RFs:RF3 expr_(cast(d_week_seq2 as BIGINT) - 53)->[cast(d_week_seq as BIGINT)]
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN shuffle] hashCondition=((date_dim.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF2 d_week_seq->[d_week_seq]
 ------------------PhysicalProject
---------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF2
+--------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF2 RF3
 ------------------PhysicalProject
 --------------------filter((date_dim.d_year = 1998))
 ----------------------PhysicalOlapScan[date_dim]

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query54.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query54.out
@@ -13,34 +13,43 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[ss_sold_date_sk]
+--------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= d_month_seq+3) build RFs:RF17 d_month_seq+3->[cast(d_month_seq as BIGINT)]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((my_customers.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF6 c_customer_sk->[ss_customer_sk]
+------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= d_month_seq+1) build RFs:RF16 d_month_seq+1->[cast(d_month_seq as BIGINT)]
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF6 RF7
---------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_county = store.s_county) and (customer_address.ca_state = store.s_state)) otherCondition=() build RFs:RF4 s_county->[ca_county];RF5 s_state->[ca_state]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF14 d_date_sk->[ss_sold_date_sk];RF15 d_date_sk->[ss_sold_date_sk]
 ------------------------------------PhysicalProject
---------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 c_current_addr_sk->[ca_address_sk]
+--------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((my_customers.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF12 c_customer_sk->[ss_customer_sk];RF13 c_customer_sk->[ss_customer_sk]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF3 RF4 RF5
+------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF12 RF13 RF14 RF15
 ----------------------------------------PhysicalProject
-------------------------------------------hashAgg[GLOBAL]
---------------------------------------------PhysicalDistribute[DistributionSpecHash]
-----------------------------------------------hashAgg[LOCAL]
+------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_county = store.s_county) and (customer_address.ca_state = store.s_state)) otherCondition=() build RFs:RF8 s_county->[ca_county];RF9 s_county->[ca_county];RF10 s_state->[ca_state];RF11 s_state->[ca_state]
+--------------------------------------------PhysicalProject
+----------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF6 c_current_addr_sk->[ca_address_sk];RF7 c_current_addr_sk->[ca_address_sk]
 ------------------------------------------------PhysicalProject
---------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_customer_sk = cs_or_ws_sales.customer_sk)) otherCondition=() build RFs:RF2 customer_sk->[c_customer_sk]
-----------------------------------------------------PhysicalProject
-------------------------------------------------------PhysicalOlapScan[customer] apply RFs: RF2
-----------------------------------------------------PhysicalProject
-------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((cs_or_ws_sales.sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk,ws_sold_date_sk]
+--------------------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF6 RF7 RF8 RF9 RF10 RF11
+------------------------------------------------PhysicalProject
+--------------------------------------------------hashAgg[GLOBAL]
+----------------------------------------------------PhysicalDistribute[DistributionSpecHash]
+------------------------------------------------------hashAgg[LOCAL]
 --------------------------------------------------------PhysicalProject
-----------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((cs_or_ws_sales.item_sk = item.i_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[cs_item_sk,ws_item_sk]
-------------------------------------------------------------PhysicalUnion
---------------------------------------------------------------PhysicalDistribute[DistributionSpecExecutionAny]
+----------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_customer_sk = cs_or_ws_sales.customer_sk)) otherCondition=() build RFs:RF4 customer_sk->[c_customer_sk];RF5 customer_sk->[c_customer_sk]
+------------------------------------------------------------PhysicalProject
+--------------------------------------------------------------PhysicalOlapScan[customer] apply RFs: RF4 RF5
+------------------------------------------------------------PhysicalProject
+--------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((cs_or_ws_sales.sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[cs_sold_date_sk,ws_sold_date_sk];RF3 d_date_sk->[cs_sold_date_sk,ws_sold_date_sk]
 ----------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1
---------------------------------------------------------------PhysicalDistribute[DistributionSpecExecutionAny]
+------------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((cs_or_ws_sales.item_sk = item.i_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[cs_item_sk,ws_item_sk];RF1 i_item_sk->[cs_item_sk,ws_item_sk]
+--------------------------------------------------------------------PhysicalUnion
+----------------------------------------------------------------------PhysicalDistribute[DistributionSpecExecutionAny]
+------------------------------------------------------------------------PhysicalProject
+--------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1 RF2 RF3
+----------------------------------------------------------------------PhysicalDistribute[DistributionSpecExecutionAny]
+------------------------------------------------------------------------PhysicalProject
+--------------------------------------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF1 RF2 RF3
+--------------------------------------------------------------------PhysicalProject
+----------------------------------------------------------------------filter((item.i_category = 'Music') and (item.i_class = 'country'))
+------------------------------------------------------------------------PhysicalOlapScan[item]
 ----------------------------------------------------------------PhysicalProject
 ------------------------------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF1
 ------------------------------------------------------------PhysicalProject
@@ -56,15 +65,7 @@ PhysicalResultSink
 --------------------------------PhysicalProject
 ----------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= d_month_seq+1)
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[date_dim]
-------------------------------------PhysicalAssertNumRows
---------------------------------------PhysicalDistribute[DistributionSpecGather]
-----------------------------------------hashAgg[GLOBAL]
-------------------------------------------PhysicalDistribute[DistributionSpecHash]
---------------------------------------------hashAgg[LOCAL]
-----------------------------------------------PhysicalProject
-------------------------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 1999))
---------------------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------PhysicalOlapScan[date_dim] apply RFs: RF16 RF17
 --------------------------------PhysicalAssertNumRows
 ----------------------------------PhysicalDistribute[DistributionSpecGather]
 ------------------------------------hashAgg[GLOBAL]

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query54.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query54.out
@@ -13,45 +13,36 @@ PhysicalResultSink
 --------------------PhysicalDistribute[DistributionSpecHash]
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= d_month_seq+3) build RFs:RF17 d_month_seq+3->[cast(d_month_seq as BIGINT)]
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF16 d_date_sk->[ss_sold_date_sk];RF17 d_date_sk->[ss_sold_date_sk]
 ----------------------------PhysicalProject
-------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= d_month_seq+1) build RFs:RF16 d_month_seq+1->[cast(d_month_seq as BIGINT)]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((my_customers.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF14 c_customer_sk->[ss_customer_sk];RF15 c_customer_sk->[ss_customer_sk]
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF14 d_date_sk->[ss_sold_date_sk];RF15 d_date_sk->[ss_sold_date_sk]
+----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF14 RF15 RF16 RF17
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_county = store.s_county) and (customer_address.ca_state = store.s_state)) otherCondition=() build RFs:RF10 s_county->[ca_county];RF11 s_county->[ca_county];RF12 s_state->[ca_state];RF13 s_state->[ca_state]
 ------------------------------------PhysicalProject
---------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((my_customers.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF12 c_customer_sk->[ss_customer_sk];RF13 c_customer_sk->[ss_customer_sk]
+--------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF8 c_current_addr_sk->[ca_address_sk];RF9 c_current_addr_sk->[ca_address_sk]
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF12 RF13 RF14 RF15
+------------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF8 RF9 RF10 RF11 RF12 RF13
 ----------------------------------------PhysicalProject
-------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_address.ca_county = store.s_county) and (customer_address.ca_state = store.s_state)) otherCondition=() build RFs:RF8 s_county->[ca_county];RF9 s_county->[ca_county];RF10 s_state->[ca_state];RF11 s_state->[ca_state]
---------------------------------------------PhysicalProject
-----------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF6 c_current_addr_sk->[ca_address_sk];RF7 c_current_addr_sk->[ca_address_sk]
+------------------------------------------hashAgg[GLOBAL]
+--------------------------------------------PhysicalDistribute[DistributionSpecHash]
+----------------------------------------------hashAgg[LOCAL]
 ------------------------------------------------PhysicalProject
---------------------------------------------------PhysicalOlapScan[customer_address] apply RFs: RF6 RF7 RF8 RF9 RF10 RF11
-------------------------------------------------PhysicalProject
---------------------------------------------------hashAgg[GLOBAL]
-----------------------------------------------------PhysicalDistribute[DistributionSpecHash]
-------------------------------------------------------hashAgg[LOCAL]
+--------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_customer_sk = cs_or_ws_sales.customer_sk)) otherCondition=() build RFs:RF6 customer_sk->[c_customer_sk];RF7 customer_sk->[c_customer_sk]
+----------------------------------------------------PhysicalProject
+------------------------------------------------------PhysicalOlapScan[customer] apply RFs: RF6 RF7
+----------------------------------------------------PhysicalProject
+------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((cs_or_ws_sales.sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[cs_sold_date_sk,ws_sold_date_sk];RF5 d_date_sk->[cs_sold_date_sk,ws_sold_date_sk]
 --------------------------------------------------------PhysicalProject
-----------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer.c_customer_sk = cs_or_ws_sales.customer_sk)) otherCondition=() build RFs:RF4 customer_sk->[c_customer_sk];RF5 customer_sk->[c_customer_sk]
-------------------------------------------------------------PhysicalProject
---------------------------------------------------------------PhysicalOlapScan[customer] apply RFs: RF4 RF5
-------------------------------------------------------------PhysicalProject
---------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((cs_or_ws_sales.sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[cs_sold_date_sk,ws_sold_date_sk];RF3 d_date_sk->[cs_sold_date_sk,ws_sold_date_sk]
+----------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((cs_or_ws_sales.item_sk = item.i_item_sk)) otherCondition=() build RFs:RF2 i_item_sk->[cs_item_sk,ws_item_sk];RF3 i_item_sk->[cs_item_sk,ws_item_sk]
+------------------------------------------------------------PhysicalUnion
+--------------------------------------------------------------PhysicalDistribute[DistributionSpecExecutionAny]
 ----------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((cs_or_ws_sales.item_sk = item.i_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[cs_item_sk,ws_item_sk];RF1 i_item_sk->[cs_item_sk,ws_item_sk]
---------------------------------------------------------------------PhysicalUnion
-----------------------------------------------------------------------PhysicalDistribute[DistributionSpecExecutionAny]
-------------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1 RF2 RF3
-----------------------------------------------------------------------PhysicalDistribute[DistributionSpecExecutionAny]
-------------------------------------------------------------------------PhysicalProject
---------------------------------------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF1 RF2 RF3
---------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------filter((item.i_category = 'Music') and (item.i_class = 'country'))
-------------------------------------------------------------------------PhysicalOlapScan[item]
+------------------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF2 RF3 RF4 RF5
+--------------------------------------------------------------PhysicalDistribute[DistributionSpecExecutionAny]
 ----------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF1
+------------------------------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF2 RF3 RF4 RF5
 ------------------------------------------------------------PhysicalProject
 --------------------------------------------------------------filter((item.i_category = 'Music') and (item.i_class = 'country'))
 ----------------------------------------------------------------PhysicalOlapScan[item]
@@ -61,11 +52,19 @@ PhysicalResultSink
 ------------------------------------PhysicalProject
 --------------------------------------PhysicalOlapScan[store]
 ----------------------------PhysicalProject
-------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= d_month_seq+3)
+------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= d_month_seq+3) build RFs:RF1 d_month_seq+3->[cast(d_month_seq as BIGINT)]
 --------------------------------PhysicalProject
-----------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= d_month_seq+1)
+----------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= d_month_seq+1) build RFs:RF0 d_month_seq+1->[cast(d_month_seq as BIGINT)]
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[date_dim] apply RFs: RF16 RF17
+--------------------------------------PhysicalOlapScan[date_dim] apply RFs: RF0 RF1
+------------------------------------PhysicalAssertNumRows
+--------------------------------------PhysicalDistribute[DistributionSpecGather]
+----------------------------------------hashAgg[GLOBAL]
+------------------------------------------PhysicalDistribute[DistributionSpecHash]
+--------------------------------------------hashAgg[LOCAL]
+----------------------------------------------PhysicalProject
+------------------------------------------------filter((date_dim.d_moy = 1) and (date_dim.d_year = 1999))
+--------------------------------------------------PhysicalOlapScan[date_dim]
 --------------------------------PhysicalAssertNumRows
 ----------------------------------PhysicalDistribute[DistributionSpecGather]
 ------------------------------------hashAgg[GLOBAL]

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query59.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query59.out
@@ -16,13 +16,13 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------PhysicalDistribute[DistributionSpecGather]
 --------PhysicalTopN[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 52)) and (y.s_store_id1 = x.s_store_id2)) otherCondition=() build RFs:RF5 s_store_id2->[s_store_id]
+------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 52)) and (y.s_store_id1 = x.s_store_id2)) otherCondition=() build RFs:RF5 s_store_id2->[s_store_id];RF6 expr_(cast(d_week_seq2 as BIGINT) - 52)->[cast(d_week_seq as BIGINT)]
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN broadcast] hashCondition=((d.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF4 d_week_seq->[d_week_seq]
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN shuffle] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF3 s_store_sk->[ss_store_sk]
 ----------------------PhysicalProject
-------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF4
+------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF4 RF6
 ----------------------PhysicalProject
 ------------------------PhysicalOlapScan[store] apply RFs: RF5
 ------------------PhysicalProject

--- a/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query2.out
+++ b/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query2.out
@@ -21,18 +21,18 @@ PhysicalCteAnchor ( cteId=CTEId#1 )
 ------PhysicalDistribute[DistributionSpecGather]
 --------PhysicalQuickSort[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF2 d_week_seq->[d_week_seq]
+------------hashJoin[INNER_JOIN broadcast] hashCondition=((date_dim.d_week_seq = d_week_seq2)) otherCondition=() build RFs:RF3 d_week_seq->[d_week_seq]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN broadcast] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 53))) otherCondition=()
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 53))) otherCondition=() build RFs:RF2 expr_(cast(d_week_seq2 as BIGINT) - 53)->[cast(d_week_seq as BIGINT)]
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN shuffle] hashCondition=((date_dim.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF1 d_week_seq->[d_week_seq]
 ----------------------PhysicalProject
-------------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF1
+------------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF1 RF2
 ----------------------PhysicalProject
 ------------------------filter((date_dim.d_year = 1998))
 --------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalProject
---------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF2
+--------------------PhysicalCteConsumer ( cteId=CTEId#1 ) apply RFs: RF3
 --------------PhysicalProject
 ----------------filter((date_dim.d_year = 1999))
 ------------------PhysicalOlapScan[date_dim]

--- a/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query59.out
+++ b/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query59.out
@@ -16,13 +16,13 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------PhysicalDistribute[DistributionSpecGather]
 --------PhysicalTopN[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN broadcast] hashCondition=((d.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF5 d_week_seq->[d_week_seq]
+------------hashJoin[INNER_JOIN broadcast] hashCondition=((d.d_week_seq = d_week_seq1)) otherCondition=() build RFs:RF6 d_week_seq->[d_week_seq]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 52)) and (y.s_store_id1 = x.s_store_id2)) otherCondition=() build RFs:RF4 s_store_id2->[s_store_id]
+----------------hashJoin[INNER_JOIN shuffle] hashCondition=((expr_cast(d_week_seq1 as BIGINT) = expr_(cast(d_week_seq2 as BIGINT) - 52)) and (y.s_store_id1 = x.s_store_id2)) otherCondition=() build RFs:RF4 s_store_id2->[s_store_id];RF5 expr_(cast(d_week_seq2 as BIGINT) - 52)->[cast(d_week_seq as BIGINT)]
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN shuffle] hashCondition=((wss.ss_store_sk = store.s_store_sk)) otherCondition=() build RFs:RF3 s_store_sk->[ss_store_sk]
 ----------------------PhysicalProject
-------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF5
+------------------------PhysicalCteConsumer ( cteId=CTEId#0 ) apply RFs: RF3 RF5 RF6
 ----------------------PhysicalProject
 ------------------------PhysicalOlapScan[store] apply RFs: RF4
 ------------------PhysicalProject

--- a/regression-test/suites/shape_check/tpcds_sf1000/shape/query54.groovy
+++ b/regression-test/suites/shape_check/tpcds_sf1000/shape/query54.groovy
@@ -32,7 +32,7 @@ suite("query54") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_runtime_filter_prune=false'
-    sql 'set runtime_filter_type=8'
+    sql 'set runtime_filter_type=12'
     sql 'set dump_nereids_memo=false'
     sql "set disable_nereids_rules=PRUNE_EMPTY_PARTITION"
 


### PR DESCRIPTION
### What problem does this PR solve?
when we check if there  is a target for runtime filter, we should use ctx.probeSlot not ctx.probeExpr

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

