### PR TITLE
[Improvement](block) remove Block::row_same_bit

### DIFF
--- a/be/src/olap/iterators.h
+++ b/be/src/olap/iterators.h
@@ -179,11 +179,13 @@ public:
     // Return Status::OK() if init successfully,
     // Return other error otherwise
     virtual Status init(const StorageReadOptions& opts) {
-        return Status::NotSupported("to be implemented");
+        return Status::InternalError("to be implemented, current class: " +
+                                     demangle(typeid(*this).name()));
     }
 
     virtual Status init(const StorageReadOptions& opts, CompactionSampleInfo* sample_info) {
-        return Status::NotSupported("to be implemented");
+        return Status::InternalError("should not reach here, current class: " +
+                                     demangle(typeid(*this).name()));
     }
 
     // If there is any valid data, this function will load data
@@ -191,28 +193,34 @@ public:
     // If there is no data to read, will return Status::EndOfFile.
     // If other error happens, other error code will be returned.
     virtual Status next_batch(vectorized::Block* block) {
-        return Status::NotSupported("to be implemented");
+        return Status::InternalError("should not reach here, current class: " +
+                                     demangle(typeid(*this).name()));
     }
 
     virtual Status next_batch(BlockWithSameBit* block_with_same_bit) {
-        return Status::NotSupported("to be implemented");
+        return Status::InternalError("should not reach here, current class: " +
+                                     demangle(typeid(*this).name()));
     }
 
     virtual Status next_batch(vectorized::BlockView* block_view) {
-        return Status::NotSupported("to be implemented");
+        return Status::InternalError("should not reach here, current class: " +
+                                     demangle(typeid(*this).name()));
     }
 
     virtual Status next_row(vectorized::IteratorRowRef* ref) {
-        return Status::NotSupported("to be implemented");
+        return Status::InternalError("should not reach here, current class: " +
+                                     demangle(typeid(*this).name()));
     }
     virtual Status unique_key_next_row(vectorized::IteratorRowRef* ref) {
-        return Status::NotSupported("to be implemented");
+        return Status::InternalError("should not reach here, current class: " +
+                                     demangle(typeid(*this).name()));
     }
 
-    virtual bool support_return_data_by_ref() { return false; }
+    virtual bool is_merge_iterator() const { return false; }
 
     virtual Status current_block_row_locations(std::vector<RowLocation>* block_row_locations) {
-        return Status::NotSupported("to be implemented");
+        return Status::InternalError("should not reach here, current class: " +
+                                     demangle(typeid(*this).name()));
     }
 
     // return schema for this Iterator

--- a/be/src/olap/iterators.h
+++ b/be/src/olap/iterators.h
@@ -159,6 +159,13 @@ struct CompactionSampleInfo {
     int64_t group_data_size;
 };
 
+struct BlockWithSameBit {
+    vectorized::Block* block;
+    std::vector<bool>& same_bit;
+
+    bool empty() const { return block->rows() == 0; }
+};
+
 class RowwiseIterator;
 using RowwiseIteratorUPtr = std::unique_ptr<RowwiseIterator>;
 class RowwiseIterator {
@@ -187,7 +194,11 @@ public:
         return Status::NotSupported("to be implemented");
     }
 
