### PR TITLE
[fix](function)The json_remove function did not initialize nullmap.

### DIFF
--- a/be/src/vec/functions/function_jsonb.cpp
+++ b/be/src/vec/functions/function_jsonb.cpp
@@ -2747,7 +2747,7 @@ public:
 
         res_chars.reserve(input_rows_count * 64);
         res_offsets.resize(input_rows_count);
-        null_map.resize(input_rows_count);
+        null_map.resize_fill(input_rows_count, 0);
 
         // Get JSON document column
         auto [json_column, json_const] =


### PR DESCRIPTION
### What problem does this PR solve?

This error can occur in this PR (https://github.com/apache/doris/pull/57909
```
mysql> SELECT JSON_REMOVE('{"a": 1, "b": 2, "c": 3}', '\$.b');
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]null map check failed for column: Const(Nullable(String))
```

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

