### PR TITLE
[optimize](paimon): Avoid redundant hadoop conf setting in each split

### DIFF
--- a/be/src/vec/exec/format/table/paimon_jni_reader.cpp
+++ b/be/src/vec/exec/format/table/paimon_jni_reader.cpp
@@ -50,7 +50,12 @@ PaimonJniReader::PaimonJniReader(const std::vector<SlotDescriptor*>& file_slot_d
     }
     std::map<String, String> params;
     params["paimon_split"] = range.table_format_params.paimon_params.paimon_split;
-    params["paimon_predicate"] = range.table_format_params.paimon_params.paimon_predicate;
+    if (range_params->__isset.paimon_predicate && !range_params->paimon_predicate.empty()) {
+        params["paimon_predicate"] = range_params->paimon_predicate;
+    } else if (range.table_format_params.paimon_params.__isset.paimon_predicate) {
+        // Fallback to split level paimon_predicate for backward compatibility
+        params["paimon_predicate"] = range.table_format_params.paimon_params.paimon_predicate;
+    }
     params["required_fields"] = join(column_names, ",");
     params["columns_types"] = join(column_types, "#");
     params["time_zone"] = _state->timezone();
@@ -67,7 +72,14 @@ PaimonJniReader::PaimonJniReader(const std::vector<SlotDescriptor*>& file_slot_d
     for (const auto& kv : range.table_format_params.paimon_params.paimon_options) {
         params[PAIMON_OPTION_PREFIX + kv.first] = kv.second;
     }
-    if (range.table_format_params.paimon_params.__isset.hadoop_conf) {
+    // Prefer hadoop conf from scan node level (range_params->properties) over split level
+    // to avoid redundant configuration in each split
+    if (range_params->__isset.properties && !range_params->properties.empty()) {
+        for (const auto& kv : range_params->properties) {
+            params[HADOOP_OPTION_PREFIX + kv.first] = kv.second;
+        }
+    } else if (range.table_format_params.paimon_params.__isset.hadoop_conf) {
+        // Fallback to split level hadoop conf for backward compatibility
         for (const auto& kv : range.table_format_params.paimon_params.hadoop_conf) {
             params[HADOOP_OPTION_PREFIX + kv.first] = kv.second;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
@@ -188,6 +188,14 @@ public class PaimonScanNode extends FileQueryScanNode {
         return Optional.of(serializedTable);
     }
 
+    @Override
+    public void createScanRangeLocations() throws UserException {
+        super.createScanRangeLocations();
+        // Set paimon_predicate at ScanNode level to avoid redundant serialization in each split
+        String serializedPredicate = PaimonUtil.encodeObjectToString(predicates);
+        params.setPaimonPredicate(serializedPredicate);
+    }
+
     private void putHistorySchemaInfo(Long schemaId) {
         if (currentQuerySchema.putIfAbsent(schemaId, Boolean.TRUE) == null) {
             PaimonExternalTable table = (PaimonExternalTable) source.getTargetTable();
@@ -223,10 +231,8 @@ public class PaimonScanNode extends FileQueryScanNode {
             fileDesc.setSchemaId(paimonSplit.getSchemaId());
         }
         fileDesc.setFileFormat(fileFormat);
-        fileDesc.setPaimonPredicate(PaimonUtil.encodeObjectToString(predicates));
-        // The hadoop conf should be same with
-        // PaimonExternalCatalog.createCatalog()#getConfiguration()
-        fileDesc.setHadoopConf(backendStorageProperties);
+        // Hadoop conf is set at ScanNode level via params.properties in createScanRangeLocations(),
+        // no need to set it for each split to avoid redundant configuration
         Optional<DeletionFile> optDeletionFile = paimonSplit.getDeletionFile();
         if (optDeletionFile.isPresent()) {
             DeletionFile deletionFile = optDeletionFile.get();

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -475,6 +475,10 @@ struct TFileScanRangeParams {
     25: optional i64 current_schema_id;
     // All schema information used in the current query process
     26: optional list<ExternalTableSchema.TSchema> history_schema_info
+
+    // Paimon predicate from FE, used for jni scanner
+    // Set at ScanNode level to avoid redundant serialization in each split
+    27: optional string paimon_predicate
 }
 
 struct TFileRangeDesc {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
Previously, PaimonScanNode.setPaimonParams() was called for each PaimonSplit and set hadoop conf (backendStorageProperties) in every split, which is redundant since these properties are the same at ScanNode level.

This commit:
1. Modifies PaimonJniReader to prefer hadoop conf from scan node level (range_params->properties) over split level, with fallback for backward compatibility
2. Removes redundant fileDesc.setHadoopConf() call in PaimonScanNode, since backendStorageProperties is already set at ScanNode level via params.properties in createScanRangeLocations()

This optimization:
- Reduces memory usage by avoiding duplicate configuration in each split
- Improves performance by eliminating redundant serialization
- Aligns with the implementation pattern used by Hudi and other data sources

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

