### PR TITLE
[fix](paimon) Align incremental query behavior with Spark Paimon for single snapshot scenario

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
@@ -553,8 +553,8 @@ public class PaimonScanNode extends FileQueryScanNode {
             if (hasStartSnapshotId) {
                 try {
                     long startSId = Long.parseLong(params.get(DORIS_START_SNAPSHOT_ID));
-                    if (startSId <= 0) {
-                        throw new UserException("startSnapshotId must be greater than 0");
+                    if (startSId < 0) {
+                        throw new UserException("startSnapshotId must be greater than or equal to 0");
                     }
                 } catch (NumberFormatException e) {
                     throw new UserException("Invalid startSnapshotId format: " + e.getMessage());
@@ -564,8 +564,8 @@ public class PaimonScanNode extends FileQueryScanNode {
             if (hasEndSnapshotId) {
                 try {
                     long endSId = Long.parseLong(params.get(DORIS_END_SNAPSHOT_ID));
-                    if (endSId <= 0) {
-                        throw new UserException("endSnapshotId must be greater than 0");
+                    if (endSId < 0) {
+                        throw new UserException("endSnapshotId must be greater than or equal to 0");
                     }
                 } catch (NumberFormatException e) {
                     throw new UserException("Invalid endSnapshotId format: " + e.getMessage());
@@ -577,8 +577,8 @@ public class PaimonScanNode extends FileQueryScanNode {
                 try {
                     long startSId = Long.parseLong(params.get(DORIS_START_SNAPSHOT_ID));
                     long endSId = Long.parseLong(params.get(DORIS_END_SNAPSHOT_ID));
-                    if (startSId >= endSId) {
-                        throw new UserException("startSnapshotId must be less than endSnapshotId");
+                    if (startSId > endSId) {
+                        throw new UserException("startSnapshotId must be less than or equal to endSnapshotId");
                     }
                 } catch (NumberFormatException e) {
                     throw new UserException("Invalid snapshot ID format: " + e.getMessage());

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/source/PaimonScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/source/PaimonScanNodeTest.java
@@ -126,14 +126,14 @@ public class PaimonScanNodeTest {
         // Test valid parameter combinations
 
         // 1. Only startSnapshotId
-        Map<String, String> params = new HashMap<>();
-        params.put("startSnapshotId", "5");
+        Map<String, String> params1 = new HashMap<>();
+        params1.put("startSnapshotId", "5");
         ExceptionChecker.expectThrowsWithMsg(UserException.class,
                 "endSnapshotId is required when using snapshot-based incremental read",
-                () -> PaimonScanNode.validateIncrementalReadParams(params));
+                () -> PaimonScanNode.validateIncrementalReadParams(params1));
 
         // 2. Both startSnapshotId and endSnapshotId
-        params.clear();
+        Map<String, String> params = new HashMap<>();
         params.put("startSnapshotId", "1");
         params.put("endSnapshotId", "5");
         Map<String, String> result = PaimonScanNode.validateIncrementalReadParams(params);

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/source/PaimonScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/source/PaimonScanNodeTest.java
@@ -226,46 +226,27 @@ public class PaimonScanNodeTest {
                     e.getMessage().contains("startSnapshotId is required when using snapshot-based incremental read"));
         }
 
-        // 11. Test invalid snapshot ID values (≤ 0)
-        params.clear();
-        params.put("startSnapshotId", "0");
-        try {
-            PaimonScanNode.validateIncrementalReadParams(params);
-            Assert.fail("Should throw exception for startSnapshotId ≤ 0");
-        } catch (UserException e) {
-            Assert.assertTrue(e.getMessage().contains("startSnapshotId must be greater than 0"));
-        }
-
+        // 11. Test invalid snapshot ID values < 0)
         params.clear();
         params.put("startSnapshotId", "-1");
         try {
             PaimonScanNode.validateIncrementalReadParams(params);
-            Assert.fail("Should throw exception for negative startSnapshotId");
+            Assert.fail("Should throw exception for startSnapshotId < 0");
         } catch (UserException e) {
-            Assert.assertTrue(e.getMessage().contains("startSnapshotId must be greater than 0"));
+            Assert.assertTrue(e.getMessage().contains("startSnapshotId must be greater than or equal to 0"));
         }
 
         params.clear();
         params.put("startSnapshotId", "1");
-        params.put("endSnapshotId", "0");
+        params.put("endSnapshotId", "-1");
         try {
             PaimonScanNode.validateIncrementalReadParams(params);
-            Assert.fail("Should throw exception for endSnapshotId ≤ 0");
+            Assert.fail("Should throw exception for endSnapshotId < 0");
         } catch (UserException e) {
-            Assert.assertTrue(e.getMessage().contains("endSnapshotId must be greater than 0"));
+            Assert.assertTrue(e.getMessage().contains("endSnapshotId must be greater than or equal to 0"));
         }
 
-        // 12. Test start ≥ end for snapshot IDs
-        params.clear();
-        params.put("startSnapshotId", "5");
-        params.put("endSnapshotId", "5");
-        try {
-            PaimonScanNode.validateIncrementalReadParams(params);
-            Assert.fail("Should throw exception when startSnapshotId = endSnapshotId");
-        } catch (UserException e) {
-            Assert.assertTrue(e.getMessage().contains("startSnapshotId must be less than endSnapshotId"));
-        }
-
+        // 12. Test start > end for snapshot IDs
         params.clear();
         params.put("startSnapshotId", "6");
         params.put("endSnapshotId", "5");
@@ -273,10 +254,19 @@ public class PaimonScanNodeTest {
             PaimonScanNode.validateIncrementalReadParams(params);
             Assert.fail("Should throw exception when startSnapshotId > endSnapshotId");
         } catch (UserException e) {
-            Assert.assertTrue(e.getMessage().contains("startSnapshotId must be less than endSnapshotId"));
+            Assert.assertTrue(e.getMessage().contains("startSnapshotId must be less than or equal to endSnapshotId"));
         }
 
-        // 13. Test invalid timestamp values (≤ 0)
+        // 12.1. Test startSnapshotId == endSnapshotId (should be allowed, consistent with Spark Paimon behavior)
+        params.clear();
+        params.put("startSnapshotId", "5");
+        params.put("endSnapshotId", "5");
+        result = PaimonScanNode.validateIncrementalReadParams(params);
+        Assert.assertEquals("5,5", result.get("incremental-between"));
+        Assert.assertTrue(result.containsKey("scan.mode") && result.get("scan.mode") == null);
+        Assert.assertEquals(3, result.size());
+
+        // 13. Test invalid timestamp values (< 0)
         params.clear();
         params.put("startTimestamp", "-1");
         try {

--- a/regression-test/data/external_table_p0/paimon/paimon_incr_read.out
+++ b/regression-test/data/external_table_p0/paimon/paimon_incr_read.out
@@ -32,6 +32,13 @@
 
 -- !scan_mode4 --
 
+-- !snapshot_id_0_0_empty --
+
+-- !snapshot_id_0_1 --
+1	Alice	30
+
+-- !snapshot_id_1_1_empty --
+
 -- !cte --
 Bob	25
 Charlie	28
@@ -72,6 +79,13 @@ Alice	30
 2	Bob	25
 
 -- !scan_mode4 --
+
+-- !snapshot_id_0_0_empty --
+
+-- !snapshot_id_0_1 --
+1	Alice	30
+
+-- !snapshot_id_1_1_empty --
 
 -- !cte --
 Bob	25

--- a/regression-test/suites/external_table_p0/paimon/paimon_incr_read.groovy
+++ b/regression-test/suites/external_table_p0/paimon/paimon_incr_read.groovy
@@ -54,7 +54,10 @@ suite("test_paimon_incr_read", "p0,external,doris,external_docker,external_docke
             order_qt_scan_mode2 """select * from paimon_incr@incr('startSnapshotId'=1, 'endSnapshotId'=2, 'incrementalBetweenScanMode' = 'diff');"""
             order_qt_scan_mode3 """select * from paimon_incr@incr('startSnapshotId'=1, 'endSnapshotId'=2, 'incrementalBetweenScanMode' = 'delta');"""
             order_qt_scan_mode4 """select * from paimon_incr@incr('startSnapshotId'=1, 'endSnapshotId'=2, 'incrementalBetweenScanMode' = 'changelog');"""
-            
+
+            order_qt_snapshot_id_0_0_empty """select * from paimon_incr@incr('startSnapshotId'=0, 'endSnapshotId'=0)"""
+            order_qt_snapshot_id_0_1 """select * from paimon_incr@incr('startSnapshotId'=0, 'endSnapshotId'=1)"""
+            order_qt_snapshot_id_1_1_empty """select * from paimon_incr@incr('startSnapshotId'=1, 'endSnapshotId'=1)"""
 
             // complex query
             qt_cte """with cte1 as (select * from paimon_incr@incr('startTimestamp'=0)) select name, age from cte1 order by age;"""
@@ -85,16 +88,16 @@ suite("test_paimon_incr_read", "p0,external,doris,external_docker,external_docke
                 exception "incrementalBetweenScanMode must be one of"
             }
             test {
-                sql """select * from paimon_incr@incr('startSnapshotId'=1, 'endSnapshotId'=1)"""
-                exception "startSnapshotId must be less than endSnapshotId"
-            }
-            test {
                 sql """select * from paimon_incr@incr('startSnapshotId'=1)"""
                 exception "endSnapshotId is required when using snapshot-based incremental read"
             }
             test {
                 sql """select * from paimon_incr@incr('startSnapshotId'=1, 'endSnapshotId'=2) for version as of 1"""
                 exception "should not spec both snapshot and scan params"
+            }
+            test {
+                sql """select * from paimon_incr@incr('startSnapshotId'=-1)"""
+                exception "startSnapshotId must be greater than or equal to 0"
             }
         }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
When a Paimon table has only 1 snapshot, users cannot perform incremental queries. The validation logic in Doris has two issues:

1. It rejects queries where `startSnapshotId = endSnapshotId`:
```sql
SELECT * FROM tb_simple@incr('startSnapshotId'='1', 'endSnapshotId'='1');
-- Error: startSnapshotId must be less than endSnapshotId
```

2. It rejects queries where `startSnapshotId = 0` (which is needed to query all data from a single snapshot):
```sql
SELECT * FROM tb_simple@incr('startSnapshotId'='0', 'endSnapshotId'='1');
-- Error: startSnapshotId must be greater than 0
```

This behavior is inconsistent with Spark Paimon, which:
- Allows `startSnapshotId = endSnapshotId` (returns empty result)
- Allows `startSnapshotId = 0` to query all data from the initial state to the specified snapshot

## Solution

Align Doris incremental query behavior with Spark Paimon:

1. **Allow `startSnapshotId = 0`**: This enables querying all data from a single snapshot by using `startSnapshotId=0, endSnapshotId=1`
2. **Allow `startSnapshotId = endSnapshotId`**: This matches Spark Paimon behavior (returns empty result when querying the same snapshot)
3. **Update validation**: Allow `startSnapshotId >= 0` and `endSnapshotId >= 0` (previously `> 0`)

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

