### PR TITLE
[improve](function) opt the input column when it's const column

### DIFF
--- a/be/src/vec/functions/array/function_array_element.h
+++ b/be/src/vec/functions/array/function_array_element.h
@@ -222,7 +222,7 @@ private:
                 null_flag = true;
             }
             // nested column nullable check
-            if (!null_flag && array_nested_null_map && array_nested_null_map[index]) {
+            if (!null_flag && array_nested_null_map[index]) {
                 null_flag = true;
             }
             // actual data copy
@@ -270,7 +270,7 @@ private:
                 null_flag = true;
             }
             // nested column nullable check
-            if (!null_flag && nested_null_map && nested_null_map[index]) {
+            if (!null_flag && nested_null_map[index]) {
                 null_flag = true;
             }
             // actual string copy
@@ -348,7 +348,7 @@ private:
                 null_flag = true;
             }
             // nested column nullable check
-            if (!null_flag && nested_null_map && nested_null_map[index]) {
+            if (!null_flag && nested_null_map[index]) {
                 null_flag = true;
             }
             // actual data copy


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:

the array column of function convert_to_full_column_if_const is very slow, 
so we could handle const column directly, to skip the convert

```
mysql> SELECT count([[], [2]][UserID % 2 + 2]) FROM array_index_table;
+----------------------------------+
| count([[], [2]][UserID % 2 + 2]) |
+----------------------------------+
|                         50000000 |
+----------------------------------+
1 row in set (3.05 sec)

mysql>
mysql>
mysql>
mysql> SELECT count([[], [2]][UserID % 2 + 2]) FROM array_index_table;
+----------------------------------+
| count([[], [2]][UserID % 2 + 2]) |
+----------------------------------+
|                         50000000 |
+----------------------------------+
1 row in set (9.21 sec)
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

