### PR TITLE
[Revert](exec) revert error change in pr55534 to keep the origin logic for index scan

### DIFF
--- a/be/src/olap/parallel_scanner_builder.h
+++ b/be/src/olap/parallel_scanner_builder.h
@@ -65,7 +65,7 @@ public:
 
     void set_min_rows_per_scanner(int64_t size) { _min_rows_per_scanner = size; }
 
-    void set_scan_parallelism_by_segment(bool v) { _scan_parallelism_by_segment = v; }
+    void set_scan_parallelism_by_per_segment(bool v) { _scan_parallelism_by_per_segment = v; }
 
     const OlapReaderStatistics* builder_stats() const { return &_builder_stats; }
 
@@ -75,7 +75,7 @@ private:
     Status _build_scanners_by_rowid(std::list<ScannerSPtr>& scanners);
 
     // Build scanners so that each segment is handled by its own scanner.
-    Status _build_scanners_by_segment(std::list<ScannerSPtr>& scanners);
+    Status _build_scanners_by_per_segment(std::list<ScannerSPtr>& scanners);
 
     std::shared_ptr<vectorized::OlapScanner> _build_scanner(
             BaseTabletSPtr tablet, int64_t version, const std::vector<OlapScanRange*>& key_ranges,
@@ -96,7 +96,7 @@ private:
     std::map<RowsetId, std::vector<size_t>> _all_segments_rows;
 
     // Force building one scanner per segment when true.
-    bool _scan_parallelism_by_segment {false};
+    bool _scan_parallelism_by_per_segment {false};
 
     std::shared_ptr<RuntimeProfile> _scanner_profile;
     OlapReaderStatistics _builder_stats;

--- a/be/src/pipeline/exec/olap_scan_operator.cpp
+++ b/be/src/pipeline/exec/olap_scan_operator.cpp
@@ -503,7 +503,7 @@ Status OlapScanLocalState::_init_scanners(std::list<vectorized::ScannerSPtr>* sc
             // TODO: Use optimize_index_scan_parallelism for ann range search in the future.
             // Currently, ann topn is enough
             if (_ann_topn_runtime != nullptr) {
-                scanner_builder.set_scan_parallelism_by_segment(true);
+                scanner_builder.set_scan_parallelism_by_per_segment(true);
             }
         }
 


### PR DESCRIPTION
### What problem does this PR solve?

The pr #55534 change scanner logic use by index scan cause perfermance problem. need revert the error change

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

