### PR TITLE
[fix](jdbc) Skip the default creation check logic

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
@@ -311,7 +311,7 @@ public class JdbcExternalCatalog extends ExternalCatalog {
 
     @Override
     public void checkWhenCreating() throws DdlException {
-        super.checkWhenCreating();
+        // Skip super.checkWhenCreating() for now;
         Map<String, String> properties = catalogProperty.getProperties();
         if (properties.containsKey(JdbcResource.DRIVER_URL)) {
             String computedChecksum = JdbcResource.computeObjectChecksum(properties.get(JdbcResource.DRIVER_URL));


### PR DESCRIPTION
Because JDBC has its own checking logic, when you explicitly add 'test_connection' = 'true' to the properties, it will trigger an error in the parent class's check. Therefore, for now, only JDBC's own check will be performed.