### PR TITLE
[Bug](Jni)should delete local ref after convert to global ref

### DIFF
--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -339,6 +339,7 @@ Status JniUtil::convert_to_java_map(JNIEnv* env, const std::map<std::string, std
     }
     env->DeleteLocalRef(hashmap_class);
     RETURN_IF_ERROR(LocalToGlobalRef(env, hashmap_local_object, hashmap_object));
+    env->DeleteLocalRef(hashmap_local_object);
     return Status::OK();
 }
 


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
hashmap_local_object is NewObject as local ref,  and it's convert to global ref to as return value,
so should call delete local ref to avoid JVM can't GC. 

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

