### PR TITLE
[Bug](exchange) avoid coredump coz nullptr

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -753,8 +753,10 @@ Status ExchangeSinkLocalState::close(RuntimeState* state, Status exec_status) {
         COUNTER_UPDATE(_wait_broadcast_buffer_timer, _broadcast_dependency->watcher_elapse_time());
     }
     for (size_t i = 0; i < _local_channels_dependency.size(); i++) {
-        COUNTER_UPDATE(_wait_channel_timer[i],
-                       _local_channels_dependency[i]->watcher_elapse_time());
+        if (_wait_channel_timer[i] && _local_channels_dependency[i]) {
+            COUNTER_UPDATE(_wait_channel_timer[i],
+                           _local_channels_dependency[i]->watcher_elapse_time());
+        }
     }
     if (_sink_buffer) {
         _sink_buffer->update_profile(profile());


### PR DESCRIPTION
### What problem does this PR solve?
In some cases (such as when the operator is triggered to cancel before opened), the operator close may encounter a core dump due to a nullptr.

```cpp
*** Current BE git commitID: 50e6e413f5 ***
*** SIGSEGV unknown detail explain (@0x0) received by PID 3836583 (TID 3840122 OR 0x7f840373a700) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_enterprise/doris/be/src/common/signal_handler.h:421
 1# os::Linux::chained_handler(int, siginfo_t*, void*) in /data1/doris/java8/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /data1/doris/java8/jre/lib/amd64/server/libjvm.so
 3# signalHandler(int, siginfo_t*, void*) in /data1/doris/java8/jre/lib/amd64/server/libjvm.so
 4# 0x00007F8FC93CD880 in /lib64/libc.so.6
 5# doris::pipeline::ExchangeSinkLocalState::close(doris::RuntimeState*, doris::Status) at /home/zcp/repo_center/doris_enterprise/doris/be/src/pipeline/exec/exchange_sink_operator.cpp:759
 6# doris::pipeline::DataSinkOperatorXBase::close(doris::RuntimeState*, doris::Status) at /home/zcp/repo_center/doris_enterprise/doris/be/src/pipeline/pipeline_x/operator.h:664
 7# doris::pipeline::PipelineXTask::close(doris::Status, bool) at /home/zcp/repo_center/doris_enterprise/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:462
 8# doris::pipeline::_close_task(doris::pipeline::PipelineTask*, doris::pipeline::PipelineTaskState, doris::Status) at /home/zcp/repo_center/doris_enterprise/doris/be/src/pipeline/task_scheduler.cpp:246
 9# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /home/zcp/repo_center/doris_enterprise/doris/be/src/pipeline/task_scheduler.cpp:288
10# doris::ThreadPool::dispatch_thread() in /data1/doris/be/lib/doris_be
11# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_enterprise/doris/be/src/util/thread.cpp:499
12# start_thread in /lib64/libpthread.so.0
13# clone in /lib64/libc.so.6
```
This pull request makes a small improvement to the `ExchangeSinkLocalState::close` method by adding a null check before updating channel timers, which helps prevent potential crashes or undefined behavior.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

