### PR TITLE
[Chore](alter) add TQueryGlobals/TQueryOptions params to TAlterTabletReqV2

### DIFF
--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -362,8 +362,9 @@ Status BlockChanger::change_block(vectorized::Block* ref_block,
                         apache::thrift::ThriftDebugString(*expr), ref_block->dump_structure());
             }
 
-            if (result_tmp_column_def.type->get_primitive_type() !=
-                _schema_mapping[idx].new_column->get_vec_type()->get_primitive_type()) {
+            auto lhs = _schema_mapping[idx].new_column->get_vec_type()->get_primitive_type();
+            auto rhs = result_tmp_column_def.type->get_primitive_type();
+            if (is_string_type(lhs) != is_string_type(rhs) && lhs != rhs) {
                 return Status::Error<ErrorCode::INTERNAL_ERROR>(
                         "result type invalid, expect={}, real={}; input expr={}, block={}",
                         _schema_mapping[idx].new_column->get_vec_type()->get_name(),

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -293,8 +293,10 @@ private:
     vectorized::Arena _arena;
 };
 
-BlockChanger::BlockChanger(TabletSchemaSPtr tablet_schema, DescriptorTbl desc_tbl)
-        : _desc_tbl(std::move(desc_tbl)) {
+BlockChanger::BlockChanger(TabletSchemaSPtr tablet_schema, DescriptorTbl desc_tbl,
+                           std::shared_ptr<RuntimeState> state)
+        : _desc_tbl(std::move(desc_tbl)), _state(std::move(state)) {
+    CHECK(_state != nullptr);
     _schema_mapping.resize(tablet_schema->num_columns());
 }
 
@@ -315,17 +317,17 @@ ColumnMapping* BlockChanger::get_mutable_column_mapping(size_t column_index) {
 
 Status BlockChanger::change_block(vectorized::Block* ref_block,
                                   vectorized::Block* new_block) const {
-    std::unique_ptr<RuntimeState> state = RuntimeState::create_unique();
-    state->set_desc_tbl(&_desc_tbl);
-    state->set_be_exec_version(_fe_compatible_version);
+    // for old version request compatibility
+    _state->set_desc_tbl(&_desc_tbl);
+    _state->set_be_exec_version(_fe_compatible_version);
     RowDescriptor row_desc =
             RowDescriptor(_desc_tbl.get_tuple_descriptor(_desc_tbl.get_row_tuples()[0]), false);
 
     if (_where_expr != nullptr) {
         vectorized::VExprContextSPtr ctx = nullptr;
         RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(*_where_expr, ctx));
-        RETURN_IF_ERROR(ctx->prepare(state.get(), row_desc));
-        RETURN_IF_ERROR(ctx->open(state.get()));
+        RETURN_IF_ERROR(ctx->prepare(_state.get(), row_desc));
+        RETURN_IF_ERROR(ctx->open(_state.get()));
 
         RETURN_IF_ERROR(vectorized::VExprContext::filter_block(ctx.get(), ref_block));
     }
@@ -340,8 +342,8 @@ Status BlockChanger::change_block(vectorized::Block* ref_block,
         if (expr != nullptr) {
             vectorized::VExprContextSPtr ctx;
             RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(*expr, ctx));
-            RETURN_IF_ERROR(ctx->prepare(state.get(), row_desc));
-            RETURN_IF_ERROR(ctx->open(state.get()));
+            RETURN_IF_ERROR(ctx->prepare(_state.get(), row_desc));
+            RETURN_IF_ERROR(ctx->open(_state.get()));
 
             int result_tmp_column_idx = -1;
             RETURN_IF_ERROR(ctx->execute(ref_block, &result_tmp_column_idx));
@@ -357,6 +359,15 @@ Status BlockChanger::change_block(vectorized::Block* ref_block,
                 return Status::Error<ErrorCode::INTERNAL_ERROR>(
                         "result size invalid, expect={}, real={}; input expr={}, block={}", row_num,
                         result_tmp_column_def.column->size(),
+                        apache::thrift::ThriftDebugString(*expr), ref_block->dump_structure());
+            }
+
+            if (result_tmp_column_def.type->get_primitive_type() !=
+                _schema_mapping[idx].new_column->get_vec_type()->get_primitive_type()) {
+                return Status::Error<ErrorCode::INTERNAL_ERROR>(
+                        "result type invalid, expect={}, real={}; input expr={}, block={}",
+                        _schema_mapping[idx].new_column->get_vec_type()->get_name(),
+                        result_tmp_column_def.type->get_name(),
                         apache::thrift::ThriftDebugString(*expr), ref_block->dump_structure());
             }
 
@@ -1059,6 +1070,14 @@ Status SchemaChangeJob::_do_process_alter_tablet(const TAlterTabletReqV2& reques
         }
         SchemaChangeParams sc_params;
 
+        if (request.__isset.query_globals && request.__isset.query_options) {
+            sc_params.runtime_state =
+                    std::make_shared<RuntimeState>(request.query_options, request.query_globals);
+        } else {
+            // for old version request compatibility
+            sc_params.runtime_state = std::make_shared<RuntimeState>();
+        }
+
         RETURN_IF_ERROR(
                 DescriptorTbl::create(&sc_params.pool, request.desc_tbl, &sc_params.desc_tbl));
         sc_params.ref_rowset_readers.reserve(rs_splits.size());
@@ -1180,7 +1199,7 @@ Status SchemaChangeJob::_convert_historical_rowsets(const SchemaChangeParams& sc
 
     // Add filter information in change, and filter column information will be set in parse_request
     // And filter some data every time the row block changes
-    BlockChanger changer(_new_tablet_schema, *sc_params.desc_tbl);
+    BlockChanger changer(_new_tablet_schema, *sc_params.desc_tbl, sc_params.runtime_state);
 
     bool sc_sorting = false;
     bool sc_directly = false;

--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -69,7 +69,8 @@ class OlapBlockDataConvertor;
 
 class BlockChanger {
 public:
-    BlockChanger(TabletSchemaSPtr tablet_schema, DescriptorTbl desc_tbl, std::shared_ptr<RuntimeState> state);
+    BlockChanger(TabletSchemaSPtr tablet_schema, DescriptorTbl desc_tbl,
+                 std::shared_ptr<RuntimeState> state);
 
     ~BlockChanger();
 

--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -43,13 +43,13 @@
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_reader.h"
 #include "olap/rowset/rowset_writer.h"
-#include "olap/rowset/segment_v2/inverted_index_writer.h"
 #include "olap/storage_engine.h"
 #include "olap/tablet.h"
 #include "olap/tablet_fwd.h"
 #include "olap/tablet_schema.h"
 #include "runtime/descriptors.h"
 #include "runtime/memory/mem_tracker.h"
+#include "runtime/runtime_state.h"
 #include "vec/data_types/data_type.h"
 
 namespace doris {
@@ -69,7 +69,7 @@ class OlapBlockDataConvertor;
 
 class BlockChanger {
 public:
-    BlockChanger(TabletSchemaSPtr tablet_schema, DescriptorTbl desc_tbl);
+    BlockChanger(TabletSchemaSPtr tablet_schema, DescriptorTbl desc_tbl, std::shared_ptr<RuntimeState> state);
 
     ~BlockChanger();
 
@@ -99,6 +99,8 @@ private:
     AlterTabletType _type;
 
     int32_t _fe_compatible_version = -1;
+
+    std::shared_ptr<RuntimeState> _state;
 };
 
 class SchemaChange {
@@ -281,6 +283,7 @@ struct SchemaChangeParams {
     int32_t be_exec_version;
     std::string vault_id;
     bool output_to_file_cache;
+    std::shared_ptr<RuntimeState> runtime_state;
 };
 
 class SchemaChangeJob {

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -157,6 +157,8 @@ RuntimeState::RuntimeState(const TQueryOptions& query_options, const TQueryGloba
           _unreported_error_idx(0),
           _per_fragment_instance_idx(0) {
     Status status = init(TUniqueId(), query_options, query_globals, nullptr);
+    _exec_env = ExecEnv::GetInstance();
+    init_mem_trackers("<unnamed>");
     DCHECK(status.ok());
 }
 

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -44,7 +44,6 @@
 #include "runtime/fragment_mgr.h"
 #include "runtime/load_path_mgr.h"
 #include "runtime/memory/mem_tracker_limiter.h"
-#include "runtime/memory/thread_mem_tracker_mgr.h"
 #include "runtime/query_context.h"
 #include "runtime/thread_context.h"
 #include "runtime_filter/runtime_filter_mgr.h"

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -151,37 +151,14 @@ RuntimeState::RuntimeState(const TUniqueId& query_id, int32_t fragment_id,
     DCHECK(_query_mem_tracker != nullptr);
 }
 
-RuntimeState::RuntimeState(const TQueryGlobals& query_globals)
+RuntimeState::RuntimeState(const TQueryOptions& query_options, const TQueryGlobals& query_globals)
         : _profile("<unnamed>"),
           _load_channel_profile("<unnamed>"),
           _obj_pool(new ObjectPool()),
           _unreported_error_idx(0),
           _per_fragment_instance_idx(0) {
-    _query_options.batch_size = DEFAULT_BATCH_SIZE;
-    if (query_globals.__isset.time_zone && query_globals.__isset.nano_seconds) {
-        _timezone = query_globals.time_zone;
-        _timestamp_ms = query_globals.timestamp_ms;
-        _nano_seconds = query_globals.nano_seconds;
-    } else if (query_globals.__isset.time_zone) {
-        _timezone = query_globals.time_zone;
-        _timestamp_ms = query_globals.timestamp_ms;
-        _nano_seconds = 0;
-    } else if (!query_globals.now_string.empty()) {
-        _timezone = TimezoneUtils::default_time_zone;
-        VecDateTimeValue dt;
-        dt.from_date_str(query_globals.now_string.c_str(), query_globals.now_string.size());
-        int64_t timestamp;
-        dt.unix_timestamp(&timestamp, _timezone);
-        _timestamp_ms = timestamp * 1000;
-        _nano_seconds = 0;
-    } else {
-        //Unit test may set into here
-        _timezone = TimezoneUtils::default_time_zone;
-        _timestamp_ms = 0;
-        _nano_seconds = 0;
-    }
-    TimezoneUtils::find_cctz_time_zone(_timezone, _timezone_obj);
-    init_mem_trackers("<unnamed>");
+    Status status = init(TUniqueId(), query_options, query_globals, nullptr);
+    DCHECK(status.ok());
 }
 
 RuntimeState::RuntimeState()

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -33,7 +33,6 @@
 #include <mutex>
 #include <shared_mutex>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "agent/be_exec_version_manager.h"
@@ -43,7 +42,6 @@
 #include "common/config.h"
 #include "common/factory_creator.h"
 #include "common/status.h"
-#include "io/fs/file_system.h"
 #include "io/fs/s3_file_system.h"
 #include "runtime/task_execution_context.h"
 #include "runtime/workload_group/workload_group.h"
@@ -812,7 +810,6 @@ private:
     std::vector<TTabletCommitInfo> _tablet_commit_infos;
     std::vector<TErrorTabletInfo> _error_tablet_infos;
     int _max_operator_id = 0;
-    pipeline::PipelineTask* _task = nullptr;
     int _task_id = -1;
     int _task_num = 0;
 
@@ -834,9 +831,6 @@ private:
     // only to lock _pipeline_id_to_profile
     std::shared_mutex _pipeline_profile_lock;
     std::vector<std::shared_ptr<RuntimeProfile>> _pipeline_id_to_profile;
-
-    // prohibit copies
-    RuntimeState(const RuntimeState&);
 
     // save error log to s3
     std::shared_ptr<io::S3FileSystem> _s3_error_fs;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -102,7 +102,7 @@ public:
                  const std::shared_ptr<MemTrackerLimiter>& query_mem_tracker);
 
     // RuntimeState for executing expr in fe-support.
-    RuntimeState(const TQueryGlobals& query_globals);
+    RuntimeState(const TQueryOptions& query_options, const TQueryGlobals& query_globals);
 
     // for job task only
     RuntimeState();

--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -137,6 +137,7 @@ Status VectorizedFnCall::prepare(RuntimeState* state, const RowDescriptor& desc,
             return Status::InternalError("Function {} is not endwith '_state'", _fn.signature);
         }
     } else {
+        LOG(WARNING)<<"mytest "<<_fn.name.function_name<<" "<<state->enable_decimal256()<<' '<<_data_type->get_name();
         // get the function. won't prepare function.
         _function = SimpleFunctionFactory::instance().get_function(
                 _fn.name.function_name, argument_template, _data_type,

--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -137,7 +137,6 @@ Status VectorizedFnCall::prepare(RuntimeState* state, const RowDescriptor& desc,
             return Status::InternalError("Function {} is not endwith '_state'", _fn.signature);
         }
     } else {
-        LOG(WARNING)<<"mytest "<<_fn.name.function_name<<" "<<state->enable_decimal256()<<' '<<_data_type->get_name();
         // get the function. won't prepare function.
         _function = SimpleFunctionFactory::instance().get_function(
                 _fn.name.function_name, argument_template, _data_type,

--- a/be/test/olap/rowset/segment_v2/inverted_index/query/conjunction_query_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index/query/conjunction_query_test.cpp
@@ -40,8 +40,7 @@ public:
         TQueryOptions query_options;
         query_options.inverted_index_conjunction_opt_threshold = 1000;
 
-        _runtime_state = std::make_shared<RuntimeState>(query_globals);
-        _runtime_state->set_query_options(query_options);
+        _runtime_state = std::make_shared<RuntimeState>(query_options, query_globals);
 
         _context = std::make_shared<IndexQueryContext>();
         _context->runtime_state = _runtime_state.get();

--- a/be/test/olap/rowset/segment_v2/inverted_index/query/disjunction_query_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index/query/disjunction_query_test.cpp
@@ -40,8 +40,7 @@ public:
         TQueryOptions query_options;
         query_options.inverted_index_conjunction_opt_threshold = 1000;
 
-        _runtime_state = std::make_shared<RuntimeState>(query_globals);
-        _runtime_state->set_query_options(query_options);
+        _runtime_state = std::make_shared<RuntimeState>(query_options, query_globals);
 
         _context = std::make_shared<IndexQueryContext>();
         _context->runtime_state = _runtime_state.get();

--- a/be/test/olap/wal/wal_manager_test.cpp
+++ b/be/test/olap/wal/wal_manager_test.cpp
@@ -65,7 +65,9 @@ public:
 
 class WalManagerTest : public testing::Test {
 public:
-    WalManagerTest() : _runtime_state(TQueryGlobals()), _global_profile("<global profile>") {
+    WalManagerTest()
+            : _runtime_state(TQueryOptions(), TQueryGlobals()),
+              _global_profile("<global profile>") {
         _runtime_state.resize_op_id_to_local_state(-1);
         init();
         _profile = _runtime_state.runtime_profile();

--- a/be/test/testutil/mock/mock_runtime_state.h
+++ b/be/test/testutil/mock/mock_runtime_state.h
@@ -45,7 +45,8 @@ public:
         _mock_desc_tbl = std::make_unique<MockDescriptorTbl1>();
         set_desc_tbl(_mock_desc_tbl.get());
     }
-    MockRuntimeState(const TQueryGlobals& query_globals) : RuntimeState(query_globals) {
+    MockRuntimeState(const TQueryGlobals& query_globals)
+            : RuntimeState(TQueryOptions(), query_globals) {
         _mock_desc_tbl = std::make_unique<MockDescriptorTbl1>();
         set_desc_tbl(_mock_desc_tbl.get());
     }

--- a/be/test/vec/exec/format/parquet/parquet_read_lines.cpp
+++ b/be/test/vec/exec/format/parquet/parquet_read_lines.cpp
@@ -145,7 +145,7 @@ static void read_parquet_lines(std::vector<std::string> numeric_types,
     p_reader->set_file_reader(reader);
     static_cast<void>(p_reader->read_by_rows(read_lines));
 
-    RuntimeState runtime_state((TQueryGlobals()));
+    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
     runtime_state.set_desc_tbl(desc_tbl);
 
     std::unordered_map<std::string, ColumnValueRangeType> colname_to_value_range;

--- a/be/test/vec/exec/format/parquet/parquet_reader_test.cpp
+++ b/be/test/vec/exec/format/parquet/parquet_reader_test.cpp
@@ -208,7 +208,7 @@ TEST_F(ParquetReaderTest, uuid_varbinary) {
     auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, 992, &ctz,
                                                     nullptr, nullptr, &cache);
     p_reader->set_file_reader(reader);
-    RuntimeState runtime_state((TQueryGlobals()));
+    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
     runtime_state.set_desc_tbl(desc_tbl);
 
     st = p_reader->init_reader(column_names, {}, nullptr, nullptr, nullptr, nullptr, nullptr);
@@ -278,7 +278,7 @@ TEST_F(ParquetReaderTest, varbinary_varbinary) {
     auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, 992, &ctz,
                                                     nullptr, nullptr, &cache);
     p_reader->set_file_reader(reader);
-    RuntimeState runtime_state((TQueryGlobals()));
+    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
     runtime_state.set_desc_tbl(desc_tbl);
 
     st = p_reader->init_reader(column_names, {}, nullptr, nullptr, nullptr, nullptr, nullptr);
@@ -350,7 +350,7 @@ TEST_F(ParquetReaderTest, varbinary_string) {
     auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, 992, &ctz,
                                                     nullptr, nullptr, &cache);
     p_reader->set_file_reader(reader);
-    RuntimeState runtime_state((TQueryGlobals()));
+    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
     runtime_state.set_desc_tbl(desc_tbl);
 
     st = p_reader->init_reader(column_names, {}, nullptr, nullptr, nullptr, nullptr, nullptr);
@@ -422,7 +422,7 @@ TEST_F(ParquetReaderTest, varbinary_string2) {
     auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, 992, &ctz,
                                                     nullptr, nullptr, &cache);
     p_reader->set_file_reader(reader);
-    RuntimeState runtime_state((TQueryGlobals()));
+    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
     runtime_state.set_desc_tbl(desc_tbl);
 
     st = p_reader->init_reader(column_names, {}, nullptr, nullptr, nullptr, nullptr, nullptr);

--- a/be/test/vec/exec/format/parquet/parquet_reader_test.cpp
+++ b/be/test/vec/exec/format/parquet/parquet_reader_test.cpp
@@ -146,7 +146,7 @@ TEST_F(ParquetReaderTest, normal) {
     auto p_reader = new ParquetReader(nullptr, scan_params, scan_range, 992, &ctz, nullptr, nullptr,
                                       &cache);
     p_reader->set_file_reader(reader);
-    RuntimeState runtime_state((TQueryGlobals()));
+    RuntimeState runtime_state((TQueryOptions()), TQueryGlobals());
     runtime_state.set_desc_tbl(desc_tbl);
 
     static_cast<void>(

--- a/be/test/vec/exec/format/table/hive/hive_reader_create_column_ids_test.cpp
+++ b/be/test/vec/exec/format/table/hive/hive_reader_create_column_ids_test.cpp
@@ -649,7 +649,7 @@ protected:
             return {nullptr, nullptr};
         }
 
-        RuntimeState runtime_state((TQueryGlobals()));
+        RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
         TFileScanRangeParams scan_params;
         scan_params.format_type = TFileFormatType::FORMAT_PARQUET;
         TFileRangeDesc scan_range;
@@ -695,7 +695,7 @@ protected:
         }
 
         // Setup runtime state
-        RuntimeState runtime_state((TQueryGlobals()));
+        RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
 
         // Setup scan parameters
         TFileScanRangeParams scan_params;

--- a/be/test/vec/exec/format/table/hive/hive_reader_test.cpp
+++ b/be/test/vec/exec/format/table/hive/hive_reader_test.cpp
@@ -511,7 +511,7 @@ TEST_F(HiveReaderTest, read_hive_parquet_file) {
     }
 
     // Setup runtime state
-    RuntimeState runtime_state((TQueryGlobals()));
+    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
 
     // Setup scan parameters
     TFileScanRangeParams scan_params;
@@ -651,7 +651,7 @@ TEST_F(HiveReaderTest, read_hive_rrc_file) {
     }
 
     // Setup runtime state
-    RuntimeState runtime_state((TQueryGlobals()));
+    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
 
     // Setup scan parameters
     TFileScanRangeParams scan_params;

--- a/be/test/vec/exec/format/table/iceberg/iceberg_reader_create_column_ids_test.cpp
+++ b/be/test/vec/exec/format/table/iceberg/iceberg_reader_create_column_ids_test.cpp
@@ -672,7 +672,7 @@ protected:
         }
 
         // Setup runtime state
-        RuntimeState runtime_state((TQueryGlobals()));
+        RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
 
         // Setup scan parameters
         TFileScanRangeParams scan_params;
@@ -727,7 +727,7 @@ protected:
         }
 
         // Setup runtime state
-        RuntimeState runtime_state((TQueryGlobals()));
+        RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
 
         // Setup scan parameters
         TFileScanRangeParams scan_params;

--- a/be/test/vec/exec/format/table/iceberg/iceberg_reader_test.cpp
+++ b/be/test/vec/exec/format/table/iceberg/iceberg_reader_test.cpp
@@ -514,7 +514,7 @@ TEST_F(IcebergReaderTest, read_iceberg_parquet_file) {
     }
 
     // Setup runtime state
-    RuntimeState runtime_state((TQueryGlobals()));
+    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
 
     // Setup scan parameters
     TFileScanRangeParams scan_params;
@@ -649,7 +649,7 @@ TEST_F(IcebergReaderTest, read_iceberg_orc_file) {
     }
 
     // Setup runtime state
-    RuntimeState runtime_state((TQueryGlobals()));
+    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
 
     // Setup scan parameters
     TFileScanRangeParams scan_params;

--- a/be/test/vec/exec/vfile_scanner_exception_test.cpp
+++ b/be/test/vec/exec/vfile_scanner_exception_test.cpp
@@ -65,7 +65,8 @@ public:
 class VfileScannerExceptionTest : public testing::Test {
 public:
     VfileScannerExceptionTest()
-            : _runtime_state(TQueryGlobals()), _global_profile("<global profile>") {
+            : _runtime_state(TQueryOptions(), TQueryGlobals()),
+              _global_profile("<global profile>") {
         _runtime_state.resize_op_id_to_local_state(-1);
         init();
         _profile = _runtime_state.runtime_profile();

--- a/be/test/vec/function/function_test_util.cpp
+++ b/be/test/vec/function/function_test_util.cpp
@@ -600,7 +600,7 @@ static Block* process_table_function(TableFunction* fn, Block* input_block,
         return nullptr;
     }
 
-    RuntimeState runtime_state((TQueryGlobals()));
+    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
     // process table function init
     if (fn->process_init(input_block, &runtime_state) != Status::OK()) {
         LOG(WARNING) << "TableFunction process_init failed";

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
@@ -30,7 +30,10 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.CoordinatorContext;
 import org.apache.doris.task.AgentTask;
+import org.apache.doris.thrift.TQueryGlobals;
+import org.apache.doris.thrift.TQueryOptions;
 import org.apache.doris.thrift.TStatusCode;
 
 import com.google.common.base.Strings;
@@ -110,6 +113,12 @@ public abstract class AlterJobV2 implements Writable {
     @SerializedName(value = "uid")
     protected UserIdentity userIdentity = null;
 
+    @SerializedName(value = "queryOptions")
+    protected TQueryOptions queryOptions = new TQueryOptions();
+
+    @SerializedName(value = "queryGlobals")
+    protected TQueryGlobals queryGlobals = new TQueryGlobals();
+
     // for show alter table command, master fe change the job state to FINISHED before writing edit log.
     // We set showJobState to FINISHED after writing edit log. otherwise, query to non master fe may read
     // data before schema change finished.
@@ -131,6 +140,8 @@ public abstract class AlterJobV2 implements Writable {
 
         if (ConnectContext.get() != null) {
             userIdentity = ConnectContext.get().getCurrentUserIdentity();
+            this.queryOptions = ConnectContext.get().getSessionVariable().toThrift();
+            this.queryGlobals = CoordinatorContext.createQueryGlobals(ConnectContext.get());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -486,7 +486,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                                 dbId, tableId, partitionId, rollupIndexId, baseIndexId, rollupTabletId, baseTabletId,
                                 rollupReplica.getId(), rollupSchemaHash, baseSchemaHash, visibleVersion, jobId,
                                 JobType.ROLLUP, defineExprs, descTable, tbl.getSchemaByIndexId(baseIndexId, true),
-                                objectPool, whereClause, expiration, vaultId);
+                                objectPool, whereClause, expiration, vaultId, queryOptions, queryGlobals);
                         rollupBatchTask.addTask(rollupTask);
                     }
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -560,7 +560,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 implements GsonPostProcessable
                                     tableId, partitionId, shadowIdxId, originIdxId, shadowTabletId, originTabletId,
                                     shadowReplica.getId(), shadowSchemaHash, originSchemaHash, visibleVersion, jobId,
                                     JobType.SCHEMA_CHANGE, defineExprs, descTable, originSchemaColumns, objectPool,
-                                    null, expiration, vaultId);
+                                    null, expiration, vaultId, queryOptions, queryGlobals);
                             schemaChangeBatchTask.addTask(rollupTask);
                         }
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/CoordinatorContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/CoordinatorContext.java
@@ -275,7 +275,7 @@ public class CoordinatorContext {
     public static CoordinatorContext buildForSql(NereidsPlanner planner, NereidsCoordinator coordinator) {
         ConnectContext connectContext = planner.getCascadesContext().getConnectContext();
         TQueryOptions queryOptions = initQueryOptions(connectContext);
-        TQueryGlobals queryGlobals = initQueryGlobals(connectContext);
+        TQueryGlobals queryGlobals = createQueryGlobals(connectContext);
         TDescriptorTable descriptorTable = planner.getDescTable().toThrift();
 
         ExecutionProfile executionProfile = new ExecutionProfile(
@@ -341,7 +341,7 @@ public class CoordinatorContext {
         return queryOptions;
     }
 
-    private static TQueryGlobals initQueryGlobals(ConnectContext context) {
+    public static TQueryGlobals createQueryGlobals(ConnectContext context) {
         TQueryGlobals queryGlobals = new TQueryGlobals();
         queryGlobals.setNowString(TimeUtils.getDatetimeFormatWithTimeZone().format(LocalDateTime.now()));
         queryGlobals.setTimestampMs(System.currentTimeMillis());

--- a/fe/fe-core/src/main/java/org/apache/doris/task/AlterReplicaTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/AlterReplicaTask.java
@@ -27,6 +27,8 @@ import org.apache.doris.thrift.TAlterMaterializedViewParam;
 import org.apache.doris.thrift.TAlterTabletReqV2;
 import org.apache.doris.thrift.TAlterTabletType;
 import org.apache.doris.thrift.TColumn;
+import org.apache.doris.thrift.TQueryGlobals;
+import org.apache.doris.thrift.TQueryOptions;
 import org.apache.doris.thrift.TTaskType;
 
 import com.google.common.collect.Lists;
@@ -60,6 +62,9 @@ public class AlterReplicaTask extends AgentTask {
     private long expiration;
 
     private String vaultId;
+
+    private TQueryOptions queryOptions;
+    private TQueryGlobals queryGlobals;
     /**
      * AlterReplicaTask constructor.
      *
@@ -69,7 +74,7 @@ public class AlterReplicaTask extends AgentTask {
             long baseIndexId, long rollupTabletId, long baseTabletId, long newReplicaId, int newSchemaHash,
             int baseSchemaHash, long version, long jobId, AlterJobV2.JobType jobType, Map<String, Expr> defineExprs,
             DescriptorTable descTable, List<Column> baseSchemaColumns, Map<Object, Object> objectPool,
-            Expr whereClause, long expiration, String vaultId) {
+            Expr whereClause, long expiration, String vaultId, TQueryOptions queryOptions, TQueryGlobals queryGlobals) {
         super(null, backendId, TTaskType.ALTER, dbId, tableId, partitionId, rollupIndexId, rollupTabletId);
 
         this.baseTabletId = baseTabletId;
@@ -89,6 +94,9 @@ public class AlterReplicaTask extends AgentTask {
         this.objectPool = objectPool;
         this.expiration = expiration;
         this.vaultId = vaultId;
+
+        this.queryOptions = queryOptions;
+        this.queryGlobals = queryGlobals;
     }
 
     public long getBaseTabletId() {
@@ -182,6 +190,9 @@ public class AlterReplicaTask extends AgentTask {
             }
         }
         req.setStorageVaultId(this.vaultId);
+
+        req.setQueryOptions(this.queryOptions);
+        req.setQueryGlobals(this.queryGlobals);
         return req;
     }
 }

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -272,6 +272,8 @@ struct TAlterTabletReqV2 {
     9: optional Descriptors.TDescriptorTable desc_tbl
     10: optional list<Descriptors.TColumn> columns
     11: optional i32 be_exec_version = 0
+    12: optional PaloInternalService.TQueryGlobals query_globals
+    13: optional PaloInternalService.TQueryOptions query_options
 
     // For cloud
     1000: optional i64 job_id


### PR DESCRIPTION
### What problem does this PR solve?
This pull request introduces improvements to schema change operations by passing query context information (`TQueryOptions` and `TQueryGlobals`) through the schema change job pipeline. This enables more accurate runtime environment setup during schema changes, improves compatibility with newer request formats, and adds stricter type validation during block conversion. The changes affect both cloud and non-cloud schema change paths and refactor the `BlockChanger` and `RuntimeState` classes to support the new context.

**Schema change context propagation:**

* Added support for passing `query_options` and `query_globals` in `TAlterTabletReqV2` for both cloud and non-cloud schema change jobs, enabling more precise runtime state setup. [[1]](diffhunk://#diff-0206e12d8413288f2daa5b1191ecf6a924bd0ceebee66e76c3f1540e647794e8R273-R274) [[2]](diffhunk://#diff-3a80bd0760c64bdaebaa5cb3fa9b0f1ff91e3b4c2db884aca31ba8588433042bR221-R228) [[3]](diffhunk://#diff-8ed52fcd40d49be70d3aa98b911d9ddc7b0366cf0a1110d45763da9be74f3834R1074-R1081)

**BlockChanger and RuntimeState enhancements:**

* Refactored `BlockChanger` to accept and use a shared `RuntimeState` instance, ensuring that runtime context is consistently available during block conversion. [[1]](diffhunk://#diff-045a9152e8ea5a0957698b6c6252238b0a3b7f9a2880141e2b5db5a940054958L72-R72) [[2]](diffhunk://#diff-045a9152e8ea5a0957698b6c6252238b0a3b7f9a2880141e2b5db5a940054958R102-R103) [[3]](diffhunk://#diff-8ed52fcd40d49be70d3aa98b911d9ddc7b0366cf0a1110d45763da9be74f3834L296-R299)
* Updated `RuntimeState` constructor to accept both `TQueryOptions` and `TQueryGlobals`, and refactored initialization logic to use the new parameters. [[1]](diffhunk://#diff-1e9d839e1befa1609458c0381610e56fa959060366f89c70a4f8ea471583d500L154-R161) [[2]](diffhunk://#diff-efeb89760ec70cdad5ae9c6169e213b9efa84fccb6ede73f626bf6583bd82333L105-R105)

**Type validation improvements:**

* Added a type check during block conversion to ensure that the result column type matches the expected schema type, improving data integrity and error reporting.

**Compatibility and code cleanup:**

* Ensured backward compatibility by falling back to default `RuntimeState` when query context is not present in older requests. [[1]](diffhunk://#diff-3a80bd0760c64bdaebaa5cb3fa9b0f1ff91e3b4c2db884aca31ba8588433042bR221-R228) [[2]](diffhunk://#diff-8ed52fcd40d49be70d3aa98b911d9ddc7b0366cf0a1110d45763da9be74f3834R1074-R1081)
* Removed unused include and updated header dependencies for clarity and correctness.

**SchemaChangeParams refactoring:**

* Added a `runtime_state` member to `SchemaChangeParams` to store the shared runtime context used throughout schema change operations.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

