### PR TITLE
branch-3.1: [fix](schema_change) fix incorrect unique id in rollup after schema change #57073

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -760,6 +760,7 @@ public class SchemaChangeHandler extends AlterHandler {
                     modColIndex = i;
                     otherCol = new Column(modColumn);
                     otherCol.setName(col.getName());
+                    otherCol.setUniqueId(col.getUniqueId());
                     otherCol.setDefineExpr(col.getDefineExpr());
                     Preconditions.checkState(modColIndex != -1);
                     Preconditions.checkState(otherCol != null);

--- a/regression-test/suites/schema_change_p0/test_alter_rollup_table.groovy
+++ b/regression-test/suites/schema_change_p0/test_alter_rollup_table.groovy
@@ -64,6 +64,7 @@ suite("test_alter_rollup_table") {
         DUPLICATE KEY(`user_id`, `event_time`, `event_date`)
         DISTRIBUTED BY HASH(`user_id`) BUCKETS 3
         PROPERTIES (
+        "replication_num" = "1",
         "file_cache_ttl_seconds" = "0",
         "bloom_filter_columns" = "country, city",
         "is_being_synced" = "false",
@@ -131,6 +132,12 @@ suite("test_alter_rollup_table") {
         values
         (1003, '2025-09-19', '2025-09-19 10:00:00', 'japan', 'tokyo', 30, 1, 1000.50, 88.8, '192.168.0.1', '{"device":"iphone"}', 1),
         (1004, '2025-09-19', '2025-09-19 11:30:00', 'usa', null, null, 0, 500.00, null, '10.0.0.2', '{"device":"android"}', 2);
+    """
+
+    sleep(10000)
+
+    sql """
+        select event_date, user_id from ${tbName}
     """
 }
 


### PR DESCRIPTION
pick master #57073 
   
When performing a schema change on rollup columns, the rollup reused the base table’s column unique id, causing inconsistent unique id in the rollup table.

