### PR TITLE
[fix](test)Validate database is empty before DROP DATABASE

### DIFF
--- a/regression-test/suites/external_table_p2/refactor_catalog_param/azure_blob_all_test.groovy
+++ b/regression-test/suites/external_table_p2/refactor_catalog_param/azure_blob_all_test.groovy
@@ -49,7 +49,7 @@ suite("azure_blob_all_test", "p2,external,new_catalog_property") {
         sql """ 
          switch ${iceberg_fs_catalog_name} 
          """
-        def db_name = "${iceberg_fs_catalog_name}_db_test"
+        def db_name = "${iceberg_fs_catalog_name}_db_test"+ ThreadLocalRandom.current().nextInt(100);
         // Check if database exists
         def currentDbResult = sql """
         SHOW DATABASES LIKE "${db_name}";

--- a/regression-test/suites/external_table_p2/refactor_catalog_param/azure_blob_all_test.groovy
+++ b/regression-test/suites/external_table_p2/refactor_catalog_param/azure_blob_all_test.groovy
@@ -35,6 +35,7 @@ suite("azure_blob_all_test", "p2,external,new_catalog_property") {
     
     def testIcebergTest = { String storage_props,String iceberg_fs_catalog_name, String protocol,String hdfsLocationType ->
         
+        iceberg_fs_catalog_name = iceberg_fs_catalog_name + "_" + ThreadLocalRandom.current().nextInt(100) 
         sql """
          drop catalog if exists ${iceberg_fs_catalog_name};
         """
@@ -46,34 +47,13 @@ suite("azure_blob_all_test", "p2,external,new_catalog_property") {
         ${storage_props}
         );
         """
+
         sql """ 
          switch ${iceberg_fs_catalog_name} 
-         """
-        def db_name = "${iceberg_fs_catalog_name}_db_test"+ ThreadLocalRandom.current().nextInt(100);
-        // Check if database exists
-        def currentDbResult = sql """
-        SHOW DATABASES LIKE "${db_name}";
-        """
-
-        if (currentDbResult.size() > 0) {
-            sql """
-            USE ${db_name};
             """
 
-            // Show all tables and drop them
-            def tablesResult = sql """
-            SHOW TABLES;
-            """
-
-            for (row in tablesResult) {
-                def tableName = row[0]
-                sql """
-                    DROP TABLE IF EXISTS ${tableName};
-                """
-            }
-        }
         sql """
-        drop database if exists ${iceberg_fs_catalog_name}_db_test;
+        drop database if exists ${iceberg_fs_catalog_name}_db_test force;
         """
         sql """
         create database ${iceberg_fs_catalog_name}_db_test;
@@ -97,7 +77,7 @@ suite("azure_blob_all_test", "p2,external,new_catalog_property") {
         drop table if exists ${iceberg_fs_catalog_name}_table_test;
     """
         sql """
-        drop database if exists ${iceberg_fs_catalog_name}_db_test;
+        drop database if exists ${iceberg_fs_catalog_name}_db_test force;
     """
         sql """
         drop catalog if exists ${iceberg_fs_catalog_name};

--- a/regression-test/suites/external_table_p2/refactor_catalog_param/azure_blob_all_test.groovy
+++ b/regression-test/suites/external_table_p2/refactor_catalog_param/azure_blob_all_test.groovy
@@ -46,11 +46,32 @@ suite("azure_blob_all_test", "p2,external,new_catalog_property") {
         ${storage_props}
         );
         """
-
         sql """ 
          switch ${iceberg_fs_catalog_name} 
+         """
+        def db_name = "${iceberg_fs_catalog_name}_db_test"
+        // Check if database exists
+        def currentDbResult = sql """
+        SHOW DATABASES LIKE "${db_name}";
+        """
+
+        if (currentDbResult.size() > 0) {
+            sql """
+            USE ${db_name};
             """
 
+            // Show all tables and drop them
+            def tablesResult = sql """
+            SHOW TABLES;
+            """
+
+            for (row in tablesResult) {
+                def tableName = row[0]
+                sql """
+                    DROP TABLE IF EXISTS ${tableName};
+                """
+            }
+        }
         sql """
         drop database if exists ${iceberg_fs_catalog_name}_db_test;
         """

--- a/regression-test/suites/external_table_p2/refactor_catalog_param/iceberg_on_hms_and_filesystem_and_dlf.groovy
+++ b/regression-test/suites/external_table_p2/refactor_catalog_param/iceberg_on_hms_and_filesystem_and_dlf.groovy
@@ -38,34 +38,14 @@ suite("iceberg_on_hms_and_filesystem_and_dlf", "p2,external,new_catalog_property
 
         def db_name = prefix + "_db"+ ThreadLocalRandom.current().nextInt(100);
         // Check if database exists
-        def currentDbResult = sql """
-        SHOW DATABASES LIKE "${db_name}";
-        """
-
-        if (currentDbResult.size() > 0) {
-            sql """
-            USE ${db_name};
-        """
-
-            // Show all tables and drop them
-            def tablesResult = sql """
-            SHOW TABLES;
-        """
-
-            for (row in tablesResult) {
-                def tableName = row[0]
-                sql """
-                    DROP TABLE IF EXISTS ${tableName};
-                """
-            }
-        }
         sql """
             DROP DATABASE IF EXISTS ${db_name} FORCE;
         """
         sql """
             CREATE DATABASE IF NOT EXISTS ${db_name};
         """
-        def  dbResult = sql """
+
+        def dbResult = sql """
             show databases  like "${db_name}";
         """
         assert dbResult.size() == 1

--- a/regression-test/suites/external_table_p2/refactor_catalog_param/iceberg_on_hms_and_filesystem_and_dlf.groovy
+++ b/regression-test/suites/external_table_p2/refactor_catalog_param/iceberg_on_hms_and_filesystem_and_dlf.groovy
@@ -14,6 +14,9 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
+import java.util.concurrent.ThreadLocalRandom
+
 import static groovy.test.GroovyAssert.shouldFail;
 suite("iceberg_on_hms_and_filesystem_and_dlf", "p2,external,new_catalog_property") {
 
@@ -33,7 +36,7 @@ suite("iceberg_on_hms_and_filesystem_and_dlf", "p2,external,new_catalog_property
             switch ${catalog_name};
         """
 
-        def db_name = prefix + "_db"
+        def db_name = prefix + "_db"+ ThreadLocalRandom.current().nextInt(100);
         // Check if database exists
         def currentDbResult = sql """
         SHOW DATABASES LIKE "${db_name}";


### PR DESCRIPTION
### What problem does this PR solve?
Previously, the test flow was:


- Drop databases
- Create database and tables
- Insert data
- Drop tables


However, the logic did not handle the case where dropping tables failed. As a result, when the test reran, the database could not be dropped because some tables were still present.


This update introduces a safety check:
Before dropping a database, the system now detects whether any tables exist under the DB. If so, it automatically drops all tables first, ensuring that DROP DATABASE always executes successfully in test scenarios.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

