### PR TITLE
[fix](nereids)keep NamedExpression's name unchanged when create an Alias in BindSink

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
@@ -329,7 +329,9 @@ public class BindSink implements AnalysisRuleFactory {
             if (castExpr instanceof NamedExpression) {
                 castExprs.add(((NamedExpression) castExpr));
             } else {
-                castExprs.add(new Alias(castExpr));
+                // use expr's original name as alias name
+                // so that the LogicalPostFilter node in stream load can bind its slot successfully
+                castExprs.add(new Alias(castExpr, expr.getName()));
             }
         }
         if (!castExprs.equals(fullOutputExprs)) {

--- a/regression-test/suites/load_p0/stream_load/test_stream_load_include_where_expr.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_stream_load_include_where_expr.groovy
@@ -26,7 +26,7 @@ suite("test_stream_load_include_where_expr", "p0") {
                     `a` INT COMMENT 'timestamp',
                     `b` INT   COMMENT 'a int value',
                     `c` INT COMMENT 'b int value',
-                    `d` varchar(100)
+                    `d` STRING
                 )
                 DUPLICATE KEY(`a`)
                 DISTRIBUTED BY HASH(a) BUCKETS AUTO


### PR DESCRIPTION
Using the original name keeps the output schema stable and ensures slot binding logic still find the correct slot. Such as bind LogicalPostFilter in stream load plan

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

