### PR TITLE
[Fix](exec) some error in condition cache because cache digest error

### DIFF
--- a/be/src/vec/exprs/vbloom_predicate.cpp
+++ b/be/src/vec/exprs/vbloom_predicate.cpp
@@ -102,10 +102,14 @@ void VBloomPredicate::set_filter(std::shared_ptr<BloomFilterFuncBase> filter) {
 }
 
 uint64_t VBloomPredicate::get_digest(uint64_t seed) const {
-    char* data;
-    int len;
-    _filter->get_data(&data, &len);
-    return HashUtil::hash64(data, len, seed);
+    seed = _children[0]->get_digest(seed);
+    if (seed) {
+        char* data;
+        int len;
+        _filter->get_data(&data, &len);
+        return HashUtil::hash64(data, len, seed);
+    }
+    return 0;
 }
 
 #include "common/compile_check_end.h"

--- a/be/src/vec/exprs/vruntimefilter_wrapper.h
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.h
@@ -62,7 +62,13 @@ public:
     const std::string& expr_name() const override;
     const VExprSPtrs& children() const override { return _impl->children(); }
 
-    uint64_t get_digest(uint64_t seed) const override { return _impl->get_digest(seed); }
+    uint64_t get_digest(uint64_t seed) const override {
+        seed = _impl->get_digest(seed);
+        if (seed) {
+            return HashUtil::crc_hash64(&_null_aware, sizeof(_null_aware), seed);
+        }
+        return seed;
+    }
 
     VExprSPtr get_impl() const override { return _impl; }
 

--- a/regression-test/data/query_p0/cache/condition_cache.out
+++ b/regression-test/data/query_p0/cache/condition_cache.out
@@ -46,6 +46,13 @@
 4	David	28	Engineering	Senior Developer
 5	Eve	26	Finance	Analyst
 
+-- !join_bf_cache1 --
+
+-- !join_bf_cache2 --
+1	Alice	25	Marketing	Manager
+3	Charlie	22	Engineering	Senior Developer
+4	David	28	Finance	Analyst
+
 -- !join_cache3 --
 4	David	28	Engineering	Senior Developer
 5	Eve	26	Finance	Analyst
@@ -105,6 +112,13 @@
 -- !join_cache2 --
 4	David	28	Engineering	Senior Developer
 5	Eve	26	Finance	Analyst
+
+-- !join_bf_cache1 --
+
+-- !join_bf_cache2 --
+1	Alice	25	Marketing	Manager
+3	Charlie	22	Engineering	Senior Developer
+4	David	28	Finance	Analyst
 
 -- !join_cache3 --
 4	David	28	Engineering	Senior Developer

--- a/regression-test/suites/query_p0/cache/condition_cache.groovy
+++ b/regression-test/suites/query_p0/cache/condition_cache.groovy
@@ -237,6 +237,29 @@ suite("condition_cache") {
         JOIN ${joinTableName} t2 ON t1.id = t2.id
         WHERE t1.age > 25 AND t2.salary > 90000
     """
+    
+       // Run the same join query with condition cache enabled and expr in bloom filter 
+        order_qt_join_bf_cache1 """
+        SELECT
+            t1.id,
+            t1.name,
+            t1.age,
+            t2.department,
+            t2.position
+        FROM ${tableName} t1
+        JOIN ${joinTableName} t2 ON t1.id + 10 = t2.id
+    """
+   // Run the same join query with condition cache enabled and expr different in bloom filter
+        order_qt_join_bf_cache2 """
+        SELECT
+            t1.id,
+            t1.name,
+            t1.age,
+            t2.department,
+            t2.position
+        FROM ${tableName} t1
+        JOIN ${joinTableName} t2 ON t1.id + 1 = t2.id
+    """
 
     sql "set runtime_filter_type=12"
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
Condition cache malfunctions occurred due to flawed cache digest calculation in two core components, leading to inconsistent hash values, incorrect cache hits/misses, or query execution errors:
In **VBloomPredicate::get_digest()** (file: be/src/vec/exprs/vbloom_predicate.cpp), the digest was computed directly using bloom filter data without incorporating the child expression’s digest, omitting critical context for hash consistency.
In **VRuntimeFilterWrapper::get_digest()** (file: be/src/vec/exprs/vruntimefilter_wrapper.h), the _null_aware flag (a key attribute controlling filter behavior) was excluded from digest calculation, resulting in invalid cache key generation.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

