### PR TITLE
[fix](filecache) fix out-of-range exception when external query

### DIFF
--- a/be/src/io/cache/file_cache_common.cpp
+++ b/be/src/io/cache/file_cache_common.cpp
@@ -202,6 +202,10 @@ std::optional<int64_t> get_tablet_id(std::string file_path) {
         return std::nullopt;
     }
 
+    if (data_prefix.length() + data_pos >= path_view.length()) {
+        return std::nullopt;
+    }
+
     // Extract the part after "data/"
     path_view = path_view.substr(data_pos + data_prefix.length() + 1);
 

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -19,6 +19,7 @@
 // and modified by Doris
 
 #include "block_file_cache_test_common.h"
+#include "olap/olap_define.h"
 
 namespace doris::io {
 
@@ -7414,6 +7415,13 @@ TEST_F(BlockFileCacheTest, reader_dryrun_when_download_file_cache) {
     FileCacheFactory::instance()->_path_to_cache.clear();
     FileCacheFactory::instance()->_capacity = 0;
     config::enable_reader_dryrun_when_download_file_cache = org;
+}
+
+TEST_F(BlockFileCacheTest, cached_remote_file_reader_tablet_id_guard) {
+    // Ensure get_tablet_id gracefully returns nullopt
+    std::string fake_path = "/mnt/data";
+    auto tablet_id = get_tablet_id(fake_path);
+    EXPECT_FALSE(tablet_id.has_value());
 }
 
 void move_dir_to_version1(const std::string& dirPath) {

--- a/regression-test/suites/cloud_p0/cache/test_file_cache_info.groovy
+++ b/regression-test/suites/cloud_p0/cache/test_file_cache_info.groovy
@@ -54,7 +54,7 @@ suite("test_file_cache_info") {
             `c_mktsegment` string NULL
         )
         DUPLICATE KEY(`c_custkey`)
-        DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 1  // only 1 tablet
+        DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 1
         PROPERTIES (
             "file_cache_ttl_seconds" = "3600"
         )
@@ -127,3 +127,4 @@ suite("test_file_cache_info") {
 
     }
 }
+


### PR DESCRIPTION
add check for external data (lakehouse data) when get_tablet_id to avoid out-of-range exception

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

