### PR TITLE
[fix](cloud) Fix read peer file cache some bugs

### DIFF
--- a/be/src/io/cache/block_file_cache_downloader.cpp
+++ b/be/src/io/cache/block_file_cache_downloader.cpp
@@ -284,6 +284,7 @@ void FileCacheBlockDownloader::download_file_cache_block(
                                 .is_index_data = meta.cache_type() == ::doris::FileCacheType::INDEX,
                                 .expiration_time = meta.expiration_time(),
                                 .is_dryrun = config::enable_reader_dryrun_when_download_file_cache,
+                                .is_warmup = true,
                         },
                 .download_done = std::move(download_done),
         };

--- a/be/src/io/cache/cached_remote_file_reader.cpp
+++ b/be/src/io/cache/cached_remote_file_reader.cpp
@@ -192,10 +192,12 @@ std::pair<std::string, int> get_peer_connection_info(const std::string& file_pat
 }
 
 // Execute peer read with fallback to S3
+// file_size is the size of the file
+// used to calculate the rightmost boundary value of the block, due to inaccurate current block meta information.
 Status execute_peer_read(const std::vector<FileBlockSPtr>& empty_blocks, size_t empty_start,
                          size_t& size, std::unique_ptr<char[]>& buffer,
-                         const std::string& file_path, bool is_doris_table, ReadStatistics& stats,
-                         const IOContext* io_ctx) {
+                         const std::string& file_path, size_t file_size, bool is_doris_table,
+                         ReadStatistics& stats, const IOContext* io_ctx) {
     auto [host, port] = get_peer_connection_info(file_path);
     VLOG_DEBUG << "PeerFileCacheReader read from peer, host=" << host << ", port=" << port
                << ", file_path=" << file_path;
@@ -211,7 +213,7 @@ Status execute_peer_read(const std::vector<FileBlockSPtr>& empty_blocks, size_t 
     peer_read_counter << 1;
     PeerFileCacheReader peer_reader(file_path, is_doris_table, host, port);
     auto st = peer_reader.fetch_blocks(empty_blocks, empty_start, Slice(buffer.get(), size), &size,
-                                       io_ctx);
+                                       file_size, io_ctx);
     if (!st.ok()) {
         LOG_WARNING("PeerFileCacheReader read from peer failed")
                 .tag("host", host)
@@ -253,7 +255,7 @@ Status CachedRemoteFileReader::_execute_remote_read(const std::vector<FileBlockS
             return execute_s3_read(empty_start, size, buffer, stats, io_ctx, _remote_file_reader);
         } else {
             return execute_peer_read(empty_blocks, empty_start, size, buffer, path().native(),
-                                     _is_doris_table, stats, io_ctx);
+                                     this->size(), _is_doris_table, stats, io_ctx);
         }
     });
 
