### PR TITLE
[fix](cloud)Support `cloud_tablet_rebalancer_interval_second` config dynamic modification

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3360,7 +3360,7 @@ public class Config extends ConfigBase {
     public static int drop_user_notify_ms_max_times = 86400;
 
     @ConfField(mutable = true, masterOnly = true)
-    public static long cloud_tablet_rebalancer_interval_second = 20;
+    public static long cloud_tablet_rebalancer_interval_second = 1;
 
     @ConfField(mutable = true, masterOnly = true)
     public static boolean enable_cloud_partition_balance = true;

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletRebalancer.java
@@ -163,8 +163,7 @@ public class CloudTabletRebalancer extends MasterDaemon {
     }
 
     public CloudTabletRebalancer(CloudSystemInfoService cloudSystemInfoService) {
-        // Daemon interval is 0, we will set interval dynamically in runOneCycle
-        super("cloud tablet rebalancer", 0);
+        super("cloud tablet rebalancer", Config.cloud_tablet_rebalancer_interval_second * 1000);
         this.cloudSystemInfoService = cloudSystemInfoService;
     }
 
@@ -322,11 +321,7 @@ public class CloudTabletRebalancer extends MasterDaemon {
             LOG.warn("cloud tablet rebalance interval second is negative, change it to default 20s");
             sleepSeconds = 20L;
         }
-        try {
-            Thread.sleep(sleepSeconds * 1000L);
-        } catch (InterruptedException e) {
-            LOG.warn("sleep interrupted", e);
-        }
+        setInterval(sleepSeconds * 1000L);
         LOG.info("finished to rebalancer. cost: {} ms, rebalancer sche interval {} s",
                 (System.currentTimeMillis() - start), sleepSeconds);
     }

--- a/regression-test/suites/cloud_p0/balance/test_expanding_node_balance.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_expanding_node_balance.groovy
@@ -1,0 +1,102 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+import org.codehaus.groovy.runtime.IOGroovyMethods
+
+suite('test_expanding_node_balance', 'docker') {
+    if (!isCloudMode()) {
+        return;
+    }
+
+    def clusterOptions = [
+        new ClusterOptions(),
+        new ClusterOptions(),
+    ]
+
+    for (options in clusterOptions) {
+        options.feConfigs += [
+            'cloud_cluster_check_interval_second=1',
+            'cloud_tablet_rebalancer_interval_second=20',
+            'sys_log_verbose_modules=org',
+            'heartbeat_interval_second=1',
+            'rehash_tablet_after_be_dead_seconds=3600',
+            'cloud_warm_up_for_rebalance_type=peer_read_async_warmup',
+            // disable Auto Analysis Job Executor
+            'auto_check_statistics_in_minutes=60',
+        ]
+        options.cloudMode = true
+        options.setFeNum(1)
+        options.setBeNum(1)
+        options.enableDebugPoints()
+    }
+
+
+    def testCase = { command, expectCost ->
+        sql """
+        CREATE TABLE `fact_sales` (
+            `order_id` varchar(255) NOT NULL,
+            `order_line_id` varchar(255) NOT NULL,
+            `order_date` date NOT NULL,
+            `time_of_day` varchar(50) NOT NULL,
+            `season` varchar(50) NOT NULL,
+            `month` int NOT NULL,
+            `location_id` varchar(255) NOT NULL,
+            `region` varchar(100) NOT NULL,
+            `product_name` varchar(255) NOT NULL,
+            `quantity` int NOT NULL,
+            `sales_amount` double NOT NULL,
+            `discount_percentage` int NOT NULL,
+            `product_id` varchar(255) NOT NULL
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`order_id`, `order_line_id`)
+        DISTRIBUTED BY HASH(`order_id`) BUCKETS 256
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1"
+        )
+        """
+
+        cluster.addBackend(15, "compute_cluster")
+
+        sql """
+        $command
+        """
+        def begin = System.currentTimeMillis();
+        awaitUntil(1000, 10) {
+            def showRet = sql_return_maparray """ADMIN SHOW REPLICA DISTRIBUTION FROM fact_sales"""
+            logger.info("show result {}", showRet)
+            showRet.any { row -> 
+                Integer.valueOf((String) row.ReplicaNum) == 16
+            }
+        }
+        def cost = (System.currentTimeMillis() - begin) / 1000;
+        log.info("exec command: {}\n  time cost: {}s", command, cost)
+        assertTrue(cost < expectCost, "cost assert wrong")
+    }
+
+    docker(clusterOptions[0]) {
+        def command = 'admin set frontend config("cloud_min_balance_tablet_num_per_run"="16");' 
+        // assert < 300s
+        testCase(command, 300)
+    }
+
+    docker(clusterOptions[1]) {
+        def command = 'admin set frontend config("cloud_tablet_rebalancer_interval_second"="0");' 
+        // assert < 50s
+        testCase(command, 50)
+    }
+}

--- a/regression-test/suites/cloud_p0/balance/test_expanding_node_balance.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_expanding_node_balance.groovy
@@ -26,6 +26,7 @@ suite('test_expanding_node_balance', 'docker') {
     def clusterOptions = [
         new ClusterOptions(),
         new ClusterOptions(),
+        new ClusterOptions(),
     ]
 
     for (options in clusterOptions) {
@@ -96,6 +97,14 @@ suite('test_expanding_node_balance', 'docker') {
 
     docker(clusterOptions[1]) {
         def command = 'admin set frontend config("cloud_tablet_rebalancer_interval_second"="0");' 
+        // assert < 50s
+        testCase(command, 50)
+    }
+
+    docker(clusterOptions[2]) {
+        GetDebugPoint().enableDebugPointForAllFEs("CloudTabletRebalancer.balanceEnd.tooLong")
+        // do nothing
+        def command = 'select 1'
         // assert < 50s
         testCase(command, 50)
     }


### PR DESCRIPTION

### What problem does this PR solve?

The fixed scheduling time requires a restart to modify. To change it, use the command admin set frontend config("cloud_tablet_rebalancer_interval_second"="3"); to apply the change without a restart.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

