### PR TITLE
[fix](nereids) Fix aggregate source repeat output is different from child repeat

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopier.java
@@ -192,7 +192,7 @@ public class LogicalPlanDeepCopier extends DefaultPlanRewriter<DeepCopierContext
             Optional<LogicalRepeat<? extends Plan>> childRepeat =
                     copiedAggregate.collectFirst(LogicalRepeat.class::isInstance);
             if (childRepeat.isPresent()) {
-                return copiedAggregate.withSourceRepeat(childRepeat.get());
+                copiedAggregate = copiedAggregate.withSourceRepeat(childRepeat.get());
             }
         }
         return copiedAggregate;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopier.java
@@ -188,14 +188,11 @@ public class LogicalPlanDeepCopier extends DefaultPlanRewriter<DeepCopierContext
                 .collect(ImmutableList.toImmutableList());
         LogicalAggregate<Plan> copiedAggregate = aggregate.withChildGroupByAndOutput(groupByExpressions,
                 outputExpressions, child);
-        if (copiedAggregate.getSourceRepeat().isPresent()) {
-            Optional<LogicalRepeat<? extends Plan>> childRepeat =
-                    copiedAggregate.collectFirst(LogicalRepeat.class::isInstance);
-            if (childRepeat.isPresent()) {
-                copiedAggregate = copiedAggregate.withSourceRepeat(childRepeat.get());
-            }
-        }
-        return copiedAggregate;
+        Optional<LogicalRepeat<? extends Plan>> childRepeat =
+                copiedAggregate.collectFirst(LogicalRepeat.class::isInstance);
+        return childRepeat.isPresent() ? aggregate.withChildGroupByAndOutputAndSourceRepeat(
+                groupByExpressions, outputExpressions, child, childRepeat)
+                : aggregate.withChildGroupByAndOutput(groupByExpressions, outputExpressions, child);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
@@ -352,6 +352,13 @@ public class LogicalAggregate<CHILD_TYPE extends Plan>
                 hasPushed, withInProjection, sourceRepeat, Optional.empty(), Optional.empty(), newChild);
     }
 
