### PR TITLE
[fix](parquet) Fix reading Parquet files with empty arrays

### DIFF
--- a/be/src/vec/exec/format/parquet/schema_desc.cpp
+++ b/be/src/vec/exec/format/parquet/schema_desc.cpp
@@ -105,6 +105,9 @@ static void set_child_node_level(FieldSchema* parent, int16_t repeated_parent_de
 }
 
 static bool is_struct_list_node(const tparquet::SchemaElement& schema) {
+    if (!schema.__isset.type) {
+        return false;
+    }
     const std::string& name = schema.name;
     static const Slice array_slice("array", 5);
     static const Slice tuple_slice("_tuple", 6);


### PR DESCRIPTION
### What problem does this PR solve?
  Doris fails to read Parquet files containing empty arrays (e.g., `[]` or `["{[]}"]`) with the following error:


  Wrong data type for column 'array', expected Struct type, actual type id 15
  

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
  The `is_struct_list_node()` function in `schema_desc.cpp` uses name-based heuristics to distinguish between:
  1. Simple list elements (e.g., `array<int>`)
  2. List of struct elements (e.g., `array<struct<...>>`)

  However, it fails to check whether a schema node has a **physical type** before applying these heuristics.

  In standard Parquet 3-level list encoding:
```
optional group column (LIST) {
  repeated group array { 
    optional binary element (STRING);
}
```
The middle "array" node is just a **structural container** without a physical type (`schema.__isset.type = false`). The current code incorrectly treats this container as a struct type because of its name, leading to:
  1. Parser takes wrong branch (treats as list-of-struct instead of simple list)
  2. Creates `StructColumnReader` instead of `ArrayColumnReader`
  3. Runtime type mismatch: expects `TypeIndex::Struct`, gets `TypeIndex::Array`


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

