### PR TITLE
[enhancement](pushagg) using count by calculating row range not direct using segment rows

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -453,7 +453,7 @@ Status ColumnReader::next_batch_of_zone_map(size_t* n, vectorized::MutableColumn
             auto sv = (StringRef*)min_value->cell_ptr();
             dst->insert_data_repeatedly(sv->data, sv->size, size);
         } else {
-            // TODO: the work may cause performance problem, opt latter
+            // If TPushAggOp==MIX, then the first 2 rows is min and max, and the rest are min
             for (int i = 0; i < size; ++i) {
                 dst->insert_many_fix_len_data(static_cast<const char*>(min_value->cell_ptr()), 1);
             }

--- a/be/src/olap/rowset/segment_v2/row_ranges.h
+++ b/be/src/olap/rowset/segment_v2/row_ranges.h
@@ -232,13 +232,13 @@ public:
         return _ranges[_ranges.size() - 1].to();
     }
 
-    size_t range_size() { return _ranges.size(); }
+    size_t range_size() const { return _ranges.size(); }
 
     int64_t get_range_from(size_t range_index) { return _ranges[range_index].from(); }
 
     int64_t get_range_to(size_t range_index) { return _ranges[range_index].to(); }
 
-    size_t get_range_count(size_t range_index) { return _ranges[range_index].count(); }
+    size_t get_range_count(size_t range_index) const { return _ranges[range_index].count(); }
 
     std::string to_string() {
         std::string result;

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -309,8 +309,9 @@ Status Segment::new_iterator(SchemaSPtr schema, const StorageReadOptions& read_o
     }
 
     if (read_options.delete_condition_predicates->num_of_column_predicate() == 0 &&
-        read_options.push_down_agg_type_opt != TPushAggOp::NONE &&
-        read_options.push_down_agg_type_opt != TPushAggOp::COUNT_ON_INDEX) {
+        (read_options.push_down_agg_type_opt == TPushAggOp::MINMAX ||
+         read_options.push_down_agg_type_opt == TPushAggOp::COUNT ||
+         read_options.push_down_agg_type_opt == TPushAggOp::MIX)) {
         iter->reset(vectorized::new_vstatistics_iterator(this->shared_from_this(), *schema));
     } else {
         *iter = std::make_unique<SegmentIterator>(this->shared_from_this(), schema);

--- a/be/src/pipeline/exec/olap_scan_operator.cpp
+++ b/be/src/pipeline/exec/olap_scan_operator.cpp
@@ -469,6 +469,7 @@ Status OlapScanLocalState::_init_scanners(std::list<vectorized::ScannerSPtr>* sc
     // then the storage layer do not need do aggregation, it could just return the partial agg data, because the compute layer will do aggregation.
     // PreAgg OFF: The storage layer must complete pre-aggregation and return fully aggregated data. (Slow data reading)
     if (enable_parallel_scan && !p._should_run_serial && !has_cpu_limit &&
+        p._push_down_agg_type == TPushAggOp::NONE &&
         (_storage_no_merge() || p._olap_scan_node.is_preaggregation)) {
         std::vector<OlapScanRange*> key_ranges;
         for (auto& range : _cond_ranges) {

--- a/be/src/pipeline/exec/olap_scan_operator.cpp
+++ b/be/src/pipeline/exec/olap_scan_operator.cpp
@@ -469,7 +469,6 @@ Status OlapScanLocalState::_init_scanners(std::list<vectorized::ScannerSPtr>* sc
     // then the storage layer do not need do aggregation, it could just return the partial agg data, because the compute layer will do aggregation.
     // PreAgg OFF: The storage layer must complete pre-aggregation and return fully aggregated data. (Slow data reading)
     if (enable_parallel_scan && !p._should_run_serial && !has_cpu_limit &&
-        p._push_down_agg_type == TPushAggOp::NONE &&
         (_storage_no_merge() || p._olap_scan_node.is_preaggregation)) {
         std::vector<OlapScanRange*> key_ranges;
         for (auto& range : _cond_ranges) {

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -57,8 +57,8 @@ Status VStatisticsIterator::init(const StorageReadOptions& opts) {
             _column_iterators.push_back(_column_iterators_map[unique_id].get());
         }
         int64_t rows_in_read_options = _segment->num_rows();
-        if (opts.row_ranges.empty()) {
-            // Not in parallel read, so that all segment rows belong to one iterator
+        if (opts.row_ranges.range_size() == 0) {
+            // Not in parallel read, so that all rows in then segment belong to one iterator
             rows_in_read_options = _segment->num_rows();
         } else {
             // Even if in parallel read, the row range should equal to 1, because every scanner can


### PR DESCRIPTION
### What problem does this PR solve?

This is just an enhancement because olap scan operator will not using statistics_iterator when using parallel scanner.
This PR just to avoid result is wrong if we want to use parallel scanner even if pushagg != NONE

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

