### PR TITLE
[fix](paimon-catalog)Fix OSS access when using DLS endpoint

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/LocationPath.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/LocationPath.java
@@ -312,6 +312,9 @@ public class LocationPath {
                 .equals(schema)) && AzurePropertyUtils.isOneLakeLocation(normalizedLocation)) {
             return TFileType.FILE_HDFS;
         }
+        if (StringUtils.isNotBlank(normalizedLocation) && isHdfsOnOssEndpoint(normalizedLocation)) {
+            return TFileType.FILE_HDFS;
+        }
         return SchemaTypeMapper.fromSchemaToFileType(schema);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
@@ -147,7 +147,6 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
      * - datalake.cn-hangzhou.aliyuncs.com          => region = cn-hangzhou
      */
     public static final Set<Pattern> ENDPOINT_PATTERN = ImmutableSet.of(STANDARD_ENDPOINT_PATTERN,
-            Pattern.compile("(?:https?://)?([a-z]{2}-[a-z0-9-]+)\\.oss-dls\\.aliyuncs\\.com"),
             Pattern.compile("^(?:https?://)?dlf(?:-vpc)?\\.([a-z0-9-]+)\\.aliyuncs\\.com(?:/.*)?$"),
             Pattern.compile("^(?:https?://)?datalake(?:-vpc)?\\.([a-z0-9-]+)\\.aliyuncs\\.com(?:/.*)?$"));
 
@@ -155,6 +154,8 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
 
     private static List<String> DLF_TYPE_KEYWORDS = Arrays.asList("hive.metastore.type",
             "iceberg.catalog.type", "paimon.catalog.type");
+
+    private static final String DLS_URI_KEYWORDS = "oss-dls.aliyuncs";
 
     protected OSSProperties(Map<String, String> origProps) {
         super(Type.OSS, origProps);
@@ -176,6 +177,9 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
                 .findFirst()
                 .orElse(null);
         if (StringUtils.isNotBlank(value)) {
+            if (value.contains(DLS_URI_KEYWORDS)) {
+                return false;
+            }
             return (value.contains("aliyuncs.com"));
         }
 
@@ -204,6 +208,10 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
         if (value == null) {
             return false;
         }
+        boolean isDls = value.contains(DLS_URI_KEYWORDS);
+        if (isDls) {
+            return false;
+        }
         if (value.startsWith("oss://")) {
             return true;
         }
@@ -212,8 +220,7 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
         }
         boolean isAliyunOss = (value.contains("oss-"));
         boolean isAmazonS3 = value.contains("s3.");
-        boolean isDls = value.contains("dls");
-        return isAliyunOss || isAmazonS3 || isDls;
+        return isAliyunOss || isAmazonS3;
     }
 
     private static boolean isDlfMSType(Map<String, String> params) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/StorageProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/StorageProperties.java
