### PR TITLE
[refactor](mysql output)Use to_string when outputting plain text to MySQL.

### DIFF
--- a/be/src/vec/data_types/serde/data_type_bitmap_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_bitmap_serde.cpp
@@ -177,10 +177,10 @@ bool DataTypeBitMapSerDe::write_column_to_mysql_text(const IColumn& column, Buff
                                                      int64_t row_idx) const {
     const auto& data_column = assert_cast<const ColumnBitmap&>(column);
     if (_return_object_as_string) {
-        BitmapValue bitmapValue = data_column.get_element(row_idx);
-        size_t size = bitmapValue.getSizeInBytes();
+        BitmapValue bitmap_value = data_column.get_element(row_idx);
+        size_t size = bitmap_value.getSizeInBytes();
         std::unique_ptr<char[]> buf = std::make_unique_for_overwrite<char[]>(size);
-        bitmapValue.write_to(buf.get());
+        bitmap_value.write_to(buf.get());
         bw.write(buf.get(), size);
         return true;
     } else {

--- a/be/src/vec/data_types/serde/data_type_bitmap_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_bitmap_serde.cpp
@@ -173,6 +173,21 @@ Status DataTypeBitMapSerDe::_write_column_to_mysql(const IColumn& column,
     return Status::OK();
 }
 
+bool DataTypeBitMapSerDe::write_column_to_mysql_text(const IColumn& column, BufferWritable& bw,
+                                                     int64_t row_idx) const {
+    const auto& data_column = assert_cast<const ColumnBitmap&>(column);
+    if (_return_object_as_string) {
+        BitmapValue bitmapValue = data_column.get_element(row_idx);
+        size_t size = bitmapValue.getSizeInBytes();
+        std::unique_ptr<char[]> buf = std::make_unique_for_overwrite<char[]>(size);
+        bitmapValue.write_to(buf.get());
+        bw.write(buf.get(), size);
+        return true;
+    } else {
+        return false;
+    }
+}
+
 Status DataTypeBitMapSerDe::write_column_to_mysql_binary(const IColumn& column,
                                                          MysqlRowBinaryBuffer& row_buffer,
                                                          int64_t row_idx, bool col_const,

--- a/be/src/vec/data_types/serde/data_type_bitmap_serde.h
+++ b/be/src/vec/data_types/serde/data_type_bitmap_serde.h
@@ -78,6 +78,9 @@ public:
                                       int64_t row_idx, bool col_const,
                                       const FormatOptions& options) const override;
 
+    bool write_column_to_mysql_text(const IColumn& column, BufferWritable& bw,
+                                    int64_t row_idx) const override;
+
     Status write_column_to_orc(const std::string& timezone, const IColumn& column,
                                const NullMap* null_map, orc::ColumnVectorBatch* orc_col_batch,
                                int64_t start, int64_t end, vectorized::Arena& arena) const override;

--- a/be/src/vec/data_types/serde/data_type_hll_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_hll_serde.cpp
@@ -170,6 +170,21 @@ Status DataTypeHLLSerDe::_write_column_to_mysql(const IColumn& column,
     return Status::OK();
 }
 
+bool DataTypeHLLSerDe::write_column_to_mysql_text(const IColumn& column, BufferWritable& bw,
+                                                  int64_t row_idx) const {
+    const auto& data_column = assert_cast<const ColumnHLL&>(column);
+    if (_return_object_as_string) {
+        const HyperLogLog& hyperLogLog = data_column.get_element(row_idx);
+        size_t size = hyperLogLog.max_serialized_size();
+        std::unique_ptr<char[]> buf = std::make_unique_for_overwrite<char[]>(size);
+        hyperLogLog.serialize((uint8_t*)buf.get());
+        bw.write(buf.get(), size);
+        return true;
+    } else {
+        return false;
+    }
+}
+
 Status DataTypeHLLSerDe::write_column_to_mysql_binary(const IColumn& column,
                                                       MysqlRowBinaryBuffer& row_buffer,
                                                       int64_t row_idx, bool col_const,

--- a/be/src/vec/data_types/serde/data_type_hll_serde.h
+++ b/be/src/vec/data_types/serde/data_type_hll_serde.h
@@ -72,6 +72,9 @@ public:
                                       int64_t row_idx, bool col_const,
                                       const FormatOptions& options) const override;
 
+    bool write_column_to_mysql_text(const IColumn& column, BufferWritable& bw,
+                                    int64_t row_idx) const override;
+
     Status write_column_to_orc(const std::string& timezone, const IColumn& column,
                                const NullMap* null_map, orc::ColumnVectorBatch* orc_col_batch,
                                int64_t start, int64_t end, vectorized::Arena& arena) const override;

--- a/be/src/vec/data_types/serde/data_type_jsonb_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_jsonb_serde.cpp
@@ -355,8 +355,14 @@ void DataTypeJsonbSerDe::to_string(const IColumn& column, size_t row_num,
     const auto& col = assert_cast<const ColumnString&, TypeCheckOnRelease::DISABLE>(column);
     const auto& data_ref = col.get_data_at(row_num);
     if (data_ref.size > 0) {
+        if (_nesting_level > 1) {
+            bw.write('"');
+        }
         std::string str = JsonbToJson::jsonb_to_json_string(data_ref.data, data_ref.size);
         bw.write(str.c_str(), str.size());
+        if (_nesting_level > 1) {
+            bw.write('"');
+        }
     } else {
         bw.write("NULL", 4);
     }

--- a/be/src/vec/data_types/serde/data_type_nullable_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_nullable_serde.cpp
@@ -353,6 +353,16 @@ Status DataTypeNullableSerDe::read_column_from_arrow(IColumn& column,
                                                 ctz);
 }
 
+bool DataTypeNullableSerDe::write_column_to_mysql_text(const IColumn& column, BufferWritable& bw,
+                                                       int64_t row_idx) const {
+    if (column.is_null_at(row_idx)) {
+        return false;
+    } else {
+        const auto& col = assert_cast<const ColumnNullable&>(column);
+        return nested_serde->write_column_to_mysql_text(col.get_nested_column(), bw, row_idx);
+    }
+}
+
 template <bool is_binary_format>
 Status DataTypeNullableSerDe::_write_column_to_mysql(const IColumn& column,
                                                      MysqlRowBuffer<is_binary_format>& result,

--- a/be/src/vec/data_types/serde/data_type_nullable_serde.h
+++ b/be/src/vec/data_types/serde/data_type_nullable_serde.h
@@ -91,6 +91,8 @@ public:
     Status write_column_to_mysql_text(const IColumn& column, MysqlRowTextBuffer& row_buffer,
                                       int64_t row_idx, bool col_const,
                                       const FormatOptions& options) const override;
+    bool write_column_to_mysql_text(const IColumn& column, BufferWritable& bw,
+                                    int64_t row_idx) const override;
 
     Status write_column_to_orc(const std::string& timezone, const IColumn& column,
                                const NullMap* null_map, orc::ColumnVectorBatch* orc_col_batch,

--- a/be/src/vec/data_types/serde/data_type_number_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_number_serde.cpp
@@ -911,7 +911,18 @@ template <PrimitiveType T>
 void DataTypeNumberSerDe<T>::to_string(const IColumn& column, size_t row_num,
                                        BufferWritable& bw) const {
     auto& data = assert_cast<const ColumnType&, TypeCheckOnRelease::DISABLE>(column).get_data();
-    value_to_string<T>(data[row_num], bw, get_scale());
+    if constexpr (is_date_type(T) || is_time_type(T) || is_ip(T)) {
+        if (_nesting_level > 1) {
+            bw.write('"');
+        }
+        value_to_string<T>(data[row_num], bw, get_scale());
+        if (_nesting_level > 1) {
+            bw.write('"');
+        }
+
+    } else {
+        value_to_string<T>(data[row_num], bw, get_scale());
+    }
 }
 
 template <PrimitiveType T>

--- a/be/src/vec/data_types/serde/data_type_number_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_number_serde.cpp
@@ -919,7 +919,6 @@ void DataTypeNumberSerDe<T>::to_string(const IColumn& column, size_t row_num,
         if (_nesting_level > 1) {
             bw.write('"');
         }
-
     } else {
         value_to_string<T>(data[row_num], bw, get_scale());
     }

--- a/be/src/vec/data_types/serde/data_type_quantilestate_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_quantilestate_serde.cpp
@@ -43,4 +43,22 @@ void DataTypeQuantileStateSerDe::read_one_cell_from_jsonb(IColumn& column,
     val.deserialize(Slice(blob->getBlob(), blob->getBlobLen()));
     col.insert_value(val);
 }
+
+bool DataTypeQuantileStateSerDe::write_column_to_mysql_text(const IColumn& column,
+                                                            BufferWritable& bw,
+                                                            int64_t row_idx) const {
+    const auto& data_column = reinterpret_cast<const ColumnQuantileState&>(column);
+
+    if (_return_object_as_string) {
+        const auto& quantile_value = data_column.get_element(row_idx);
+        size_t size = quantile_value.get_serialized_size();
+        std::unique_ptr<char[]> buf = std::make_unique_for_overwrite<char[]>(size);
+        quantile_value.serialize((uint8_t*)buf.get());
+        bw.write(buf.get(), size);
+        return true;
+    } else {
+        return false;
+    }
+}
+
 } // namespace doris::vectorized

--- a/be/src/vec/data_types/serde/data_type_quantilestate_serde.h
+++ b/be/src/vec/data_types/serde/data_type_quantilestate_serde.h
@@ -136,6 +136,9 @@ public:
         return _write_column_to_mysql(column, row_buffer, row_idx, col_const, options);
     }
 
+    bool write_column_to_mysql_text(const IColumn& column, BufferWritable& bw,
+                                    int64_t row_idx) const override;
+
     Status write_column_to_orc(const std::string& timezone, const IColumn& column,
                                const NullMap* null_map, orc::ColumnVectorBatch* orc_col_batch,
                                int64_t start, int64_t end,

--- a/be/src/vec/data_types/serde/data_type_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_serde.cpp
@@ -135,6 +135,12 @@ void DataTypeSerDe::to_string(const IColumn& column, size_t row_num, BufferWrita
                            "Data type {} to_string_batch not implement.", get_name());
 }
 
+bool DataTypeSerDe::write_column_to_mysql_text(const IColumn& column, BufferWritable& bw,
+                                               int64_t row_idx) const {
+    to_string(column, row_idx, bw);
+    return true;
+}
+
 const std::string DataTypeSerDe::NULL_IN_COMPLEX_TYPE = "null";
 const std::string DataTypeSerDe::NULL_IN_CSV_FOR_ORDINARY_TYPE = "\\N";
 

--- a/be/src/vec/data_types/serde/data_type_serde.h
+++ b/be/src/vec/data_types/serde/data_type_serde.h
@@ -431,6 +431,11 @@ public:
                                               int64_t row_idx, bool col_const,
                                               const FormatOptions& options) const = 0;
 
+    // return true if output as string
+    // return false if output null
+    virtual bool write_column_to_mysql_text(const IColumn& column, BufferWritable& bw,
+                                            int64_t row_idx) const;
+
     virtual Status write_column_to_mysql_binary(const IColumn& column,
                                                 MysqlRowBinaryBuffer& row_buffer, int64_t row_idx,
                                                 bool col_const,

--- a/be/src/vec/sink/vmysql_result_writer.cpp
+++ b/be/src/vec/sink/vmysql_result_writer.cpp
@@ -188,7 +188,8 @@ void direct_write_to_mysql_result_string(std::string& mysql_rows, const char* st
         mysql_rows.append(buf, 1);
     } else if (size < 65536ULL) {
         buf[0] = static_cast<char>(252);
-        int2store(buf + 1, size);
+        uint16_t temp16 = static_cast<uint16_t>(size);
+        memcpy(buf + 1, &temp16, sizeof(temp16));
         mysql_rows.append(buf, 3);
     } else if (size < 16777216ULL) {
         buf[0] = static_cast<char>(253);
@@ -196,7 +197,8 @@ void direct_write_to_mysql_result_string(std::string& mysql_rows, const char* st
         mysql_rows.append(buf, 4);
     } else {
         buf[0] = static_cast<char>(254);
-        int8store(buf + 1, size);
+        uint64_t temp64 = static_cast<uint64_t>(size);
+        memcpy(buf + 1, &temp64, sizeof(temp64));
         mysql_rows.append(buf, 9);
     }
 

--- a/be/src/vec/sink/vmysql_result_writer.cpp
+++ b/be/src/vec/sink/vmysql_result_writer.cpp
@@ -182,22 +182,19 @@ void direct_write_to_mysql_result_string(std::string& mysql_rows, const char* st
     // < 16777216: 1 byte (253) + 3 bytes for length
     // >= 16777216: 1 byte (254) + 8 bytes for length
 
+    char buf[16];
     if (size < 251ULL) {
-        char buf[1];
         int1store(buf, size);
         mysql_rows.append(buf, 1);
     } else if (size < 65536ULL) {
-        char buf[3];
         buf[0] = static_cast<char>(252);
         int2store(buf + 1, size);
         mysql_rows.append(buf, 3);
     } else if (size < 16777216ULL) {
-        char buf[4];
         buf[0] = static_cast<char>(253);
         int3store(buf + 1, size);
         mysql_rows.append(buf, 4);
     } else {
-        char buf[9];
         buf[0] = static_cast<char>(254);
         int8store(buf + 1, size);
         mysql_rows.append(buf, 9);


### PR DESCRIPTION
### What problem does this PR solve?

before
write to a MySQL buffer and then copy that into a Thrift structure. 
now
cast it to a string and then encode it into the Thrift structure.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

