### PR TITLE
[fix](auth)Fixed an issue where the wrong catalog was used when checking permissions with use cluster 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/use/UseCloudClusterCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/use/UseCloudClusterCommand.java
@@ -28,7 +28,6 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.UserException;
-import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.commands.Command;
@@ -38,7 +37,6 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
 
 import com.google.common.base.Strings;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Representation of a use cluster statement.
@@ -107,13 +105,15 @@ public class UseCloudClusterCommand extends Command implements NoForward {
             return;
         }
         if (!Env.getCurrentEnv().getAccessManager()
-                .checkDbPriv(ConnectContext.get(),
-                StringUtils.isEmpty(catalogName) ? InternalCatalog.INTERNAL_CATALOG_NAME : catalogName,
-                database,
-                PrivPredicate.SHOW)) {
+                .checkDbPriv(ConnectContext.get(), getAuthCatalogName(), database,
+                        PrivPredicate.SHOW)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_DBACCESS_DENIED_ERROR,
                     ctx.getQualifiedUser(), database);
         }
+    }
+
+    public String getAuthCatalogName() {
+        return catalogName == null ? ConnectContext.get().getDefaultCatalog() : catalogName;
     }
 
     private void handleUseCloudClusterCommand(ConnectContext context) throws AnalysisException {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/UseCloudClusterCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/UseCloudClusterCommandTest.java
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands;
+
+import org.apache.doris.nereids.trees.plans.commands.use.UseCloudClusterCommand;
+import org.apache.doris.utframe.TestWithFeService;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class UseCloudClusterCommandTest extends TestWithFeService {
+    @Override
+    protected void runBeforeAll() throws Exception {
+        connectContext.changeDefaultCatalog("dummycatalog");
+    }
+
+    @Test
+    public void testNotSpecifyCatalog() {
+        UseCloudClusterCommand command = new UseCloudClusterCommand("c1", "db1");
+        Assertions.assertEquals("dummycatalog", command.getAuthCatalogName());
+    }
+
+    @Test
+    public void testSpecifyCatalog() {
+        UseCloudClusterCommand command = new UseCloudClusterCommand("c1", "db1", "ctl1");
+        Assertions.assertEquals("ctl1", command.getAuthCatalogName());
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

when

switch catalog1;

use `db1`@`group1`;

check priv of internal.db1

should check priv of catalog1.db1

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

