### PR TITLE
[Chore](exchange) call add_rows with data and eos at once

### DIFF
--- a/be/src/pipeline/shuffle/writer.cpp
+++ b/be/src/pipeline/shuffle/writer.cpp
@@ -96,19 +96,11 @@ Status Writer::_channel_add_rows(RuntimeState* state,
     uint32_t offset = 0;
     for (size_t i = 0; i < partition_count; ++i) {
         uint32_t size = _partition_rows_histogram[i];
-        if (!channels[i]->is_receiver_eof() && size > 0) {
-            status = channels[i]->add_rows(block, _row_idx.data(), offset, size, false);
+        if (!channels[i]->is_receiver_eof() && (size > 0 || eos)) {
+            status = channels[i]->add_rows(block, _row_idx.data(), offset, size, eos);
             HANDLE_CHANNEL_STATUS(state, channels[i], status);
         }
         offset += size;
-    }
-    if (eos) {
-        for (int i = 0; i < partition_count; ++i) {
-            if (!channels[i]->is_receiver_eof()) {
-                status = channels[i]->add_rows(block, _row_idx.data(), 0, 0, true);
-                HANDLE_CHANNEL_STATUS(state, channels[i], status);
-            }
-        }
     }
     return Status::OK();
 }


### PR DESCRIPTION
### What problem does this PR solve?
This pull request simplifies the logic for handling end-of-stream (EOS) conditions in the `_channel_add_rows` method of the `Status Writer` class. The change ensures that EOS is processed together with regular row additions, removing redundant code and improving maintainability.

**Refactoring EOS handling:**

* The EOS logic is now integrated into the main loop, so channels receive EOS flags along with regular row additions, eliminating the need for a separate loop for EOS. (`be/src/pipeline/shuffle/writer.cpp`, [be/src/pipeline/shuffle/writer.cppL99-L112](diffhunk://#diff-907673827bb9b79f913966cf9a582f8dce272a622d8f1382bf8e297454955194L99-L112))

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

