### PR TITLE
[improve](glue) Glue endpoint is required.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/AWSGlueMetaStoreBaseProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/AWSGlueMetaStoreBaseProperties.java
@@ -116,16 +116,12 @@ public class AWSGlueMetaStoreBaseProperties {
                         "glue.access_key and glue.secret_key must be set together")
                 .requireAtLeastOne(new String[]{glueAccessKey, glueIAMRole},
                         "At least one of glue.access_key or glue.role_arn must be set")
-                .requireAtLeastOne(new String[]{glueEndpoint, glueRegion},
-                        "At least one of glue.endpoint or glue.region must be set");
+                .require(glueEndpoint, "glue.endpoint must be set");
     }
 
     private void checkAndInit() {
         buildRules().validate();
         if (StringUtils.isNotBlank(glueRegion) && StringUtils.isNotBlank(glueEndpoint)) {
-            return;
-        }
-        if (StringUtils.isBlank(glueEndpoint) && StringUtils.isNotBlank(glueRegion)) {
             return;
         }
         // glue region is not set, try to extract from endpoint

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/AWSGlueMetaStoreBasePropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/AWSGlueMetaStoreBasePropertiesTest.java
@@ -96,7 +96,7 @@ public class AWSGlueMetaStoreBasePropertiesTest {
                 IllegalArgumentException.class,
                 () -> AWSGlueMetaStoreBaseProperties.of(props)
         );
-        Assertions.assertTrue(ex.getMessage().contains("At least one of glue.endpoint or glue.region must be set"));
+        Assertions.assertTrue(ex.getMessage().contains("glue.endpoint must be set"));
     }
 
     @Test


### PR DESCRIPTION
follow #57365
`error: NullPointerException: The URI scheme of endpointOverride must not be null.`

For glue, endpoint is a required field, so it must be filled in manually when it is no longer automatically generated based on region.
