### PR TITLE
[Chore](join) add check for broadcast join wake up before signaled

### DIFF
--- a/be/src/pipeline/exec/hashjoin_build_sink.h
+++ b/be/src/pipeline/exec/hashjoin_build_sink.h
@@ -172,6 +172,7 @@ private:
 
     bool _use_shared_hash_table = false;
     std::atomic<bool> _signaled = false;
+    std::atomic<bool> _shared_terminated = false; // indicate whether build_hash_table-instance terminate has been called
     std::mutex _mutex;
     std::vector<std::shared_ptr<pipeline::Dependency>> _finish_dependencies;
     std::map<int, std::shared_ptr<RuntimeFilterWrapper>> _runtime_filters;

--- a/be/src/pipeline/exec/hashjoin_build_sink.h
+++ b/be/src/pipeline/exec/hashjoin_build_sink.h
@@ -172,7 +172,8 @@ private:
 
     bool _use_shared_hash_table = false;
     std::atomic<bool> _signaled = false;
-    std::atomic<bool> _shared_terminated = false; // indicate whether build_hash_table-instance terminate has been called
+    std::atomic<bool> _shared_terminated =
+            false; // indicate whether build_hash_table-instance terminate has been called
     std::mutex _mutex;
     std::vector<std::shared_ptr<pipeline::Dependency>> _finish_dependencies;
     std::map<int, std::shared_ptr<RuntimeFilterWrapper>> _runtime_filters;


### PR DESCRIPTION
### What problem does this PR solve?
Try to avoid coredump like the following:
```cpp
unknown detail explain (@0x17d3) received by PID 6099 (TID 6591 OR 0x7bd0f51fc640) from PID 6099; stack trace: ***     @              (nil)  (unknown)     @     0x557ae20954c5  std::_Function_handler<>::_M_invoke()     @     0x557ad99bff7e  std::function<>::operator()()     @     0x557ae1fffd07  doris::Thread::supervise_thread()     @     0x557ad9720d27  asan_thread_start()     @     0x7fd4a78c1ac3  (/usr/lib/x86_64-linux-gnu/libc.so.6 (deleted)+0x94ac2)     @     0x7fd4a7953850  (/usr/lib/x86_64-linux-gnu/libc.so.6 (deleted)+0x12684f)     @              (nil)  (unknown)
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/common/signal_handler.h:420  1# 0x00007FD4A786F520 in /lib/x86_64-linux-gnu/libc.so.6  2# pthread_kill at ./nptl/pthread_kill.c:89  3# raise at ../sysdeps/posix/raise.c:27  4# abort at ./stdlib/abort.c:81  5# 0x0000557B0648D945 in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be  6# 0x0000557B0647F1FA in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be  7# google::LogMessage::SendToLog() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be  8# google::LogMessage::Flush() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be  9# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be 10# doris::RuntimeFilterProducerHelper::build(doris::RuntimeState*, doris::vectorized::Block const*, bool, std::map<int, std::shared_ptr<doris::RuntimeFilterWrapper>, std::less<int>, std::allocator<std::pair<int const, std::shared_ptr<doris::RuntimeFilterWrapper> > > >&) at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/runtime_filter/runtime_filter_producer_helper.cpp:116 11# doris::pipeline::HashJoinBuildSinkLocalState::close(doris::RuntimeState*, doris::Status) at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/pipeline/exec/hashjoin_build_sink.cpp:243 12# doris::pipeline::DataSinkOperatorXBase::close(doris::RuntimeState*, doris::Status) at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/pipeline/exec/operator.h:676 13# doris::pipeline::PipelineTask::close(doris::Status, bool) at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/pipeline/pipeline_task.cpp:728 14# doris::pipeline::close_task(doris::pipeline::PipelineTask*, doris::Status, doris::pipeline::PipelineFragmentContext*) at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/pipeline/task_scheduler.cpp:87 15# doris::pipeline::TaskScheduler::_do_work(int)::$_0::operator()() const at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/pipeline/task_scheduler.cpp:135 16# doris::Defer<doris::pipeline::TaskScheduler::_do_work(int)::$_0>::~Defer() in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be 17# doris::pipeline::TaskScheduler::_do_work(int) at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/pipeline/task_scheduler.cpp:172 18# doris::pipeline::TaskScheduler::start()::$_0::operator()() const at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/pipeline/task_scheduler.cpp:67 19# void std::__invoke_impl<void, doris::pipeline::TaskScheduler::start()::$_0&>(std::__invoke_other, doris::pipeline::TaskScheduler::start()::$_0&) at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:63 20# std::enable_if<is_invocable_r_v<void, doris::pipeline::TaskScheduler::start()::$_0&>, void>::type std::__invoke_r<void, doris::pipeline::TaskScheduler::start()::$_0&>(doris::pipeline::TaskScheduler::start()::$_0&) at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:119 21# std::_Function_handler<void (), doris::pipeline::TaskScheduler::start()::$_0>::_M_invoke(std::_Any_data const&) at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:292 22# std::function<void ()>::operator()() const at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:593 23# doris::FunctionRunnable::run() at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/util/threadpool.cpp:60 24# doris::ThreadPool::dispatch_thread() at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/util/threadpool.cpp:614 25# void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:76 26# std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:98 27# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/functional:515 28# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/functional:600 29# void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:63 30# std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:119 31# std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:292 32# std::function<void ()>::operator()() const at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:593 33# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/util/thread.cpp:460 34# asan_thread_start(void*) in /mnt/hdd01/PERFORMANCE_ENV/be/lib/doris_be 35# start_thread at ./nptl/pthread_create.c:442 36# 0x00007FD4A7953850 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83
```

This pull request introduces improvements to the handling of shared hash table termination and error reporting in the hash join build sink operator. The main changes ensure more robust coordination between instances using a shared hash table and provide clearer diagnostics when issues arise.

### Shared hash table coordination

* Added a new atomic flag `_shared_terminated` in `HashJoinBuildSinkOperatorX` to track whether the build hash table instance has terminated, improving synchronization between operator instances.
* In `HashJoinBuildSinkLocalState::terminate`, set `_shared_terminated` to `true` when terminating a build hash table instance, ensuring other instances are aware of the termination state.

### Error handling and diagnostics

* Enhanced error handling in `HashJoinBuildSinkLocalState::close` to check for premature wake-up of non-build instances and return a detailed internal error if termination or signaling states are inconsistent.
* Improved error messages to include more diagnostic information, such as termination state, shared termination flag, signaling status, and cancellation state, making debugging easier.
### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

