### PR TITLE
[fix](cloud) Do not recycle operation log during WRITE_ONLY

### DIFF
--- a/cloud/src/recycler/snapshot_data_migrator.cpp
+++ b/cloud/src/recycler/snapshot_data_migrator.cpp
@@ -350,6 +350,7 @@ int InstanceDataMigrator::enable_instance_snapshot_switch() {
     }
 
     instance_info.set_snapshot_switch_status(SnapshotSwitchStatus::SNAPSHOT_SWITCH_OFF);
+    instance_info.clear_migrated_key_sets();
     txn->atomic_add(system_meta_service_instance_update_key(), 1);
     txn->put(key, instance_info.SerializeAsString());
     err = txn->commit();

--- a/cloud/test/recycler_operation_log_test.cpp
+++ b/cloud/test/recycler_operation_log_test.cpp
@@ -2257,6 +2257,16 @@ TEST(OperationLogRecycleCheckerTest, InitAndBasicCheck) {
         ASSERT_TRUE(checker.can_recycle(old_version, 1)) << old_version.version();
     }
 
+    {
+        // Even a log has no min_timestamp, it can be recycled.
+        InstanceInfoPB instance_info;
+        OperationLogRecycleChecker checker(test_instance_id, txn_kv.get(), instance_info);
+        ASSERT_EQ(checker.init(), 0);
+
+        OperationLogPB op_log;
+        ASSERT_TRUE(checker.can_recycle(old_version, op_log.min_timestamp()));
+    }
+
     auto write_snapshot = [&]() {
         // Write snapshot
         SnapshotPB snapshot;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

because the data migrator will migrate single version keys into versioned keys and those keys need to be recycled later.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

