### PR TITLE
[enhancement](load)add LogicalPostProject to cast outputs according to dest table's schema

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadUtils.java
@@ -202,8 +202,12 @@ public class NereidsLoadUtils {
         CascadesContext cascadesContext = CascadesContext.initContext(new StatementContext(), currentRootPlan,
                 PhysicalProperties.ANY);
         ConnectContext ctx = cascadesContext.getConnectContext();
+        // we force convert nullable column to non-nullable column for load
+        // so set feDebug to false to avoid AdjustNullableRule report error
+        boolean oldFeDebugValue = ctx.getSessionVariable().feDebug;
         try {
             ctx.getSessionVariable().setDebugSkipFoldConstant(true);
+            ctx.getSessionVariable().feDebug = false;
 
             Analyzer.buildCustomAnalyzer(cascadesContext, ImmutableList.of(Analyzer.bottomUp(
                     new BindExpression(),
@@ -240,6 +244,7 @@ public class NereidsLoadUtils {
             throw new UserException(exception.getMessage());
         } finally {
             ctx.getSessionVariable().setDebugSkipFoldConstant(false);
+            ctx.getSessionVariable().feDebug = oldFeDebugValue;
         }
 
         return (LogicalPlan) cascadesContext.getRewritePlan();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleType.java
@@ -262,6 +262,8 @@ public enum RuleType {
     REWRITE_LOAD_PROJECT_FOR_STREAM_LOAD(RuleTypeClass.REWRITE),
     // add post filter node for load
     ADD_POST_FILTER_FOR_LOAD(RuleTypeClass.REWRITE),
+    // add post project node for load
+    ADD_POST_PROJECT_FOR_LOAD(RuleTypeClass.REWRITE),
 
     // Merge Consecutive plan
     MERGE_PROJECTS(RuleTypeClass.REWRITE),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalPostProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalPostProject.java
@@ -1,0 +1,234 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.logical;
+
+import org.apache.doris.nereids.analyzer.Unbound;
+import org.apache.doris.nereids.analyzer.UnboundStar;
+import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait;
+import org.apache.doris.nereids.properties.LogicalProperties;
+import org.apache.doris.nereids.trees.expressions.Alias;
+import org.apache.doris.nereids.trees.expressions.BoundStar;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.functions.NoneMovableFunction;
+import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.PlanType;
+import org.apache.doris.nereids.trees.plans.algebra.Project;
+import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
+import org.apache.doris.nereids.util.Utils;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.ImmutableSet;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Logical post project only use for load plan.
+ */
+public class LogicalPostProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TYPE>
+        implements Project, OutputPrunable {
+
+    private final List<NamedExpression> projects;
+    private final Supplier<Set<NamedExpression>> projectsSet;
+    private final boolean isDistinct;
+
+    public LogicalPostProject(List<NamedExpression> projects, CHILD_TYPE child) {
+        this(projects, false, ImmutableList.of(child));
+    }
+
+    public LogicalPostProject(List<NamedExpression> projects, boolean isDistinct, List<Plan> child) {
+        this(projects, isDistinct, Optional.empty(), Optional.empty(), child);
+    }
+
+    public LogicalPostProject(List<NamedExpression> projects, boolean isDistinct, Plan child) {
+        this(projects, isDistinct,
+                Optional.empty(), Optional.empty(), ImmutableList.of(child));
+    }
+
+    private LogicalPostProject(List<NamedExpression> projects, boolean isDistinct,
+            Optional<GroupExpression> groupExpression, Optional<LogicalProperties> logicalProperties,
+            List<Plan> child) {
+        super(PlanType.LOGICAL_PROJECT, groupExpression, logicalProperties, child);
+        Preconditions.checkArgument(projects != null, "projects can not be null");
+        // only ColumnPrune rule may produce empty projects, this happens in rewrite phase
+        // so if projects is empty, all plans have been bound already.
+        Preconditions.checkArgument(!projects.isEmpty() || !(child instanceof Unbound),
+                "projects can not be empty when child plan is unbound");
+        this.projects = projects.isEmpty()
+                ? ImmutableList.of(new Alias(new TinyIntLiteral((byte) 1)))
+                : projects;
+        this.projectsSet = Suppliers.memoize(() -> ImmutableSet.copyOf(this.projects));
+        this.isDistinct = isDistinct;
+    }
+
+    /**
+     * Get project list.
+     *
+     * @return all project of this node.
+     */
+    @Override
+    public List<NamedExpression> getProjects() {
+        return projects;
+    }
+
+    @Override
+    public List<Slot> computeOutput() {
+        Builder<Slot> slots = ImmutableList.builderWithExpectedSize(projects.size());
+        for (NamedExpression project : projects) {
+            slots.add(project.toSlot());
+        }
+        return slots.build();
+    }
+
+    @Override
+    public String toString() {
+        return Utils.toSqlString("LogicalPostProject[" + id.asInt() + "]",
+                "distinct", isDistinct,
+                "projects", projects);
+    }
+
+    @Override
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
+        return visitor.visitLogicalPostProject(this, context);
+    }
+
+    @Override
+    public List<? extends Expression> getExpressions() {
+        return projects;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LogicalPostProject<?> that = (LogicalPostProject<?>) o;
+        boolean equal = projectsSet.get().equals(that.projectsSet.get())
+                && isDistinct == that.isDistinct;
+        // TODO: should add exprId for UnBoundStar and BoundStar for equality comparison
+        if (!projects.isEmpty() && (projects.get(0) instanceof UnboundStar || projects.get(0) instanceof BoundStar)) {
+            equal = child().getLogicalProperties().equals(that.child().getLogicalProperties());
+        }
+        return equal;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(projectsSet.get(), isDistinct);
+    }
+
+    @Override
+    public LogicalPostProject<Plan> withChildren(List<Plan> children) {
+        Preconditions.checkArgument(children.size() == 1);
+        return new LogicalPostProject<>(projects, isDistinct, Utils.fastToImmutableList(children));
+    }
+
+    @Override
+    public LogicalPostProject<Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
+        return new LogicalPostProject<>(projects, isDistinct,
+                groupExpression, Optional.of(getLogicalProperties()), children);
+    }
+
+    @Override
+    public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
+            Optional<LogicalProperties> logicalProperties, List<Plan> children) {
+        Preconditions.checkArgument(children.size() == 1);
+        return new LogicalPostProject<>(projects, isDistinct,
+                groupExpression, logicalProperties, children);
+    }
+
+    public LogicalPostProject<Plan> withProjects(List<NamedExpression> projects) {
+        return new LogicalPostProject<>(projects, isDistinct, children);
+    }
+
+    public LogicalPostProject<Plan> withProjectsAndChild(List<NamedExpression> projects, Plan child) {
+        return new LogicalPostProject<>(projects, isDistinct, ImmutableList.of(child));
+    }
+
+    public LogicalPostProject<Plan> withDistinct(boolean isDistinct) {
+        return new LogicalPostProject<>(projects, isDistinct, children);
+    }
+
+    public boolean isDistinct() {
+        return isDistinct;
+    }
+
+    @Override
+    public List<NamedExpression> getOutputs() {
+        return projects;
+    }
+
+    @Override
+    public Plan pruneOutputs(List<NamedExpression> prunedOutputs) {
+        List<NamedExpression> allProjects = new ArrayList<>(prunedOutputs);
+        for (NamedExpression expression : projects) {
+            if (expression.containsType(NoneMovableFunction.class)) {
+                if (!prunedOutputs.contains(expression)) {
+                    allProjects.add(expression);
+                }
+            }
+        }
+        return withProjects(allProjects);
+    }
+
+    @Override
+    public JSONObject toJson() {
+        JSONObject logicalProject = super.toJson();
+        JSONObject properties = new JSONObject();
+        properties.put("Projects", projects.toString());
+        properties.put("IsDistinct", isDistinct);
+        logicalProject.put("Properties", properties);
+        return logicalProject;
+    }
+
+    @Override
+    public void computeUnique(DataTrait.Builder builder) {
+    }
+
+    @Override
+    public void computeUniform(DataTrait.Builder builder) {
+    }
+
+    @Override
+    public void computeEqualSet(DataTrait.Builder builder) {
+    }
+
+    @Override
+    public void computeFd(DataTrait.Builder builder) {
+    }
+
+    @Override
+    public boolean canProcessProject(List<NamedExpression> parentProjects) {
+        return false;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/PlanVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/PlanVisitor.java
@@ -40,6 +40,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalLimit;
 import org.apache.doris.nereids.trees.plans.logical.LogicalLoadProject;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPartitionTopN;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPostProject;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPreAggOnHint;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPreFilter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
@@ -224,6 +225,10 @@ public abstract class PlanVisitor<R, C> implements CommandVisitor<R, C>, Relatio
     }
 
     public R visitLogicalLoadProject(LogicalLoadProject<? extends Plan> project, C context) {
+        return visit(project, context);
+    }
+
+    public R visitLogicalPostProject(LogicalPostProject<? extends Plan> project, C context) {
         return visit(project, context);
     }
 


### PR DESCRIPTION
LogicalPostProject is used to cast sink's output slot's datatype according to dest table's schema. Most importantly, make the nullable info is same as dest table

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

