### PR TITLE
[Improvement](exchange) avoid random partition send empty block

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -380,6 +380,26 @@ Status ExchangeSinkOperatorX::sink(RuntimeState* state, vectorized::Block* block
         return Status::OK();
     }
 
+    auto send_to_current_channel = [&]() -> Status {
+        // 1. select channel
+        auto& current_channel = local_state.channels[local_state.current_channel_idx];
+        if (!current_channel->is_receiver_eof()) {
+            // 2. serialize, send and rollover block
+            if (current_channel->is_local()) {
+                auto status = current_channel->send_local_block(block, eos, true);
+                HANDLE_CHANNEL_STATUS(state, current_channel, status);
+            } else {
+                auto pblock = std::make_unique<PBlock>();
+                if (!block->empty()) {
+                    RETURN_IF_ERROR(local_state._serializer.serialize_block(block, pblock.get()));
+                }
+                auto status = current_channel->send_remote_block(std::move(pblock), eos);
+                HANDLE_CHANNEL_STATUS(state, current_channel, status);
+            }
+        }
+        return Status::OK();
+    };
+
     if (_part_type == TPartitionType::UNPARTITIONED) {
         // 1. serialize depends on it is not local exchange
         // 2. send block
@@ -454,20 +474,7 @@ Status ExchangeSinkOperatorX::sink(RuntimeState* state, vectorized::Block* block
             }
         }
     } else if (_part_type == TPartitionType::RANDOM) {
-        // 1. select channel
-        auto& current_channel = local_state.channels[local_state.current_channel_idx];
-        if (!current_channel->is_receiver_eof()) {
-            // 2. serialize, send and rollover block
-            if (current_channel->is_local()) {
-                auto status = current_channel->send_local_block(block, eos, true);
-                HANDLE_CHANNEL_STATUS(state, current_channel, status);
-            } else {
-                auto pblock = std::make_unique<PBlock>();
-                RETURN_IF_ERROR(local_state._serializer.serialize_block(block, pblock.get()));
-                auto status = current_channel->send_remote_block(std::move(pblock), eos);
-                HANDLE_CHANNEL_STATUS(state, current_channel, status);
-            }
-        }
+        RETURN_IF_ERROR(send_to_current_channel());
         local_state.current_channel_idx =
                 (local_state.current_channel_idx + 1) % local_state.channels.size();
     } else if (_part_type == TPartitionType::HASH_PARTITIONED ||
@@ -477,24 +484,8 @@ Status ExchangeSinkOperatorX::sink(RuntimeState* state, vectorized::Block* block
         RETURN_IF_ERROR(local_state._writer->write(&local_state, state, block, eos));
     } else if (_part_type == TPartitionType::HIVE_TABLE_SINK_UNPARTITIONED) {
         // Control the number of channels according to the flow, thereby controlling the number of table sink writers.
-        // 1. select channel
-        auto& current_channel = local_state.channels[local_state.current_channel_idx];
-        if (!current_channel->is_receiver_eof()) {
-            // 2. serialize, send and rollover block
-            if (current_channel->is_local()) {
-                auto status = current_channel->send_local_block(block, eos, true);
-                HANDLE_CHANNEL_STATUS(state, current_channel, status);
-            } else {
-                auto pblock = std::make_unique<PBlock>();
-                if (!block->empty()) {
-                    RETURN_IF_ERROR(local_state._serializer.serialize_block(block, pblock.get()));
-                }
-                auto status = current_channel->send_remote_block(std::move(pblock), eos);
-                HANDLE_CHANNEL_STATUS(state, current_channel, status);
-            }
-            _data_processed += block->bytes();
-        }
-
+        RETURN_IF_ERROR(send_to_current_channel());
+        _data_processed += block->bytes();
         if (_writer_count < local_state.channels.size()) {
             if (_data_processed >=
                 _writer_count *


### PR DESCRIPTION
### What problem does this PR solve?
```cpp
F20251120 11:27:16.692677 39854 sort_cursor.h:148] Check failed: !block->empty() or _is_eof
11:50:02   *** Check failure stack trace: ***
11:50:02       @     0x55b93a57a6cf  google::LogMessage::SendToLog()
11:50:02       @     0x55b93a570ce0  google::LogMessage::Flush()
11:50:02       @     0x55b93a5743d9  google::LogMessageFatal::~LogMessageFatal()
11:50:02       @     0x55b937195df9  doris::vectorized::BlockSupplierSortCursorImpl::process_next()
11:50:02       @     0x55b93717e8ca  doris::vectorized::VSortedRunMerger::get_next()
11:50:02       @     0x55b9371072ed  doris::vectorized::VDataStreamRecvr::get_next()
11:50:02       @     0x55b938c171c4  doris::pipeline::ExchangeSourceOperatorX::get_block()
11:50:02       @     0x55b9374f73e2  doris::pipeline::OperatorXBase::get_block_after_projects()
11:50:02       @     0x55b93a002004  doris::pipeline::PipelineTask::execute()
11:50:02       @     0x55b93a08056e  doris::pipeline::TaskScheduler::_do_work()
11:50:02       @     0x55b924b6644e  doris::ThreadPool::dispatch_thread()
11:50:02       @     0x55b924b39d37  doris::Thread::supervise_thread()
11:50:02       @     0x55b91f4e3d27  asan_thread_start()
11:50:02       @     0x7f06680fa609  start_thread
11:50:02       @     0x7f066800d133  clone
11:50:02       @              (nil)  (unknown)
11:50:02   *** Query id: 1c2cff2969b746f6-9f8a203e21a8b07e ***
11:50:02   *** is nereids: 1 ***
11:50:02   *** tablet id: 0 ***
11:50:02   *** Aborted at 1763609237 (unix time) try "date -d @1763609237" if you are using GNU date ***
11:50:02   *** Current BE git commitID: 6c6fd6b467 ***
11:50:02   *** SIGABRT unknown detail explain (@0x98c3) received by PID 39107 (TID 39854 OR 0x7b035bdf4700) from PID 39107; stack trace: ***
11:50:02    0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:420
11:50:02    1# 0x00007F0668106420 in /lib/x86_64-linux-gnu/libpthread.so.0
11:50:02    2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
11:50:02    3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
11:50:02    4# 0x000055B93A57F705 in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
11:50:02    5# 0x000055B93A570FBA in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
11:50:02   + echo 'cp -r /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0//Cluster0/fe/log /home/work/pipline/backup_center/58002_b5ae6748c1142931e756f7ec6898b28a8308bef4_p0/fe/'
11:50:02    6# google::LogMessage::SendToLog() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
11:50:02   + cp -r /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0//Cluster0/fe/log /home/work/pipline/backup_center/58002_b5ae6748c1142931e756f7ec6898b28a8308bef4_p0/fe/
11:50:02    7# google::LogMessage::Flush() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
11:50:02    8# google::LogMessageFatal::~LogMessageFatal() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
11:50:02    9# doris::vectorized::BlockSupplierSortCursorImpl::process_next() at /root/doris/be/src/vec/core/sort_cursor.h:148
11:50:02   10# doris::vectorized::VSortedRunMerger::get_next(doris::vectorized::Block*, bool*) at /root/doris/be/src/vec/runtime/vsorted_run_merger.cpp:99
11:50:02   11# doris::vectorized::VDataStreamRecvr::get_next(doris::vectorized::Block*, bool*) at /root/doris/be/src/vec/runtime/vdata_stream_recvr.cpp:508
11:50:02   12# doris::pipeline::ExchangeSourceOperatorX::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /root/doris/be/src/pipeline/exec/exchange_source_operator.cpp:165
11:50:02   13# doris::pipeline::OperatorXBase::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /root/doris/be/src/pipeline/exec/operator.cpp:404
11:50:02   14# doris::pipeline::PipelineTask::execute(bool*) at /root/doris/be/src/pipeline/pipeline_task.cpp:534
11:50:02   15# doris::pipeline::TaskScheduler::_do_work(int) at /root/doris/be/src/pipeline/task_scheduler.cpp:153
11:50:02   16# doris::ThreadPool::dispatch_thread() at /root/doris/be/src/util/threadpool.cpp:621
11:50:02   17# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:461
11:50:02   18# asan_thread_start(void*) in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
11:50:02   19# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
11:50:02   20# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97
```

This pull request refactors the logic for sending data blocks to exchange channels in the `ExchangeSinkOperatorX::sink` method, improving code maintainability and reducing duplication. The main change is the introduction of a reusable lambda function to handle sending blocks to the current channel, which is now used in multiple partitioning scenarios.

**Code refactoring for channel block sending logic:**

* Introduced a lambda function `send_to_current_channel` that encapsulates the logic for selecting the current channel and sending a block, handling both local and remote channels, and checking for receiver EOF.

**Application of the new lambda in partitioning cases:**

* Replaced duplicated channel selection and block sending code in the `RANDOM` partitioning case with a call to `send_to_current_channel`, simplifying the code and ensuring consistent behavior.
* Replaced duplicated channel selection and block sending code in the `HIVE_TABLE_SINK_UNPARTITIONED` partitioning case with a call to `send_to_current_channel`, further reducing code repetition.
### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

