### PR TITLE
[fix](snapshot) Disable chunked encoding for s3 client

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/DefaultRemote.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/DefaultRemote.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
@@ -159,7 +160,9 @@ public class DefaultRemote extends RemoteBase {
             StaticCredentialsProvider scp = StaticCredentialsProvider.create(credentials);
             URI endpointUri = URI.create("http://" + obj.getEndpoint());
             s3Client = S3Client.builder().endpointOverride(endpointUri).credentialsProvider(scp)
-                    .region(Region.of(obj.getRegion())).build();
+                    .region(Region.of(obj.getRegion()))
+                    .serviceConfiguration(S3Configuration.builder().chunkedEncodingEnabled(false).build())
+                    .build();
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

For oss, aws s3 sdk don't support put object with chunked encoding.
```
https://help.aliyun.com/zh/oss/developer-reference/use-aws-sdks-to-access-oss?spm=a2c4g.11186623.help-menu-31815.d_1_3_1.287d74b2KaWRRJ&scm=20140722.H_451966._.OR_help-T_cn~zh-V_1#:~:text=%E4%B8%8A%E4%BC%A0%E5%A4%B1%E8%B4%A5%EF%BC%9AInvalidArgument%3A%20aws%2Dchunked%20encoding%20is%20not%20supported
```
```
Failed to put object for S3, Error message=aws-chunked encoding is not supported with the specified x-amz-content-sha256 value
```
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

