### PR TITLE
[fix](iceberg) fix querying iceberg partition table error

### DIFF
--- a/docker/thirdparties/docker-compose/iceberg/scripts/create_preinstalled_scripts/iceberg/run19.sql
+++ b/docker/thirdparties/docker-compose/iceberg/scripts/create_preinstalled_scripts/iceberg/run19.sql
@@ -364,6 +364,25 @@ VALUES (1, 'z', 0.00),
     (9, 'big', 9999999.99),
     (10, 'null', NULL);
 
+-- create table for testing query partitions with snapshot has been expired
+
+CREATE TABLE test_partitions_with_expired_snapshot (
+    id BIGINT,
+    name STRING,
+    value DOUBLE,
+    dt TIMESTAMP
+) USING ICEBERG PARTITIONED BY (month(dt));
+
+INSERT INTO test_partitions_with_expired_snapshot VALUES (1, 'a', 1.0, TIMESTAMP '2024-01-01 00:00:00');
+INSERT INTO test_partitions_with_expired_snapshot VALUES (2, 'b', 2.0, TIMESTAMP '2024-02-02 00:00:00');
+INSERT INTO test_partitions_with_expired_snapshot VALUES (3, 'c', 3.0, TIMESTAMP '2024-03-03 00:00:00');
+
+-- Expire snapshots older than futurama, retaining only the last 1 snapshot
+CALL demo.system.expire_snapshots(
+    table => 'transform_partition_db.test_partitions_with_expired_snapshot',
+    older_than => TIMESTAMP '3000-01-01 00:00:00',
+    retain_last => 1
+);
 
 create database if not exists demo.test_db;
 use demo.test_db;
@@ -401,23 +420,3 @@ INSERT INTO test_invalid_avro_name_orc VALUES
     (3, 'row3'),
     (4, 'row4'),
     (5, 'row5');
-
--- create table for testing query partitions with snapshot has been expired
-
-CREATE TABLE test_partitions_with_expired_snapshot (
-    id BIGINT,
-    name STRING,
-    value DOUBLE,
-    dt TIMESTAMP
-) USING ICEBERG PARTITIONED BY (month(dt));
-
-INSERT INTO test_partitions_with_expired_snapshot VALUES (1, 'a', 1.0, TIMESTAMP '2024-01-01 00:00:00');
-INSERT INTO test_partitions_with_expired_snapshot VALUES (2, 'b', 2.0, TIMESTAMP '2024-02-02 00:00:00');
-INSERT INTO test_partitions_with_expired_snapshot VALUES (3, 'c', 3.0, TIMESTAMP '2024-03-03 00:00:00');
-
--- Expire snapshots older than futurama, retaining only the last 1 snapshot
-CALL demo.system.expire_snapshots(
-    table => 'transform_partition_db.test_partitions_with_expired_snapshot',
-    older_than => TIMESTAMP '3000-01-01 00:00:00',
-    retain_last => 1
-);

--- a/docker/thirdparties/docker-compose/iceberg/scripts/create_preinstalled_scripts/iceberg/run19.sql
+++ b/docker/thirdparties/docker-compose/iceberg/scripts/create_preinstalled_scripts/iceberg/run19.sql
@@ -402,4 +402,22 @@ INSERT INTO test_invalid_avro_name_orc VALUES
     (4, 'row4'),
     (5, 'row5');
 
+-- create table for testing query partitions with snapshot has been expired
 
