### PR TITLE
[fix](mtmv) Fix sync materialized view use wrong check method when in the same regression test database

### DIFF
--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/case_ignore.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/case_ignore.groovy
@@ -18,6 +18,9 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("case_ignore") {
+
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO, so set NOT_IN_RBO explicitly
     sql "set pre_materialized_view_rewrite_strategy = NOT_IN_RBO"
     sql """ DROP TABLE IF EXISTS case_ignore; """
@@ -38,9 +41,7 @@ suite ("case_ignore") {
     sql "insert into case_ignore select 2,2,2,'b';"
     sql "insert into case_ignore select 3,-3,null,'c';"
 
-
-    createMV ("create materialized view k12a as select K1 as a1,abs(K2) from case_ignore;")
-    sleep(3000)
+    create_sync_mv(db, "case_ignore", "k12a", "select K1 as a1,abs(K2) from case_ignore;")
 
     sql "insert into case_ignore select -4,-4,-4,'d';"
     sql "SET experimental_enable_nereids_planner=true"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_gb_mv_abs.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_gb_mv_abs.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("dup_gb_mv_abs") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO, so set NOT_IN_RBO explicitly
     sql "set pre_materialized_view_rewrite_strategy = NOT_IN_RBO"
     sql """ DROP TABLE IF EXISTS dup_gb_mv_abs; """
@@ -38,8 +40,7 @@ suite ("dup_gb_mv_abs") {
     sql "insert into dup_gb_mv_abs select 2,2,2,'b';"
     sql "insert into dup_gb_mv_abs select 3,-3,null,'c';"
 
-    createMV ("create materialized view k12sa as select k1 as a1,sum(abs(k2)) from dup_gb_mv_abs group by k1;")
-    sleep(3000)
+    create_sync_mv(db, "dup_gb_mv_abs", "k12sa", "select k1 as a1,sum(abs(k2)) from dup_gb_mv_abs group by k1;")
 
     sql "insert into dup_gb_mv_abs select -4,-4,-4,'d';"
 

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_gb_mv_plus.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_gb_mv_plus.groovy
@@ -18,6 +18,9 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("dup_gb_mv_plus") {
+
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO, so set NOT_IN_RBO explicitly
     sql "set pre_materialized_view_rewrite_strategy = NOT_IN_RBO"
     sql """ DROP TABLE IF EXISTS dup_gb_mv_plus; """
@@ -38,8 +41,7 @@ suite ("dup_gb_mv_plus") {
     sql "insert into dup_gb_mv_plus select 2,2,2,'b';"
     sql "insert into dup_gb_mv_plus select 3,-3,null,'c';"
 
-    createMV( "create materialized view k12sp as select k1 as a1,sum(k2+1) from dup_gb_mv_plus group by k1;")
-    sleep(3000)
+    create_sync_mv(db, "dup_gb_mv_plus", "k12sp", "select k1 as a1,sum(k2+1) from dup_gb_mv_plus group by k1;")
 
     sql "insert into dup_gb_mv_plus select -4,-4,-4,'d';"
 

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_abs.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_abs.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("dup_mv_abs") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO, so set NOT_IN_RBO explicitly
     sql "set pre_materialized_view_rewrite_strategy = NOT_IN_RBO"
     sql """ DROP TABLE IF EXISTS dup_mv_abs; """
@@ -37,8 +39,7 @@ suite ("dup_mv_abs") {
     sql "insert into dup_mv_abs select 2,2,2,'b';"
     sql "insert into dup_mv_abs select 3,-3,null,'c';"
 
-    createMV ("create materialized view k12a as select k1 as a1,abs(k2) from dup_mv_abs;")
-    sleep(3000)
+    create_sync_mv(db, "dup_mv_abs", "k12a", "select k1 as a1,abs(k2) from dup_mv_abs;")
 
     sql "insert into dup_mv_abs select -4,-4,-4,'d';"
 

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_bin.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_bin.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("dup_mv_bin") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO, so set NOT_IN_RBO explicitly
     sql "set pre_materialized_view_rewrite_strategy = NOT_IN_RBO"
     sql """ DROP TABLE IF EXISTS dup_mv_bin; """
@@ -38,8 +40,7 @@ suite ("dup_mv_bin") {
     sql "insert into dup_mv_bin select 2,2,2,'b';"
     sql "insert into dup_mv_bin select 3,-3,null,'c';"
 
-    createMV( "create materialized view k12b as select k1 as a1,bin(k2) from dup_mv_bin;")
-    sleep(3000)
+    create_sync_mv(db, "dup_mv_bin", "k12b", "select k1 as a1,bin(k2) from dup_mv_bin;")
 
     sql "insert into dup_mv_bin select -4,-4,-4,'d';"
 

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_bm_hash.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_bm_hash.groovy
@@ -16,6 +16,8 @@
 // under the License.
 
 suite ("dup_mv_bm_hash") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO, so set NOT_IN_RBO explicitly
     sql "set pre_materialized_view_rewrite_strategy = NOT_IN_RBO"
     sql """ DROP TABLE IF EXISTS dup_mv_bm_hash; """
@@ -35,7 +37,7 @@ suite ("dup_mv_bm_hash") {
     sql "insert into dup_mv_bm_hash select 2,2,'b';"
     sql "insert into dup_mv_bm_hash select 3,3,'c';"
 
-    createMV( "create materialized view dup_mv_bm_hash_mv1 as select k1 as a1,bitmap_union(to_bitmap(k2)) as a2 from dup_mv_bm_hash group by k1;")
+    create_sync_mv(db, "dup_mv_bm_hash", "dup_mv_bm_hash_mv1", "select k1 as a1,bitmap_union(to_bitmap(k2)) as a2 from dup_mv_bm_hash group by k1;")
 
     sql "SET experimental_enable_nereids_planner=true"
     sql "SET enable_fallback_to_original_planner=false"
@@ -51,7 +53,7 @@ suite ("dup_mv_bm_hash") {
     sql """set enable_stats=true;"""
     mv_rewrite_success("select bitmap_union_count(to_bitmap(k2)) from dup_mv_bm_hash group by k1 order by k1;", "dup_mv_bm_hash_mv1")
 
-    createMV("create materialized view dup_mv_bm_hash_mv2 as select k1 as a3,bitmap_union(bitmap_hash(k3)) as a4 from dup_mv_bm_hash group by k1;")
+    create_sync_mv(db, "dup_mv_bm_hash", "dup_mv_bm_hash_mv2", "select k1 as a3,bitmap_union(bitmap_hash(k3)) as a4 from dup_mv_bm_hash group by k1;")
 
     sql "insert into dup_mv_bm_hash select 2,2,'bb';"
     sql "insert into dup_mv_bm_hash select 3,3,'c';"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_plus.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_plus.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("dup_mv_plus") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO, so set NOT_IN_RBO explicitly
     sql "set pre_materialized_view_rewrite_strategy = NOT_IN_RBO"
     sql """ DROP TABLE IF EXISTS dup_mv_plus; """
@@ -38,8 +40,7 @@ suite ("dup_mv_plus") {
     sql "insert into dup_mv_plus select 2,2,2,'b';"
     sql "insert into dup_mv_plus select 3,-3,null,'c';"
 
-    createMV ("create materialized view k12p as select k1 as a1,k2+1 from dup_mv_plus;")
-    sleep(3000)
+    create_sync_mv(db, "dup_mv_plus", "k12p", "select k1 as a1,k2+1 from dup_mv_plus;")
 
     sql "insert into dup_mv_plus select -4,-4,-4,'d';"
     sql "SET experimental_enable_nereids_planner=true"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_year.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_year.groovy
@@ -16,6 +16,8 @@
 // under the License.
 
 suite ("dup_mv_year") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO, so set NOT_IN_RBO explicitly
     sql "set pre_materialized_view_rewrite_strategy = NOT_IN_RBO"
     sql """ DROP TABLE IF EXISTS dup_mv_year; """
@@ -51,7 +53,7 @@ suite ("dup_mv_year") {
     sql """set enable_stats=true;"""
     mv_rewrite_success("select k1,year(k2) from dup_mv_year order by k1;", "k12y")
 
-    createMV "create materialized view k13y as select k1 as a3,year(k3) as a4 from dup_mv_year;"
+    create_sync_mv(db, "dup_mv_year", "k13y", "select k1 as a3,year(k3) as a4 from dup_mv_year;")
 
     sql "insert into dup_mv_year select 4,'2033-12-31','2033-12-31 01:02:03';"
     Thread.sleep(1000)

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot1.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot1.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("multi_slot1") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO, so set NOT_IN_RBO explicitly
     sql "set pre_materialized_view_rewrite_strategy = NOT_IN_RBO"
     sql """ DROP TABLE IF EXISTS multi_slot1; """
@@ -38,8 +40,7 @@ suite ("multi_slot1") {
     sql "insert into multi_slot1 select 2,2,2,'b';"
     sql "insert into multi_slot1 select 3,-3,null,'c';"
 
-    createMV ("create materialized view k1a2p2ap3p as select abs(k1)+k2+1 as a1,abs(k2+2)+k3+3 as a2 from multi_slot1;")
-    sleep(3000)
+    create_sync_mv(db, "multi_slot1", "k1a2p2ap3p", "select abs(k1)+k2+1 as a1,abs(k2+2)+k3+3 as a2 from multi_slot1;")
 
     sql "insert into multi_slot1 select -4,-4,-4,'d';"
     sql "SET experimental_enable_nereids_planner=true"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot2.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot2.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("multi_slot2") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO, so set NOT_IN_RBO explicitly
     sql "set pre_materialized_view_rewrite_strategy = NOT_IN_RBO"
     sql """ DROP TABLE IF EXISTS multi_slot2; """
@@ -46,9 +48,8 @@ suite ("multi_slot2") {
     }
     assertTrue(createFail);
 
-    createMV ("create materialized view k1a2p2ap3ps as select abs(k1)+k2+1 as a3,sum(abs(k2+2)+k3+3) as a4 from multi_slot2 group by abs(k1)+k2+1;")
+    create_sync_mv(db, "multi_slot2", "k1a2p2ap3ps", "select abs(k1)+k2+1 as a3,sum(abs(k2+2)+k3+3) as a4 from multi_slot2 group by abs(k1)+k2+1;")
 
-    sleep(3000)
     sql "insert into multi_slot2 select -4,-4,-4,'d';"
     sql "SET experimental_enable_nereids_planner=true"
     sql "SET enable_fallback_to_original_planner=false"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot3.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot3.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("multi_slot3") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO, so set NOT_IN_RBO explicitly
     sql "set pre_materialized_view_rewrite_strategy = NOT_IN_RBO"
     sql """ DROP TABLE IF EXISTS multi_slot3; """
@@ -38,9 +40,7 @@ suite ("multi_slot3") {
     sql "insert into multi_slot3 select 2,2,2,'b';"
     sql "insert into multi_slot3 select 3,-3,null,'c';"
 
-    createMV ("create materialized view k1p2ap3p as select k1+1,abs(k2+2)+k3+3 from multi_slot3;")
-
-    sleep(3000)
+    create_sync_mv(db, "multi_slot3", "k1p2ap3p", "select k1+1,abs(k2+2)+k3+3 from multi_slot3;")
 
     sql "insert into multi_slot3 select -4,-4,-4,'d';"
     sql "SET experimental_enable_nereids_planner=true"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot4.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot4.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("multi_slot4") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO, so set NOT_IN_RBO explicitly
     sql "set pre_materialized_view_rewrite_strategy = NOT_IN_RBO"
     sql """ DROP TABLE IF EXISTS multi_slot4; """
@@ -45,9 +47,7 @@ suite ("multi_slot4") {
     sql "insert into multi_slot4 select 3,-3,null,'c';"
     sql "insert into multi_slot4 select 3,-3,null,'c';"
 
-    createMV ("create materialized view k1p2ap3ps as select k1+1,sum(abs(k2+2)+k3+3) from multi_slot4 group by k1+1;")
-
-    sleep(3000)
+    create_sync_mv(db, "multi_slot4", "k1p2ap3ps", "select k1+1,sum(abs(k2+2)+k3+3) from multi_slot4 group by k1+1;")
 
     sql "insert into multi_slot4 select -4,-4,-4,'d';"
     sql "insert into multi_slot4 select -4,-4,-4,'d';"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot5.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot5.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("multi_slot5") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO, so set NOT_IN_RBO explicitly
     sql "set pre_materialized_view_rewrite_strategy = NOT_IN_RBO"
     sql """ DROP TABLE IF EXISTS multi_slot5; """
@@ -38,9 +40,7 @@ suite ("multi_slot5") {
     sql "insert into multi_slot5 select 2,2,2,'b';"
     sql "insert into multi_slot5 select 3,-3,null,'c';"
 
-    createMV ("create materialized view k123p as select k1 as a1,k2+k3 from multi_slot5;")
-
-    sleep(3000)
+    create_sync_mv(db, "multi_slot5", "k123p", "select k1 as a1,k2+k3 from multi_slot5;")
 
     sql "insert into multi_slot5 select -4,-4,-4,'d';"
     sql "insert into multi_slot5 select 3,-3,null,'c';"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot6.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot6.groovy
@@ -16,6 +16,8 @@
 // under the License.
 
 suite ("multi_slot6") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql """ DROP TABLE IF EXISTS multi_slot6; """
@@ -36,9 +38,9 @@ suite ("multi_slot6") {
     sql "insert into multi_slot6 select 2,2,2,'b';"
     sql "insert into multi_slot6 select 3,-3,null,'c';"
 
-    createMV ("create materialized view k1a2p2ap3p as select abs(k1)+k2+1,abs(k2+2)+k3+3 from multi_slot6;")
+    create_sync_mv(db, "multi_slot6", "k1a2p2ap3p", "select abs(k1)+k2+1,abs(k2+2)+k3+3 from multi_slot6;")
 
-    createMV("create materialized view k1a2p2ap3ps as select abs(k1)+k2+1 as a1,sum(abs(k2+2)+k3+3) as a2 from multi_slot6 group by abs(k1)+k2+1;")
+    create_sync_mv(db, "multi_slot6", "k1a2p2ap3ps", "select abs(k1)+k2+1 as a3,sum(abs(k2+2)+k3+3) as a4 from multi_slot6 group by abs(k1)+k2+1;")
 
     sql "insert into multi_slot6 select -4,-4,-4,'d';"
 

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/mv_with_view.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/mv_with_view.groovy
@@ -18,7 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("mv_with_view") {
-
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO, so set NOT_IN_RBO explicitly
     sql "set pre_materialized_view_rewrite_strategy = NOT_IN_RBO"
     sql """ DROP TABLE IF EXISTS d_table; """
@@ -38,7 +39,7 @@ suite ("mv_with_view") {
     sql """insert into d_table select 1,1,1,'a';"""
     sql """insert into d_table select 2,2,2,'b';"""
 
-    createMV("create materialized view k312 as select k3 as a1,k1 as a2,k2 as a3 from d_table;")
+    create_sync_mv(db, "d_table", "k312", "select k3 as a1,k1 as a2,k2 as a3 from d_table;")
 
     sql """insert into d_table select 3,-3,null,'c';"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/rollback1.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/rollback1.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("rollback1") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO, so set NOT_IN_RBO explicitly
     sql "set pre_materialized_view_rewrite_strategy = NOT_IN_RBO"
     sql """ DROP TABLE IF EXISTS rollback1; """
@@ -38,9 +40,7 @@ suite ("rollback1") {
     sql "insert into rollback1 select 2,2,2,'b';"
     sql "insert into rollback1 select 3,-3,null,'c';"
 
-    createMV("create materialized view k123p as select k1 as a1,k2+k3 from rollback1;")
-
-    sleep(3000)
+    create_sync_mv(db, "rollback1", "k123p_2", "select k1 as a1,k2+k3 from rollback1;")
 
     sql "insert into rollback1 select -4,-4,-4,'d';"
     sql "SET experimental_enable_nereids_planner=true"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/single_slot.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/single_slot.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("single_slot") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql """ DROP TABLE IF EXISTS single_slot; """
@@ -38,9 +40,7 @@ suite ("single_slot") {
     sql "insert into single_slot select 1,3,2,'b';"
     sql "insert into single_slot select 2,5,null,'c';"
 
-    createMV("create materialized view k1ap2spa as select abs(k1)+1,sum(abs(k2+1)) from single_slot group by abs(k1)+1;")
-
-    sleep(3000)
+    create_sync_mv(db, "single_slot", "k1ap2spa", "select abs(k1)+1 t,sum(abs(k2+1)) from single_slot group by abs(k1)+1;")
 
     sql "insert into single_slot select 2,-4,-4,'d';"
 

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/sum_devide_count.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/sum_devide_count.groovy
@@ -16,6 +16,8 @@
 // under the License.
 
 suite ("sum_devide_count") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql """ DROP TABLE IF EXISTS sum_devide_count; """
@@ -48,9 +50,7 @@ suite ("sum_devide_count") {
     sql "SET experimental_enable_nereids_planner=true"
     sql "SET enable_fallback_to_original_planner=false"
 
-    createMV ("create materialized view kavg as select k1 as a1,k4 as a2,sum(k2),count(k2) from sum_devide_count group by k1,k4;")
-
-    sleep(3000)
+    create_sync_mv(db, "sum_devide_count", "kavg", "select k1 as a1,k4 as a2,sum(k2),count(k2) from sum_devide_count group by k1,k4;")
 
     sql "insert into sum_devide_count select -4,-4,-4,'d';"
     sql "insert into sum_devide_count select -4,-4,-4,'d';"

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/unique_mv.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/unique_mv.groovy
@@ -16,6 +16,8 @@
 // under the License.
 
 suite ("unique_mv") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql """set enable_nereids_planner=true;"""
@@ -40,7 +42,7 @@ suite ("unique_mv") {
             );
         """
 
-    createMV("""create materialized view mv_1 as select call_uuid as a1,org_id as a2,call_time as a3,id as a4,campaign_id as a5,aa as a6 from c5816_t""")
+    create_sync_mv(db, "c5816_t", "mv_1", "select call_uuid as a1,org_id as a2,call_time as a3,id as a4,campaign_id as a5,aa as a6 from c5816_t;")
     sql """insert into c5816_t values (1,2,"2023-11-20 00:00:00",4,"adc",12);"""
 
     sql "analyze table c5816_t with sync;"

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/MVMultiUsage.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/MVMultiUsage.groovy
@@ -18,6 +18,7 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("MVMultiUsage") {
+
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql "SET experimental_enable_nereids_planner=true"

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/MVWithAs.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/MVWithAs.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("MVWithAs") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql "SET experimental_enable_nereids_planner=true"
@@ -40,9 +42,7 @@ suite ("MVWithAs") {
     sql """insert into MVWithAs values("2020-01-02",2,"b",2);"""
     sql """insert into MVWithAs values("2020-01-02",2,"b",2);"""
 
-    createMV("create materialized view MVWithAs_mv as select user_id as a1, count(tag_id) from MVWithAs group by user_id;")
-
-    sleep(3000)
+    create_sync_mv(db, "MVWithAs", "MVWithAs_mv", "select user_id as a1, count(tag_id) from MVWithAs group by user_id;")
 
     sql """insert into MVWithAs values("2020-01-01",1,"a",1);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggMVCalcAggFun.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggMVCalcAggFun.groovy
@@ -19,6 +19,8 @@ import org.codehaus.groovy.runtime.IOGroovyMethods
 
 // testAggregateMVCalcAggFunctionQuery
 suite ("aggMVCalcAggFun") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql "SET experimental_enable_nereids_planner=true"
@@ -40,9 +42,7 @@ suite ("aggMVCalcAggFun") {
     sql """insert into aggMVCalcAggFun values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into aggMVCalcAggFun values("2020-01-03",3,"c",3,3,3);"""
 
-    createMV("create materialized view aggMVCalcAggFunMv as select deptno as a1, empid as a2, sum(salary) from aggMVCalcAggFun group by empid, deptno;")
-
-    sleep(3000)
+    create_sync_mv(db, "aggMVCalcAggFun", "aggMVCalcAggFunMv", "select deptno as a1, empid as a2, sum(salary) from aggMVCalcAggFun group by empid, deptno;")
 
     sql """insert into aggMVCalcAggFun values("2020-01-01",1,"a",1,1,1);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV1.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV1.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("aggOnAggMV1") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql "SET experimental_enable_nereids_planner=true"
@@ -46,9 +48,7 @@ suite ("aggOnAggMV1") {
     sql """insert into aggOnAggMV1 values("2020-01-03",3,"c",3,3,3);"""
 
 
-    createMV("create materialized view aggOnAggMV1_mv as select deptno as a1, sum(salary), max(commission) from aggOnAggMV1 group by deptno ;")
-
-    sleep(3000)
+    create_sync_mv(db, "aggOnAggMV1", "aggOnAggMV1_mv", "select deptno as a1, sum(salary), max(commission) from aggOnAggMV1 group by deptno;")
 
     sql """insert into aggOnAggMV1 values("2020-01-01",1,"a",1,1,1);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV10.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV10.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("aggOnAggMV10") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql "SET experimental_enable_nereids_planner=true"

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV11.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV11.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("aggOnAggMV11") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql "SET experimental_enable_nereids_planner=true"
@@ -43,9 +45,7 @@ suite ("aggOnAggMV11") {
     sql """insert into aggOnAggMV11 values("2020-01-03",3,"c",3,3,3);"""
     sql """insert into aggOnAggMV11 values("2020-01-03",3,"c",3,3,3);"""
 
-    createMV("create materialized view aggOnAggMV11_mv as select deptno as a1, count(salary) from aggOnAggMV11 group by deptno;")
-
-    sleep(3000)
+    create_sync_mv(db, "aggOnAggMV11", "aggOnAggMV11_mv", "select deptno as a1, count(salary) from aggOnAggMV11 group by deptno;")
 
     sql """insert into aggOnAggMV11 values("2020-01-01",1,"a",1,1,1);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV2.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV2.groovy
@@ -16,6 +16,8 @@
 // under the License.
 
 suite ("aggOnAggMV2") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql "SET experimental_enable_nereids_planner=true"
@@ -48,9 +50,7 @@ suite ("aggOnAggMV2") {
     }
     order_qt_select_emps_mv "select deptno, sum(salary) from aggOnAggMV2 group by deptno order by deptno;"
 
-    createMV("create materialized view aggOnAggMV2_mv as select deptno as x1, sum(salary) from aggOnAggMV2 group by deptno ;")
-
-    sleep(3000)
+    create_sync_mv(db, "aggOnAggMV2", "aggOnAggMV2_mv", "select deptno as x1, sum(salary) from aggOnAggMV2 group by deptno ;")
  
     sql "analyze table aggOnAggMV2 with sync;"
     sql """alter table aggOnAggMV2 modify column time_col set stats ('row_count'='8');"""

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV3.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV3.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("aggOnAggMV3") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql "SET experimental_enable_nereids_planner=true"
@@ -46,9 +48,7 @@ suite ("aggOnAggMV3") {
 
 
 
-    createMV("create materialized view aggOnAggMV3_mv as select deptno as a1, commission as a2, sum(salary) from aggOnAggMV3 group by deptno, commission ;")
-
-    sleep(3000)
+    create_sync_mv(db, "aggOnAggMV3", "aggOnAggMV3_mv", "select deptno as a1, commission as a2, sum(salary) from aggOnAggMV3 group by deptno, commission ;")
 
     sql "analyze table aggOnAggMV3 with sync;"
     sql """alter table aggOnAggMV3 modify column time_col set stats ('row_count'='8');"""

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV5.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV5.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("aggOnAggMV5") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql "SET experimental_enable_nereids_planner=true"
@@ -44,8 +46,7 @@ suite ("aggOnAggMV5") {
     sql """insert into aggOnAggMV5 values("2020-01-03",3,"c",3,3,3);"""
     sql """insert into aggOnAggMV5 values("2020-01-03",3,"c",3,3,3);"""
 
-    createMV("create materialized view aggOnAggMV5_mv as select deptno as a1, commission as a2, sum(salary) from aggOnAggMV5 group by deptno, commission;")
-
+    create_sync_mv(db, "aggOnAggMV5", "aggOnAggMV5_mv", "select deptno as a1, commission as a2, sum(salary) from aggOnAggMV5 group by deptno, commission ;")
     sql """insert into aggOnAggMV5 values("2020-01-01",1,"a",1,1,1);"""
 
     sql "analyze table aggOnAggMV5 with sync;"

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV6.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV6.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("aggOnAggMV6") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql "SET experimental_enable_nereids_planner=true"
@@ -42,9 +44,7 @@ suite ("aggOnAggMV6") {
     sql """insert into aggOnAggMV6 values("2020-01-03",3,"c",3,3,3);"""
     sql """insert into aggOnAggMV6 values("2020-01-03",3,"c",3,3,3);"""
 
-    createMV("create materialized view aggOnAggMV6_mv as select deptno as a1, commission as a2, sum(salary) from aggOnAggMV6 group by deptno, commission;")
-
-    sleep(3000)
+    create_sync_mv(db, "aggOnAggMV6", "aggOnAggMV6_mv", "select deptno as a1, commission as a2, sum(salary) from aggOnAggMV6 group by deptno, commission ;")
 
     sql """insert into aggOnAggMV6 values("2020-01-01",1,"a",1,1,1);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV7.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV7.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("aggOnAggMV7") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql "SET experimental_enable_nereids_planner=true"
@@ -42,9 +44,7 @@ suite ("aggOnAggMV7") {
     sql """insert into aggOnAggMV7 values("2020-01-03",3,"c",3,3,3);"""
     sql """insert into aggOnAggMV7 values("2020-01-03",3,"c",3,3,3);"""
 
-    createMV("create materialized view aggOnAggMV7_mv as select deptno as a1, commission as a2, sum(salary) from aggOnAggMV7 group by deptno, commission;")
-
-    sleep(3000)
+    create_sync_mv(db, "aggOnAggMV7", "aggOnAggMV7_mv", "select deptno as a1, commission as a2, sum(salary) from aggOnAggMV7 group by deptno, commission ;")
 
     sql """insert into aggOnAggMV7 values("2020-01-01",1,"a",1,1,1);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/bitmapUnionIn.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/bitmapUnionIn.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("bitmapUnionIn") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql "SET experimental_enable_nereids_planner=true"
@@ -36,9 +38,7 @@ suite ("bitmapUnionIn") {
     sql """insert into bitmapUnionIn values("2020-01-01",1,"a",1);"""
     sql """insert into bitmapUnionIn values("2020-01-02",2,"b",2);"""
 
-    createMV("create materialized view bitmapUnionIn_mv as select user_id as a1, bitmap_union(to_bitmap(tag_id)) from bitmapUnionIn group by user_id;")
-
-    sleep(3000)
+    create_sync_mv(db, "bitmapUnionIn", "bitmapUnionIn_mv", "select user_id as a1, bitmap_union(to_bitmap(tag_id)) from bitmapUnionIn group by user_id;")
 
     sql """insert into bitmapUnionIn values("2020-01-01",1,"a",2);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/incMVReInSub.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/incMVReInSub.groovy
@@ -19,6 +19,8 @@ import org.codehaus.groovy.runtime.IOGroovyMethods
 
 // nereids_testIncorrectMVRewriteInSubquery
 suite ("incMVReInSub") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql "SET experimental_enable_nereids_planner=true"
@@ -37,9 +39,7 @@ suite ("incMVReInSub") {
     sql """insert into incMVReInSub values("2020-01-01",1,"a",1);"""
     sql """insert into incMVReInSub values("2020-01-02",2,"b",2);"""
 
-    createMV("create materialized view incMVReInSub_mv as select user_id as a1, bitmap_union(to_bitmap(tag_id)) from incMVReInSub group by user_id;")
-
-    sleep(3000)
+    create_sync_mv(db, "incMVReInSub", "incMVReInSub_mv", "select user_id as a1, bitmap_union(to_bitmap(tag_id)) from incMVReInSub group by user_id;")
 
     sql """insert into incMVReInSub values("2020-01-01",1,"a",2);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/joinOnCalcToJoin.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/joinOnCalcToJoin.groovy
@@ -17,6 +17,8 @@
 
 // nereids_testJoinOnLeftProjectToJoin
 suite ("joinOnCalcToJoin") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql "SET experimental_enable_nereids_planner=true"
@@ -53,11 +55,9 @@ suite ("joinOnCalcToJoin") {
     sql """insert into joinOnCalcToJoin_1 values("2020-01-03",3,"c",3);"""
     sql """insert into joinOnCalcToJoin_1 values("2020-01-02",2,"b",1);"""
 
+    create_sync_mv(db, "joinOnCalcToJoin", "joinOnLeftPToJoin_mv", "select empid as a1, deptno as a2 from joinOnCalcToJoin ;")
 
-    createMV("create materialized view joinOnLeftPToJoin_mv as select empid as a1, deptno as a2 from joinOnCalcToJoin;")
-    sleep(3000)
-    createMV("create materialized view joinOnLeftPToJoin_1_mv as select deptno as a3, cost as a4 from joinOnCalcToJoin_1;")
-    sleep(3000)
+    create_sync_mv(db, "joinOnCalcToJoin_1", "joinOnLeftPToJoin_1_mv", "select deptno as a3, cost as a4 from joinOnCalcToJoin_1 ;")
 
     sql "analyze table joinOnCalcToJoin with sync;"
     sql "analyze table joinOnCalcToJoin_1 with sync;"

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/joinOnLeftPToJoin.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/joinOnLeftPToJoin.groovy
@@ -17,6 +17,8 @@
 
 // nereids_testJoinOnLeftProjectToJoin
 suite ("joinOnLeftPToJoin") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql "SET experimental_enable_nereids_planner=true"
@@ -54,10 +56,9 @@ suite ("joinOnLeftPToJoin") {
     sql """insert into joinOnLeftPToJoin_1 values("2020-01-03",3,"c",3);"""
     sql """insert into joinOnLeftPToJoin_1 values("2020-01-02",2,"b",1);"""
 
-    createMV("create materialized view joinOnLeftPToJoin_mv as select deptno as a1, sum(salary) as a2, sum(commission) as a3 from joinOnLeftPToJoin group by deptno;")
-    sleep(3000)
-    createMV("create materialized view joinOnLeftPToJoin_1_mv as select deptno as a4, max(cost) as a5 from joinOnLeftPToJoin_1 group by deptno;")
-    sleep(3000)
+    create_sync_mv(db, "joinOnLeftPToJoin", "joinOnLeftPToJoin_mv", "select deptno as a1, sum(salary) as a2, sum(commission) as a3 from joinOnLeftPToJoin group by deptno;")
+
+    create_sync_mv(db, "joinOnLeftPToJoin_1", "joinOnLeftPToJoin_1_mv", "select deptno as a4, max(cost) as a5 from joinOnLeftPToJoin_1 group by deptno;")
 
     sql "analyze table joinOnLeftPToJoin with sync;"
     sql "analyze table joinOnLeftPToJoin_1 with sync;"

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/onStar.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/onStar.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("onStar") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql "SET experimental_enable_nereids_planner=true"
@@ -38,9 +40,7 @@ suite ("onStar") {
     sql """insert into onStar values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into onStar values("2020-01-02",2,"b",2,2,2);"""
 
-    createMV("create materialized view onStar_mv as select time_col as a1, deptno as a7,empid as a2, name as a3, salary as a4, commission as a5 from onStar order by time_col, deptno, empid;")
-
-    sleep(3000)
+    create_sync_mv(db, "onStar", "onStar_mv", "select time_col as a1, deptno as a7,empid as a2, name as a3, salary as a4, commission as a5 from onStar order by time_col, deptno, empid;")
 
     sql """insert into onStar values("2020-01-01",1,"a",1,1,1);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/onlyGroupBy.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/onlyGroupBy.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("onlyGroupBy") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql "SET experimental_enable_nereids_planner=true"
@@ -46,8 +48,7 @@ suite ("onlyGroupBy") {
     sql """insert into onlyGroupBy values("2020-01-03",3,"c",3,3,3);"""
     sql """insert into onlyGroupBy values("2020-01-03",3,"c",3,3,3);"""
 
-    createMV("create materialized view onlyGroupBy_mv as select deptno as a1, count(salary) from onlyGroupBy group by deptno;")
-
+    create_sync_mv(db, "onlyGroupBy", "onlyGroupBy_mv", "select deptno as a1, count(salary) from onlyGroupBy group by deptno;")
     sql """insert into onlyGroupBy values("2020-01-01",1,"a",1,1,1);"""
 
     sql "analyze table onlyGroupBy with sync;"

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/orderByOnPView.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/orderByOnPView.groovy
@@ -19,6 +19,8 @@ import org.codehaus.groovy.runtime.IOGroovyMethods
 
 // nereids_testOrderByQueryOnProjectView
 suite ("orderByOnPView") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql "SET experimental_enable_nereids_planner=true"
@@ -40,9 +42,7 @@ suite ("orderByOnPView") {
     sql """insert into orderByOnPView values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into orderByOnPView values("2020-01-03",3,"c",3,3,3);"""
 
-    createMV("create materialized view orderByOnPView_mv as select deptno as a1, empid as a2 from orderByOnPView;")
-
-    sleep(3000)
+    create_sync_mv(db, "orderByOnPView", "orderByOnPView_mv", "select deptno as a1, empid as a2 from orderByOnPView;")
 
     sql """insert into orderByOnPView values("2020-01-01",1,"a",1,1,1);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV1.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV1.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("projectMV1") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql "SET experimental_enable_nereids_planner=true"
@@ -41,9 +43,7 @@ suite ("projectMV1") {
     sql """insert into projectMV1 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into projectMV1 values("2020-01-02",2,"b",2,2,2);"""
 
-    createMV("create materialized view projectMV1_mv as select deptno as a1, empid as a2 from projectMV1 order by deptno;")
-
-    sleep(3000)
+    create_sync_mv(db, "projectMV1", "projectMV1_mv", "select deptno as a1, empid as a2 from projectMV1 order by deptno;")
 
     sql """insert into projectMV1 values("2020-01-01",1,"a",1,1,1);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV2.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV2.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("projectMV2") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
     sql "SET experimental_enable_nereids_planner=true"
@@ -39,9 +41,7 @@ suite ("projectMV2") {
     sql """insert into projectMV2 values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into projectMV2 values("2020-01-02",2,"b",2,2,2);"""
 
-    createMV("create materialized view projectMV2_mv as select deptno as a1, empid as a2 from projectMV2 order by deptno;")
-
-    sleep(3000)
+    create_sync_mv(db, "projectMV2", "projectMV2_mv", "select deptno as a1, empid as a2 from projectMV2 order by deptno;")
 
     sql """insert into projectMV2 values("2020-01-01",1,"a",1,1,1);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV3.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV3.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("projectMV3") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     sql "SET experimental_enable_nereids_planner=true"
     sql "SET enable_fallback_to_original_planner=false"
     sql """ DROP TABLE IF EXISTS projectMV3; """
@@ -42,8 +44,7 @@ suite ("projectMV3") {
     def result = "null"
 
     createMV("create materialized view projectMV3_mv as select deptno as a1, empid as a2, name as a3 from projectMV3 order by deptno;")
-
-    sleep(3000)
+    create_sync_mv(db, "projectMV3", "projectMV3_mv", "select deptno as a1, empid as a2, name as a3 from projectMV3 order by deptno;")
 
     sql """insert into projectMV3 values("2020-01-01",1,"a",1,1,1);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV4.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV4.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("projectMV4") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     sql "SET experimental_enable_nereids_planner=true"
     sql "SET enable_fallback_to_original_planner=false"
     sql """ DROP TABLE IF EXISTS projectMV4; """
@@ -41,9 +43,7 @@ suite ("projectMV4") {
 
     def result = "null"
 
-    createMV("create materialized view projectMV4_mv as select name as a1, deptno as a2, salary as a3 from projectMV4;")
-
-    sleep(3000)
+    create_sync_mv(db, "projectMV4", "projectMV4_mv", "select name as a1, deptno as a2, salary as a3 from projectMV4;")
 
     sql """insert into projectMV4 values("2020-01-01",1,"a",1,1,1);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/subQuery.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/subQuery.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("subQuery") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     sql "SET experimental_enable_nereids_planner=true"
     sql "SET enable_fallback_to_original_planner=false"
     sql """ DROP TABLE IF EXISTS subQuery; """
@@ -39,9 +41,7 @@ suite ("subQuery") {
     sql """insert into subQuery values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into subQuery values("2020-01-03",3,"c",3,3,3);"""
 
-    createMV("create materialized view subQuery_mv as select deptno as a1, empid as a2 from subQuery;")
-
-    sleep(3000)
+    create_sync_mv(db, "subQuery", "subQuery_mv", "select deptno as a1, empid as a2 from subQuery order by deptno;")
 
     sql """insert into subQuery values("2020-01-01",1,"a",1,1,1);"""
 

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/unionDis.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/unionDis.groovy
@@ -18,6 +18,8 @@
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite ("unionDis") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
     sql "SET experimental_enable_nereids_planner=true"
     sql "SET enable_fallback_to_original_planner=false"
     sql """ DROP TABLE IF EXISTS unionDis; """
@@ -39,9 +41,7 @@ suite ("unionDis") {
     sql """insert into unionDis values("2020-01-02",2,"b",2,2,2);"""
     sql """insert into unionDis values("2020-01-03",3,"c",3,3,3);"""
 
-    createMV("create materialized view unionDis_mv as select empid as a1, deptno as a2 from unionDis order by empid, deptno;")
-
-    sleep(3000)
+    create_sync_mv(db, "unionDis", "unionDis_mv", "select empid as a1, deptno as a2 from unionDis order by empid, deptno;")
 
     sql """insert into unionDis values("2020-01-01",1,"a",1,1,1);"""
 


### PR DESCRIPTION
### What problem does this PR solve?

The validation method for creating a synchronous materialized view uses the sleep method. If there are multiple synchronous materialized views in a database, this method is prone to failure. Modified to use `create_sync_mv`.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

