### PR TITLE
[fix](inverted index) Fix skipping data reads for columns when index is hit

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -1240,7 +1240,9 @@ bool SegmentIterator::_need_read_data(ColumnId cid) {
     //    and the operation is a push down of the 'COUNT_ON_INDEX' aggregation function.
     // If any of the above conditions are met, log a debug message indicating that there's no need to read data for the indexed column.
     // Then, return false.
-    int32_t unique_id = _opts.tablet_schema->column(cid).unique_id();
+    const auto& column = _opts.tablet_schema->column(cid);
+    int32_t unique_id =
+            column.is_extracted_column() ? column.parent_unique_id() : column.unique_id();
     if ((_need_read_data_indices.contains(cid) && !_need_read_data_indices[cid] &&
          !_output_columns.contains(unique_id)) ||
         (_need_read_data_indices.contains(cid) && !_need_read_data_indices[cid] &&

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -1241,8 +1241,11 @@ bool SegmentIterator::_need_read_data(ColumnId cid) {
     // If any of the above conditions are met, log a debug message indicating that there's no need to read data for the indexed column.
     // Then, return false.
     const auto& column = _opts.tablet_schema->column(cid);
-    int32_t unique_id =
-            column.is_extracted_column() ? column.parent_unique_id() : column.unique_id();
+    // Different subcolumns may share the same parent_unique_id, so we choose to abandon this optimization.
+    if (column.is_extracted_column()) {
+        return true;
+    }
+    int32_t unique_id = column.unique_id();
     if ((_need_read_data_indices.contains(cid) && !_need_read_data_indices[cid] &&
          !_output_columns.contains(unique_id)) ||
         (_need_read_data_indices.contains(cid) && !_need_read_data_indices[cid] &&

--- a/regression-test/data/variant_p0/predefine/test_predefine_type_index.out
+++ b/regression-test/data/variant_p0/predefine/test_predefine_type_index.out
@@ -71,3 +71,9 @@
 -- !sql --
 20
 
+-- !sql --
+Bright Red
+
+-- !sql --
+Bright Red
+

--- a/regression-test/suites/variant_p0/predefine/test_predefine_type_index.groovy
+++ b/regression-test/suites/variant_p0/predefine/test_predefine_type_index.groovy
@@ -107,5 +107,7 @@ suite("test_variant_predefine_index_type", "p0"){
     trigger_and_wait_compaction(tableName, "cumulative")
     sql "set enable_match_without_inverted_index = false"
     qt_sql "select count() from objects where (overflow_properties['color'] MATCH_PHRASE 'Blue')"    
-    qt_sql "select count() from objects where (array_contains(cast(overflow_properties['tags'] as array<string>), 'plastic'))"    
+    qt_sql "select count() from objects where (array_contains(cast(overflow_properties['tags'] as array<string>), 'plastic'))"   
+    qt_sql "select cast(overflow_properties['color'] as string) from objects where overflow_properties['color'] IS NOT NULL and id = 6 limit 1"
+    qt_sql "select overflow_properties['color'] from objects where overflow_properties['color'] IS NOT NULL and id = 6 limit 1"
 }


### PR DESCRIPTION
### What problem does this PR solve?

 Different subcolumns from variant share the same parent_unique_id, so we choose to abandon this optimization.


Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

