### PR TITLE
[fix](nereids) inferPredicate should not pullup predicates from mark join's right child

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InferPredicates.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InferPredicates.java
@@ -22,7 +22,10 @@ import org.apache.doris.nereids.jobs.JobContext;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
+import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
 import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalEmptyRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalExcept;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalIntersect;
@@ -115,6 +118,9 @@ public class InferPredicates extends DefaultPlanRewriter<JobContext> implements 
 
     @Override
     public Plan visitLogicalFilter(LogicalFilter<? extends Plan> filter, JobContext context) {
+        if (filter.getConjuncts().contains(BooleanLiteral.FALSE)) {
+            return new LogicalEmptyRelation(StatementScopeIdGenerator.newRelationId(), filter.getOutput());
+        }
         filter = visitChildren(this, filter, context);
         Set<Expression> filterPredicates = pullUpPredicates(filter);
         filterPredicates.removeAll(pullUpAllPredicates(filter.child()));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpPredicates.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpPredicates.java
@@ -236,6 +236,22 @@ public class PullUpPredicates extends PlanVisitor<ImmutableSet<Expression>, Void
                     () -> join.right().accept(this, context));
             switch (join.getJoinType()) {
                 case CROSS_JOIN:
+                    /*
+                     * select * from t1 where exsits (select * from t2) or t1.a=t1.b
+                     * The above SQL will generate a mark join, with the join type being CROSS_JOIN.
+                     * In this case,
+                     * it is equivalent to simulating a left semi join using a cross join, and
+                     * predicates cannot be pulled up from the right child.
+                     */
+                    if (join.isMarkJoin()) {
+                        predicates.addAll(leftPredicates.get());
+                    } else {
+                        predicates.addAll(leftPredicates.get());
+                        predicates.addAll(rightPredicates.get());
+                        predicates.addAll(join.getHashJoinConjuncts());
+                        predicates.addAll(join.getOtherJoinConjuncts());
+                    }
+                    break;
                 case INNER_JOIN: {
                     predicates.addAll(leftPredicates.get());
                     predicates.addAll(rightPredicates.get());

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/InferPredicatesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/InferPredicatesTest.java
@@ -17,13 +17,33 @@
 
 package org.apache.doris.nereids.rules.rewrite;
 
+import org.apache.doris.nereids.CascadesContext;
+import org.apache.doris.nereids.hint.DistributeHint;
+import org.apache.doris.nereids.trees.expressions.EqualTo;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.MarkJoinSlotReference;
+import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
+import org.apache.doris.nereids.trees.plans.DistributeType;
 import org.apache.doris.nereids.trees.plans.JoinType;
+import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
+import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
+import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.nereids.util.MemoPatternMatchSupported;
+import org.apache.doris.nereids.util.MemoTestUtils;
 import org.apache.doris.nereids.util.PlanChecker;
+import org.apache.doris.nereids.util.PlanConstructor;
 import org.apache.doris.utframe.TestWithFeService;
 
+import static org.mockito.ArgumentMatchers.any;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
 
 class InferPredicatesTest extends TestWithFeService implements MemoPatternMatchSupported {
 
@@ -804,5 +824,41 @@ class InferPredicatesTest extends TestWithFeService implements MemoPatternMatchS
                 .matches(logicalFilter(logicalOlapScan().when(scan -> scan.getTable().getName().equals("score")))
                         .when(filter -> filter.getConjuncts().size() == 1
                                 && filter.getConjuncts().iterator().next().isInferred()));
+    }
+
+    @Test
+    void pullUpPredicatesShouldIgnoreRightSideForCrossJoinMarkJoin() {
+        LogicalOlapScan leftScan = PlanConstructor.newLogicalOlapScan(10, "mark_left", 0);
+        LogicalOlapScan rightScan = PlanConstructor.newLogicalOlapScan(11, "mark_right", 0);
+        Expression leftPredicate = new EqualTo(leftScan.getOutput().get(0), new IntegerLiteral(1));
+        Expression rightPredicate = new EqualTo(rightScan.getOutput().get(0), new IntegerLiteral(2));
+
+        LogicalFilter<LogicalOlapScan> leftFilter = new LogicalFilter<>(ImmutableSet.of(leftPredicate),
+                leftScan);
+        LogicalFilter<LogicalOlapScan> rightFilter = new LogicalFilter<>(ImmutableSet.of(rightPredicate),
+                rightScan);
+
+        LogicalJoin<LogicalPlan, LogicalPlan> markJoin = new LogicalJoin<>(
+                JoinType.CROSS_JOIN,
+                ImmutableList.<Expression>of(),
+                ImmutableList.<Expression>of(),
+                ImmutableList.<Expression>of(),
+                new DistributeHint(DistributeType.NONE),
+                Optional.of(new MarkJoinSlotReference("mark")),
+                leftFilter,
+                rightFilter,
+                null);
+
+        CascadesContext cascadesContext = MemoTestUtils.createCascadesContext(connectContext, markJoin);
+        PullUpPredicates pullUpPredicates = new PullUpPredicates(false, cascadesContext);
+        PullUpPredicates pullUpAllPredicates = new PullUpPredicates(true, cascadesContext);
+
+        ImmutableSet<Expression> predicates = markJoin.accept(pullUpPredicates, null);
+        ImmutableSet<Expression> allPredicates = markJoin.accept(pullUpAllPredicates, null);
+
+        Assertions.assertTrue(predicates.contains(leftPredicate));
+        Assertions.assertFalse(predicates.contains(rightPredicate));
+        Assertions.assertTrue(allPredicates.contains(leftPredicate));
+        Assertions.assertFalse(allPredicates.contains(rightPredicate));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/InferPredicatesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/InferPredicatesTest.java
@@ -36,8 +36,6 @@ import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.nereids.util.PlanConstructor;
 import org.apache.doris.utframe.TestWithFeService;
 
-import static org.mockito.ArgumentMatchers.any;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Assertions;


### PR DESCRIPTION
### What problem does this PR solve?
 select * from t1 where exsits (select * from t2) or t1.a=t1.b
 The above SQL will generate a mark join, with the join type being CROSS_JOIN.
 In this case,
 it is equivalent to simulating a left semi join using a cross join, and
 predicates cannot be pulled up from the right child.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

