### PR TITLE
[fix](variable) fix unset global variable in non-master FE

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/UnsetVariableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/UnsetVariableCommand.java
@@ -33,6 +33,7 @@ import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.qe.VariableMgr;
+import org.apache.doris.qe.VariableMgr.VarContext;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -125,7 +126,12 @@ public class UnsetVariableCommand extends Command implements Forward {
             }
             SetVar var = new SetVar(SetType.SESSION, getVariable(),
                     new StringLiteral(defaultValue), SetVar.SetVarType.SET_SESSION_VAR);
-            VariableMgr.setVar(context.getSessionVariable(), var);
+            VarContext varCtx = VariableMgr.getVarContext(var.getVariable());
+            // only unset for session variable.
+            // If this is a global variable, no need to do this because it has been synced from editlog already.
+            if (varCtx != null && (varCtx.getFlag() & VariableMgr.SESSION) != 0) {
+                VariableMgr.setVar(context.getSessionVariable(), var);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -319,7 +319,7 @@ public class VariableMgr {
     }
 
     @Nullable
-    private static VarContext getVarContext(String name) {
+    public static VarContext getVarContext(String name) {
         String varName = name;
         boolean hasExpPrefix = false;
         if (varName.startsWith(VariableAnnotation.EXPERIMENTAL.getPrefix())) {
@@ -893,7 +893,7 @@ public class VariableMgr {
         boolean affectQueryResult() default false;
     }
 
-    private static class VarContext {
+    public static class VarContext {
         private Field field;
         private Object obj;
         private int flag;


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
When executing `unset global variable xxx` in non-master FE.
if `xxx` is a global variable, it will return error:
```
mysql> unset global variable enable_nested_namespace;
ERROR 1105 (HY000): errCode = 2, detailMessage = Variable 'enable_nested_namespace' is a GLOBAL variable and should be set with SET GLOBAL
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

