### PR TITLE
[fix](auto-partition) Replace std::mutex with bthread::Mutex in VTabletWriter

### DIFF
--- a/be/src/vec/sink/writer/vtablet_writer.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer.cpp
@@ -1333,7 +1333,7 @@ void VTabletWriter::_send_batch_process() {
 
     while (true) {
         // incremental open will temporarily make channels into abnormal state. stop checking when this.
-        std::unique_lock<std::mutex> l(_stop_check_channel);
+        std::unique_lock<bthread::Mutex> l(_stop_check_channel);
 
         int running_channels_num = 0;
         int opened_nodes = 0;
@@ -1637,7 +1637,7 @@ Status VTabletWriter::_init(RuntimeState* state, RuntimeProfile* profile) {
 Status VTabletWriter::_incremental_open_node_channel(
         const std::vector<TOlapTablePartition>& partitions) {
     // do what we did in prepare() for partitions. indexes which don't change when we create new partition is orthogonal to partitions.
-    std::unique_lock<std::mutex> _l(_stop_check_channel);
+    std::unique_lock<bthread::Mutex> _l(_stop_check_channel);
     for (int i = 0; i < _schema->indexes().size(); ++i) {
         const OlapTableIndexSchema* index = _schema->indexes()[i];
         std::vector<TTabletWithPartition> tablets;

--- a/be/src/vec/sink/writer/vtablet_writer.h
+++ b/be/src/vec/sink/writer/vtablet_writer.h
@@ -31,6 +31,8 @@
 #include <google/protobuf/stubs/callback.h>
 
 // IWYU pragma: no_include <bits/chrono.h>
+#include <bthread/mutex.h>
+
 #include <atomic>
 #include <chrono> // IWYU pragma: keep
 #include <cstddef>
@@ -702,7 +704,7 @@ private:
     std::unique_ptr<OlapTabletFinder> _tablet_finder;
 
     // index_channel
-    std::mutex _stop_check_channel;
+    bthread::Mutex _stop_check_channel;
     std::vector<std::shared_ptr<IndexChannel>> _channels;
     std::unordered_map<int64_t, std::shared_ptr<IndexChannel>> _index_id_to_channel;
 


### PR DESCRIPTION


### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
Fix potential performance issue where std::mutex was used in bthread context. When bthread blocks on std::mutex, it blocks the entire pthread instead of just yielding the current bthread, which can cause other bthreads on the same pthread to be blocked unnecessarily.

This ensures proper bthread scheduling and improves performance in high concurrency scenarios during data writing operations.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

