### PR TITLE
[fix](cloud) Recycle operation logs if multi version status is WRITE_ONLY

### DIFF
--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -2059,12 +2059,11 @@ std::pair<MetaServiceCode, std::string> handle_snapshot_switch(const std::string
         std::string url =
                 "${MS_ENDPOINT}/MetaService/http/"
                 "set_multi_version_status?multi_version_status=MULTI_VERSION_READ_WRITE";
-        return std::make_pair(
-                MetaServiceCode::INVALID_ARGUMENT,
-                fmt::format("Cannot enable snapshot when multi_version_status is not "
-                            "MULTI_VERSION_READ_WRITE, instance_id: {}. Consider enabling "
-                            "MULTI_VERSION_READ_WRITE status by curl {}",
-                            instance_id));
+        return std::make_pair(MetaServiceCode::INVALID_ARGUMENT,
+                              fmt::format("Cannot enable snapshot when multi_version_status is not "
+                                          "MULTI_VERSION_READ_WRITE. Consider enabling "
+                                          "MULTI_VERSION_READ_WRITE status by curl {}",
+                                          instance_id));
     } else if (value == "true") {
         instance->set_snapshot_switch_status(SNAPSHOT_SWITCH_ON);
 

--- a/cloud/src/recycler/recycler_operation_log.cpp
+++ b/cloud/src/recycler/recycler_operation_log.cpp
@@ -633,7 +633,9 @@ int InstanceRecycler::recycle_operation_logs() {
             return -1;
         }
 
-        if (!operation_log.has_min_timestamp()) {
+        // Recycle operation log directly if multi_version_status is WRITE_ONLY.
+        if (!operation_log.has_min_timestamp() &&
+            instance_info_.multi_version_status() != MultiVersionStatus::MULTI_VERSION_WRITE_ONLY) {
             LOG_WARNING("operation log has not set the min_timestamp")
                     .tag("key", hex(key))
                     .tag("version", log_versionstamp.version())

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -11584,6 +11584,7 @@ TEST(MetaServiceTest, SetSnapshotPropertyTest) {
         InstanceInfoPB instance;
         instance.ParseFromString(val);
         instance.set_snapshot_switch_status(SNAPSHOT_SWITCH_OFF);
+        instance.set_multi_version_status(MULTI_VERSION_READ_WRITE);
         val = instance.SerializeAsString();
         txn->put(key, val);
         ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -11569,7 +11569,7 @@ TEST(MetaServiceTest, SetSnapshotPropertyTest) {
         meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &res, nullptr);
         ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT);
-        ASSERT_TRUE(res.status().msg().find("Snapshot not ready") != std::string::npos);
+        ASSERT_TRUE(res.status().msg().find("Snapshot is not ready") != std::string::npos);
     }
 
     // Initialize snapshot switch status to OFF so we can test snapshot functionality
@@ -11923,6 +11923,38 @@ TEST(MetaServiceTest, SnapshotConfigLimitsTest) {
         ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
     }
 
+    {
+        brpc::Controller cntl;
+        AlterInstanceRequest alter_req;
+        AlterInstanceResponse alter_res;
+        alter_req.set_op(AlterInstanceRequest::SET_SNAPSHOT_PROPERTY);
+        alter_req.set_instance_id("test_snapshot_config_instance");
+        (*alter_req.mutable_properties())[AlterInstanceRequest_SnapshotProperty_Name(
+                AlterInstanceRequest::ENABLE_SNAPSHOT)] = "true";
+
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &alter_req, &alter_res, nullptr);
+        ASSERT_EQ(alter_res.status().code(), MetaServiceCode::INVALID_ARGUMENT);
+        ASSERT_TRUE(alter_res.status().msg().find("MULTI_VERSION_READ_WRITE") != std::string::npos);
+    }
+
+    // Set multi-version status to READ_WRITE
+    {
+        InstanceKeyInfo key_info {"test_snapshot_config_instance"};
+        std::string key;
+        std::string val;
+        instance_key(key_info, &key);
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+        ASSERT_EQ(txn->get(key, &val), TxnErrorCode::TXN_OK);
+        InstanceInfoPB instance;
+        instance.ParseFromString(val);
+        instance.set_multi_version_status(MULTI_VERSION_READ_WRITE);
+        val = instance.SerializeAsString();
+        txn->put(key, val);
+        ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+    }
+
     // Enable snapshot for this instance
     {
         brpc::Controller cntl;
@@ -12076,6 +12108,7 @@ TEST(MetaServiceTest, SnapshotDefaultValuesTest) {
         InstanceInfoPB instance;
         instance.ParseFromString(val);
         instance.set_snapshot_switch_status(SNAPSHOT_SWITCH_OFF);
+        instance.set_multi_version_status(MULTI_VERSION_READ_WRITE);
         val = instance.SerializeAsString();
         txn->put(key, val);
         ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

and require mv status is READ_WRITE to turn on snapshot (so the min_versionstamp of the operation log will be set).


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

