### PR TITLE
[Bug](runtime-filter) set rf disabled before release_undone_filters

### DIFF
--- a/be/src/runtime_filter/runtime_filter_merger.h
+++ b/be/src/runtime_filter/runtime_filter_merger.h
@@ -93,6 +93,16 @@ public:
 
     bool ready() const { return _rf_state == State::READY; }
 
+    void set_wrapper_state_and_ready_to_apply(RuntimeFilterWrapper::State state,
+                                              std::string reason = "") {
+        std::unique_lock<std::recursive_mutex> l(_rmtx);
+        if (_rf_state == State::READY) {
+            return;
+        }
+        _wrapper->set_state(state, reason);
+        _rf_state = State::READY;
+    }
+
 private:
     RuntimeFilterMerger(const QueryContext* query_ctx, const TRuntimeFilterDesc* desc)
             : RuntimeFilter(desc), _rf_state(State::WAITING_FOR_PRODUCT) {}

--- a/be/src/runtime_filter/runtime_filter_mgr.h
+++ b/be/src/runtime_filter/runtime_filter_mgr.h
@@ -72,7 +72,7 @@ struct GlobalMergeContext {
     std::vector<TRuntimeFilterTargetParamsV2> targetv2_info;
     std::unordered_set<UniqueId> arrive_id;
     std::vector<PNetworkAddress> source_addrs;
-    bool done = false;
+    std::atomic<bool> done = false;
 };
 
 // owned by RuntimeState


### PR DESCRIPTION
### What problem does this PR solve?

The issue introduced by https://github.com/apache/doris/pull/56632.
This PR(#57462) adds an operation that sends all unfinished runtime filters when the query context is destructed.
The initial consideration was as follows: if a query context is destructed, it means the query has actually ended. The remaining pipeline tasks are useless, so all remaining RFs are sent directly to ensure that tasks blocked in "wait infinity" can be released properly.
However, when `enable_parallel_result_sink` is enabled, multiple backends may have query contexts. If the query context on the coordinator BE is destructed at this point, it does not necessarily mean the query has ended. The query contexts on other BEs still need to continue executing the query to obtain results. In this case, the unfinished RFs sent by the coordinator would cause incorrect query results on other BEs.
This PR currently provides a temporary fix by setting the RFs to "disabled" when sending unfinished RFs, which prevents them from affecting the query results.
However, this approach may lead to performance degradation in other parts of the query due to the absence of RFs. In the long term, a better mechanism for managing the lifecycle of the RF coordinator is needed. The current integration between `enable_parallel_result_sink` and the "RF-coordinator on one of the top-sinks" mechanism is not sufficiently robust.


This pull request improves the robustness and correctness of the runtime filter merging and application process in the runtime filter manager. The main changes ensure that runtime filters are applied or disabled exactly once, prevent duplicate application, and provide better state management and error handling.

**Concurrency and State Management Improvements:**

* Changed the `done` flag in `GlobalMergeContext` to `std::atomic<bool>` to ensure thread-safe updates and prevent race conditions when marking a filter as processed.
* Added a guard in `_send_rf_to_target` to return an error if the runtime filter has already been sent, preventing duplicate sends. The `done` flag is now set immediately after this check.

**Filter State Handling Enhancements:**

* Added a new method `set_wrapper_state_and_ready_to_apply` in `RuntimeFilterMerger` to atomically set the wrapper state and mark the filter as ready, improving clarity and reducing the risk of inconsistent state.
* In `release_undone_filters`, now explicitly disables filters that were not applied before the query context was released, using the new method to set the state and provide a clear reason.
### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

