### PR TITLE
 [fix](bitmap) fix several issues when enable_set_in_bitmap_value (may crash or get incrorrect result)

### DIFF
--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -990,6 +990,8 @@ public:
             break;
         }
         _is_shared = other._is_shared;
+        other._type = EMPTY;
+        other._is_shared = false;
         return *this;
     }
 
@@ -2371,6 +2373,7 @@ private:
                 }
             }
             _bitmap.reset();
+            _is_shared = false;
         } else if (_type == SET) {
             if (_set.size() == 1 && !config::enable_set_in_bitmap_value) {
                 _type = SINGLE;

--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -2146,7 +2146,7 @@ public:
         return *std::max_element(_set.begin(), _set.end());
     }
 
-    bool empty() const { 
+    bool empty() const {
         //equal cardinality()==0
         switch (_type) {
         case EMPTY:

--- a/be/test/util/bitmap_value_test.cpp
+++ b/be/test/util/bitmap_value_test.cpp
@@ -311,7 +311,7 @@ TEST(BitmapValueTest, set) {
 TEST(BitmapValueTest, set_extra) {
     const auto old_config = config::enable_set_in_bitmap_value;
     config::enable_set_in_bitmap_value = true;
-    {   
+    {
         //BitmapValue::empty() and BitmapValue::minimum() special case for SET type with 0 element
         BitmapValue bitmap_value;
         bitmap_value.add(1);
@@ -333,9 +333,9 @@ TEST(BitmapValueTest, set_extra) {
         //BitmapValue xor make a SET type with more than 32 element
         BitmapValue bitmap_value;
         bitmap_value.add(1);
-        for(int i = 0;i <32 ; i++) {
+        for (int i = 0; i < 32; i++) {
             BitmapValue tmp;
-            tmp.add(i+2);
+            tmp.add(i + 2);
             bitmap_value ^= tmp;
         }
         //now will get a SET type with 33 element
@@ -346,14 +346,14 @@ TEST(BitmapValueTest, set_extra) {
         //this line will crash before fix, because deserialize CHECK(count <= SET_TYPE_THRESHOLD)
         EXPECT_TRUE(res.deserialize(buf.data()));
     }
-    
+
     {
         //BitmapValue xor may not clear set, when covert to bitmap
         BitmapValue b1;
         b1.add(2);
         //b1 is set type {2}
         EXPECT_EQ(b1.get_type_code(), BitmapTypeCode::SET);
-        EXPECT_EQ(b1.to_string(),"2");
+        EXPECT_EQ(b1.to_string(), "2");
 
         BitmapValue b2;
         for (int i = 0; i < 33; i++) {
@@ -364,12 +364,12 @@ TEST(BitmapValueTest, set_extra) {
         }
         //b2 is bitmap type {2,3}
         EXPECT_EQ(b2.get_type_code(), BitmapTypeCode::BITMAP32);
-        EXPECT_EQ(b2.to_string(),"2,3");
+        EXPECT_EQ(b2.to_string(), "2,3");
 
         b1 ^= b2;
 
         //the correct result is 3, but  it is 2,3 before fix
-        EXPECT_EQ(b1.to_string(),"3");
+        EXPECT_EQ(b1.to_string(), "3");
     }
 
     {
@@ -378,7 +378,7 @@ TEST(BitmapValueTest, set_extra) {
         b1.add(2);
         //b1 is set type {2}
         EXPECT_EQ(b1.get_type_code(), BitmapTypeCode::SET);
-        EXPECT_EQ(b1.to_string(),"2");
+        EXPECT_EQ(b1.to_string(), "2");
 
         BitmapValue b2;
         for (int i = 0; i < 33; i++) {
@@ -389,8 +389,8 @@ TEST(BitmapValueTest, set_extra) {
         }
         //b2 is bitmap type {2,3}
         EXPECT_EQ(b2.get_type_code(), BitmapTypeCode::BITMAP32);
-        EXPECT_EQ(b2.to_string(),"2,3");
-    
+        EXPECT_EQ(b2.to_string(), "2,3");
+
         b1 |= b2;
         //b1 is bitmap type {2,3}, but the set is not clear with {2}
 
@@ -401,7 +401,7 @@ TEST(BitmapValueTest, set_extra) {
         b1 &= b3;
 
         //the correct result is 3, but it is 2,3 before fix
-        EXPECT_EQ(b1.to_string(),"3");
+        EXPECT_EQ(b1.to_string(), "3");
     }
     config::enable_set_in_bitmap_value = old_config;
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

all  reproduce detail can be found in TEST(BitmapValueTest, set_extra) 

**case1:**
BitmapValue::empty() and BitmapValue::minimum() is not correct for a BitmapValue with empty set

**case2:**
BitmapValue xor operator can make a SET type with more than 32 element
so  deserialize will crash when CHECK(count <= SET_TYPE_THRESHOLD)
<img width="516" height="251" alt="image" src="https://github.com/user-attachments/assets/1e7e4145-b6ca-4763-8e2d-fbc7b67d8625" />


also can be reproduced with the following sql
```
select BITMAP_UNION(x)
from
(
    select group_bitmap_xor(b) as x
    from (select to_bitmap(number) as b from numbers("number" = "64")) t
    union all
    select group_bitmap_xor(b) as x
    from (select to_bitmap(number) as b from numbers("number" = "64")) t2
) t3;
```

**case3:**
BitmapValue xor operator does not clear set, when set covert to bitmap.
<img width="276" height="268" alt="image" src="https://github.com/user-attachments/assets/e1233931-48a3-432c-b271-ab0227cc7ea8" />

then _convert_to_smaller_type will back to set, when bitmap card = 1, and the final set is not correct because 
_set has old item
<img width="669" height="567" alt="image" src="https://github.com/user-attachments/assets/9183bd77-6bf4-4eae-ac67-735905dffd94" />

also can be reproduced with the following sql
```
select
    bitmap_to_array(
        bitmap_xor(
            bitmap_and(
                bitmap_from_array([1,2]),
                bitmap_from_array([2,3])
            ),
            bitmap_and(
                bitmap_from_array(
                    [2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34]
                ),
                bitmap_from_array(
                    [2,3,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134]
                )
            )
        )
    );
```

**case4:**
BitmapValue or operator not clear set, when  set covert to bitmap
<img width="356" height="212" alt="image" src="https://github.com/user-attachments/assets/4e040abf-a153-4ac9-bdc9-a6f6c381a510" />

then this BitmapValue call and operator , may get  incorrect result
<img width="451" height="271" alt="image" src="https://github.com/user-attachments/assets/4b356ea2-8e41-4307-a18d-190e6d589232" />


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

