### PR TITLE
[feat](profile) add automatic profile archiving to compressed ZIP files

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3124,6 +3124,41 @@ public class Config extends ConfigBase {
             "Profile will be spilled to storage after query has finished for this time"})
     public static int profile_waiting_time_for_spill_seconds = 10;
 
+    // Enable profile archive feature. When enabled, profiles exceeding storage limits
+    // will be archived to compressed ZIP files instead of being directly deleted.
+    @ConfField(mutable = true, description = {"是否启用 profile 归档功能。启用后，超过存储限制的 profile 将被归档到压缩文件而不是直接删除",
+            "Enable profile archive feature. When enabled, profiles exceeding storage limits "
+                    + "will be archived to compressed ZIP files instead of being directly deleted"})
+    public static boolean enable_profile_archive = true;
+
+    // Number of profiles to include in each archive ZIP file.
+    // Recommended value: 100
+    @ConfField(mutable = true, description = {"每个归档 ZIP 文件包含的 profile 数量。推荐值 100",
+            "Number of profiles per archive ZIP file. Recommended: 100"})
+    public static int profile_archive_batch_size = 100;
+
+    // Storage path for archived profiles.
+    // If empty, defaults to ${spilled_profile_storage_path}/archive
+    @ConfField(description = {"profile 归档文件的存储路径。为空时使用 ${spilled_profile_storage_path}/archive",
+            "Storage path for archived profiles. Use ${spilled_profile_storage_path}/archive if empty"})
+    public static String profile_archive_path = "";
+
+    // Retention period for archive files in seconds.
+    // -1: keep forever
+    // 0: disable archiving (equivalent to enable_profile_archive = false)
+    // >0: delete archives older than specified seconds (e.g., 604800 = 30 days)
+    @ConfField(mutable = true, description = {"归档文件的保留时长（秒）。-1 表示永久保留，0 表示不保留",
+            "Retention period for archive files in seconds. -1 for unlimited, 0 to disable archiving"})
+    public static int profile_archive_retention_seconds = 604800; // 7 days
+
+    // Maximum waiting time for pending archive files in seconds.
+    // If the oldest file in pending directory exceeds this time, archive will be forced
+    // even if the batch size is not reached.
+    @ConfField(mutable = true, description = {"待归档缓冲区的最大等待时间（秒）。超过此时间即使未满批次也会强制归档",
+            "Maximum waiting time for pending archive files in seconds. "
+                    + "Force archive even if batch is not full"})
+    public static int profile_archive_pending_timeout_seconds = 86400; // 24 hours
+
     @ConfField(mutable = true, description = {
             "是否通过检测协调者BE心跳来 abort 事务",
             "SHould abort txn by checking coorinator be heartbeat"})

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3132,10 +3132,10 @@ public class Config extends ConfigBase {
     public static boolean enable_profile_archive = true;
 
     // Number of profiles to include in each archive ZIP file.
-    // Recommended value: 100
-    @ConfField(mutable = true, description = {"每个归档 ZIP 文件包含的 profile 数量。推荐值 100",
-            "Number of profiles per archive ZIP file. Recommended: 100"})
-    public static int profile_archive_batch_size = 100;
+    // Recommended value: 1000
+    @ConfField(mutable = true, description = {"每个归档 ZIP 文件包含的 profile 数量。推荐值 1000",
+            "Number of profiles per archive ZIP file. Recommended: 1000"})
+    public static int profile_archive_batch_size = 1000;
 
     // Storage path for archived profiles.
     // If empty, defaults to ${spilled_profile_storage_path}/archive
@@ -3149,7 +3149,7 @@ public class Config extends ConfigBase {
     // >0: delete archives older than specified seconds (e.g., 604800 = 30 days)
     @ConfField(mutable = true, description = {"归档文件的保留时长（秒）。-1 表示永久保留，0 表示不保留",
             "Retention period for archive files in seconds. -1 for unlimited, 0 to disable archiving"})
-    public static int profile_archive_retention_seconds = 604800; // 7 days
+    public static int profile_archive_retention_seconds = 28800; // 8 hours
 
     // Maximum waiting time for pending archive files in seconds.
     // If the oldest file in pending directory exceeds this time, archive will be forced
@@ -3157,7 +3157,7 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, description = {"待归档缓冲区的最大等待时间（秒）。超过此时间即使未满批次也会强制归档",
             "Maximum waiting time for pending archive files in seconds. "
                     + "Force archive even if batch is not full"})
-    public static int profile_archive_pending_timeout_seconds = 86400; // 24 hours
+    public static int profile_archive_pending_timeout_seconds = 3600; // 1 hours
 
     @ConfField(mutable = true, description = {
             "是否通过检测协调者BE心跳来 abort 事务",

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileArchiveManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileArchiveManager.java
@@ -1,0 +1,682 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.profile;
+
+import org.apache.doris.common.Config;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * ProfileArchiveManager handles archiving of profile files from the spilled profile storage
+ * to compressed ZIP archives. This is triggered when the number of profiles or total storage
+ * size exceeds configured limits.
+ *
+ * <p>Archive Strategy:
+ * <ul>
+ *   <li>Profiles are moved to pending directory first</li>
+ *   <li>When pending has >= batch_size files OR oldest file > timeout hours: archive is triggered</li>
+ *   <li>Batch size: configurable via Config.profile_archive_batch_size (default 1000)</li>
+ *   <li>Naming pattern: profiles_YYYYMMDD_HHMMSS_YYYYMMDD_HHMMSS.zip</li>
+ *   <li>Archive location: ${LOG_DIR}/profile/archive (or Config.profile_archive_path)</li>
+ *   <li>Archives oldest profiles first (by finish timestamp)</li>
+ * </ul>
+ *
+ * <p>Directory Structure:
+ * <pre>
+ * ${spilled_profile_storage_path}/
+ * ├── {timestamp}_{queryid}.zip          (active spilled profiles)
+ * └── archive/
+ *     ├── pending/                       (pending buffer for archiving)
+ *     │   └── {timestamp}_{queryid}.zip
+ *     └── profiles_20240101_000000_20240101_235959.zip  (archived ZIPs)
+ * </pre>
+ */
+public class ProfileArchiveManager {
+    private static final Logger LOG = LogManager.getLogger(ProfileArchiveManager.class);
+
+    // Default batch size for archiving profiles
+    private static final int DEFAULT_ARCHIVE_BATCH_SIZE = 100;
+
+    // Date format for archive file names (thread-safe)
+    private static final DateTimeFormatter DATE_FORMAT =
+            DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss").withZone(ZoneId.systemDefault());
+
+    // Archive directory name
+    private static final String ARCHIVE_DIR_NAME = "archive";
+
+    // Pending directory name (buffer for files waiting to be archived)
+    private static final String PENDING_DIR_NAME = "pending";
+
+    private final String spilledProfileStoragePath;
+    private final String archivePath;
+    private final String pendingPath;
+    private final int archiveBatchSize;
+
+    /**
+     * Constructs a ProfileArchiveManager with default batch size.
+     *
+     * @param spilledProfileStoragePath the path where spilled profiles are stored
+     */
+    public ProfileArchiveManager(String spilledProfileStoragePath) {
+        this(spilledProfileStoragePath, DEFAULT_ARCHIVE_BATCH_SIZE);
+    }
+
+    /**
+     * Constructs a ProfileArchiveManager with custom batch size.
+     *
+     * @param spilledProfileStoragePath the path where spilled profiles are stored
+     * @param archiveBatchSize number of profiles to include in each archive
+     */
+    public ProfileArchiveManager(String spilledProfileStoragePath, int archiveBatchSize) {
+        this.spilledProfileStoragePath = spilledProfileStoragePath;
+        // Use custom archive path from config if specified, otherwise use default
+        this.archivePath = Config.profile_archive_path.isEmpty()
+                ? spilledProfileStoragePath + File.separator + ARCHIVE_DIR_NAME
+                : Config.profile_archive_path;
+        this.pendingPath = archivePath + File.separator + PENDING_DIR_NAME;
+        this.archiveBatchSize = archiveBatchSize;
+    }
+
+    /**
+     * Creates the archive directory if it doesn't exist.
+     *
+     * @return true if directory exists or was created successfully
+     */
+    public boolean createArchiveDirectoryIfNecessary() {
+        File archiveDir = new File(archivePath);
+        if (archiveDir.exists()) {
+            return true;
+        }
+
+        if (archiveDir.mkdirs()) {
+            LOG.info("Created profile archive directory: {}", archivePath);
+            return true;
+        } else {
+            LOG.error("Failed to create profile archive directory: {}", archivePath);
+            return false;
+        }
+    }
+
+    /**
+     * Creates the pending directory if it doesn't exist.
+     *
+     * @return true if directory exists or was created successfully
+     */
+    public boolean createPendingDirectoryIfNecessary() {
+        File pendingDir = new File(pendingPath);
+        if (pendingDir.exists()) {
+            return true;
+        }
+
+        if (pendingDir.mkdirs()) {
+            LOG.info("Created profile pending directory: {}", pendingPath);
+            return true;
+        } else {
+            LOG.error("Failed to create profile pending directory: {}", pendingPath);
+            return false;
+        }
+    }
+
+    /**
+     * Gets the list of profile files from the spilled storage directory,
+     * excluding the archive subdirectory.
+     *
+     * @return list of profile files sorted by filename timestamp (oldest first)
+     */
+    public List<File> getProfileFilesFromStorage() {
+        File storageDir = new File(spilledProfileStoragePath);
+        if (!storageDir.exists() || !storageDir.isDirectory()) {
+            LOG.warn("Profile storage directory does not exist: {}", spilledProfileStoragePath);
+            return new ArrayList<>();
+        }
+
+        File[] files = storageDir.listFiles(file -> {
+            // Only include files (not directories), exclude hidden files and archive directory
+            return file.isFile() && !file.getName().startsWith(".");
+        });
+
+        if (files == null || files.length == 0) {
+            return new ArrayList<>();
+        }
+
+        // Sort by timestamp extracted from filename (oldest first)
+        List<File> profileFiles = new ArrayList<>(Arrays.asList(files));
+        profileFiles.sort(Comparator.comparingLong(file -> {
+            long timestamp = extractTimestampFromProfileFile(file);
+            // Files with invalid timestamps go to the end
+            return timestamp == -1 ? Long.MAX_VALUE : timestamp;
+        }));
+
+        return profileFiles;
+    }
+
+    /**
+     * Gets the list of profile files from the pending directory.
+     *
+     * @return list of profile files sorted by filename timestamp (oldest first)
+     */
+    private List<File> getPendingProfileFiles() {
+        File pendingDir = new File(pendingPath);
+        if (!pendingDir.exists() || !pendingDir.isDirectory()) {
+            return new ArrayList<>();
+        }
+
+        File[] files = pendingDir.listFiles(File::isFile);
+        if (files == null || files.length == 0) {
+            return new ArrayList<>();
+        }
+
+        List<File> profileFiles = new ArrayList<>(Arrays.asList(files));
+        // Sort by timestamp extracted from filename (oldest first)
+        profileFiles.sort(Comparator.comparingLong(file -> {
+            long timestamp = extractTimestampFromProfileFile(file);
+            // Files with invalid timestamps go to the end
+            return timestamp == -1 ? Long.MAX_VALUE : timestamp;
+        }));
+
+        return profileFiles;
+    }
+
+    /**
+     * Extracts timestamp from profile filename.
+     * Profile filename format: timestamp_queryid.zip
+     *
+     * @param profileFile the profile file
+     * @return timestamp in milliseconds, or -1 if parsing fails
+     */
+    private long extractTimestampFromProfileFile(File profileFile) {
+        String filename = profileFile.getName();
+        if (!filename.endsWith(".zip")) {
+            return -1;
+        }
+
+        // Remove .zip extension
+        filename = filename.substring(0, filename.length() - 4);
+
+        // Extract timestamp (format: timestamp_queryid)
+        String[] parts = filename.split("_", 2);
+        if (parts.length < 1) {
+            return -1;
+        }
+
+        try {
+            return Long.parseLong(parts[0]);
+        } catch (NumberFormatException e) {
+            LOG.warn("Failed to parse timestamp from profile filename: {}", profileFile.getName());
+            return -1;
+        }
+    }
+
+    /**
+     * Extracts timestamp from archive filename.
+     * Archive filename format: profiles_YYYYMMDD_HHMMSS_YYYYMMDD_HHMMSS.zip
+     * or profiles_YYYYMMDD_HHMMSS_YYYYMMDD_HHMMSS_N.zip (with suffix)
+     *
+     * @param archiveFile the archive file
+     * @return timestamp in milliseconds (parsed from first date), or -1 if parsing fails
+     */
+    private long extractTimestampFromArchiveFile(File archiveFile) {
+        String filename = archiveFile.getName();
+        if (!filename.startsWith("profiles_") || !filename.endsWith(".zip")) {
+            return -1;
+        }
+
+        // Remove "profiles_" prefix and ".zip" extension
+        // Format: YYYYMMDD_HHMMSS_YYYYMMDD_HHMMSS[_N]
+        String dateStr = filename.substring(9, filename.length() - 4);
+
+        // Extract first timestamp: YYYYMMDD_HHMMSS
+        String[] parts = dateStr.split("_");
+        if (parts.length < 2) {
+            return -1;
+        }
+
+        try {
+            // Parse YYYYMMDD_HHMMSS format
+            String firstTimestamp = parts[0] + "_" + parts[1];
+            Instant instant = Instant.from(DATE_FORMAT.parse(firstTimestamp));
+            return instant.toEpochMilli();
+        } catch (Exception e) {
+            LOG.warn("Failed to parse timestamp from archive filename: {}", archiveFile.getName(), e);
+            return -1;
+        }
+    }
+
+    /**
+     * Archives a batch of profile files into a single ZIP archive.
+     *
+     * @param profilesToArchive list of profile files to archive
+     * @return the created archive file, or null if archiving failed
+     */
+    public File archiveProfiles(List<File> profilesToArchive) {
+        if (profilesToArchive == null || profilesToArchive.isEmpty()) {
+            LOG.warn("No profiles to archive");
+            return null;
+        }
+
+        if (!createArchiveDirectoryIfNecessary()) {
+            LOG.error("Failed to create archive directory");
+            return null;
+        }
+
+        // Extract timestamps to determine archive filename
+        List<Long> timestamps = profilesToArchive.stream()
+                .map(this::extractTimestampFromProfileFile)
+                .filter(ts -> ts > 0)
+                .sorted()
+                .collect(Collectors.toList());
+
+        if (timestamps.isEmpty()) {
+            LOG.error("Failed to extract timestamps from profile files");
+            return null;
+        }
+
+        long minTimestamp = timestamps.get(0);
+        long maxTimestamp = timestamps.get(timestamps.size() - 1);
+
+        // Generate archive filename: profiles_YYYYMMDD_HHMMSS_YYYYMMDD_HHMMSS.zip
+        String minDateStr = DATE_FORMAT.format(Instant.ofEpochMilli(minTimestamp));
+        String maxDateStr = DATE_FORMAT.format(Instant.ofEpochMilli(maxTimestamp));
+        String archiveFilename = String.format("profiles_%s_%s.zip", minDateStr, maxDateStr);
+
+        File archiveFile = new File(archivePath, archiveFilename);
+
+        // If archive file already exists, append a suffix
+        int suffix = 1;
+        while (archiveFile.exists()) {
+            archiveFilename = String.format("profiles_%s_%s_%d.zip", minDateStr, maxDateStr, suffix);
+            archiveFile = new File(archivePath, archiveFilename);
+            suffix++;
+        }
+
+        // Create the archive
+        try (FileOutputStream fos = new FileOutputStream(archiveFile);
+                ZipOutputStream zos = new ZipOutputStream(fos)) {
+
+            for (File profileFile : profilesToArchive) {
+                try (FileInputStream fis = new FileInputStream(profileFile)) {
+                    // Add profile file to archive with its original name
+                    ZipEntry zipEntry = new ZipEntry(profileFile.getName());
+                    zos.putNextEntry(zipEntry);
+
+                    byte[] buffer = new byte[8192];
+                    int bytesRead;
+                    while ((bytesRead = fis.read(buffer)) != -1) {
+                        zos.write(buffer, 0, bytesRead);
+                    }
+
+                    zos.closeEntry();
+                } catch (IOException e) {
+                    LOG.error("Failed to add profile {} to archive", profileFile.getName(), e);
+                    // Continue with other files
+                }
+            }
+
+            LOG.info("Created archive {} with {} profiles", archiveFilename, profilesToArchive.size());
+            return archiveFile;
+
+        } catch (IOException e) {
+            LOG.error("Failed to create archive file: {}", archiveFilename, e);
+            // Clean up partial archive file
+            FileUtils.deleteQuietly(archiveFile);
+            return null;
+        }
+    }
+
+    /**
+     * Deletes profile files from the spilled storage after they have been archived.
+     *
+     * @param profileFiles list of profile files to delete
+     * @return number of files successfully deleted
+     */
+    public int deleteArchivedProfiles(List<File> profileFiles) {
+        int deletedCount = 0;
+
+        for (File profileFile : profileFiles) {
+            if (FileUtils.deleteQuietly(profileFile)) {
+                deletedCount++;
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Deleted archived profile: {}", profileFile.getName());
+                }
+            } else {
+                LOG.warn("Failed to delete archived profile: {}", profileFile.getName());
+            }
+        }
+
+        LOG.info("Deleted {} out of {} archived profiles", deletedCount, profileFiles.size());
+        return deletedCount;
+    }
+
+    /**
+     * Moves a profile file to the pending archive directory.
+     * The file will be archived later when batch size is reached or timeout occurs.
+     *
+     * @param profileFile the profile file to move
+     * @return true if the file was moved successfully, false otherwise
+     */
+    public boolean moveToArchivePending(File profileFile) {
+        if (profileFile == null || !profileFile.exists()) {
+            LOG.warn("Profile file does not exist: {}", profileFile);
+            return false;
+        }
+
+        // Create pending directory if necessary
+        if (!createPendingDirectoryIfNecessary()) {
+            LOG.error("Failed to create pending directory");
+            return false;
+        }
+
+        // Move file to pending directory
+        File targetFile = new File(pendingPath, profileFile.getName());
+        try {
+            Files.move(profileFile.toPath(), targetFile.toPath(),
+                    StandardCopyOption.REPLACE_EXISTING);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Moved profile to pending: {}", profileFile.getName());
+            }
+            return true;
+        } catch (IOException e) {
+            LOG.error("Failed to move profile to pending: {}", profileFile.getName(), e);
+            return false;
+        }
+    }
+
+    /**
+     * Checks the pending directory and archives profiles if conditions are met.
+     * Archiving is triggered when:
+     * 1. Number of pending files >= batch size, OR
+     * 2. Oldest file in pending has exceeded timeout hours
+     *
+     * Archiving strategy:
+     * - If triggered by batch size: only archive complete batches, leave incomplete batch in pending
+     * - If triggered by timeout: archive all files including incomplete batch
+     *
+     * @return number of profiles successfully archived
+     */
+    public int checkAndArchivePendingProfiles() {
+        File pendingDir = new File(pendingPath);
+        if (!pendingDir.exists()) {
+            return 0;
+        }
+
+        // Get all pending files
+        List<File> pendingFiles = getPendingProfileFiles();
+        if (pendingFiles.isEmpty()) {
+            return 0;
+        }
+
+        // Check if archiving should be triggered
+        boolean shouldArchive = false;
+        boolean isTimeoutTriggered = false;
+        String reason = "";
+
+        // Condition 1: Number of files >= batch size
+        if (pendingFiles.size() >= archiveBatchSize) {
+            shouldArchive = true;
+            isTimeoutTriggered = false;
+            reason = String.format("batch size reached (%d files >= %d)",
+                    pendingFiles.size(), archiveBatchSize);
+        }
+
+        // Condition 2: Oldest file exceeds timeout
+        // Use filename timestamp (query finish time) instead of file modification time
+        if (!shouldArchive) {
+            long oldestFileTimestamp = extractTimestampFromProfileFile(pendingFiles.get(0));
+            if (oldestFileTimestamp > 0) {
+                long currentTime = System.currentTimeMillis();
+                long ageSeconds = (currentTime - oldestFileTimestamp) / 1000;
+
+                if (ageSeconds >= Config.profile_archive_pending_timeout_seconds) {
+                    shouldArchive = true;
+                    isTimeoutTriggered = true;
+                    reason = String.format("oldest file age %d seconds exceeds timeout %d seconds",
+                            ageSeconds, Config.profile_archive_pending_timeout_seconds);
+                }
+            }
+        }
+
+        if (!shouldArchive) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Pending profiles: {} files, not ready to archive", pendingFiles.size());
+            }
+            return 0;
+        }
+
+        // Determine how many files to archive based on trigger condition
+        int filesToArchiveCount;
+        if (isTimeoutTriggered) {
+            // Timeout triggered: archive all files including incomplete batch
+            filesToArchiveCount = pendingFiles.size();
+            LOG.info("Archiving all {} pending profiles due to timeout, reason: {}",
+                    filesToArchiveCount, reason);
+        } else {
+            // Batch size triggered: only archive complete batches
+            filesToArchiveCount = (pendingFiles.size() / archiveBatchSize) * archiveBatchSize;
+            int remainingFiles = pendingFiles.size() - filesToArchiveCount;
+            LOG.info("Archiving {} pending profiles (complete batches only), {} files remain in pending, reason: {}",
+                    filesToArchiveCount, remainingFiles, reason);
+        }
+
+        int totalArchived = 0;
+        // Archive in batches
+        List<File> filesToArchive = pendingFiles.subList(0, filesToArchiveCount);
+        for (int i = 0; i < filesToArchive.size(); i += archiveBatchSize) {
+            int endIdx = Math.min(i + archiveBatchSize, filesToArchive.size());
+            List<File> batch = filesToArchive.subList(i, endIdx);
+
+            File archiveFile = archiveProfiles(batch);
+            if (archiveFile != null) {
+                // Delete original files after successful archiving
+                int deleted = deleteArchivedProfiles(batch);
+                totalArchived += deleted;
+            } else {
+                LOG.error("Failed to create archive for batch starting at index {}", i);
+                // Continue with next batch
+            }
+        }
+
+        LOG.info("Successfully archived {} profiles from pending, {} files remain",
+                totalArchived, pendingFiles.size() - totalArchived);
+        return totalArchived;
+    }
+
+    /**
+     * Archives profiles in batches from the spilled storage.
+     * This should be called when storage limits are exceeded.
+     *
+     * @param numProfilesToArchive number of profiles to archive
+     * @return number of profiles successfully archived
+     */
+    public int archiveOldestProfiles(int numProfilesToArchive) {
+        if (numProfilesToArchive <= 0) {
+            return 0;
+        }
+
+        List<File> allProfileFiles = getProfileFilesFromStorage();
+        if (allProfileFiles.isEmpty()) {
+            LOG.info("No profiles available to archive");
+            return 0;
+        }
+
+        // Limit to available profiles
+        int profilesToArchive = Math.min(numProfilesToArchive, allProfileFiles.size());
+        List<File> filesToArchive = allProfileFiles.subList(0, profilesToArchive);
+
+        int totalArchived = 0;
+
+        // Archive in batches
+        for (int i = 0; i < filesToArchive.size(); i += archiveBatchSize) {
+            int endIdx = Math.min(i + archiveBatchSize, filesToArchive.size());
+            List<File> batch = filesToArchive.subList(i, endIdx);
+
+            File archiveFile = archiveProfiles(batch);
+            if (archiveFile != null) {
+                // Delete original files after successful archiving
+                int deleted = deleteArchivedProfiles(batch);
+                totalArchived += deleted;
+            } else {
+                LOG.error("Failed to create archive for batch starting at index {}", i);
+                // Continue with next batch
+            }
+        }
+
+        LOG.info("Successfully archived {} profiles", totalArchived);
+        return totalArchived;
+    }
+
+    /**
+     * Gets the list of archive files sorted by archive timestamp (from filename).
+     *
+     * @return list of archive files sorted by archive timestamp (oldest first)
+     */
+    public List<File> getArchiveFiles() {
+        File archiveDir = new File(archivePath);
+        if (!archiveDir.exists() || !archiveDir.isDirectory()) {
+            return new ArrayList<>();
+        }
+
+        File[] files = archiveDir.listFiles(file ->
+            file.isFile() && file.getName().startsWith("profiles_") && file.getName().endsWith(".zip")
+        );
+
+        if (files == null || files.length == 0) {
+            return new ArrayList<>();
+        }
+
+        List<File> archiveFiles = new ArrayList<>();
+        for (File file : files) {
+            archiveFiles.add(file);
+        }
+
+        // Sort by timestamp extracted from archive filename (oldest first)
+        archiveFiles.sort(Comparator.comparingLong(file -> {
+            long timestamp = extractTimestampFromArchiveFile(file);
+            // Files with invalid timestamps go to the end
+            return timestamp == -1 ? Long.MAX_VALUE : timestamp;
+        }));
+
+        return archiveFiles;
+    }
+
+    /**
+     * Gets the total size of all archive files in bytes.
+     *
+     * @return total archive size in bytes
+     */
+    public long getTotalArchiveSize() {
+        List<File> archiveFiles = getArchiveFiles();
+        long totalSize = 0;
+
+        for (File file : archiveFiles) {
+            totalSize += file.length();
+        }
+
+        return totalSize;
+    }
+
+    /**
+     * Gets the archive directory path.
+     *
+     * @return archive directory path
+     */
+    public String getArchivePath() {
+        return archivePath;
+    }
+
+    /**
+     * Cleans up old archive files that exceed the retention period.
+     * Retention period is configured via Config.profile_archive_retention_seconds.
+     * -1 means keep forever, 0 means don't retain (disable archiving), >0 means delete after N seconds.
+     *
+     * The age of an archive file is determined by the timestamp in its filename
+     * (profiles_YYYYMMDD_HHMMSS_...), not by the file system modification time.
+     *
+     * @return number of archive files deleted
+     */
+    public int cleanOldArchives() {
+        if (Config.profile_archive_retention_seconds < 0) {
+            // -1 means keep forever
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Archive retention is set to unlimited, no cleanup needed");
+            }
+            return 0;
+        }
+
+        if (Config.profile_archive_retention_seconds == 0) {
+            // 0 means don't retain, but this should be handled by disabling archive feature
+            LOG.warn("profile_archive_retention_seconds is 0, consider disabling archive feature");
+            return 0;
+        }
+
+        List<File> archiveFiles = getArchiveFiles();
+        if (archiveFiles.isEmpty()) {
+            return 0;
+        }
+
+        long retentionMillis = Config.profile_archive_retention_seconds * 1000L;
+        long currentTime = System.currentTimeMillis();
+
+        int deletedCount = 0;
+        for (File archiveFile : archiveFiles) {
+            // Use timestamp from filename instead of file modification time
+            long archiveTimestamp = extractTimestampFromArchiveFile(archiveFile);
+            if (archiveTimestamp <= 0) {
+                // Skip files with invalid timestamps
+                LOG.warn("Skipping archive file with invalid timestamp: {}", archiveFile.getName());
+                continue;
+            }
+
+            long fileAge = currentTime - archiveTimestamp;
+            if (fileAge >= retentionMillis) {
+                if (FileUtils.deleteQuietly(archiveFile)) {
+                    deletedCount++;
+                    LOG.info("Deleted old archive file: {}, age: {} seconds",
+                            archiveFile.getName(), fileAge / 1000);
+                } else {
+                    LOG.warn("Failed to delete old archive file: {}", archiveFile.getName());
+                }
+            }
+        }
+
+        if (deletedCount > 0) {
+            LOG.info("Cleaned {} old archive files, retention: {} seconds",
+                    deletedCount, Config.profile_archive_retention_seconds);
+        }
+
+        return deletedCount;
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileArchiveManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileArchiveManagerTest.java
@@ -1,0 +1,1111 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.profile;
+
+import org.apache.doris.common.util.DebugUtil;
+import org.apache.doris.thrift.TUniqueId;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * Unit tests for ProfileArchiveManager.
+ * Tests cover archive creation, profile batching, timestamp extraction,
+ * archive file management, and error handling.
+ */
+public class ProfileArchiveManagerTest {
+    private static final Logger LOG = LogManager.getLogger(ProfileArchiveManagerTest.class);
+
+    private File tempDir;
+    private ProfileArchiveManager archiveManager;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        tempDir = Files.createTempDirectory("profile_archive_test_").toFile();
+        archiveManager = new ProfileArchiveManager(tempDir.getAbsolutePath());
+    }
+
+    @AfterEach
+    void tearDown() {
+        FileUtils.deleteQuietly(tempDir);
+    }
+
+    /**
+     * Helper method to create a mock profile file.
+     */
+    private File createMockProfileFile(long timestamp) throws IOException {
+        UUID taskId = UUID.randomUUID();
+        TUniqueId queryId = new TUniqueId(taskId.getMostSignificantBits(), taskId.getLeastSignificantBits());
+        String profileId = DebugUtil.printId(queryId);
+
+        Profile profile = ProfileManagerTest.constructProfile(profileId);
+        profile.setQueryFinishTimestamp(timestamp);
+
+        // Write profile to storage
+        profile.writeToStorage(tempDir.getAbsolutePath());
+
+        // Find the created file
+        String filename = timestamp + "_" + profileId + ".zip";
+        File profileFile = new File(tempDir, filename);
+
+        if (!profileFile.exists()) {
+            throw new IOException("Failed to create profile file: " + filename);
+        }
+
+        return profileFile;
+    }
+
+    /**
+     * Test: Archive directory creation.
+     * Verifies that the archive directory is created successfully.
+     */
+    @Test
+    void testCreateArchiveDirectory() {
+        // Archive directory should not exist initially
+        File archiveDir = new File(archiveManager.getArchivePath());
+        Assertions.assertFalse(archiveDir.exists());
+
+        // Create archive directory
+        boolean created = archiveManager.createArchiveDirectoryIfNecessary();
+        Assertions.assertTrue(created);
+        Assertions.assertTrue(archiveDir.exists());
+        Assertions.assertTrue(archiveDir.isDirectory());
+
+        // Second call should also return true (idempotent)
+        created = archiveManager.createArchiveDirectoryIfNecessary();
+        Assertions.assertTrue(created);
+    }
+
+    /**
+     * Test: Get profile files from storage.
+     * Verifies that profile files are correctly retrieved and sorted by filename timestamp.
+     */
+    @Test
+    void testGetProfileFilesFromStorage() throws IOException, InterruptedException {
+        // Create multiple profile files with different timestamps
+        List<Long> timestamps = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            long timestamp = System.currentTimeMillis() + i * 1000;
+            timestamps.add(timestamp);
+            createMockProfileFile(timestamp);
+            Thread.sleep(100); // Ensure different modification times
+        }
+
+        // Get profile files
+        List<File> profileFiles = archiveManager.getProfileFilesFromStorage();
+
+        // Verify count
+        Assertions.assertEquals(5, profileFiles.size());
+
+        // Verify files are sorted by filename timestamp (oldest first)
+        for (int i = 0; i < profileFiles.size() - 1; i++) {
+            // Extract timestamps from filenames
+            String filename1 = profileFiles.get(i).getName();
+            String filename2 = profileFiles.get(i + 1).getName();
+            long ts1 = Long.parseLong(filename1.substring(0, filename1.indexOf('_')));
+            long ts2 = Long.parseLong(filename2.substring(0, filename2.indexOf('_')));
+            Assertions.assertTrue(ts1 <= ts2,
+                    "Files should be sorted by filename timestamp");
+        }
+    }
+
+    /**
+     * Test: Archive a single batch of profiles.
+     * Verifies that profiles are correctly archived into a ZIP file.
+     */
+    @Test
+    void testArchiveSingleBatch() throws IOException, InterruptedException {
+        // Create 5 profile files
+        List<File> profilesToArchive = new ArrayList<>();
+        long baseTimestamp = System.currentTimeMillis();
+
+        for (int i = 0; i < 5; i++) {
+            long timestamp = baseTimestamp + i * 1000;
+            File profileFile = createMockProfileFile(timestamp);
+            profilesToArchive.add(profileFile);
+            Thread.sleep(100);
+        }
+
+        // Archive the profiles
+        File archiveFile = archiveManager.archiveProfiles(profilesToArchive);
+
+        // Verify archive was created
+        Assertions.assertNotNull(archiveFile);
+        Assertions.assertTrue(archiveFile.exists());
+        Assertions.assertTrue(archiveFile.getName().startsWith("profiles_"));
+        Assertions.assertTrue(archiveFile.getName().endsWith(".zip"));
+
+        // Verify archive location
+        Assertions.assertTrue(archiveFile.getParentFile().getName().equals("archive"));
+
+        // Verify archive contents
+        int entryCount = 0;
+        try (ZipInputStream zis = new ZipInputStream(new FileInputStream(archiveFile))) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                entryCount++;
+                // Verify entry name matches original profile filename
+                Assertions.assertTrue(entry.getName().endsWith(".zip"));
+                zis.closeEntry();
+            }
+        }
+
+        Assertions.assertEquals(5, entryCount, "Archive should contain 5 profile files");
+    }
+
+    /**
+     * Test: Archive filename format.
+     * Verifies that archive filenames follow the correct naming convention.
+     */
+    @Test
+    void testArchiveFilenameFormat() throws IOException {
+        // Create 3 profile files with known timestamps
+        long timestamp1 = 1704067200000L; // 2024-01-01 00:00:00
+        long timestamp2 = 1704070800000L; // 2024-01-01 01:00:00
+        long timestamp3 = 1704074400000L; // 2024-01-01 02:00:00
+
+        List<File> profilesToArchive = new ArrayList<>();
+        profilesToArchive.add(createMockProfileFile(timestamp1));
+        profilesToArchive.add(createMockProfileFile(timestamp2));
+        profilesToArchive.add(createMockProfileFile(timestamp3));
+
+        // Archive the profiles
+        File archiveFile = archiveManager.archiveProfiles(profilesToArchive);
+
+        // Verify filename format: profiles_YYYYMMDD_HHMMSS_YYYYMMDD_HHMMSS.zip
+        Assertions.assertNotNull(archiveFile);
+        String filename = archiveFile.getName();
+        Assertions.assertTrue(filename.matches("profiles_\\d{8}_\\d{6}_\\d{8}_\\d{6}\\.zip"),
+                "Archive filename should match pattern: profiles_YYYYMMDD_HHMMSS_YYYYMMDD_HHMMSS.zip");
+
+        // Verify filename contains correct date range
+        Assertions.assertTrue(filename.startsWith("profiles_20240101_"));
+    }
+
+    /**
+     * Test: Delete archived profiles.
+     * Verifies that profile files are correctly deleted after archiving.
+     */
+    @Test
+    void testDeleteArchivedProfiles() throws IOException, InterruptedException {
+        // Create profile files
+        List<File> profileFiles = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            long timestamp = System.currentTimeMillis() + i * 1000;
+            File profileFile = createMockProfileFile(timestamp);
+            profileFiles.add(profileFile);
+            Thread.sleep(100);
+        }
+
+        // Verify files exist
+        for (File file : profileFiles) {
+            Assertions.assertTrue(file.exists());
+        }
+
+        // Delete the files
+        int deletedCount = archiveManager.deleteArchivedProfiles(profileFiles);
+
+        // Verify all files were deleted
+        Assertions.assertEquals(3, deletedCount);
+        for (File file : profileFiles) {
+            Assertions.assertFalse(file.exists());
+        }
+    }
+
+    /**
+     * Test: Archive oldest profiles.
+     * Verifies that the oldest profiles are selected for archiving.
+     */
+    @Test
+    void testArchiveOldestProfiles() throws IOException, InterruptedException {
+        // Create 10 profile files with different timestamps
+        long baseTimestamp = System.currentTimeMillis();
+        for (int i = 0; i < 10; i++) {
+            long timestamp = baseTimestamp + i * 1000;
+            createMockProfileFile(timestamp);
+            Thread.sleep(100);
+        }
+
+        // Archive the oldest 5 profiles
+        int archived = archiveManager.archiveOldestProfiles(5);
+
+        // Verify 5 profiles were archived
+        Assertions.assertEquals(5, archived);
+
+        // Verify 5 profiles remain in storage
+        List<File> remainingFiles = archiveManager.getProfileFilesFromStorage();
+        Assertions.assertEquals(5, remainingFiles.size());
+
+        // Verify archive was created
+        List<File> archiveFiles = archiveManager.getArchiveFiles();
+        Assertions.assertEquals(1, archiveFiles.size());
+    }
+
+    /**
+     * Test: Archive profiles in multiple batches.
+     * Verifies that profiles are correctly batched when archiving many profiles.
+     */
+    @Test
+    void testArchiveMultipleBatches() throws IOException, InterruptedException {
+        // Create archive manager with small batch size
+        ProfileArchiveManager smallBatchManager = new ProfileArchiveManager(tempDir.getAbsolutePath(), 3);
+
+        // Create 10 profile files
+        long baseTimestamp = System.currentTimeMillis();
+        for (int i = 0; i < 10; i++) {
+            long timestamp = baseTimestamp + i * 1000;
+            createMockProfileFile(timestamp);
+            Thread.sleep(50);
+        }
+
+        // Archive all 10 profiles (should create 4 archives: 3 + 3 + 3 + 1)
+        int archived = smallBatchManager.archiveOldestProfiles(10);
+
+        // Verify all profiles were archived
+        Assertions.assertEquals(10, archived);
+
+        // Verify multiple archive files were created
+        List<File> archiveFiles = smallBatchManager.getArchiveFiles();
+        Assertions.assertEquals(4, archiveFiles.size());
+
+        // Verify no profiles remain in storage
+        List<File> remainingFiles = smallBatchManager.getProfileFilesFromStorage();
+        Assertions.assertEquals(0, remainingFiles.size());
+    }
+
+    /**
+     * Test: Get archive files.
+     * Verifies that archive files are correctly retrieved.
+     */
+    @Test
+    void testGetArchiveFiles() throws IOException, InterruptedException {
+        // Initially no archives
+        List<File> archives = archiveManager.getArchiveFiles();
+        Assertions.assertTrue(archives.isEmpty());
+
+        // Create and archive some profiles
+        List<File> profilesToArchive = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            long timestamp = System.currentTimeMillis() + i * 1000;
+            profilesToArchive.add(createMockProfileFile(timestamp));
+            Thread.sleep(100);
+        }
+
+        File archiveFile = archiveManager.archiveProfiles(profilesToArchive);
+        Assertions.assertNotNull(archiveFile);
+
+        // Verify archive is in the list
+        archives = archiveManager.getArchiveFiles();
+        Assertions.assertEquals(1, archives.size());
+        Assertions.assertEquals(archiveFile.getName(), archives.get(0).getName());
+    }
+
+    /**
+     * Test: Get total archive size.
+     * Verifies that total archive size is correctly calculated.
+     */
+    @Test
+    void testGetTotalArchiveSize() throws IOException, InterruptedException {
+        // Initially total size should be 0
+        long totalSize = archiveManager.getTotalArchiveSize();
+        Assertions.assertEquals(0, totalSize);
+
+        // Create and archive some profiles
+        List<File> profilesToArchive1 = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            long timestamp = System.currentTimeMillis() + i * 1000;
+            profilesToArchive1.add(createMockProfileFile(timestamp));
+            Thread.sleep(100);
+        }
+
+        File archive1 = archiveManager.archiveProfiles(profilesToArchive1);
+        Assertions.assertNotNull(archive1);
+
+        // Verify total size equals first archive size
+        totalSize = archiveManager.getTotalArchiveSize();
+        Assertions.assertEquals(archive1.length(), totalSize);
+
+        // Create and archive more profiles
+        List<File> profilesToArchive2 = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            long timestamp = System.currentTimeMillis() + i * 1000;
+            profilesToArchive2.add(createMockProfileFile(timestamp));
+            Thread.sleep(100);
+        }
+
+        File archive2 = archiveManager.archiveProfiles(profilesToArchive2);
+        Assertions.assertNotNull(archive2);
+
+        // Verify total size equals sum of both archives
+        totalSize = archiveManager.getTotalArchiveSize();
+        Assertions.assertEquals(archive1.length() + archive2.length(), totalSize);
+    }
+
+    /**
+     * Test: Archive with empty profile list.
+     * Verifies that archiving with no profiles returns null.
+     */
+    @Test
+    void testArchiveEmptyList() {
+        List<File> emptyList = new ArrayList<>();
+        File archiveFile = archiveManager.archiveProfiles(emptyList);
+
+        Assertions.assertNull(archiveFile, "Archiving empty list should return null");
+    }
+
+    /**
+     * Test: Archive with null profile list.
+     * Verifies that archiving with null list returns null.
+     */
+    @Test
+    void testArchiveNullList() {
+        File archiveFile = archiveManager.archiveProfiles(null);
+        Assertions.assertNull(archiveFile, "Archiving null list should return null");
+    }
+
+    /**
+     * Test: Archive oldest profiles with zero count.
+     * Verifies that archiving zero profiles returns 0.
+     */
+    @Test
+    void testArchiveZeroProfiles() throws IOException {
+        // Create some profiles
+        for (int i = 0; i < 5; i++) {
+            createMockProfileFile(System.currentTimeMillis() + i * 1000);
+        }
+
+        int archived = archiveManager.archiveOldestProfiles(0);
+        Assertions.assertEquals(0, archived);
+
+        // Verify all profiles still in storage
+        List<File> files = archiveManager.getProfileFilesFromStorage();
+        Assertions.assertEquals(5, files.size());
+    }
+
+    /**
+     * Test: Archive more profiles than available.
+     * Verifies that archiving handles requests for more profiles than exist.
+     */
+    @Test
+    void testArchiveMoreThanAvailable() throws IOException, InterruptedException {
+        // Create only 3 profiles
+        for (int i = 0; i < 3; i++) {
+            long timestamp = System.currentTimeMillis() + i * 1000;
+            createMockProfileFile(timestamp);
+            Thread.sleep(100);
+        }
+
+        // Try to archive 10 profiles (more than available)
+        int archived = archiveManager.archiveOldestProfiles(10);
+
+        // Verify only 3 were archived
+        Assertions.assertEquals(3, archived);
+
+        // Verify no profiles remain in storage
+        List<File> remainingFiles = archiveManager.getProfileFilesFromStorage();
+        Assertions.assertEquals(0, remainingFiles.size());
+    }
+
+    /**
+     * Test: Archive from non-existent storage directory.
+     * Verifies that archiving from non-existent directory handles gracefully.
+     */
+    @Test
+    void testArchiveFromNonExistentDirectory() throws IOException {
+        File nonExistentDir = new File(tempDir, "nonexistent");
+        ProfileArchiveManager manager = new ProfileArchiveManager(nonExistentDir.getAbsolutePath());
+
+        List<File> files = manager.getProfileFilesFromStorage();
+        Assertions.assertTrue(files.isEmpty());
+
+        int archived = manager.archiveOldestProfiles(5);
+        Assertions.assertEquals(0, archived);
+    }
+
+    /**
+     * Test: Duplicate archive filename handling.
+     * Verifies that duplicate archive filenames are handled by adding suffixes.
+     */
+    @Test
+    void testDuplicateArchiveFilenames() throws IOException, InterruptedException {
+        // Create profiles with same timestamp (to force duplicate archive names)
+        long timestamp = System.currentTimeMillis();
+        List<File> batch1 = new ArrayList<>();
+        List<File> batch2 = new ArrayList<>();
+
+        for (int i = 0; i < 2; i++) {
+            batch1.add(createMockProfileFile(timestamp));
+            Thread.sleep(50);
+        }
+
+        for (int i = 0; i < 2; i++) {
+            batch2.add(createMockProfileFile(timestamp));
+            Thread.sleep(50);
+        }
+
+        // Archive both batches
+        File archive1 = archiveManager.archiveProfiles(batch1);
+        File archive2 = archiveManager.archiveProfiles(batch2);
+
+        // Verify both archives were created with different names
+        Assertions.assertNotNull(archive1);
+        Assertions.assertNotNull(archive2);
+        Assertions.assertNotEquals(archive1.getName(), archive2.getName());
+
+        // Verify both exist
+        Assertions.assertTrue(archive1.exists());
+        Assertions.assertTrue(archive2.exists());
+    }
+
+    /**
+     * Test: Archive file integrity.
+     * Verifies that archived profiles can be extracted and read correctly.
+     */
+    @Test
+    void testArchiveFileIntegrity() throws IOException, InterruptedException {
+        // Create profile files
+        List<File> originalFiles = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            long timestamp = System.currentTimeMillis() + i * 1000;
+            File profileFile = createMockProfileFile(timestamp);
+            originalFiles.add(profileFile);
+            Thread.sleep(100);
+        }
+
+        // Archive the profiles
+        File archiveFile = archiveManager.archiveProfiles(originalFiles);
+        Assertions.assertNotNull(archiveFile);
+
+        // Verify each original file exists in the archive
+        List<String> originalFilenames = new ArrayList<>();
+        for (File file : originalFiles) {
+            originalFilenames.add(file.getName());
+        }
+
+        List<String> archivedFilenames = new ArrayList<>();
+        try (ZipInputStream zis = new ZipInputStream(new FileInputStream(archiveFile))) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                archivedFilenames.add(entry.getName());
+                zis.closeEntry();
+            }
+        }
+
+        // Verify all original files are in the archive
+        Assertions.assertEquals(originalFilenames.size(), archivedFilenames.size());
+        for (String filename : originalFilenames) {
+            Assertions.assertTrue(archivedFilenames.contains(filename),
+                    "Archive should contain file: " + filename);
+        }
+    }
+
+
+    /**
+     * Test: Large batch archiving performance.
+     * Verifies that archiving large batches completes in reasonable time.
+     */
+    @Test
+    void testLargeBatchArchiving() throws IOException, InterruptedException {
+        // Create 100 profile files
+        for (int i = 0; i < 100; i++) {
+            long timestamp = System.currentTimeMillis() + i * 10;
+            createMockProfileFile(timestamp);
+            if (i % 10 == 0) {
+                Thread.sleep(10); // Brief pause every 10 files
+            }
+        }
+
+        long startTime = System.currentTimeMillis();
+
+        // Archive all 100 profiles
+        int archived = archiveManager.archiveOldestProfiles(100);
+
+        long duration = System.currentTimeMillis() - startTime;
+
+        // Verify all were archived
+        Assertions.assertEquals(100, archived);
+
+        // Verify performance (should complete in under 30 seconds)
+        Assertions.assertTrue(duration < 30000,
+                "Archiving 100 profiles should complete in under 30 seconds, took: " + duration + "ms");
+
+        LOG.info("Archived 100 profiles in {}ms", duration);
+    }
+
+    /**
+     * Test: Move profile to pending directory.
+     * Verifies that profiles are correctly moved to the pending buffer.
+     */
+    @Test
+    void testMoveToArchivePending() throws IOException {
+        // Create a profile file
+        File profileFile = createMockProfileFile(System.currentTimeMillis());
+        Assertions.assertTrue(profileFile.exists());
+
+        // Move to pending
+        boolean moved = archiveManager.moveToArchivePending(profileFile);
+        Assertions.assertTrue(moved);
+
+        // Verify original file no longer exists
+        Assertions.assertFalse(profileFile.exists());
+
+        // Verify file exists in pending directory
+        File pendingFile = new File(archiveManager.getArchivePath() + File.separator + "pending",
+                profileFile.getName());
+        Assertions.assertTrue(pendingFile.exists());
+    }
+
+    /**
+     * Test: Check and archive pending profiles with batch size condition.
+     * Verifies that archiving is triggered when batch size is reached.
+     */
+    @Test
+    void testCheckAndArchivePendingWithBatchSize() throws IOException, InterruptedException {
+        // Create manager with small batch size for testing
+        ProfileArchiveManager smallBatchManager = new ProfileArchiveManager(tempDir.getAbsolutePath(), 5);
+
+        // Move 5 profiles to pending
+        for (int i = 0; i < 5; i++) {
+            File profileFile = createMockProfileFile(System.currentTimeMillis() + i * 1000);
+            smallBatchManager.moveToArchivePending(profileFile);
+            Thread.sleep(100);
+        }
+
+        // Check and archive (should trigger because batch size is reached)
+        int archived = smallBatchManager.checkAndArchivePendingProfiles();
+
+        // Verify all 5 profiles were archived
+        Assertions.assertEquals(5, archived);
+
+        // Verify archive file was created
+        List<File> archiveFiles = smallBatchManager.getArchiveFiles();
+        Assertions.assertEquals(1, archiveFiles.size());
+
+        // Verify pending directory is empty
+        File pendingDir = new File(smallBatchManager.getArchivePath() + File.separator + "pending");
+        File[] pendingFiles = pendingDir.listFiles();
+        Assertions.assertTrue(pendingFiles == null || pendingFiles.length == 0);
+    }
+
+    /**
+     * Test: Check and archive pending profiles with timeout condition.
+     * Verifies that archiving is triggered when oldest file exceeds timeout.
+     */
+    @Test
+    void testCheckAndArchivePendingWithTimeout() throws IOException, InterruptedException {
+        // Create manager with large batch size
+        ProfileArchiveManager manager = new ProfileArchiveManager(tempDir.getAbsolutePath(), 1000);
+
+        // Create one profile with timestamp 25 hours ago (exceeds 24 hour timeout)
+        long oldTimestamp = System.currentTimeMillis() - (25 * 3600 * 1000L);
+        File oldProfileFile = createMockProfileFile(oldTimestamp);
+        manager.moveToArchivePending(oldProfileFile);
+        Thread.sleep(100);
+
+        // Create 2 more recent profiles
+        for (int i = 0; i < 2; i++) {
+            File profileFile = createMockProfileFile(System.currentTimeMillis() + i * 1000);
+            manager.moveToArchivePending(profileFile);
+            Thread.sleep(100);
+        }
+
+        // Verify all 3 files are in pending
+        File pendingDir = new File(manager.getArchivePath() + File.separator + "pending");
+        File[] pendingFiles = pendingDir.listFiles();
+        Assertions.assertNotNull(pendingFiles);
+        Assertions.assertEquals(3, pendingFiles.length);
+
+        // Check and archive (should trigger because oldest filename timestamp exceeds timeout)
+        int archived = manager.checkAndArchivePendingProfiles();
+
+        // Verify all 3 profiles were archived
+        Assertions.assertEquals(3, archived);
+
+        // Verify archive file was created
+        List<File> archiveFiles = manager.getArchiveFiles();
+        Assertions.assertEquals(1, archiveFiles.size());
+    }
+
+    /**
+     * Test: Check and archive pending profiles below threshold.
+     * Verifies that archiving is NOT triggered when conditions are not met.
+     */
+    @Test
+    void testCheckAndArchivePendingBelowThreshold() throws IOException {
+        // Create manager with large batch size
+        ProfileArchiveManager manager = new ProfileArchiveManager(tempDir.getAbsolutePath(), 1000);
+
+        // Move only 2 profiles to pending (well below batch size)
+        for (int i = 0; i < 2; i++) {
+            File profileFile = createMockProfileFile(System.currentTimeMillis() + i * 1000);
+            manager.moveToArchivePending(profileFile);
+        }
+
+        // Check and archive (should NOT trigger)
+        int archived = manager.checkAndArchivePendingProfiles();
+
+        // Verify nothing was archived
+        Assertions.assertEquals(0, archived);
+
+        // Verify no archive files were created
+        List<File> archiveFiles = manager.getArchiveFiles();
+        Assertions.assertEquals(0, archiveFiles.size());
+
+        // Verify pending files still exist
+        File pendingDir = new File(manager.getArchivePath() + File.separator + "pending");
+        File[] pendingFiles = pendingDir.listFiles();
+        Assertions.assertNotNull(pendingFiles);
+        Assertions.assertEquals(2, pendingFiles.length);
+    }
+
+    /**
+     * Test: Clean old archives with retention period.
+     * Verifies that archives older than retention period are deleted.
+     */
+    @Test
+    void testCleanOldArchivesWithRetention() throws IOException, InterruptedException {
+        // Temporarily override retention config for testing
+        int originalRetention = org.apache.doris.common.Config.profile_archive_retention_seconds;
+        org.apache.doris.common.Config.profile_archive_retention_seconds = 7 * 24 * 3600; // 7 days retention
+
+        try {
+            // Create some profiles and archive them
+            List<File> batch1 = new ArrayList<>();
+            for (int i = 0; i < 3; i++) {
+                batch1.add(createMockProfileFile(System.currentTimeMillis() + i * 1000));
+                Thread.sleep(100);
+            }
+
+            File archive1 = archiveManager.archiveProfiles(batch1);
+            Assertions.assertNotNull(archive1);
+
+            // Set the archive file's modification time to 10 days ago (exceeds 7 day retention)
+            long oldTime = System.currentTimeMillis() - (10 * 24 * 3600 * 1000L);
+            archive1.setLastModified(oldTime);
+
+            // Create another archive (recent)
+            List<File> batch2 = new ArrayList<>();
+            for (int i = 0; i < 2; i++) {
+                batch2.add(createMockProfileFile(System.currentTimeMillis() + i * 1000));
+                Thread.sleep(100);
+            }
+            File archive2 = archiveManager.archiveProfiles(batch2);
+            Assertions.assertNotNull(archive2);
+
+            // Clean old archives
+            int deleted = archiveManager.cleanOldArchives();
+
+            // Verify only the old archive was deleted
+            Assertions.assertEquals(1, deleted);
+            Assertions.assertFalse(archive1.exists());
+            Assertions.assertTrue(archive2.exists());
+
+        } finally {
+            // Restore original config
+            org.apache.doris.common.Config.profile_archive_retention_seconds = originalRetention;
+        }
+    }
+
+    /**
+     * Test: Clean old archives with unlimited retention.
+     * Verifies that no archives are deleted when retention is set to -1 (unlimited).
+     */
+    @Test
+    void testCleanOldArchivesUnlimitedRetention() throws IOException, InterruptedException {
+        // Temporarily override retention config for testing
+        int originalRetention = org.apache.doris.common.Config.profile_archive_retention_seconds;
+        org.apache.doris.common.Config.profile_archive_retention_seconds = -1; // Unlimited retention
+
+        try {
+            // Create and archive some profiles
+            List<File> batch = new ArrayList<>();
+            for (int i = 0; i < 3; i++) {
+                batch.add(createMockProfileFile(System.currentTimeMillis() + i * 1000));
+                Thread.sleep(100);
+            }
+
+            File archive = archiveManager.archiveProfiles(batch);
+            Assertions.assertNotNull(archive);
+
+            // Set very old modification time
+            long oldTime = System.currentTimeMillis() - (100 * 24 * 3600 * 1000L);
+            archive.setLastModified(oldTime);
+
+            // Clean old archives (should not delete anything)
+            int deleted = archiveManager.cleanOldArchives();
+
+            // Verify nothing was deleted
+            Assertions.assertEquals(0, deleted);
+            Assertions.assertTrue(archive.exists());
+
+        } finally {
+            // Restore original config
+            org.apache.doris.common.Config.profile_archive_retention_seconds = originalRetention;
+        }
+    }
+
+    /**
+     * Test: Pending directory creation.
+     * Verifies that the pending directory is created correctly.
+     */
+    @Test
+    void testCreatePendingDirectory() {
+        File pendingDir = new File(archiveManager.getArchivePath() + File.separator + "pending");
+        Assertions.assertFalse(pendingDir.exists());
+
+        boolean created = archiveManager.createPendingDirectoryIfNecessary();
+        Assertions.assertTrue(created);
+        Assertions.assertTrue(pendingDir.exists());
+        Assertions.assertTrue(pendingDir.isDirectory());
+
+        // Second call should also return true (idempotent)
+        created = archiveManager.createPendingDirectoryIfNecessary();
+        Assertions.assertTrue(created);
+    }
+
+    /**
+     * Test: Pending files sorted by filename timestamp (not file modification time).
+     * Verifies that pending files are sorted by timestamp in filename, regardless of file modification time.
+     */
+    @Test
+    void testPendingFilesSortedByFilenameTimestamp() throws IOException, InterruptedException {
+        ProfileArchiveManager manager = new ProfileArchiveManager(tempDir.getAbsolutePath(), 10);
+
+        // Create profiles with timestamps in non-sequential order: 3000, 1000, 5000, 2000, 4000
+        long baseTimestamp = System.currentTimeMillis();
+        long[] timestamps = {baseTimestamp + 3000, baseTimestamp + 1000, baseTimestamp + 5000,
+                baseTimestamp + 2000, baseTimestamp + 4000};
+
+        for (long timestamp : timestamps) {
+            File profileFile = createMockProfileFile(timestamp);
+            manager.moveToArchivePending(profileFile);
+            Thread.sleep(100); // Different modification times
+        }
+
+        // Trigger archiving to get the sorted list (but won't actually archive due to batch size)
+        manager.checkAndArchivePendingProfiles();
+
+        // Manually get pending files using reflection to test sorting
+        File pendingDir = new File(manager.getArchivePath() + File.separator + "pending");
+        File[] files = pendingDir.listFiles(File::isFile);
+        Assertions.assertNotNull(files);
+        Assertions.assertEquals(5, files.length);
+
+        // Sort using the same logic as getPendingProfileFiles
+        List<File> sortedFiles = new ArrayList<>(Arrays.asList(files));
+        sortedFiles.sort(Comparator.comparingLong(file -> {
+            String filename = file.getName();
+            long ts = Long.parseLong(filename.substring(0, filename.indexOf('_')));
+            return ts;
+        }));
+
+        // Verify files are sorted by filename timestamp (not modification time)
+        for (int i = 0; i < sortedFiles.size() - 1; i++) {
+            String filename1 = sortedFiles.get(i).getName();
+            String filename2 = sortedFiles.get(i + 1).getName();
+            long ts1 = Long.parseLong(filename1.substring(0, filename1.indexOf('_')));
+            long ts2 = Long.parseLong(filename2.substring(0, filename2.indexOf('_')));
+            Assertions.assertTrue(ts1 < ts2,
+                    String.format("Files should be sorted by filename timestamp: %d < %d", ts1, ts2));
+        }
+
+        // Expected order: baseTimestamp+1000, +2000, +3000, +4000, +5000
+        String firstFilename = sortedFiles.get(0).getName();
+        long firstTs = Long.parseLong(firstFilename.substring(0, firstFilename.indexOf('_')));
+        Assertions.assertEquals(baseTimestamp + 1000, firstTs,
+                "First file should have smallest timestamp");
+
+        String lastFilename = sortedFiles.get(4).getName();
+        long lastTs = Long.parseLong(lastFilename.substring(0, lastFilename.indexOf('_')));
+        Assertions.assertEquals(baseTimestamp + 5000, lastTs,
+                "Last file should have largest timestamp");
+    }
+
+    /**
+     * Test: Archive files sorted by filename timestamp (not file modification time).
+     * Verifies that archive files are sorted by timestamp in filename, regardless of file modification time.
+     */
+    @Test
+    void testArchiveFilesSortedByFilenameTimestamp() throws IOException, InterruptedException {
+        // Create multiple archives with different timestamp ranges
+        // Archive 1: timestamps 1000-2000
+        List<File> batch1 = new ArrayList<>();
+        long baseTime = 1704067200000L; // 2024-01-01 00:00:00
+        batch1.add(createMockProfileFile(baseTime + 1000));
+        batch1.add(createMockProfileFile(baseTime + 2000));
+        File archive1 = archiveManager.archiveProfiles(batch1);
+        Assertions.assertNotNull(archive1);
+        Thread.sleep(100);
+
+        // Archive 2: timestamps 5000-6000 (created second but should be sorted after archive3)
+        List<File> batch2 = new ArrayList<>();
+        batch2.add(createMockProfileFile(baseTime + 5000));
+        batch2.add(createMockProfileFile(baseTime + 6000));
+        File archive2 = archiveManager.archiveProfiles(batch2);
+        Assertions.assertNotNull(archive2);
+        Thread.sleep(100);
+
+        // Archive 3: timestamps 3000-4000 (created last but should be sorted between archive1 and archive2)
+        List<File> batch3 = new ArrayList<>();
+        batch3.add(createMockProfileFile(baseTime + 3000));
+        batch3.add(createMockProfileFile(baseTime + 4000));
+        File archive3 = archiveManager.archiveProfiles(batch3);
+        Assertions.assertNotNull(archive3);
+
+        // Set different modification times to ensure we're sorting by filename, not mod time
+        archive1.setLastModified(System.currentTimeMillis() - 10000);
+        archive2.setLastModified(System.currentTimeMillis() - 5000);
+        archive3.setLastModified(System.currentTimeMillis());
+
+        // Get archive files (should be sorted by filename timestamp)
+        List<File> archiveFiles = archiveManager.getArchiveFiles();
+        Assertions.assertEquals(3, archiveFiles.size());
+
+        // Verify sorting by filename timestamp
+        // Expected order: archive1 (1000-2000), archive3 (3000-4000), archive2 (5000-6000)
+        String name1 = archiveFiles.get(0).getName();
+        String name2 = archiveFiles.get(1).getName();
+        String name3 = archiveFiles.get(2).getName();
+
+        // Extract first timestamp from each archive filename
+        Assertions.assertTrue(name1.contains("20240101"),
+                "First archive should be archive1");
+        Assertions.assertTrue(name2.contains("20240101"),
+                "Second archive should be archive3");
+        Assertions.assertTrue(name3.contains("20240101"),
+                "Third archive should be archive2");
+
+        // Verify they are in the correct order by comparing the actual archive files
+        Assertions.assertEquals(archive1.getName(), archiveFiles.get(0).getName(),
+                "First should be archive1 (oldest timestamp range)");
+        Assertions.assertEquals(archive3.getName(), archiveFiles.get(1).getName(),
+                "Second should be archive3 (middle timestamp range)");
+        Assertions.assertEquals(archive2.getName(), archiveFiles.get(2).getName(),
+                "Third should be archive2 (newest timestamp range)");
+    }
+
+    /**
+     * Test: Archive pending profiles - batch size triggered, incomplete batch remains.
+     * Scenario: 23 pending profiles, batch size 10
+     * Expected: Archive only 20 profiles (2 complete batches), 3 remain in pending
+     */
+    @Test
+    void testBatchSizeTriggeredIncompleteBatchRemains() throws IOException, InterruptedException {
+        // Create manager with batch size 10
+        ProfileArchiveManager manager = new ProfileArchiveManager(tempDir.getAbsolutePath(), 10);
+
+        // Move 23 profiles to pending
+        for (int i = 0; i < 23; i++) {
+            File profileFile = createMockProfileFile(System.currentTimeMillis() + i * 1000);
+            manager.moveToArchivePending(profileFile);
+            Thread.sleep(50);
+        }
+
+        // Check and archive (triggered by batch size)
+        int archived = manager.checkAndArchivePendingProfiles();
+
+        // Verify only 20 profiles were archived (2 complete batches)
+        Assertions.assertEquals(20, archived, "Should archive only complete batches (20 profiles)");
+
+        // Verify 2 archive files were created
+        List<File> archiveFiles = manager.getArchiveFiles();
+        Assertions.assertEquals(2, archiveFiles.size(), "Should create 2 archive files");
+
+        // Verify 3 profiles remain in pending
+        File pendingDir = new File(manager.getArchivePath() + File.separator + "pending");
+        File[] pendingFiles = pendingDir.listFiles();
+        Assertions.assertNotNull(pendingFiles);
+        Assertions.assertEquals(3, pendingFiles.length, "3 profiles should remain in pending");
+    }
+
+    /**
+     * Test: Archive pending profiles - batch size condition takes priority.
+     * Scenario: 23 pending profiles (2+ batches), oldest file exceeds timeout
+     * Expected: Batch size condition triggers first, archive 20 profiles (complete batches only),
+     *           remaining 3 profiles stay in pending and will be archived on next check if timeout condition met
+     */
+    @Test
+    void testTimeoutTriggeredIncompletesBatchArchived() throws IOException, InterruptedException {
+        // Create manager with batch size 10
+        ProfileArchiveManager manager = new ProfileArchiveManager(tempDir.getAbsolutePath(), 10);
+
+        // Create one profile with timestamp 25 hours ago (exceeds timeout)
+        long oldTimestamp = System.currentTimeMillis() - (25 * 3600 * 1000L);
+        File oldProfileFile = createMockProfileFile(oldTimestamp);
+        manager.moveToArchivePending(oldProfileFile);
+        Thread.sleep(50);
+
+        // Move 22 more recent profiles to pending (total 23)
+        for (int i = 0; i < 22; i++) {
+            File profileFile = createMockProfileFile(System.currentTimeMillis() + i * 1000);
+            manager.moveToArchivePending(profileFile);
+            Thread.sleep(50);
+        }
+
+        // Verify all 23 files are in pending
+        File pendingDir = new File(manager.getArchivePath() + File.separator + "pending");
+        File[] pendingFiles = pendingDir.listFiles();
+        Assertions.assertNotNull(pendingFiles);
+        Assertions.assertEquals(23, pendingFiles.length);
+
+        // Check and archive (batch size condition takes priority)
+        int archived = manager.checkAndArchivePendingProfiles();
+
+        // Verify 20 profiles were archived (complete batches only)
+        Assertions.assertEquals(20, archived, "Should archive 20 profiles (complete batches)");
+
+        // Verify 2 archive files were created (10 + 10)
+        List<File> archiveFiles = manager.getArchiveFiles();
+        Assertions.assertEquals(2, archiveFiles.size(), "Should create 2 archive files");
+
+        // Verify 3 profiles remain in pending
+        pendingFiles = pendingDir.listFiles();
+        Assertions.assertNotNull(pendingFiles);
+        Assertions.assertEquals(3, pendingFiles.length, "3 profiles should remain in pending");
+    }
+
+    /**
+     * Test: Archive pending profiles - exact batch size.
+     * Scenario: Exactly 20 pending profiles with batch size 10
+     * Expected: Archive all 20 profiles in 2 complete batches
+     */
+    @Test
+    void testExactBatchSize() throws IOException, InterruptedException {
+        // Create manager with batch size 10
+        ProfileArchiveManager manager = new ProfileArchiveManager(tempDir.getAbsolutePath(), 10);
+
+        // Move exactly 20 profiles to pending (2 complete batches)
+        for (int i = 0; i < 20; i++) {
+            File profileFile = createMockProfileFile(System.currentTimeMillis() + i * 1000);
+            manager.moveToArchivePending(profileFile);
+            Thread.sleep(50);
+        }
+
+        // Check and archive
+        int archived = manager.checkAndArchivePendingProfiles();
+
+        // Verify all 20 profiles were archived
+        Assertions.assertEquals(20, archived, "Should archive all 20 profiles");
+
+        // Verify 2 archive files were created
+        List<File> archiveFiles = manager.getArchiveFiles();
+        Assertions.assertEquals(2, archiveFiles.size(), "Should create 2 archive files");
+
+        // Verify pending directory is empty
+        File pendingDir = new File(manager.getArchivePath() + File.separator + "pending");
+        File[] pendingFiles = pendingDir.listFiles();
+        Assertions.assertTrue(pendingFiles == null || pendingFiles.length == 0,
+                "Pending directory should be empty");
+    }
+
+    /**
+     * Test: Archive pending profiles - less than batch size with no timeout.
+     * Scenario: 5 pending profiles with batch size 10, no timeout
+     * Expected: No archiving should occur
+     */
+    @Test
+    void testLessThanBatchSizeNoTimeout() throws IOException, InterruptedException {
+        // Create manager with batch size 10
+        ProfileArchiveManager manager = new ProfileArchiveManager(tempDir.getAbsolutePath(), 10);
+
+        // Move only 5 profiles to pending (less than batch size)
+        for (int i = 0; i < 5; i++) {
+            File profileFile = createMockProfileFile(System.currentTimeMillis() + i * 1000);
+            manager.moveToArchivePending(profileFile);
+            Thread.sleep(50);
+        }
+
+        // Check and archive (should not trigger)
+        int archived = manager.checkAndArchivePendingProfiles();
+
+        // Verify nothing was archived
+        Assertions.assertEquals(0, archived, "Should not archive incomplete batch without timeout");
+
+        // Verify no archive files were created
+        List<File> archiveFiles = manager.getArchiveFiles();
+        Assertions.assertEquals(0, archiveFiles.size(), "Should not create any archive files");
+
+        // Verify all 5 profiles remain in pending
+        File pendingDir = new File(manager.getArchivePath() + File.separator + "pending");
+        File[] pendingFiles = pendingDir.listFiles();
+        Assertions.assertNotNull(pendingFiles);
+        Assertions.assertEquals(5, pendingFiles.length, "All 5 profiles should remain in pending");
+    }
+
+    /**
+     * Test: Archive pending profiles - less than batch size with timeout.
+     * Scenario: 5 pending profiles with batch size 10, but oldest file exceeds timeout
+     * Expected: Archive all 5 profiles (incomplete batch allowed due to timeout)
+     */
+    @Test
+    void testLessThanBatchSizeWithTimeout() throws IOException, InterruptedException {
+        // Create manager with batch size 10
+        ProfileArchiveManager manager = new ProfileArchiveManager(tempDir.getAbsolutePath(), 10);
+
+        // Create one profile with timestamp 25 hours ago (exceeds timeout)
+        long oldTimestamp = System.currentTimeMillis() - (25 * 3600 * 1000L);
+        File oldProfileFile = createMockProfileFile(oldTimestamp);
+        manager.moveToArchivePending(oldProfileFile);
+        Thread.sleep(50);
+
+        // Move 4 more recent profiles to pending (total 5, less than batch size 10)
+        for (int i = 0; i < 4; i++) {
+            File profileFile = createMockProfileFile(System.currentTimeMillis() + i * 1000);
+            manager.moveToArchivePending(profileFile);
+            Thread.sleep(50);
+        }
+
+        // Verify all 5 files are in pending
+        File pendingDir = new File(manager.getArchivePath() + File.separator + "pending");
+        File[] pendingFiles = pendingDir.listFiles();
+        Assertions.assertNotNull(pendingFiles);
+        Assertions.assertEquals(5, pendingFiles.length);
+
+        // Check and archive (triggered by timeout)
+        int archived = manager.checkAndArchivePendingProfiles();
+
+        // Verify all 5 profiles were archived (timeout allows incomplete batch)
+        Assertions.assertEquals(5, archived, "Should archive all profiles due to timeout");
+
+        // Verify 1 archive file was created with 5 profiles
+        List<File> archiveFiles = manager.getArchiveFiles();
+        Assertions.assertEquals(1, archiveFiles.size(), "Should create 1 archive file");
+
+        // Verify pending directory is empty
+        pendingFiles = pendingDir.listFiles();
+        Assertions.assertTrue(pendingFiles == null || pendingFiles.length == 0,
+                "Pending directory should be empty");
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileManagerTest.java
@@ -524,8 +524,10 @@ class ProfileManagerTest {
     @Test
     void testDeleteOutdatedProfilesFromStorage() throws IOException {
         int originMaxSpilledProfileNum = Config.max_spilled_profile_num;
+        boolean originalArchiveEnabled = Config.enable_profile_archive;
 
         try {
+            Config.enable_profile_archive = false; // Disable archiving for this test
             Config.max_spilled_profile_num = 10;
 
             // Create test profiles
@@ -557,6 +559,7 @@ class ProfileManagerTest {
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         } finally {
+            Config.enable_profile_archive = originalArchiveEnabled;
             Config.max_spilled_profile_num = originMaxSpilledProfileNum;
         }
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileManagerTest.java
@@ -845,4 +845,231 @@ class ProfileManagerTest {
             Assertions.assertTrue(profileManager.queryIdToProfileMap.containsKey(profile.getId()));
         }
     }
+
+    /**
+     * Integration Test: Test ProfileManager archives profiles when storage limit is exceeded.
+     * This tests the integration between ProfileManager and ProfileArchiveManager.
+     */
+    @Test
+    void testProfileArchiveIntegration() throws Exception {
+        // Save original config
+        boolean originalArchiveEnabled = Config.enable_profile_archive;
+        int originalMaxSpilled = Config.max_spilled_profile_num;
+        int originalBatchSize = Config.profile_archive_batch_size;
+
+        try {
+            // Enable archiving with small limits for testing
+            Config.enable_profile_archive = true;
+            Config.max_spilled_profile_num = 5;
+            Config.profile_archive_batch_size = 3;
+
+            // Create and store profiles
+            List<Profile> profiles = new ArrayList<>();
+            for (int i = 0; i < 10; i++) {
+                Thread.sleep(100);
+                Profile profile = ProfilePersistentTest.constructRandomProfile(1);
+                profile.isQueryFinished = true;
+                profile.setQueryFinishTimestamp(System.currentTimeMillis());
+
+                new Expectations(profile) {
+                    {
+                        profile.profileHasBeenStored();
+                        result = true;
+                    }
+                };
+
+                profileManager.pushProfile(profile);
+                profile.writeToStorage(ProfileManager.PROFILE_STORAGE_PATH);
+                profiles.add(profile);
+            }
+
+            // Trigger cleanup - should move old profiles to pending and possibly archive
+            profileManager.isProfileLoaded = true;
+            profileManager.deleteOutdatedProfilesFromStorage();
+
+            // Verify storage directory only has max allowed profiles
+            File storageDir = new File(ProfileManager.PROFILE_STORAGE_PATH);
+            File[] storageFiles = storageDir.listFiles(file -> file.isFile() && !file.getName().equals(".gitkeep"));
+            Assertions.assertNotNull(storageFiles);
+            Assertions.assertTrue(storageFiles.length <= Config.max_spilled_profile_num,
+                    "Storage should have at most " + Config.max_spilled_profile_num + " files, but has " + storageFiles.length);
+
+            // Verify pending directory exists and may contain profiles
+            File pendingDir = new File(ProfileManager.PROFILE_STORAGE_PATH + "/pending");
+            if (pendingDir.exists()) {
+                File[] pendingFiles = pendingDir.listFiles(File::isFile);
+                if (pendingFiles != null && pendingFiles.length > 0) {
+                    LOG.info("Pending directory has {} profiles waiting for archive", pendingFiles.length);
+                }
+            }
+
+            // Verify archive directory may exist if batch was completed
+            File archiveDir = new File(ProfileManager.PROFILE_STORAGE_PATH + "/archive");
+            if (archiveDir.exists()) {
+                File[] archiveFiles = archiveDir.listFiles(file -> file.getName().endsWith(".zip"));
+                if (archiveFiles != null && archiveFiles.length > 0) {
+                    LOG.info("Archive directory has {} archive files", archiveFiles.length);
+                    Assertions.assertTrue(archiveFiles.length > 0, "Archive files should exist");
+                }
+            }
+
+        } finally {
+            // Restore config
+            Config.enable_profile_archive = originalArchiveEnabled;
+            Config.max_spilled_profile_num = originalMaxSpilled;
+            Config.profile_archive_batch_size = originalBatchSize;
+        }
+    }
+
+    /**
+     * Integration Test: Test that profiles are directly deleted when archiving is disabled.
+     */
+    @Test
+    void testProfileDeletionWhenArchiveDisabled() throws Exception {
+        boolean originalArchiveEnabled = Config.enable_profile_archive;
+        int originalMaxSpilled = Config.max_spilled_profile_num;
+
+        try {
+            // Disable archiving
+            Config.enable_profile_archive = false;
+            Config.max_spilled_profile_num = 5;
+
+            // Create and store profiles
+            for (int i = 0; i < 10; i++) {
+                Thread.sleep(100);
+                Profile profile = ProfilePersistentTest.constructRandomProfile(1);
+                profile.isQueryFinished = true;
+                profile.setQueryFinishTimestamp(System.currentTimeMillis());
+
+                int finalI = i;
+                new Expectations(profile) {
+                    {
+                        profile.profileHasBeenStored();
+                        result = true;
+                        profile.deleteFromStorage();
+                        times = finalI < 5 ? 1 : 0; // First 5 should be deleted
+                    }
+                };
+
+                profileManager.pushProfile(profile);
+                profile.writeToStorage(ProfileManager.PROFILE_STORAGE_PATH);
+            }
+
+            // Trigger cleanup - should directly delete old profiles
+            profileManager.isProfileLoaded = true;
+            profileManager.deleteOutdatedProfilesFromStorage();
+
+            // Verify no pending or archive directories were created
+            File pendingDir = new File(ProfileManager.PROFILE_STORAGE_PATH + "/pending");
+            File archiveDir = new File(ProfileManager.PROFILE_STORAGE_PATH + "/archive");
+
+            Assertions.assertFalse(pendingDir.exists() && pendingDir.listFiles() != null && pendingDir.listFiles().length > 0,
+                    "Pending directory should not have files when archiving is disabled");
+            Assertions.assertFalse(archiveDir.exists() && archiveDir.listFiles() != null && archiveDir.listFiles().length > 0,
+                    "Archive directory should not have files when archiving is disabled");
+
+        } finally {
+            Config.enable_profile_archive = originalArchiveEnabled;
+            Config.max_spilled_profile_num = originalMaxSpilled;
+        }
+    }
+
+    /**
+     * Integration Test: Test periodic archive cleanup (runAfterCatalogReady).
+     */
+    @Test
+    void testPeriodicArchiveCleanup() throws Exception {
+        boolean originalArchiveEnabled = Config.enable_profile_archive;
+        int originalRetention = Config.profile_archive_retention_seconds;
+        int originalMaxSpilled = Config.max_spilled_profile_num;
+        int originalBatchSize = Config.profile_archive_batch_size;
+
+        try {
+            // Enable archiving with short retention for testing
+            Config.enable_profile_archive = true;
+            Config.profile_archive_retention_seconds = 1; // 1 second retention for testing
+            Config.max_spilled_profile_num = 3;
+            Config.profile_archive_batch_size = 2;
+
+            // Create archive manager
+            ProfileArchiveManager archiveManager = new ProfileArchiveManager(
+                    ProfileManager.PROFILE_STORAGE_PATH, Config.profile_archive_batch_size);
+            archiveManager.createArchiveDirectoryIfNecessary();
+
+            // Create an archive file with old timestamp in filename (2 seconds ago)
+            long oldTimestamp = System.currentTimeMillis() - (2 * 1000L);
+            String oldDateStr = java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")
+                    .withZone(java.time.ZoneId.systemDefault())
+                    .format(java.time.Instant.ofEpochMilli(oldTimestamp));
+            String archiveFilename = String.format("profiles_%s_%s.zip", oldDateStr, oldDateStr);
+            File archive = new File(archiveManager.getArchivePath(), archiveFilename);
+            archive.createNewFile();
+            Assertions.assertTrue(archive.exists());
+
+            // Simulate periodic cleanup via runAfterCatalogReady
+            // Note: The first call will trigger cleanup since lastArchiveCleanupTime is 0
+            profileManager.isProfileLoaded = true;
+            profileManager.runAfterCatalogReady();
+
+            // Verify that the old archive was deleted by runAfterCatalogReady
+            Assertions.assertFalse(archive.exists(), "Old archive should be deleted by runAfterCatalogReady");
+
+        } finally {
+            Config.enable_profile_archive = originalArchiveEnabled;
+            Config.profile_archive_retention_seconds = originalRetention;
+            Config.max_spilled_profile_num = originalMaxSpilled;
+            Config.profile_archive_batch_size = originalBatchSize;
+        }
+    }
+
+    /**
+     * Integration Test: Test archive pending timeout triggers archiving even when batch is not full.
+     */
+    @Test
+    void testArchivePendingTimeoutIntegration() throws Exception {
+        boolean originalArchiveEnabled = Config.enable_profile_archive;
+        int originalTimeout = Config.profile_archive_pending_timeout_seconds;
+        int originalBatchSize = Config.profile_archive_batch_size;
+
+        try {
+            // Enable archiving with short timeout and large batch size
+            Config.enable_profile_archive = true;
+            Config.profile_archive_pending_timeout_seconds = 1; // 1 second timeout
+            Config.profile_archive_batch_size = 100; // Large batch that won't be reached
+
+            ProfileArchiveManager archiveManager = new ProfileArchiveManager(
+                    ProfileManager.PROFILE_STORAGE_PATH, Config.profile_archive_batch_size);
+
+            // Move a few profiles to pending (less than batch size)
+            for (int i = 0; i < 3; i++) {
+                UUID taskId = UUID.randomUUID();
+                TUniqueId queryId = new TUniqueId(taskId.getMostSignificantBits(), taskId.getLeastSignificantBits());
+                String profileId = DebugUtil.printId(queryId);
+                File profileFile = new File(tempDir, System.currentTimeMillis() + "_" + profileId + ".zip");
+                profileFile.createNewFile();
+
+                boolean moved = archiveManager.moveToArchivePending(profileFile);
+                Assertions.assertTrue(moved);
+            }
+
+            // Wait for timeout
+            Thread.sleep(1500);
+
+            // Check and archive - should trigger due to timeout even though batch is not full
+            int archived = archiveManager.checkAndArchivePendingProfiles();
+            Assertions.assertTrue(archived > 0, "Profiles should be archived due to timeout");
+
+            // Verify archive was created
+            File archiveDir = new File(ProfileManager.PROFILE_STORAGE_PATH + "/archive");
+            Assertions.assertTrue(archiveDir.exists());
+            File[] archiveFiles = archiveDir.listFiles(file -> file.getName().endsWith(".zip"));
+            Assertions.assertNotNull(archiveFiles);
+            Assertions.assertTrue(archiveFiles.length > 0);
+
+        } finally {
+            Config.enable_profile_archive = originalArchiveEnabled;
+            Config.profile_archive_pending_timeout_seconds = originalTimeout;
+            Config.profile_archive_batch_size = originalBatchSize;
+        }
+    }
 }


### PR DESCRIPTION
# Profile Archive Feature

## Summary

Add automatic profile archiving feature to preserve query profiles beyond current memory and disk limits. When profile storage reaches capacity, old profiles are automatically archived to compressed ZIP files instead of being deleted, enabling long-term profile retention for troubleshooting and analysis.

## Problem

Currently, Doris has strict limits on profile storage:
- **Memory profiles**: Maximum 500 profiles (`max_query_profile_num`)
- **Spilled profiles**: Maximum 500 profiles (`max_spilled_profile_num`)
- **Storage size**: Maximum 1GB (`spilled_profile_storage_limit_bytes`)

When these limits are exceeded, old profiles are **permanently deleted**, making it impossible to analyze historical slow queries beyond the retention window. This is problematic for:
- Post-incident analysis of production issues
- Long-term performance trend analysis
- Debugging intermittent query problems

## Solution

Implement an automatic profile archiving system that:
1. **Moves** outdated profiles to an archive directory instead of deleting them
2. **Batches** profiles into compressed ZIP files for efficient storage
3. **Retains** profiles for a configurable period (default 7 days)
4. **Provides** predictable file naming for easy profile location

### Key Features

- **Pending Buffer Strategy**: Profiles are staged in `archive/pending/` before archiving to ensure optimal batch sizes
- **Dual Trigger Mechanism**:
  - Archive when batch size reaches configured limit (default 100 profiles)
  - Archive when oldest pending file exceeds timeout (default 24 hours)
- **Automatic Cleanup**: Remove archives older than retention period (configurable)
- **Graceful Degradation**: Falls back to direct deletion if archiving fails

## Implementation Details

### Directory Structure

```
${LOG_DIR}/profile/
├── {timestamp}_{queryid}.zip          # Active spilled profiles
└── archive/                           # Archive root
    ├── pending/                       # Staging area for batching
    │   └── {timestamp}_{queryid}.zip
    └── profiles_20240101_000000_20240101_235959.zip  # Archived batches
```

### Archive File Naming

Archive ZIPs follow the naming pattern: `profiles_{start_timestamp}_{end_timestamp}.zip`
- `start_timestamp`: Earliest profile in the batch (YYYYMMDD_HHMMSS)
- `end_timestamp`: Latest profile in the batch (YYYYMMDD_HHMMSS)

This enables quick location of profiles by query time.

### Workflow

```
Query Profile Creation
    ↓
Memory Storage (max 500)
    ↓
Spilled to Disk (when memory full)
    ↓
Periodic Cleanup (every 1s)
    ↓
Move to archive/pending/ (when limits exceeded)
    ↓
Archive to ZIP (batch size reached OR timeout exceeded)
    ↓
Delete Pending Files
    ↓
Cleanup Old Archives (every 24h, default retention 7 days)
```

### Code Changes

**New Files:**
- `ProfileArchiveManager.java` (682 lines) - Core archiving logic

**Modified Files:**
- `Config.java` (+35 lines) - Configuration parameters
- `ProfileManager.java` (+157/-17 lines) - Integration with archive system

**Test Files:**
- `ProfileArchiveManagerTest.java` (+1111 lines) - 26 comprehensive test cases
- `ProfileManagerTest.java` (+227 lines) - Integration tests


## Configuration

All parameters have sensible defaults and can be tuned via FE configuration:

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `enable_profile_archive` | boolean | `true` | Enable/disable profile archiving |
| `profile_archive_batch_size` | int | `100` | Number of profiles per ZIP file |
| `profile_archive_path` | String | `""` | Custom archive path (empty = use default `${spilled_profile_storage_path}/archive`) |
| `profile_archive_retention_seconds` | int | `604800` | Archive retention period in seconds (7 days). Set to `-1` for unlimited retention, `0` to disable archiving |
| `profile_archive_pending_timeout_seconds` | int | `86400` | Maximum wait time for pending files in seconds (24 hours). Force archive even if batch is not full |

### Configuration Examples

```properties
# Increase batch size for larger archives (reduces file count)
profile_archive_batch_size = 1000

# Keep archives for 30 days
profile_archive_retention_seconds = 2592000

# Use custom archive path (e.g., mounted network storage)
profile_archive_path = /mnt/nfs/doris-profiles/archive

# Force archive after 12 hours instead of 24
profile_archive_pending_timeout_seconds = 43200

# Disable archiving (keep current behavior)
enable_profile_archive = false
```



## Usage

### For System Administrators

**Step 1: Locate Slow Query**
```sql
SELECT query_id, time, frontend_ip, query_time
FROM __internal_schema.audit_log
WHERE time >= NOW() - INTERVAL 1 DAY
  AND query_time > 10000
ORDER BY query_time DESC;
```

**Step 2: Find Archive File**
```bash
ssh user@<frontend_ip>
cd ${LOG_DIR}/profile/archive
ls -lh profiles_*.zip
```

**Step 3: Extract and Analyze**
```bash
unzip profiles_20240101_120000_20240101_130000.zip -d /tmp/analysis/
ls /tmp/analysis/ | grep <query_id>
vim /tmp/analysis/<timestamp>_<query_id>.profile
```

### Space Management

```bash
# Check archive storage usage
du -sh ${LOG_DIR}/profile/archive

# Manual cleanup (if needed beyond automatic retention)
find ${LOG_DIR}/profile/archive -name "profiles_*.zip" -mtime +90 -delete
```



## Backward Compatibility

- **Fully backward compatible** - existing profile storage continues to work
- **Default enabled** - archives are created automatically
- **Can be disabled** - set `enable_profile_archive = false` to restore old behavior
- **No schema changes** - no database migration required






## Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [X] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

