### PR TITLE
[improve](glue)Enforce HTTPS protocol for Glue endpoint

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/ParamRules.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/ParamRules.java
@@ -29,7 +29,7 @@ public class ParamRules {
     /**
      * Require that the given value is present (non-null and not empty).
      *
-     * @param value        the value to check
+     * @param value the value to check
      * @param errorMessage the error message to throw if validation fails
      * @return this ParamRules instance for chaining
      */
@@ -45,8 +45,8 @@ public class ParamRules {
     /**
      * Require that two parameters are mutually exclusive, i.e. both cannot be present at the same time.
      *
-     * @param value1       first value to check
-     * @param value2       second value to check
+     * @param value1 first value to check
+     * @param value2 second value to check
      * @param errorMessage error message to throw if both are present
      * @return this ParamRules instance for chaining
      */
@@ -63,9 +63,9 @@ public class ParamRules {
      * Require that the requiredValue is present if the conditionValue equals the expectedValue.
      *
      * @param conditionValue the value to compare
-     * @param expectedValue  the expected value for the condition
-     * @param requiredValue  the value required if condition matches
-     * @param errorMessage   error message to throw if requiredValue is missing
+     * @param expectedValue the expected value for the condition
+     * @param requiredValue the value required if condition matches
+     * @param errorMessage error message to throw if requiredValue is missing
      * @return this ParamRules instance for chaining
      */
     public ParamRules requireIf(String conditionValue, String expectedValue, String requiredValue,
@@ -82,9 +82,9 @@ public class ParamRules {
      * Require that the requiredValues are present if conditionValue is non-empty and equals expectedValue.
      *
      * @param conditionValue the value to check for presence and match
-     * @param expectedValue  the expected value to match against
+     * @param expectedValue the expected value to match against
      * @param requiredValues values that must be present if conditionValue matches expectedValue
-     * @param errorMessage   error message to throw if any required value is missing
+     * @param errorMessage error message to throw if any required value is missing
      * @return this ParamRules instance for chaining
      */
     public ParamRules requireIf(String conditionValue, String expectedValue, String[] requiredValues,
@@ -131,7 +131,7 @@ public class ParamRules {
      *
      * @param conditionValue the value whose presence triggers the requirement
      * @param requiredValues array of values all required if conditionValue is present
-     * @param errorMessage   error message to throw if any required value is missing
+     * @param errorMessage error message to throw if any required value is missing
      * @return this ParamRules instance for chaining
      */
     public ParamRules requireAllIfPresent(String conditionValue, String[] requiredValues, String errorMessage) {
@@ -150,10 +150,10 @@ public class ParamRules {
     /**
      * Require that if a is present and equals expectedValue, then none of the forbiddenValues may be present.
      *
-     * @param a               the condition value
-     * @param expectedValue   the expected value of a
+     * @param a the condition value
+     * @param expectedValue the expected value of a
      * @param forbiddenValues values that must not be present if a matches expectedValue
-     * @param errorMessage    the error message to throw if any forbiddenValue is present
+     * @param errorMessage the error message to throw if any forbiddenValue is present
      * @return this ParamRules instance for chaining
      */
     public ParamRules forbidIf(String a, String expectedValue, String[] forbiddenValues, String errorMessage) {
@@ -172,7 +172,7 @@ public class ParamRules {
     /**
      * Require that all values must either all exist or all be null/empty.
      *
-     * @param values       array of values to check
+     * @param values array of values to check
      * @param errorMessage error message if the requirement is violated
      * @return this ParamRules instance for chaining
      */
@@ -199,7 +199,7 @@ public class ParamRules {
     /**
      * Require that at least one value in the array is present (non-null and not empty).
      *
-     * @param values       array of values to check
+     * @param values array of values to check
      * @param errorMessage error message if none of the values are present
      * @return this ParamRules instance for chaining
      */
@@ -220,26 +220,17 @@ public class ParamRules {
     }
 
     /**
-     * A utility class for validating method parameters or any other values using a fluent API.
+     * Add a custom validation rule using a lambda expression.
      * <p>
-     * You can chain multiple validation rules together. If a rule fails, an
-     * {@link IllegalArgumentException} is thrown with the provided error message.
-     * <p>
-     * Supports built-in rules like {@link #require}, {@link #mutuallyExclusive}, etc.,
-     * and also allows custom lambda-based validations via {@link #check(BooleanSupplier, String)}.
-     * <p>
-     * <b>Example usage:</b>
-     * <pre>{@code
-     * ParamRules rules = new ParamRules();
+     * The validation rule will be executed when {@link #validate()} is called.
+     * If the condition evaluates to true, an {@link IllegalArgumentException} will be thrown
+     * with the provided error message.
      *
-     * String a = "foo";
-     * String b = "bar";
+     * @param condition a BooleanSupplier that returns true if validation should fail
+     * @param errorMessage the error message to throw if condition evaluates to true
+     * @return this ParamRules instance for chaining
      *
-     * rules.require(a, "a must not be empty")
-     *      .mutuallyExclusive(a, b, "a and b cannot both be present")
-     *      .check(() -> a.equals(b), "a and b cannot be equal") // custom lambda rule
-     *      .validate(); // executes all rules
-     * }</pre>
+     * @see #validate()
      */
     public ParamRules check(BooleanSupplier condition, String errorMessage) {
         rules.add(() -> {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/ParamRules.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/ParamRules.java
@@ -20,6 +20,7 @@ package org.apache.doris.datasource.property;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.BooleanSupplier;
 
 public class ParamRules {
 
@@ -28,7 +29,7 @@ public class ParamRules {
     /**
      * Require that the given value is present (non-null and not empty).
      *
-     * @param value the value to check
+     * @param value        the value to check
      * @param errorMessage the error message to throw if validation fails
      * @return this ParamRules instance for chaining
      */
@@ -44,8 +45,8 @@ public class ParamRules {
     /**
      * Require that two parameters are mutually exclusive, i.e. both cannot be present at the same time.
      *
-     * @param value1 first value to check
-     * @param value2 second value to check
+     * @param value1       first value to check
+     * @param value2       second value to check
      * @param errorMessage error message to throw if both are present
      * @return this ParamRules instance for chaining
      */
@@ -62,9 +63,9 @@ public class ParamRules {
      * Require that the requiredValue is present if the conditionValue equals the expectedValue.
      *
      * @param conditionValue the value to compare
-     * @param expectedValue the expected value for the condition
-     * @param requiredValue the value required if condition matches
-     * @param errorMessage error message to throw if requiredValue is missing
+     * @param expectedValue  the expected value for the condition
+     * @param requiredValue  the value required if condition matches
+     * @param errorMessage   error message to throw if requiredValue is missing
      * @return this ParamRules instance for chaining
      */
     public ParamRules requireIf(String conditionValue, String expectedValue, String requiredValue,
@@ -81,9 +82,9 @@ public class ParamRules {
      * Require that the requiredValues are present if conditionValue is non-empty and equals expectedValue.
      *
      * @param conditionValue the value to check for presence and match
-     * @param expectedValue the expected value to match against
+     * @param expectedValue  the expected value to match against
      * @param requiredValues values that must be present if conditionValue matches expectedValue
-     * @param errorMessage error message to throw if any required value is missing
+     * @param errorMessage   error message to throw if any required value is missing
      * @return this ParamRules instance for chaining
      */
     public ParamRules requireIf(String conditionValue, String expectedValue, String[] requiredValues,
@@ -130,7 +131,7 @@ public class ParamRules {
      *
      * @param conditionValue the value whose presence triggers the requirement
      * @param requiredValues array of values all required if conditionValue is present
-     * @param errorMessage error message to throw if any required value is missing
+     * @param errorMessage   error message to throw if any required value is missing
      * @return this ParamRules instance for chaining
      */
     public ParamRules requireAllIfPresent(String conditionValue, String[] requiredValues, String errorMessage) {
@@ -149,10 +150,10 @@ public class ParamRules {
     /**
      * Require that if a is present and equals expectedValue, then none of the forbiddenValues may be present.
      *
-     * @param a the condition value
-     * @param expectedValue the expected value of a
+     * @param a               the condition value
+     * @param expectedValue   the expected value of a
      * @param forbiddenValues values that must not be present if a matches expectedValue
-     * @param errorMessage the error message to throw if any forbiddenValue is present
+     * @param errorMessage    the error message to throw if any forbiddenValue is present
      * @return this ParamRules instance for chaining
      */
     public ParamRules forbidIf(String a, String expectedValue, String[] forbiddenValues, String errorMessage) {
@@ -171,7 +172,7 @@ public class ParamRules {
     /**
      * Require that all values must either all exist or all be null/empty.
      *
-     * @param values array of values to check
+     * @param values       array of values to check
      * @param errorMessage error message if the requirement is violated
      * @return this ParamRules instance for chaining
      */
@@ -198,7 +199,7 @@ public class ParamRules {
     /**
      * Require that at least one value in the array is present (non-null and not empty).
      *
-     * @param values array of values to check
+     * @param values       array of values to check
      * @param errorMessage error message if none of the values are present
      * @return this ParamRules instance for chaining
      */
@@ -212,6 +213,37 @@ public class ParamRules {
                 }
             }
             if (!anyPresent) {
+                throw new IllegalArgumentException(errorMessage);
+            }
+        });
+        return this;
+    }
+
+    /**
+     * A utility class for validating method parameters or any other values using a fluent API.
+     * <p>
+     * You can chain multiple validation rules together. If a rule fails, an
+     * {@link IllegalArgumentException} is thrown with the provided error message.
+     * <p>
+     * Supports built-in rules like {@link #require}, {@link #mutuallyExclusive}, etc.,
+     * and also allows custom lambda-based validations via {@link #check(BooleanSupplier, String)}.
+     * <p>
+     * <b>Example usage:</b>
+     * <pre>{@code
+     * ParamRules rules = new ParamRules();
+     *
+     * String a = "foo";
+     * String b = "bar";
+     *
+     * rules.require(a, "a must not be empty")
+     *      .mutuallyExclusive(a, b, "a and b cannot both be present")
+     *      .check(() -> a.equals(b), "a and b cannot be equal") // custom lambda rule
+     *      .validate(); // executes all rules
+     * }</pre>
+     */
+    public ParamRules check(BooleanSupplier condition, String errorMessage) {
+        rules.add(() -> {
+            if (condition.getAsBoolean()) {
                 throw new IllegalArgumentException(errorMessage);
             }
         });

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/AWSGlueMetaStoreBaseProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/AWSGlueMetaStoreBaseProperties.java
@@ -116,7 +116,9 @@ public class AWSGlueMetaStoreBaseProperties {
                         "glue.access_key and glue.secret_key must be set together")
                 .requireAtLeastOne(new String[]{glueAccessKey, glueIAMRole},
                         "At least one of glue.access_key or glue.role_arn must be set")
-                .require(glueEndpoint, "glue.endpoint must be set");
+                .require(glueEndpoint, "glue.endpoint must be set")
+                .check(() -> StringUtils.isNotBlank(glueEndpoint) && !glueEndpoint.startsWith("https://"),
+                        "glue.endpoint must use https protocol,please set glue.endpoint to https://...");
     }
 
     private void checkAndInit() {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/ParamRulesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/ParamRulesTest.java
@@ -147,4 +147,45 @@ public class ParamRulesTest {
                 );
         Assertions.assertDoesNotThrow(() -> rightRule3.validate());
     }
+
+    @Test
+    void testComplexLambdaValidation() {
+        String username = "alice";
+        String password = "";
+        String email = "alice@example.com";
+        int age = 17;
+        int maxAge = 100;
+
+        ParamRules rules = new ParamRules();
+
+        // Add multiple lambda rules
+        rules.check(() -> username == null || username.isEmpty(), "Username must not be empty")
+                .check(() -> password == null || password.length() < 6, "Password must be at least 6 characters")
+                .check(() -> !email.contains("@"), "Email must be valid")
+                .check(() -> age < 18 || age > maxAge, "Age must be between 18 and 100")
+                .check(() -> username.equals(email), "Username and email cannot be the same");
+        // Validate with prefix message
+        IllegalArgumentException ex = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> rules.validate("Validation Failed"));
+        // Check that the error message is prefixed
+        assert ex.getMessage().startsWith("Validation Failed: ");
+    }
+
+    @Test
+    void testComplexLambdaValidationSuccess() {
+        String username = "alice";
+        String password = "password123";
+        String email = "alice@example.com";
+        int age = 25;
+        int maxAge = 100;
+        ParamRules rules = new ParamRules();
+        // Should pass without exception
+        Assertions.assertDoesNotThrow(() -> {
+            rules.check(() -> username == null || username.isEmpty(), "Username must not be empty")
+                    .check(() -> password == null || password.length() < 6, "Password must be at least 6 characters")
+                    .check(() -> !email.contains("@"), "Email must be valid")
+                    .check(() -> age < 18 || age > maxAge, "Age must be between 18 and 100")
+                    .check(() -> username.equals(email), "Username and email cannot be the same");
+        });
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/AWSGlueMetaStoreBasePropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/AWSGlueMetaStoreBasePropertiesTest.java
@@ -28,7 +28,7 @@ public class AWSGlueMetaStoreBasePropertiesTest {
         Map<String, String> props = new HashMap<>();
         props.put("glue.access_key", "ak");
         props.put("glue.secret_key", "sk");
-        props.put("glue.endpoint", "glue.us-east-1.amazonaws.com");
+        props.put("glue.endpoint", "https://glue.us-east-1.amazonaws.com");
         return props;
     }
 
@@ -103,15 +103,28 @@ public class AWSGlueMetaStoreBasePropertiesTest {
     void testInvalidEndpoint() {
         Map<String, String> props = baseValidProps();
         props.put("glue.endpoint", "http://invalid-endpoint.com");
-        Assertions.assertDoesNotThrow(() -> AWSGlueMetaStoreBaseProperties.of(props));
+        IllegalArgumentException ex = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> AWSGlueMetaStoreBaseProperties.of(props)
+        );
+        Assertions.assertTrue(ex.getMessage().contains("glue.endpoint must use https protocol,please set glue.endpoint to https://..."));
+        props.put("glue.endpoint", "http://glue.us-east-1.amazonaws.com");
+        ex = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> AWSGlueMetaStoreBaseProperties.of(props)
+        );
+        Assertions.assertTrue(ex.getMessage().contains("glue.endpoint must use https protocol,please set glue.endpoint to https://..."));
     }
 
     @Test
     void testExtractRegionFailsWhenPatternMatchesButNoRegion() {
         Map<String, String> props = baseValidProps();
         props.put("glue.endpoint", "glue..amazonaws.com"); // malformed
-        Assertions.assertDoesNotThrow(() -> AWSGlueMetaStoreBaseProperties.of(props)
+        IllegalArgumentException ex = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> AWSGlueMetaStoreBaseProperties.of(props)
         );
+        Assertions.assertTrue(ex.getMessage().contains("glue.endpoint must use https protocol,please set glue.endpoint to https://..."));
     }
 
     @Test


### PR DESCRIPTION
FYI https://docs.aws.amazon.com/general/latest/gr/glue.html

This PR adds a validation to ensure that the Glue endpoint uses the HTTPS protocol.

- Adds a check for Glue endpoint URLs.
- Throws an IllegalArgumentException if the endpoint does not start with "https://".
- Error message: "glue.endpoint must use https protocol, please set glue.endpoint to https://"


None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

