### PR TITLE
[improve](ann index)Accumulate multiple small batches before training

### DIFF
--- a/be/src/olap/rowset/segment_v2/ann_index/ann_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/ann_index/ann_index_writer.cpp
@@ -78,9 +78,7 @@ Status AnnIndexColumnWriter::init() {
             build_parameter.ef_construction, quantizer);
 
     size_t block_size = CHUNK_SIZE * build_parameter.dim;
-    // The array capacity will not change after resizing
-    _float_array.resize(block_size);
-    _array_offset = 0;
+    _float_array.reserve(block_size);
 
     return Status::OK();
 }
@@ -111,22 +109,21 @@ Status AnnIndexColumnWriter::add_array_values(size_t field_size, const void* val
 
     const float* p = reinterpret_cast<const float*>(value_ptr);
 
+    const size_t full_elements = CHUNK_SIZE * dim;
     size_t remaining_elements = num_rows * dim;
     size_t src_offset = 0;
     while (remaining_elements > 0) {
-        size_t available_space = _float_array.size() - _array_offset;
+        size_t available_space = full_elements - _float_array.size();
         size_t elements_to_add = std::min(remaining_elements, available_space);
 
-        memcpy(_float_array.data() + _array_offset, p + src_offset,
-               elements_to_add * sizeof(float));
-        _array_offset += elements_to_add;
+        _float_array.insert(_float_array.end(), p + src_offset, p + src_offset + elements_to_add);
         src_offset += elements_to_add;
         remaining_elements -= elements_to_add;
 
-        if (_array_offset == _float_array.size()) {
+        if (_float_array.size() == full_elements) {
             RETURN_IF_ERROR(_vector_index->train(CHUNK_SIZE, _float_array.data()));
             RETURN_IF_ERROR(_vector_index->add(CHUNK_SIZE, _float_array.data()));
-            _array_offset = 0;
+            _float_array.clear();
         }
     }
 
@@ -152,12 +149,12 @@ int64_t AnnIndexColumnWriter::size() const {
 
 Status AnnIndexColumnWriter::finish() {
     // train/add the remaining data
-    if (_array_offset > 0) {
-        DCHECK(_array_offset % _vector_index->get_dimension() == 0);
-        vectorized::Int64 num_rows = _array_offset / _vector_index->get_dimension();
+    if (!_float_array.empty()) {
+        DCHECK(_float_array.size() % _vector_index->get_dimension() == 0);
+        vectorized::Int64 num_rows = _float_array.size() / _vector_index->get_dimension();
         RETURN_IF_ERROR(_vector_index->train(num_rows, _float_array.data()));
         RETURN_IF_ERROR(_vector_index->add(num_rows, _float_array.data()));
-        _array_offset = 0;
+        _float_array.clear();
     }
 
     return _vector_index->save(_dir.get());

--- a/be/src/olap/rowset/segment_v2/ann_index/ann_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/ann_index/ann_index_writer.cpp
@@ -106,6 +106,7 @@ Status AnnIndexColumnWriter::add_array_values(size_t field_size, const void* val
     const float* p = reinterpret_cast<const float*>(value_ptr);
 
     // Add to buffer
+    _ann_vec.reserve(_ann_vec.size() + num_rows * dim);
     _ann_vec.insert(_ann_vec.end(), p, p + num_rows * dim);
     DCHECK(_ann_vec.size() % dim == 0);
 

--- a/be/src/olap/rowset/segment_v2/ann_index/ann_index_writer.h
+++ b/be/src/olap/rowset/segment_v2/ann_index/ann_index_writer.h
@@ -70,6 +70,7 @@ private:
     // VectorIndex should be weak shared by AnnIndexWriter and VectorIndexReader
     // This should be a weak_ptr
     std::shared_ptr<VectorIndex> _vector_index;
+    std::vector<float> _ann_vec;
     IndexFileWriter* _index_file_writer;
     const TabletIndex* _index_meta;
     std::shared_ptr<DorisFSDirectory> _dir;

--- a/be/src/olap/rowset/segment_v2/ann_index/ann_index_writer.h
+++ b/be/src/olap/rowset/segment_v2/ann_index/ann_index_writer.h
@@ -34,6 +34,7 @@
 #include "olap/rowset/segment_v2/inverted_index_fs_directory.h"
 #include "olap/tablet_schema.h"
 #include "runtime/collection_value.h"
+#include "vec/common/custom_allocator.h"
 
 namespace doris::segment_v2 {
 #include "common/compile_check_begin.h"
@@ -70,7 +71,7 @@ private:
     // VectorIndex should be weak shared by AnnIndexWriter and VectorIndexReader
     // This should be a weak_ptr
     std::shared_ptr<VectorIndex> _vector_index;
-    std::vector<float> _ann_vec;
+    DorisVector<float> _ann_vec;
     IndexFileWriter* _index_file_writer;
     const TabletIndex* _index_meta;
     std::shared_ptr<DorisFSDirectory> _dir;

--- a/be/src/olap/rowset/segment_v2/ann_index/ann_index_writer.h
+++ b/be/src/olap/rowset/segment_v2/ann_index/ann_index_writer.h
@@ -34,12 +34,17 @@
 #include "olap/rowset/segment_v2/inverted_index_fs_directory.h"
 #include "olap/tablet_schema.h"
 #include "runtime/collection_value.h"
-#include "vec/common/custom_allocator.h"
+#include "vec/common/pod_array.h"
 
 namespace doris::segment_v2 {
 #include "common/compile_check_begin.h"
 class AnnIndexColumnWriter : public IndexColumnWriter {
 public:
+#ifdef BE_TEST
+    static constexpr int64_t CHUNK_SIZE = 10;
+#else
+    static constexpr int64_t CHUNK_SIZE = 1'000'000;
+#endif
     static constexpr const char* INDEX_TYPE = "index_type";
     static constexpr const char* METRIC_TYPE = "metric_type";
     static constexpr const char* DIM = "dim";
@@ -71,7 +76,8 @@ private:
     // VectorIndex should be weak shared by AnnIndexWriter and VectorIndexReader
     // This should be a weak_ptr
     std::shared_ptr<VectorIndex> _vector_index;
-    DorisVector<float> _ann_vec;
+    vectorized::PODArray<float> _float_array;
+    size_t _array_offset;
     IndexFileWriter* _index_file_writer;
     const TabletIndex* _index_meta;
     std::shared_ptr<DorisFSDirectory> _dir;

--- a/be/src/olap/rowset/segment_v2/ann_index/ann_index_writer.h
+++ b/be/src/olap/rowset/segment_v2/ann_index/ann_index_writer.h
@@ -77,7 +77,6 @@ private:
     // This should be a weak_ptr
     std::shared_ptr<VectorIndex> _vector_index;
     vectorized::PODArray<float> _float_array;
-    size_t _array_offset;
     IndexFileWriter* _index_file_writer;
     const TabletIndex* _index_meta;
     std::shared_ptr<DorisFSDirectory> _dir;

--- a/be/test/olap/vector_search/ann_index_writer_test.cpp
+++ b/be/test/olap/vector_search/ann_index_writer_test.cpp
@@ -36,6 +36,32 @@ using namespace doris::vector_search_utils;
 
 namespace doris::segment_v2 {
 
+class MockVectorIndex : public VectorIndex {
+public:
+    MockVectorIndex() { _dimension = 4; } // Set dimension for test
+    MOCK_METHOD(doris::Status, train, (vectorized::Int64 n, const float* vec), (override));
+    MOCK_METHOD(doris::Status, add, (vectorized::Int64 n, const float* vec), (override));
+    MOCK_METHOD(doris::Status, ann_topn_search,
+                (const float* query_vec, int k, const segment_v2::IndexSearchParameters& params,
+                 segment_v2::IndexSearchResult& result),
+                (override));
+    MOCK_METHOD(doris::Status, range_search,
+                (const float* query_vec, const float& radius,
+                 const segment_v2::IndexSearchParameters& params,
+                 segment_v2::IndexSearchResult& result),
+                (override));
+    MOCK_METHOD(doris::Status, save, (lucene::store::Directory * dir), (override));
+    MOCK_METHOD(doris::Status, load, (lucene::store::Directory * dir), (override));
+};
+
+class TestAnnIndexColumnWriter : public AnnIndexColumnWriter {
+public:
+    TestAnnIndexColumnWriter(IndexFileWriter* index_file_writer, const TabletIndex* index_meta)
+            : AnnIndexColumnWriter(index_file_writer, index_meta) {}
+
+    void set_vector_index(std::shared_ptr<VectorIndex> index) { _vector_index = index; }
+};
+
 class AnnIndexWriterTest : public ::testing::Test {
 protected:
     void SetUp() override {
@@ -382,6 +408,69 @@ TEST_F(AnnIndexWriterTest, TestInvalidMetricType) {
 
     // This should throw an exception due to invalid metric type
     EXPECT_THROW(writer->init(), doris::Exception);
+}
+
+TEST_F(AnnIndexWriterTest, TestAddMoreThanChunkSize) {
+    auto mock_index = std::make_shared<MockVectorIndex>();
+    auto writer = std::make_unique<TestAnnIndexColumnWriter>(_index_file_writer.get(),
+                                                             _tablet_index.get());
+
+    auto fs_dir = std::make_shared<DorisRAMFSDirectory>();
+    fs_dir->init(doris::io::global_local_filesystem(), "./ut_dir/tmp_vector_search", nullptr);
+    EXPECT_CALL(*_index_file_writer, open(testing::_)).WillOnce(testing::Return(fs_dir));
+
+    ASSERT_TRUE(writer->init().ok());
+    writer->set_vector_index(mock_index);
+
+    EXPECT_CALL(*mock_index, train(10, testing::_))
+            .Times(1)
+            .WillOnce(testing::Return(Status::OK()));
+    EXPECT_CALL(*mock_index, add(10, testing::_)).Times(1).WillOnce(testing::Return(Status::OK()));
+    EXPECT_CALL(*mock_index, train(2, testing::_)).Times(1).WillOnce(testing::Return(Status::OK()));
+    EXPECT_CALL(*mock_index, add(2, testing::_)).Times(1).WillOnce(testing::Return(Status::OK()));
+    EXPECT_CALL(*mock_index, save(testing::_)).Times(1).WillOnce(testing::Return(Status::OK()));
+
+    // CHUNK_SIZE = 10
+    const size_t dim = 4;
+
+    {
+        const size_t num_rows = 6;
+        std::vector<float> vectors = {
+                1.0f,  2.0f,  3.0f,  4.0f,  // Row 0
+                5.0f,  6.0f,  7.0f,  8.0f,  // Row 1
+                9.0f,  10.0f, 11.0f, 12.0f, // Row 2
+                13.0f, 14.0f, 15.0f, 16.0f, // Row 3
+                17.0f, 18.0f, 19.0f, 20.0f, // Row 4
+                21.0f, 22.0f, 23.0f, 24.0f  // Row 5
+        };
+        std::vector<size_t> offsets = {0, 4, 8, 12, 16, 20, 24};
+
+        Status status = writer->add_array_values(sizeof(float), vectors.data(), nullptr,
+                                                 reinterpret_cast<const uint8_t*>(offsets.data()),
+                                                 num_rows);
+        EXPECT_TRUE(status.ok());
+    }
+
+    {
+        const size_t num_rows = 6;
+        std::vector<float> vectors = {
+                25.0f, 26.0f, 27.0f, 28.0f, // Row 6
+                29.0f, 30.0f, 31.0f, 32.0f, // Row 7
+                33.0f, 34.0f, 35.0f, 36.0f, // Row 8
+                37.0f, 38.0f, 39.0f, 40.0f, // Row 9
+                41.0f, 42.0f, 43.0f, 44.0f, // Row 10
+                45.0f, 46.0f, 47.0f, 48.0f  // Row 11
+        };
+        std::vector<size_t> offsets = {0, 4, 8, 12, 16, 20, 24};
+
+        Status status = writer->add_array_values(sizeof(float), vectors.data(), nullptr,
+                                                 reinterpret_cast<const uint8_t*>(offsets.data()),
+                                                 num_rows);
+        EXPECT_TRUE(status.ok());
+    }
+
+    Status status = writer->finish();
+    EXPECT_TRUE(status.ok());
 }
 
 } // namespace doris::segment_v2

--- a/regression-test/suites/ann_index_p0/product_quantization.groovy
+++ b/regression-test/suites/ann_index_p0/product_quantization.groovy
@@ -46,7 +46,7 @@ suite("product_quantization") {
             properties('replication_num' = '1');"""
     test {
         sql """insert into product_quantization values (1, [1.0, 2.0, 3.0, 4.0])"""
-        exception """Not enough training data for PQ index"""
+        exception """exception occurred during training"""
     }
 
     sql """drop table if exists product_quantization"""


### PR DESCRIPTION
### What problem does this PR solve?

Accumulate multiple small batches to avoid the following error when training:
`Error: 'nx >= k' failed: Number of training points should be at least as large as number of clusters`,
and significantly reduce the time for faiss train/add.

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

