### PR TITLE
[fix](file-cache) Fix warm up select missing privilege of blackhole table.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/WarmupSelectCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/WarmupSelectCommand.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.commands.insert.AbstractInsertExecutor.InsertExecutorListener;
@@ -213,5 +214,15 @@ public class WarmupSelectCommand extends InsertIntoTableCommand {
 
         ShowResultSet resultSet = new ShowResultSet(metaData, rows);
         executor.sendResultSet(resultSet);
+    }
+
+    /**
+     * Skip auth check for warmup select command.
+     * The blackhole table is a system table and doesn't require LOAD privilege.
+     * Nereids analyzer will check SELECT privilege on source tables.
+     */
+    @Override
+    protected boolean needAuthCheck(TableIf targetTableIf) {
+        return false;
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #54822

Problem Summary:

### Release note

Fix warm up select missing privilege of blackhole table.
```
ERROR 1105 (HY000) at line 1: errCode = 2, detailMessage = LOAD command denied to user 'xxx'@'xxx.xxx.xxx.xxx' for table 'information_schema.blackhole'
```


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