-    virtual Status next_block_view(vectorized::BlockView* block_view) {
+    virtual Status next_batch(BlockWithSameBit* block_with_same_bit) {
+        return Status::NotSupported("to be implemented");
+    }
+
+    virtual Status next_batch(vectorized::BlockView* block_view) {
         return Status::NotSupported("to be implemented");
     }
 

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -318,7 +318,7 @@ Status BetaRowsetReader::_init_iterator() {
         _read_context->merged_rows = &_merged_rows;
     }
     // merge or union segment iterator
-    if (_is_merge_iterator()) {
+    if (is_merge_iterator()) {
         auto sequence_loc = -1;
         if (_read_context->sequence_id_idx != -1) {
             for (int loc = 0; loc < _read_context->return_columns->size(); loc++) {

--- a/be/src/olap/rowset/beta_rowset_reader.h
+++ b/be/src/olap/rowset/beta_rowset_reader.h
@@ -60,7 +60,11 @@ public:
     Status next_batch(BlockWithSameBit* block_with_same_bit) override {
         return _next_batch(block_with_same_bit);
     }
-    bool support_return_data_by_ref() override { return _is_merge_iterator(); }
+
+    bool is_merge_iterator() const override {
+        return _read_context->need_ordered_result &&
+               _rowset->rowset_meta()->is_segments_overlapping() && _get_segment_num() > 1;
+    }
 
     bool delete_flag() override { return _rowset->delete_flag(); }
 
@@ -127,10 +131,6 @@ private:
     [[nodiscard]] Status _init_iterator_once();
     [[nodiscard]] Status _init_iterator();
     bool _should_push_down_value_predicates() const;
-    bool _is_merge_iterator() const {
-        return _read_context->need_ordered_result &&
-               _rowset->rowset_meta()->is_segments_overlapping() && _get_segment_num() > 1;
-    }
 
     int64_t _get_segment_num() const {
         auto [seg_start, seg_end] = _segment_offsets;

--- a/be/src/olap/rowset/rowset_reader.h
+++ b/be/src/olap/rowset/rowset_reader.h
@@ -64,7 +64,7 @@ public:
     virtual Status next_batch(vectorized::Block* block) = 0;
     virtual Status next_batch(vectorized::BlockView* block_view) = 0;
     virtual Status next_batch(BlockWithSameBit* block_view) = 0;
-    virtual bool support_return_data_by_ref() { return false; }
+    virtual bool is_merge_iterator() const { return false; }
 
     virtual bool delete_flag() = 0;
 

--- a/be/src/olap/rowset/rowset_reader.h
+++ b/be/src/olap/rowset/rowset_reader.h
@@ -61,9 +61,9 @@ public:
                                          bool use_cache = false) = 0;
     virtual void reset_read_options() = 0;
 
-    virtual Status next_block(vectorized::Block* block) = 0;
-
-    virtual Status next_block_view(vectorized::BlockView* block_view) = 0;
+    virtual Status next_batch(vectorized::Block* block) = 0;
+    virtual Status next_batch(vectorized::BlockView* block_view) = 0;
+    virtual Status next_batch(BlockWithSameBit* block_view) = 0;
     virtual bool support_return_data_by_ref() { return false; }
 
     virtual bool delete_flag() = 0;

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -554,7 +554,7 @@ Status VSchemaChangeDirectly::_inner_process(RowsetReaderSharedPtr rowset_reader
         auto new_block = vectorized::Block::create_unique(new_tablet_schema->create_block());
         auto ref_block = vectorized::Block::create_unique(base_tablet_schema->create_block(false));
 
-        auto st = rowset_reader->next_block(ref_block.get());
+        auto st = rowset_reader->next_batch(ref_block.get());
         if (!st) {
             if (st.is<ErrorCode::END_OF_FILE>()) {
                 if (ref_block->rows() == 0) {
@@ -622,7 +622,7 @@ Status VBaseSchemaChangeWithSorting::_inner_process(RowsetReaderSharedPtr rowset
     bool eof = false;
     do {
         auto ref_block = vectorized::Block::create_unique(base_tablet_schema->create_block(false));
-        auto st = rowset_reader->next_block(ref_block.get());
+        auto st = rowset_reader->next_batch(ref_block.get());
         if (!st) {
             if (st.is<ErrorCode::END_OF_FILE>()) {
                 if (ref_block->rows() == 0) {

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -545,6 +545,20 @@ Status LinkedSchemaChange::process(RowsetReaderSharedPtr rowset_reader, RowsetWr
     return Status::OK();
 }
 
+Status next_batch(RowsetReaderSharedPtr rowset_reader, vectorized::Block* input_block,
+                  std::vector<bool>& row_same_bit) {
+    Status st;
+    if (rowset_reader->is_merge_iterator()) {
+        row_same_bit.clear();
+        BlockWithSameBit block_with_same_bit = {.block = input_block, .same_bit = row_same_bit};
+        st = rowset_reader->next_batch(&block_with_same_bit);
+        // todo: use row_same_bit to clean some useless row
+    } else {
+        st = rowset_reader->next_batch(input_block);
+    }
+    return st;
+}
+
 Status VSchemaChangeDirectly::_inner_process(RowsetReaderSharedPtr rowset_reader,
                                              RowsetWriter* rowset_writer, BaseTabletSPtr new_tablet,
                                              TabletSchemaSPtr base_tablet_schema,
@@ -554,7 +568,7 @@ Status VSchemaChangeDirectly::_inner_process(RowsetReaderSharedPtr rowset_reader
         auto new_block = vectorized::Block::create_unique(new_tablet_schema->create_block());
         auto ref_block = vectorized::Block::create_unique(base_tablet_schema->create_block(false));
 
-        auto st = rowset_reader->next_batch(ref_block.get());
+        Status st = next_batch(rowset_reader, ref_block.get(), _row_same_bit);
         if (!st) {
             if (st.is<ErrorCode::END_OF_FILE>()) {
                 if (ref_block->rows() == 0) {
@@ -622,7 +636,7 @@ Status VBaseSchemaChangeWithSorting::_inner_process(RowsetReaderSharedPtr rowset
     bool eof = false;
     do {
         auto ref_block = vectorized::Block::create_unique(base_tablet_schema->create_block(false));
-        auto st = rowset_reader->next_batch(ref_block.get());
+        Status st = next_batch(rowset_reader, ref_block.get(), _row_same_bit);
         if (!st) {
             if (st.is<ErrorCode::END_OF_FILE>()) {
                 if (ref_block->rows() == 0) {

--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -170,6 +170,8 @@ protected:
 private:
     uint64_t _filtered_rows {};
     uint64_t _merged_rows {};
+protected:
+    std::vector<bool> _row_same_bit;
 };
 
 class LinkedSchemaChange : public SchemaChange {

--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -170,6 +170,7 @@ protected:
 private:
     uint64_t _filtered_rows {};
     uint64_t _merged_rows {};
+
 protected:
     std::vector<bool> _row_same_bit;
 };

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -244,9 +244,6 @@ void Block::erase_tail(size_t start) {
             ++it;
         }
     }
-    if (start < row_same_bit.size()) {
-        row_same_bit.erase(row_same_bit.begin() + start, row_same_bit.end());
-    }
 }
 
 void Block::erase(size_t position) {
@@ -277,9 +274,6 @@ void Block::erase_impl(size_t position) {
                 ++it;
             }
         }
-    }
-    if (position < row_same_bit.size()) {
-        row_same_bit.erase(row_same_bit.begin() + position);
     }
 }
 
@@ -433,9 +427,6 @@ void Block::set_num_rows(size_t length) {
                 elem.column = elem.column->shrink(length);
             }
         }
-        if (length < row_same_bit.size()) {
-            row_same_bit.resize(length);
-        }
     }
 }
 
@@ -449,9 +440,6 @@ void Block::skip_num_rows(int64_t& length) {
             if (elem.column) {
                 elem.column = elem.column->cut(length, origin_rows - length);
             }
-        }
-        if (length < row_same_bit.size()) {
-            row_same_bit.assign(row_same_bit.begin() + length, row_same_bit.end());
         }
     }
 }
@@ -783,7 +771,6 @@ DataTypes Block::get_data_types() const {
 void Block::clear() {
     data.clear();
     index_by_name.clear();
-    row_same_bit.clear();
 }
 
 void Block::clear_column_data(int64_t column_size) noexcept {
@@ -802,7 +789,6 @@ void Block::clear_column_data(int64_t column_size) noexcept {
             (*std::move(d.column)).assume_mutable()->clear();
         }
     }
-    row_same_bit.clear();
 }
 
 void Block::erase_tmp_columns() noexcept {
@@ -836,14 +822,12 @@ void Block::swap(Block& other) noexcept {
     SCOPED_SKIP_MEMORY_CHECK();
     data.swap(other.data);
     index_by_name.swap(other.index_by_name);
-    row_same_bit.swap(other.row_same_bit);
 }
 
 void Block::swap(Block&& other) noexcept {
     SCOPED_SKIP_MEMORY_CHECK();
     data = std::move(other.data);
     index_by_name = std::move(other.index_by_name);
-    row_same_bit = std::move(other.row_same_bit);
 }
 
 void Block::shuffle_columns(const std::vector<int>& result_column_ids) {
@@ -1167,9 +1151,6 @@ void MutableBlock::erase(const String& name) {
             ++it;
         }
     }
-    // if (position < row_same_bit.size()) {
-    //     row_same_bit.erase(row_same_bit.begin() + position);
-    // }
 }
 
 Block MutableBlock::to_block(int start_column) {

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -76,7 +76,6 @@ private:
     using IndexByName = phmap::flat_hash_map<String, size_t>;
     Container data;
     IndexByName index_by_name;
-    std::vector<bool> row_same_bit;
 
     int64_t _decompress_time_ns = 0;
     int64_t _decompressed_bytes = 0;
@@ -367,21 +366,6 @@ public:
     int64_t get_decompressed_bytes() const { return _decompressed_bytes; }
     int64_t get_compress_time() const { return _compress_time_ns; }
 
-    void set_same_bit(std::vector<bool>::const_iterator begin,
-                      std::vector<bool>::const_iterator end) {
-        row_same_bit.insert(row_same_bit.end(), begin, end);
-
-        DCHECK_EQ(row_same_bit.size(), rows());
-    }
-
-    bool get_same_bit(size_t position) {
-        if (position >= row_same_bit.size()) {
-            return false;
-        }
-        return row_same_bit[position];
-    }
-
-    void clear_same_bit() { row_same_bit.clear(); }
 
     // remove tmp columns in block
     // in inverted index apply logic, in order to optimize query performance,

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -366,7 +366,6 @@ public:
     int64_t get_decompressed_bytes() const { return _decompressed_bytes; }
     int64_t get_compress_time() const { return _compress_time_ns; }
 
-
     // remove tmp columns in block
     // in inverted index apply logic, in order to optimize query performance,
     // we built some temporary columns into block

--- a/be/src/vec/exec/scan/scanner.cpp
+++ b/be/src/vec/exec/scan/scanner.cpp
@@ -106,9 +106,6 @@ Status Scanner::get_block(RuntimeState* state, Block* block, bool* eof) {
 
     {
         do {
-            // if step 2 filter all rows of block, and block will be reused to get next rows,
-            // must clear row_same_bit of block, or will get wrong row_same_bit.size() which not equal block.rows()
-            block->clear_same_bit();
             // 1. Get input block from scanner
             {
                 // get block time

--- a/be/src/vec/olap/block_reader.cpp
+++ b/be/src/vec/olap/block_reader.cpp
@@ -309,7 +309,7 @@ Status BlockReader::_agg_key_next_block(Block* block, bool* eof) {
             return res;
         }
 
-        if (!_get_next_row_same()) {
+        if (!_next_row.is_same) {
             if (target_block_row == _reader_context.batch_size) {
                 break;
             }
@@ -530,13 +530,5 @@ void BlockReader::_update_agg_value(MutableColumns& columns, int begin, int end,
     }
 }
 
-bool BlockReader::_get_next_row_same() {
-    if (_next_row.is_same) {
-        return true;
-    } else {
-        auto* block = _next_row.block.get();
-        return block->get_same_bit(_next_row.row_pos);
-    }
-}
 #include "common/compile_check_end.h"
 } // namespace doris::vectorized

--- a/be/src/vec/olap/block_reader.h
+++ b/be/src/vec/olap/block_reader.h
@@ -84,8 +84,6 @@ private:
 
     void _update_agg_value(MutableColumns& columns, int begin, int end, bool is_close = true);
 
-    bool _get_next_row_same();
-
     // return false if keys of rowsets are mono ascending and disjoint
     bool _rowsets_not_mono_asc_disjoint(const ReaderParams& read_params);
 

--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -534,12 +534,11 @@ Status VCollectIterator::Level0Iterator::refresh_current_row() {
 }
 
 Status VCollectIterator::Level0Iterator::next(IteratorRowRef* ref) {
-    DCHECK(_merge);
     if (_get_data_by_ref) {
         _current++;
     } else {
         _ref.row_pos++;
-        if (_ref.row_pos < _block->rows()) {
+        if (_merge && _ref.row_pos < _block->rows()) {
             _ref.is_same = _row_is_same[_ref.row_pos];
         }
     }

--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -534,11 +534,12 @@ Status VCollectIterator::Level0Iterator::refresh_current_row() {
 }
 
 Status VCollectIterator::Level0Iterator::next(IteratorRowRef* ref) {
+    DCHECK(_merge);
     if (_get_data_by_ref) {
         _current++;
     } else {
         _ref.row_pos++;
-        if (_merge && _ref.row_pos < _block->rows()) {
+        if (_ref.row_pos < _block->rows()) {
             _ref.is_same = _row_is_same[_ref.row_pos];
         }
     }

--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -456,7 +456,8 @@ VCollectIterator::Level0Iterator::Level0Iterator(RowsetReaderSharedPtr rs_reader
 }
 
 Status VCollectIterator::Level0Iterator::init(bool get_data_by_ref) {
-    _get_data_by_ref = get_data_by_ref && _rs_reader->support_return_data_by_ref();
+    _is_merge_iterator = _rs_reader->is_merge_iterator();
+    _get_data_by_ref = get_data_by_ref && _is_merge_iterator;
     if (!_get_data_by_ref) {
         _block = std::make_shared<Block>(_schema.create_block(
                 _reader->_return_columns, _reader->_tablet_columns_convert_to_null_set));
@@ -478,7 +479,8 @@ Status VCollectIterator::Level0Iterator::init(bool get_data_by_ref) {
 // }
 // so first child load first row and other child row_pos = -1
 void VCollectIterator::Level0Iterator::init_for_union(bool get_data_by_ref) {
-    _get_data_by_ref = get_data_by_ref && _rs_reader->support_return_data_by_ref();
+    _is_merge_iterator = _rs_reader->is_merge_iterator();
+    _get_data_by_ref = get_data_by_ref && _is_merge_iterator;
 }
 
 Status VCollectIterator::Level0Iterator::ensure_first_row_ref() {
@@ -538,7 +540,7 @@ Status VCollectIterator::Level0Iterator::next(IteratorRowRef* ref) {
         _current++;
     } else {
         _ref.row_pos++;
-        if (_ref.row_pos < _block->rows()) {
+        if (_is_merge_iterator && _ref.row_pos < _block->rows()) {
             _ref.is_same = _row_is_same[_ref.row_pos];
         }
     }

--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -103,7 +103,7 @@ Status VCollectIterator::add_child(const RowSetSplits& rs_splits) {
         return Status::OK();
     }
 
-    _children.push_back(std::make_unique<Level0Iterator>(rs_splits.rs_reader, _reader));
+    _children.push_back(std::make_unique<Level0Iterator>(rs_splits.rs_reader, _reader, _merge));
     return Status::OK();
 }
 
@@ -450,8 +450,8 @@ bool VCollectIterator::BlockRowPosComparator::operator()(const size_t& lpos,
 }
 
 VCollectIterator::Level0Iterator::Level0Iterator(RowsetReaderSharedPtr rs_reader,
-                                                 TabletReader* reader)
-        : LevelIterator(reader), _rs_reader(rs_reader), _reader(reader) {
+                                                 TabletReader* reader, bool merge)
+        : LevelIterator(reader, merge), _rs_reader(rs_reader), _reader(reader) {
     DCHECK_EQ(RowsetTypePB::BETA_ROWSET, rs_reader->type());
 }
 
@@ -534,6 +534,7 @@ Status VCollectIterator::Level0Iterator::refresh_current_row() {
 }
 
 Status VCollectIterator::Level0Iterator::next(IteratorRowRef* ref) {
+    DCHECK(_merge);
     if (_get_data_by_ref) {
         _current++;
     } else {
@@ -597,10 +598,9 @@ Status VCollectIterator::Level0Iterator::current_block_row_locations(
 VCollectIterator::Level1Iterator::Level1Iterator(
         std::list<std::unique_ptr<VCollectIterator::LevelIterator>> children, TabletReader* reader,
         bool merge, bool is_reverse, bool skip_same)
-        : LevelIterator(reader),
+        : LevelIterator(reader, merge),
           _children(std::move(children)),
           _reader(reader),
-          _merge(merge),
           _is_reverse(is_reverse),
           _skip_same(skip_same) {
     _ref.reset();

--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -103,7 +103,7 @@ Status VCollectIterator::add_child(const RowSetSplits& rs_splits) {
         return Status::OK();
     }
 
-    _children.push_back(std::make_unique<Level0Iterator>(rs_splits.rs_reader, _reader, _merge));
+    _children.push_back(std::make_unique<Level0Iterator>(rs_splits.rs_reader, _reader));
     return Status::OK();
 }
 
@@ -450,8 +450,8 @@ bool VCollectIterator::BlockRowPosComparator::operator()(const size_t& lpos,
 }
 
 VCollectIterator::Level0Iterator::Level0Iterator(RowsetReaderSharedPtr rs_reader,
-                                                 TabletReader* reader, bool merge)
-        : LevelIterator(reader, merge), _rs_reader(rs_reader), _reader(reader) {
+                                                 TabletReader* reader)
+        : LevelIterator(reader), _rs_reader(rs_reader), _reader(reader) {
     DCHECK_EQ(RowsetTypePB::BETA_ROWSET, rs_reader->type());
 }
 
@@ -534,7 +534,6 @@ Status VCollectIterator::Level0Iterator::refresh_current_row() {
 }
 
 Status VCollectIterator::Level0Iterator::next(IteratorRowRef* ref) {
-    DCHECK(_merge);
     if (_get_data_by_ref) {
         _current++;
     } else {
@@ -598,9 +597,10 @@ Status VCollectIterator::Level0Iterator::current_block_row_locations(
 VCollectIterator::Level1Iterator::Level1Iterator(
         std::list<std::unique_ptr<VCollectIterator::LevelIterator>> children, TabletReader* reader,
         bool merge, bool is_reverse, bool skip_same)
-        : LevelIterator(reader, merge),
+        : LevelIterator(reader),
           _children(std::move(children)),
           _reader(reader),
+          _merge(merge),
           _is_reverse(is_reverse),
           _skip_same(skip_same) {
     _ref.reset();

--- a/be/src/vec/olap/vcollect_iterator.h
+++ b/be/src/vec/olap/vcollect_iterator.h
@@ -252,10 +252,14 @@ private:
             if (_get_data_by_ref) {
                 return _rs_reader->next_batch(&_block_view);
             } else {
-                _row_is_same.clear();
-                BlockWithSameBit block_with_same_bit {.block = _block.get(),
-                                                      .same_bit = _row_is_same};
-                return _rs_reader->next_batch(&block_with_same_bit);
+                if (_is_merge_iterator) {
+                    _row_is_same.clear();
+                    BlockWithSameBit block_with_same_bit {.block = _block.get(),
+                                                          .same_bit = _row_is_same};
+                    return _rs_reader->next_batch(&block_with_same_bit);
+                } else {
+                    return _rs_reader->next_batch(_block.get());
+                }
             }
         }
 
@@ -267,6 +271,7 @@ private:
         BlockView _block_view;
         std::vector<RowLocation> _block_row_locations;
         std::vector<bool> _row_is_same;
+        bool _is_merge_iterator = false;
         bool _get_data_by_ref = false;
     };
 

--- a/be/src/vec/olap/vcollect_iterator.h
+++ b/be/src/vec/olap/vcollect_iterator.h
@@ -116,9 +116,10 @@ private:
     // then merged with other rowset readers.
     class LevelIterator {
     public:
-        LevelIterator(TabletReader* reader)
+        LevelIterator(TabletReader* reader, bool merge)
                 : _schema(reader->tablet_schema()),
-                  _compare_columns(reader->_reader_context.read_orderby_key_columns) {}
+                  _compare_columns(reader->_reader_context.read_orderby_key_columns),
+                  _merge(merge) {}
 
         virtual Status init(bool get_data_by_ref = false) = 0;
 
@@ -154,6 +155,13 @@ private:
         const TabletSchema& _schema;
         IteratorRowRef _ref;
         std::vector<uint32_t>* _compare_columns = nullptr;
+
+        // when `_merge == true`, rowset reader returns ordered rows and VCollectIterator uses a priority queue to merge
+        // sort them. The output of VCollectIterator is also ordered.
+        // When `_merge == false`, rowset reader returns *partial* ordered rows. VCollectIterator simply returns all rows
+        // from the first rowset, the second rowset, .., the last rowset. The output of CollectorIterator is also
+        // *partially* ordered.
+        bool _merge = true;
     };
 
     // Compare row cursors between multiple merge elements,
@@ -182,7 +190,7 @@ private:
     // Iterate from rowset reader. This Iterator usually like a leaf node
     class Level0Iterator : public LevelIterator {
     public:
-        Level0Iterator(RowsetReaderSharedPtr rs_reader, TabletReader* reader);
+        Level0Iterator(RowsetReaderSharedPtr rs_reader, TabletReader* reader, bool merge);
         ~Level0Iterator() override = default;
 
         Status init(bool get_data_by_ref = false) override;
@@ -253,9 +261,13 @@ private:
                 return _rs_reader->next_batch(&_block_view);
             } else {
                 _row_is_same.clear();
-                BlockWithSameBit block_with_same_bit {.block = _block.get(),
-                                                      .same_bit = _row_is_same};
-                return _rs_reader->next_batch(&block_with_same_bit);
+                if (_merge) {
+                    BlockWithSameBit block_with_same_bit {.block = _block.get(),
+                                                          .same_bit = _row_is_same};
+                    return _rs_reader->next_batch(&block_with_same_bit);
+                } else {
+                    return _rs_reader->next_batch(_block.get());
+                }
             }
         }
 
@@ -317,12 +329,6 @@ private:
         std::unique_ptr<LevelIterator> _cur_child;
         TabletReader* _reader = nullptr;
 
-        // when `_merge == true`, rowset reader returns ordered rows and VCollectIterator uses a priority queue to merge
-        // sort them. The output of VCollectIterator is also ordered.
-        // When `_merge == false`, rowset reader returns *partial* ordered rows. VCollectIterator simply returns all rows
-        // from the first rowset, the second rowset, .., the last rowset. The output of CollectorIterator is also
-        // *partially* ordered.
-        bool _merge = true;
         // reverse the compare order
         bool _is_reverse = false;
 

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -135,9 +135,9 @@ bool VMergeIteratorContext::compare(const VMergeIteratorContext& rhs) const {
 }
 
 // `advanced = false` when current block finished
-Status VMergeIteratorContext::copy_rows(Block* block, bool advanced) {
+Status VMergeIteratorContext::copy_rows(BlockWithSameBit* block_with_same_bit, bool advanced) {
     Block& src = *_block;
-    Block& dst = *block;
+    Block& dst = *block_with_same_bit->block;
     if (_cur_batch_num == 0) {
         return Status::OK();
     }
@@ -157,7 +157,9 @@ Status VMergeIteratorContext::copy_rows(Block* block, bool advanced) {
         }
     });
     const auto& tmp_pre_ctx_same_bit = get_pre_ctx_same();
-    dst.set_same_bit(tmp_pre_ctx_same_bit.begin(), tmp_pre_ctx_same_bit.begin() + _cur_batch_num);
+    block_with_same_bit->same_bit.insert(block_with_same_bit->same_bit.end(),
+                                         tmp_pre_ctx_same_bit.begin(),
+                                         tmp_pre_ctx_same_bit.begin() + _cur_batch_num);
     _cur_batch_num = 0;
     return Status::OK();
 }

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -110,7 +110,7 @@ public:
     bool compare(const VMergeIteratorContext& rhs) const;
 
     // `advanced = false` when current block finished
-    Status copy_rows(Block* block, bool advanced = true);
+    Status copy_rows(BlockWithSameBit* block, bool advanced = true);
 
     Status copy_rows(BlockView* view, bool advanced = true);
 
@@ -200,8 +200,10 @@ public:
 
     Status init(const StorageReadOptions& opts) override;
 
-    Status next_batch(Block* block) override { return _next_batch(block); }
-    Status next_block_view(BlockView* block_view) override { return _next_batch(block_view); }
+    Status next_batch(BlockWithSameBit* block_with_same_bit) override {
+        return _next_batch(block_with_same_bit);
+    }
+    Status next_batch(BlockView* block_view) override { return _next_batch(block_view); }
 
     const Schema& schema() const override { return *_schema; }
 
@@ -218,7 +220,9 @@ public:
     }
 
 private:
-    int _get_size(Block* block) { return cast_set<int>(block->rows()); }
+    int _get_size(const BlockWithSameBit* block_with_same_bit) {
+        return cast_set<int>(block_with_same_bit->block->rows());
+    }
     int _get_size(BlockView* block_view) { return cast_set<int>(block_view->size()); }
 
     template <typename T>

--- a/be/test/olap/collection_statistics_test.cpp
+++ b/be/test/olap/collection_statistics_test.cpp
@@ -196,12 +196,16 @@ public:
 
     void reset_read_options() override {}
 
-    Status next_block(vectorized::Block* block) override {
-        return Status::NotSupported("MockRowsetReader::next_block not implemented");
+    Status next_batch(vectorized::Block* block) override {
+        return Status::NotSupported("MockRowsetReader::next_batch not implemented");
     }
 
-    Status next_block_view(vectorized::BlockView* block_view) override {
-        return Status::NotSupported("MockRowsetReader::next_block_view not implemented");
+    Status next_batch(vectorized::BlockView* block_view) override {
+        return Status::NotSupported("MockRowsetReader::next_batch not implemented");
+    }
+
+    Status next_batch(BlockWithSameBit* block_view) override {
+        return Status::NotSupported("MockRowsetReader::next_batch not implemented");
     }
 
     bool delete_flag() override { return false; }

--- a/be/test/olap/ordered_data_compaction_test.cpp
+++ b/be/test/olap/ordered_data_compaction_test.cpp
@@ -520,7 +520,7 @@ TEST_F(OrderedDataCompactionTest, test_01) {
     Status s = Status::OK();
     do {
         block_create(tablet_schema, &output_block);
-        s = output_rs_reader->next_block(&output_block);
+        s = output_rs_reader->next_batch(&output_block);
         auto columns = output_block.get_columns_with_type_and_name();
         EXPECT_EQ(columns.size(), 2);
         for (auto i = 0; i < output_block.rows(); i++) {

--- a/be/test/olap/rowid_conversion_test.cpp
+++ b/be/test/olap/rowid_conversion_test.cpp
@@ -371,7 +371,7 @@ protected:
         std::vector<std::tuple<int64_t, int64_t>> output_data;
         do {
             vectorized::Block output_block = tablet_schema->create_block();
-            s = output_rs_reader->next_block(&output_block);
+            s = output_rs_reader->next_batch(&output_block);
             auto columns = output_block.get_columns_with_type_and_name();
             EXPECT_EQ(columns.size(), 2);
             for (auto i = 0; i < output_block.rows(); i++) {

--- a/be/test/olap/segcompaction_mow_test.cpp
+++ b/be/test/olap/segcompaction_mow_test.cpp
@@ -254,7 +254,10 @@ protected:
                 std::shared_ptr<vectorized::Block> output_block =
                         std::make_shared<vectorized::Block>(
                                 tablet_schema->create_block(return_columns));
-                s = rowset_reader->next_batch(output_block.get());
+                std::vector<bool> row_is_same;
+                BlockWithSameBit block_with_same_bit {.block = output_block.get(),
+                                                      .same_bit = row_is_same};
+                s = rowset_reader->next_batch(&block_with_same_bit);
                 if (s != Status::OK()) {
                     eof = true;
                 }

--- a/be/test/olap/segcompaction_mow_test.cpp
+++ b/be/test/olap/segcompaction_mow_test.cpp
@@ -254,7 +254,7 @@ protected:
                 std::shared_ptr<vectorized::Block> output_block =
                         std::make_shared<vectorized::Block>(
                                 tablet_schema->create_block(return_columns));
-                s = rowset_reader->next_block(output_block.get());
+                s = rowset_reader->next_batch(output_block.get());
                 if (s != Status::OK()) {
                     eof = true;
                 }

--- a/be/test/olap/segcompaction_test.cpp
+++ b/be/test/olap/segcompaction_test.cpp
@@ -363,7 +363,7 @@ TEST_F(SegCompactionTest, SegCompactionThenRead) {
                 std::shared_ptr<vectorized::Block> output_block =
                         std::make_shared<vectorized::Block>(
                                 tablet_schema->create_block(return_columns));
-                s = rowset_reader->next_block(output_block.get());
+                s = rowset_reader->next_batch(output_block.get());
                 if (s != Status::OK()) {
                     eof = true;
                 }
@@ -869,7 +869,7 @@ TEST_F(SegCompactionTest, SegCompactionThenReadUniqueTableSmall) {
                 std::shared_ptr<vectorized::Block> output_block =
                         std::make_shared<vectorized::Block>(
                                 tablet_schema->create_block(return_columns));
-                s = rowset_reader->next_block(output_block.get());
+                s = rowset_reader->next_batch(output_block.get());
                 if (s != Status::OK()) {
                     eof = true;
                 }
@@ -1134,7 +1134,7 @@ TEST_F(SegCompactionTest, SegCompactionThenReadAggTableSmall) {
                 std::shared_ptr<vectorized::Block> output_block =
                         std::make_shared<vectorized::Block>(
                                 tablet_schema->create_block(return_columns));
-                s = rowset_reader->next_block(output_block.get());
+                s = rowset_reader->next_batch(output_block.get());
                 if (s != Status::OK()) {
                     eof = true;
                 }

--- a/be/test/olap/segcompaction_test.cpp
+++ b/be/test/olap/segcompaction_test.cpp
@@ -363,7 +363,10 @@ TEST_F(SegCompactionTest, SegCompactionThenRead) {
                 std::shared_ptr<vectorized::Block> output_block =
                         std::make_shared<vectorized::Block>(
                                 tablet_schema->create_block(return_columns));
-                s = rowset_reader->next_batch(output_block.get());
+                std::vector<bool> row_is_same;
+                BlockWithSameBit block_with_same_bit {.block = output_block.get(),
+                                                      .same_bit = row_is_same};
+                s = rowset_reader->next_batch(&block_with_same_bit);
                 if (s != Status::OK()) {
                     eof = true;
                 }
@@ -869,7 +872,10 @@ TEST_F(SegCompactionTest, SegCompactionThenReadUniqueTableSmall) {
                 std::shared_ptr<vectorized::Block> output_block =
                         std::make_shared<vectorized::Block>(
                                 tablet_schema->create_block(return_columns));
-                s = rowset_reader->next_batch(output_block.get());
+                std::vector<bool> row_is_same;
+                BlockWithSameBit block_with_same_bit {.block = output_block.get(),
+                                                      .same_bit = row_is_same};
+                s = rowset_reader->next_batch(&block_with_same_bit);
                 if (s != Status::OK()) {
                     eof = true;
                 }
@@ -1134,7 +1140,10 @@ TEST_F(SegCompactionTest, SegCompactionThenReadAggTableSmall) {
                 std::shared_ptr<vectorized::Block> output_block =
                         std::make_shared<vectorized::Block>(
                                 tablet_schema->create_block(return_columns));
-                s = rowset_reader->next_batch(output_block.get());
+                std::vector<bool> row_is_same;
+                BlockWithSameBit block_with_same_bit {.block = output_block.get(),
+                                                      .same_bit = row_is_same};
+                s = rowset_reader->next_batch(&block_with_same_bit);
                 if (s != Status::OK()) {
                     eof = true;
                 }

--- a/be/test/vec/core/block_test.cpp
+++ b/be/test/vec/core/block_test.cpp
@@ -963,38 +963,6 @@ TEST(BlockTest, compare_at) {
     ASSERT_GT(ret, 0);
 }
 
-TEST(BlockTest, same_bit) {
-    auto block = vectorized::ColumnHelper::create_block<vectorized::DataTypeInt32>({1, 1, 3});
-    std::vector<bool> same_bit = {false, true, false};
-    block.set_same_bit(same_bit.begin(), same_bit.end());
-    ASSERT_EQ(block.get_same_bit(0), false);
-    ASSERT_EQ(block.get_same_bit(1), true);
-    ASSERT_EQ(block.get_same_bit(2), false);
-
-    auto block2 = block;
-    block2.set_num_rows(2);
-    ASSERT_EQ(block2.rows(), 2);
-
-    int64_t length = 3;
-    block2.skip_num_rows(length);
-    ASSERT_EQ(1, length);
-    ASSERT_EQ(block2.rows(), 0);
-
-    block2 = block;
-    length = 1;
-    block2.skip_num_rows(length);
-    ASSERT_EQ(block2.rows(), 2);
-    ASSERT_EQ(block2.get_same_bit(0), true);
-
-    block2.skip_num_rows(length);
-    ASSERT_EQ(block2.rows(), 1);
-    ASSERT_EQ(block2.get_same_bit(0), false);
-
-    block.clear_same_bit();
-
-    ASSERT_EQ(block.get_same_bit(1), false);
-}
-
 TEST(BlockTest, dump) {
     auto block = vectorized::ColumnHelper::create_block<vectorized::DataTypeInt32>({});
     auto types = block.dump_types();

--- a/be/test/vec/exec/vgeneric_iterators_test.cpp
+++ b/be/test/vec/exec/vgeneric_iterators_test.cpp
@@ -160,10 +160,12 @@ TEST(VGenericIteratorsTest, MergeAgg) {
     EXPECT_TRUE(st.ok());
 
     vectorized::Block block;
+    std::vector<bool> row_is_same;
+    BlockWithSameBit block_with_same_bit {.block = &block, .same_bit = row_is_same};
     create_block(schema, block);
 
     do {
-        st = iter->next_batch(&block);
+        st = iter->next_batch(&block_with_same_bit);
     } while (st.ok());
 
     EXPECT_TRUE(st.is<END_OF_FILE>());
@@ -207,10 +209,12 @@ TEST(VGenericIteratorsTest, MergeUnique) {
     EXPECT_TRUE(st.ok());
 
     vectorized::Block block;
+    std::vector<bool> row_is_same;
+    BlockWithSameBit block_with_same_bit {.block = &block, .same_bit = row_is_same};
     create_block(schema, block);
 
     do {
-        st = iter->next_batch(&block);
+        st = iter->next_batch(&block_with_same_bit);
     } while (st.ok());
 
     EXPECT_TRUE(st.is<END_OF_FILE>());
@@ -328,10 +332,12 @@ TEST(VGenericIteratorsTest, MergeWithSeqColumn) {
     EXPECT_TRUE(st.ok());
 
     vectorized::Block block;
+    std::vector<bool> row_is_same;
+    BlockWithSameBit block_with_same_bit {.block = &block, .same_bit = row_is_same};
     create_block(schema, block);
 
     do {
-        st = iter->next_batch(&block);
+        st = iter->next_batch(&block_with_same_bit);
     } while (st.ok());
 
     EXPECT_TRUE(st.is<END_OF_FILE>());

--- a/be/test/vec/olap/vertical_compaction_test.cpp
+++ b/be/test/vec/olap/vertical_compaction_test.cpp
@@ -510,7 +510,7 @@ TEST_F(VerticalCompactionTest, TestDupKeyVerticalMerge) {
     std::vector<std::tuple<int64_t, int64_t>> output_data;
     do {
         block_create(tablet_schema, &output_block);
-        s = output_rs_reader->next_block(&output_block);
+        s = output_rs_reader->next_batch(&output_block);
         auto columns = output_block.get_columns_with_type_and_name();
         EXPECT_EQ(columns.size(), 2);
         for (auto i = 0; i < output_block.rows(); i++) {
@@ -615,7 +615,7 @@ TEST_F(VerticalCompactionTest, TestDupWithoutKeyVerticalMerge) {
     std::vector<std::tuple<int64_t, int64_t>> output_data;
     do {
         block_create(tablet_schema, &output_block);
-        s = output_rs_reader->next_block(&output_block);
+        s = output_rs_reader->next_batch(&output_block);
         auto columns = output_block.get_columns_with_type_and_name();
         EXPECT_EQ(columns.size(), 2);
         for (auto i = 0; i < output_block.rows(); i++) {
@@ -721,7 +721,7 @@ TEST_F(VerticalCompactionTest, TestUniqueKeyVerticalMerge) {
     std::vector<std::tuple<int64_t, int64_t>> output_data;
     do {
         block_create(tablet_schema, &output_block);
-        s = output_rs_reader->next_block(&output_block);
+        s = output_rs_reader->next_batch(&output_block);
         auto columns = output_block.get_columns_with_type_and_name();
         EXPECT_EQ(columns.size(), 2);
         for (auto i = 0; i < output_block.rows(); i++) {
@@ -830,7 +830,7 @@ TEST_F(VerticalCompactionTest, TestDupKeyVerticalMergeWithDelete) {
     std::vector<std::tuple<int64_t, int64_t>> output_data;
     do {
         block_create(tablet_schema, &output_block);
-        st = output_rs_reader->next_block(&output_block);
+        st = output_rs_reader->next_batch(&output_block);
         auto columns = output_block.get_columns_with_type_and_name();
         EXPECT_EQ(columns.size(), 2);
         for (auto i = 0; i < output_block.rows(); i++) {
@@ -931,7 +931,7 @@ TEST_F(VerticalCompactionTest, TestDupWithoutKeyVerticalMergeWithDelete) {
     std::vector<std::tuple<int64_t, int64_t>> output_data;
     do {
         block_create(tablet_schema, &output_block);
-        st = output_rs_reader->next_block(&output_block);
+        st = output_rs_reader->next_batch(&output_block);
         auto columns = output_block.get_columns_with_type_and_name();
         EXPECT_EQ(columns.size(), 2);
         for (auto i = 0; i < output_block.rows(); i++) {
@@ -1021,7 +1021,7 @@ TEST_F(VerticalCompactionTest, TestAggKeyVerticalMerge) {
     std::vector<std::tuple<int64_t, int64_t>> output_data;
     do {
         block_create(tablet_schema, &output_block);
-        s = output_rs_reader->next_block(&output_block);
+        s = output_rs_reader->next_batch(&output_block);
         auto columns = output_block.get_columns_with_type_and_name();
         EXPECT_EQ(columns.size(), 2);
         for (auto i = 0; i < output_block.rows(); i++) {


### PR DESCRIPTION
### What problem does this PR solve?
This pull request refactors the block reading interface and handling of row "same bit" flags in the storage engine. The main changes include unifying the batch reading interface, removing the `row_same_bit` member from the `Block` class, and introducing a new mechanism to handle "same bit" information separately. This improves code clarity, reduces coupling, and streamlines how batch data and metadata are passed through the system.

**API and Interface Refactoring:**

* Unified the block reading interface by replacing `next_block` and `next_block_view` methods with a single set of `next_batch` methods in the `RowsetReader` and `RowwiseIterator` classes, supporting different block types (including a new `BlockWithSameBit` struct for passing "same bit" metadata). [[1]](diffhunk://#diff-8dec3cee74c5e0821835a7125bede7e3358bd3b5067b2748262193cb4cf80d48R162-R168) [[2]](diffhunk://#diff-8dec3cee74c5e0821835a7125bede7e3358bd3b5067b2748262193cb4cf80d48L175-R223) [[3]](diffhunk://#diff-d2e7a265f639b3d0a0b2a5d4aeaebd7a351418996e44df421b4d807cd5312b09L56-R67) [[4]](diffhunk://#diff-d2e7a265f639b3d0a0b2a5d4aeaebd7a351418996e44df421b4d807cd5312b09R101-L98) [[5]](diffhunk://#diff-80e5d260c10f55c4970732994c4894139b047271a4ed49c3bbad70a4e1d6cac8L64-R67) [[6]](diffhunk://#diff-54bf53f905d18156fd41a478f116f9e5d499896f97402f213a0d145c1f5f9820L294-R294)

* Added the `is_merge_iterator` virtual method to the iterator and reader interfaces to clearly indicate support for merge operations. [[1]](diffhunk://#diff-8dec3cee74c5e0821835a7125bede7e3358bd3b5067b2748262193cb4cf80d48L175-R223) [[2]](diffhunk://#diff-d2e7a265f639b3d0a0b2a5d4aeaebd7a351418996e44df421b4d807cd5312b09L56-R67) [[3]](diffhunk://#diff-80e5d260c10f55c4970732994c4894139b047271a4ed49c3bbad70a4e1d6cac8L64-R67)

**"Same Bit" Handling Improvements:**

* Removed the `row_same_bit` member and all related methods from the `Block` class, decoupling row sameness tracking from block data and moving it to higher-level logic. [[1]](diffhunk://#diff-5a2c9e19a27153df9fce7277a09325589cd009441c63da55761c286627417fb3L79) [[2]](diffhunk://#diff-5a2c9e19a27153df9fce7277a09325589cd009441c63da55761c286627417fb3L370-L385) F9690e13L53R53, [[3]](diffhunk://#diff-76dba768c36c76cce660f7fe39514a98b509030a8976aabc9ac47d58bc923976L281-L283) [[4]](diffhunk://#diff-76dba768c36c76cce660f7fe39514a98b509030a8976aabc9ac47d58bc923976L436-L438) [[5]](diffhunk://#diff-76dba768c36c76cce660f7fe39514a98b509030a8976aabc9ac47d58bc923976L453-L455) [[6]](diffhunk://#diff-76dba768c36c76cce660f7fe39514a98b509030a8976aabc9ac47d58bc923976L786) [[7]](diffhunk://#diff-76dba768c36c76cce660f7fe39514a98b509030a8976aabc9ac47d58bc923976L805) [[8]](diffhunk://#diff-76dba768c36c76cce660f7fe39514a98b509030a8976aabc9ac47d58bc923976L839-L846) [[9]](diffhunk://#diff-76dba768c36c76cce660f7fe39514a98b509030a8976aabc9ac47d58bc923976L1170-L1172) [[10]](diffhunk://#diff-2c575051a29b06200611882d17cb4c0fea6df46659e8ea953c705aaca2c2b5a4L109-L111)

* Introduced a new function `next_batch` in `schema_change.cpp` to handle batch reading and "same bit" population outside of the block structure, and updated schema change processing logic to use this new mechanism. [[1]](diffhunk://#diff-8ed52fcd40d49be70d3aa98b911d9ddc7b0366cf0a1110d45763da9be74f3834R548-R561) [[2]](diffhunk://#diff-8ed52fcd40d49be70d3aa98b911d9ddc7b0366cf0a1110d45763da9be74f3834L557-R571) [[3]](diffhunk://#diff-8ed52fcd40d49be70d3aa98b911d9ddc7b0366cf0a1110d45763da9be74f3834L625-R639) [[4]](diffhunk://#diff-045a9152e8ea5a0957698b6c6252238b0a3b7f9a2880141e2b5db5a940054958R173-R175)

**Code Cleanup and Consistency:**

* Refactored and removed now-unnecessary methods and logic related to `row_same_bit` in block manipulation, aggregation, and scanning. [[1]](diffhunk://#diff-88e1176f094af15c45f8ea991be868e85fc49eae772ed479a51c781acffddb3dL312-R312) [[2]](diffhunk://#diff-88e1176f094af15c45f8ea991be868e85fc49eae772ed479a51c781acffddb3dL533-L540) [[3]](diffhunk://#diff-b16cc78a130797afb18e70729aacb7196b862de99deab41bb14911e6ab067296L87-L88)

* Updated all affected call sites to use the new unified batch interface and external "same bit" handling. [[1]](diffhunk://#diff-66ec81528c724b2f69e242d61f35d8a54d7bb5286a7e334c486166a3cc946642L321-R321) [[2]](diffhunk://#diff-66ec81528c724b2f69e242d61f35d8a54d7bb5286a7e334c486166a3cc946642L351-L404) [[3]](diffhunk://#diff-54bf53f905d18156fd41a478f116f9e5d499896f97402f213a0d145c1f5f9820L294-R294)

These changes improve the modularity and maintainability of the codebase by separating data and metadata concerns and unifying the batch processing API.
### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

