### PR TITLE
[fix](filecache) fix warm up cancel failure when BE is down

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/CloudWarmUpJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/CloudWarmUpJob.java
@@ -24,6 +24,7 @@ import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.common.ClientPool;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Triple;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/CloudWarmUpJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/CloudWarmUpJob.java
@@ -56,6 +56,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -539,20 +540,42 @@ public class CloudWarmUpJob implements Writable {
     private final void clearJobOnBEs() {
         try {
             initClients();
-            for (Map.Entry<Long, Client> entry : beToClient.entrySet()) {
+            // Iterate with explicit iterator so we can remove invalidated clients during iteration.
+            Iterator<Map.Entry<Long, Client>> iter = beToClient.entrySet().iterator();
+            while (iter.hasNext()) {
+                Map.Entry<Long, Client> entry = iter.next();
+                long beId = entry.getKey();
+                Client client = entry.getValue();
                 TWarmUpTabletsRequest request = new TWarmUpTabletsRequest();
                 request.setType(TWarmUpTabletsRequestType.CLEAR_JOB);
                 request.setJobId(jobId);
                 if (this.isEventDriven()) {
                     TWarmUpEventType event = getTWarmUpEventType();
                     if (event == null) {
-                        throw new IllegalArgumentException("Unknown SyncEvent " + syncEvent);
+                        // If event type is unknown, skip this BE but continue others.
+                        LOG.warn("Unknown SyncEvent {}, skip CLEAR_JOB for BE {}", syncEvent, beId);
+                        continue;
                     }
                     request.setEvent(event);
                 }
-                LOG.info("send warm up request to BE {}. job_id={}, request_type=CLEAR_JOB",
-                        entry.getKey(), jobId);
-                entry.getValue().warmUpTablets(request);
+                LOG.info("send warm up request to BE {}. job_id={}, request_type=CLEAR_JOB", beId, jobId);
+                try {
+                    client.warmUpTablets(request);
+                } catch (Exception e) {
+                    // If RPC to this BE fails, invalidate this client and remove it from map,
+                    // then continue to next BE so that one bad BE won't block others.
+                    LOG.warn("send warm up request to BE {} failed: {}", beId, e.getMessage());
+                    try {
+                        TNetworkAddress addr = beToAddr == null ? null : beToAddr.get(beId);
+                        if (addr != null) {
+                            ClientPool.backendPool.invalidateObject(addr, client);
+                        }
+                    } catch (Exception ie) {
+                        LOG.warn("invalidate client for BE {} failed: {}", beId, ie.getMessage());
+                    }
+                    // remove from local map so releaseClients won't try to return an invalidated client
+                    iter.remove();
+                }
             }
         } catch (Exception e) {
             LOG.warn("send warm up request failed. job_id={}, request_type=CLEAR_JOB, exception={}",


### PR DESCRIPTION
Fixed issue where cancel flow would exit if a BE was offline,preventing subsequent BEs from receiving clear_job RPC.Now skips failed BEs and continues sending RPCs to others.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

