### PR TITLE
[opt](outfile) support compressed csv with names and types in outfile

### DIFF
--- a/be/src/vec/runtime/vcsv_transformer.cpp
+++ b/be/src/vec/runtime/vcsv_transformer.cpp
@@ -93,10 +93,15 @@ Status VCSVTransformer::open() {
                 _file_writer->append(Slice(reinterpret_cast<const char*>(bom), sizeof(bom))));
     }
     if (!_csv_header.empty()) {
+        Slice header(_csv_header.data(), _csv_header.size());
         if (_compress_codec) {
-            return Status::InternalError("compressed csv with header is not supported yet");
+            faststring compressed_data;
+            RETURN_IF_ERROR(_compress_codec->compress(header, &compressed_data));
+            RETURN_IF_ERROR(
+                    _file_writer->append(Slice(compressed_data.data(), compressed_data.size())));
+        } else {
+            return _file_writer->append(header);
         }
-        return _file_writer->append(Slice(_csv_header.data(), _csv_header.size()));
     }
     return Status::OK();
 }

--- a/be/src/vec/runtime/vcsv_transformer.cpp
+++ b/be/src/vec/runtime/vcsv_transformer.cpp
@@ -86,11 +86,15 @@ VCSVTransformer::VCSVTransformer(RuntimeState* state, doris::io::FileWriter* fil
 Status VCSVTransformer::open() {
     RETURN_IF_ERROR(get_block_compression_codec(_compress_type, &_compress_codec));
     if (_with_bom) {
+        Slice bom_slice(reinterpret_cast<const char*>(bom), sizeof(bom));
         if (_compress_codec) {
-            return Status::InternalError("compressed csv with bom is not supported yet");
+            faststring compressed_data;
+            RETURN_IF_ERROR(_compress_codec->compress(bom_slice, &compressed_data));
+            RETURN_IF_ERROR(
+                    _file_writer->append(Slice(compressed_data.data(), compressed_data.size())));
+        } else {
+            RETURN_IF_ERROR(_file_writer->append(bom_slice));
         }
-        RETURN_IF_ERROR(
-                _file_writer->append(Slice(reinterpret_cast<const char*>(bom), sizeof(bom))));
     }
     if (!_csv_header.empty()) {
         Slice header(_csv_header.data(), _csv_header.size());

--- a/regression-test/data/export_p0/test_outfile_csv_compress.out
+++ b/regression-test/data/export_p0/test_outfile_csv_compress.out
@@ -114,6 +114,234 @@ c1	text	Yes	false	\N	NONE
 c2	text	Yes	false	\N	NONE
 
 -- !select --
+1	zhangsan
+1	zhangsan1
+10	zhangsan10
+10	zhangsan110
+10	zhangsan1210
+10	zhangsan12410
+10	zhangsan12510
+10	zhangsan1310
+10	zhangsan13610
+10	zhangsan1410
+
+-- !select --
+1048576	1048576
+
+-- !select --
+c1	text	Yes	false	\N	NONE
+c2	text	Yes	false	\N	NONE
+
+-- !select --
+1	zhangsan
+1	zhangsan1
+10	zhangsan10
+10	zhangsan110
+10	zhangsan1210
+10	zhangsan12410
+10	zhangsan12510
+10	zhangsan1310
+10	zhangsan13610
+10	zhangsan1410
+
+-- !select --
+1048576	1048576
+
+-- !select --
+c1	text	Yes	false	\N	NONE
+c2	text	Yes	false	\N	NONE
+
+-- !select --
+1	zhangsan
+1	zhangsan1
+10	zhangsan10
+10	zhangsan110
+10	zhangsan1210
+10	zhangsan12410
+10	zhangsan12510
+10	zhangsan1310
+10	zhangsan13610
+10	zhangsan1410
+
+-- !select --
+1048576	1048576
+
+-- !select --
+c1	text	Yes	false	\N	NONE
+c2	text	Yes	false	\N	NONE
+
+-- !select --
+1	zhangsan
+1	zhangsan1
+10	zhangsan10
+10	zhangsan110
+10	zhangsan1210
+10	zhangsan12410
+10	zhangsan12510
+10	zhangsan1310
+10	zhangsan13610
+10	zhangsan1410
+
+-- !select --
+1048576	1048576
+
+-- !select --
+c1	text	Yes	false	\N	NONE
+c2	text	Yes	false	\N	NONE
+
+-- !select --
+1	zhangsan
+1	zhangsan1
+10	zhangsan10
+10	zhangsan110
+10	zhangsan1210
+10	zhangsan12410
+10	zhangsan12510
+10	zhangsan1310
+10	zhangsan13610
+10	zhangsan1410
+
+-- !select --
+1048576	1048576
+
+-- !select --
+c1	text	Yes	false	\N	NONE
+c2	text	Yes	false	\N	NONE
+
+-- !select --
+1	zhangsan
+1	zhangsan1
+10	zhangsan10
+10	zhangsan110
+10	zhangsan1210
+10	zhangsan12410
+10	zhangsan12510
+10	zhangsan1310
+10	zhangsan13610
+10	zhangsan1410
+
+-- !select --
+1048576	1048576
+
+-- !select --
+c1	text	Yes	false	\N	NONE
+c2	text	Yes	false	\N	NONE
+
+-- !select --
+1	zhangsan
+1	zhangsan1
+10	zhangsan10
+10	zhangsan110
+10	zhangsan1210
+10	zhangsan12410
+10	zhangsan12510
+10	zhangsan1310
+10	zhangsan13610
+10	zhangsan1410
+
+-- !select --
+1048576	1048576
+
+-- !select --
+c1	text	Yes	false	\N	NONE
+c2	text	Yes	false	\N	NONE
+
+-- !select --
+1	zhangsan
+1	zhangsan1
+10	zhangsan10
+10	zhangsan110
+10	zhangsan1210
+10	zhangsan12410
+10	zhangsan12510
+10	zhangsan1310
+10	zhangsan13610
+10	zhangsan1410
+
+-- !select --
+1048576	1048576
+
+-- !select --
+c1	text	Yes	false	\N	NONE
+c2	text	Yes	false	\N	NONE
+
+-- !select --
+1	zhangsan
+1	zhangsan1
+10	zhangsan10
+10	zhangsan110
+10	zhangsan1210
+10	zhangsan12410
+10	zhangsan12510
+10	zhangsan1310
+10	zhangsan13610
+10	zhangsan1410
+
+-- !select --
+1048576	1048576
+
+-- !select --
+c1	text	Yes	false	\N	NONE
+c2	text	Yes	false	\N	NONE
+
+-- !select --
+1	zhangsan
+1	zhangsan1
+10	zhangsan10
+10	zhangsan110
+10	zhangsan1210
+10	zhangsan12410
+10	zhangsan12510
+10	zhangsan1310
+10	zhangsan13610
+10	zhangsan1410
+
+-- !select --
+1048576	1048576
+
+-- !select --
+c1	text	Yes	false	\N	NONE
+c2	text	Yes	false	\N	NONE
+
+-- !select --
+1	zhangsan
+1	zhangsan1
+10	zhangsan10
+10	zhangsan110
+10	zhangsan1210
+10	zhangsan12410
+10	zhangsan12510
+10	zhangsan1310
+10	zhangsan13610
+10	zhangsan1410
+
+-- !select --
+1048576	1048576
+
+-- !select --
+c1	text	Yes	false	\N	NONE
+c2	text	Yes	false	\N	NONE
+
+-- !select --
+1	zhangsan
+1	zhangsan1
+10	zhangsan10
+10	zhangsan110
+10	zhangsan1210
+10	zhangsan12410
+10	zhangsan12510
+10	zhangsan1310
+10	zhangsan13610
+10	zhangsan1410
+
+-- !select --
+1048576	1048576
+
+-- !select --
+c1	text	Yes	false	\N	NONE
+c2	text	Yes	false	\N	NONE
+
+-- !select --
 1	2
 
 -- !select --

--- a/regression-test/data/export_p0/test_outfile_csv_compress.out
+++ b/regression-test/data/export_p0/test_outfile_csv_compress.out
@@ -404,3 +404,15 @@ c2	text	Yes	false	\N	NONE
 -- !select --
 __dummy_col	text	Yes	false	\N	NONE
 
+-- !select --
+1	zhangsan
+1	zhangsan1
+10	zhangsan10
+10	zhangsan110
+10	zhangsan1210
+10	zhangsan12410
+10	zhangsan12510
+10	zhangsan1310
+10	zhangsan13610
+10	zhangsan1410
+

--- a/regression-test/data/export_p0/test_outfile_csv_compress.out
+++ b/regression-test/data/export_p0/test_outfile_csv_compress.out
@@ -129,8 +129,8 @@ c2	text	Yes	false	\N	NONE
 1048576	1048576
 
 -- !select --
-c1	text	Yes	false	\N	NONE
-c2	text	Yes	false	\N	NONE
+id	text	Yes	false	\N	NONE
+name	text	Yes	false	\N	NONE
 
 -- !select --
 1	zhangsan
@@ -148,8 +148,8 @@ c2	text	Yes	false	\N	NONE
 1048576	1048576
 
 -- !select --
-c1	text	Yes	false	\N	NONE
-c2	text	Yes	false	\N	NONE
+id	text	Yes	false	\N	NONE
+name	text	Yes	false	\N	NONE
 
 -- !select --
 1	zhangsan
@@ -167,8 +167,8 @@ c2	text	Yes	false	\N	NONE
 1048576	1048576
 
 -- !select --
-c1	text	Yes	false	\N	NONE
-c2	text	Yes	false	\N	NONE
+id	text	Yes	false	\N	NONE
+name	text	Yes	false	\N	NONE
 
 -- !select --
 1	zhangsan
@@ -186,8 +186,8 @@ c2	text	Yes	false	\N	NONE
 1048576	1048576
 
 -- !select --
-c1	text	Yes	false	\N	NONE
-c2	text	Yes	false	\N	NONE
+id	text	Yes	false	\N	NONE
+name	text	Yes	false	\N	NONE
 
 -- !select --
 1	zhangsan
@@ -205,8 +205,8 @@ c2	text	Yes	false	\N	NONE
 1048576	1048576
 
 -- !select --
-c1	text	Yes	false	\N	NONE
-c2	text	Yes	false	\N	NONE
+id	text	Yes	false	\N	NONE
+name	text	Yes	false	\N	NONE
 
 -- !select --
 1	zhangsan
@@ -224,8 +224,8 @@ c2	text	Yes	false	\N	NONE
 1048576	1048576
 
 -- !select --
-c1	text	Yes	false	\N	NONE
-c2	text	Yes	false	\N	NONE
+id	text	Yes	false	\N	NONE
+name	text	Yes	false	\N	NONE
 
 -- !select --
 1	zhangsan
@@ -243,8 +243,8 @@ c2	text	Yes	false	\N	NONE
 1048576	1048576
 
 -- !select --
-c1	text	Yes	false	\N	NONE
-c2	text	Yes	false	\N	NONE
+id	text	Yes	false	\N	NONE
+name	text	Yes	false	\N	NONE
 
 -- !select --
 1	zhangsan
@@ -262,8 +262,8 @@ c2	text	Yes	false	\N	NONE
 1048576	1048576
 
 -- !select --
-c1	text	Yes	false	\N	NONE
-c2	text	Yes	false	\N	NONE
+id	text	Yes	false	\N	NONE
+name	text	Yes	false	\N	NONE
 
 -- !select --
 1	zhangsan
@@ -281,8 +281,8 @@ c2	text	Yes	false	\N	NONE
 1048576	1048576
 
 -- !select --
-c1	text	Yes	false	\N	NONE
-c2	text	Yes	false	\N	NONE
+id	text	Yes	false	\N	NONE
+name	text	Yes	false	\N	NONE
 
 -- !select --
 1	zhangsan
@@ -300,8 +300,8 @@ c2	text	Yes	false	\N	NONE
 1048576	1048576
 
 -- !select --
-c1	text	Yes	false	\N	NONE
-c2	text	Yes	false	\N	NONE
+id	text	Yes	false	\N	NONE
+name	text	Yes	false	\N	NONE
 
 -- !select --
 1	zhangsan
@@ -319,8 +319,8 @@ c2	text	Yes	false	\N	NONE
 1048576	1048576
 
 -- !select --
-c1	text	Yes	false	\N	NONE
-c2	text	Yes	false	\N	NONE
+id	text	Yes	false	\N	NONE
+name	text	Yes	false	\N	NONE
 
 -- !select --
 1	zhangsan
@@ -338,8 +338,8 @@ c2	text	Yes	false	\N	NONE
 1048576	1048576
 
 -- !select --
-c1	text	Yes	false	\N	NONE
-c2	text	Yes	false	\N	NONE
+id	text	Yes	false	\N	NONE
+name	text	Yes	false	\N	NONE
 
 -- !select --
 1	2

--- a/regression-test/suites/export_p0/test_outfile_csv_compress.groovy
+++ b/regression-test/suites/export_p0/test_outfile_csv_compress.groovy
@@ -56,11 +56,11 @@ suite("test_outfile_csv_compress", "p0") {
     create_table(table_name)
 
     def outFilePath = """s3://${bucket}/outfile_"""
-    def csv_outfile_result = { the_table_name, compression_type ->
+    def csv_outfile_result = { the_table_name, compression_type, format_type ->
         def result = sql """
                 select * from ${the_table_name}
                 into outfile "${outFilePath}"
-                FORMAT AS CSV
+                FORMAT AS ${format_type}
                 PROPERTIES(
                     "s3.endpoint" = "${s3_endpoint}",
                     "s3.region" = "${region}",
@@ -73,38 +73,40 @@ suite("test_outfile_csv_compress", "p0") {
     }
 
     for (String compression_type: ["plain", "gz", "bz2", "snappyblock", "lz4block", "zstd"]) {
-        def outfile_url = csv_outfile_result(table_name, compression_type);
-        print("http://${bucket}.${s3_endpoint}${outfile_url.substring(5 + bucket.length(), outfile_url.length() - 1)}0.")
-        qt_select """ select c1, c2 from s3(
-                    "uri" = "http://${bucket}.${s3_endpoint}${outfile_url.substring(5 + bucket.length(), outfile_url.length() - 1)}*",
-                    "ACCESS_KEY"= "${ak}",
-                    "SECRET_KEY" = "${sk}",
-                    "format" = "csv",
-                    "provider" = "${getS3Provider()}",
-                    "region" = "${region}",
-                    "compress_type" = "${compression_type}"
-                ) order by c1, c2 limit 10;
-                """
-        qt_select """ select count(c1), count(c2) from s3(
-                    "uri" = "http://${bucket}.${s3_endpoint}${outfile_url.substring(5 + bucket.length(), outfile_url.length() - 1)}*",
-                    "ACCESS_KEY"= "${ak}",
-                    "SECRET_KEY" = "${sk}",
-                    "format" = "csv",
-                    "provider" = "${getS3Provider()}",
-                    "region" = "${region}",
-                    "compress_type" = "${compression_type}"
-                );
-                """
-        qt_select """desc function s3(
-                    "uri" = "http://${bucket}.${s3_endpoint}${outfile_url.substring(5 + bucket.length(), outfile_url.length() - 1)}*",
-                    "ACCESS_KEY"= "${ak}",
-                    "SECRET_KEY" = "${sk}",
-                    "format" = "csv",
-                    "provider" = "${getS3Provider()}",
-                    "region" = "${region}",
-                    "compress_type" = "${compression_type}"
-                );
-                """
+        for (String format_type : ["csv", "csv_with_names", "csv_with_names_and_types"]) {
+            def outfile_url = csv_outfile_result(table_name, compression_type, format_type);
+            print("http://${bucket}.${s3_endpoint}${outfile_url.substring(5 + bucket.length(), outfile_url.length() - 1)}0.")
+            qt_select """ select c1, c2 from s3(
+                        "uri" = "http://${bucket}.${s3_endpoint}${outfile_url.substring(5 + bucket.length(), outfile_url.length() - 1)}*",
+                        "ACCESS_KEY"= "${ak}",
+                        "SECRET_KEY" = "${sk}",
+                        "format" = "${format_type}",
+                        "provider" = "${getS3Provider()}",
+                        "region" = "${region}",
+                        "compress_type" = "${compression_type}"
+                    ) order by c1, c2 limit 10;
+                    """
+            qt_select """ select count(c1), count(c2) from s3(
+                        "uri" = "http://${bucket}.${s3_endpoint}${outfile_url.substring(5 + bucket.length(), outfile_url.length() - 1)}*",
+                        "ACCESS_KEY"= "${ak}",
+                        "SECRET_KEY" = "${sk}",
+                        "format" = "${format_type}",
+                        "provider" = "${getS3Provider()}",
+                        "region" = "${region}",
+                        "compress_type" = "${compression_type}"
+                    );
+                    """
+            qt_select """desc function s3(
+                        "uri" = "http://${bucket}.${s3_endpoint}${outfile_url.substring(5 + bucket.length(), outfile_url.length() - 1)}*",
+                        "ACCESS_KEY"= "${ak}",
+                        "SECRET_KEY" = "${sk}",
+                        "format" = "${format_type}",
+                        "provider" = "${getS3Provider()}",
+                        "region" = "${region}",
+                        "compress_type" = "${compression_type}"
+                    );
+                    """
+        }
     }
 
     for (String compression_type: ["plain", "gz", "bz2", "snappyblock", "lz4block", "zstd"]) {

--- a/regression-test/suites/export_p0/test_outfile_csv_compress.groovy
+++ b/regression-test/suites/export_p0/test_outfile_csv_compress.groovy
@@ -148,7 +148,7 @@ suite("test_outfile_csv_compress", "p0") {
 
     for (String compression_type: ["plain", "gz", "bz2", "snappyblock", "lz4block", "zstd"]) {
         def small = "small_${table_name}"
-        def outfile_url = csv_outfile_result(small, compression_type);
+        def outfile_url = csv_outfile_result(small, compression_type, "csv");
         print("http://${bucket}.${s3_endpoint}${outfile_url.substring(5 + bucket.length(), outfile_url.length() - 1)}0.")
         qt_select """ select c1, c2 from s3(
                     "uri" = "http://${bucket}.${s3_endpoint}${outfile_url.substring(5 + bucket.length(), outfile_url.length() - 1)}*",
@@ -202,7 +202,7 @@ suite("test_outfile_csv_compress", "p0") {
     // test empty table
     sql """drop table if exists test_outfile_csv_compress_empty_table"""
     sql """create table test_outfile_csv_compress_empty_table(k1 int) distributed by hash(k1) buckets 1 properties("replication_num" = "1")"""
-    def empty_outfile_url = csv_outfile_result("test_outfile_csv_compress_empty_table", "gz");
+    def empty_outfile_url = csv_outfile_result("test_outfile_csv_compress_empty_table", "gz", "csv");
     qt_select """desc function s3(
                 "uri" = "http://${bucket}.${s3_endpoint}${empty_outfile_url.substring(5 + bucket.length(), empty_outfile_url.length() - 1)}*",
                 "ACCESS_KEY"= "${ak}",

--- a/regression-test/suites/export_p0/test_outfile_csv_compress.groovy
+++ b/regression-test/suites/export_p0/test_outfile_csv_compress.groovy
@@ -73,7 +73,7 @@ suite("test_outfile_csv_compress", "p0") {
     }
 
     for (String compression_type: ["plain", "gz", "bz2", "snappyblock", "lz4block", "zstd"]) {
-        for (String format_type : ["csv", "csv_with_names", "csv_with_names_and_types"]) {
+        for (String format_type : ["csv"]) {
             def outfile_url = csv_outfile_result(table_name, compression_type, format_type);
             print("http://${bucket}.${s3_endpoint}${outfile_url.substring(5 + bucket.length(), outfile_url.length() - 1)}0.")
             qt_select """ select c1, c2 from s3(
@@ -87,6 +87,43 @@ suite("test_outfile_csv_compress", "p0") {
                     ) order by c1, c2 limit 10;
                     """
             qt_select """ select count(c1), count(c2) from s3(
+                        "uri" = "http://${bucket}.${s3_endpoint}${outfile_url.substring(5 + bucket.length(), outfile_url.length() - 1)}*",
+                        "ACCESS_KEY"= "${ak}",
+                        "SECRET_KEY" = "${sk}",
+                        "format" = "${format_type}",
+                        "provider" = "${getS3Provider()}",
+                        "region" = "${region}",
+                        "compress_type" = "${compression_type}"
+                    );
+                    """
+            qt_select """desc function s3(
+                        "uri" = "http://${bucket}.${s3_endpoint}${outfile_url.substring(5 + bucket.length(), outfile_url.length() - 1)}*",
+                        "ACCESS_KEY"= "${ak}",
+                        "SECRET_KEY" = "${sk}",
+                        "format" = "${format_type}",
+                        "provider" = "${getS3Provider()}",
+                        "region" = "${region}",
+                        "compress_type" = "${compression_type}"
+                    );
+                    """
+        }
+    }
+
+    for (String compression_type: ["plain", "gz", "bz2", "snappyblock", "lz4block", "zstd"]) {
+        for (String format_type : ["csv_with_names", "csv_with_names_and_types"]) {
+            def outfile_url = csv_outfile_result(table_name, compression_type, format_type);
+            print("http://${bucket}.${s3_endpoint}${outfile_url.substring(5 + bucket.length(), outfile_url.length() - 1)}0.")
+            qt_select """ select id, name from s3(
+                        "uri" = "http://${bucket}.${s3_endpoint}${outfile_url.substring(5 + bucket.length(), outfile_url.length() - 1)}*",
+                        "ACCESS_KEY"= "${ak}",
+                        "SECRET_KEY" = "${sk}",
+                        "format" = "${format_type}",
+                        "provider" = "${getS3Provider()}",
+                        "region" = "${region}",
+                        "compress_type" = "${compression_type}"
+                    ) order by id, name limit 10;
+                    """
+            qt_select """ select count(id), count(name) from s3(
                         "uri" = "http://${bucket}.${s3_endpoint}${outfile_url.substring(5 + bucket.length(), outfile_url.length() - 1)}*",
                         "ACCESS_KEY"= "${ak}",
                         "SECRET_KEY" = "${sk}",


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #55392

Problem Summary:
Support compression when outfile with `csv_with_names` and `cvs_with_names_and_types`

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

