### PR TITLE
[refine](expr)Mark expr's execution function as const.

### DIFF
--- a/be/src/vec/exprs/lambda_function/lambda_function.h
+++ b/be/src/vec/exprs/lambda_function/lambda_function.h
@@ -38,7 +38,7 @@ public:
 
     virtual doris::Status execute(VExprContext* context, doris::vectorized::Block* block,
                                   int* result_column_id, const DataTypePtr& result_type,
-                                  const VExprSPtrs& children) = 0;
+                                  const VExprSPtrs& children) const = 0;
 
     int batch_size;
 };

--- a/be/src/vec/exprs/lambda_function/varray_filter_function.cpp
+++ b/be/src/vec/exprs/lambda_function/varray_filter_function.cpp
@@ -54,7 +54,7 @@ public:
 
     doris::Status execute(VExprContext* context, doris::vectorized::Block* block,
                           int* result_column_id, const DataTypePtr& result_type,
-                          const VExprSPtrs& children) override {
+                          const VExprSPtrs& children) const override {
         ///* array_filter(array, array<boolean>) *///
 
         //1. child[0:end]->execute(src_block)

--- a/be/src/vec/exprs/lambda_function/varray_map_function.cpp
+++ b/be/src/vec/exprs/lambda_function/varray_map_function.cpp
@@ -77,7 +77,7 @@ public:
     std::string get_name() const override { return name; }
 
     Status execute(VExprContext* context, vectorized::Block* block, int* result_column_id,
-                   const DataTypePtr& result_type, const VExprSPtrs& children) override {
+                   const DataTypePtr& result_type, const VExprSPtrs& children) const override {
         LambdaArgs args_info;
         // collect used slot ref in lambda function body
         std::vector<int>& output_slot_ref_indexs = args_info.output_slot_ref_indexs;
@@ -340,12 +340,12 @@ public:
     }
 
 private:
-    bool _contains_column_id(const std::vector<int>& output_slot_ref_indexs, int id) {
+    bool _contains_column_id(const std::vector<int>& output_slot_ref_indexs, int id) const {
         const auto it = std::find(output_slot_ref_indexs.begin(), output_slot_ref_indexs.end(), id);
         return it != output_slot_ref_indexs.end();
     }
 
-    void _set_column_ref_column_id(VExprSPtr expr, int gap) {
+    void _set_column_ref_column_id(VExprSPtr expr, int gap) const {
         for (const auto& child : expr->children()) {
             if (child->is_column_ref()) {
                 auto* ref = static_cast<VColumnRef*>(child.get());
@@ -356,7 +356,8 @@ private:
         }
     }
 
-    void _collect_slot_ref_column_id(VExprSPtr expr, std::vector<int>& output_slot_ref_indexs) {
+    void _collect_slot_ref_column_id(VExprSPtr expr,
+                                     std::vector<int>& output_slot_ref_indexs) const {
         for (const auto& child : expr->children()) {
             if (child->is_slot_ref()) {
                 const auto* ref = static_cast<VSlotRef*>(child.get());
@@ -369,7 +370,7 @@ private:
 
     void _extend_data(std::vector<MutableColumnPtr>& columns, Block* block,
                       int current_repeat_times, int size, int64_t current_row_idx,
-                      const std::vector<int>& output_slot_ref_indexs) {
+                      const std::vector<int>& output_slot_ref_indexs) const {
         if (!current_repeat_times || !size) {
             return;
         }

--- a/be/src/vec/exprs/vbitmap_predicate.cpp
+++ b/be/src/vec/exprs/vbitmap_predicate.cpp
@@ -77,7 +77,7 @@ doris::Status vectorized::VBitmapPredicate::open(doris::RuntimeState* state,
 
 doris::Status vectorized::VBitmapPredicate::execute(vectorized::VExprContext* context,
                                                     doris::vectorized::Block* block,
-                                                    int* result_column_id) {
+                                                    int* result_column_id) const {
     DCHECK(_open_finished || _getting_const_col);
     doris::vectorized::ColumnNumbers arguments(_children.size());
     for (int i = 0; i < _children.size(); ++i) {

--- a/be/src/vec/exprs/vbitmap_predicate.h
+++ b/be/src/vec/exprs/vbitmap_predicate.h
@@ -49,7 +49,7 @@ public:
 
     ~VBitmapPredicate() override = default;
 
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
 
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
 

--- a/be/src/vec/exprs/vbloom_predicate.cpp
+++ b/be/src/vec/exprs/vbloom_predicate.cpp
@@ -70,7 +70,7 @@ void VBloomPredicate::close(VExprContext* context, FunctionContext::FunctionStat
     VExpr::close(context, scope);
 }
 
-Status VBloomPredicate::execute(VExprContext* context, Block* block, int* result_column_id) {
+Status VBloomPredicate::execute(VExprContext* context, Block* block, int* result_column_id) const {
     DCHECK(_open_finished || _getting_const_col);
     doris::vectorized::ColumnNumbers arguments(_children.size());
     for (int i = 0; i < _children.size(); ++i) {

--- a/be/src/vec/exprs/vbloom_predicate.h
+++ b/be/src/vec/exprs/vbloom_predicate.h
@@ -43,7 +43,7 @@ class VBloomPredicate final : public VExpr {
 public:
     VBloomPredicate(const TExprNode& node);
     ~VBloomPredicate() override = default;
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;

--- a/be/src/vec/exprs/vcase_expr.cpp
+++ b/be/src/vec/exprs/vcase_expr.cpp
@@ -76,7 +76,7 @@ void VCaseExpr::close(VExprContext* context, FunctionContext::FunctionStateScope
     VExpr::close(context, scope);
 }
 
-Status VCaseExpr::execute(VExprContext* context, Block* block, int* result_column_id) {
+Status VCaseExpr::execute(VExprContext* context, Block* block, int* result_column_id) const {
     if (is_const_and_have_executed()) { // const have execute in open function
         return get_result_from_const(block, EXPR_NAME, result_column_id);
     }

--- a/be/src/vec/exprs/vcase_expr.h
+++ b/be/src/vec/exprs/vcase_expr.h
@@ -52,7 +52,7 @@ class VCaseExpr final : public VExpr {
 public:
     VCaseExpr(const TExprNode& node);
     ~VCaseExpr() override = default;
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
@@ -224,7 +224,7 @@ private:
 
     template <typename IndexType>
     ColumnPtr _execute_impl(const std::vector<ColumnPtr>& when_columns,
-                            std::vector<ColumnPtr>& then_columns, size_t rows_count) {
+                            std::vector<ColumnPtr>& then_columns, size_t rows_count) const {
         std::vector<IndexType> then_idx(rows_count, 0);
         IndexType* __restrict then_idx_ptr = then_idx.data();
         for (IndexType i = 0; i < when_columns.size(); i++) {

--- a/be/src/vec/exprs/vcast_expr.cpp
+++ b/be/src/vec/exprs/vcast_expr.cpp
@@ -105,7 +105,7 @@ void VCastExpr::close(VExprContext* context, FunctionContext::FunctionStateScope
 }
 
 doris::Status VCastExpr::execute(VExprContext* context, doris::vectorized::Block* block,
-                                 int* result_column_id) {
+                                 int* result_column_id) const {
     DCHECK(_open_finished || _getting_const_col)
             << _open_finished << _getting_const_col << _expr_name;
     if (is_const_and_have_executed()) { // const have executed in open function
@@ -135,7 +135,7 @@ bool cast_error_code(Status& st) {
     }
 }
 
-DataTypePtr TryCastExpr::original_cast_return_type() {
+DataTypePtr TryCastExpr::original_cast_return_type() const {
     if (_original_cast_return_is_nullable) {
         return _data_type;
     } else {
@@ -143,7 +143,7 @@ DataTypePtr TryCastExpr::original_cast_return_type() {
     }
 }
 
-Status TryCastExpr::execute(VExprContext* context, Block* block, int* result_column_id) {
+Status TryCastExpr::execute(VExprContext* context, Block* block, int* result_column_id) const {
     DCHECK(_open_finished || _getting_const_col)
             << _open_finished << _getting_const_col << _expr_name;
     if (is_const_and_have_executed()) { // const have executed in open function
@@ -203,7 +203,7 @@ Status TryCastExpr::execute(VExprContext* context, Block* block, int* result_col
 template <bool original_cast_reutrn_is_nullable>
 Status TryCastExpr::single_row_execute(VExprContext* context,
                                        const ColumnWithTypeAndName& input_info,
-                                       ColumnPtr& return_column) {
+                                       ColumnPtr& return_column) const {
     auto input_column = input_info.column;
     const auto& input_type = input_info.type;
     const auto& input_name = input_info.name;

--- a/be/src/vec/exprs/vcast_expr.h
+++ b/be/src/vec/exprs/vcast_expr.h
@@ -48,7 +48,7 @@ public:
 #endif
     VCastExpr(const TExprNode& node) : VExpr(node) {}
     ~VCastExpr() override = default;
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
@@ -82,15 +82,15 @@ public:
 
     TryCastExpr(const TExprNode& node)
             : VCastExpr(node), _original_cast_return_is_nullable(node.is_cast_nullable) {}
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
     ~TryCastExpr() override = default;
     std::string cast_name() const override { return "TRY CAST"; }
 
 private:
-    DataTypePtr original_cast_return_type();
+    DataTypePtr original_cast_return_type() const;
     template <bool original_cast_reutrn_is_nullable>
     Status single_row_execute(VExprContext* context, const ColumnWithTypeAndName& input_info,
-                              ColumnPtr& return_column);
+                              ColumnPtr& return_column) const;
 
     //Try_cast always returns nullable,
     // but we also need the information of whether the return value of the original cast is nullable.

--- a/be/src/vec/exprs/vcolumn_ref.h
+++ b/be/src/vec/exprs/vcolumn_ref.h
@@ -57,7 +57,7 @@ public:
         return Status::OK();
     }
 
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override {
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
         DCHECK(_open_finished || _getting_const_col);
         *result_column_id = _column_id + _gap;
         return Status::OK();

--- a/be/src/vec/exprs/vcompound_pred.h
+++ b/be/src/vec/exprs/vcompound_pred.h
@@ -155,7 +155,7 @@ public:
         return Status::OK();
     }
 
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override {
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
         if (fast_execute(context, block, result_column_id)) {
             return Status::OK();
         }

--- a/be/src/vec/exprs/vdirect_in_predicate.h
+++ b/be/src/vec/exprs/vdirect_in_predicate.h
@@ -54,7 +54,7 @@ public:
         return Status::OK();
     }
 
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override {
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
         ColumnNumbers arguments;
         return _do_execute(context, block, result_column_id, arguments);
     }
@@ -111,7 +111,7 @@ public:
 
 private:
     Status _do_execute(VExprContext* context, Block* block, int* result_column_id,
-                       ColumnNumbers& arguments) {
+                       ColumnNumbers& arguments) const {
         DCHECK(_open_finished || _getting_const_col);
         arguments.resize(_children.size());
         for (int i = 0; i < _children.size(); ++i) {

--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -186,7 +186,7 @@ Status VectorizedFnCall::evaluate_inverted_index(VExprContext* context, uint32_t
 
 Status VectorizedFnCall::_do_execute(doris::vectorized::VExprContext* context,
                                      doris::vectorized::Block* block, int* result_column_id,
-                                     ColumnNumbers& args) {
+                                     ColumnNumbers& args) const {
     if (is_const_and_have_executed()) { // const have executed in open function
         return get_result_from_const(block, _expr_name, result_column_id);
     }
@@ -267,7 +267,7 @@ Status VectorizedFnCall::execute_runtime_filter(doris::vectorized::VExprContext*
 }
 
 Status VectorizedFnCall::execute(VExprContext* context, vectorized::Block* block,
-                                 int* result_column_id) {
+                                 int* result_column_id) const {
     ColumnNumbers arguments;
     return _do_execute(context, block, result_column_id, arguments);
 }

--- a/be/src/vec/exprs/vectorized_fn_call.h
+++ b/be/src/vec/exprs/vectorized_fn_call.h
@@ -52,7 +52,7 @@ public:
     VectorizedFnCall() = default;
 #endif
     VectorizedFnCall(const TExprNode& node);
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
     Status execute_runtime_filter(doris::vectorized::VExprContext* context,
                                   doris::vectorized::Block* block, int* result_column_id,
                                   ColumnNumbers& args) override;
@@ -102,7 +102,7 @@ protected:
 
 private:
     Status _do_execute(doris::vectorized::VExprContext* context, doris::vectorized::Block* block,
-                       int* result_column_id, ColumnNumbers& args);
+                       int* result_column_id, ColumnNumbers& args) const;
 };
 
 #include "common/compile_check_end.h"

--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -823,7 +823,7 @@ uint64_t VExpr::get_digest(uint64_t seed) const {
 }
 
 Status VExpr::get_result_from_const(vectorized::Block* block, const std::string& expr_name,
-                                    int* result_column_id) {
+                                    int* result_column_id) const {
     *result_column_id = block->columns();
     auto column = ColumnConst::create(_constant_col->column_ptr, block->rows());
     block->insert({std::move(column), _data_type, expr_name});
@@ -974,7 +974,7 @@ size_t VExpr::estimate_memory(const size_t rows) {
 }
 
 bool VExpr::fast_execute(doris::vectorized::VExprContext* context, doris::vectorized::Block* block,
-                         int* result_column_id) {
+                         int* result_column_id) const {
     if (context->get_inverted_index_context() &&
         context->get_inverted_index_context()->get_inverted_index_result_column().contains(this)) {
         uint32_t num_columns_without_result = block->columns();

--- a/be/src/vec/exprs/vexpr.h
+++ b/be/src/vec/exprs/vexpr.h
@@ -130,7 +130,7 @@ public:
         return Status::InternalError(expr_name() + " is not ready when execute");
     }
 
-    virtual Status execute(VExprContext* context, Block* block, int* result_column_id) = 0;
+    virtual Status execute(VExprContext* context, Block* block, int* result_column_id) const = 0;
     // `is_blockable` means this expr will be blocked in `execute` (e.g. AI Function, Remote Function)
     [[nodiscard]] virtual bool is_blockable() const {
         return std::any_of(_children.begin(), _children.end(),
@@ -277,7 +277,7 @@ public:
 
     // fast_execute can direct copy expr filter result which build by apply index in segment_iterator
     bool fast_execute(doris::vectorized::VExprContext* context, doris::vectorized::Block* block,
-                      int* result_column_id);
+                      int* result_column_id) const;
 
     virtual bool can_push_down_to_index() const { return false; }
     virtual bool equals(const VExpr& other);
@@ -344,10 +344,12 @@ protected:
         return res;
     }
 
-    bool is_const_and_have_executed() { return (is_constant() && (_constant_col != nullptr)); }
+    bool is_const_and_have_executed() const {
+        return (is_constant() && (_constant_col != nullptr));
+    }
 
     Status get_result_from_const(vectorized::Block* block, const std::string& expr_name,
-                                 int* result_column_id);
+                                 int* result_column_id) const;
 
     Status check_constant(const Block& block, ColumnNumbers arguments) const;
 

--- a/be/src/vec/exprs/vin_predicate.cpp
+++ b/be/src/vec/exprs/vin_predicate.cpp
@@ -114,7 +114,7 @@ Status VInPredicate::evaluate_inverted_index(VExprContext* context, uint32_t seg
     return _evaluate_inverted_index(context, _function, segment_num_rows);
 }
 
-Status VInPredicate::execute(VExprContext* context, Block* block, int* result_column_id) {
+Status VInPredicate::execute(VExprContext* context, Block* block, int* result_column_id) const {
     if (is_const_and_have_executed()) { // const have execute in open function
         return get_result_from_const(block, _expr_name, result_column_id);
     }

--- a/be/src/vec/exprs/vin_predicate.h
+++ b/be/src/vec/exprs/vin_predicate.h
@@ -45,7 +45,7 @@ public:
     VInPredicate() = default;
 #endif
     ~VInPredicate() override = default;
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
     size_t estimate_memory(const size_t rows) override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,

--- a/be/src/vec/exprs/vinfo_func.cpp
+++ b/be/src/vec/exprs/vinfo_func.cpp
@@ -55,7 +55,8 @@ VInfoFunc::VInfoFunc(const TExprNode& node) : VExpr(node) {
     this->_column_ptr = _data_type->create_column_const(1, field);
 }
 
-Status VInfoFunc::execute(VExprContext* context, vectorized::Block* block, int* result_column_id) {
+Status VInfoFunc::execute(VExprContext* context, vectorized::Block* block,
+                          int* result_column_id) const {
     // Info function should return least one row, e.g. select current_user().
     size_t row_size = std::max(block->rows(), 1UL);
     *result_column_id = VExpr::insert_param(block, {_column_ptr, _data_type, _expr_name}, row_size);

--- a/be/src/vec/exprs/vinfo_func.h
+++ b/be/src/vec/exprs/vinfo_func.h
@@ -39,7 +39,7 @@ public:
     ~VInfoFunc() override = default;
 
     const std::string& expr_name() const override { return _expr_name; }
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
 
 private:
     const std::string _expr_name = "vinfofunc expr";

--- a/be/src/vec/exprs/virtual_slot_ref.cpp
+++ b/be/src/vec/exprs/virtual_slot_ref.cpp
@@ -110,7 +110,7 @@ Status VirtualSlotRef::open(RuntimeState* state, VExprContext* context,
     return Status::OK();
 }
 
-Status VirtualSlotRef::execute(VExprContext* context, Block* block, int* result_column_id) {
+Status VirtualSlotRef::execute(VExprContext* context, Block* block, int* result_column_id) const {
     if (_column_id >= 0 && _column_id >= block->columns()) {
         return Status::Error<ErrorCode::INTERNAL_ERROR>(
                 "input block not contain slot column {}, column_id={}, block={}", *_column_name,

--- a/be/src/vec/exprs/virtual_slot_ref.h
+++ b/be/src/vec/exprs/virtual_slot_ref.h
@@ -31,7 +31,7 @@ public:
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
     const std::string& expr_name() const override;
     std::string expr_label() override;
     std::string debug_string() const override;

--- a/be/src/vec/exprs/vlambda_function_call_expr.h
+++ b/be/src/vec/exprs/vlambda_function_call_expr.h
@@ -63,7 +63,7 @@ public:
         return Status::OK();
     }
 
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override {
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
         DCHECK(_open_finished || _getting_const_col);
         return _lambda_function->execute(context, block, result_column_id, _data_type, _children);
     }

--- a/be/src/vec/exprs/vlambda_function_expr.h
+++ b/be/src/vec/exprs/vlambda_function_expr.h
@@ -42,7 +42,7 @@ public:
         return Status::OK();
     }
 
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override {
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
         DCHECK(_open_finished || _getting_const_col);
         return get_child(0)->execute(context, block, result_column_id);
     }

--- a/be/src/vec/exprs/vliteral.cpp
+++ b/be/src/vec/exprs/vliteral.cpp
@@ -49,7 +49,8 @@ Status VLiteral::prepare(RuntimeState* state, const RowDescriptor& desc, VExprCo
     return Status::OK();
 }
 
-Status VLiteral::execute(VExprContext* context, vectorized::Block* block, int* result_column_id) {
+Status VLiteral::execute(VExprContext* context, vectorized::Block* block,
+                         int* result_column_id) const {
     // Literal expr should return least one row.
     // sometimes we just use a VLiteral without open or prepare. so can't check it at this moment
     size_t row_size = std::max(block->rows(), _column_ptr->size());

--- a/be/src/vec/exprs/vliteral.h
+++ b/be/src/vec/exprs/vliteral.h
@@ -48,7 +48,7 @@ public:
 #endif
 
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
 
     const std::string& expr_name() const override { return _expr_name; }
     std::string debug_string() const override;

--- a/be/src/vec/exprs/vmatch_predicate.cpp
+++ b/be/src/vec/exprs/vmatch_predicate.cpp
@@ -135,7 +135,7 @@ Status VMatchPredicate::evaluate_inverted_index(VExprContext* context, uint32_t 
     return _evaluate_inverted_index(context, _function, segment_num_rows);
 }
 
-Status VMatchPredicate::execute(VExprContext* context, Block* block, int* result_column_id) {
+Status VMatchPredicate::execute(VExprContext* context, Block* block, int* result_column_id) const {
     DCHECK(_open_finished || _getting_const_col);
     if (fast_execute(context, block, result_column_id)) {
         return Status::OK();

--- a/be/src/vec/exprs/vmatch_predicate.h
+++ b/be/src/vec/exprs/vmatch_predicate.h
@@ -49,7 +49,7 @@ class VMatchPredicate final : public VExpr {
 public:
     VMatchPredicate(const TExprNode& node);
     ~VMatchPredicate() override;
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;

--- a/be/src/vec/exprs/vruntimefilter_wrapper.cpp
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.cpp
@@ -87,7 +87,8 @@ void VRuntimeFilterWrapper::close(VExprContext* context,
     _impl->close(context, scope);
 }
 
-Status VRuntimeFilterWrapper::execute(VExprContext* context, Block* block, int* result_column_id) {
+Status VRuntimeFilterWrapper::execute(VExprContext* context, Block* block,
+                                      int* result_column_id) const {
     DCHECK(_open_finished || _getting_const_col);
     if (_judge_counter.fetch_sub(1) == 0) {
         reset_judge_selectivity();

--- a/be/src/vec/exprs/vruntimefilter_wrapper.h
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.h
@@ -53,7 +53,7 @@ public:
     VRuntimeFilterWrapper(const TExprNode& node, VExprSPtr impl, double ignore_thredhold,
                           bool null_aware, int filter_id);
     ~VRuntimeFilterWrapper() override = default;
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
@@ -119,7 +119,7 @@ public:
     }
 
 private:
-    void reset_judge_selectivity() {
+    void reset_judge_selectivity() const {
         _always_true = false;
         _judge_counter = config::runtime_filter_sampling_frequency;
         _judge_input_rows = 0;
@@ -135,10 +135,10 @@ private:
     // is evaluated as true, the logic for always_true is applied for the rest of that period
     // without recalculating. At the beginning of the next period,
     // reset_judge_selectivity is used to reset these variables.
-    std::atomic_int _judge_counter = 0;
-    std::atomic_uint64_t _judge_input_rows = 0;
-    std::atomic_uint64_t _judge_filter_rows = 0;
-    std::atomic_int _always_true = false;
+    mutable std::atomic_int _judge_counter = 0;
+    mutable std::atomic_uint64_t _judge_input_rows = 0;
+    mutable std::atomic_uint64_t _judge_filter_rows = 0;
+    mutable std::atomic_int _always_true = false;
 
     std::shared_ptr<RuntimeProfile::Counter> _rf_input_rows =
             std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0);

--- a/be/src/vec/exprs/vsearch.cpp
+++ b/be/src/vec/exprs/vsearch.cpp
@@ -125,7 +125,7 @@ const std::string& VSearchExpr::expr_name() const {
     return name;
 }
 
-Status VSearchExpr::execute(VExprContext* context, Block* block, int* result_column_id) {
+Status VSearchExpr::execute(VExprContext* context, Block* block, int* result_column_id) const {
     if (fast_execute(context, block, result_column_id)) {
         return Status::OK();
     }

--- a/be/src/vec/exprs/vsearch.h
+++ b/be/src/vec/exprs/vsearch.h
@@ -26,7 +26,7 @@ class VSearchExpr : public VExpr {
 public:
     VSearchExpr(const TExprNode& node);
     ~VSearchExpr() override = default;
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
     const std::string& expr_name() const override;
     Status evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) override;
 

--- a/be/src/vec/exprs/vslot_ref.cpp
+++ b/be/src/vec/exprs/vslot_ref.cpp
@@ -88,7 +88,7 @@ Status VSlotRef::open(RuntimeState* state, VExprContext* context,
     return Status::OK();
 }
 
-Status VSlotRef::execute(VExprContext* context, Block* block, int* result_column_id) {
+Status VSlotRef::execute(VExprContext* context, Block* block, int* result_column_id) const {
     if (_column_id >= 0 && _column_id >= block->columns()) {
         return Status::Error<ErrorCode::INTERNAL_ERROR>(
                 "input block not contain slot column {}, column_id={}, block={}", *_column_name,

--- a/be/src/vec/exprs/vslot_ref.h
+++ b/be/src/vec/exprs/vslot_ref.h
@@ -46,7 +46,7 @@ public:
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override;
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
 
     const std::string& expr_name() const override;
     std::string expr_label() override;

--- a/be/src/vec/exprs/vtopn_pred.h
+++ b/be/src/vec/exprs/vtopn_pred.h
@@ -81,7 +81,7 @@ public:
         return Status::OK();
     }
 
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override {
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
         if (!_predicate->has_value()) {
             block->insert({create_always_true_column(block->rows(), _data_type->is_nullable()),
                            _data_type, _expr_name});

--- a/be/test/exprs/mock_vexpr.h
+++ b/be/test/exprs/mock_vexpr.h
@@ -29,8 +29,8 @@ class MockVExpr : public VExpr {
 public:
     MOCK_CONST_METHOD0(clone, VExprSPtr());
     MOCK_CONST_METHOD0(expr_name, const std::string&());
-    MOCK_METHOD3(execute,
-                 Status(VExprContext* context, vectorized::Block* block, int* result_column_id));
+    MOCK_CONST_METHOD3(execute, Status(VExprContext* context, vectorized::Block* block,
+                                       int* result_column_id));
 }; // class MockVExpr
 
 } // namespace vectorized

--- a/be/test/exprs/virtual_slot_ref_test.cpp
+++ b/be/test/exprs/virtual_slot_ref_test.cpp
@@ -168,7 +168,7 @@ TEST_F(VirtualSlotRefTest, EqualsFunction_WithDifferentTypes) {
     class MockVExpr : public VExpr {
     public:
         MockVExpr() : VExpr(std::make_shared<DataTypeString>(), false) {}
-        Status execute(VExprContext* context, Block* block, int* result_column_id) override {
+        Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
             return Status::OK();
         }
         const std::string& expr_name() const override {
@@ -283,7 +283,7 @@ TEST_F(VirtualSlotRefTest, EqualsFunction_TestAllBranches) {
         DifferentVExpr() : VExpr(std::make_shared<DataTypeString>(), false) {
             _node_type = TExprNodeType::SLOT_REF; // Different from VIRTUAL_SLOT_REF
         }
-        Status execute(VExprContext* context, Block* block, int* result_column_id) override {
+        Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
             return Status::OK();
         }
         const std::string& expr_name() const override {
@@ -303,7 +303,7 @@ TEST_F(VirtualSlotRefTest, EqualsFunction_TestAllBranches) {
         NonVirtualSlotRefExpr() : VExpr(std::make_shared<DataTypeString>(), false) {
             _node_type = TExprNodeType::VIRTUAL_SLOT_REF; // Same type but different class
         }
-        Status execute(VExprContext* context, Block* block, int* result_column_id) override {
+        Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
             return Status::OK();
         }
         const std::string& expr_name() const override {

--- a/be/test/olap/collection_statistics_test.cpp
+++ b/be/test/olap/collection_statistics_test.cpp
@@ -48,7 +48,7 @@ public:
     TExprNodeType::type node_type() const override { return _mock_node_type; }
 
     Status execute(vectorized::VExprContext* context, vectorized::Block* block,
-                   int32_t* result_column_id) override {
+                   int32_t* result_column_id) const override {
         return Status::OK();
     }
 

--- a/be/test/testutil/mock/mock_fn_call.h
+++ b/be/test/testutil/mock/mock_fn_call.h
@@ -40,7 +40,7 @@ public:
         return Status::OK();
     }
 
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override {
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
         return Status::OK();
     }
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override {

--- a/be/test/testutil/mock/mock_in_expr.h
+++ b/be/test/testutil/mock/mock_in_expr.h
@@ -32,7 +32,7 @@ class MockInExpr final : public VInPredicate {
 public:
     MockInExpr() = default;
 
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override {
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
         return Status::OK();
     }
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;

--- a/be/test/testutil/mock/mock_slot_ref.h
+++ b/be/test/testutil/mock/mock_slot_ref.h
@@ -47,7 +47,7 @@ public:
         _data_type = data_type;
     }
 
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override {
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
         *result_column_id = _column_id;
         return Status::OK();
     }

--- a/be/test/vec/exprs/try_cast_expr_test.cpp
+++ b/be/test/vec/exprs/try_cast_expr_test.cpp
@@ -127,7 +127,7 @@ public:
     MOCK_CONST_METHOD0(clone, VExprSPtr());
     MOCK_CONST_METHOD0(expr_name, const std::string&());
 
-    Status execute(VExprContext* context, Block* block, int* result_column_id) override {
+    Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
         auto int_type = std::make_shared<DataTypeInt32>();
         auto int_column = int_type->create_column();
         for (int i = 0; i < 3; i++) {

--- a/be/test/vec/exprs/vsearch_expr_test.cpp
+++ b/be/test/vec/exprs/vsearch_expr_test.cpp
@@ -69,7 +69,7 @@ public:
         return kName;
     }
 
-    Status execute(VExprContext*, Block*, int*) override { return Status::OK(); }
+    Status execute(VExprContext*, Block*, int*) const override { return Status::OK(); }
 };
 
 const std::string& intern_column_name(const std::string& name) {


### PR DESCRIPTION
### What problem does this PR solve?


Our expr is actually a const function; any mutable data must be stored in VExprContext. Currently only VRuntimeFilterWrapper contains mutable data (because it needs to check the filter rate).

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

