### PR TITLE
[refactor](load) remove castToSlot in load planner

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadPlanInfoCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadPlanInfoCollector.java
@@ -19,10 +19,8 @@ package org.apache.doris.nereids.load;
 
 import org.apache.doris.analysis.DescriptorTable;
 import org.apache.doris.analysis.Expr;
-import org.apache.doris.analysis.NullLiteral;
 import org.apache.doris.analysis.SlotDescriptor;
 import org.apache.doris.analysis.SlotId;
-import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.analysis.TupleId;
 import org.apache.doris.catalog.AggregateFunction;
@@ -33,7 +31,6 @@ import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.PartitionInfo;
 import org.apache.doris.catalog.PartitionItem;
 import org.apache.doris.catalog.PartitionType;
-import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
@@ -44,16 +41,24 @@ import org.apache.doris.common.util.FileFormatConstants;
 import org.apache.doris.info.PartitionNamesInfo;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.StatementContext;
+import org.apache.doris.nereids.analyzer.Scope;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.glue.translator.ExpressionTranslator;
 import org.apache.doris.nereids.glue.translator.PlanTranslatorContext;
+import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.properties.PhysicalProperties;
+import org.apache.doris.nereids.rules.analysis.ExpressionAnalyzer;
+import org.apache.doris.nereids.rules.expression.rules.ConvertAggStateCast;
 import org.apache.doris.nereids.rules.expression.rules.PartitionPruner;
 import org.apache.doris.nereids.rules.expression.rules.SortedPartitionRanges;
+import org.apache.doris.nereids.trees.expressions.Alias;
+import org.apache.doris.nereids.trees.expressions.Cast;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapTableSink;
@@ -62,6 +67,9 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPreFilter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.trees.plans.visitor.DefaultPlanVisitor;
+import org.apache.doris.nereids.types.DataType;
+import org.apache.doris.nereids.types.VarcharType;
+import org.apache.doris.nereids.util.TypeCoercionUtils;
 import org.apache.doris.planner.GroupCommitBlockSink;
 import org.apache.doris.planner.OlapTableSink;
 import org.apache.doris.thrift.TExpr;
@@ -75,6 +83,7 @@ import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.thrift.TUniqueKeyUpdateMode;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
@@ -339,9 +348,6 @@ public class NereidsLoadPlanInfoCollector extends DefaultPlanVisitor<Void, PlanT
             }
         }
 
-        List<Expr> projectList = outputs.stream().map(e -> ExpressionTranslator.translate(e, context))
-                .collect(Collectors.toList());
-
         // For Broker load with multiple file groups, all file groups share the same destTuple.
         // Create slots for destTuple only when processing the first file group (when slots are empty).
         // Subsequent file groups will reuse the slots created by the first file group.
@@ -374,23 +380,23 @@ public class NereidsLoadPlanInfoCollector extends DefaultPlanVisitor<Void, PlanT
                 context.createSlotDesc(loadPlanInfo.destTuple, (SlotReference) slot, destTable);
             }
         }
-
-        loadPlanInfo.destSlotIdToExprMap = Maps.newHashMap();
         List<SlotDescriptor> slotDescriptorList = loadPlanInfo.destTuple.getSlots();
