### PR TITLE
[regression](filecache) Update eviction size assertion in TTL LRU test

### DIFF
--- a/regression-test/suites/cloud_p0/cache/ttl/test_ttl_lru_evict.groovy
+++ b/regression-test/suites/cloud_p0/cache/ttl/test_ttl_lru_evict.groovy
@@ -253,7 +253,7 @@ suite("test_ttl_lru_evict") {
     // sequentially, coz we don't know what other cases are
     // doing with TTL cache
     logger.info("ttl evict diff:" + (ttl_cache_evict_size_end - ttl_cache_evict_size_begin).toString())
-    assertTrue((ttl_cache_evict_size_end - ttl_cache_evict_size_begin) > 838860800)
+    assertTrue((ttl_cache_evict_size_end - ttl_cache_evict_size_begin) > 238860800)
 
     // then we test skip_cache count when doing query when ttl cache is full
     // we expect it to be rare


### PR DESCRIPTION
because the data loaded into doris are compressed, so the origin assertion of amount of data evict by overfill the cache would be to large for the compressed data.


