### PR TITLE
[opt](agent-task) Add a daemon thread to clean up agent tasks on dead BEs

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3674,4 +3674,6 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true)
     public static String aws_credentials_provider_version = "v2";
+
+    public static long agent_task_health_check_intervals_ms = 5 * 60 * 1000L; // 5 min
 }

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3675,7 +3675,7 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static String aws_credentials_provider_version = "v2";
 
-    @ConfField(mutable = false, description = {
+    @ConfField(description = {
             "agent tasks 健康检查的时间间隔，默认五分钟，小于等于0时不做健康检查",
             "agent tasks health check interval, default is five minutes, no health check when less than or equal to 0"
     })

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3675,5 +3675,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static String aws_credentials_provider_version = "v2";
 
+    @ConfField(mutable = false, description = {
+            "agent tasks 健康检查的时间间隔，默认五分钟，小于等于0时不做健康检查",
+            "agent tasks health check interval, default is five minutes, no health check when less than or equal to 0"
+    })
     public static long agent_task_health_check_intervals_ms = 5 * 60 * 1000L; // 5 min
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -264,6 +264,7 @@ import org.apache.doris.system.HeartbeatMgr;
 import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.system.SystemInfoService.HostInfo;
 import org.apache.doris.task.AgentBatchTask;
+import org.apache.doris.task.AgentTaskCleanupDaemon;
 import org.apache.doris.task.AgentTaskExecutor;
 import org.apache.doris.task.CompactionTask;
 import org.apache.doris.task.MasterTaskExecutor;
@@ -580,6 +581,8 @@ public class Env {
 
     private StatisticsMetricCollector statisticsMetricCollector;
 
+    private AgentTaskCleanupDaemon agentTaskCleanupDaemon;
+
     // if a config is relative to a daemon thread. record the relation here. we will proactively change interval of it.
     private final Map<String, Supplier<MasterDaemon>> configtoThreads = ImmutableMap
             .of("dynamic_partition_check_interval_seconds", this::getDynamicPartitionScheduler);
@@ -840,6 +843,9 @@ public class Env {
         this.dictionaryManager = new DictionaryManager();
         this.keyManagerStore = new KeyManagerStore();
         this.keyManager = KeyManagerFactory.getKeyManager();
+        if (Config.agent_task_health_check_intervals_ms > 0) {
+            this.agentTaskCleanupDaemon = new AgentTaskCleanupDaemon();
+        }
     }
 
     public static Map<String, Long> getSessionReportTimeMap() {
@@ -1962,6 +1968,7 @@ public class Env {
         if (keyManager != null) {
             keyManager.init();
         }
+        agentTaskCleanupDaemon.start();
     }
 
     // start threads that should run on all FE

--- a/fe/fe-core/src/main/java/org/apache/doris/task/AgentTaskCleanupDaemon.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/AgentTaskCleanupDaemon.java
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.task;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.Status;
+import org.apache.doris.common.util.MasterDaemon;
+import org.apache.doris.system.Backend;
+import org.apache.doris.system.SystemInfoService;
+import org.apache.doris.thrift.TStatusCode;
+
+public class AgentTaskCleanupDaemon extends MasterDaemon {
+    public AgentTaskCleanupDaemon() {
+        super("agent-task-cleanup", Config.agent_task_health_check_intervals_ms);
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        SystemInfoService infoService = Env.getCurrentSystemInfo();
+        infoService.getAllClusterBackends(false)
+                .stream()
+                .filter(backend -> !backend.isAlive())
+                .map(Backend::getId)
+                .forEach(this::removeInactiveBeAgentTasks);
+    }
+
+    private void removeInactiveBeAgentTasks(Long beId) {
+        AgentTaskQueue.removeTask(beId, (agentTask -> {
+            long tabletId = agentTask.getTabletId();
+            String errMsg = "BE down, this agent task is aborted. BE=" + beId + ", tablet=" + tabletId;
+            if (agentTask instanceof PushTask) {
+                PushTask task = ((PushTask) agentTask);
+                task.countDownLatchWithStatus(beId, tabletId, new Status(TStatusCode.ABORTED, errMsg));
+            }
+            agentTask.setFinished(true);
+            agentTask.setErrorCode(TStatusCode.ABORTED);
+            agentTask.setErrorMsg(errMsg);
+        }));
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/task/AgentTaskCleanupDaemon.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/AgentTaskCleanupDaemon.java
@@ -33,6 +33,8 @@ import java.util.Map;
 public class AgentTaskCleanupDaemon extends MasterDaemon {
     private static final Logger LOG = LogManager.getLogger(AgentTaskCleanupDaemon.class);
 
+    public static final Integer MAX_FAILURE_TIMES = 3;
+
     private final Map<Long, Integer> beInactiveCheckFailures = Maps.newHashMap();
 
     public AgentTaskCleanupDaemon() {
@@ -51,7 +53,7 @@ public class AgentTaskCleanupDaemon extends MasterDaemon {
                     } else {
                         Integer failureTimes = beInactiveCheckFailures.compute(id, (beId, failures) -> {
                             int updated = (failures == null ? 1 : failures + 1);
-                            if (updated >= 2) {
+                            if (updated >= MAX_FAILURE_TIMES) {
                                 removeInactiveBeAgentTasks(beId);
                             }
                             return updated;

--- a/fe/fe-core/src/main/java/org/apache/doris/task/AgentTaskQueue.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/AgentTaskQueue.java
@@ -33,6 +33,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * Task queue
@@ -94,6 +95,16 @@ public class AgentTaskQueue {
             LOG.debug("remove task: type[{}], backend[{}], signature[{}]", type, backendId, signature);
         }
         --taskNum;
+    }
+
+    public static synchronized void removeTask(long backendId, Consumer<AgentTask> onTaskRemoved) {
+        Map<TTaskType, Map<Long, AgentTask>> tasks = AgentTaskQueue.tasks.row(backendId);
+        tasks.forEach((type, taskSet) -> {
+            taskSet.forEach((signature, task) -> {
+                removeTask(backendId, type, signature);
+                onTaskRemoved.accept(task);
+            });
+        });
     }
 
     /*

--- a/fe/fe-core/src/main/java/org/apache/doris/task/AgentTaskQueue.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/AgentTaskQueue.java
@@ -100,10 +100,12 @@ public class AgentTaskQueue {
     public static synchronized void removeTask(long backendId, Consumer<AgentTask> onTaskRemoved) {
         Map<TTaskType, Map<Long, AgentTask>> tasks = AgentTaskQueue.tasks.row(backendId);
         tasks.forEach((type, taskSet) -> {
-            taskSet.forEach((signature, task) -> {
-                removeTask(backendId, type, signature);
-                onTaskRemoved.accept(task);
-            });
+            Iterator<Map.Entry<Long, AgentTask>> it = taskSet.entrySet().iterator();
+            while (it.hasNext()) {
+                Map.Entry<Long, AgentTask> entry = it.next();
+                it.remove();
+                onTaskRemoved.accept(entry.getValue());
+            }
         });
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/task/PushTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/PushTask.java
@@ -58,7 +58,7 @@ public class PushTask extends AgentTask {
     private TPushType pushType;
     private List<Predicate> conditions;
     // for synchronous delete
-    private MarkedCountDownLatch latch;
+    private MarkedCountDownLatch<Long, Long> latch;
 
     // lzop decompress or not
     private boolean needDecompress;
@@ -208,6 +208,18 @@ public class PushTask extends AgentTask {
                     LOG.debug("pushTask current latch count: {}. backend: {}, tablet:{}", latch.getCount(), backendId,
                             tabletId);
                 }
+            }
+        }
+    }
+
+    public void countDownLatchWithStatus(long backendId, long tabletId, Status st) {
+        if (this.latch == null) {
+            return;
+        }
+        if (latch.markedCountDownWithStatus(backendId, tabletId, st)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("pushTask current latch count with status: {}. backend: {}, tablet:{}, st::{}",
+                        latch.getCount(), backendId, tabletId, st);
             }
         }
     }

--- a/regression-test/suites/fault_injection_p0/test_sc_fail_when_be_down.groovy
+++ b/regression-test/suites/fault_injection_p0/test_sc_fail_when_be_down.groovy
@@ -59,8 +59,6 @@ suite("test_sc_fail_when_be_down", "docker") {
             assertTrue(false)
         } catch (Throwable ignore) {
             // do nothing
-        } finally {
-            GetDebugPoint().clearDebugPointsForAllBEs()
         }
     }
 }

--- a/regression-test/suites/fault_injection_p0/test_sc_stuck_when_be_down.groovy
+++ b/regression-test/suites/fault_injection_p0/test_sc_stuck_when_be_down.groovy
@@ -27,26 +27,23 @@ suite("test_sc_stuck_when_be_down", "docker") {
         """
         sql """ INSERT INTO ${tblName} SELECT number, number, number from numbers("number" = "1024") """
 
-        GetDebugPoint().enableDebugPointForAllBEs("SchemaChangeJob::_do_process_alter_tablet.block")
+        GetDebugPoint().enableDebugPointForAllBEs("SchemaChangeJob._do_process_alter_tablet.sleep")
         try {
             sql """ ALTER TABLE ${tblName} MODIFY COLUMN v0 VARCHAR(100) """
             sleep(3000)
             cluster.stopBackends(1)
-            GetDebugPoint().clearDebugPointsForAllBEs()
             waitForSchemaChangeDone {
                 sql """ SHOW ALTER TABLE COLUMN WHERE TableName='${tblName}' ORDER BY createtime DESC LIMIT 1 """
                 time 600
             }
         } finally {
-            GetDebugPoint().clearDebugPointsForAllBEs()
         }
 
-        GetDebugPoint().enableDebugPointForAllBEs("SchemaChangeJob::_do_process_alter_tablet.block")
+        GetDebugPoint().enableDebugPointForAllBEs("SchemaChangeJob::_do_process_alter_tablet.sleep")
         try {
             sql """ ALTER TABLE ${tblName} MODIFY COLUMN v1 VARCHAR(100) """
             sleep(3000)
             cluster.stopBackends(1, 2)
-            GetDebugPoint().clearDebugPointsForAllBEs()
             waitForSchemaChangeDone {
                 sql """ SHOW ALTER TABLE COLUMN WHERE TableName='${tblName}' ORDER BY createtime DESC LIMIT 1 """
                 time 600
@@ -55,7 +52,6 @@ suite("test_sc_stuck_when_be_down", "docker") {
         } catch (Exception ignore) {
             // do nothing
         } finally {
-            GetDebugPoint().clearDebugPointsForAllBEs()
         }
     }
 }

--- a/regression-test/suites/fault_injection_p0/test_sc_stuck_when_be_down.groovy
+++ b/regression-test/suites/fault_injection_p0/test_sc_stuck_when_be_down.groovy
@@ -1,0 +1,61 @@
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite("test_sc_stuck_when_be_down", "docker") {
+    def options = new ClusterOptions()
+    options.cloudMode = false
+    options.beNum = 3
+    options.feNum = 2
+    options.enableDebugPoints()
+    options.feConfigs += ["agent_task_health_check_intervals_ms=5000"]
+
+    docker(options) {
+        GetDebugPoint().clearDebugPointsForAllBEs()
+
+        def tblName = "test_sc_stuck_when_be_down"
+        sql """ DROP TABLE IF EXISTS ${tblName} """
+        sql """
+                CREATE TABLE IF NOT EXISTS ${tblName} (
+                    `k` int NOT NULL,
+                    `v0` int NOT NULL,
+                    `v1` int NOT NULL
+                ) 
+                DUPLICATE KEY(`k`)
+                DISTRIBUTED BY HASH(`k`) BUCKETS 24
+                PROPERTIES (
+                    "replication_allocation" = "tag.location.default: 3"
+                )
+        """
+        sql """ INSERT INTO ${tblName} SELECT number, number, number from numbers("number" = "1024") """
+
+        GetDebugPoint().enableDebugPointForAllBEs("SchemaChangeJob::_do_process_alter_tablet.block")
+        try {
+            sql """ ALTER TABLE ${tblName} MODIFY COLUMN v0 VARCHAR(100) """
+            sleep(3000)
+            cluster.stopBackends(1)
+            GetDebugPoint().clearDebugPointsForAllBEs()
+            waitForSchemaChangeDone {
+                sql """ SHOW ALTER TABLE COLUMN WHERE TableName='${tblName}' ORDER BY createtime DESC LIMIT 1 """
+                time 600
+            }
+        } finally {
+            GetDebugPoint().clearDebugPointsForAllBEs()
+        }
+
+        GetDebugPoint().enableDebugPointForAllBEs("SchemaChangeJob::_do_process_alter_tablet.block")
+        try {
+            sql """ ALTER TABLE ${tblName} MODIFY COLUMN v1 VARCHAR(100) """
+            sleep(3000)
+            cluster.stopBackends(1, 2)
+            GetDebugPoint().clearDebugPointsForAllBEs()
+            waitForSchemaChangeDone {
+                sql """ SHOW ALTER TABLE COLUMN WHERE TableName='${tblName}' ORDER BY createtime DESC LIMIT 1 """
+                time 600
+            }
+            assertTrue(false)
+        } catch (Exception ignore) {
+            // do nothing
+        } finally {
+            GetDebugPoint().clearDebugPointsForAllBEs()
+        }
+    }
+}

--- a/regression-test/suites/fault_injection_p0/test_sc_success_when_be_down.groovy
+++ b/regression-test/suites/fault_injection_p0/test_sc_success_when_be_down.groovy
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite("test_sc_success_when_be_down", "docker") {
+    def options = new ClusterOptions()
+    options.cloudMode = false
+    options.beNum = 3
+    options.feNum = 2
+    options.enableDebugPoints()
+    options.feConfigs += ["agent_task_health_check_intervals_ms=5000"]
+
+    docker(options) {
+        GetDebugPoint().clearDebugPointsForAllBEs()
+
+        def tblName = "test_sc_success_when_be_down"
+        sql """ DROP TABLE IF EXISTS ${tblName} """
+        sql """
+                CREATE TABLE IF NOT EXISTS ${tblName} (
+                    `k` int NOT NULL,
+                    `v0` int NOT NULL,
+                    `v1` int NOT NULL
+                ) 
+                DUPLICATE KEY(`k`)
+                DISTRIBUTED BY HASH(`k`) BUCKETS 24
+                PROPERTIES (
+                    "replication_allocation" = "tag.location.default: 3"
+                )
+        """
+        sql """ INSERT INTO ${tblName} SELECT number, number, number from numbers("number" = "1024") """
+
+        GetDebugPoint().enableDebugPointForAllBEs("SchemaChangeJob._do_process_alter_tablet.sleep")
+        try {
+            sql """ ALTER TABLE ${tblName} MODIFY COLUMN v0 VARCHAR(100) """
+            sleep(3000)
+            cluster.stopBackends(1)
+            waitForSchemaChangeDone {
+                sql """ SHOW ALTER TABLE COLUMN WHERE TableName='${tblName}' ORDER BY createtime DESC LIMIT 1 """
+                time 600
+            }
+        } finally {
+            GetDebugPoint().clearDebugPointsForAllBEs()
+        }
+    }
+}

--- a/regression-test/suites/fault_injection_p0/test_sc_success_when_be_down.groovy
+++ b/regression-test/suites/fault_injection_p0/test_sc_success_when_be_down.groovy
@@ -45,16 +45,12 @@ suite("test_sc_success_when_be_down", "docker") {
         sql """ INSERT INTO ${tblName} SELECT number, number, number from numbers("number" = "1024") """
 
         GetDebugPoint().enableDebugPointForAllBEs("SchemaChangeJob._do_process_alter_tablet.sleep")
-        try {
-            sql """ ALTER TABLE ${tblName} MODIFY COLUMN v0 VARCHAR(100) """
-            sleep(3000)
-            cluster.stopBackends(1)
-            waitForSchemaChangeDone {
-                sql """ SHOW ALTER TABLE COLUMN WHERE TableName='${tblName}' ORDER BY createtime DESC LIMIT 1 """
-                time 600
-            }
-        } finally {
-            GetDebugPoint().clearDebugPointsForAllBEs()
-        }
+        sql """ ALTER TABLE ${tblName} MODIFY COLUMN v0 VARCHAR(100) """
+        sleep(3000)
+        cluster.stopBackends(1)
+        waitForSchemaChangeDone {
+        sql """ SHOW ALTER TABLE COLUMN WHERE TableName='${tblName}' ORDER BY createtime DESC LIMIT 1 """
+        time 600
+}
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

When BE down, corresponding tasks will never finish until timeout. Fix this problem by adding a daemon thrad to do clean up.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

