### PR TITLE
[improvement](BeConfig)Add Be config to control the public or private endpoint

### DIFF
--- a/be/src/cloud/config.cpp
+++ b/be/src/cloud/config.cpp
@@ -65,6 +65,8 @@ DEFINE_mInt32(mow_stream_load_commit_retry_times, "5");
 
 DEFINE_mBool(save_load_error_log_to_s3, "false");
 
+DEFINE_mBool(use_public_endpoint_for_error_log, "true");
+
 DEFINE_mInt32(sync_load_for_tablets_thread, "32");
 
 DEFINE_mBool(enable_new_tablet_do_compaction, "true");

--- a/be/src/cloud/config.h
+++ b/be/src/cloud/config.h
@@ -107,6 +107,9 @@ DECLARE_mInt32(mow_stream_load_commit_retry_times);
 
 DECLARE_mBool(save_load_error_log_to_s3);
 
+// Whether to use public endpoint for error log presigned URL
+DECLARE_mBool(use_public_endpoint_for_error_log);
+
 // the theads which sync the datas which loaded in other clusters
 DECLARE_mInt32(sync_load_for_tablets_thread);
 

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -424,9 +424,10 @@ std::string RuntimeState::get_error_log_file_path() {
         }
         // expiration must be less than a week (in seconds) for presigned url
         static const unsigned EXPIRATION_SECONDS = 7 * 24 * 60 * 60 - 1;
-        // We should return a public endpoint to user.
-        _error_log_file_path = _s3_error_fs->generate_presigned_url(_s3_error_log_file_path,
-                                                                    EXPIRATION_SECONDS, true);
+        // Use public or private endpoint based on configuration
+        _error_log_file_path = _s3_error_fs->generate_presigned_url(
+                _s3_error_log_file_path, EXPIRATION_SECONDS,
+                config::use_public_endpoint_for_error_log);
     }
     return _error_log_file_path;
 }

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -425,9 +425,9 @@ std::string RuntimeState::get_error_log_file_path() {
         // expiration must be less than a week (in seconds) for presigned url
         static const unsigned EXPIRATION_SECONDS = 7 * 24 * 60 * 60 - 1;
         // Use public or private endpoint based on configuration
-        _error_log_file_path = _s3_error_fs->generate_presigned_url(
-                _s3_error_log_file_path, EXPIRATION_SECONDS,
-                config::use_public_endpoint_for_error_log);
+        _error_log_file_path =
+                _s3_error_fs->generate_presigned_url(_s3_error_log_file_path, EXPIRATION_SECONDS,
+                                                     config::use_public_endpoint_for_error_log);
     }
     return _error_log_file_path;
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

we need to control the public or private endpoint, so add a config in Be:

use_public_endpoint_for_error_log = true  :  aliyuncs.com
use_public_endpoint_for_error_log = false :  -internal.aliyuncs.com

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

