### PR TITLE
[refine](function) Remove unused code from the function framework and optimize the default NULL-handling logic.

### DIFF
--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -120,6 +120,10 @@ public:
         std::swap(data, new_data);
     }
 
+    // Use this method only when you are certain index_by_name will not be used
+    // This is a temporary compromise; index_by_name may be removed in the future
+    void simple_insert(const ColumnWithTypeAndName& elem) { data.emplace_back(elem); }
+
     void initialize_index_by_name();
 
     /// References are invalidated after calling functions above.

--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -236,7 +236,7 @@ Status VectorizedFnCall::_do_execute(doris::vectorized::VExprContext* context,
     });
 
     RETURN_IF_ERROR(_function->execute(context->fn_context(_fn_context_index), *block, args,
-                                       num_columns_without_result, block->rows(), false));
+                                       num_columns_without_result, block->rows()));
     *result_column_id = num_columns_without_result;
     RETURN_IF_ERROR(block->check_type_and_column());
     return Status::OK();

--- a/be/src/vec/exprs/vin_predicate.cpp
+++ b/be/src/vec/exprs/vin_predicate.cpp
@@ -141,7 +141,7 @@ Status VInPredicate::execute(VExprContext* context, Block* block, int* result_co
     block->insert({nullptr, _data_type, _expr_name});
 
     RETURN_IF_ERROR(_function->execute(context->fn_context(_fn_context_index), *block, arguments,
-                                       num_columns_without_result, block->rows(), false));
+                                       num_columns_without_result, block->rows()));
     *result_column_id = num_columns_without_result;
     return Status::OK();
 }

--- a/be/src/vec/exprs/vmatch_predicate.cpp
+++ b/be/src/vec/exprs/vmatch_predicate.cpp
@@ -170,7 +170,7 @@ Status VMatchPredicate::execute(VExprContext* context, Block* block, int* result
     // prepare a column to save result
     block->insert({nullptr, _data_type, _expr_name});
     RETURN_IF_ERROR(_function->execute(context->fn_context(_fn_context_index), *block, arguments,
-                                       num_columns_without_result, block->rows(), false));
+                                       num_columns_without_result, block->rows()));
     *result_column_id = num_columns_without_result;
     return Status::OK();
 }

--- a/be/src/vec/exprs/vtopn_pred.h
+++ b/be/src/vec/exprs/vtopn_pred.h
@@ -104,7 +104,7 @@ public:
         uint32_t num_columns_without_result = block->columns();
         block->insert({nullptr, _data_type, _expr_name});
         RETURN_IF_ERROR(_function->execute(nullptr, *block, arguments, num_columns_without_result,
-                                           block->rows(), false));
+                                           block->rows()));
         *result_column_id = num_columns_without_result;
 
         if (is_nullable() && _predicate->nulls_first()) {

--- a/be/src/vec/functions/cast/cast_to_variant.h
+++ b/be/src/vec/functions/cast/cast_to_variant.h
@@ -67,7 +67,7 @@ struct CastFromVariant {
                 // Note: here we should return the nullable result column
                 col_to = wrap_in_nullable(
                         col_to, Block({{nested, nested_from_type, ""}, {col_to, data_type_to, ""}}),
-                        {0}, 1, input_rows_count);
+                        {0}, input_rows_count);
             }
         } else {
             if (variant.only_have_default_values()) {

--- a/be/src/vec/functions/cast/function_cast.cpp
+++ b/be/src/vec/functions/cast/function_cast.cpp
@@ -193,7 +193,7 @@ WrapperType prepare_remove_nullable(FunctionContext* context, const DataTypePtr&
 
             block.get_by_position(result).column =
                     wrap_in_nullable(block.get_by_position(nested_result_index).column, block,
-                                     arguments, result, input_rows_count);
+                                     arguments, input_rows_count);
 
             block.erase(nested_source_index);
             block.erase(nested_result_index);

--- a/be/src/vec/functions/function.cpp
+++ b/be/src/vec/functions/function.cpp
@@ -209,8 +209,7 @@ Status PreparedFunctionImpl::default_implementation_for_nulls(
         for (int i = 0; i < args.size(); ++i) {
             uint32_t arg = args[i];
             new_args.push_back(i);
-            new_block.simple_insert(
-                    new_block.get_by_position(arg).unnest_nullable(need_to_default));
+            new_block.simple_insert(block.get_by_position(arg).unnest_nullable(need_to_default));
         }
         new_block.simple_insert(block.get_by_position(result));
         int new_result = new_block.columns() - 1;

--- a/be/src/vec/functions/function_rpc.h
+++ b/be/src/vec/functions/function_rpc.h
@@ -72,7 +72,7 @@ public:
     String get_name() const override { return "RPCPreparedFunction: "; }
 
     Status execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
-                   uint32_t result, size_t input_rows_count, bool dry_run) const override {
+                   uint32_t result, size_t input_rows_count) const override {
         auto* fn = reinterpret_cast<RPCFnImpl*>(
                 context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
         return fn->vec_call(context, block, arguments, result, input_rows_count);


### PR DESCRIPTION
### What problem does this PR solve?


There used to be many unused parameters in the function framework; this PR removes them. 
The previous default-NULL handling framework inserted intermediate results into the block and then erased them — when blocks are large this caused significant overhead. 
Now intermediates are handled using a temporary block, and a simple_insert function is provided that only inserts values into the data.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

