### PR TITLE
[feat](snapshot) fix AdminCreateClusterSnapshotCommand

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminCreateClusterSnapshotCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminCreateClusterSnapshotCommand.java
@@ -87,14 +87,23 @@ public class AdminCreateClusterSnapshotCommand extends Command implements Forwar
                             "Invalid value: " + entry.getValue() + " of property: " + entry.getKey());
                 }
                 if (ttl <= 0) {
-                    throw new AnalysisException(
-                            "Invalid value: " + entry.getValue() + " of property: " + entry.getKey());
+                    throw new AnalysisException("Property 'ttl' must be positive: " + entry.getValue());
                 }
             } else if (entry.getKey().equalsIgnoreCase(PROP_LABEL)) {
                 label = entry.getValue();
+                if (label == null || label.isEmpty()) {
+                    throw new AnalysisException("Property 'label' cannot be empty");
+                }
             } else {
                 throw new AnalysisException("Unknown property: " + entry.getKey());
             }
+        }
+
+        if (ttl <= 0) {
+            throw new AnalysisException("Property 'ttl' is required");
+        }
+        if (label == null || label.isEmpty()) {
+            throw new AnalysisException("Property 'label' is required");
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
before, manual snapshot allow user does not set ttl and label like `ADMIN CREATE CLUSTER SNAPSHOT`.
this pr requires that user must set ttl and label.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

