### PR TITLE
[fix](azure) Use `LOG_WARNING` instead of `LOG_FATAL` for not support azure

### DIFF
--- a/be/src/util/s3_util.cpp
+++ b/be/src/util/s3_util.cpp
@@ -252,7 +252,7 @@ std::shared_ptr<io::ObjStorageClient> S3ClientFactory::_create_azure_client(
     LOG_INFO("create one azure client with {}", s3_conf.to_string());
     return std::make_shared<io::AzureObjStorageClient>(std::move(containerClient));
 #else
-    LOG_FATAL("BE is not compiled with azure support, export BUILD_AZURE=ON before building");
+    LOG(WARNING) << "BE is not compiled with azure support, export BUILD_AZURE=ON before building";
     return nullptr;
 #endif
 }

--- a/cloud/src/recycler/s3_accessor.cpp
+++ b/cloud/src/recycler/s3_accessor.cpp
@@ -393,8 +393,9 @@ int S3Accessor::init() {
         obj_client_ = std::make_shared<AzureObjClient>(std::move(container_client));
         return 0;
 #else
-        LOG_FATAL("BE is not compiled with azure support, export BUILD_AZURE=ON before building");
-        return 0;
+        LOG(WARNING)
+                << "BE is not compiled with azure support, export BUILD_AZURE=ON before building";
+        return -1;
 #endif
     }
     default: {


### PR DESCRIPTION
### What problem does this PR solve?

1. `LOG_FATAL` will throw exception.
2. the result of null ptr will be resolved at caller.

now:
```
mysql> SELECT * FROM S3
    -> (
    ->     "uri" = "s3://xxx/1.csv",
    ->     "format" = "csv",
    ->     "provider" = "AZURE",
    ->     "azure.endpoint" = "xxx",
    ->     "azure.region" = "xxx",
    ->     "azure.access_key" = "xxx",
    ->     "azure.secret_key" = "xxx",
    ->     "column_separator" = ",",
    ->     "csv_schema" = "k1:int;k2:int;k3:int"
    -> );
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INTERNAL_ERROR]failed to init reader, err: [INVALID_ARGUMENT]failed to init s3 client with conf (ak=xxx, token=, endpoint=xxx, region=dummy_region, bucket=xxx, max_connections=-1, request_timeout_ms=-1, connect_timeout_ms=-1, use_virtual_addressing=true, cred_provider_type=0,role_arn=, external_id=. cur path: xxx
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

