### PR TITLE
[Fix](Olap)Fixs uninitialized group_data_size in CompactionSampleInfo

### DIFF
--- a/be/src/olap/iterators.h
+++ b/be/src/olap/iterators.h
@@ -156,7 +156,7 @@ public:
 struct CompactionSampleInfo {
     int64_t bytes = 0;
     int64_t rows = 0;
-    int64_t group_data_size;
+    int64_t group_data_size = 0;
 };
 
 class RowwiseIterator;

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -477,7 +477,7 @@ Status Merger::vertical_merge_rowsets(BaseTabletSPtr tablet, ReaderType reader_t
             tablet->tablet_id(), dst_rowset_writer->context().tablet_path, reader_type);
     {
         std::unique_lock<std::mutex> lock(tablet->sample_info_lock);
-        tablet->sample_infos.resize(column_groups.size(), {0, 0, 0});
+        tablet->sample_infos.resize(column_groups.size());
     }
     // compact group one by one
     for (auto i = 0; i < column_groups.size(); ++i) {


### PR DESCRIPTION
### What problem does this PR solve?

Fixs the uninitialized `group_data_size` in CompactionSampleInfo, which resulted in an unreasonable `batch_size` for the estimate_batch_size() method.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