+        loadPlanInfo.destSlotIdToExprMap = Maps.newHashMap();
         for (int i = 0; i < slotDescriptorList.size(); ++i) {
-            SlotDescriptor slotDescriptor = slotDescriptorList.get(i);
-            Expr expr = projectList.get(i);
-            PrimitiveType dstType = slotDescriptor.getType().getPrimitiveType();
-            PrimitiveType srcType = expr.getType().getPrimitiveType();
-            if (!(dstType == PrimitiveType.JSONB
-                    && (srcType == PrimitiveType.VARCHAR || srcType == PrimitiveType.STRING))) {
-                try {
-                    expr = castToSlot(slotDescriptor, expr);
-                } catch (org.apache.doris.common.AnalysisException e) {
-                    throw new AnalysisException(e.getMessage(), e.getCause());
+            DataType targetType = DataType.fromCatalogType(slotDescriptorList.get(i).getType());
+            Expression output = outputs.get(i);
+            if (!(targetType.isJsonType() && output.getDataType().isStringLikeType())) {
+                if (output instanceof Alias) {
+                    output = TypeCoercionUtils.castIfNotSameType(((Alias) output).child(), targetType);
+                } else {
+                    output = TypeCoercionUtils.castIfNotSameType(output, targetType);
+                }
+                if (output instanceof Cast && output.getDataType().isAggStateType()) {
+                    output = ConvertAggStateCast.convert((Cast) output);
                 }
             }
-            loadPlanInfo.destSlotIdToExprMap.put(slotDescriptor.getId(), expr);
+            Expr expr = ExpressionTranslator.translate(output, context);
+            loadPlanInfo.destSlotIdToExprMap.put(slotDescriptorList.get(i).getId(), expr);
         }
         return null;
     }
@@ -470,33 +476,36 @@ public class NereidsLoadPlanInfoCollector extends DefaultPlanVisitor<Void, PlanT
         for (SlotDescriptor slotDescriptor : oneRowTuple.getSlots()) {
             Column column = destTable.getColumn(slotDescriptor.getColumn().getName());
             if (column != null) {
-                Expr expr;
+                Expression expression;
                 if (column.getDefaultValue() != null) {
                     if (column.getDefaultValueExprDef() != null) {
                         try {
-                            expr = column.getDefaultValueExpr();
+                            expression = new NereidsParser().parseExpression(
+                                    column.getDefaultValueExpr().toSqlWithoutTbl());
+                            ExpressionAnalyzer analyzer = new ExpressionAnalyzer(
+                                    null, new Scope(ImmutableList.of()), null, true, true);
+                            expression = analyzer.analyze(expression);
                         } catch (org.apache.doris.common.AnalysisException e) {
                             throw new AnalysisException(e.getMessage(), e.getCause());
                         }
                     } else {
-                        expr = new StringLiteral(column.getDefaultValue());
+                        expression = new StringLiteral(column.getDefaultValue());
                     }
                 } else {
                     if (column.isAllowNull()) {
-                        expr = NullLiteral.create(org.apache.doris.catalog.Type.VARCHAR);
+                        expression = new NullLiteral(VarcharType.SYSTEM_DEFAULT);
                     } else {
-                        expr = null;
+                        expression = null;
                     }
                 }
                 if (exprMap.containsKey(column.getName())) {
                     continue;
                 }
-                if (expr != null) {
-                    try {
-                        expr = castToSlot(slotDescriptor, expr);
-                    } catch (org.apache.doris.common.AnalysisException e) {
-                        throw new AnalysisException(e.getMessage(), e.getCause());
-                    }
+                Expr expr = null;
+                if (expression != null) {
+                    expression = TypeCoercionUtils.castIfNotSameType(expression,
+                            DataType.fromCatalogType(slotDescriptor.getType()));
+                    expr = ExpressionTranslator.translate(expression, context);
                 }
                 loadPlanInfo.srcSlotIdToDefaultValueMap.put(slotDescriptor.getId(), expr);
                 srcSlots.put(column.getName(), slotDescriptor);
@@ -512,20 +521,6 @@ public class NereidsLoadPlanInfoCollector extends DefaultPlanVisitor<Void, PlanT
             context.createSlotDesc(tupleDescriptor, (SlotReference) slot, table);
         }
         return tupleDescriptor;
-    }
-
-    private Expr castToSlot(SlotDescriptor slotDesc, Expr expr) throws org.apache.doris.common.AnalysisException {
-        PrimitiveType dstType = slotDesc.getType().getPrimitiveType();
-        PrimitiveType srcType = expr.getType().getPrimitiveType();
-        if (PrimitiveType.typeWithPrecision.contains(dstType) && PrimitiveType.typeWithPrecision.contains(srcType)
-                && !slotDesc.getType().equals(expr.getType())) {
-            return expr.castTo(slotDesc.getType());
-        } else if (dstType != srcType || slotDesc.getType().isAggStateType() && expr.getType().isAggStateType()
-                && !slotDesc.getType().equals(expr.getType())) {
-            return expr.castTo(slotDesc.getType());
-        } else {
-            return expr;
-        }
     }
 
     // get all specified partition ids.


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

castToSlot use lagecy planner's Expr#castTo. we should not rely on it anymore

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

