### PR TITLE
[fix](scanner) Make Scanner close() method thread-safe using atomic operations

### DIFF
--- a/be/src/vec/exec/scan/es_scanner.cpp
+++ b/be/src/vec/exec/scan/es_scanner.cpp
@@ -191,8 +191,7 @@ Status EsScanner::_get_next(std::vector<vectorized::MutableColumnPtr>& columns) 
 }
 
 Status EsScanner::close(RuntimeState* state) {
-    bool expected = false;
-    if (!_is_closed.compare_exchange_strong(expected, true)) {
+    if (!_try_close()) {
         return Status::OK();
     }
 

--- a/be/src/vec/exec/scan/es_scanner.cpp
+++ b/be/src/vec/exec/scan/es_scanner.cpp
@@ -191,7 +191,8 @@ Status EsScanner::_get_next(std::vector<vectorized::MutableColumnPtr>& columns) 
 }
 
 Status EsScanner::close(RuntimeState* state) {
-    if (_is_closed) {
+    bool expected = false;
+    if (!_is_closed.compare_exchange_strong(expected, true)) {
         return Status::OK();
     }
 

--- a/be/src/vec/exec/scan/file_scanner.cpp
+++ b/be/src/vec/exec/scan/file_scanner.cpp
@@ -1714,8 +1714,7 @@ Status FileScanner::_init_expr_ctxes() {
 }
 
 Status FileScanner::close(RuntimeState* state) {
-    bool expected = false;
-    if (!_is_closed.compare_exchange_strong(expected, true)) {
+    if (!_try_close()) {
         return Status::OK();
     }
 

--- a/be/src/vec/exec/scan/file_scanner.cpp
+++ b/be/src/vec/exec/scan/file_scanner.cpp
@@ -1714,7 +1714,8 @@ Status FileScanner::_init_expr_ctxes() {
 }
 
 Status FileScanner::close(RuntimeState* state) {
-    if (_is_closed) {
+    bool expected = false;
+    if (!_is_closed.compare_exchange_strong(expected, true)) {
         return Status::OK();
     }
 

--- a/be/src/vec/exec/scan/jdbc_scanner.cpp
+++ b/be/src/vec/exec/scan/jdbc_scanner.cpp
@@ -188,6 +188,10 @@ void JdbcScanner::_update_profile() {
 }
 
 Status JdbcScanner::close(RuntimeState* state) {
+    bool expected = false;
+    if (!_is_closed.compare_exchange_strong(expected, true)) {
+        return Status::OK();
+    }
     RETURN_IF_ERROR(Scanner::close(state));
     RETURN_IF_ERROR(_jdbc_connector->close());
     return Status::OK();

--- a/be/src/vec/exec/scan/jdbc_scanner.cpp
+++ b/be/src/vec/exec/scan/jdbc_scanner.cpp
@@ -188,8 +188,7 @@ void JdbcScanner::_update_profile() {
 }
 
 Status JdbcScanner::close(RuntimeState* state) {
-    bool expected = false;
-    if (!_is_closed.compare_exchange_strong(expected, true)) {
+    if (!_try_close()) {
         return Status::OK();
     }
     RETURN_IF_ERROR(Scanner::close(state));

--- a/be/src/vec/exec/scan/meta_scanner.cpp
+++ b/be/src/vec/exec/scan/meta_scanner.cpp
@@ -521,8 +521,7 @@ Status MetaScanner::_build_partition_values_metadata_request(
 
 Status MetaScanner::close(RuntimeState* state) {
     VLOG_CRITICAL << "MetaScanner::close";
-    bool expected = false;
-    if (!_is_closed.compare_exchange_strong(expected, true)) {
+    if (!_try_close()) {
         return Status::OK();
     }
     if (_reader) {

--- a/be/src/vec/exec/scan/meta_scanner.cpp
+++ b/be/src/vec/exec/scan/meta_scanner.cpp
@@ -521,6 +521,10 @@ Status MetaScanner::_build_partition_values_metadata_request(
 
 Status MetaScanner::close(RuntimeState* state) {
     VLOG_CRITICAL << "MetaScanner::close";
+    bool expected = false;
+    if (!_is_closed.compare_exchange_strong(expected, true)) {
+        return Status::OK();
+    }
     if (_reader) {
         RETURN_IF_ERROR(_reader->close());
     }

--- a/be/src/vec/exec/scan/olap_scanner.cpp
+++ b/be/src/vec/exec/scan/olap_scanner.cpp
@@ -594,8 +594,7 @@ Status OlapScanner::_get_block_impl(RuntimeState* state, Block* block, bool* eof
 }
 
 Status OlapScanner::close(RuntimeState* state) {
-    bool expected = false;
-    if (!_is_closed.compare_exchange_strong(expected, true)) {
+    if (!_try_close()) {
         return Status::OK();
     }
     RETURN_IF_ERROR(Scanner::close(state));

--- a/be/src/vec/exec/scan/olap_scanner.cpp
+++ b/be/src/vec/exec/scan/olap_scanner.cpp
@@ -594,7 +594,8 @@ Status OlapScanner::_get_block_impl(RuntimeState* state, Block* block, bool* eof
 }
 
 Status OlapScanner::close(RuntimeState* state) {
-    if (_is_closed) {
+    bool expected = false;
+    if (!_is_closed.compare_exchange_strong(expected, true)) {
         return Status::OK();
     }
     RETURN_IF_ERROR(Scanner::close(state));

--- a/be/src/vec/exec/scan/scan_node.h
+++ b/be/src/vec/exec/scan/scan_node.h
@@ -25,7 +25,7 @@ class Scanner;
 class VSlotRef;
 
 // We want to close scanner automatically, so using a delegate class
-// and call close method in the delegate class's dctor.
+// and call close method in the delegate class's destructor.
 class ScannerDelegate {
 public:
     ScannerSPtr _scanner;

--- a/be/src/vec/exec/scan/scanner.cpp
+++ b/be/src/vec/exec/scan/scanner.cpp
@@ -231,13 +231,13 @@ Status Scanner::try_append_late_arrival_runtime_filter() {
 }
 
 Status Scanner::close(RuntimeState* state) {
-    if (_is_closed) {
+    bool expected = false;
+    if (!_is_closed.compare_exchange_strong(expected, true)) {
         return Status::OK();
     }
 #ifndef BE_TEST
     COUNTER_UPDATE(_local_state->_scanner_wait_worker_timer, _scanner_wait_worker_timer);
 #endif
-    _is_closed = true;
     return Status::OK();
 }
 

--- a/be/src/vec/exec/scan/scanner.cpp
+++ b/be/src/vec/exec/scan/scanner.cpp
@@ -231,14 +231,15 @@ Status Scanner::try_append_late_arrival_runtime_filter() {
 }
 
 Status Scanner::close(RuntimeState* state) {
-    bool expected = false;
-    if (!_is_closed.compare_exchange_strong(expected, true)) {
-        return Status::OK();
-    }
 #ifndef BE_TEST
     COUNTER_UPDATE(_local_state->_scanner_wait_worker_timer, _scanner_wait_worker_timer);
 #endif
     return Status::OK();
+}
+
+bool Scanner::_try_close() {
+    bool expected = false;
+    return _is_closed.compare_exchange_strong(expected, true);
 }
 
 void Scanner::_collect_profile_before_close() {

--- a/be/src/vec/exec/scan/scanner.h
+++ b/be/src/vec/exec/scan/scanner.h
@@ -106,6 +106,11 @@ protected:
     // Update the counters before closing this scanner
     virtual void _collect_profile_before_close();
 
+    // Check if scanner is already closed, if not, mark it as closed.
+    // Returns true if the scanner was successfully marked as closed (first time).
+    // Returns false if the scanner was already closed.
+    bool _try_close();
+
     // Filter the output block finally.
     Status _filter_output_block(Block* block);
 

--- a/be/src/vec/exec/scan/scanner.h
+++ b/be/src/vec/exec/scan/scanner.h
@@ -20,6 +20,7 @@
 #include <stdint.h>
 
 #include <algorithm>
+#include <atomic>
 #include <vector>
 
 #include "common/status.h"
@@ -196,7 +197,7 @@ protected:
     Block _input_block;
 
     bool _is_open = false;
-    bool _is_closed = false;
+    std::atomic<bool> _is_closed {false};
     bool _need_to_close = false;
     Status _status;
 


### PR DESCRIPTION
### What problem does this PR solve?
close: #56328

Problem Summary:
The current close() method in Scanner class and its derived classes has thread safety issues in multi-threaded environments. Multiple threads may call close() simultaneously, leading to:
1. Race conditions: Multiple threads may check _is_closed status and execute close operations simultaneously
2. Double close: May cause resources to be released or cleaned up multiple times
3. Potential memory leaks or crash risks

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

