### PR TITLE
[fix](cloud) Make CloudTabletRebalancer to adapt its scheduling inter…

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3316,6 +3316,9 @@ public class Config extends ConfigBase {
     public static long cloud_tablet_rebalancer_interval_second = 20;
 
     @ConfField(mutable = true, masterOnly = true)
+    public static boolean cloud_tablet_rebalancer_fixed_interval = true;
+
+    @ConfField(mutable = true, masterOnly = true)
     public static boolean enable_cloud_partition_balance = true;
 
     @ConfField(mutable = true, masterOnly = true)


### PR DESCRIPTION
…vals based on system load

### What problem does this PR solve?

1. The fixed scheduling time requires a restart to modify. To change it, use the command `admin set frontend config("cloud_tablet_rebalancer_interval_second"="3");` to apply the change without a restart.
2. A switch has been added that allows the scheduling period to adapt to JVM load.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

