### PR TITLE
[Bug](scan) fix topn_next fail

### DIFF
--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -165,7 +165,6 @@ Status VMergeIteratorContext::copy_rows(BlockWithSameBit* block_with_same_bit, b
     block_with_same_bit->same_bit.insert(block_with_same_bit->same_bit.end(),
                                          tmp_pre_ctx_same_bit.begin(),
                                          tmp_pre_ctx_same_bit.begin() + _cur_batch_num);
-    
     return copy_rows(block_with_same_bit->block, advanced);
 }
 

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -134,10 +134,9 @@ bool VMergeIteratorContext::compare(const VMergeIteratorContext& rhs) const {
     return result;
 }
 
-// `advanced = false` when current block finished
-Status VMergeIteratorContext::copy_rows(BlockWithSameBit* block_with_same_bit, bool advanced) {
+Status VMergeIteratorContext::copy_rows(Block* block, bool advanced) {
     Block& src = *_block;
-    Block& dst = *block_with_same_bit->block;
+    Block& dst = *block;
     if (_cur_batch_num == 0) {
         return Status::OK();
     }
@@ -156,12 +155,18 @@ Status VMergeIteratorContext::copy_rows(BlockWithSameBit* block_with_same_bit, b
             d_cp->assume_mutable()->insert_range_from(*s_cp, start, _cur_batch_num);
         }
     });
+    _cur_batch_num = 0;
+    return Status::OK();
+}
+
+// `advanced = false` when current block finished
+Status VMergeIteratorContext::copy_rows(BlockWithSameBit* block_with_same_bit, bool advanced) {
     const auto& tmp_pre_ctx_same_bit = get_pre_ctx_same();
     block_with_same_bit->same_bit.insert(block_with_same_bit->same_bit.end(),
                                          tmp_pre_ctx_same_bit.begin(),
                                          tmp_pre_ctx_same_bit.begin() + _cur_batch_num);
-    _cur_batch_num = 0;
-    return Status::OK();
+    
+    return copy_rows(block_with_same_bit->block, advanced);
 }
 
 Status VMergeIteratorContext::copy_rows(BlockView* view, bool advanced) {


### PR DESCRIPTION
### What problem does this PR solve?
introduced by #57522
failed case is datatype_p2.scalar_types.sql

```cpp
W 2025-11-10 18:21:08,774 13079 status.h:438] meet error status: [INTERNAL_ERROR]should not reach here, current class: doris::vectorized::VMergeIterator

	0#  doris::RowwiseIterator::next_batch(doris::vectorized::Block*) at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/basic_string.h:239
	1#  doris::Status doris::BetaRowsetReader::_next_batch<doris::vectorized::Block>(doris::vectorized::Block*) at /home/zcp/repo_center/doris_master/doris/be/src/common/status.h:524
	2#  doris::BetaRowsetReader::next_batch(doris::vectorized::Block*) at /home/zcp/repo_center/doris_master/doris/be/src/olap/rowset/beta_rowset_reader.h:56
	3#  doris::vectorized::VCollectIterator::_topn_next(doris::vectorized::Block*) at /home/zcp/repo_center/doris_master/doris/be/src/common/status.h:524
	4#  doris::vectorized::VCollectIterator::next(doris::vectorized::Block*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/olap/vcollect_iterator.cpp:255
	5#  doris::vectorized::BlockReader::_direct_next_block(doris::vectorized::Block*, bool*) at /home/zcp/repo_center/doris_master/doris/be/src/common/status.h:524
	6#  doris::vectorized::BlockReader::next_block_with_aggregation(doris::vectorized::Block*, bool*) at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/basic_string.h:1165
	7#  doris::vectorized::OlapScanner::_get_block_impl(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /home/zcp/repo_center/doris_master/doris/be/src/common/status.h:524
	8#  doris::vectorized::Scanner::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exec/scan/scanner.cpp:0
	9#  doris::vectorized::Scanner::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exec/scan/scanner.cpp:87
	10# doris::vectorized::ScannerScheduler::_scanner_scan(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:182
```

This pull request refactors the row copying logic in `VMergeIteratorContext` to improve code clarity and performance, especially when handling different block types. The most significant changes include splitting the handling of `Block` and `BlockWithSameBit`, reducing unnecessary processing of the `same_bit` field, and adding supporting methods for block size calculation and batch iteration.

### Row copying logic refactor

* Added a new overload `copy_rows(Block* block, bool advanced = true)` in `VMergeIteratorContext`, which skips processing the `same_bit` field for plain `Block` types, improving performance when merging ordered data.
* Refactored the implementation so that `copy_rows(BlockWithSameBit* block_with_same_bit, bool advanced)` now delegates to the new `copy_rows(Block* block, bool advanced)` after handling `same_bit`, reducing code duplication. [[1]](diffhunk://#diff-3e76cb08743e14159e259cdbae6b55624571859471dadefa49b0a17f7e941985L137-R139) [[2]](diffhunk://#diff-3e76cb08743e14159e259cdbae6b55624571859471dadefa49b0a17f7e941985R158-R169)

### Iterator interface and utility enhancements

* Implemented `next_batch(Block* block)` in `VMergeIterator`, allowing direct batch iteration for plain blocks, supporting the new row copying logic.
* Added `_get_size(Block* block)` utility method to `VMergeIterator` for consistent row counting across different block types.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

