### PR TITLE
[Fix](feut) try to fix MissingInvocation of refreshAndGetDiskInfo

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/PartitionExprUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/PartitionExprUtilTest.java
@@ -35,7 +35,6 @@ import org.apache.doris.utframe.TestWithFeService;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +43,6 @@ import java.util.List;
 
 public class PartitionExprUtilTest extends TestWithFeService {
 
-    @Mocked
     ExecuteEnv exeEnv;
 
     @Override
@@ -55,6 +53,7 @@ public class PartitionExprUtilTest extends TestWithFeService {
         Config.dynamic_partition_check_interval_seconds = 1;
         Config.autobucket_max_buckets = 10000;
         createDatabase("test");
+        exeEnv = ExecuteEnv.getInstance();
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

```
[ERROR] testAutoBucketLargeDataCalculatesBuckets  Time elapsed: 9.815 s  <<< ERROR!
mockit.internal.expectations.invocation.MissingInvocation:
Missing 1 invocation to:
org.apache.doris.service.ExecuteEnv#refreshAndGetDiskInfo(true)
   on mock instance: org.apache.doris.service.ExecuteEnv@79c9db18
Caused by: mockit.internal.expectations.invocation.ExpectationError
```

not found the `Expectations` of `refreshAndGetDiskInfo`. just try to fix.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

