### PR TITLE
[fix](cloud) Fixed uneven tablet performance during upgrades from older versions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletRebalancer.java
@@ -651,7 +651,9 @@ public class CloudTabletRebalancer extends MasterDaemon {
                     // primary backend is alive or dead not long
                     Backend be = replica.getPrimaryBackend(cluster, false);
                     if (be != null && (be.isQueryAvailable()
-                            || (!be.isQueryDisabled() && be.getLastUpdateMs() > needRehashDeadTime))) {
+                            || (!be.isQueryDisabled()
+                            // Compatible with older version upgrades, see https://github.com/apache/doris/pull/42986
+                            && (be.getLastUpdateMs() <= 0 || be.getLastUpdateMs() > needRehashDeadTime)))) {
                         beIds.add(be.getId());
                         tabletIds.add(tablet.getId());
                         continue;


### PR DESCRIPTION
…er versions.

### What problem does this PR solve?
Prior to this https://github.com/apache/doris/pull/42986 PR, the `getLastUpdateMs` field of the backend was not written to the fe image. This caused the tablet mapping on the cloud to lose the PrimaryBackend information after the upgrade, resulting in the regeneration of an incorrect PrimaryBackend and uneven tablet distribution.

detail:
<img width="930" height="859" alt="image" src="https://github.com/user-attachments/assets/23d62adc-0bbb-49cb-b5b0-d1768f6422c7" />


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

