### PR TITLE
[Fix](agg) fix push agg op in nullable column before projection

### DIFF
--- a/regression-test/suites/nereids_p0/explain/test_pushdown_explain.groovy
+++ b/regression-test/suites/nereids_p0/explain/test_pushdown_explain.groovy
@@ -107,6 +107,40 @@ suite("test_pushdown_explain") {
         contains "pushAggOp=COUNT"
     }
 
+    // test projection in agg pushdown rule
+    explain {
+        sql("select count(a) from (select non_nullable_col as a from test_null_columns) t1;")
+        contains "pushAggOp=COUNT"
+    }
+    explain {
+        sql("select count(a) from (select nullable_col as a from test_null_columns) t1;")
+        contains "pushAggOp=NONE"
+    }
+    explain {
+        sql("select count(a), min(a) from (select non_nullable_col as a from test_null_columns) t1;")
+        contains "pushAggOp=MIX"
+    }
+    explain {
+        sql("select count(a), min(a) from (select nullable_col as a from test_null_columns) t1;")
+        contains "pushAggOp=NONE"
+    }
+    explain {
+        sql("select count(a), min(b) from (select nullable_col as a, non_nullable_col as b from test_null_columns) t1;")
+        contains "pushAggOp=NONE"
+    }
+    explain {
+        sql("select count(b), min(a) from (select nullable_col as a, non_nullable_col as b from test_null_columns) t1;")
+        contains "pushAggOp=MIX"
+    }
+    explain {
+        sql("select count(non_nullable_col), max(nullable_col) from test_null_columns;")
+        contains "pushAggOp=MIX"
+    }
+    explain {
+        sql("select count(nullable_col), max(non_nullable_col) from test_null_columns;")
+        contains "pushAggOp=NONE"
+    }
+
     explain {
         sql("select count(non_nullable_col), min(non_nullable_col), max(non_nullable_col) from test_null_columns;")
         contains "pushAggOp=MIX"


### PR DESCRIPTION
### What problem does this PR solve?

[Fix](chrome-extension://dbjibobgilijgolhjdcbdebjhejelffo/agg) Fix push aggregate operation in nullable column before projection
# Changes
Core Logic Adjustment (AggregateStrategies.java):
Removed redundant Count function-specific nullable slot checking logic, unifying aggregate function argument validation into a single stream-based check
Enhanced argument type verification: For SlotReference and numeric-type Cast (with SlotReference as child) arguments, uniformly collect slots to checkNullSlots for nullability validation
Fixed inconsistent aggregate pushdown judgment for nested projection scenarios, ensuring consistent validation logic for aggregate function arguments across different code branches

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

