### PR TITLE
[Improvement](block) remove some MutableBlock::get_by_name usage

### DIFF
--- a/be/src/common/consts.h
+++ b/be/src/common/consts.h
@@ -25,7 +25,6 @@ const std::string CSV = "csv";
 const std::string CSV_WITH_NAMES = "csv_with_names";
 const std::string CSV_WITH_NAMES_AND_TYPES = "csv_with_names_and_types";
 const std::string BLOCK_TEMP_COLUMN_PREFIX = "__TEMP__";
-const std::string BLOCK_TEMP_COLUMN_SCANNER_FILTERED = "__TEMP__scanner_filtered";
 const std::string ROWID_COL = "__DORIS_ROWID_COL__";
 const std::string GLOBAL_ROWID_COL = "__DORIS_GLOBAL_ROWID_COL__";
 const std::string ROW_STORE_COL = "__DORIS_ROW_STORE_COL__";

--- a/be/src/common/consts.h
+++ b/be/src/common/consts.h
@@ -24,7 +24,6 @@ namespace BeConsts {
 const std::string CSV = "csv";
 const std::string CSV_WITH_NAMES = "csv_with_names";
 const std::string CSV_WITH_NAMES_AND_TYPES = "csv_with_names_and_types";
-const std::string BLOCK_TEMP_COLUMN_PREFIX = "__TEMP__";
 const std::string ROWID_COL = "__DORIS_ROWID_COL__";
 const std::string GLOBAL_ROWID_COL = "__DORIS_GLOBAL_ROWID_COL__";
 const std::string ROW_STORE_COL = "__DORIS_ROW_STORE_COL__";

--- a/be/src/olap/base_tablet.cpp
+++ b/be/src/olap/base_tablet.cpp
@@ -949,7 +949,7 @@ const signed char* BaseTablet::get_delete_sign_column_data(int32_t delete_sign_i
     const vectorized::ColumnWithTypeAndName& delete_sign_column =
             block.safe_get_by_position(block.columns() - 1);
     if (delete_sign_column.name != DELETE_SIGN) {
-        throw Exception(ErrorCode::INTERNAL_ERROR, "The last column is not delete sign column");
+        return nullptr;
     }
     const auto& delete_sign_col =
             assert_cast<const vectorized::ColumnInt8&>(*(delete_sign_column.column));

--- a/be/src/olap/base_tablet.h
+++ b/be/src/olap/base_tablet.h
@@ -210,7 +210,8 @@ public:
                                            int64_t txn_id, const RowsetIdUnorderedSet& rowset_ids,
                                            std::vector<RowsetSharedPtr>* rowsets = nullptr);
 
-    static const signed char* get_delete_sign_column_data(const vectorized::Block& block,
+    static const signed char* get_delete_sign_column_data(int32_t delete_sign_idx,
+                                                          const vectorized::Block& block,
                                                           size_t rows_at_least = 0);
 
     static Status generate_default_value_block(const TabletSchema& schema,

--- a/be/src/olap/partial_update_info.cpp
+++ b/be/src/olap/partial_update_info.cpp
@@ -311,7 +311,10 @@ Status FixedReadPlan::read_columns_by_plan(
         const signed char* __restrict cur_delete_signs) const {
     if (force_read_old_delete_signs) {
         // always read delete sign column from historical data
-        if (auto del_col_cid = tablet_schema.field_index(DELETE_SIGN); del_col_cid != -1) {
+        if (const vectorized::ColumnWithTypeAndName* old_delete_sign_column =
+                    block.try_get_by_name(DELETE_SIGN);
+            old_delete_sign_column == nullptr) {
+            auto del_col_cid = tablet_schema.field_index(DELETE_SIGN);
             cids_to_read.emplace_back(del_col_cid);
             block.swap(tablet_schema.create_block_by_cids(cids_to_read));
         }

--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -478,10 +478,10 @@ Status PushBrokerReader::_cast_to_input_block() {
         if (slot_desc->type()->get_primitive_type() == PrimitiveType::TYPE_VARIANT) {
             continue;
         }
-        auto& arg = _src_block_ptr->get_by_name(slot_desc->col_name());
         // remove nullable here, let the get_function decide whether nullable
         auto return_type = slot_desc->get_data_type_ptr();
         idx = _src_block_name_to_idx[slot_desc->col_name()];
+        auto& arg = _src_block_ptr->get_by_position(idx);
         // bitmap convert：src -> to_base64 -> bitmap_from_base64
         if (slot_desc->type()->get_primitive_type() == TYPE_BITMAP) {
             auto base64_return_type = vectorized::DataTypeFactory::instance().create_data_type(
@@ -491,7 +491,7 @@ Status PushBrokerReader::_cast_to_input_block() {
             RETURN_IF_ERROR(func_to_base64->execute(nullptr, *_src_block_ptr, {idx}, idx,
                                                     arg.column->size()));
             _src_block_ptr->get_by_position(idx).type = std::move(base64_return_type);
-            auto& arg_base64 = _src_block_ptr->get_by_name(slot_desc->col_name());
+            auto& arg_base64 = _src_block_ptr->get_by_position(idx);
             auto func_bitmap_from_base64 =
                     vectorized::SimpleFunctionFactory::instance().get_function(
                             "bitmap_from_base64", {arg_base64}, return_type);

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -557,8 +557,8 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
     bool has_default_or_nullable = false;
     std::vector<bool> use_default_or_null_flag;
     use_default_or_null_flag.reserve(num_rows);
-    const auto* delete_signs =
-            BaseTablet::get_delete_sign_column_data(full_block, row_pos + num_rows);
+    const auto* delete_signs = BaseTablet::get_delete_sign_column_data(
+            _tablet_schema->delete_sign_idx(), full_block, row_pos + num_rows);
 
     const std::vector<RowsetSharedPtr>& specified_rowsets = _mow_context->rowset_ptrs;
     std::vector<std::unique_ptr<SegmentCacheHandle>> segment_caches(specified_rowsets.size());

--- a/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
@@ -542,8 +542,8 @@ Status VerticalSegmentWriter::_append_block_with_partial_content(RowsInBlock& da
     bool has_default_or_nullable = false;
     std::vector<bool> use_default_or_null_flag;
     use_default_or_null_flag.reserve(data.num_rows);
-    const auto* delete_signs =
-            BaseTablet::get_delete_sign_column_data(full_block, data.row_pos + data.num_rows);
+    const auto* delete_signs = BaseTablet::get_delete_sign_column_data(
+            _tablet_schema->delete_sign_idx(), full_block, data.row_pos + data.num_rows);
 
     DBUG_EXECUTE_IF("VerticalSegmentWriter._append_block_with_partial_content.sleep",
                     { sleep(60); })
@@ -708,8 +708,8 @@ Status VerticalSegmentWriter::_append_block_with_flexible_partial_content(
             assert_cast<vectorized::ColumnBitmap*>(
                     data.block->get_by_position(skip_bitmap_col_idx).column->assume_mutable().get())
                     ->get_data());
-    const auto* delete_signs =
-            BaseTablet::get_delete_sign_column_data(*data.block, data.row_pos + data.num_rows);
+    const auto* delete_signs = BaseTablet::get_delete_sign_column_data(
+            _tablet_schema->delete_sign_idx(), *data.block, data.row_pos + data.num_rows);
     DCHECK(delete_signs != nullptr);
 
     for (std::size_t cid {0}; cid < _tablet_schema->num_key_columns(); cid++) {

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -463,7 +463,6 @@ public:
     void set_skip_write_index_on_load(bool skip) { _skip_write_index_on_load = skip; }
     bool skip_write_index_on_load() const { return _skip_write_index_on_load; }
     int32_t delete_sign_idx() const { return _delete_sign_idx; }
-    void set_delete_sign_idx(int32_t delete_sign_idx) { _delete_sign_idx = delete_sign_idx; }
     bool has_sequence_col() const { return _sequence_col_idx != -1; }
     int32_t sequence_col_idx() const { return _sequence_col_idx; }
     void set_version_col_idx(int32_t version_col_idx) { _version_col_idx = version_col_idx; }

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -1329,13 +1329,6 @@ Status ScanOperatorX<LocalStateType>::get_block(RuntimeState* state, vectorized:
                                                 bool* eos) {
     auto& local_state = get_local_state(state);
     SCOPED_TIMER(local_state.exec_time_counter());
-    // in inverted index apply logic, in order to optimize query performance,
-    // we built some temporary columns into block, these columns only used in scan node level,
-    // remove them when query leave scan node to avoid other nodes use block->columns() to make a wrong decision
-    Defer drop_block_temp_column {[&]() {
-        std::unique_lock l(local_state._block_lock);
-        block->erase_tmp_columns();
-    }};
 
     if (state->is_cancelled()) {
         if (local_state._scanner_ctx) {

--- a/be/src/pipeline/exec/schema_scan_operator.cpp
+++ b/be/src/pipeline/exec/schema_scan_operator.cpp
@@ -250,12 +250,10 @@ Status SchemaScanOperatorX::get_block(RuntimeState* state, vectorized::Block* bl
         if (src_block.rows()) {
             // block->check_number_of_rows();
             for (int i = 0; i < _slot_num; ++i) {
-                auto* dest_slot_desc = _dest_tuple_desc->slots()[i];
                 vectorized::MutableColumnPtr column_ptr =
                         std::move(*block->get_by_position(i).column).mutate();
-                column_ptr->insert_range_from(
-                        *src_block.get_by_name(dest_slot_desc->col_name()).column, 0,
-                        src_block.rows());
+                column_ptr->insert_range_from(*src_block.get_by_position(i).column, 0,
+                                              src_block.rows());
             }
             RETURN_IF_ERROR(local_state.filter_block(local_state._conjuncts, block,
                                                      _dest_tuple_desc->slots().size()));

--- a/be/src/pipeline/exec/schema_scan_operator.cpp
+++ b/be/src/pipeline/exec/schema_scan_operator.cpp
@@ -254,7 +254,7 @@ Status SchemaScanOperatorX::get_block(RuntimeState* state, vectorized::Block* bl
                 vectorized::MutableColumnPtr column_ptr =
                         std::move(*block->get_by_position(i).column).mutate();
                 column_ptr->insert_range_from(
-                        *src_block.get_by_position(dest_slot_desc->id()).column, 0,
+                        *src_block.safe_get_by_position(dest_slot_desc->id()).column, 0,
                         src_block.rows());
             }
             RETURN_IF_ERROR(local_state.filter_block(local_state._conjuncts, block,

--- a/be/src/pipeline/exec/schema_scan_operator.cpp
+++ b/be/src/pipeline/exec/schema_scan_operator.cpp
@@ -250,9 +250,10 @@ Status SchemaScanOperatorX::get_block(RuntimeState* state, vectorized::Block* bl
         if (src_block.rows()) {
             // block->check_number_of_rows();
             for (int i = 0; i < _slot_num; ++i) {
+                auto* dest_slot_desc = _dest_tuple_desc->slots()[i];
                 vectorized::MutableColumnPtr column_ptr =
                         std::move(*block->get_by_position(i).column).mutate();
-                column_ptr->insert_range_from(*src_block.get_by_position(i).column, 0,
+                column_ptr->insert_range_from(*src_block.get_by_position(dest_slot_desc->id()).column, 0,
                                               src_block.rows());
             }
             RETURN_IF_ERROR(local_state.filter_block(local_state._conjuncts, block,

--- a/be/src/pipeline/exec/schema_scan_operator.cpp
+++ b/be/src/pipeline/exec/schema_scan_operator.cpp
@@ -253,8 +253,9 @@ Status SchemaScanOperatorX::get_block(RuntimeState* state, vectorized::Block* bl
                 auto* dest_slot_desc = _dest_tuple_desc->slots()[i];
                 vectorized::MutableColumnPtr column_ptr =
                         std::move(*block->get_by_position(i).column).mutate();
-                column_ptr->insert_range_from(*src_block.get_by_position(dest_slot_desc->id()).column, 0,
-                                              src_block.rows());
+                column_ptr->insert_range_from(
+                        *src_block.get_by_position(dest_slot_desc->id()).column, 0,
+                        src_block.rows());
             }
             RETURN_IF_ERROR(local_state.filter_block(local_state._conjuncts, block,
                                                      _dest_tuple_desc->slots().size()));

--- a/be/src/pipeline/exec/schema_scan_operator.cpp
+++ b/be/src/pipeline/exec/schema_scan_operator.cpp
@@ -179,6 +179,7 @@ Status SchemaScanOperatorX::prepare(RuntimeState* state) {
         int j = 0;
         for (; j < columns_desc.size(); ++j) {
             if (boost::iequals(_dest_tuple_desc->slots()[i]->col_name(), columns_desc[j].name)) {
+                _slot_offsets[i] = j;
                 break;
             }
         }
@@ -250,11 +251,10 @@ Status SchemaScanOperatorX::get_block(RuntimeState* state, vectorized::Block* bl
         if (src_block.rows()) {
             // block->check_number_of_rows();
             for (int i = 0; i < _slot_num; ++i) {
-                auto* dest_slot_desc = _dest_tuple_desc->slots()[i];
                 vectorized::MutableColumnPtr column_ptr =
                         std::move(*block->get_by_position(i).column).mutate();
                 column_ptr->insert_range_from(
-                        *src_block.safe_get_by_position(dest_slot_desc->id()).column, 0,
+                        *src_block.safe_get_by_position(_slot_offsets[i]).column, 0,
                         src_block.rows());
             }
             RETURN_IF_ERROR(local_state.filter_block(local_state._conjuncts, block,

--- a/be/src/pipeline/exec/schema_scan_operator.h
+++ b/be/src/pipeline/exec/schema_scan_operator.h
@@ -19,6 +19,8 @@
 
 #include <stdint.h>
 
+#include <unordered_map>
+
 #include "common/status.h"
 #include "exec/schema_scanner.h"
 #include "operator.h"
@@ -85,6 +87,9 @@ private:
     int _tuple_idx;
     // slot num need to fill in and return
     int _slot_num;
+
+    // slot index mapping to src column index
+    std::unordered_map<int, int> _slot_offsets;
 };
 
 #include "common/compile_check_end.h"

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -788,15 +788,6 @@ void Block::clear_column_data(int64_t column_size) noexcept {
     }
 }
 
-void Block::erase_tmp_columns() noexcept {
-    auto all_column_names = get_names();
-    for (auto& name : all_column_names) {
-        if (name.rfind(BeConsts::BLOCK_TEMP_COLUMN_PREFIX, 0) == 0) {
-            erase(name);
-        }
-    }
-}
-
 void Block::clear_column_mem_not_keep(const std::vector<bool>& column_keep_flags,
                                       bool need_keep_first) {
     if (data.size() >= column_keep_flags.size()) {

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -1300,10 +1300,6 @@ void MutableBlock::initialize_index_by_name() {
     }
 }
 
-bool MutableBlock::has(const std::string& name) const {
-    return index_by_name.end() != index_by_name.find(name);
-}
-
 size_t MutableBlock::get_position_by_name(const std::string& name) const {
     auto it = index_by_name.find(name);
     if (index_by_name.end() == it) {

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -356,11 +356,6 @@ public:
     // for String type or Array<String> type
     void shrink_char_type_column_suffix_zero(const std::vector<size_t>& char_type_idx);
 
-    // remove tmp columns in block
-    // in inverted index apply logic, in order to optimize query performance,
-    // we built some temporary columns into block
-    void erase_tmp_columns() noexcept;
-
     void clear_column_mem_not_keep(const std::vector<bool>& column_keep_flags,
                                    bool need_keep_first);
 

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -160,8 +160,6 @@ public:
     Container::const_iterator cbegin() const { return data.cbegin(); }
     Container::const_iterator cend() const { return data.cend(); }
 
-    bool has(const std::string& name) const;
-
     size_t get_position_by_name(const std::string& name) const;
 
     const ColumnsWithTypeAndName& get_columns_with_type_and_name() const;
@@ -383,9 +381,6 @@ private:
     DataTypes _data_types;
     std::vector<std::string> _names;
 
-    using IndexByName = phmap::flat_hash_map<String, size_t>;
-    IndexByName index_by_name;
-
 public:
     static MutableBlock build_mutable_block(Block* block) {
         return block == nullptr ? MutableBlock() : MutableBlock(block);
@@ -399,21 +394,16 @@ public:
     MutableBlock(Block* block)
             : _columns(block->mutate_columns()),
               _data_types(block->get_data_types()),
-              _names(block->get_names()) {
-        initialize_index_by_name();
-    }
+              _names(block->get_names()) {}
     MutableBlock(Block&& block)
             : _columns(block.mutate_columns()),
               _data_types(block.get_data_types()),
-              _names(block.get_names()) {
-        initialize_index_by_name();
-    }
+              _names(block.get_names()) {}
 
     void operator=(MutableBlock&& m_block) {
         _columns = std::move(m_block._columns);
         _data_types = std::move(m_block._data_types);
         _names = std::move(m_block._names);
-        initialize_index_by_name();
     }
 
     size_t rows() const;
@@ -544,7 +534,6 @@ public:
                     _columns[i] = _data_types[i]->create_column();
                 }
             }
-            initialize_index_by_name();
         } else {
             if (_columns.size() != block.columns()) {
                 return Status::Error<ErrorCode::INTERNAL_ERROR>(
@@ -591,9 +580,6 @@ public:
     Status add_rows(const Block* block, size_t row_begin, size_t length);
     Status add_rows(const Block* block, const std::vector<int64_t>& rows);
 
-    /// remove the column with the specified name
-    void erase(const String& name);
-
     std::string dump_data(size_t row_limit = 100) const;
     std::string dump_data_json(size_t row_limit = 100) const;
 
@@ -619,13 +605,8 @@ public:
 
     std::vector<std::string>& get_names() { return _names; }
 
-    size_t get_position_by_name(const std::string& name) const;
-
     /** Get a list of column names separated by commas. */
     std::string dump_names() const;
-
-private:
-    void initialize_index_by_name();
 };
 
 struct IteratorRowRef {

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -619,8 +619,6 @@ public:
 
     std::vector<std::string>& get_names() { return _names; }
 
-    bool has(const std::string& name) const;
-
     size_t get_position_by_name(const std::string& name) const;
 
     /** Get a list of column names separated by commas. */

--- a/be/src/vec/core/sort_block.cpp
+++ b/be/src/vec/core/sort_block.cpp
@@ -32,10 +32,7 @@ ColumnsWithSortDescriptions get_columns_with_sort_description(const Block& block
 
     for (size_t i = 0; i < size; ++i) {
         const IColumn* column =
-                !description[i].column_name.empty()
-                        ? block.get_by_name(description[i].column_name).column.get()
-                        : block.safe_get_by_position(description[i].column_number).column.get();
-
+                block.safe_get_by_position(description[i].column_number).column.get();
         res.emplace_back(column, description[i]);
     }
 
@@ -53,9 +50,7 @@ void sort_block(Block& src_block, Block& dest_block, const SortDescription& desc
         bool reverse = description[0].direction == -1;
 
         const IColumn* column =
-                !description[0].column_name.empty()
-                        ? src_block.get_by_name(description[0].column_name).column.get()
-                        : src_block.safe_get_by_position(description[0].column_number).column.get();
+                src_block.safe_get_by_position(description[0].column_number).column.get();
 
         IColumn::Permutation perm;
         column->get_permutation(reverse, limit, description[0].nulls_direction, perm);

--- a/be/src/vec/core/sort_description.h
+++ b/be/src/vec/core/sort_description.h
@@ -20,20 +20,15 @@
 
 #pragma once
 
-#include "cstddef"
-#include "memory"
-#include "string"
-#include "vec/core/field.h"
 #include "vector"
 
 namespace doris::vectorized {
 
 /// Description of the sorting rule by one column.
 struct SortColumnDescription {
-    std::string column_name; /// The name of the column.
-    int column_number;       /// Column number (used if no name is given).
-    int direction;           /// 1 - ascending, -1 - descending.
-    int nulls_direction;     /// 1 - NULLs and NaNs are greater, -1 - less.
+    int column_number;   /// Column number (used if no name is given).
+    int direction;       /// 1 - ascending, -1 - descending.
+    int nulls_direction; /// 1 - NULLs and NaNs are greater, -1 - less.
 
     SortColumnDescription(int column_number_, int direction_, int nulls_direction_)
             : column_number(column_number_),

--- a/be/src/vec/exec/format/arrow/arrow_stream_reader.cpp
+++ b/be/src/vec/exec/format/arrow/arrow_stream_reader.cpp
@@ -103,10 +103,17 @@ Status ArrowStreamReader::get_next_block(Block* block, size_t* read_rows, bool* 
         auto num_columns = batch.num_columns();
         for (int c = 0; c < num_columns; ++c) {
             arrow::Array* column = batch.column(c).get();
+            std::string column_name = batch.schema()->field(c)->name();
 
             try {
                 const vectorized::ColumnWithTypeAndName& column_with_name =
-                        block->get_by_position(c);
+                        block->safe_get_by_position(c);
+
+                if (column_with_name.name != column_name) {
+                    return Status::InternalError("Column name mismatch: expected {}, got {}",
+                                                 column_with_name.name, column_name);
+                }
+
                 RETURN_IF_ERROR(column_with_name.type->get_serde()->read_column_from_arrow(
                         column_with_name.column->assume_mutable_ref(), column, 0, num_rows, _ctzz));
             } catch (Exception& e) {

--- a/be/src/vec/exec/format/arrow/arrow_stream_reader.cpp
+++ b/be/src/vec/exec/format/arrow/arrow_stream_reader.cpp
@@ -104,11 +104,9 @@ Status ArrowStreamReader::get_next_block(Block* block, size_t* read_rows, bool* 
         for (int c = 0; c < num_columns; ++c) {
             arrow::Array* column = batch.column(c).get();
 
-            std::string column_name = batch.schema()->field(c)->name();
-
             try {
                 const vectorized::ColumnWithTypeAndName& column_with_name =
-                        block->get_by_name(column_name);
+                        block->get_by_position(c);
                 RETURN_IF_ERROR(column_with_name.type->get_serde()->read_column_from_arrow(
                         column_with_name.column->assume_mutable_ref(), column, 0, num_rows, _ctzz));
             } catch (Exception& e) {

--- a/be/src/vec/exec/scan/olap_scanner.cpp
+++ b/be/src/vec/exec/scan/olap_scanner.cpp
@@ -428,8 +428,8 @@ Status OlapScanner::_init_tablet_reader_params(
     DBUG_EXECUTE_IF("NewOlapScanner::_init_tablet_reader_params.block", DBUG_BLOCK);
 
     if (!_state->skip_storage_engine_merge()) {
-        TOlapScanNode& olap_scan_node =
-                ((pipeline::OlapScanLocalState*)_local_state)->olap_scan_node();
+        auto* olap_scan_local_state = (pipeline::OlapScanLocalState*)_local_state;
+        TOlapScanNode& olap_scan_node = olap_scan_local_state->olap_scan_node();
         // order by table keys optimization for topn
         // will only read head/tail of data file since it's already sorted by keys
         if (olap_scan_node.__isset.sort_info && !olap_scan_node.sort_info.is_asc_order.empty()) {
@@ -441,16 +441,20 @@ Status OlapScanner::_init_tablet_reader_params(
             _tablet_reader_params.read_orderby_key_num_prefix_columns =
                     olap_scan_node.sort_info.is_asc_order.size();
             _tablet_reader_params.read_orderby_key_limit = _limit;
-            _tablet_reader_params.filter_block_conjuncts = _conjuncts;
+
+            if (_tablet_reader_params.read_orderby_key_limit > 0 &&
+                olap_scan_local_state->_storage_no_merge()) {
+                _tablet_reader_params.filter_block_conjuncts = _conjuncts;
+                _conjuncts.clear();
+            }
         }
 
         // set push down topn filter
         _tablet_reader_params.topn_filter_source_node_ids =
-                ((pipeline::OlapScanLocalState*)_local_state)
-                        ->get_topn_filter_source_node_ids(_state, true);
+                olap_scan_local_state->get_topn_filter_source_node_ids(_state, true);
         if (!_tablet_reader_params.topn_filter_source_node_ids.empty()) {
             _tablet_reader_params.topn_filter_target_node_id =
-                    ((pipeline::OlapScanLocalState*)_local_state)->parent()->node_id();
+                    olap_scan_local_state->parent()->node_id();
         }
     }
 

--- a/be/src/vec/exec/scan/scanner.cpp
+++ b/be/src/vec/exec/scan/scanner.cpp
@@ -146,10 +146,6 @@ Status Scanner::get_block(RuntimeState* state, Block* block, bool* eof) {
 
 Status Scanner::_filter_output_block(Block* block) {
     Defer clear_tmp_block([&]() { block->erase_tmp_columns(); });
-    if (block->has(BeConsts::BLOCK_TEMP_COLUMN_SCANNER_FILTERED)) {
-        // scanner filter_block is already done (only by _topn_next currently), just skip it
-        return Status::OK();
-    }
     auto old_rows = block->rows();
     Status st = VExprContext::filter_block(_conjuncts, block, block->columns());
     _counter.num_rows_unselected += old_rows - block->rows();

--- a/be/src/vec/exec/scan/scanner.cpp
+++ b/be/src/vec/exec/scan/scanner.cpp
@@ -113,8 +113,6 @@ Status Scanner::get_block(RuntimeState* state, Block* block, bool* eof) {
                 RETURN_IF_ERROR(_get_block_impl(state, block, eof));
                 if (*eof) {
                     DCHECK(block->rows() == 0);
-                    // clear TEMP columns to avoid column align problem
-                    block->erase_tmp_columns();
                     break;
                 }
                 _num_rows_read += block->rows();
@@ -145,7 +143,6 @@ Status Scanner::get_block(RuntimeState* state, Block* block, bool* eof) {
 }
 
 Status Scanner::_filter_output_block(Block* block) {
-    Defer clear_tmp_block([&]() { block->erase_tmp_columns(); });
     auto old_rows = block->rows();
     Status st = VExprContext::filter_block(_conjuncts, block, block->columns());
     _counter.num_rows_unselected += old_rows - block->rows();

--- a/be/src/vec/functions/function_helpers.cpp
+++ b/be/src/vec/functions/function_helpers.cpp
@@ -97,14 +97,6 @@ std::tuple<Block, ColumnNumbers> create_block_with_nested_columns(const Block& b
         }
     }
 
-    // TODO: only support match function, rethink the logic
-    for (const auto& ctn : block) {
-        if (ctn.name.size() > BeConsts::BLOCK_TEMP_COLUMN_PREFIX.size() &&
-            starts_with(ctn.name, BeConsts::BLOCK_TEMP_COLUMN_PREFIX)) {
-            res.insert(ctn);
-        }
-    }
-
     return {std::move(res), std::move(res_args)};
 }
 

--- a/be/src/vec/olap/block_reader.cpp
+++ b/be/src/vec/olap/block_reader.cpp
@@ -411,7 +411,6 @@ Status BlockReader::_unique_key_next_block(Block* block, bool* eof) {
         block->insert(column_with_type_and_name);
         RETURN_IF_ERROR(Block::filter_block(block, target_columns_size, target_columns_size));
         _stats.rows_del_filtered += target_block_row - block->rows();
-        DCHECK(block->try_get_by_name("__DORIS_COMPACTION_FILTER__") == nullptr);
         if (UNLIKELY(_reader_context.record_rowids)) {
             DCHECK_EQ(_block_row_locations.size(), block->rows() + delete_count);
         }

--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -93,6 +93,7 @@ void VCollectIterator::init(TabletReader* reader, bool ori_data_overlapping, boo
         _topn_limit = _reader->_reader_context.read_orderby_key_limit;
     } else {
         _topn_limit = 0;
+        DCHECK_EQ(_reader->_reader_context.filter_block_conjuncts.size(), 0);
     }
 }
 
@@ -452,12 +453,6 @@ Status VCollectIterator::_topn_next(Block* block) {
                << " sorted_row_pos.size()=" << sorted_row_pos.size()
                << " mutable_block.rows()=" << mutable_block.rows();
     *block = mutable_block.to_block();
-    // append a column to indicate scanner filter_block is already done
-    auto filtered_datatype = std::make_shared<DataTypeUInt8>();
-    auto filtered_column = filtered_datatype->create_column_const(
-            block->rows(), Field::create_field<TYPE_BOOLEAN>(1));
-    block->insert(
-            {filtered_column, filtered_datatype, BeConsts::BLOCK_TEMP_COLUMN_SCANNER_FILTERED});
 
     _topn_eof = true;
     return block->rows() > 0 ? Status::OK() : Status::Error<END_OF_FILE>("");

--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -260,8 +260,6 @@ Status VCollectIterator::_topn_next(Block* block) {
         return Status::Error<END_OF_FILE>("");
     }
 
-    // clear TEMP columns to avoid column align problem
-    block->erase_tmp_columns();
     auto clone_block = block->clone_empty();
     /*
     select id, "${tR2}",
@@ -317,8 +315,6 @@ Status VCollectIterator::_topn_next(Block* block) {
                 if (status.is<END_OF_FILE>()) {
                     eof = true;
                     if (block->rows() == 0) {
-                        // clear TEMP columns to avoid column align problem in segment iterator
-                        block->erase_tmp_columns();
                         break;
                     }
                 } else {
@@ -329,8 +325,6 @@ Status VCollectIterator::_topn_next(Block* block) {
             // filter block
             RETURN_IF_ERROR(VExprContext::filter_block(
                     _reader->_reader_context.filter_block_conjuncts, block, block->columns()));
-            // clear TMPE columns to avoid column align problem in mutable_block.add_rows bellow
-            block->erase_tmp_columns();
 
             // update read rows
             read_rows += block->rows();
@@ -889,8 +883,6 @@ Status VCollectIterator::Level1Iterator::_normal_next(Block* block) {
     while (res.is<END_OF_FILE>() && !_children.empty()) {
         _cur_child = std::move(*(_children.begin()));
         _children.pop_front();
-        // clear TEMP columns to avoid column align problem
-        block->erase_tmp_columns();
         res = _cur_child->next(block);
     }
 

--- a/be/src/vec/olap/vertical_block_reader.cpp
+++ b/be/src/vec/olap/vertical_block_reader.cpp
@@ -515,7 +515,6 @@ Status VerticalBlockReader::_unique_key_next_block(Block* block, bool* eof) {
             RETURN_IF_ERROR(
                     Block::filter_block(block, target_columns.size(), target_columns.size()));
             _stats.rows_del_filtered += block_rows - block->rows();
-            DCHECK(block->try_get_by_name("__DORIS_COMPACTION_FILTER__") == nullptr);
             if (UNLIKELY(_reader_context.record_rowids)) {
                 DCHECK_EQ(_block_row_locations.size(), block->rows() + delete_count);
             }

--- a/be/src/vec/sink/vtablet_block_convertor.cpp
+++ b/be/src/vec/sink/vtablet_block_convertor.cpp
@@ -691,10 +691,6 @@ Status OlapTableBlockConvertor::_fill_auto_inc_cols(vectorized::Block* block, si
 
 Status OlapTableBlockConvertor::_partial_update_fill_auto_inc_cols(vectorized::Block* block,
                                                                    size_t rows) {
-    // avoid duplicate PARTIAL_UPDATE_AUTO_INC_COL
-    if (block->has(BeConsts::PARTIAL_UPDATE_AUTO_INC_COL)) {
-        return Status::OK();
-    }
     auto dst_column = vectorized::ColumnInt64::create();
     vectorized::ColumnInt64::Container& dst_values = dst_column->get_data();
     size_t null_value_count = rows;

--- a/be/src/vec/sink/vtablet_block_convertor.cpp
+++ b/be/src/vec/sink/vtablet_block_convertor.cpp
@@ -691,6 +691,11 @@ Status OlapTableBlockConvertor::_fill_auto_inc_cols(vectorized::Block* block, si
 
 Status OlapTableBlockConvertor::_partial_update_fill_auto_inc_cols(vectorized::Block* block,
                                                                    size_t rows) {
+    if (_output_tuple_desc->slots().size() != block->columns() + 1) {
+        return Status::InternalError(
+                "Output tuple descriptor and block columns size mismatch, desc:{} ,block:{}",
+                _output_tuple_desc->debug_string(), block->dump_structure());
+    }
     auto dst_column = vectorized::ColumnInt64::create();
     vectorized::ColumnInt64::Container& dst_values = dst_column->get_data();
     size_t null_value_count = rows;

--- a/be/src/vec/sink/vtablet_block_convertor.cpp
+++ b/be/src/vec/sink/vtablet_block_convertor.cpp
@@ -691,11 +691,6 @@ Status OlapTableBlockConvertor::_fill_auto_inc_cols(vectorized::Block* block, si
 
 Status OlapTableBlockConvertor::_partial_update_fill_auto_inc_cols(vectorized::Block* block,
                                                                    size_t rows) {
-    if (_output_tuple_desc->slots().size() != block->columns() + 1) {
-        return Status::InternalError(
-                "Output tuple descriptor and block columns size mismatch, desc:{} ,block:{}",
-                _output_tuple_desc->debug_string(), block->dump_structure());
-    }
     auto dst_column = vectorized::ColumnInt64::create();
     vectorized::ColumnInt64::Container& dst_values = dst_column->get_data();
     size_t null_value_count = rows;

--- a/be/test/vec/core/block_test.cpp
+++ b/be/test/vec/core/block_test.cpp
@@ -1216,14 +1216,7 @@ TEST(BlockTest, insert_erase) {
 
     block.insert({nullptr, std::make_shared<vectorized::DataTypeString>(), "col2"});
 
-    vectorized::MutableBlock mutable_block(&block);
-    mutable_block.erase("col1");
-    ASSERT_EQ(mutable_block.columns(), 2);
-
-    EXPECT_ANY_THROW(mutable_block.erase("col1"));
-    ASSERT_EQ(mutable_block.columns(), 2);
-    mutable_block.erase("col2");
-    ASSERT_EQ(mutable_block.columns(), 1);
+    ASSERT_EQ(block.columns(), 3);
 }
 
 TEST(BlockTest, check_number_of_rows) {

--- a/be/test/vec/core/block_test.cpp
+++ b/be/test/vec/core/block_test.cpp
@@ -1402,8 +1402,6 @@ TEST(BlockTest, others) {
 
     mutable_block.clear_column_data();
     ASSERT_EQ(mutable_block.get_column_by_position(0)->size(), 0);
-    ASSERT_TRUE(mutable_block.has("column"));
-    ASSERT_EQ(mutable_block.get_position_by_name("column"), 0);
 
     auto dumped_names = mutable_block.dump_names();
     ASSERT_TRUE(dumped_names.find("column") != std::string::npos);

--- a/be/test/vec/core/block_test.cpp
+++ b/be/test/vec/core/block_test.cpp
@@ -1193,12 +1193,6 @@ TEST(BlockTest, insert_erase) {
     ASSERT_NE(block.try_get_by_name("column"), nullptr);
     EXPECT_EQ(block.get_position_by_name("column"), 0);
 
-    block.insert({nullptr, nullptr, BeConsts::BLOCK_TEMP_COLUMN_PREFIX});
-    EXPECT_NO_THROW(auto item = block.get_by_name(BeConsts::BLOCK_TEMP_COLUMN_PREFIX));
-
-    block.erase_tmp_columns();
-    ASSERT_EQ(block.try_get_by_name(BeConsts::BLOCK_TEMP_COLUMN_PREFIX), nullptr);
-
     {
         // test const block
         const auto const_block = block;


### PR DESCRIPTION
### What problem does this PR solve?
try to remove some Block::get_by_name usage

This pull request refactors how columns are accessed and managed in vectorized blocks, removes name-based column indexing from `MutableBlock`, and improves performance and reliability by switching to position-based access throughout the codebase. Additionally, it simplifies sort descriptions and optimizes some scanner logic. The most important changes are grouped below:

### Refactoring column access from name-based to position-based

* Replaced some usages of `get_by_name` and related name-based column access with `get_by_position` or `safe_get_by_position` in multiple files, including `push_handler.cpp`, `schema_scan_operator.cpp`, `sort_block.cpp`, and `arrow_stream_reader.cpp`. This change ensures column access is always by index, improving performance and reducing errors due to name mismatches. [[1]](diffhunk://#diff-aa97e616efca2638565e6a58aa9295252714265fcc1ed904d503425ef4930ce7L481-R484) [[2]](diffhunk://#diff-aa97e616efca2638565e6a58aa9295252714265fcc1ed904d503425ef4930ce7L494-R494) [[3]](diffhunk://#diff-991f87a3acb91e58d14e3b30520de5dd07ecade8d4ecf885c02bf436873b4262L253-R257) [[4]](diffhunk://#diff-85d81b4f613117660ee5c1eb1e6738656086b9db38adacc070a0d96048ee7acbL35-R35) [[5]](diffhunk://#diff-85d81b4f613117660ee5c1eb1e6738656086b9db38adacc070a0d96048ee7acbL56-R53) [[6]](diffhunk://#diff-839ab9c69c56c8322090b8699e01b4d4de406be344856a69ed82a5095e14ad1aL106-R116)
* Removed the `has`, `get_position_by_name`, and `erase` methods, along with the `index_by_name` member, from `MutableBlock` and related code, fully deprecating name-based indexing. [[1]](diffhunk://#diff-5a2c9e19a27153df9fce7277a09325589cd009441c63da55761c286627417fb3L386-L388) [[2]](diffhunk://#diff-5a2c9e19a27153df9fce7277a09325589cd009441c63da55761c286627417fb3L402-L416) [[3]](diffhunk://#diff-5a2c9e19a27153df9fce7277a09325589cd009441c63da55761c286627417fb3L547) [[4]](diffhunk://#diff-5a2c9e19a27153df9fce7277a09325589cd009441c63da55761c286627417fb3L594-L596) [[5]](diffhunk://#diff-5a2c9e19a27153df9fce7277a09325589cd009441c63da55761c286627417fb3L622-L630) [[6]](diffhunk://#diff-76dba768c36c76cce660f7fe39514a98b509030a8976aabc9ac47d58bc923976L345-L348) [[7]](diffhunk://#diff-76dba768c36c76cce660f7fe39514a98b509030a8976aabc9ac47d58bc923976L1052) [[8]](diffhunk://#diff-76dba768c36c76cce660f7fe39514a98b509030a8976aabc9ac47d58bc923976L1070) [[9]](diffhunk://#diff-76dba768c36c76cce660f7fe39514a98b509030a8976aabc9ac47d58bc923976L1133-L1157) [[10]](diffhunk://#diff-76dba768c36c76cce660f7fe39514a98b509030a8976aabc9ac47d58bc923976L1297-L1316)

### Schema scan and operator improvements

* Added `_slot_offsets` mapping to `SchemaScanOperatorX` to track the correspondence between slot indices and source column indices, and updated related logic to use this mapping for column access. [[1]](diffhunk://#diff-991f87a3acb91e58d14e3b30520de5dd07ecade8d4ecf885c02bf436873b4262R182) [[2]](diffhunk://#diff-82ea988d6a5179d6698c2844ad8f06167ebdb362225b07b35e9a5ba0a7bb173aR90-R92) [[3]](diffhunk://#diff-82ea988d6a5179d6698c2844ad8f06167ebdb362225b07b35e9a5ba0a7bb173aR22-R23)
* Updated the logic in `schema_scan_operator.cpp` to use `_slot_offsets` for column copying, ensuring correct mapping between destination and source columns by index.

### Sort description simplification

* Removed the `column_name` field from `SortColumnDescription` and refactored sorting logic to rely solely on column indices, simplifying the sort API and reducing ambiguity. [[1]](diffhunk://#diff-97571bb0d7dc80faf66b3a211dc917c2a0acef692a26d514db7321d91d2b77ecL23-L33) [[2]](diffhunk://#diff-85d81b4f613117660ee5c1eb1e6738656086b9db38adacc070a0d96048ee7acbL35-R35) [[3]](diffhunk://#diff-85d81b4f613117660ee5c1eb1e6738656086b9db38adacc070a0d96048ee7acbL56-R53)

### Scanner and filter logic optimizations

* Removed the use of the temporary column `BLOCK_TEMP_COLUMN_SCANNER_FILTERED` and related checks, streamlining scanner filter logic. [[1]](diffhunk://#diff-2c575051a29b06200611882d17cb4c0fea6df46659e8ea953c705aaca2c2b5a4L149-L152) [[2]](diffhunk://#diff-d569a6c78638e9c539783057051e89bcb135cc254c763e3bc5e3a71e334df883L28)
* Minor logic improvements in scanner and compaction code for clarity and correctness.

### Miscellaneous improvements

* Improved handling of auto-increment columns in partial update logic to use position-based access, assuming the auto-increment column is last in the block.
* Minor code cleanups and improved error handling for column name mismatches in Arrow reader. [[1]](diffhunk://#diff-839ab9c69c56c8322090b8699e01b4d4de406be344856a69ed82a5095e14ad1aL106-R116) [[2]](diffhunk://#diff-16b50a2c723ed27ac870468690c11061bb870e74b778b44d4d2e93ca73b0efb4L431-R432) [[3]](diffhunk://#diff-16b50a2c723ed27ac870468690c11061bb870e74b778b44d4d2e93ca73b0efb4R444-R457)

These changes collectively modernize and optimize how columns are managed in the vectorized execution engine, reducing potential bugs and improving performance.
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

