### PR TITLE
[fix](core)Provide add_blocks interface for VDataStreamRecvr

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -101,7 +101,8 @@ ExchangeSinkBuffer::ExchangeSinkBuffer(PUniqueId query_id, PlanNodeId dest_node_
           _state(state),
           _context(state->get_query_ctx()),
           _exchange_sink_num(sender_ins_ids.size()),
-          _send_multi_blocks(false) {
+          _send_multi_blocks(state->query_options().__isset.exchange_multi_blocks_byte_size &&
+                             state->query_options().exchange_multi_blocks_byte_size > 0) {
     if (_send_multi_blocks) {
         _send_multi_blocks_byte_size = state->query_options().exchange_multi_blocks_byte_size;
     }

--- a/be/src/vec/runtime/vdata_stream_mgr.cpp
+++ b/be/src/vec/runtime/vdata_stream_mgr.cpp
@@ -146,50 +146,25 @@ Status VDataStreamMgr::transmit_block(const PTransmitDataParams* request,
     }
 
     bool eos = request->eos();
-    if (!request->blocks().empty()) {
-        for (int i = 0; i < request->blocks_size(); i++) {
-            // Previously there was a const_cast here, but in our internal tests this occasionally caused a hard-to-reproduce core dump.
-            // We suspect it was caused by the const_cast, so we switched to making a copy here.
-            // In fact, for PBlock, most of the data resides in the PColumnMeta column_metas field, so the copy overhead is small.
-            // To make the intent explicit, we do not use
-            // std::unique_ptr<PBlock> pblock_ptr = std::make_unique<PBlock>(request->blocks(i));
-            std::unique_ptr<PBlock> pblock_ptr = std::make_unique<PBlock>();
-            pblock_ptr->CopyFrom(request->blocks(i));
-            auto pass_done = [&]() -> ::google::protobuf::Closure** {
-                // If it is eos, no callback is needed, done can be nullptr
-                if (eos) {
-                    return nullptr;
-                }
-                // If it is the last block, a callback is needed, pass done
-                if (i == request->blocks_size() - 1) {
-                    return done;
-                } else {
-                    // If it is not the last block, the blocks in the request currently belong to the same queue,
-                    // and the callback is handled by the done of the last block
-                    return nullptr;
-                }
-            };
-            RETURN_IF_ERROR(recvr->add_block(
-                    std::move(pblock_ptr), request->sender_id(), request->be_number(),
-                    request->packet_seq() - request->blocks_size() + i, pass_done(),
-                    wait_for_worker, cpu_time_stop_watch.elapsed_time()));
-        }
-    }
+    Status exec_status =
+            request->has_exec_status() ? Status::create(request->exec_status()) : Status::OK();
 
-    // old logic, for compatibility
-    if (request->has_block()) {
+    auto sender_id = request->sender_id();
+    auto be_number = request->be_number();
+    if (!request->blocks().empty()) {
+        RETURN_IF_ERROR(recvr->add_blocks(request, done, wait_for_worker,
+                                          cpu_time_stop_watch.elapsed_time()));
+    } else if (request->has_block()) {
+        // old logic, for compatibility
         std::unique_ptr<PBlock> pblock_ptr = std::make_unique<PBlock>();
         pblock_ptr->CopyFrom(request->block());
-        RETURN_IF_ERROR(recvr->add_block(std::move(pblock_ptr), request->sender_id(),
-                                         request->be_number(), request->packet_seq(),
-                                         eos ? nullptr : done, wait_for_worker,
-                                         cpu_time_stop_watch.elapsed_time()));
+        RETURN_IF_ERROR(recvr->add_block(std::move(pblock_ptr), sender_id, be_number,
+                                         request->packet_seq(), eos ? nullptr : done,
+                                         wait_for_worker, cpu_time_stop_watch.elapsed_time()));
     }
 
     if (eos) {
-        Status exec_status =
-                request->has_exec_status() ? Status::create(request->exec_status()) : Status::OK();
-        recvr->remove_sender(request->sender_id(), request->be_number(), exec_status);
+        recvr->remove_sender(sender_id, be_number, exec_status);
     }
     return Status::OK();
 }

--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -218,7 +218,7 @@ Status VDataStreamRecvr::SenderQueue::add_blocks(const PTransmitDataParams* requ
         const int64_t packet_seq = request->packet_seq() - 1;
         auto iter = _packet_seq_map.find(be_number);
         if (iter != _packet_seq_map.end()) {
-            if (iter->second >= (packet_seq - request->blocks_size())) {
+            if (iter->second > (packet_seq - request->blocks_size())) {
                 return Status::InternalError(
                         "packet already exist [cur_packet_id= {} receive_packet_id={}]",
                         iter->second, packet_seq);

--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -212,7 +212,10 @@ Status VDataStreamRecvr::SenderQueue::add_blocks(const PTransmitDataParams* requ
             return Status::OK();
         }
         const int be_number = request->be_number();
-        const int64_t packet_seq = request->packet_seq();
+        // In the request, the packet_seq for blocks is [request->packet_seq() - blocks_size(), request->packet_seq())
+        // Note this is a left-closed, right-open interval; the packet_seq of the last block is request->packet_seq() - 1
+        // We store the packet_seq of the last block in _packet_seq_map so we can compare it with the packet_seq of the next received packet
+        const int64_t packet_seq = request->packet_seq() - 1;
         auto iter = _packet_seq_map.find(be_number);
         if (iter != _packet_seq_map.end()) {
             if (iter->second >= (packet_seq - request->blocks_size())) {

--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -215,7 +215,7 @@ Status VDataStreamRecvr::SenderQueue::add_blocks(const PTransmitDataParams* requ
         const int64_t packet_seq = request->packet_seq();
         auto iter = _packet_seq_map.find(be_number);
         if (iter != _packet_seq_map.end()) {
-            if (iter->second >= packet_seq) {
+            if (iter->second >= (packet_seq - request->blocks_size())) {
                 return Status::InternalError(
                         "packet already exist [cur_packet_id= {} receive_packet_id={}]",
                         iter->second, packet_seq);

--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -73,9 +73,8 @@ Status VDataStreamRecvr::SenderQueue::get_batch(Block* block, bool* eos) {
     if (!_is_cancelled && _block_queue.empty() && _num_remaining_senders > 0) {
         throw doris::Exception(ErrorCode::INTERNAL_ERROR,
                                "_is_cancelled: {}, _block_queue_empty: {}, "
-                               "_num_remaining_senders: {}, _debug_string_info: {}",
-                               _is_cancelled, _block_queue.empty(), _num_remaining_senders,
-                               _debug_string_info());
+                               "_num_remaining_senders: {}",
+                               _is_cancelled, _block_queue.empty(), _num_remaining_senders);
     }
 #endif
     BlockItem block_item;
@@ -111,7 +110,6 @@ Status VDataStreamRecvr::SenderQueue::get_batch(Block* block, bool* eos) {
     _recvr->_memory_used_counter->update(-(int64_t)block_byte_size);
     INJECT_MOCK_SLEEP(std::lock_guard<std::mutex> l(_lock));
     sub_blocks_memory_usage(block_byte_size);
-    _record_debug_info();
     if (_block_queue.empty() && _source_dependency) {
         if (!_is_cancelled && _num_remaining_senders > 0) {
             _source_dependency->block();
@@ -187,7 +185,7 @@ Status VDataStreamRecvr::SenderQueue::add_block(std::unique_ptr<PBlock> pblock, 
 
         DCHECK(_num_remaining_senders >= 0);
         if (_num_remaining_senders == 0) {
-            DCHECK(_sender_eos_set.end() != _sender_eos_set.find(be_number));
+            DCHECK(_sender_eos_set.contains(be_number));
             return Status::OK();
         }
     }
@@ -209,7 +207,6 @@ Status VDataStreamRecvr::SenderQueue::add_block(std::unique_ptr<PBlock> pblock, 
 
     _block_queue.emplace_back(std::move(pblock), block_byte_size);
     COUNTER_UPDATE(_recvr->_remote_bytes_received_counter, block_byte_size);
-    _record_debug_info();
     set_source_ready(l);
 
     // if done is nullptr, this function can't delay this response
@@ -222,6 +219,76 @@ Status VDataStreamRecvr::SenderQueue::add_block(std::unique_ptr<PBlock> pblock, 
     }
     _recvr->_memory_used_counter->update(block_byte_size);
     add_blocks_memory_usage(block_byte_size);
+    return Status::OK();
+}
+
+Status VDataStreamRecvr::SenderQueue::add_blocks(const PTransmitDataParams* request,
+                                                 ::google::protobuf::Closure** done,
+                                                 const int64_t wait_for_worker,
+                                                 const uint64_t time_to_find_recvr) {
+    {
+        INJECT_MOCK_SLEEP(std::lock_guard<std::mutex> l(_lock));
+        if (_is_cancelled) {
+            return Status::OK();
+        }
+        const int be_number = request->be_number();
+        const int64_t packet_seq = request->packet_seq();
+        auto iter = _packet_seq_map.find(be_number);
+        if (iter != _packet_seq_map.end()) {
+            if (iter->second >= packet_seq) {
+                return Status::InternalError(
+                        "packet already exist [cur_packet_id= {} receive_packet_id={}]",
+                        iter->second, packet_seq);
+            }
+            iter->second = packet_seq;
+        } else {
+            _packet_seq_map.emplace(be_number, packet_seq);
+        }
+
+        DCHECK(_num_remaining_senders >= 0);
+        if (_num_remaining_senders == 0) {
+            DCHECK(_sender_eos_set.end() != _sender_eos_set.find(be_number));
+            return Status::OK();
+        }
+    }
+
+    INJECT_MOCK_SLEEP(std::lock_guard<std::mutex> l(_lock));
+    if (_is_cancelled) {
+        return Status::OK();
+    }
+
+    int64_t total_block_byte_size = 0;
+    for (int i = 0; i < request->blocks_size(); i++) {
+        std::unique_ptr<PBlock> pblock = std::make_unique<PBlock>();
+        pblock->CopyFrom(request->blocks(i));
+
+        const auto block_byte_size = pblock->ByteSizeLong();
+        COUNTER_UPDATE(_recvr->_blocks_produced_counter, 1);
+        if (_recvr->_max_wait_worker_time->value() < wait_for_worker) {
+            _recvr->_max_wait_worker_time->set(wait_for_worker);
+        }
+
+        if (_recvr->_max_find_recvr_time->value() < time_to_find_recvr) {
+            _recvr->_max_find_recvr_time->set((int64_t)time_to_find_recvr);
+        }
+
+        _block_queue.emplace_back(std::move(pblock), block_byte_size);
+        COUNTER_UPDATE(_recvr->_remote_bytes_received_counter, block_byte_size);
+        total_block_byte_size += block_byte_size;
+    }
+
+    set_source_ready(l);
+
+    // if done is nullptr, this function can't delay this response
+    if (done != nullptr && _recvr->exceeds_limit(total_block_byte_size)) {
+        MonotonicStopWatch monotonicStopWatch;
+        monotonicStopWatch.start();
+        DCHECK(*done != nullptr);
+        _pending_closures.emplace_back(*done, monotonicStopWatch);
+        *done = nullptr;
+    }
+    _recvr->_memory_used_counter->update(total_block_byte_size);
+    add_blocks_memory_usage(total_block_byte_size);
     return Status::OK();
 }
 
@@ -260,7 +327,6 @@ void VDataStreamRecvr::SenderQueue::add_block(Block* block, bool use_move) {
             return;
         }
         _block_queue.emplace_back(std::move(nblock), block_mem_size);
-        _record_debug_info();
         set_source_ready(l);
         COUNTER_UPDATE(_recvr->_local_bytes_received_counter, block_mem_size);
         _recvr->_memory_used_counter->update(block_mem_size);
@@ -276,7 +342,6 @@ void VDataStreamRecvr::SenderQueue::decrement_senders(int be_number) {
     _sender_eos_set.insert(be_number);
     DCHECK_GT(_num_remaining_senders, 0);
     _num_remaining_senders--;
-    _record_debug_info();
     VLOG_FILE << "decremented senders: fragment_instance_id="
               << print_id(_recvr->fragment_instance_id()) << " node_id=" << _recvr->dest_node_id()
               << " #senders=" << _num_remaining_senders;
@@ -421,6 +486,19 @@ Status VDataStreamRecvr::add_block(std::unique_ptr<PBlock> pblock, int sender_id
     int use_sender_id = _is_merging ? sender_id : 0;
     return _sender_queues[use_sender_id]->add_block(std::move(pblock), be_number, packet_seq, done,
                                                     wait_for_worker, time_to_find_recvr);
+}
+
+Status VDataStreamRecvr::add_blocks(const PTransmitDataParams* request,
+                                    ::google::protobuf::Closure** done,
+                                    const int64_t wait_for_worker,
+                                    const uint64_t time_to_find_recvr) {
+    SCOPED_ATTACH_TASK(_resource_ctx);
+    if (_query_context->low_memory_mode()) {
+        set_low_memory_mode();
+    }
+    int use_sender_id = _is_merging ? request->sender_id() : 0;
+    return _sender_queues[use_sender_id]->add_blocks(request, done, wait_for_worker,
+                                                     time_to_find_recvr);
 }
 
 void VDataStreamRecvr::add_block(Block* block, int sender_id, bool use_move) {

--- a/be/src/vec/runtime/vdata_stream_recvr.h
+++ b/be/src/vec/runtime/vdata_stream_recvr.h
@@ -90,6 +90,9 @@ public:
                      int64_t packet_seq, ::google::protobuf::Closure** done,
                      const int64_t wait_for_worker, const uint64_t time_to_find_recvr);
 
+    Status add_blocks(const PTransmitDataParams* request, ::google::protobuf::Closure** done,
+                      const int64_t wait_for_worker, const uint64_t time_to_find_recvr);
+
     void add_block(Block* block, int sender_id, bool use_move);
     std::string debug_string();
 
@@ -185,6 +188,10 @@ public:
     Status add_block(std::unique_ptr<PBlock> pblock, int be_number, int64_t packet_seq,
                      ::google::protobuf::Closure** done, const int64_t wait_for_worker,
                      const uint64_t time_to_find_recvr);
+
+    Status add_blocks(const PTransmitDataParams* request, ::google::protobuf::Closure** done,
+                      const int64_t wait_for_worker, const uint64_t time_to_find_recvr);
+
     std::string debug_string();
 
     void add_block(Block* block, bool use_move);
@@ -208,50 +215,6 @@ protected:
     friend class pipeline::ExchangeLocalState;
 
     void set_source_ready(std::lock_guard<std::mutex>&);
-
-    // To record information about several variables in the event of a DCHECK failure.
-    //  DCHECK(_is_cancelled || !_block_queue.empty() || _num_remaining_senders == 0)
-#ifndef NDEBUG
-    constexpr static auto max_record_number = 128;
-    std::list<size_t> _record_block_queue;
-    std::list<int> _record_num_remaining_senders;
-#else
-#endif
-
-    // only in debug
-    ALWAYS_INLINE inline void _record_debug_info() {
-#ifndef NDEBUG
-        if (_record_block_queue.size() > max_record_number) {
-            _record_block_queue.pop_front();
-        }
-        if (_record_num_remaining_senders.size() > max_record_number) {
-            _record_num_remaining_senders.pop_front();
-        }
-        _record_block_queue.push_back(_block_queue.size());
-        _record_num_remaining_senders.push_back(_num_remaining_senders);
-#else
-#endif
-    }
-
-    ALWAYS_INLINE inline std::string _debug_string_info() {
-#ifndef NDEBUG
-        std::stringstream out;
-        DCHECK_EQ(_record_block_queue.size(), _record_num_remaining_senders.size());
-        out << "record_debug_info [  \n";
-
-        auto it1 = _record_block_queue.begin();
-        auto it2 = _record_num_remaining_senders.begin();
-        for (; it1 != _record_block_queue.end(); it1++, it2++) {
-            out << "( "
-                << "_block_queue size : " << *it1 << " , _num_remaining_senders : " << *it2
-                << " ) \n";
-        }
-        out << "  ]\n";
-        return out.str();
-#else
-#endif
-        return "";
-    }
 
     // Not managed by this class
     VDataStreamRecvr* _recvr = nullptr;


### PR DESCRIPTION
### What problem does this PR solve?

We previously had a crash. The cause is that we should not access the request after calling add_block(...) because add_block may enqueue a closure that runs on another thread and frees the request

```
==730145==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7be1efd803a0 at pc 0x556b38d9d625 bp 0x7b16bf0193f0 sp 0x7b16bf0193e8
READ of size 4 at 0x7be1efd803a0 thread T1559
    #0 0x556b38d9d624 in google::protobuf::internal::RepeatedPtrFieldBase::size() const /home/zcp/repo_center/doris_master/doris/thirdparty/installed/include/google/protobuf/repeated_ptr_field.h:185:29
    #1 0x556b408ab062 in google::protobuf::RepeatedPtrField<doris::PBlock>::size() const /home/zcp/repo_center/doris_master/doris/thirdparty/installed/include/google/protobuf/repeated_ptr_field.h:1248:32
    #2 0x556b408aaff4 in doris::PTransmitDataParams::_internal_blocks_size() const /home/zcp/repo_center/doris_master/doris/be/../gensrc/build/gen_cpp/internal_service.pb.h:32149:25
    #3 0x556b4089731c in doris::PTransmitDataParams::blocks_size() const /home/zcp/repo_center/doris_master/doris/be/../gensrc/build/gen_cpp/internal_service.pb.h:32152:10
    #4 0x556b60a83c17 in doris::vectorized::VDataStreamMgr::transmit_block(doris::PTransmitDataParams const*, google::protobuf::Closure**, long) /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vdata_stream_mgr.cpp:150:38
    #5 0x556b407f7408 in doris::PInternalService::_transmit_block(google::protobuf::RpcController*, doris::PTransmitDataParams const*, doris::PTransmitDataResult*, google::protobuf::Closure*, doris::Status const&, long) /home/zcp/repo_center/doris_master/doris/be/src/service/internal_service.cpp:1673:40
    #6 0x556b407f52bb in doris::PInternalService::transmit_block(google::protobuf::RpcController*, doris::PTransmitDataParams const*, doris::PTransmitDataResult*, google::protobuf::Closure*) /home/zcp/repo_center/doris_master/doris/be/src/service/internal_service.cpp:1610:9
    #7 0x556b43fceba2 in doris::PBackendService::CallMethod(google::protobuf::MethodDescriptor const*, google::protobuf::RpcController*, google::protobuf::Message const*, google::protobuf::Message*, google::protobuf::Closure*) /home/zcp/repo_center/doris_master/doris/gensrc/build/gen_cpp/internal_service.pb.cc:49452:7
    #8 0x556b6736273e in brpc::policy::ProcessRpcRequest(brpc::InputMessageBase*) (/mnt/hdd01/selectdb-cloud-chaos/cluster0/be/lib/doris_be+0x770bd73e)
    #9 0x556b67357426 in brpc::ProcessInputMessage(void*) (/mnt/hdd01/selectdb-cloud-chaos/cluster0/be/lib/doris_be+0x770b2426)
    #10 0x556b67357f20 in brpc::InputMessenger::InputMessageClosure::~InputMessageClosure() (/mnt/hdd01/selectdb-cloud-chaos/cluster0/be/lib/doris_be+0x770b2f20)
    #11 0x556b673588dd in brpc::InputMessenger::OnNewMessages(brpc::Socket*) (/mnt/hdd01/selectdb-cloud-chaos/cluster0/be/lib/doris_be+0x770b38dd)
    #12 0x556b674a0adc in brpc::Socket::ProcessEvent(void*) (/mnt/hdd01/selectdb-cloud-chaos/cluster0/be/lib/doris_be+0x771fbadc)
    #13 0x556b672e0f76 in bthread::TaskGroup::task_runner(long) (/mnt/hdd01/selectdb-cloud-chaos/cluster0/be/lib/doris_be+0x7703bf76)
    #14 0x556b672cbbe0 in bthread_make_fcontext (/mnt/hdd01/selectdb-cloud-chaos/cluster0/be/lib/doris_be+0x77026be0)
```

```
        Note: The done pointer will be saved in add_block and may be called in another thread via done->Run().
        For example, when blocks_size == 1, the process is as follows:
        transmit_block (i=0)
          └─> recvr->add_block(..., done, ...)  // Pass done
               └─> SenderQueue::add_block
                    └─> _pending_closures.push(done)  // done is saved

        get_batch() [another thread]
          └─> closure_pair.first->Run()  // ⚠️ done->Run() is called
               └─> brpc releases request and response

        transmit_block (i=1)  [original thread continues]
          └─> request->blocks_size()  // ⚠️ request has already been released!

        At this point, a use-after-free issue occurs.

        TODO: We should consider refactoring this part because add_block may release the request.
        We should not access the request after calling add_block.
```


https://github.com/apache/doris/pull/50113


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

