### PR TITLE
[refine](csv reader) Set eof flag based on _line_reader_eof

### DIFF
--- a/be/src/vec/exec/format/csv/csv_reader.h
+++ b/be/src/vec/exec/format/csv/csv_reader.h
@@ -236,6 +236,9 @@ private:
     // TODO(ftw): parse type
     Status _parse_col_types(size_t col_nums, std::vector<DataTypePtr>* col_types);
 
+    Status _process_one_line(Block* block, MutableColumns& columns, size_t* rows,
+                             bool* is_remove_bom, bool is_count_agg);
+
     // If the CSV file is an UTF8 encoding with BOM,
     // then remove the first 3 bytes at the beginning of this file
     // and set size = size - 3.


### PR DESCRIPTION
### What problem does this PR solve?

1. set eof flag based on _line_reader_eof rather than rows=0, to prevent unnecessary extra one call when reaching end of file during batch reading
2. refactor CsvReader::get_next_block extract _process_one_line method to reduce code duplication

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