@@ -266,7 +268,7 @@ Status CachedRemoteFileReader::_execute_remote_read(const std::vector<FileBlockS
         // ATTN: Save original size before peer read, as it may be modified by fetch_blocks, read peer ref size
         size_t original_size = size;
         auto st = execute_peer_read(empty_blocks, empty_start, size, buffer, path().native(),
-                                    _is_doris_table, stats, io_ctx);
+                                    this->size(), _is_doris_table, stats, io_ctx);
         if (!st.ok()) {
             // Restore original size for S3 fallback, as peer read may have modified it
             size = original_size;

--- a/be/src/io/cache/peer_file_cache_reader.cpp
+++ b/be/src/io/cache/peer_file_cache_reader.cpp
@@ -66,7 +66,8 @@ PeerFileCacheReader::~PeerFileCacheReader() {
 }
 
 Status PeerFileCacheReader::fetch_blocks(const std::vector<FileBlockSPtr>& blocks, size_t off,
-                                         Slice s, size_t* bytes_read, const IOContext* ctx) {
+                                         Slice s, size_t* bytes_read, size_t file_size,
+                                         const IOContext* ctx) {
     VLOG_DEBUG << "enter PeerFileCacheReader::fetch_blocks, off=" << off
                << " bytes_read=" << *bytes_read;
     if (blocks.empty()) {
@@ -80,6 +81,7 @@ Status PeerFileCacheReader::fetch_blocks(const std::vector<FileBlockSPtr>& block
     PFetchPeerDataRequest req;
     req.set_type(PFetchPeerDataRequest_Type_PEER_FILE_CACHE_BLOCK);
     req.set_path(_path.filename().native());
+    req.set_file_size(static_cast<int64_t>(file_size));
     for (const auto& blk : blocks) {
         auto* cb = req.add_cache_req();
         cb->set_block_offset(static_cast<int64_t>(blk->range().left));

--- a/be/src/io/cache/peer_file_cache_reader.cpp
+++ b/be/src/io/cache/peer_file_cache_reader.cpp
@@ -69,8 +69,8 @@ Status PeerFileCacheReader::fetch_blocks(const std::vector<FileBlockSPtr>& block
                                          Slice s, size_t* bytes_read, const IOContext* ctx) {
     VLOG_DEBUG << "enter PeerFileCacheReader::fetch_blocks, off=" << off
                << " bytes_read=" << *bytes_read;
-    *bytes_read = 0;
     if (blocks.empty()) {
+        *bytes_read = 0;
         return Status::OK();
     }
     if (!_is_doris_table) {
@@ -154,13 +154,13 @@ Status PeerFileCacheReader::fetch_blocks(const std::vector<FileBlockSPtr>& block
     }
     VLOG_DEBUG << "peer cache read filled=" << filled;
     peer_bytes_read_total << filled;
-    *bytes_read = filled;
     peer_bytes_per_read << filled;
     if (filled != s.size) {
         peer_cache_reader_failed_counter << 1;
         return Status::InternalError("peer cache read incomplete: need={}, got={}", s.size, filled);
     }
     peer_cache_reader_succ_counter << 1;
+    *bytes_read = filled;
     return Status::OK();
 }
 

--- a/be/src/io/cache/peer_file_cache_reader.h
+++ b/be/src/io/cache/peer_file_cache_reader.h
@@ -62,6 +62,7 @@ public:
      * - off: Base file offset corresponding to the start of Slice s.
      * - s: Destination buffer; must be large enough to hold all requested block bytes.
      * - n: Output number of bytes successfully written.
+     * - file_size: Size of the file to be read.
      * - ctx: IO context (kept for interface symmetry).
      *
      * Returns:
@@ -69,7 +70,7 @@ public:
      * - NotSupported: The file is not a Doris table segment.
      */
     Status fetch_blocks(const std::vector<FileBlockSPtr>& blocks, size_t off, Slice s,
-                        size_t* bytes_read, const IOContext* ctx);
+                        size_t* bytes_read, size_t file_size, const IOContext* ctx);
 
 private:
     io::Path _path;

--- a/be/src/io/cache/peer_file_cache_reader.h
+++ b/be/src/io/cache/peer_file_cache_reader.h
@@ -61,7 +61,7 @@ public:
      * - blocks: List of file blocks to fetch (global file offsets, inclusive ranges).
      * - off: Base file offset corresponding to the start of Slice s.
      * - s: Destination buffer; must be large enough to hold all requested block bytes.
-     * - n: Output number of bytes successfully written.
+     * - bytes_read: Output number of bytes read.
      * - file_size: Size of the file to be read.
      * - ctx: IO context (kept for interface symmetry).
      *

--- a/regression-test/suites/cloud_p0/balance/test_balance_warm_up.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_balance_warm_up.groovy
@@ -215,6 +215,8 @@ suite('test_balance_warm_up', 'docker') {
         // test expired be tablet cache info be removed
         // after cache_read_from_peer_expired_seconds = 100s
         assert(0 == getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "balance_tablet_be_mapping_size"))
+        assert(0 == getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_peer_read"))
+        assert(0 != getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_s3_read"))
     }
 
     docker(options) {


### PR DESCRIPTION
### What problem does this PR solve?

1. Fixed an issue where reading from peer back to S3 resulted in an incorrect size (ref parameter passing).
2. Fixed a large number of reads from peer during warm-up.
3. Fixed block meta Inaccurate, this caused an error in reading data with a last block size less than 1m.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

