### PR TITLE
[Improvement](exchange) avoid hash shuffle when partition type is bucket shuffle and only one instance

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -295,9 +295,7 @@ ExchangeSinkOperatorX::ExchangeSinkOperatorX(
         _output_tuple_id = sink.output_tuple_id;
     }
 
-    // Bucket shuffle may contain some same bucket so no need change the BUCKET_SHFFULE_HASH_PARTITIONED
-    if (_part_type != TPartitionType::UNPARTITIONED &&
-        _part_type != TPartitionType::BUCKET_SHFFULE_HASH_PARTITIONED) {
+    if (_part_type != TPartitionType::UNPARTITIONED) {
         // if the destinations only one dest, we need to use broadcast
         std::unordered_set<UniqueId> dest_fragment_ids_set;
         for (const auto& dest : _dests) {
@@ -306,7 +304,7 @@ ExchangeSinkOperatorX::ExchangeSinkOperatorX(
                 break;
             }
         }
-        _part_type = dest_fragment_ids_set.size() == 1 ? TPartitionType::UNPARTITIONED : _part_type;
+        _part_type = dest_fragment_ids_set.size() == 1 ? TPartitionType::RANDOM : _part_type;
     }
 }
 

--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -486,7 +486,9 @@ Status ExchangeSinkOperatorX::sink(RuntimeState* state, vectorized::Block* block
                 HANDLE_CHANNEL_STATUS(state, current_channel, status);
             } else {
                 auto pblock = std::make_unique<PBlock>();
-                RETURN_IF_ERROR(local_state._serializer.serialize_block(block, pblock.get()));
+                if (!block->empty()) {
+                    RETURN_IF_ERROR(local_state._serializer.serialize_block(block, pblock.get()));
+                }
                 auto status = current_channel->send_remote_block(std::move(pblock), eos);
                 HANDLE_CHANNEL_STATUS(state, current_channel, status);
             }

--- a/be/src/vec/core/sort_cursor.h
+++ b/be/src/vec/core/sort_cursor.h
@@ -145,6 +145,7 @@ struct BlockSupplierSortCursorImpl : public MergeSortCursorImpl {
         }
         block->clear();
         THROW_IF_ERROR(_block_supplier(block.get(), &_is_eof));
+        DCHECK(!block->empty() or _is_eof);
         if (!block->empty()) {
             if (!_ordering_expr.empty()) {
                 DCHECK_EQ(_ordering_expr.size(), desc.size());

--- a/be/src/vec/core/sort_cursor.h
+++ b/be/src/vec/core/sort_cursor.h
@@ -145,7 +145,6 @@ struct BlockSupplierSortCursorImpl : public MergeSortCursorImpl {
         }
         block->clear();
         THROW_IF_ERROR(_block_supplier(block.get(), &_is_eof));
-        DCHECK(!block->empty() or _is_eof);
         if (!block->empty()) {
             if (!_ordering_expr.empty()) {
                 DCHECK_EQ(_ordering_expr.size(), desc.size());


### PR DESCRIPTION
### What problem does this PR solve?
This pull request updates the logic for partition type handling and improves robustness in the `ExchangeSinkOperatorX` implementation. The main changes include refining how partition types are set, especially for single-destination cases, and ensuring that empty blocks are handled efficiently to avoid unnecessary serialization and sending.

Partition type logic improvements:
* The condition for changing the partition type now only excludes `UNPARTITIONED`, allowing other partition types to be considered for broadcast scenarios.
* When there is only one destination fragment, the partition type is set to `RANDOM` instead of `UNPARTITIONED`, clarifying the intended behavior for single-destination exchanges.

Handling of empty blocks:
* Added an early return in the `sink` method when the input block is empty and not at end-of-stream (`eos`), preventing unnecessary processing.
* Serialization and sending of remote blocks now only occurs if the block is non-empty, further optimizing resource usage.
### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