@@ -171,13 +171,22 @@ public abstract class StorageProperties extends ConnectionProperties {
             Arrays.asList(
                     props -> (isFsSupport(props, FS_HDFS_SUPPORT)
                             || HdfsProperties.guessIsMe(props)) ? new HdfsProperties(props) : null,
-                    props -> ((isFsSupport(props, FS_OSS_HDFS_SUPPORT)
-                            || isFsSupport(props, DEPRECATED_OSS_HDFS_SUPPORT))
-                            || OSSHdfsProperties.guessIsMe(props)) ? new OSSHdfsProperties(props) : null,
+                    props -> {
+                        // OSS-HDFS and OSS are mutually exclusive - check OSS-HDFS first
+                        if ((isFsSupport(props, FS_OSS_HDFS_SUPPORT)
+                                || isFsSupport(props, DEPRECATED_OSS_HDFS_SUPPORT))
+                                || OSSHdfsProperties.guessIsMe(props)) {
+                            return new OSSHdfsProperties(props);
+                        }
+                        // Only check for regular OSS if OSS-HDFS is not enabled
+                        if (isFsSupport(props, FS_OSS_SUPPORT)
+                                || OSSProperties.guessIsMe(props)) {
+                            return new OSSProperties(props);
+                        }
+                        return null;
+                    },
                     props -> (isFsSupport(props, FS_S3_SUPPORT)
                             || S3Properties.guessIsMe(props)) ? new S3Properties(props) : null,
-                    props -> (isFsSupport(props, FS_OSS_SUPPORT)
-                            || OSSProperties.guessIsMe(props)) ? new OSSProperties(props) : null,
                     props -> (isFsSupport(props, FS_OBS_SUPPORT)
                             || OBSProperties.guessIsMe(props)) ? new OBSProperties(props) : null,
                     props -> (isFsSupport(props, FS_COS_SUPPORT)

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSHdfsPropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSHdfsPropertiesTest.java
@@ -112,18 +112,9 @@ public class OSSHdfsPropertiesTest {
         origProps.put("oss.endpoint", "cn-north-2-gov-1.oss-dls.aliyuncs.com");
         props = (OSSHdfsProperties) StorageProperties.createPrimary(origProps);
         Assertions.assertEquals("cn-north-2-gov-1", props.getBackendConfigProperties().get("fs.oss.region"));
-        origProps.put("dlf.endpoint", "dlf-vpc.cn-beijing.aliyuncs.com");
-        props = (OSSHdfsProperties) StorageProperties.createPrimary(origProps);
-        Assertions.assertEquals("cn-beijing", props.getBackendConfigProperties().get("fs.oss.region"));
         origProps.remove("dlf.endpoint");
         props = (OSSHdfsProperties) StorageProperties.createPrimary(origProps);
         Assertions.assertEquals("cn-north-2-gov-1", props.getBackendConfigProperties().get("fs.oss.region"));
-        origProps.put("dlf.endpoint", "dlf-vpc.ap-southeast-5.aliyuncs.com");
-        props = (OSSHdfsProperties) StorageProperties.createPrimary(origProps);
-        Assertions.assertEquals("ap-southeast-5", props.getBackendConfigProperties().get("fs.oss.region"));
-        origProps.put("dlf.endpoint", "dlf.us-east-1.aliyuncs.com");
-        props = (OSSHdfsProperties) StorageProperties.createAll(origProps).get(0);
-        Assertions.assertEquals("us-east-1", props.getBackendConfigProperties().get("fs.oss.region"));
     }
 
     @Test
@@ -165,6 +156,64 @@ public class OSSHdfsPropertiesTest {
         origProps.remove("oss.hdfs.fs.defaultFS");
         props = (OSSHdfsProperties) StorageProperties.createPrimary(origProps);
         Assertions.assertEquals("oss://bucket", props.getBackendConfigProperties().get("fs.defaultFS"));
+    }
+
+    @Test
+    public void testOssAndOssHDFS() throws UserException {
+        Map<String, String> origProps = new HashMap<>();
+        origProps.put("oss.endpoint", "cn-shanghai.oss-dls.aliyuncs.com");
+        origProps.put("oss.access_key", "testAccessKey");
+        origProps.put("oss.secret_key", "testSecretKey");
+        origProps.put("oss.hdfs.fs.defaultFS", "oss://my-bucket");
+        origProps.put("dlf.endpoint", "cn-shanghai.oss-dlf.aliyuncs.com");
+        origProps.put("dlf.access_key", "testAccessKey");
+        origProps.put("dlf.secret_key", "testSecretKey");
+        StorageProperties props = StorageProperties.createPrimary(origProps);
+        Assertions.assertEquals("OSSHDFS", props.getStorageName());
+        Assertions.assertEquals("oss://my-bucket", props.getBackendConfigProperties().get("fs.defaultFS"));
+        Assertions.assertEquals("cn-shanghai", props.getBackendConfigProperties().get("fs.oss.region"));
+    }
+
+    @Test
+    public void testDlfAndOssHDFS() throws UserException {
+
+        Map<String, String> origProps = new HashMap<>();
+        origProps.put("dlf.endpoint", "dlf-vpc.cn-beijing.aliyuncs.com");
+        origProps.put("dlf.access_key", "testAccessKey");
+        origProps.put("dlf.secret_key", "testSecretKey");
+        origProps.put("oss.hdfs.enabled", "true");
+        StorageProperties props = StorageProperties.createPrimary(origProps);
+        Assertions.assertEquals("OSSHDFS", props.getStorageName());
+    }
+
+
+    @Test
+    public void testOssHDFSNewProps() throws UserException {
+        Map<String, String> origProps = new HashMap<>();
+        origProps.put("oss.hdfs.endpoint", "cn-shanghai.oss-dls.aliyuncs.com");
+        origProps.put("oss.hdfs.access_key", "testAccessKey");
+        origProps.put("oss.hdfs.secret_key", "testSecretKey");
+        StorageProperties props = StorageProperties.createPrimary(origProps);
+        Assertions.assertEquals("OSSHDFS", props.getStorageName());
+        Assertions.assertEquals("cn-shanghai", props.getBackendConfigProperties().get("fs.oss.region"));
+        Assertions.assertEquals("com.aliyun.jindodata.oss.JindoOssFileSystem",
+                props.getBackendConfigProperties().get("fs.oss.impl"));
+        origProps.put("oss.endpoint", "cn-shanghai.oss.aliyuncs.com");
+        origProps.put("oss.access_key", "testAccessKey");
+        origProps.put("oss.secret_key", "testSecretKey");
+        props = StorageProperties.createPrimary(origProps);
+        Assertions.assertEquals("OSSHDFS", props.getStorageName());
+        Assertions.assertEquals("cn-shanghai", props.getBackendConfigProperties().get("fs.oss.region"));
+        Assertions.assertEquals("com.aliyun.jindodata.oss.JindoOssFileSystem",
+                props.getBackendConfigProperties().get("fs.oss.impl"));
+        origProps.put("dlf.endpoint", "dlf-vpc.cn-beijing.aliyuncs.com");
+        origProps.put("dlf.access_key", "testAccessKey");
+        origProps.put("dlf.secret_key", "testSecretKey");
+        props = StorageProperties.createPrimary(origProps);
+        Assertions.assertEquals("OSSHDFS", props.getStorageName());
+        Assertions.assertEquals("cn-shanghai", props.getBackendConfigProperties().get("fs.oss.region"));
+        Assertions.assertEquals("com.aliyun.jindodata.oss.JindoOssFileSystem",
+                props.getBackendConfigProperties().get("fs.oss.impl"));
     }
 
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSPropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSPropertiesTest.java
@@ -120,7 +120,7 @@ public class OSSPropertiesTest {
         origProps.put("oss.endpoint", "http://s3.oss-cn-hongkong.aliyuncs.com");
         Assertions.assertEquals("cn-hongkong", ((OSSProperties) StorageProperties.createPrimary(origProps)).getRegion());
         origProps.put("oss.endpoint", "https://dlf.cn-beijing.aliyuncs.com");
-        Assertions.assertEquals("cn-beijing", ((OSSProperties) StorageProperties.createAll(origProps).get(1)).getRegion());
+        Assertions.assertEquals("cn-beijing", ((OSSProperties) StorageProperties.createAll(origProps).get(0)).getRegion());
         origProps.put("oss.endpoint", "datalake-vpc.cn-shenzhen.aliyuncs.com");
         Assertions.assertEquals("cn-shenzhen", ((OSSProperties) StorageProperties.createPrimary(origProps)).getRegion());
         origProps.put("oss.endpoint", "https://datalake-vpc.cn-shenzhen.aliyuncs.com");


### PR DESCRIPTION
### What This PR Does
- Adds explicit differentiation between **OSSHDFS** and **OSS** storage types.
- Ensures DLS endpoints automatically route through the OSSHDFS protocol.
- Avoids incorrectly treating DLS endpoints as standard OSS, which previously
  caused runtime errors.

### Why This Matters
This update ensures stable compatibility with DLS endpoints and prevents
unexpected failures for users whose OSS configuration points to DLS.