### PR TITLE
[enhance](job) terminate streaming task execute threads promptly when idle

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1976,10 +1976,10 @@ public class Config extends ConfigBase {
                     + " greater than 0, otherwise it defaults to 3." })
     public static int job_dictionary_task_consumer_thread_num = 3;
 
-    @ConfField(masterOnly = true, description = {"用于执行 Streaming 任务的线程数,值应该大于0，否则默认为10",
+    @ConfField(masterOnly = true, description = {"用于执行 Streaming 任务的线程数,值应该大于0，否则默认为100",
             "The number of threads used to execute Streaming Tasks, "
-                    + "the value should be greater than 0, if it is <=0, default is 10."})
-    public static int job_streaming_task_exec_thread_num = 10;
+                    + "the value should be greater than 0, if it is <=0, default is 100."})
+    public static int job_streaming_task_exec_thread_num = 100;
 
     @ConfField(masterOnly = true, description = {"最大的 Streaming 作业数量,值应该大于0，否则默认为1024",
             "The maximum number of Streaming jobs, "

--- a/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/StreamingTaskScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/StreamingTaskScheduler.java
@@ -40,15 +40,21 @@ import java.util.concurrent.TimeUnit;
 
 @Log4j2
 public class StreamingTaskScheduler extends MasterDaemon {
-    private final ThreadPoolExecutor threadPool = new ThreadPoolExecutor(
-                    Config.job_streaming_task_exec_thread_num,
-                    Config.job_streaming_task_exec_thread_num,
-                    0,
-                    TimeUnit.SECONDS,
-                    new ArrayBlockingQueue<>(Config.max_streaming_job_num),
-                    new CustomThreadFactory("streaming-task-execute"),
-                    new ThreadPoolExecutor.AbortPolicy()
-            );
+    private final ThreadPoolExecutor threadPool;
+
+    {
+        threadPool = new ThreadPoolExecutor(
+                Config.job_streaming_task_exec_thread_num,
+                Config.job_streaming_task_exec_thread_num,
+                60L,
+                TimeUnit.SECONDS,
+                new ArrayBlockingQueue<>(Config.max_streaming_job_num),
+                new CustomThreadFactory("streaming-task-execute"),
+                new ThreadPoolExecutor.AbortPolicy()
+        );
+        threadPool.allowCoreThreadTimeOut(true);
+    }
+
     private final ScheduledThreadPoolExecutor delayScheduler
                 = new ScheduledThreadPoolExecutor(1, new CustomThreadFactory("streaming-task-delay-scheduler"));
 


### PR DESCRIPTION
### What problem does this PR solve?

1. terminate streaming task execute threads promptly when idle.
2. set job_streaming_task_exec_thread_num default value from 10 to 100.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

