### PR TITLE
[fix](load) Fix undefined behavior in the JSON reader caused by multiple calls to the get_string method

### DIFF
--- a/be/src/vec/exec/format/json/new_json_reader.cpp
+++ b/be/src/vec/exec/format/json/new_json_reader.cpp
@@ -910,6 +910,7 @@ Status NewJsonReader::_simdjson_set_column_value(simdjson::ondemand::object* val
     bool has_valid_value = false;
     // iterate through object, simdjson::ondemond will parsing on the fly
     size_t key_index = 0;
+
     for (auto field : *value) {
         std::string_view key = field.unescaped_key();
         StringRef name_ref(key.data(), key.size());
@@ -938,7 +939,7 @@ Status NewJsonReader::_simdjson_set_column_value(simdjson::ondemand::object* val
         }
         simdjson::ondemand::value val = field.value();
         auto* column_ptr = block.get_by_position(column_index).column->assume_mutable().get();
-        RETURN_IF_ERROR(_simdjson_write_data_to_column(
+        RETURN_IF_ERROR(_simdjson_write_data_to_column<false>(
                 val, slot_descs[column_index]->type(), column_ptr,
                 slot_descs[column_index]->col_name(), _serdes[column_index], valid));
         if (!(*valid)) {
@@ -1029,6 +1030,7 @@ Status NewJsonReader::_simdjson_set_column_value(simdjson::ondemand::object* val
     return Status::OK();
 }
 
+template <bool use_string_cache>
 Status NewJsonReader::_simdjson_write_data_to_column(simdjson::ondemand::value& value,
                                                      const DataTypePtr& type_desc,
                                                      vectorized::IColumn* column_ptr,
@@ -1065,7 +1067,20 @@ Status NewJsonReader::_simdjson_write_data_to_column(simdjson::ondemand::value& 
     auto primitive_type = type_desc->get_primitive_type();
     if (_is_load || !is_complex_type(primitive_type)) {
         if (value.type() == simdjson::ondemand::json_type::string) {
-            std::string_view value_string = value.get_string();
+            std::string_view value_string;
+            if constexpr (use_string_cache) {
+                const auto cache_key = value.raw_json().value();
+                if (_cached_string_values.contains(cache_key)) {
+                    value_string = _cached_string_values[cache_key];
+                } else {
+                    value_string = value.get_string();
+                    _cached_string_values.emplace(cache_key, value_string);
+                }
+            } else {
+                DCHECK(_cached_string_values.empty());
+                value_string = value.get_string();
+            }
+
             Slice slice {value_string.data(), value_string.size()};
             RETURN_IF_ERROR(data_serde->deserialize_one_cell_from_json(*data_column_ptr, slice,
                                                                        _serde_options));
@@ -1126,7 +1141,7 @@ Status NewJsonReader::_simdjson_write_data_to_column(simdjson::ondemand::value& 
             has_value[sub_column_idx] = true;
 
             const auto& sub_col_type = type_struct->get_element(sub_column_idx);
-            RETURN_IF_ERROR(_simdjson_write_data_to_column(
+            RETURN_IF_ERROR(_simdjson_write_data_to_column<use_string_cache>(
                     sub.value(), sub_col_type, sub_column_ptr.get(), column_name + "." + sub_key,
                     sub_serdes[sub_column_idx], valid));
         }
@@ -1185,7 +1200,7 @@ Status NewJsonReader::_simdjson_write_data_to_column(simdjson::ondemand::value& 
                               sub_serdes[0], _serde_options, valid));
 
             simdjson::ondemand::value field_value = member_value.value();
-            RETURN_IF_ERROR(_simdjson_write_data_to_column(
+            RETURN_IF_ERROR(_simdjson_write_data_to_column<use_string_cache>(
                     field_value,
                     assert_cast<const DataTypeMap*>(remove_nullable(type_desc).get())
                             ->get_value_type(),
@@ -1210,7 +1225,7 @@ Status NewJsonReader::_simdjson_write_data_to_column(simdjson::ondemand::value& 
 
         int field_count = 0;
         for (simdjson::ondemand::value sub_value : array_value) {
-            RETURN_IF_ERROR(_simdjson_write_data_to_column(
+            RETURN_IF_ERROR(_simdjson_write_data_to_column<use_string_cache>(
                     sub_value,
                     assert_cast<const DataTypeArray*>(remove_nullable(type_desc).get())
                             ->get_nested_type(),
@@ -1406,6 +1421,9 @@ Status NewJsonReader::_simdjson_write_columns_by_jsonpath(
         Block& block, bool* valid) {
     // write by jsonpath
     bool has_valid_value = false;
+
+    Defer clear_defer([this]() { _cached_string_values.clear(); });
+
     for (size_t i = 0; i < slot_descs.size(); i++) {
         auto* slot_desc = slot_descs[i];
         if (!slot_desc->is_materialized()) {
@@ -1440,9 +1458,9 @@ Status NewJsonReader::_simdjson_write_columns_by_jsonpath(
                 return Status::OK();
             }
         } else {
-            RETURN_IF_ERROR(_simdjson_write_data_to_column(json_value, slot_desc->type(),
-                                                           column_ptr, slot_desc->col_name(),
-                                                           _serdes[i], valid));
+            RETURN_IF_ERROR(_simdjson_write_data_to_column<true>(json_value, slot_desc->type(),
+                                                                 column_ptr, slot_desc->col_name(),
+                                                                 _serdes[i], valid));
             if (!(*valid)) {
                 return Status::OK();
             }

--- a/regression-test/data/load_p0/stream_load/load_json_with_jsonpath.out
+++ b/regression-test/data/load_p0/stream_load/load_json_with_jsonpath.out
@@ -9,3 +9,13 @@
 1000	7395.231067
 2000	\N
 
+-- !test_select2 --
+22	7291	7291	7291	\N	I am a long string here.	I am a long string here.	I am a long string here.	I am another long string here 4.	I am another long string here 4.	I am another long string here 4.	I am another long string here 4.	I am another long string here 4.	I am another long string here 4.	I am another long string here 4.	I am another long string here 4.	\N
+7291.703724	2000	2000	2000	\N	I am a long string here.	I am a long string here.	I am a long string here.	I am another long string here 3.	I am another long string here 3.	I am another long string here 3.	I am another long string here 3.	I am another long string here 3.	I am another long string here 3.	I am another long string here 3.	I am another long string here 3.	\N
+7395.231067	1000	1000	1000	\N	I am a long string here.	I am a long string here.	I am a long string here.	I am another long string here 2.	I am another long string here 2.	I am another long string here 2.	I am another long string here 2.	I am another long string here 2.	I am another long string here 2.	I am another long string here 2.	I am another long string here 2.	\N
+
+-- !test_select3 --
+22	7291	I am a long string here.	I am another long string here 4.
+7291.703724	2000	I am a long string here.	I am another long string here 3.
+7395.231067	1000	I am a long string here.	I am another long string here 2.
+

--- a/regression-test/data/load_p0/stream_load/test_load_with_jsonpath2.json
+++ b/regression-test/data/load_p0/stream_load/test_load_with_jsonpath2.json
@@ -1,0 +1,20 @@
+[
+    {
+        "k1": "7395.231067",
+        "k2": "1000",
+        "k3": "I am a long string here.",
+        "k4": "I am another long string here 2."
+    },
+    {
+        "k1": "7291.703724",
+        "k2": "2000",
+        "k3": "I am a long string here.",
+        "k4": "I am another long string here 3."
+    },
+    {
+        "k1": "22",
+        "k2": "7291",
+        "k3": "I am a long string here.",
+        "k4": "I am another long string here 4."
+    }
+]


### PR DESCRIPTION
### What problem does this PR solve?

<img width="2118" height="1222" alt="image" src="https://github.com/user-attachments/assets/aeefb709-f59d-406e-824f-0c9b250bb5af" />

```text
doris_be: /root/doris/thirdparty/installed/include/simdjson/generic/ondemand/json_iterator-inl.h:359: simdjson_result<std::string_view> simdjson::fallback::ondemand::json_iterator::unescape(raw_json_string, bool): Assertion `!parser->string_buffer_overflow(_string_buf_loc)' failed.
*** Query id: 24468c5d0b372cf0-3e6c777580238e96 ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1763545679 (unix time) try "date -d @1763545679" if you are using GNU date ***
*** Current BE git commitID: cbc3d21884 ***
*** SIGABRT unknown detail explain (@0x3f8001618b8) received by PID 1448120 (TID 1450358 OR 0x7b0fb9f4e700) from PID 1448120; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:420
 1# 0x00007F183C476D10 in /lib64/libpthread.so.0
 2# __GI_raise in /lib64/libc.so.6
 3# __GI_abort in /lib64/libc.so.6
 4# _nl_load_domain.cold.0 in /lib64/libc.so.6
 5# 0x00007F183BCC8E86 in /lib64/libc.so.6
 6# simdjson::fallback::ondemand::json_iterator::unescape(simdjson::fallback::ondemand::raw_json_string, bool) at /root/doris/thirdparty/installed/include/simdjson/generic/ondemand/json_iterator-inl.h:359
 7# simdjson::fallback::ondemand::raw_json_string::unescape(simdjson::fallback::ondemand::json_iterator&, bool) const at /root/doris/thirdparty/installed/include/simdjson/generic/ondemand/raw_json_string-inl.h:160
 8# simdjson::simdjson_result<simdjson::fallback::ondemand::raw_json_string>::unescape(simdjson::fallback::ondemand::json_iterator&, bool) const in /root/doris/be/output/lib/doris_be
 9# simdjson::fallback::ondemand::value_iterator::get_string(bool) at /root/doris/thirdparty/installed/include/simdjson/generic/ondemand/value_iterator-inl.h:514
10# simdjson::fallback::ondemand::value::get_string(bool) at /root/doris/thirdparty/installed/include/simdjson/generic/ondemand/value-inl.h:48
11# doris::Status doris::vectorized::NewJsonReader::_simdjson_write_data_to_column<false>(simdjson::fallback::ondemand::value&, std::shared_ptr<doris::vectorized::IDataType const> const&, doris::vectorized::IColumn*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::shared_ptr<doris::vectorized::DataTypeSerDe>, bool*) at /root/doris/be/src/vec/exec/format/json/new_json_reader.cpp:1080
12# doris::vectorized::NewJsonReader::_simdjson_write_columns_by_jsonpath(simdjson::fallback::ondemand::object*, std::vector<doris::SlotDescriptor*, std::allocator<doris::SlotDescriptor*> > const&, doris::vectorized::Block&, bool*) at /root/doris/be/src/vec/exec/format/json/new_json_reader.cpp:1460
13# doris::vectorized::NewJsonReader::_simdjson_handle_flat_array_complex_json_write_columns(doris::vectorized::Block&, std::vector<doris::SlotDescriptor*, std::allocator<doris::SlotDescriptor*> > const&, bool*, bool*) at /root/doris/be/src/vec/exec/format/json/new_json_reader.cpp:806
14# doris::vectorized::NewJsonReader::_simdjson_handle_flat_array_complex_json(doris::RuntimeState*, doris::vectorized::Block&, std::vector<doris::SlotDescriptor*, std::allocator<doris::SlotDescriptor*> > const&, bool*, bool*) at /root/doris/be/src/vec/exec/format/json/new_json_reader.cpp:753
15# doris::vectorized::NewJsonReader::_read_json_column(doris::RuntimeState*, doris::vectorized::Block&, std::vector<doris::SlotDescriptor*, std::allocator<doris::SlotDescriptor*> > const&, bool*, bool*) at /root/doris/be/src/vec/exec/format/json/new_json_reader.cpp:485
16# doris::vectorized::NewJsonReader::get_next_block(doris::vectorized::Block*, unsigned long*, bool*) at /root/doris/be/src/vec/exec/format/json/new_json_reader.cpp:209
17# doris::vectorized::FileScanner::_get_block_wrapped(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /root/doris/be/src/vec/exec/scan/file_scanner.cpp:480
18# doris::vectorized::FileScanner::_get_block_impl(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /root/doris/be/src/vec/exec/scan/file_scanner.cpp:417
19# doris::vectorized::Scanner::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /root/doris/be/src/vec/exec/scan/scanner.cpp:113
20# doris::vectorized::Scanner::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /root/doris/be/src/vec/exec/scan/scanner.cpp:85
21# doris::vectorized::ScannerScheduler::_scanner_scan(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>) at /root/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:182
22# doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}::operator()() const::{lambda()#1}::operator()() const at /root/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:96
23# doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}::operator()() const at /root/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:95
```

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

