### PR TITLE
[fix](iceberg) Support client.region and iceberg.rest.* properties invended credentials

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/credentials/CredentialUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/credentials/CredentialUtils.java
@@ -34,13 +34,15 @@ public class CredentialUtils {
      * Supported cloud storage prefixes for filtering vended credentials
      */
     private static final Set<String> CLOUD_STORAGE_PREFIXES = new HashSet<>(Arrays.asList(
-            "fs.",      // file system
-            "s3.",      // Amazon S3
-            "oss.",     // Alibaba OSS
-            "cos.",     // Tencent COS
-            "obs.",     // Huawei OBS
-            "gs.",      // Google Cloud Storage
-            "azure."    // Microsoft Azure
+            "fs.",           // file system
+            "s3.",           // Amazon S3
+            "oss.",          // Alibaba OSS
+            "cos.",          // Tencent COS
+            "obs.",          // Huawei OBS
+            "gs.",           // Google Cloud Storage
+            "azure.",        // Microsoft Azure
+            "client.",       // Iceberg client properties (e.g., client.region)
+            "iceberg.rest."  // Iceberg REST catalog properties (e.g., iceberg.rest.access-key-id)
     ));
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/S3Properties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/S3Properties.java
@@ -65,7 +65,7 @@ public class S3Properties extends AbstractS3CompatibleProperties {
     };
 
     private static final String[] REGION_NAMES_FOR_GUESSING = {
-            "s3.region", "glue.region", "aws.glue.region", "iceberg.rest.signing-region"
+            "s3.region", "glue.region", "aws.glue.region", "iceberg.rest.signing-region", "client.region"
     };
 
     @Setter
@@ -79,7 +79,7 @@ public class S3Properties extends AbstractS3CompatibleProperties {
     @Setter
     @Getter
     @ConnectorProperty(names = {"s3.region", "AWS_REGION", "region", "REGION", "aws.region", "glue.region",
-            "aws.glue.region", "iceberg.rest.signing-region"},
+            "aws.glue.region", "iceberg.rest.signing-region", "client.region"},
             required = false,
             description = "The region of S3.")
     protected String region = "";


### PR DESCRIPTION
 When using Iceberg REST catalog with vended credentials enabled:
  - **Polaris** returns `s3.region`, `s3.access-key-id`, etc.
  - **Gravitino** returns `client.region`, `s3.access-key-id`, etc. (following Iceberg official naming)

  Current implementation only filters properties with `s3.`, `oss.`, etc. prefixes, causing `client.region` to be filtered out, which leads to `No storage
  properties found for schema: s3` error.
