### PR TITLE
[fix](catalog) max_meta_object_cache_num config must > 0

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -351,7 +351,7 @@ public abstract class ExternalCatalog
                     name,
                     OptionalLong.of(Config.external_cache_expire_time_seconds_after_access),
                     OptionalLong.of(Config.external_cache_refresh_time_minutes * 60L),
-                    Config.max_meta_object_cache_num,
+                    Math.max(Config.max_meta_object_cache_num, 1),
                     ignored -> getFilteredDatabaseNames(),
                     localDbName -> Optional.ofNullable(
                             buildDbForInit(null, localDbName, Util.genIdByName(name, localDbName), logType,

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.datasource;
 
+import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.DatabaseProperty;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.InfoSchemaDb;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.datasource;
 
-import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.DatabaseProperty;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.InfoSchemaDb;
@@ -64,7 +63,7 @@ import java.util.stream.Collectors;
  * @param <T> External table type is ExternalTable or its subclass.
  */
 public abstract class ExternalDatabase<T extends ExternalTable>
-        implements DatabaseIf<T>, GsonPostProcessable {
+        implements DatabaseIfJ<T>, GsonPostProcessable {
     private static final Logger LOG = LogManager.getLogger(ExternalDatabase.class);
 
     protected MonitoredReentrantReadWriteLock rwLock = new MonitoredReentrantReadWriteLock(true);
@@ -173,8 +172,7 @@ public abstract class ExternalDatabase<T extends ExternalTable>
                             buildTableForInit(null, localTableName,
                                     Util.genIdByName(extCatalog.getName(), name, localTableName),
                                     extCatalog,
-                                    this, true)),
-                    (key, value, cause) -> value.ifPresent(ExternalTable::unsetObjectCreated));
+                                    this, true)), null);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -167,7 +167,7 @@ public abstract class ExternalDatabase<T extends ExternalTable>
                     name,
                     OptionalLong.of(Config.external_cache_expire_time_seconds_after_access),
                     OptionalLong.of(Config.external_cache_refresh_time_minutes * 60L),
-                    Config.max_meta_object_cache_num,
+                    Math.max(Config.max_meta_object_cache_num, 1),
                     ignored -> listTableNames(),
                     localTableName -> Optional.ofNullable(
                             buildTableForInit(null, localTableName,

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -63,7 +63,7 @@ import java.util.stream.Collectors;
  * @param <T> External table type is ExternalTable or its subclass.
  */
 public abstract class ExternalDatabase<T extends ExternalTable>
-        implements DatabaseIfJ<T>, GsonPostProcessable {
+        implements DatabaseIf<T>, GsonPostProcessable {
     private static final Logger LOG = LogManager.getLogger(ExternalDatabase.class);
 
     protected MonitoredReentrantReadWriteLock rwLock = new MonitoredReentrantReadWriteLock(true);


### PR DESCRIPTION
### What problem does this PR solve?

1.
Issue Number: close #55426

When `max_meta_object_cache_num = 0`, the desc command fails because it tries to access disabled meta cache.
```
ERROR 1105 (HY000): errCode = 2, detailMessage = Unknown table '7311664922056505694'
```

So force set `max_meta_object_cache_num` > 0

2.
Remove the removalListener of ExternalDatabase's meta cache, it may cause thread pool exausted:

```
"CommonRefreshExecutor-55" #19386 daemon prio=5 os_prio=0 tid=0x00007ef928005000 nid=0x61aa waiting on condition [0x00007ef8aaf5a000]
   java.lang.Thread.State: TIMED_WAITING (parking)
    at sun.misc.Unsafe.park(Native Method)
    - parking to wait for  <0x00007f03c435af50> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
    at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:215)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:2078)
    at java.util.concurrent.LinkedBlockingQueue.offer(LinkedBlockingQueue.java:385)
    at org.apache.doris.common.ThreadPoolManager$BlockedPolicy.rejectedExecution(ThreadPoolManager.java:347)
    at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:830)
    at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1379)
    at com.github.benmanes.caffeine.cache.BoundedLocalCache.notifyRemoval(BoundedLocalCache.java:333)
    at com.github.benmanes.caffeine.cache.BoundedLocalCache.removeNode(BoundedLocalCache.java:1882)
    at com.github.benmanes.caffeine.cache.BoundedLocalCache.clear(BoundedLocalCache.java:1819)
    at com.github.benmanes.caffeine.cache.LocalManualCache.invalidateAll(LocalManualCache.java:150)
    at org.apache.doris.datasource.metacache.MetaCache.invalidateAll(MetaCache.java:121)
    at org.apache.doris.datasource.ExternalDatabase.setUnInitialized(ExternalDatabase.java:123)
    at org.apache.doris.datasource.ExternalCatalog.lambda$null$2(ExternalCatalog.java:248)
    at org.apache.doris.datasource.ExternalCatalog$$Lambda$3280/1787323570.accept(Unknown Source)
    at java.util.Optional.ifPresent(Optional.java:159)
    at org.apache.doris.datasource.ExternalCatalog.lambda$makeSureInitialized$3(ExternalCatalog.java:248)
    at org.apache.doris.datasource.ExternalCatalog$$Lambda$2317/2029647164.onRemoval(Unknown Source)
    at com.github.benmanes.caffeine.cache.BoundedLocalCache.lambda$notifyRemoval$1(BoundedLocalCache.java:327)
    at com.github.benmanes.caffeine.cache.BoundedLocalCache$$Lambda$3279/2010922194.run(Unknown Source)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:750)
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