+CREATE TABLE test_partitions_with_expired_snapshot (
+    id BIGINT,
+    name STRING,
+    value DOUBLE,
+    dt TIMESTAMP
+) USING ICEBERG PARTITIONED BY (month(dt));
+
+INSERT INTO test_partitions_with_expired_snapshot VALUES (1, 'a', 1.0, TIMESTAMP '2024-01-01 00:00:00');
+INSERT INTO test_partitions_with_expired_snapshot VALUES (2, 'b', 2.0, TIMESTAMP '2024-02-02 00:00:00');
+INSERT INTO test_partitions_with_expired_snapshot VALUES (3, 'c', 3.0, TIMESTAMP '2024-03-03 00:00:00');
+
+-- Expire snapshots older than futurama, retaining only the last 1 snapshot
+CALL demo.system.expire_snapshots(
+    table => 'transform_partition_db.test_partitions_with_expired_snapshot',
+    older_than => TIMESTAMP '3000-01-01 00:00:00',
+    retain_last => 1
+);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/IcebergDlaTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/IcebergDlaTable.java
@@ -83,8 +83,17 @@ public class IcebergDlaTable extends HMSDlaTable {
         IcebergSnapshotCacheValue snapshotValue =
                 IcebergUtils.getOrFetchSnapshotCacheValue(snapshot, hmsTable);
         long latestSnapshotId = snapshotValue.getPartitionInfo().getLatestSnapshotId(partitionName);
+        // If partition snapshot ID is unavailable (<= 0), fallback to table snapshot ID
+        // This can happen when last_updated_snapshot_id is null in Iceberg metadata
         if (latestSnapshotId <= 0) {
-            throw new AnalysisException("can not find partition: " + partitionName);
+            long tableSnapshotId = snapshotValue.getSnapshot().getSnapshotId();
+            // If table snapshot ID is also invalid, it means empty table
+            if (tableSnapshotId <= 0) {
+                throw new AnalysisException("can not find partition: " + partitionName
+                        + ", and table snapshot ID is also invalid");
+            }
+            // Use table snapshot ID as fallback when partition snapshot ID is unavailable
+            return new MTMVSnapshotIdSnapshot(tableSnapshotId);
         }
         return new MTMVSnapshotIdSnapshot(latestSnapshotId);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergPartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergPartitionInfo.java
@@ -62,11 +62,15 @@ public class IcebergPartitionInfo {
         if (icebergPartitionNames == null) {
             return nameToIcebergPartition.get(partitionName).getLastSnapshotId();
         }
-        long latestSnapshotId = 0;
+        long latestSnapshotId = -1;
         long latestUpdateTime = -1;
         for (String name : icebergPartitionNames) {
             IcebergPartition partition = nameToIcebergPartition.get(name);
             long lastUpdateTime = partition.getLastUpdateTime();
+            // Skip partitions with invalid update time (<= 0 means unknown/invalid)
+            if (lastUpdateTime <= 0) {
+                continue;
+            }
             if (latestUpdateTime < lastUpdateTime) {
                 latestUpdateTime = lastUpdateTime;
                 latestSnapshotId = partition.getLastSnapshotId();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
@@ -1179,8 +1179,20 @@ public class IcebergUtils {
         long recordCount = row.get(2, Long.class);
         long fileCount = row.get(3, Integer.class);
         long fileSizeInBytes = row.get(4, Long.class);
-        long lastUpdateTime = row.get(9, Long.class);
-        long lastUpdateSnapShotId = row.get(10, Long.class);
+        // last_updated_at and last_updated_snapshot_id are optional, so we need to
+        // handle the null case.
+        long lastUpdateTime;
+        long lastUpdateSnapShotId;
+        try {
+            lastUpdateTime = row.get(9, Long.class);
+        } catch (NullPointerException e) {
+            lastUpdateTime = 0;
+        }
+        try {
+            lastUpdateSnapShotId = row.get(10, Long.class);
+        } catch (NullPointerException e) {
+            lastUpdateSnapShotId = UNKNOWN_SNAPSHOT_ID;
+        }
         return new IcebergPartition(partitionName, specId, recordCount, fileSizeInBytes, fileCount,
             lastUpdateTime, lastUpdateSnapShotId, partitionValues, transforms);
     }

--- a/regression-test/data/external_table_p0/iceberg/test_iceberg_transform_partitions.out
+++ b/regression-test/data/external_table_p0/iceberg/test_iceberg_transform_partitions.out
@@ -122,3 +122,8 @@
 -- !truncate_decimal_10_select1 --
 5	p19	19.99
 
+-- !query_partitions_with_expired_snapshot_select --
+1	a	1	2024-01-01T00:00
+2	b	2	2024-02-02T00:00
+3	c	3	2024-03-03T00:00
+

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_transform_partitions.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_transform_partitions.groovy
@@ -196,9 +196,17 @@ suite("test_iceberg_transform_partitions", "p0,external,doris,external_docker,ex
         """
     }
 
+    def test_iceberg_query_partitions_with_expired_snapshot = {
+        // Query partitions with snapshot has been expired
+        qt_query_partitions_with_expired_snapshot_select """
+            select * from test_partitions_with_expired_snapshot order by id;
+        """
+    }
+
     try {
         sql """ set time_zone = 'Asia/Shanghai'; """
         test_iceberg_transform_partitions()
+        test_iceberg_query_partitions_with_expired_snapshot()
     } finally {
         sql """ unset variable time_zone; """
     }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

java.lang.Thread.run(Thread.java:833) ~[?:?] Caused by: java.lang.NullPointerException: Cannot invoke "java.lang.Long.longValue()" because the return value of "org.apache.iceberg.StructLike.get(int, java.lang.Class)" is null at org.apache.doris.datasource.iceberg.IcebergUtils.generateIcebergPartition(IcebergUtils.java:1185) ~[doris-fe.jar:1.2-SNAPSHOT] at org.apache.doris.datasource.iceberg.IcebergUtils.loadIcebergPartition(IcebergUtils.java:1132)

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

