### PR TITLE
[fix](cloud) Fix cloud drop tablet tasks pile up

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -124,10 +124,6 @@ bool register_task_info(const TTaskType::type task_type, int64_t signature) {
         // no need to report task of these types
         return true;
     }
-    if (task_type == TTaskType::type::DROP && config::is_cloud_mode()) {
-        // cloud no need to report drop task status
-        return true;
-    }
 
     if (signature == -1) { // No need to report task with unintialized signature
         return true;
@@ -1872,6 +1868,8 @@ void drop_tablet_callback(StorageEngine& engine, const TAgentTaskRequest& req) {
 
 void drop_tablet_callback(CloudStorageEngine& engine, const TAgentTaskRequest& req) {
     const auto& drop_tablet_req = req.drop_tablet_req;
+    // here drop_tablet_req.tablet_id is the signature of the task, see DropReplicaTask in fe
+    Defer defer = [&] { remove_task_info(req.task_type, req.signature); };
     DBUG_EXECUTE_IF("WorkPoolCloudDropTablet.drop_tablet_callback.failed", {
         LOG_WARNING("WorkPoolCloudDropTablet.drop_tablet_callback.failed")
                 .tag("tablet_id", drop_tablet_req.tablet_id);


### PR DESCRIPTION
### What problem does this PR solve?

Previously, since clean tablet task was a lightweight operation on the BE, it was assumed that dropping tablets would not cause task backlog. However, online observations showed that tasks were still backlogged, causing the BE to consume a lot of memory. Therefore, tablet deduplication logic was added to prevent task backlog.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

