### PR TITLE
[fix](test) Try to fix possible -238 in test_non_overlap_seg_heavy_sc

### DIFF
--- a/regression-test/suites/schema_change_p0/test_non_overlap_seg_heavy_sc.groovy
+++ b/regression-test/suites/schema_change_p0/test_non_overlap_seg_heavy_sc.groovy
@@ -40,7 +40,7 @@ suite("test_non_overlap_seg_heavy_sc", "nonConcurrent") {
     GetDebugPoint().clearDebugPointsForAllBEs();
     GetDebugPoint().enableDebugPointForAllBEs("MemTable.need_flush");
     try {
-        sql """ INSERT INTO ${tblName} select number, number, number from numbers("number" = "3240960") """
+        sql """ INSERT INTO ${tblName} select number, number, number from numbers("number" = "1240960") """
 
         sql """ DELETE FROM ${tblName} WHERE v2 = 24 """
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Success Rate: 95.5% in test_non_overlap_seg_heavy_sc, the rest 0.05% fail because -238 may happend due to the large number of segment and not in time segcompaction. Try to reduce some segment, but not too much to ensure this case can trigger a certain path in vmerge iterator.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

