### PR TITLE
[feat](schema change) enforce key keyword when add key column on AGG table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -970,7 +970,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 if (!newColumn.isKey()) {
                     throw new DdlException(
                             String.format("Please specify `key` as keyword for adding key column on AGG_KEYS table: %s",
-                            newColumn.getName()));
+                                    newColName));
                 }
             } else if (newColumn.getAggregationType() == AggregateType.SUM && newColumn.getDefaultValue() != null
                     && !newColumn.getDefaultValue().equals("0")) {

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -968,8 +968,9 @@ public class SchemaChangeHandler extends AlterHandler {
                 throw new DdlException("Can not assign aggregation method on key column: " + newColName);
             } else if (null == newColumn.getAggregationType()) {
                 if (!newColumn.isKey()) {
-                    throw new DdlException("Please specify `key` as keyword for adding key column on AGG_KEYS table" 
-                        + ", invalid col=" + newColName);
+                    throw new DdlException(
+                            String.format("Please specify `key` as keyword for adding key column on AGG_KEYS table: %s",
+                            newColumn.getName()));
                 }
             } else if (newColumn.getAggregationType() == AggregateType.SUM && newColumn.getDefaultValue() != null
                     && !newColumn.getDefaultValue().equals("0")) {

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -967,7 +967,10 @@ public class SchemaChangeHandler extends AlterHandler {
             if (newColumn.isKey() && newColumn.getAggregationType() != null) {
                 throw new DdlException("Can not assign aggregation method on key column: " + newColName);
             } else if (null == newColumn.getAggregationType()) {
-                newColumn.setIsKey(true);
+                if (!newColumn.isKey()) {
+                    throw new DdlException("Please specify `key` as keyword for adding key column on AGG_KEYS table" 
+                        + ", invalid col=" + newColName);
+                }
             } else if (newColumn.getAggregationType() == AggregateType.SUM && newColumn.getDefaultValue() != null
                     && !newColumn.getDefaultValue().equals("0")) {
                 throw new DdlException(

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AddColumnClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AddColumnClause.java
@@ -90,10 +90,6 @@ public class AddColumnClause extends AlterTableClause {
                     .getCatalogOrDdlException(tableNameInfo.getCtl())
                     .getDbOrDdlException(tableNameInfo.getDb())
                     .getTableOrDdlException(tableNameInfo.getTbl());
-            if (table instanceof OlapTable && ((OlapTable) table).getKeysType() == KeysType.AGG_KEYS
-                    && columnDef.getAggregateType() == null) {
-                columnDef.setIsKey(true);
-            }
             if (table instanceof OlapTable) {
                 columnDef.setKeysType(((OlapTable) table).getKeysType());
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AddColumnClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AddColumnClause.java
@@ -20,7 +20,6 @@ package org.apache.doris.analysis;
 import org.apache.doris.alter.AlterOpType;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
-import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.AnalysisException;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/AddColumnOp.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/AddColumnOp.java
@@ -29,6 +29,7 @@ import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.UserException;
@@ -161,7 +162,11 @@ public class AddColumnOp extends AlterTableOp {
             }
             if (keysType == KeysType.AGG_KEYS) {
                 if (aggregateType == null) {
-                    columnDef.setIsKey(true);
+                    if (!columnDef.isKey()) {
+                        throw new AnalysisException(
+                                String.format("Please specify `key` as keyword for adding key column"
+                                        + " on AGG_KEYS table: %s", columnDef.getName()));
+                    }
                 } else {
                     if (aggregateType == AggregateType.NONE) {
                         throw new AnalysisException(

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/AddColumnOp.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/AddColumnOp.java
@@ -29,7 +29,6 @@ import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.UserException;

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
@@ -355,8 +355,14 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
             tbl.readUnlock();
         }
 
+
+        // test negative agg add key column schema change without keyword
+        String negativeAddKeyColStmtStr = "alter table test.sc_agg add column new_k1 int default '1'";
+        expectException(negativeAddKeyColStmtStr,
+                "errCode = 2, detailMessage = Please specify `key` as keyword for adding key column on AGG_KEYS table: new_k1");
+
         // process agg add key column schema change
-        String addKeyColStmtStr = "alter table test.sc_agg add column new_k1 int default '1'";
+        String addKeyColStmtStr = "alter table test.sc_agg add column new_k1 int key default '1'";
         alterTable(addKeyColStmtStr, connectContext);
 
         // check alter job

--- a/regression-test/suites/backup_restore/test_backup_restore_atomic_with_alter.groovy
+++ b/regression-test/suites/backup_restore/test_backup_restore_atomic_with_alter.groovy
@@ -179,7 +179,7 @@ suite("test_backup_restore_atomic_with_alter", "backup_restore,nonConcurrent") {
     expectExceptionLike({
         sql """
             ALTER TABLE ${dbName}.${tableNamePrefix}_1
-            ADD COLUMN new_col INT DEFAULT "0" AFTER id
+            ADD COLUMN new_col INT key DEFAULT "0" AFTER id
         """
     }, "Do not allow doing ALTER ops")
     expectExceptionLike({

--- a/regression-test/suites/doc/table-design/schema-change.md.groovy
+++ b/regression-test/suites/doc/table-design/schema-change.md.groovy
@@ -77,7 +77,7 @@ suite("docs/table-design/schema-change.md") {
             DISTRIBUTED BY HASH(col1) BUCKETS 10
         """
         sql """
-            ALTER TABLE example_db.my_table ADD COLUMN (c1 INT DEFAULT "1", c2 FLOAT SUM DEFAULT "0");
+            ALTER TABLE example_db.my_table ADD COLUMN (c1 INT key DEFAULT "1", c2 FLOAT SUM DEFAULT "0");
         """
         waitUntilSchemaChangeDone("my_table")
 
@@ -161,9 +161,9 @@ suite("docs/table-design/schema-change.md") {
         """
         sql """
             ALTER TABLE tbl1
-            ADD COLUMN k4 INT default "1" to rollup1,
-            ADD COLUMN k4 INT default "1" to rollup2,
-            ADD COLUMN k5 INT default "1" to rollup2
+            ADD COLUMN k4 INT key default "1" to rollup1,
+            ADD COLUMN k4 INT key default "1" to rollup2,
+            ADD COLUMN k5 INT key default "1" to rollup2
         """
         waitUntilSchemaChangeDone("tbl1")
 

--- a/regression-test/suites/doc/table-design/schema-change.md.groovy
+++ b/regression-test/suites/doc/table-design/schema-change.md.groovy
@@ -57,7 +57,7 @@ suite("docs/table-design/schema-change.md") {
             DISTRIBUTED BY HASH(col1) BUCKETS 10
         """
         sql """
-            ALTER TABLE example_db.my_table ADD COLUMN key_col INT DEFAULT "0" AFTER col1;
+            ALTER TABLE example_db.my_table ADD COLUMN key_col INT key DEFAULT "0" AFTER col1;
         """
         waitUntilSchemaChangeDone("my_table")
         sql """

--- a/regression-test/suites/partition_p0/multi_partition/test_multi_column_partition.groovy
+++ b/regression-test/suites/partition_p0/multi_partition/test_multi_column_partition.groovy
@@ -301,7 +301,7 @@ suite("test_multi_partition_key", "p0") {
             """,
             false
     )
-    sql "ALTER TABLE test_multi_col_test_partition_key_add_col ADD COLUMN add_key int NOT NULL DEFAULT '0' AFTER k1"
+    sql "ALTER TABLE test_multi_col_test_partition_key_add_col ADD COLUMN add_key int key NOT NULL DEFAULT '0' AFTER k1"
     assertEquals("FINISHED", getAlterColumnFinalState("test_multi_col_test_partition_key_add_col"))
     sql "insert into test_multi_col_test_partition_key_add_col " +
             "values(0, 100, 0, 0, 0, 0, '2000-01-01 00:00:00', '2000-01-01', 'a', 'a', 0.001, -0.001, 0.001)"

--- a/regression-test/suites/schema_change_p0/datev2/test_agg_keys_schema_change_datev2.groovy
+++ b/regression-test/suites/schema_change_p0/datev2/test_agg_keys_schema_change_datev2.groovy
@@ -67,7 +67,7 @@ suite("test_agg_keys_schema_change_datev2") {
     sql """ insert into ${tbName} (`datek2`, `datev1`, `datev2`) values('2022-01-06 11:11:11', '2022-01-06', '2022-01-06 11:11:11');"""
     qt_sql """select * from ${tbName} ORDER BY `datek1`;"""
 
-    sql """ alter table ${tbName} add column `datev3` datev2 DEFAULT '2022-01-01' """
+    sql """ alter table ${tbName} add column `datev3` datev2 key DEFAULT '2022-01-01' """
     int max_try_secs = 300
     Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         String result = getJobState(tbName)
@@ -108,7 +108,7 @@ suite("test_agg_keys_schema_change_datev2") {
     sql """ insert into ${tbName} (`datek2`, `datev1`, `datev2`) values('2022-01-06 11:11:11', '2022-01-06', '2022-01-06 11:11:11');"""
     sql """sync"""
     qt_sql """select * from ${tbName} ORDER BY `datek1`;"""
-    sql """ alter  table ${tbName} add column `datev3` datetimev2 DEFAULT '2022-01-01 11:11:11' """
+    sql """ alter  table ${tbName} add column `datev3` datetimev2 key DEFAULT '2022-01-01 11:11:11' """
     Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         String result = getJobState(tbName)
         if (result == "FINISHED") {
@@ -147,7 +147,7 @@ suite("test_agg_keys_schema_change_datev2") {
     sql """ insert into ${tbName} (`datek2`, `datev1`, `datev2`) values('2022-01-06 11:11:11', '2022-01-06', '2022-01-06 11:11:11');"""
     sql """sync"""
     qt_sql """select * from ${tbName} ORDER BY `datek1`;"""
-    sql """ alter  table ${tbName} add column `datev3` datetimev2(3) DEFAULT '2022-01-01 11:11:11.111' """
+    sql """ alter  table ${tbName} add column `datev3` datetimev2(3) key DEFAULT '2022-01-01 11:11:11.111' """
 
     Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         String result = getJobState(tbName)

--- a/regression-test/suites/schema_change_p0/decimalv2/test_agg_keys_schema_change_decimalv2.groovy
+++ b/regression-test/suites/schema_change_p0/decimalv2/test_agg_keys_schema_change_decimalv2.groovy
@@ -72,7 +72,7 @@ suite("test_agg_keys_schema_change_decimalv2", "nonConcurrent") {
     """
     qt_sql1 """select * from ${tbName} ORDER BY 1,2,3,4;"""
 
-    sql """ alter table ${tbName} add column `decimalv2v3` decimalv2(27,9) """
+    sql """ alter table ${tbName} add column `decimalv2v3` decimalv2(27,9) key """
     int max_try_secs = 300
     Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(500, TimeUnit.MILLISECONDS).await().until(() -> {
         String result = getJobState(tbName)

--- a/regression-test/suites/schema_change_p0/decimalv3/test_agg_keys_schema_change_decimalv3.groovy
+++ b/regression-test/suites/schema_change_p0/decimalv3/test_agg_keys_schema_change_decimalv3.groovy
@@ -56,7 +56,7 @@ suite("test_agg_keys_schema_change_decimalv3") {
     sql """ insert into ${tbName} values(0.111111111111111111111111111111111,11111111111111111111111111111.11,0.111111111111111111111111111111111,11111111111111111111111111111.11);"""
     qt_sql """select * from ${tbName} ORDER BY `decimalv3k1`;"""
 
-    sql """ alter table ${tbName} add column `decimalv3v3` DECIMALV3(38,4) """
+    sql """ alter table ${tbName} add column `decimalv3v3` DECIMALV3(38,4) key """
     int max_try_secs = 300
     Awaitility.await().atMost(max_try_secs, TimeUnit.SECONDS).with().pollDelay(100, TimeUnit.MILLISECONDS).await().until(() -> {
         String result = getJobState(tbName)

--- a/regression-test/suites/schema_change_p0/test_agg_keys_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_agg_keys_schema_change.groovy
@@ -74,7 +74,7 @@ suite ("test_agg_keys_schema_change") {
 
         // add key column case 1, not light schema change
         sql """
-            ALTER table ${tableName} ADD COLUMN new_key_column INT default "2"
+            ALTER table ${tableName} ADD COLUMN new_key_column INT key default "2"
             """
 
         int max_try_time = 3000
@@ -108,12 +108,12 @@ suite ("test_agg_keys_schema_change") {
 
         // test add double or float key column
         test {
-            sql "ALTER table ${tableName} ADD COLUMN new_key_column_double DOUBLE"
+            sql "ALTER table ${tableName} ADD COLUMN new_key_column_double DOUBLE key"
             exception "Float or double can not used as a key, use decimal instead."
         }
 
         test {
-            sql "ALTER table ${tableName} ADD COLUMN new_key_column_float FLOAT"
+            sql "ALTER table ${tableName} ADD COLUMN new_key_column_float FLOAT key"
             exception "Float or double can not used as a key, use decimal instead."
         }
 

--- a/regression-test/suites/schema_change_p0/test_agg_schema_key_add.groovy
+++ b/regression-test/suites/schema_change_p0/test_agg_schema_key_add.groovy
@@ -493,7 +493,7 @@ suite("test_agg_schema_key_add", "p0") {
     expectException({
         sql initTable
         sql initTableData
-        sql """ alter  table ${tbName1} add  column   j    JSON   DEFAULT '{\"a\": 300}' AFTER username """
+        sql """ alter  table ${tbName1} add  column   j    JSON key  DEFAULT '{\"a\": 300}' AFTER username """
         insertSql = " insert into ${tbName1} values(923456689, 'Alice', '{\"k1\":\"v31\", \"k2\": 300}', 'Yaan',  25, 0, 13812345678, 'No. 123 Street, Beijing', '2022-01-01 10:00:00'); "
         waitForSchemaChangeDone({
             sql getTableStatusSql

--- a/regression-test/suites/schema_change_p0/test_agg_schema_value_add.groovy
+++ b/regression-test/suites/schema_change_p0/test_agg_schema_value_add.groovy
@@ -266,7 +266,7 @@ suite("test_agg_schema_value_add", "p0") {
     //Test the AGGREGATE model by adding a value column with BIGINT
     sql initTable
     sql initTableData
-    sql """ alter  table ${tbName1} add  column house_price1 BIGINT  DEFAULT "99999991" AFTER username """
+    sql """ alter  table ${tbName1} add  column house_price1 BIGINT key DEFAULT "99999991" AFTER username """
     insertSql = " insert into ${tbName1} values(923456689, 'Alice', 88889494646, 'Yaan',  25, 0, 13812345678, 'No. 123 Street, Beijing', '2022-01-01 10:00:00'); "
     waitForSchemaChangeDone({
         sql getTableStatusSql
@@ -354,7 +354,7 @@ suite("test_agg_schema_value_add", "p0") {
     expectException({
         sql initTable
         sql initTableData
-        sql """ alter  table ${tbName1} add  column phone FLOAT  DEFAULT "166.68" AFTER username """
+        sql """ alter  table ${tbName1} add  column phone FLOAT key DEFAULT "166.68" AFTER username """
         insertSql = " insert into ${tbName1} values(923456689, 'Alice', 189.98, 'Yaan',  25, 0, 13812345678, 'No. 123 Street, Beijing', '2022-01-01 10:00:00');"
         waitForSchemaChangeDone({
             sql getTableStatusSql
@@ -368,7 +368,7 @@ suite("test_agg_schema_value_add", "p0") {
     expectException({
         sql initTable
         sql initTableData
-        sql """ alter  table ${tbName1} add  column watch DOUBLE  DEFAULT "166.689" AFTER username """
+        sql """ alter  table ${tbName1} add  column watch DOUBLE key DEFAULT "166.689" AFTER username """
         insertSql = " insert into ${tbName1} values(923456689, 'Alice', 189.479, 'Yaan',  25, 0, 13812345678, 'No. 123 Street, Beijing', '2022-01-01 10:00:00'); "
         waitForSchemaChangeDone({
             sql getTableStatusSql
@@ -380,7 +380,7 @@ suite("test_agg_schema_value_add", "p0") {
     //Test the AGGREGATE model by adding a value column with DECIMAL
     sql initTable
     sql initTableData
-    sql """ alter  table ${tbName1} add  column watch DECIMAL(38,10)  DEFAULT "16899.6464689" AFTER username """
+    sql """ alter  table ${tbName1} add  column watch DECIMAL(38,10) key DEFAULT "16899.6464689" AFTER username """
     insertSql = " insert into ${tbName1} values(923456689, 'Alice', 16499.6464689, 'Yaan',  25, 0, 13812345678, 'No. 123 Street, Beijing', '2022-01-01 10:00:00');"
     waitForSchemaChangeDone({
         sql getTableStatusSql
@@ -557,7 +557,7 @@ suite("test_agg_schema_value_add", "p0") {
     expectException({
         sql initTable
         sql initTableData
-        sql """ alter  table ${tbName1} add  column comment STRING  DEFAULT "我是小说家" AFTER username """
+        sql """ alter  table ${tbName1} add  column comment STRING key DEFAULT "我是小说家" AFTER username """
         insertSql = " insert into ${tbName1} values(923456689, 'Alice', '我是侦探家', 'Yaan',  25, 0, 13812345678, 'No. 123 Street, Beijing', '2022-01-01 10:00:00');  "
         waitForSchemaChangeDone({
             sql getTableStatusSql
@@ -615,7 +615,7 @@ suite("test_agg_schema_value_add", "p0") {
     expectException({
         sql initTable
         sql initTableData
-        sql """ alter  table ${tbName1} add  column   j  JSON   AFTER username """
+        sql """ alter  table ${tbName1} add  column   j  JSON key  AFTER username """
         insertSql = " insert into ${tbName1} values(923456689, 'Alice', '{\"k1\":\"v31\", \"k2\": 300}', 'Yaan',  25, 0, 13812345678, 'No. 123 Street, Beijing', '2022-01-01 10:00:00'); "
         waitForSchemaChangeDone({
             sql getTableStatusSql
@@ -643,7 +643,7 @@ suite("test_agg_schema_value_add", "p0") {
     expectException({
         sql initTable
         sql initTableData
-        sql """ alter  table ${tbName1} add  column  s_info  STRUCT<s_id:int(11), s_name:string, s_address:string>   AFTER username """
+        sql """ alter  table ${tbName1} add  column  s_info  STRUCT<s_id:int(11), s_name:string, s_address:string> key AFTER username """
         insertSql = " insert into ${tbName1} values(923456689, 'Alice', [6,7,8], 'Yaan',  25, 0, 13812345678, 'No. 123 Street, Beijing', '2022-01-01 10:00:00'); "
         waitForSchemaChangeDone({
             sql getTableStatusSql

--- a/regression-test/suites/schema_change_p0/test_agg_schema_value_add.groovy
+++ b/regression-test/suites/schema_change_p0/test_agg_schema_value_add.groovy
@@ -224,7 +224,7 @@ suite("test_agg_schema_value_add", "p0") {
     //Test the AGGREGATE model by adding a value column with INT
     sql initTable
     sql initTableData
-    sql """ alter  table ${tbName1} add  column house_price INT  DEFAULT "999" AFTER username """
+    sql """ alter  table ${tbName1} add  column house_price INT key DEFAULT "999" AFTER username """
     insertSql = " insert into ${tbName1} values(923456689, 'Alice', 22536, 'Yaan', 25, 0, 13812345678, 'No. 123 Street, Beijing', '2022-01-01 10:00:00'); "
     waitForSchemaChangeDone({
         sql getTableStatusSql

--- a/regression-test/suites/schema_change_p0/test_agg_schema_value_add.groovy
+++ b/regression-test/suites/schema_change_p0/test_agg_schema_value_add.groovy
@@ -601,7 +601,7 @@ suite("test_agg_schema_value_add", "p0") {
     expectException({
         sql initTable
         sql initTableData
-        sql """ alter  table ${tbName1} add  column m   Map<STRING, INT>   AFTER username """
+        sql """ alter  table ${tbName1} add  column m   Map<STRING, INT> key  AFTER username """
         insertSql = " insert into ${tbName1} values(923456689, 'Alice', {'a': 100, 'b': 200}, 'Yaan',  25, 0, 13812345678, 'No. 123 Street, Beijing', '2022-01-01 10:00:00');  "
         waitForSchemaChangeDone({
             sql getTableStatusSql
@@ -629,7 +629,7 @@ suite("test_agg_schema_value_add", "p0") {
     expectException({
         sql initTable
         sql initTableData
-        sql """ alter  table ${tbName1} add  column   c_array  ARRAY<int(11)>   AFTER username """
+        sql """ alter  table ${tbName1} add  column   c_array  ARRAY<int(11)> key AFTER username """
         insertSql = " insert into ${tbName1} values(923456689, 'Alice', [6,7,8], 'Yaan',  25, 0, 13812345678, 'No. 123 Street, Beijing', '2022-01-01 10:00:00'); "
         waitForSchemaChangeDone({
             sql getTableStatusSql

--- a/regression-test/suites/schema_change_p0/test_alter_table_add_columns.groovy
+++ b/regression-test/suites/schema_change_p0/test_alter_table_add_columns.groovy
@@ -57,7 +57,7 @@ suite("test_alter_table_add_columns") {
 
     // Add one value column light schema change is false
 
-    sql """ alter table ${tbName} ADD COLUMN (new_k1 INT DEFAULT '1', new_k2 INT DEFAULT '2');"""
+    sql """ alter table ${tbName} ADD COLUMN (new_k1 INT key DEFAULT '1', new_k2 INT key DEFAULT '2');"""
 
     waitForSchemaChangeDone {
         sql """ SHOW ALTER TABLE COLUMN WHERE TableName='${tbName}' ORDER BY createtime DESC LIMIT 1 """

--- a/regression-test/suites/schema_change_p0/test_schema_change_agg.groovy
+++ b/regression-test/suites/schema_change_p0/test_schema_change_agg.groovy
@@ -149,7 +149,7 @@ suite("test_schema_change_agg", "p0") {
 
     // check add column without agg type
     test {
-        sql """ alter table ${tableName3} add column v16 int NOT NULL default "0" after k13 """
+        sql """ alter table ${tableName3} add column v16 int key NOT NULL default "0" after k13 """
         exception "can't add key column v16 after value column k13"
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

force add `key` keyword when adding key columns on AGG table, reason:
1. be consistent with official doc
2. prevent someone from adding key columns by accident but without proper ways to remove them 


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

