### PR TITLE
[chore](memtable) remove memtable memory limiter useless logic

### DIFF
--- a/be/src/olap/memtable_memory_limiter.cpp
+++ b/be/src/olap/memtable_memory_limiter.cpp
@@ -196,10 +196,6 @@ void MemTableMemoryLimiter::handle_memtable_flush(std::function<bool()> cancel_c
 }
 
 int64_t MemTableMemoryLimiter::_flush_active_memtables(int64_t need_flush) {
-    if (need_flush <= 0) {
-        return 0;
-    }
-
     _refresh_mem_tracker();
     if (_active_writers.size() == 0) {
         return 0;


### PR DESCRIPTION
### What problem does this PR solve?

```
if (need_flush > 0) {
          ...
            _flush_active_memtables(need_flush);
        }
```

invalid logic:
```
int64_t MemTableMemoryLimiter::_flush_active_memtables(int64_t need_flush) {
    if (need_flush <= 0) {
        return 0;
    }

```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

