### PR TITLE
[chore](dep)Exclude AWS SDK bundle to reduce dependency size and include only required S3 modules

### DIFF
--- a/fe/be-java-extensions/preload-extensions/pom.xml
+++ b/fe/be-java-extensions/preload-extensions/pom.xml
@@ -159,6 +159,10 @@ under the License.
             <artifactId>s3tables</artifactId>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3-transfer-manager</artifactId>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.s3tables</groupId>
             <artifactId>s3-tables-catalog-for-iceberg</artifactId>
             <version>${s3tables.catalog.version}</version>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -636,6 +636,10 @@ under the License.
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3-transfer-manager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
             <exclusions>
                 <exclusion>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -1169,6 +1169,11 @@ under the License.
                 <artifactId>hadoop-aws</artifactId>
                 <version>${hadoop.version}</version>
                 <exclusions>
+                    <!-- NB: Exclude the AWS SDK bundle because it’s a large monolithic package, and we only need the S3 modules to reduce dependency size.-->
+                    <exclusion>
+                        <groupId>software.amazon.awssdk</groupId>
+                        <artifactId>bundle</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-log4j12</artifactId>


### PR DESCRIPTION
…

This PR excludes the aws-java-sdk-bundle from the hadoop-aws dependency to reduce the overall project size by including only the necessary S3 SDK modules.
