### PR TITLE
[Fix](funtion) Fix utc_time result when input null

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/UtcTime.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/UtcTime.java
@@ -84,8 +84,13 @@ public class UtcTime extends ScalarFunction
 
     @Override
     public void checkLegalityAfterRewrite() {
-        if (arity() == 1 && !child(0).isLiteral()) {
-            throw new AnalysisException("UTC_TIME scale argument must be a constant literal.");
+        if (arity() == 1) {
+            if (child(0).isNullLiteral()) {
+                throw new AnalysisException("UTC_TIME argument cannot be NULL.");
+            }
+            if (!child(0).isLiteral()) {
+                throw new AnalysisException("UTC_TIME scale argument must be a constant literal.");
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/UtcTimestamp.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/UtcTimestamp.java
@@ -79,8 +79,13 @@ public class UtcTimestamp extends ScalarFunction
 
     @Override
     public void checkLegalityAfterRewrite() {
-        if (arity() == 1 && !child(0).isLiteral()) {
-            throw new AnalysisException("UTC_TIMESTAMP scale argument must be a constant literal.");
+        if (arity() == 1) {
+            if (child(0).isNullLiteral()) {
+                throw new AnalysisException("UTC_TIME argument cannot be NULL.");
+            }
+            if (!child(0).isLiteral()) {
+                throw new AnalysisException("UTC_TIME scale argument must be a constant literal.");
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/UtcTimestamp.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/UtcTimestamp.java
@@ -81,10 +81,10 @@ public class UtcTimestamp extends ScalarFunction
     public void checkLegalityAfterRewrite() {
         if (arity() == 1) {
             if (child(0).isNullLiteral()) {
-                throw new AnalysisException("UTC_TIME argument cannot be NULL.");
+                throw new AnalysisException("UTC_TIMESTAMP argument cannot be NULL.");
             }
             if (!child(0).isLiteral()) {
-                throw new AnalysisException("UTC_TIME scale argument must be a constant literal.");
+                throw new AnalysisException("UTC_TIMESTAMP scale argument must be a constant literal.");
             }
         }
     }

--- a/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_function.groovy
@@ -506,7 +506,12 @@ suite("test_date_function") {
         sql """ select utc_timestamp(7) """
         exception "scale must be between 0 and 6"
     }
+    test {
+        sql """ SELECT UTC_TIMESTAMP(NULL); """
+        exception "UTC_TIMESTAMP argument cannot be NULL."
+    }
 
+    // UTC_TIME
     def utc_time_str = sql """ select utc_time(),utc_time() + 1 """
     assertTrue(utc_time_str[0].size() == 2)
     utc_time_str = sql """ select utc_time(6), utc_time(6) + 1 """
@@ -514,6 +519,10 @@ suite("test_date_function") {
     test {
         sql """ select utc_time(7) """
         exception "scale must be between 0 and 6"
+    }
+    test {
+        sql """ SELECT UTC_TIME(NULL); """
+        exception "UTC_TIME argument cannot be NULL."
     }
 
     def utc_date_str = sql """ select utc_date(),utc_date() + 1 """


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: https://github.com/apache/doris/pull/57347

Problem Summary:

Before:
```text
mysql> select utc_time(NULL);
+----------------+
| utc_time(NULL) |
+----------------+
| 00:00:00       |
+----------------+
```

After(throw error same with MySQL):
```text
mysql> select utc_time(NULL);
ERROR 1105 (HY000): errCode = 2, detailMessage = UTC_TIME argument cannot be NULL.
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. https://github.com/apache/doris-website/pull/3009
### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

