### PR TITLE
(opt)(nereids)print change node in explain plan process command

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
@@ -570,7 +570,8 @@ public class CascadesContext implements ScheduleContext {
 
     public static void printPlanProcess(List<PlanProcess> planProcesses) {
         for (PlanProcess row : planProcesses) {
-            LOG.info("RULE: {}\nBEFORE:\n{}\nafter:\n{}", row.ruleName, row.beforeShape, row.afterShape);
+            LOG.info("RULE: {}\nINPUT_PLAN:\n{}\nCHANGE_NODE:\n{}AFTER_CHANGE:\n{}",
+                    row.ruleName, row.inputPlan, row.changeNode, row.rewrittenSubTree);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -235,7 +235,7 @@ public class NereidsPlanner extends Planner {
                         case ALL_PLAN:
                             cascadesContext.addPlanProcess(
                                     new PlanProcess("ImplementSqlCache",
-                                            parsedPlan.treeString(), physicalPlan.treeString())
+                                            parsedPlan.treeString(), physicalPlan.treeString(), parsedPlan.toString())
                             );
                             break;
                         default: {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/PlanProcess.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/PlanProcess.java
@@ -20,13 +20,15 @@ package org.apache.doris.nereids;
 /** PlanProcess */
 public class PlanProcess {
     public final String ruleName;
-    public final String beforeShape;
-    public final String afterShape;
+    public final String inputPlan;
+    public final String rewrittenSubTree;
+    public final String changeNode;
 
-    public PlanProcess(String ruleName, String beforeShape, String afterShape) {
+    public PlanProcess(String ruleName, String inputPlan, String rewrittenSubTree, String changeNode) {
         this.ruleName = ruleName;
-        this.beforeShape = beforeShape;
-        this.afterShape = afterShape;
+        this.inputPlan = inputPlan;
+        this.rewrittenSubTree = rewrittenSubTree;
+        this.changeNode = changeNode;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundRelation.java
@@ -177,6 +177,7 @@ public class UnboundRelation extends LogicalRelation implements Unbound, BlockFu
 
     @Override
     public String toString() {
+        String nameAndId = "UnboundRelation" + "[" + id.asInt() + "]";
         List<Object> args = Lists.newArrayList(
                 "id", relationId,
                 "nameParts", StringUtils.join(nameParts, ".")
@@ -185,7 +186,7 @@ public class UnboundRelation extends LogicalRelation implements Unbound, BlockFu
             args.add("hints");
             args.add(StringUtils.join(hints, ", "));
         }
-        return Utils.toSqlString("UnboundRelation", args.toArray());
+        return Utils.toSqlString(nameAndId, args.toArray());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/BottomUpVisitorRewriteJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/BottomUpVisitorRewriteJob.java
@@ -133,12 +133,11 @@ public class BottomUpVisitorRewriteJob implements RewriteJob {
                 currentRule.acceptPlan(result);
 
                 if (cascadesContext.showPlanProcess()) {
-                    String beforeShape = processState.getNewestPlan().treeString(true);
-                    String afterShape = processState.updateChildAndGetNewest(originParent, childIndex, result)
-                            .treeString(true);
+                    String inputPlan = processState.getNewestPlan().treeString(true);
+                    String rewrittenNode = result.treeString();
                     cascadesContext.addPlanProcess(
-                        new PlanProcess(currentRule.getRuleType().name(), beforeShape, afterShape)
-                    );
+                        new PlanProcess(currentRule.getRuleType().name(), inputPlan, rewrittenNode,
+                                plan.toString()));
                 }
                 // if rewrite success, record the rule type
                 cascadesContext.getStatementContext().ruleSetApplied(currentRule.getRuleType());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/CustomRewriteJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/CustomRewriteJob.java
@@ -68,7 +68,8 @@ public class CustomRewriteJob implements RewriteJob {
         if (!root.deepEquals(rewrittenRoot)) {
             if (cascadesContext.showPlanProcess()) {
                 PlanProcess planProcess = new PlanProcess(
-                        ruleType.name(), root.treeString(true), rewrittenRoot.treeString(true));
+                        ruleType.name(), root.treeString(true), rewrittenRoot.treeString(true),
+                        root.toString());
                 cascadesContext.addPlanProcess(planProcess);
             }
             // if rewrite success, record the rule type

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/PlanTreeRewriteJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/PlanTreeRewriteJob.java
@@ -70,8 +70,9 @@ public abstract class PlanTreeRewriteJob extends Job {
                     context.setRewritten(true);
                     rule.acceptPlan(newPlan);
                     if (showPlanProcess) {
-                        String traceAfter = getCurrentPlanTreeString();
-                        PlanProcess planProcess = new PlanProcess(rule.getRuleType().name(), traceBefore, traceAfter);
+                        PlanProcess planProcess = new PlanProcess(rule.getRuleType().name(), traceBefore,
+                                newPlan.treeString(),
+                                plan.toString());
                         cascadesContext.addPlanProcess(planProcess);
                     }
                     // if rewrite success, record the rule type

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/TopDownVisitorRewriteJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/rewrite/TopDownVisitorRewriteJob.java
@@ -114,11 +114,11 @@ public class TopDownVisitorRewriteJob implements RewriteJob {
                     Plan newPlan = transform.get(0);
                     currentRule.acceptPlan(originPlan);
                     if (cascadesContext.showPlanProcess()) {
-                        String beforeShape = processState.getNewestPlan().treeString(true);
-                        String afterShape = processState.updateChildAndGetNewest(originParent, childIndex, newPlan)
-                                .treeString(true);
+                        String inputPlan = processState.getNewestPlan().treeString(true);
                         cascadesContext.addPlanProcess(
-                                new PlanProcess(currentRule.getRuleType().name(), beforeShape, afterShape)
+                                new PlanProcess(currentRule.getRuleType().name(), inputPlan,
+                                        newPlan.treeString(),
+                                        plan.toString())
                         );
                     }
                     // if rewrite success, record the rule type

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCheckPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCheckPolicy.java
@@ -89,7 +89,7 @@ public class LogicalCheckPolicy<CHILD_TYPE extends Plan> extends LogicalUnary<CH
 
     @Override
     public String toString() {
-        return Utils.toSqlString("LogicalCheckPolicy");
+        return Utils.toSqlString("LogicalCheckPolicy[" + id.asInt() +"]");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCheckPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCheckPolicy.java
@@ -89,7 +89,7 @@ public class LogicalCheckPolicy<CHILD_TYPE extends Plan> extends LogicalUnary<CH
 
     @Override
     public String toString() {
-        return Utils.toSqlString("LogicalCheckPolicy[" + id.asInt() +"]");
+        return Utils.toSqlString("LogicalCheckPolicy[" + id.asInt() + "]");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
@@ -289,7 +289,8 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan 
 
     @Override
     public String toString() {
-        return Utils.toSqlStringSkipNull("LogicalOlapScan",
+        String nameAndId = "LogicalOlapScan[" + id.asInt() + "]";
+        return Utils.toSqlStringSkipNull(nameAndId,
                 "qualified", qualifiedName(),
                 "alias", tableAlias,
                 "indexName", getSelectedMaterializedIndexName().orElse("<index_not_selected>"),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSubQueryAlias.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSubQueryAlias.java
@@ -131,10 +131,11 @@ public class LogicalSubQueryAlias<CHILD_TYPE extends Plan> extends LogicalUnary<
 
     @Override
     public String toString() {
-        return columnAliases.map(strings -> Utils.toSqlString("LogicalSubQueryAlias",
+        String nameAndId = "LogicalSubQueryAlias[" + id.asInt() + "]";
+        return columnAliases.map(strings -> Utils.toSqlString(nameAndId,
                 "qualifier", qualifier,
                 "columnAliases", StringUtils.join(strings, ",")
-        )).orElseGet(() -> Utils.toSqlString("LogicalSubQueryAlias",
+        )).orElseGet(() -> Utils.toSqlString(nameAndId,
                 "qualifier", qualifier
         ));
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1769,10 +1769,10 @@ public class StmtExecutor {
 
             for (PlanProcess row : result) {
                 serializer.reset();
-                serializer.writeLenEncodedString(row.ruleName+"\n\n");
-                serializer.writeLenEncodedString(row.inputPlan +"\n\n");
-                serializer.writeLenEncodedString(row.changeNode +"\n\n");
-                serializer.writeLenEncodedString(row.rewrittenSubTree +"\n\n");
+                serializer.writeLenEncodedString(row.ruleName + "\n\n");
+                serializer.writeLenEncodedString(row.inputPlan + "\n\n");
+                serializer.writeLenEncodedString(row.changeNode + "\n\n");
+                serializer.writeLenEncodedString(row.rewrittenSubTree + "\n\n");
                 context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1760,17 +1760,19 @@ public class StmtExecutor {
     public void handleExplainPlanProcessStmt(List<PlanProcess> result) throws IOException {
         ShowResultSetMetaData metaData = ShowResultSetMetaData.builder()
                 .addColumn(new Column("Rule", ScalarType.createVarchar(-1)))
-                .addColumn(new Column("Before", ScalarType.createVarchar(-1)))
-                .addColumn(new Column("After", ScalarType.createVarchar(-1)))
+                .addColumn(new Column("inputPlan", ScalarType.createVarchar(-1)))
+                .addColumn(new Column("changeNode", ScalarType.createVarchar(-1)))
+                .addColumn(new Column("rewrittenSubTree", ScalarType.createVarchar(-1)))
                 .build();
         if (context.getConnectType() == ConnectType.MYSQL) {
             sendMetaData(metaData);
 
             for (PlanProcess row : result) {
                 serializer.reset();
-                serializer.writeLenEncodedString(row.ruleName);
-                serializer.writeLenEncodedString(row.beforeShape);
-                serializer.writeLenEncodedString(row.afterShape);
+                serializer.writeLenEncodedString(row.ruleName+"\n\n");
+                serializer.writeLenEncodedString(row.inputPlan +"\n\n");
+                serializer.writeLenEncodedString(row.changeNode +"\n\n");
+                serializer.writeLenEncodedString(row.rewrittenSubTree +"\n\n");
                 context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
             }
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
@@ -195,7 +195,8 @@ public class PlanChecker {
         List<PlanProcess> planProcesses = explainPlanProcess(sql);
         for (PlanProcess row : planProcesses) {
             System.out.println("RULE: " + row.ruleName + "\nBEFORE:\n"
-                    + row.beforeShape + "\nafter:\n" + row.afterShape);
+                    + row.inputPlan + "\nafter:\n" + row.rewrittenSubTree
+                    + "\nchange point: " + row.changeNode);
         }
         return this;
     }


### PR DESCRIPTION
### What problem does this PR solve?
before this pr, explain-plan-process command output schema "rule, inputPlan, outputPlan".
there are 2 improvements
1. add changeNode (the plan node which is changed),
2.  do not construct complete plan after rule applied, only print the rewritten sub tree
example:
suppose we have plan tree:
node1->node2->node3
after rule R, node3 is changed to node4.
now the output is:
inputPlan: node1->node2->node3
changeNode: node3
rewrittenSubTree: node4

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