+    public LogicalAggregate<Plan> withChildGroupByAndOutputAndSourceRepeat(List<Expression> groupByExprList,
+                                                            List<NamedExpression> outputExpressionList, Plan newChild,
+                                                                           Optional<LogicalRepeat<?>> sourceRepeat) {
+        return new LogicalAggregate<>(groupByExprList, outputExpressionList, normalized, ordinalIsResolved, generated,
+                hasPushed, withInProjection, sourceRepeat, Optional.empty(), Optional.empty(), newChild);
+    }
+
     public LogicalAggregate<Plan> withChildAndOutput(CHILD_TYPE child,
                                                        List<NamedExpression> outputExpressionList) {
         return new LogicalAggregate<>(groupByExpressions, outputExpressionList, normalized, ordinalIsResolved,

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopierTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopierTest.java
@@ -26,7 +26,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalRepeat;
 import org.apache.doris.nereids.util.PlanConstructor;
 
-import com.google.cloud.hadoop.repackaged.gcs.com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopierTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopierTest.java
@@ -17,12 +17,22 @@
 
 package org.apache.doris.nereids.trees.copier;
 
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalRepeat;
 import org.apache.doris.nereids.util.PlanConstructor;
 
+import com.google.cloud.hadoop.repackaged.gcs.com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class LogicalPlanDeepCopierTest {
 
@@ -30,9 +40,73 @@ public class LogicalPlanDeepCopierTest {
     public void testDeepCopyOlapScan() {
         LogicalOlapScan relationPlan = PlanConstructor.newLogicalOlapScan(0, "a", 0);
         relationPlan = (LogicalOlapScan) relationPlan.withOperativeSlots(relationPlan.getOutput());
-        LogicalOlapScan aCopy = (LogicalOlapScan) relationPlan.accept(LogicalPlanDeepCopier.INSTANCE, new DeepCopierContext());
+        LogicalOlapScan aCopy =
+                (LogicalOlapScan) relationPlan.accept(LogicalPlanDeepCopier.INSTANCE, new DeepCopierContext());
         for (Slot opSlot : aCopy.getOperativeSlots()) {
             Assertions.assertTrue(aCopy.getOutputSet().contains(opSlot));
         }
+    }
+
+    @Test
+    public void testDeepCopyAggregateWithSourceRepeat() {
+        LogicalOlapScan scan = PlanConstructor.newLogicalOlapScan(0, "t", 0);
+        List<? extends NamedExpression> groupingKeys = scan.getOutput().subList(0, 1);
+        List<List<Expression>> groupingSets = ImmutableList.of(
+                ImmutableList.of(groupingKeys.get(0)),
+                ImmutableList.of()
+        );
+        LogicalRepeat<Plan> repeat = new LogicalRepeat<>(
+                groupingSets,
+                scan.getOutput().stream().map(NamedExpression.class::cast).collect(Collectors.toList()),
+                scan
+        );
+        List<? extends NamedExpression> groupByExprs = repeat.getOutput().subList(0, 1).stream()
+                .map(e -> (NamedExpression) e)
+                .collect(ImmutableList.toImmutableList());
+        List<? extends NamedExpression> outputExprs = repeat.getOutput();
+        LogicalAggregate aggregate = new LogicalAggregate(
+                groupByExprs,
+                outputExprs,
+                repeat
+        );
+        aggregate = aggregate.withSourceRepeat(repeat);
+        DeepCopierContext context = new DeepCopierContext();
+        LogicalAggregate<? extends Plan> copiedAggregate = (LogicalAggregate<? extends Plan>) aggregate.accept(
+                LogicalPlanDeepCopier.INSTANCE,
+                context
+        );
+        Assertions.assertTrue(copiedAggregate.getSourceRepeat().isPresent());
+
+        Optional<LogicalRepeat<? extends Plan>> copiedRepeat =
+                copiedAggregate.collectFirst(LogicalRepeat.class::isInstance);
+        Assertions.assertTrue(copiedRepeat.isPresent());
+        Assertions.assertSame(copiedAggregate.getSourceRepeat().get(), copiedRepeat.get());
+
+        Assertions.assertNotSame(aggregate, copiedAggregate);
+        Assertions.assertNotSame(repeat, copiedRepeat.get());
+    }
+
+    @Test
+    public void testDeepCopyAggregateWithoutSourceRepeat() {
+        LogicalOlapScan scan = PlanConstructor.newLogicalOlapScan(0, "t", 0);
+        List<Expression> groupByExprs = scan.getOutput().subList(0, 1).stream()
+                .map(e -> (Expression) e)
+                .collect(ImmutableList.toImmutableList());
+        List<? extends NamedExpression> outputExprs = scan.getOutput();
+
+        LogicalAggregate aggregate = new LogicalAggregate(
+                groupByExprs,
+                outputExprs,
+                scan
+        );
+        DeepCopierContext context = new DeepCopierContext();
+        LogicalAggregate<? extends Plan> copiedAggregate = (LogicalAggregate<? extends Plan>) aggregate.accept(
+                LogicalPlanDeepCopier.INSTANCE,
+                context
+        );
+        Assertions.assertFalse(copiedAggregate.getSourceRepeat().isPresent());
+        Assertions.assertNotSame(aggregate, copiedAggregate);
+        Assertions.assertEquals(aggregate.getGroupByExpressions().size(),
+                copiedAggregate.getGroupByExpressions().size());
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

if cte def has group sets, after cte inline, the aggregate source repeat output is different from child repeat
the pr fix this

such query as following
```sql
            with t as (
                select t1.l_partkey, t1.l_suppkey, o_orderdate,
                grouping(t1.l_suppkey),
                grouping(o_orderdate),
                grouping_id(t1.l_partkey, t1.l_suppkey),
                grouping_id(t1.l_partkey, t1.l_suppkey, o_orderdate),
                sum(o_totalprice),
                max(o_totalprice),
                min(o_totalprice),
                count(*),
                count(distinct case when o_shippriority > 1 and o_orderkey IN (1, 3) then o_custkey else null end)
                from (select * from lineitem where l_shipdate = '2023-12-11') t1
                left join orders on t1.l_orderkey = orders.o_orderkey and t1.l_shipdate = o_orderdate
                group by
                GROUPING SETS ((l_shipdate, o_orderdate, l_partkey), (l_partkey, l_suppkey), (l_suppkey), ())
            )
            select t1.l_suppkey, t2.o_orderdate
            from
            t t1
            inner join
            t t2 on t1.l_partkey = t2.l_partkey;
```


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

