### PR TITLE
[feat](snapshot) reference_instance_id is not set in compaction operation log

### DIFF
--- a/cloud/src/meta-store/clone_chain_reader.cpp
+++ b/cloud/src/meta-store/clone_chain_reader.cpp
@@ -867,6 +867,9 @@ TxnErrorCode CloneChainReader::get_rowset_metas(Transaction* txn, int64_t tablet
                                 version);
                     return TxnErrorCode::TXN_INVALID_DATA;
                 }
+                if (!rowset.has_reference_instance_id()) {
+                    rowset.set_reference_instance_id(current_instance_id);
+                }
                 version_to_rowset[version] = std::move(rowset);
             }
         }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

recycle versioned rowsets use `reference_instance_id` the check rowset ref count.
`reference_instance_id` is not set when write compaction operation log.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

