### PR TITLE
[fix](jni)Adjust the statistical time of JNI appenddata.

### DIFF
--- a/fe/be-java-extensions/avro-scanner/src/main/java/org/apache/doris/avro/AvroJNIScanner.java
+++ b/fe/be-java-extensions/avro-scanner/src/main/java/org/apache/doris/avro/AvroJNIScanner.java
@@ -39,8 +39,10 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -193,14 +195,36 @@ public class AvroJNIScanner extends JniScanner {
         }
     }
 
-    @Override
-    protected int getNext() throws IOException {
-        int numRows = 0;
-        for (; numRows < getBatchSize(); numRows++) {
+    private List<GenericRecord> readNextBatch() throws IOException {
+        List<GenericRecord> records = new ArrayList<>();
+
+        for (int numRows = 0; numRows < getBatchSize(); numRows++) {
             if (!avroReader.hasNext(inputPair, ignore)) {
                 break;
             }
             GenericRecord rowRecord = (GenericRecord) avroReader.getNext();
+            records.add(rowRecord);
+
+            // for (int i = 0; i < requiredFields.length; i++) {
+            //     Object fieldData = rowRecord.get(requiredFields[i]);
+            //     if (fieldData == null) {
+            //         appendData(i, null);
+            //     } else {
+            //         AvroColumnValue fieldValue = new AvroColumnValue(fieldInspectors[i], fieldData);
+            //         appendData(i, fieldValue);
+            //     }
+            // }
+        }
+        return records;
+    }
+
+
+    @Override
+    protected int getNext() throws IOException {
+        List<GenericRecord> records = readNextBatch();
+
+        long startTime = System.nanoTime();
+        for (GenericRecord rowRecord : records) {
             for (int i = 0; i < requiredFields.length; i++) {
                 Object fieldData = rowRecord.get(requiredFields[i]);
                 if (fieldData == null) {
@@ -211,7 +235,9 @@ public class AvroJNIScanner extends JniScanner {
                 }
             }
         }
-        return numRows;
+        appendDataTime += System.nanoTime() - startTime;
+
+        return records.size();
     }
 
     @Override

--- a/fe/be-java-extensions/hadoop-hudi-scanner/src/main/java/org/apache/doris/hudi/HadoopHudiJniScanner.java
+++ b/fe/be-java-extensions/hadoop-hudi-scanner/src/main/java/org/apache/doris/hudi/HadoopHudiJniScanner.java
@@ -50,6 +50,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -166,6 +167,7 @@ public class HadoopHudiJniScanner extends JniScanner {
             return preExecutionAuthenticator.execute(() -> {
                 NullWritable key = reader.createKey();
                 ArrayWritable value = reader.createValue();
+                List<Object> records = new ArrayList<>();
                 int numRows = 0;
                 for (; numRows < fetchSize; numRows++) {
                     if (!reader.next(key, value)) {
@@ -173,6 +175,16 @@ public class HadoopHudiJniScanner extends JniScanner {
                     }
                     if (fields.length > 0) {
                         Object rowData = deserializer.deserialize(value);
+                        records.add(rowData);
+                    }
+                }
+
+                long startTime = System.nanoTime();
+                // vectorTable is virtual
+                if (fields.length == 0) {
+                    vectorTable.appendVirtualData(numRows);
+                } else {
+                    for (Object rowData : records) {
                         for (int i = 0; i < fields.length; i++) {
                             Object fieldData = rowInspector.getStructFieldData(rowData, structFields[i]);
                             columnValue.setRow(fieldData);
@@ -181,10 +193,8 @@ public class HadoopHudiJniScanner extends JniScanner {
                         }
                     }
                 }
-                // vectorTable is virtual
-                if (fields.length == 0) {
-                    vectorTable.appendVirtualData(numRows);
-                }
+                appendDataTime += System.nanoTime() - startTime;
+
                 return numRows;
             });
         } catch (Exception e) {

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/MockJniScanner.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/MockJniScanner.java
@@ -205,6 +205,7 @@ public class MockJniScanner extends JniScanner {
             return 0;
         }
         int rows = Math.min(batchSize, mockRows - readRows);
+        long startTime = System.nanoTime();
         for (int i = 0; i < rows; ++i) {
             for (int j = 0; j < types.length; ++j) {
                 if ((i + j) % 16 == 0) {
@@ -215,6 +216,7 @@ public class MockJniScanner extends JniScanner {
                 }
             }
         }
+        appendDataTime += System.nanoTime() - startTime;
         readRows += rows;
         return rows;
     }

--- a/fe/be-java-extensions/max-compute-scanner/src/main/java/org/apache/doris/maxcompute/MaxComputeJniScanner.java
+++ b/fe/be-java-extensions/max-compute-scanner/src/main/java/org/apache/doris/maxcompute/MaxComputeJniScanner.java
@@ -263,6 +263,7 @@ public class MaxComputeJniScanner extends JniScanner {
 
                 List<FieldVector> fieldVectors = data.getFieldVectors();
                 int batchRows = 0;
+                long startTime = System.nanoTime();
                 for (FieldVector column : fieldVectors) {
                     Integer readColumnId = readColumnsToId.get(column.getName());
                     batchRows = column.getValueCount();
@@ -275,6 +276,8 @@ public class MaxComputeJniScanner extends JniScanner {
                         appendData(readColumnId, columnValue);
                     }
                 }
+                appendDataTime += System.nanoTime() - startTime;
+
                 curReadRows += batchRows;
             } catch (Exception e) {
                 String errorMsg = String.format("MaxComputeJniScanner Fail to read arrow data. "

--- a/fe/be-java-extensions/trino-connector-scanner/src/main/java/org/apache/doris/trinoconnector/TrinoConnectorJniScanner.java
+++ b/fe/be-java-extensions/trino-connector-scanner/src/main/java/org/apache/doris/trinoconnector/TrinoConnectorJniScanner.java
@@ -179,6 +179,9 @@ public class TrinoConnectorJniScanner extends JniScanner {
 
     @Override
     public void close() throws IOException {
+        for (long appendDataTimeN : appendDataTimeNs) {
+            appendDataTime += appendDataTimeN;
+        }
         if (source != null) {
             source.close();
         }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
PR #49688 adds a profile statistics interface for `appendDataTime` to JNI. 
This PR has two main benefits: 
1. it adds this statistical interface to all `JniScanner` instances; 
2. it changes the previous statistics method for `PaimonJniScanner`. The old method called `System.nanoTime` multiple times (rows * columns *2   times), which significantly increased CPU usage and reduced overall performance.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

