### PR TITLE
[fix](executor) Fix time-sharing task executor don't re-schedule when exceeded concurrency limit case.

### DIFF
--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -233,7 +233,7 @@ protected:
     doris::vectorized::ScannerScheduler* _scanner_scheduler_global = nullptr;
     SimplifiedScanScheduler* _scanner_scheduler = nullptr;
     // Using stack so that we can resubmit scanner in a LIFO order, maybe more cache friendly
-    std::stack<std::weak_ptr<ScannerDelegate>> _pending_scanners;
+    std::stack<std::shared_ptr<ScanTask>> _pending_scanners;
     // Scanner that is submitted to the scheduler.
     std::atomic_int _num_scheduled_scanners = 0;
     // Scanner that is eos or error.

--- a/be/test/scan/scanner_context_test.cpp
+++ b/be/test/scan/scanner_context_test.cpp
@@ -493,12 +493,13 @@ TEST_F(ScannerContextTest, pull_next_scan_task) {
             scan_task, scanner_context->_max_scan_concurrency - 1);
     EXPECT_EQ(pull_scan_task.get(), scan_task.get());
 
-    scanner_context->_pending_scanners = std::stack<std::weak_ptr<ScannerDelegate>>();
+    scanner_context->_pending_scanners = std::stack<std::shared_ptr<ScanTask>>();
     pull_scan_task = scanner_context->_pull_next_scan_task(
             nullptr, scanner_context->_max_scan_concurrency - 1);
     EXPECT_EQ(pull_scan_task, nullptr);
 
-    scanner_context->_pending_scanners.push(std::make_shared<ScannerDelegate>(scanner));
+    scanner_context->_pending_scanners.push(
+            std::make_shared<ScanTask>(std::make_shared<ScannerDelegate>(scanner)));
     pull_scan_task = scanner_context->_pull_next_scan_task(
             nullptr, scanner_context->_max_scan_concurrency - 1);
     EXPECT_NE(pull_scan_task, nullptr);


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

### Release note

Fix time-sharing task executor don't re-schedule when exceeded concurrency limit case. The time-sharing task executor needs the state of `ScanTask` to track split scheduling and determine whether to schedule it as the first time by `enqueue_splits` or reschedule it by `re_enqueue_split`.
```
virtual Status submit_scan_task(SimplifiedScanTask scan_task) override {
        if (!_is_stop) {
            std::cout << "submitting scan task to task executor scheduler, context id: "
                      << scan_task.scanner_context->ctx_id << std::endl;
            std::shared_ptr<SplitRunner> split_runner;
            if (scan_task.scan_task->is_first_schedule) {
                split_runner = std::make_shared<ScannerSplitRunner>("scanner_split_runner",
                                                                    scan_task.scan_func);
                RETURN_IF_ERROR(split_runner->init());
                auto result = _task_executor->enqueue_splits(
                        scan_task.scanner_context->task_handle(), false, {split_runner});
                if (!result.has_value()) {
                    LOG(WARNING) << "enqueue_splits failed: " << result.error();
                    return result.error();
                }
                scan_task.scan_task->is_first_schedule = false;
            } else {
                split_runner = scan_task.scan_task->split_runner.lock();
                if (split_runner == nullptr) {
                    return Status::OK();
                }
                RETURN_IF_ERROR(_task_executor->re_enqueue_split(
                        scan_task.scanner_context->task_handle(), false, split_runner));
            }
            scan_task.scan_task->split_runner = split_runner;
            return Status::OK();
        } else {
            return Status::InternalError<false>("scanner pool {} is shutdown.", _sched_name);
        }
    }
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    tpcds1000 q88
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

