### PR TITLE
[refine](util) add cast_to_column to cast ColumnPtr 

### DIFF
--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -30,6 +30,7 @@
 #include "common/status.h"
 #include "olap/olap_common.h"
 #include "runtime/define_primitive_type.h"
+#include "vec/common/assert_cast.h"
 #include "vec/common/cow.h"
 #include "vec/common/pod_array_fwd.h"
 #include "vec/common/string_ref.h"
@@ -759,7 +760,18 @@ ColumnType::Ptr check_and_get_column_ptr(const ColumnPtr& column) {
     if (raw_type_ptr == nullptr) {
         return nullptr;
     }
-    return typename ColumnType::Ptr(raw_type_ptr);
+    return ColumnType::cast_to_column_ptr(raw_type_ptr);
+}
+
+template <typename ColumnType>
+ColumnType::Ptr cast_to_column(const ColumnPtr& column) {
+    const ColumnType* raw_type_ptr = assert_cast<const ColumnType*>(column.get());
+    return ColumnType::cast_to_column_ptr(raw_type_ptr);
+}
+template <typename ColumnType>
+ColumnType::MutablePtr cast_to_column(MutableColumnPtr column) {
+    ColumnType* raw_type_ptr = assert_cast<ColumnType*>(column.get());
+    return ColumnType::cast_to_column_mutptr(raw_type_ptr);
 }
 
 /// True if column's an ColumnConst instance. It's just a syntax sugar for type check.

--- a/be/src/vec/common/cow.h
+++ b/be/src/vec/common/cow.h
@@ -417,6 +417,12 @@ public:
     }
 #include "common/compile_check_avoid_end.h"
 
+    static Ptr cast_to_column_ptr(const Derived* raw_type_ptr) { return Ptr(raw_type_ptr); }
+
+    static MutablePtr cast_to_column_mutptr(Derived* raw_type_ptr) {
+        return MutablePtr(raw_type_ptr);
+    }
+
     typename Base::MutablePtr clone() const override {
         return typename Base::MutablePtr(new Derived(static_cast<const Derived&>(*this)));
     }

--- a/be/src/vec/functions/dictionary.cpp
+++ b/be/src/vec/functions/dictionary.cpp
@@ -116,7 +116,9 @@ void IDictionary::load_values(const std::vector<ColumnPtr>& values_column) {
                     using ValueRealDataType = std::decay_t<decltype(type)>;
                     auto& att = _values_data[i];
                     auto init_column_with_type = [&](auto& column_with_type) {
-                        column_with_type.column = value_column_without_nullable;
+                        using Type = std::decay_t<decltype(column_with_type)>::RealColumnType;
+                        column_with_type.column =
+                                cast_to_column<Type>(value_column_without_nullable);
                         // if original value is nullable, the null_map must be not null
                         if (values_column[i]->is_nullable()) {
                             column_with_type.null_map =

--- a/be/src/vec/functions/dictionary.h
+++ b/be/src/vec/functions/dictionary.h
@@ -132,15 +132,14 @@ protected:
     template <typename Type>
     struct ColumnWithType {
         // OutputColumnType is used as the result column type
-        using OutputColumnType = Type::ColumnType;
-        ColumnPtr column;
         ColumnPtr null_map;
         // RealColumnType is the real type of the column, as there may be ColumnString64, but the result column will not be ColumnString64
+
+        using OutputColumnType = Type::ColumnType;
         using RealColumnType = std::conditional_t<std::is_same_v<DictDataTypeString64, Type>,
                                                   ColumnString64, OutputColumnType>;
-        const RealColumnType* get() const {
-            return assert_cast<const RealColumnType*, TypeCheckOnRelease::DISABLE>(column.get());
-        }
+        RealColumnType::Ptr column;
+        const RealColumnType* get() const { return column.get(); }
 
         const ColumnUInt8* get_null_map() const {
             if (!null_map) {

--- a/be/src/vec/functions/function.cpp
+++ b/be/src/vec/functions/function.cpp
@@ -49,7 +49,7 @@ ColumnPtr wrap_in_nullable(const ColumnPtr& src, const Block& block, const Colum
     ColumnPtr src_not_nullable = src;
     MutableColumnPtr mutable_result_null_map_column;
 
-    if (const auto* nullable = check_and_get_column<ColumnNullable>(*src)) {
+    if (auto nullable = check_and_get_column_ptr<ColumnNullable>(src)) {
         src_not_nullable = nullable->get_nested_column_ptr();
         result_null_map_column = nullable->get_null_map_column_ptr();
     }
@@ -60,8 +60,7 @@ ColumnPtr wrap_in_nullable(const ColumnPtr& src, const Block& block, const Colum
             continue;
         }
 
-        if (const auto* nullable = assert_cast<const ColumnNullable*>(elem.column.get());
-            nullable->has_null()) {
+        if (auto nullable = cast_to_column<ColumnNullable>(elem.column); nullable->has_null()) {
             const ColumnPtr& null_map_column = nullable->get_null_map_column_ptr();
             if (!result_null_map_column) { // NOLINT(bugprone-use-after-move)
                 result_null_map_column = null_map_column->clone_resized(input_rows_count);

--- a/be/test/vec/columns/check_and_get_column_ptr_test.cpp
+++ b/be/test/vec/columns/check_and_get_column_ptr_test.cpp
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 
+#include "runtime/primitive_type.h"
 #include "testutil/column_helper.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_nullable.h"
@@ -139,4 +140,33 @@ TEST(CheckAndGetColumnPtrTest, destructstest) {
 
     EXPECT_EQ(column_ptr->use_count(), 1);
 }
+
+TEST(CheckAndGetColumnPtrTest, cast_to_column_immut) {
+    {
+        ColumnPtr column_ptr = ColumnHelper::create_column<DataTypeInt32>({1, 2, 3});
+
+        EXPECT_EQ(column_ptr->use_count(), 1);
+        ColumnInt32::Ptr column_i32 = cast_to_column<ColumnInt32>(column_ptr);
+
+        EXPECT_TRUE(column_i32);
+
+        EXPECT_EQ(column_ptr->use_count(), 2);
+
+        EXPECT_EQ(column_i32->use_count(), 2);
+    }
+}
+
+TEST(CheckAndGetColumnPtrTest, cast_to_column_mut) {
+    {
+        MutableColumnPtr column_ptr = ColumnInt32::create();
+
+        EXPECT_EQ(column_ptr->use_count(), 1);
+        ColumnInt32::MutablePtr column_i32 = cast_to_column<ColumnInt32>(std::move(column_ptr));
+
+        EXPECT_TRUE(column_i32);
+
+        EXPECT_EQ(column_i32->use_count(), 1);
+    }
+}
+
 } // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?

This is similar to std::dynamic_pointer_cast.
```C++
        ColumnPtr column_ptr = ColumnHelper::create_column<DataTypeInt32>({1, 2, 3});
        EXPECT_EQ(column_ptr->use_count(), 1);
        ColumnInt32::Ptr column_i32 = cast_to_column<ColumnInt32>(column_ptr);
        EXPECT_TRUE(column_i32);
        EXPECT_EQ(column_ptr->use_count(), 2);
        EXPECT_EQ(column_i32->use_count(), 2);
    
    

        MutableColumnPtr column_ptr = ColumnInt32::create();
        EXPECT_EQ(column_ptr->use_count(), 1);
        ColumnInt32::MutablePtr column_i32 = cast_to_column<ColumnInt32>(std::move(column_ptr));
        EXPECT_TRUE(column_i32);
        EXPECT_EQ(column_i32->use_count(), 1);
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

