### PR TITLE
[fix](hive) Fix partition path scheme mismatch when inserting into Hive partitioned tables on object storage

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
@@ -274,7 +274,7 @@ public class HMSTransaction implements Transaction {
                                 nameMapping,
                                 false,
                                 sd.getInputFormat(),
-                                pu.getLocation().getTargetPath(),
+                                writePath,
                                 HiveUtil.toPartitionValues(pu.getName()),
                                 Maps.newHashMap(),
                                 sd.getOutputFormat(),

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
@@ -270,11 +270,16 @@ public class HMSTransaction implements Transaction {
                     case NEW:
                     case OVERWRITE:
                         StorageDescriptor sd = table.getSd();
+                        // For object storage (FILE_S3), use writePath to keep original scheme (oss://, cos://)
+                        // For HDFS, use targetPath which is the final path after rename
+                        String pathForHMS = this.fileType == TFileType.FILE_S3
+                                ? writePath
+                                : pu.getLocation().getTargetPath();
                         HivePartition hivePartition = new HivePartition(
                                 nameMapping,
                                 false,
                                 sd.getInputFormat(),
-                                writePath,
+                                pathForHMS,
                                 HiveUtil.toPartitionValues(pu.getName()),
                                 Maps.newHashMap(),
                                 sd.getOutputFormat(),


### PR DESCRIPTION
## Problem
  When inserting data into Hive partitioned tables stored on S3-compatible object storage (OSS/COS/OBS), the operation fails with authentication error because
  BE unifies all object storage under "s3://" scheme, but HMS expects the original scheme (e.g., "oss://"). The mismatch causes s3a FileSystem to access OSS
  endpoints with wrong credentials.

## Solution
  Changed `HMSTransaction.finishInsertTable()` line 277 to use `writePath` instead of `getTargetPath()`. The `writePath` variable already contains the correct
  original scheme from HMS, avoiding the scheme conversion issue.

## Test
  Added partition table insert tests for OSS/COS/OBS in `hive_on_hms_and_dlf.groovy`.

