### PR TITLE
[fix](cloud) Fix virtual compute group expand the usage permissions o…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/system/CloudSystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/system/CloudSystemInfoService.java
@@ -181,10 +181,10 @@ public class CloudSystemInfoService extends SystemInfoService {
                 if (computeGroupName.equals(vcg.getPolicy().getActiveComputeGroup())) {
                     return vcg.getName();
                 }
-                if (vcg.getPolicy().getStandbyComputeGroup().contains(computeGroupName)) {
+                if (vcg.getPolicy().getStandbyComputeGroup().equals(computeGroupName)) {
                     return vcg.getName();
                 }
-                if (vcg.getSubComputeGroups().contains(computeGroupName)) {
+                if (vcg.getSubComputeGroups().stream().anyMatch(subCgName -> subCgName.equals(computeGroupName))) {
                     return vcg.getName();
                 }
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/CloudAuthTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/CloudAuthTest.java
@@ -367,6 +367,8 @@ public class CloudAuthTest extends TestWithFeService {
         ComputeGroup vcg  = new ComputeGroup("vcg_id", "vcg", ComputeGroup.ComputeTypeEnum.VIRTUAL);
         vcg.setSubComputeGroups(Lists.newArrayList("cg2", "cg1"));
         systemInfoService.addComputeGroup("vcg_id", vcg);
+        ComputeGroup cg  = new ComputeGroup("vcg_id", "vcg", ComputeGroup.ComputeTypeEnum.COMPUTE);
+        systemInfoService.addComputeGroup("cg", cg);
         ComputeGroup.Policy policy = new ComputeGroup.Policy();
         policy.setActiveComputeGroup("cg1");
         policy.setStandbyComputeGroup("cg2");
@@ -379,6 +381,8 @@ public class CloudAuthTest extends TestWithFeService {
         Assert.assertTrue(accessManager.checkCloudPriv(new UserIdentity("testUser", "%"), "cg1",
                 PrivPredicate.USAGE, ResourceTypeEnum.CLUSTER));
         Assert.assertTrue(accessManager.checkCloudPriv(new UserIdentity("testUser", "%"), "cg2",
+                PrivPredicate.USAGE, ResourceTypeEnum.CLUSTER));
+        Assert.assertFalse(accessManager.checkCloudPriv(new UserIdentity("testUser", "%"), "cg",
                 PrivPredicate.USAGE, ResourceTypeEnum.CLUSTER));
         ShowGrantsCommand sg = new ShowGrantsCommand(new UserIdentity("testUser", "%"), false);
         ShowResultSet showResultSet = sg.doRun(connectContext, null);


### PR DESCRIPTION
…f compute group

### What problem does this PR solve?

Fixed the logic for determining whether a regular compute group belongs to a specific virtual compute group; the compute group name needs to use the equal judgment.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

