### PR TITLE
[fix](metacache) Fix query hang caused by Caffeine cache deadlock in external table queries

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/CacheFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/CacheFactory.java
@@ -86,7 +86,9 @@ public class CacheFactory {
     public <K, V> LoadingCache<K, V> buildCacheWithSyncRemovalListener(CacheLoader<K, V> cacheLoader,
             RemovalListener<K, V> removalListener) {
         Caffeine<Object, Object> builder = buildWithParams();
-        builder.removalListener(removalListener);
+        if (removalListener != null) {
+            builder.removalListener(removalListener);
+        }
         builder.executor(Runnable::run);  // Sync execution to avoid thread pool deadlock
         return builder.build(cacheLoader);
     }
@@ -97,7 +99,9 @@ public class CacheFactory {
             ExecutorService executor) {
         Caffeine<Object, Object> builder = buildWithParams();
         builder.executor(executor);
-        builder.removalListener(removalListener);
+        if (removalListener != null) {
+            builder.removalListener(removalListener);
+        }
         return builder.build(cacheLoader);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/CacheFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/CacheFactory.java
@@ -76,12 +76,28 @@ public class CacheFactory {
 
     // Build a loading cache, with executor, it will use given executor for refresh
     public <K, V> LoadingCache<K, V> buildCache(CacheLoader<K, V> cacheLoader,
-            RemovalListener<K, V> removalListener, ExecutorService executor) {
+            ExecutorService executor) {
         Caffeine<Object, Object> builder = buildWithParams();
         builder.executor(executor);
-        if (removalListener != null) {
-            builder.removalListener(removalListener);
-        }
+        return builder.build(cacheLoader);
+    }
+
+    // Build cache with sync removal listener to prevent deadlock when listener calls invalidateAll()
+    public <K, V> LoadingCache<K, V> buildCacheWithSyncRemovalListener(CacheLoader<K, V> cacheLoader,
+            RemovalListener<K, V> removalListener) {
+        Caffeine<Object, Object> builder = buildWithParams();
+        builder.removalListener(removalListener);
+        builder.executor(Runnable::run);  // Sync execution to avoid thread pool deadlock
+        return builder.build(cacheLoader);
+    }
+
+    // Build cache with async removal listener. Use with caution if listener may trigger nested operations
+    public <K, V> LoadingCache<K, V> buildCacheWithAsyncRemovalListener(CacheLoader<K, V> cacheLoader,
+            RemovalListener<K, V> removalListener,
+            ExecutorService executor) {
+        Caffeine<Object, Object> builder = buildWithParams();
+        builder.executor(executor);
+        builder.removalListener(removalListener);
         return builder.build(cacheLoader);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalSchemaCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalSchemaCache.java
@@ -58,7 +58,7 @@ public class ExternalSchemaCache {
                 Config.max_external_schema_cache_num,
                 false,
                 null);
-        schemaCache = schemaCacheFactory.buildCache(this::loadSchema, null, executor);
+        schemaCache = schemaCacheFactory.buildCache(this::loadSchema, executor);
     }
 
     private void initMetrics() {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -141,7 +141,7 @@ public class HiveMetaStoreCache {
                 Config.max_hive_partition_table_cache_num,
                 true,
                 null);
-        partitionValuesCache = partitionValuesCacheFactory.buildCache(this::loadPartitionValues, null,
+        partitionValuesCache = partitionValuesCacheFactory.buildCache(this::loadPartitionValues,
                 refreshExecutor);
 
         CacheFactory partitionCacheFactory = new CacheFactory(
@@ -160,7 +160,7 @@ public class HiveMetaStoreCache {
             public Map<PartitionCacheKey, HivePartition> loadAll(Iterable<? extends PartitionCacheKey> keys) {
                 return loadPartitions(keys);
             }
-        }, null, refreshExecutor);
+        }, refreshExecutor);
 
         setNewFileCache();
     }
@@ -196,7 +196,7 @@ public class HiveMetaStoreCache {
 
         LoadingCache<FileCacheKey, FileCacheValue> oldFileCache = fileCacheRef.get();
 
-        fileCacheRef.set(fileCacheFactory.buildCache(loader, null, this.refreshExecutor));
+        fileCacheRef.set(fileCacheFactory.buildCache(loader, this.refreshExecutor));
         if (Objects.nonNull(oldFileCache)) {
             oldFileCache.invalidateAll();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedFsViewProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedFsViewProcessor.java
@@ -48,7 +48,7 @@ public class HudiCachedFsViewProcessor {
                 Config.max_external_table_cache_num,
                 true,
                 null);
-        this.fsViewCache = partitionCacheFactory.buildCache(this::createFsView, null, executor);
+        this.fsViewCache = partitionCacheFactory.buildCache(this::createFsView, executor);
     }
 
     private HoodieTableFileSystemView createFsView(FsViewKey key) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedMetaClientProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedMetaClientProcessor.java
@@ -51,7 +51,6 @@ public class HudiCachedMetaClientProcessor {
 
         this.hudiTableMetaClientCache = partitionCacheFactory.buildCache(
                 this::createHoodieTableMetaClient,
-                null,
                 executor);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedPartitionProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hudi/source/HudiCachedPartitionProcessor.java
@@ -63,7 +63,7 @@ public class HudiCachedPartitionProcessor extends HudiPartitionProcessor {
                 Config.max_external_table_cache_num,
                 true,
                 null);
-        this.partitionCache = partitionCacheFactory.buildCache(key -> new TablePartitionValues(), null, executor);
+        this.partitionCache = partitionCacheFactory.buildCache(key -> new TablePartitionValues(), executor);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataCache.java
@@ -64,7 +64,7 @@ public class IcebergMetadataCache {
                 Config.max_external_table_cache_num,
                 true,
                 null);
-        this.snapshotListCache = snapshotListCacheFactory.buildCache(key -> loadSnapshots(key), null, executor);
+        this.snapshotListCache = snapshotListCacheFactory.buildCache(key -> loadSnapshots(key), executor);
 
         CacheFactory tableCacheFactory = new CacheFactory(
                 OptionalLong.of(Config.external_cache_expire_time_seconds_after_access),
@@ -72,7 +72,7 @@ public class IcebergMetadataCache {
                 Config.max_external_table_cache_num,
                 true,
                 null);
-        this.tableCache = tableCacheFactory.buildCache(key -> loadTable(key), null, executor);
+        this.tableCache = tableCacheFactory.buildCache(key -> loadTable(key), executor);
 
         CacheFactory snapshotCacheFactory = new CacheFactory(
                 OptionalLong.of(Config.external_cache_expire_time_seconds_after_access),
@@ -80,8 +80,8 @@ public class IcebergMetadataCache {
                 Config.max_external_table_cache_num,
                 true,
                 null);
-        this.snapshotCache = snapshotCacheFactory.buildCache(key -> loadSnapshot(key), null, executor);
-        this.viewCache = tableCacheFactory.buildCache(key -> loadView(key), null, executor);
+        this.snapshotCache = snapshotCacheFactory.buildCache(key -> loadSnapshot(key), executor);
+        this.viewCache = tableCacheFactory.buildCache(key -> loadView(key), executor);
     }
 
     public Table getIcebergTable(ExternalTable dorisTable) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/MetaCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/MetaCache.java
@@ -74,8 +74,10 @@ public class MetaCache<T> {
                 maxSize,
                 true,
                 null);
-        namesCache = namesCacheFactory.buildCache(namesCacheLoader, null, executor);
-        metaObjCache = objCacheFactory.buildCache(metaObjCacheLoader, removalListener, executor);
+        namesCache = namesCacheFactory.buildCache(namesCacheLoader, executor);
+        // Use sync removal listener to prevent deadlock (removal listener calls invalidateAll)
+        // NOTE: This cache should NOT use refreshAfterWrite, as it would become synchronous
+        metaObjCache = objCacheFactory.buildCacheWithSyncRemovalListener(metaObjCacheLoader, removalListener);
     }
 
     public List<String> listNames() {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonMetadataCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonMetadataCache.java
@@ -60,7 +60,7 @@ public class PaimonMetadataCache {
                 Config.max_external_table_cache_num,
                 true,
                 null);
-        this.snapshotCache = snapshotCacheFactory.buildCache(key -> loadSnapshot(key), null, executor);
+        this.snapshotCache = snapshotCacheFactory.buildCache(key -> loadSnapshot(key), executor);
     }
 
     @NotNull

--- a/fe/fe-core/src/test/java/org/apache/doris/common/CacheFactoryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/CacheFactoryTest.java
@@ -124,7 +124,7 @@ public class CacheFactoryTest {
                 false,
                 ticker::read);
         LoadingCache<Integer, CacheValue> loadingCache = cacheFactory.buildCache(
-                key -> CacheValue.createValue("value" + key, counter), null, executor);
+                key -> CacheValue.createValue("value" + key, counter), executor);
         CacheValue value = loadingCache.get(1);
         Assertions.assertEquals("value1", value.getValue());
         Assertions.assertEquals(1, counter.get());
@@ -155,7 +155,7 @@ public class CacheFactoryTest {
                 false,
                 ticker::read);
         LoadingCache<Integer, CacheValue> loadingCache = cacheFactory.buildCache(
-                key -> CacheValue.createValue("value" + key, counter), null, executor);
+                key -> CacheValue.createValue("value" + key, counter), executor);
         CacheValue value = loadingCache.get(1);
         Assertions.assertEquals("value1", value.getValue());
         Assertions.assertEquals(1, counter.get());
@@ -193,7 +193,7 @@ public class CacheFactoryTest {
                 false,
                 ticker::read);
         LoadingCache<Integer, CacheValue> loadingCache = cacheFactory.buildCache(
-                key -> CacheValue.createValue("value" + key, counter), null, executor);
+                key -> CacheValue.createValue("value" + key, counter), executor);
         CacheValue value = loadingCache.get(1);
         Assertions.assertEquals("value1", value.getValue());
         Assertions.assertEquals(1, counter.get());

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/metacache/MetaCacheDeadlockTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/metacache/MetaCacheDeadlockTest.java
@@ -1,0 +1,114 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.metacache;
+
+import org.apache.doris.common.Pair;
+import org.apache.doris.common.ThreadPoolManager;
+
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test to verify MetaCache does not deadlock when removal listener calls invalidateAll().
+ */
+public class MetaCacheDeadlockTest {
+
+    @Test
+    public void testNestedInvalidateAllWithBoundedExecutor() throws InterruptedException {
+        ExecutorService executor = new ThreadPoolExecutor(
+                1, 1,
+                0L, TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>(1),
+                new ThreadPoolManager.BlockedPolicy("TestExecutor", 200)
+        );
+
+        CacheLoader<String, List<Pair<String, String>>> namesCacheLoader = key -> Lists.newArrayList();
+        CacheLoader<String, Optional<String>> tableLoader = key -> Optional.of("table-" + key);
+
+        MetaCache<String> tableCache = new MetaCache<>(
+                "tableCache",
+                executor,
+                OptionalLong.empty(),
+                OptionalLong.empty(),
+                100,
+                namesCacheLoader,
+                tableLoader,
+                (key, value, cause) -> { });
+
+        for (int i = 0; i < 100; i++) {
+            tableCache.updateCache("table" + i, "table" + i, "table-" + i, i);
+        }
+
+        CacheLoader<String, Optional<String>> dbLoader = key -> {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return Optional.of("db-" + key);
+        };
+
+        MetaCache<String> dbCache = new MetaCache<>(
+                "databaseCache",
+                executor,
+                OptionalLong.empty(),
+                OptionalLong.empty(),
+                1,
+                namesCacheLoader,
+                dbLoader,
+                (key, value, cause) -> tableCache.invalidateAll());
+
+        dbCache.updateCache("db0", "db0", "db-0", 0);
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(5);
+        for (int i = 1; i <= 5; i++) {
+            final int idx = i;
+            new Thread(() -> {
+                try {
+                    startLatch.await();
+                    dbCache.updateCache("db" + idx, "db" + idx, "db-" + idx, idx);
+                } catch (Exception e) {
+                    // Ignore
+                } finally {
+                    doneLatch.countDown();
+                }
+            }).start();
+        }
+
+        startLatch.countDown();
+        boolean completed = doneLatch.await(2, TimeUnit.SECONDS);
+
+        executor.shutdown();
+        boolean terminated = executor.awaitTermination(1, TimeUnit.SECONDS);
+
+        Assert.assertTrue("MetaCache deadlock detected. Ensure metaObjCache uses buildCacheWithSyncRemovalListener.",
+                completed && terminated);
+    }
+}


### PR DESCRIPTION
 **Symptom:** External table queries hang indefinitely, FE process frozen.

**User-facing impact:** Query threads blocked waiting for schema cache:

  ```
  "mysql-nio-pool-14981" TIMED_WAITING
     at LinkedBlockingQueue.offer(LinkedBlockingQueue.java:385)
     at ThreadPoolManager$BlockedPolicy.rejectedExecution(ThreadPoolManager.java:347)
     at ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1379)
     at CompletableFuture.asyncSupplyStage(CompletableFuture.java:1618)
     at CacheLoader.asyncReload(CacheLoader.java:188)
     at BoundedLocalCache.refreshIfNeeded(BoundedLocalCache.java:1214)
     at LocalLoadingCache.get(LocalLoadingCache.java:56)
     at ExternalSchemaCache.getSchemaValue(ExternalSchemaCache.java:86)
     at ExternalTable.getSchemaCacheValue(ExternalTable.java:371)
     at HMSExternalTable.getPartitionColumns(HMSExternalTable.java:288)
     at PruneFileScanPartition.pruneHivePartitions(PruneFileScanPartition.java:84)

  "CommonRefreshExecutor-63" TIMED_WAITING
     at LinkedBlockingQueue.offer(LinkedBlockingQueue.java:385)
     at ThreadPoolManager$BlockedPolicy.rejectedExecution(ThreadPoolManager.java:347)
     at ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1379)
     at CompletableFuture.asyncSupplyStage(CompletableFuture.java:1618)
     at CacheLoader.asyncReload(CacheLoader.java:188)
     at BoundedLocalCache.refreshIfNeeded(BoundedLocalCache.java:1214)

  "CommonRefreshExecutor-62" TIMED_WAITING
     at LinkedBlockingQueue.offer(LinkedBlockingQueue.java:385)
     at ThreadPoolManager$BlockedPolicy.rejectedExecution(ThreadPoolManager.java:347)
     at ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1379)
     at BoundedLocalCache.notifyRemoval(BoundedLocalCache.java:333)
     at BoundedLocalCache.removeNode(BoundedLocalCache.java:1882)
     at LocalManualCache.invalidateAll(LocalManualCache.java:150)
     at MetaCache.invalidateAll(MetaCache.java:121)
     at ExternalDatabase.setUnInitialized(ExternalDatabase.java:123)
```

 **Root cause**: Caffeine cache deadlock when:
  1. MetaCache uses bounded executor (CommonRefreshExecutor: 64 threads + 640K queue) for both async operations and removal listeners
  2. Database cache removal listener calls tableCache.invalidateAll()
  3. Executor is full (all threads busy + queue full)
  4. Both async reload and removal listener try to submit tasks to full executor
  5. Deadlock: executor threads wait for tasks, tasks wait for executor slots

  Jstack evidence: 82 CommonRefreshExecutor threads blocked on LinkedBlockingQueue.offer():

**Solution**

  - Add CacheFactory.buildCacheWithSyncRemovalListener() using Runnable::run executor
  - MetaCache.metaObjCache uses sync removal listener to avoid executor contention
  - Removal listener runs inline on calling thread instead of submitting to executor

**Changes**

  - CacheFactory: Add buildCacheWithSyncRemovalListener() and buildCacheWithAsyncRemovalListener()
  - MetaCache: Use buildCacheWithSyncRemovalListener() for metaObjCache
  - Add MetaCacheDeadlockTest to verify fix

**Test**

  Unit test reproduces deadlock with async removal listener and verifies fix with sync removal listener.