### PR TITLE
[fix](nereids)PushDownJoinOnAssertNumRows rule process project alias bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckAfterRewrite.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckAfterRewrite.java
@@ -94,6 +94,18 @@ public class CheckAfterRewrite extends OneAnalysisRuleFactory {
         }
     }
 
+    /**
+     *
+     * used for test
+     * after applying a rule, use this method to check whether all slots are from children
+     */
+    public void checkTreeAllSlotReferenceFromChildren(Plan plan) {
+        checkAllSlotReferenceFromChildren(plan);
+        for (Plan child : plan.children()) {
+            checkTreeAllSlotReferenceFromChildren(child);
+        }
+    }
+
     private void checkAllSlotReferenceFromChildren(Plan plan) {
         Set<Slot> inputSlots = plan.getInputSlots();
         RoaringBitmap childrenOutput = plan.getChildrenOutputExprIdBitSet();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownJoinOnAssertNumRowsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownJoinOnAssertNumRowsTest.java
@@ -470,7 +470,6 @@ class PushDownJoinOnAssertNumRowsTest implements MemoPatternMatchSupported {
         Assertions.assertTrue(newPlan instanceof LogicalProject
                 && newPlan.getOutput().size() == 2
                 && ((LogicalProject<?>) newPlan).getOutputs().get(0).equals(slot)
-                && ((LogicalProject<?>) newPlan).getOutputs().get(1).equals(alias)
-                && newPlan.child(0) instanceof LogicalProject);
+                && ((LogicalProject<?>) newPlan).getOutputs().get(1).equals(alias));
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?
pr #57414 will generate error project: LogicalProject(a as b, b as c), in which 'b as c' is not correct, because 'b' is not in output of project.child()
pr #57804 fixed above issue, but made another issue, that is when the bottom project is not resued in result plan, some aliases definitions are lost.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

