### PR TITLE
[opt](staticstis) use count(1) for rowCount when scan full table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
@@ -271,6 +271,7 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
             params.put("scaleFactor", "1");
             params.put("sampleHints", "");
             params.put("ndvFunction", "ROUND(NDV(`${colName}`) * ${scaleFactor})");
+            // For full table scan, use COUNT(1) for table row count.
             params.put("rowCount", "COUNT(1)");
             params.put("rowCount2", "(SELECT COUNT(1) FROM cte1 WHERE `${colName}` IS NOT NULL)");
             scanFullTable = true;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
@@ -271,6 +271,7 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
             params.put("scaleFactor", "1");
             params.put("sampleHints", "");
             params.put("ndvFunction", "ROUND(NDV(`${colName}`) * ${scaleFactor})");
+            params.put("rowCount", "COUNT(1)");
             params.put("rowCount2", "(SELECT COUNT(1) FROM cte1 WHERE `${colName}` IS NOT NULL)");
             scanFullTable = true;
             return;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
@@ -53,6 +53,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 /**
@@ -62,7 +63,8 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
 
     private static final String BASIC_STATS_TEMPLATE = "SELECT "
             + "SUBSTRING(CAST(MIN(`${colName}`) AS STRING), 1, 1024) as min, "
-            + "SUBSTRING(CAST(MAX(`${colName}`) AS STRING), 1, 1024) as max "
+            + "SUBSTRING(CAST(MAX(`${colName}`) AS STRING), 1, 1024) as max, "
+            + "COUNT(1) as row_count "
             + "FROM `${dbName}`.`${tblName}` ${index}";
 
     private boolean keyColumnSampleTooManyRows = false;
@@ -109,19 +111,30 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
             LOG.debug("Will do sample collection for column {}", col.getName());
         }
         // Get basic stats, including min and max.
-        ResultRow minMax = collectMinMax();
-        String min = StatisticsUtil.escapeSQL(minMax != null && minMax.getValues().size() > 0
-                ? minMax.get(0) : null);
-        String max = StatisticsUtil.escapeSQL(minMax != null && minMax.getValues().size() > 1
-                ? minMax.get(1) : null);
+        ResultRow minMaxCount = collectMinMaxCount();
+        BiFunction<ResultRow, Integer, String> escapeCell = (row, i) ->
+                StatisticsUtil.escapeSQL(row != null && row.getValues().size() > i ? row.getValues().get(i) : null);
+        String min = escapeCell.apply(minMaxCount, 0);
+        String max = escapeCell.apply(minMaxCount, 1);
+        String tableRowCountStr = escapeCell.apply(minMaxCount, 2);
+        long tableRowCount = -1;
+        if (tableRowCountStr != null) {
+            try {
+                tableRowCount = Long.parseLong(tableRowCountStr);
+            } catch (Exception e) {
+                // ignore parse exception
+            }
+        }
+        if (tableRowCount < 0) {
+            tableRowCount = info.indexId == -1
+                    ? tbl.getRowCount()
+                    : ((OlapTable) tbl).getRowCountForIndex(info.indexId, false);
+        }
 
         Map<String, String> params = buildSqlParams();
         params.put("min", StatisticsUtil.quote(min));
         params.put("max", StatisticsUtil.quote(max));
         params.put("hotValueCollectCount", String.valueOf(SessionVariable.getHotValueCollectCount()));
-        long tableRowCount = info.indexId == -1
-                ? tbl.getRowCount()
-                : ((OlapTable) tbl).getRowCountForIndex(info.indexId, false);
         getSampleParams(params, tableRowCount);
         StringSubstitutor stringSubstitutor = new StringSubstitutor(params);
         String sql;
@@ -136,7 +149,7 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
         runQuery(sql);
     }
 
-    protected ResultRow collectMinMax() {
+    protected ResultRow collectMinMaxCount() {
         long startTime = System.currentTimeMillis();
         Map<String, String> params = buildSqlParams();
         StringSubstitutor stringSubstitutor = new StringSubstitutor(params);
@@ -146,7 +159,7 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
             stmtExecutor = new StmtExecutor(r.connectContext, sql);
             resultRow = stmtExecutor.executeInternalQuery().get(0);
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Cost time in millisec: " + (System.currentTimeMillis() - startTime) + " Min max SQL: "
+                LOG.debug("Cost time in millisec: " + (System.currentTimeMillis() - startTime) + " Min max count SQL: "
                         + sql + " QueryId: " + DebugUtil.printId(stmtExecutor.getContext().queryId()));
             }
             // Release the reference to stmtExecutor, reduce memory usage.

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/OlapAnalysisTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/OlapAnalysisTaskTest.java
@@ -375,6 +375,11 @@ public class OlapAnalysisTaskTest {
         Assertions.assertEquals("", params.get("sampleHints"));
         Assertions.assertEquals("ROUND(NDV(`${colName}`) * ${scaleFactor})", params.get("ndvFunction"));
         Assertions.assertNull(params.get("preAggHint"));
+        Assertions.assertEquals("COUNT(1)", params.get("rowCount"));
+        params.clear();
+
+        task.getSampleParams(params, 10000);
+        Assertions.assertEquals("10000", params.get("rowCount"));
         params.clear();
 
         new MockUp<OlapTable>() {

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/OlapAnalysisTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/OlapAnalysisTaskTest.java
@@ -111,8 +111,8 @@ public class OlapAnalysisTaskTest {
 
         new Expectations() {
             {
-                // tableIf.getRowCount();
-                // result = 20000000;
+                tableIf.getRowCount();
+                result = 20000000;
                 tableIf.getId();
                 result = 30001;
                 catalogIf.getId();
@@ -126,11 +126,10 @@ public class OlapAnalysisTaskTest {
 
         new MockUp<OlapAnalysisTask>() {
             @Mock
-            public ResultRow collectMinMaxCount() {
+            public ResultRow collectMinMax() {
                 List<String> values = Lists.newArrayList();
                 values.add("1");
                 values.add("2");
-                values.add("20000000");
                 return new ResultRow(values);
             }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/OlapAnalysisTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/OlapAnalysisTaskTest.java
@@ -111,8 +111,8 @@ public class OlapAnalysisTaskTest {
 
         new Expectations() {
             {
-                tableIf.getRowCount();
-                result = 20000000;
+                // tableIf.getRowCount();
+                // result = 20000000;
                 tableIf.getId();
                 result = 30001;
                 catalogIf.getId();
@@ -126,10 +126,11 @@ public class OlapAnalysisTaskTest {
 
         new MockUp<OlapAnalysisTask>() {
             @Mock
-            public ResultRow collectMinMax() {
+            public ResultRow collectMinMaxCount() {
                 List<String> values = Lists.newArrayList();
                 values.add("1");
                 values.add("2");
+                values.add("20000000");
                 return new ResultRow(values);
             }
 


### PR DESCRIPTION
### What problem does this PR solve?

when do sample,  it will use table.getRowCount() as rowsCount,   but the table.getRowCount() may be stale because it depend on BE's report,  then it may occur  rowsCount < ndv.

Then when if 10 * rowsCount < ndv， the analyze sql will fail.

Then the regression test statistics/analyze_stats.groovy is not stable,  and cause error:

```
Exception:
java.sql.SQLException: errCode = 2, detailMessage = Failed to analyze following columns:[id] Reasons: java.lang.RuntimeException: ColStatsData is invalid, skip analyzing. ('1763112020393--1-id',0,1763112019723,1763112020393,-1,'id',null,1,16,0,'1','201',64,'2025-11-14 17:41:14','105 :0.06 ;104 :0.06 ;103 :0.06 ;102 :0.06 ;101 :0.06 ;10 :0.06 ;9 :0.06 ;8 :0.06 ;7 :0.06 ;6 :0.06')
  at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:129)
  at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
  at com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:953)
  at com.mysql.cj.jdbc.ClientPreparedStatement.execute(ClientPreparedStatement.java:371)
  at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
  at org.apache.doris.regression.util.JdbcUtils$_executeToList_closure1.doCall(JdbcUtils.groovy:47)
  at sun.reflect.GeneratedMethodAccessor33.invoke(Unknown Source)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.lang.reflect.Method.invoke(Method.java:498)
  at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:343)
  at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:328)
  at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:279)
```

so when do sample and scan whole table, we use count(1) to represent rowsCount.

Notice that this replace will not increase the excute cost, because the staticstic sql has contained `count(1)`.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

