### PR TITLE
[fix](nereids) pull up left join right predicate with or is null

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InferPredicateByReplace.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InferPredicateByReplace.java
@@ -29,6 +29,7 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.InPredicate;
 import org.apache.doris.nereids.trees.expressions.Like;
 import org.apache.doris.nereids.trees.expressions.Not;
+import org.apache.doris.nereids.trees.expressions.Or;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.functions.ExpressionTrait;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
@@ -122,6 +123,14 @@ public class InferPredicateByReplace {
             }
             for (Expression expr : getAllSubExpressions(like.child(0))) {
                 context.computeIfAbsent(expr, k -> new LinkedHashSet<>()).add(like);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitOr(Or or, Map<Expression, Set<Expression>> context) {
+            for (Expression expr : getAllSubExpressions(or)) {
+                context.computeIfAbsent(expr, k -> new LinkedHashSet<>()).add(or);
             }
             return null;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InferPredicates.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InferPredicates.java
@@ -253,7 +253,7 @@ public class InferPredicates extends DefaultPlanRewriter<JobContext> implements 
                     if (newOrChildren.size() == 1) {
                         predicates.add(withInferredIfSupported(newOrChildren.get(0), expr));
                     } else if (newOrChildren.size() > 1) {
-                        predicates.add(new Or(newOrChildren, true));
+                        predicates.add(ExpressionUtils.or(newOrChildren).withInferred(true));
                     }
                 } else {
                     predicates.add(expr);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpPredicates.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpPredicates.java
@@ -406,9 +406,7 @@ public class PullUpPredicates extends PlanVisitor<ImmutableSet<Expression>, Void
                     orChildren.add(new IsNull(slot));
                 }
             }
-            if (orChildren.isEmpty()) {
-                tolerant.add(predicate);
-            } else {
+            if (!orChildren.isEmpty()) {
                 List<Expression> expandedOr = new ArrayList<>(2);
                 expandedOr.add(predicate);
                 expandedOr.addAll(orChildren);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/CompoundPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/CompoundPredicate.java
@@ -37,7 +37,11 @@ public abstract class CompoundPredicate extends Expression implements ExpectsInp
     private String symbol;
 
     public CompoundPredicate(List<Expression> children, String symbol) {
-        super(children);
+        this(children, symbol, false);
+    }
+
+    public CompoundPredicate(List<Expression> children, String symbol, boolean inferred) {
+        super(children, inferred);
         this.symbol = symbol;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Or.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Or.java
@@ -36,20 +36,28 @@ public class Or extends CompoundPredicate {
      * @param right right child of comparison predicate
      */
     public Or(Expression left, Expression right) {
+        this(left, right, false);
+    }
+
+    public Or(Expression left, Expression right, boolean inferred) {
         this(ExpressionUtils.mergeList(
                 ExpressionUtils.extractDisjunction(left),
-                ExpressionUtils.extractDisjunction(right)));
+                ExpressionUtils.extractDisjunction(right)), inferred);
     }
 
     public Or(List<Expression> children) {
-        super(children, "OR");
+        this(children, false);
+    }
+
+    public Or(List<Expression> children, boolean inferred) {
+        super(children, "OR", inferred);
         Preconditions.checkArgument(children.size() >= 2);
     }
 
     @Override
     public Expression withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() >= 2);
-        return new Or(children);
+        return new Or(children, this.isInferred());
     }
 
     @Override
@@ -89,5 +97,10 @@ public class Or extends CompoundPredicate {
             }
         }
         return flattenChildren;
+    }
+
+    @Override
+    public Expression withInferred(boolean inferred) {
+        return new Or(children, inferred);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
@@ -354,7 +354,7 @@ public class LogicalAggregate<CHILD_TYPE extends Plan>
 
     public LogicalAggregate<Plan> withChildGroupByAndOutputAndSourceRepeat(List<Expression> groupByExprList,
                                                             List<NamedExpression> outputExpressionList, Plan newChild,
-                                                                           Optional<LogicalRepeat<?>> sourceRepeat) {
+                                                            Optional<LogicalRepeat<? extends Plan>> sourceRepeat) {
         return new LogicalAggregate<>(groupByExprList, outputExpressionList, normalized, ordinalIsResolved, generated,
                 hasPushed, withInProjection, sourceRepeat, Optional.empty(), Optional.empty(), newChild);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/InferPredicateByReplaceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/InferPredicateByReplaceTest.java
@@ -152,7 +152,7 @@ public class InferPredicateByReplaceTest {
         inputs.add(equalTo);
 
         Set<Expression> result = InferPredicateByReplace.infer(inputs);
-        Assertions.assertEquals(2, result.size());
+        Assertions.assertEquals(3, result.size());
     }
 
     @Test

--- a/regression-test/data/nereids_rules_p0/infer_predicate/extend_infer_equal_predicate.out
+++ b/regression-test/data/nereids_rules_p0/infer_predicate/extend_infer_equal_predicate.out
@@ -114,14 +114,16 @@ PhysicalResultSink
 --hashJoin[INNER_JOIN] hashCondition=((t1.a = t2.a)) otherCondition=()
 ----filter(OR[(t1.a < 2),(t1.a > 10)])
 ------PhysicalOlapScan[extend_infer_t3(t1)]
-----PhysicalOlapScan[extend_infer_t4(t2)]
+----filter(OR[(t2.a < 2),(t2.a > 10)])
+------PhysicalOlapScan[extend_infer_t4(t2)]
 
 -- !test_or2 --
 PhysicalResultSink
 --hashJoin[INNER_JOIN] hashCondition=((t1.a = t2.a)) otherCondition=()
 ----filter(OR[(t1.a < 2),(t1.a > 10)])
 ------PhysicalOlapScan[extend_infer_t3(t1)]
-----PhysicalOlapScan[extend_infer_t4(t2)]
+----filter(OR[(t2.a < 2),(t2.a > 10)])
+------PhysicalOlapScan[extend_infer_t4(t2)]
 
 -- !test_sign_predicate --
 PhysicalResultSink
@@ -771,4 +773,15 @@ PhysicalResultSink
 
 -- !pull_up_from_agg --
 0
+
+-- !leftjoin_right_pull_up_shape --
+PhysicalResultSink
+--hashJoin[LEFT_OUTER_JOIN] hashCondition=((t2.a = t3.a)) otherCondition=()
+----hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.a = t2.a)) otherCondition=()
+------filter((t1.a = 1))
+--------PhysicalOlapScan[extend_infer_t3(t1)]
+------filter((t2.a = 1))
+--------PhysicalOlapScan[extend_infer_t4(t2)]
+----filter((t3.a = 1))
+------PhysicalOlapScan[extend_infer_t5(t3)]
 

--- a/regression-test/data/nereids_rules_p0/infer_predicate/extend_infer_equal_predicate.out
+++ b/regression-test/data/nereids_rules_p0/infer_predicate/extend_infer_equal_predicate.out
@@ -774,7 +774,7 @@ PhysicalResultSink
 -- !pull_up_from_agg --
 0
 
--- !leftjoin_right_pull_up_shape --
+-- !qt_leftjoin_right_pull_up_shape_shape --
 PhysicalResultSink
 --hashJoin[LEFT_OUTER_JOIN] hashCondition=((t2.a = t3.a)) otherCondition=()
 ----hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.a = t2.a)) otherCondition=()
@@ -784,4 +784,106 @@ PhysicalResultSink
 --------PhysicalOlapScan[extend_infer_t4(t2)]
 ----filter((t3.a = 1))
 ------PhysicalOlapScan[extend_infer_t5(t3)]
+
+-- !qt_leftjoin_right_pull_up_shape_result --
+
+-- !qt_multi_leftjoin_right_pull_up_shape_shape --
+PhysicalResultSink
+--hashJoin[LEFT_OUTER_JOIN] hashCondition=((t2.a = t5.a)) otherCondition=()
+----hashJoin[LEFT_OUTER_JOIN] hashCondition=((t4.a = t3.a)) otherCondition=()
+------hashJoin[LEFT_OUTER_JOIN] hashCondition=((t2.a = t3.a)) otherCondition=()
+--------hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.a = t2.a)) otherCondition=()
+----------filter((t1.a = 1))
+------------PhysicalOlapScan[extend_infer_t3(t1)]
+----------filter((t2.a = 1))
+------------PhysicalOlapScan[extend_infer_t4(t2)]
+--------filter((t3.a = 1))
+----------PhysicalOlapScan[extend_infer_t5(t3)]
+------filter((t4.a = 1))
+--------PhysicalOlapScan[extend_infer_t5(t4)]
+----filter((t5.a = 1))
+------PhysicalOlapScan[extend_infer_t5(t5)]
+
+-- !qt_multi_leftjoin_right_pull_up_shape_result --
+
+-- !qt_leftjoin_right_pull_up_in_shape_shape --
+PhysicalResultSink
+--hashJoin[LEFT_OUTER_JOIN] hashCondition=((t2.a = t3.a)) otherCondition=()
+----hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.a = t2.a)) otherCondition=()
+------filter(a IN (1, 2))
+--------PhysicalOlapScan[extend_infer_t3(t1)]
+------filter(a IN (1, 2))
+--------PhysicalOlapScan[extend_infer_t4(t2)]
+----filter(a IN (1, 2))
+------PhysicalOlapScan[extend_infer_t5(t3)]
+
+-- !qt_leftjoin_right_pull_up_in_shape_result --
+
+-- !qt_leftjoin_right_pull_up_is_null_shape_shape --
+PhysicalResultSink
+--hashJoin[LEFT_OUTER_JOIN] hashCondition=((t2.a = t3.a)) otherCondition=()
+----hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.a = t2.a)) otherCondition=()
+------filter(a IS NULL)
+--------PhysicalOlapScan[extend_infer_t3(t1)]
+------PhysicalOlapScan[extend_infer_t4(t2)]
+----PhysicalOlapScan[extend_infer_t5(t3)]
+
+-- !qt_leftjoin_right_pull_up_is_null_shape_result --
+\N	\N	9	3	\N	\N	\N	\N	\N	\N	\N	\N
+\N	d2	3	55	\N	\N	\N	\N	\N	\N	\N	\N
+
+-- !qt_leftjoin_right_pull_up_is_not_null_shape_shape --
+PhysicalResultSink
+--hashJoin[LEFT_OUTER_JOIN] hashCondition=((t2.a = t3.a)) otherCondition=()
+----hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.a = t2.a)) otherCondition=()
+------filter(( not a IS NULL))
+--------PhysicalOlapScan[extend_infer_t3(t1)]
+------PhysicalOlapScan[extend_infer_t4(t2)]
+----PhysicalOlapScan[extend_infer_t5(t3)]
+
+-- !qt_leftjoin_right_pull_up_is_not_null_shape_result --
+0	d2	3	5	0	d2	2	2	\N	\N	\N	\N
+100	d2	3	5	100	d2	3	\N	\N	\N	\N	\N
+12	\N	9	3	\N	\N	\N	\N	\N	\N	\N	\N
+33	d2	2	5	33	d2	23	5	\N	\N	\N	\N
+78	\N	9	3	78	d2	23	5	\N	\N	\N	\N
+
+-- !qt_left_join_inner_shape --
+PhysicalResultSink
+--NestedLoopJoin[INNER_JOIN]
+----NestedLoopJoin[INNER_JOIN]
+------filter((t1.a = 1))
+--------PhysicalOlapScan[extend_infer_t3(t1)]
+------filter((t2.a = 1))
+--------PhysicalOlapScan[extend_infer_t4(t2)]
+----filter((t3.a = 1))
+------PhysicalOlapScan[extend_infer_t5(t3)]
+
+-- !qt_left_join_inner_result --
+
+-- !qt_left_join_semi_shape --
+PhysicalResultSink
+--NestedLoopJoin[LEFT_SEMI_JOIN]
+----NestedLoopJoin[INNER_JOIN]
+------filter((t1.a = 1))
+--------PhysicalOlapScan[extend_infer_t3(t1)]
+------filter((t2.a = 1))
+--------PhysicalOlapScan[extend_infer_t4(t2)]
+----filter((t3.a = 1))
+------PhysicalOlapScan[extend_infer_t5(t3)]
+
+-- !qt_left_join_semi_result --
+
+-- !qt_left_join_anti_shape --
+PhysicalResultSink
+--hashJoin[LEFT_ANTI_JOIN] hashCondition=((t2.a = t3.a)) otherCondition=()
+----hashJoin[LEFT_OUTER_JOIN] hashCondition=((t1.a = t2.a)) otherCondition=()
+------filter((t1.a = 1))
+--------PhysicalOlapScan[extend_infer_t3(t1)]
+------filter((t2.a = 1))
+--------PhysicalOlapScan[extend_infer_t4(t2)]
+----filter((t3.a = 1))
+------PhysicalOlapScan[extend_infer_t5(t3)]
+
+-- !qt_left_join_anti_result --
 

--- a/regression-test/data/nereids_rules_p0/infer_predicate/pull_up_predicate_agg.out
+++ b/regression-test/data/nereids_rules_p0/infer_predicate/pull_up_predicate_agg.out
@@ -46,11 +46,13 @@ PhysicalResultSink
 --PhysicalQuickSort[MERGE_SORT]
 ----PhysicalQuickSort[LOCAL_SORT]
 ------hashJoin[INNER_JOIN] hashCondition=((t.col1 = t2.a) and (t.col2 = t2.c)) otherCondition=()
---------hashAgg[GLOBAL]
-----------hashAgg[LOCAL]
-------------filter((test_pull_up_agg_t1.a <= 20) and (test_pull_up_agg_t1.c < 200))
---------------PhysicalOlapScan[test_pull_up_agg_t1]
---------PhysicalOlapScan[test_pull_up_agg_t2(t2)]
+--------filter((t.col1 <= 20) and (t.col2 < 200))
+----------hashAgg[GLOBAL]
+------------hashAgg[LOCAL]
+--------------filter((test_pull_up_agg_t1.a <= 20) and (test_pull_up_agg_t1.c < 200))
+----------------PhysicalOlapScan[test_pull_up_agg_t1]
+--------filter((t2.a <= 20) and (t2.c < 200))
+----------PhysicalOlapScan[test_pull_up_agg_t2(t2)]
 
 -- !pull_up_from_agg_to_filter_with_same_cond_shape --
 PhysicalResultSink

--- a/regression-test/suites/nereids_rules_p0/infer_predicate/extend_infer_equal_predicate.groovy
+++ b/regression-test/suites/nereids_rules_p0/infer_predicate/extend_infer_equal_predicate.groovy
@@ -377,4 +377,9 @@ suite("extend_infer_equal_predicate") {
     qt_pull_up_from_intersect """select a from(select a from (select t1.a from extend_infer_t3 t1 where t1.a<10 intersect select t2.a from extend_infer_t4 t2 where t2.a<10  ) tt
             limit 10) t  where a<10 order by 1 ;"""
     qt_pull_up_from_agg """select a from (select a from extend_infer_t3 t1 where a<10 group by a limit 10) t where a<10 order by 1"""
+
+    // test left join right table predicate pull up
+    qt_leftjoin_right_pull_up_shape """
+        explain shape plan select * from extend_infer_t3 t1 left join extend_infer_t4 t2 on t1.a=t2.a left join extend_infer_t5 t3 on t2.a= t3.a where t1.a=1;
+    """
 }

--- a/regression-test/suites/nereids_rules_p0/infer_predicate/extend_infer_equal_predicate.groovy
+++ b/regression-test/suites/nereids_rules_p0/infer_predicate/extend_infer_equal_predicate.groovy
@@ -378,8 +378,38 @@ suite("extend_infer_equal_predicate") {
             limit 10) t  where a<10 order by 1 ;"""
     qt_pull_up_from_agg """select a from (select a from extend_infer_t3 t1 where a<10 group by a limit 10) t where a<10 order by 1"""
 
+    def explain_and_result = { tag, sql ->
+        "qt_${tag}_shape"          "explain shape plan ${sql}"
+        "order_qt_${tag}_result"   "${sql}"
+    }
+
     // test left join right table predicate pull up
-    qt_leftjoin_right_pull_up_shape """
-        explain shape plan select * from extend_infer_t3 t1 left join extend_infer_t4 t2 on t1.a=t2.a left join extend_infer_t5 t3 on t2.a= t3.a where t1.a=1;
+    explain_and_result 'qt_leftjoin_right_pull_up_shape', '''
+        select * from extend_infer_t3 t1 left join extend_infer_t4 t2 on t1.a=t2.a left join extend_infer_t5 t3 on t2.a= t3.a where t1.a=1;
+    '''
+    // test multi left join right table predicate pull up
+    explain_and_result "qt_multi_leftjoin_right_pull_up_shape", """
+        select * from extend_infer_t3 t1 left join extend_infer_t4 t2 on t1.a=t2.a left join extend_infer_t5 t3 on t2.a= t3.a left join extend_infer_t5 t4 on t4.a=t3.a left join extend_infer_t5 t5 on t2.a=t5.a where t1.a=1;
     """
+    explain_and_result "qt_leftjoin_right_pull_up_in_shape", """
+        select * from extend_infer_t3 t1 left join extend_infer_t4 t2 on t1.a=t2.a left join extend_infer_t5 t3 on t2.a= t3.a where t1.a in (1,2);
+    """
+    // is null may be can be inferred but we do not infer it now
+    explain_and_result "qt_leftjoin_right_pull_up_is_null_shape", """
+        select * from extend_infer_t3 t1 left join extend_infer_t4 t2 on t1.a=t2.a left join extend_infer_t5 t3 on t2.a= t3.a where t1.a is null;
+    """
+    // is not null may be need not be innfered
+    explain_and_result "qt_leftjoin_right_pull_up_is_not_null_shape", """
+        select * from extend_infer_t3 t1 left join extend_infer_t4 t2 on t1.a=t2.a left join extend_infer_t5 t3 on t2.a= t3.a where t1.a is not null;
+    """
+
+    explain_and_result 'qt_left_join_inner', '''
+        select * from extend_infer_t3 t1 left join extend_infer_t4 t2 on t1.a=t2.a inner join extend_infer_t5 t3 on t2.a= t3.a where t1.a=1;
+    '''
+    explain_and_result 'qt_left_join_semi', '''
+        select * from extend_infer_t3 t1 left join extend_infer_t4 t2 on t1.a=t2.a left semi join extend_infer_t5 t3 on t2.a= t3.a where t1.a=1;
+    '''
+    explain_and_result 'qt_left_join_anti', '''
+        select * from extend_infer_t3 t1 left join extend_infer_t4 t2 on t1.a=t2.a left anti join extend_infer_t5 t3 on t2.a= t3.a where t1.a=1;
+    '''
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #41731

Problem Summary:

### Release note
The optimizer cannot derive predicates across multiple LEFT JOINs. For example, given a filter on the leftmost table in a chain of LEFT JOINs, the optimizer should be able to derive predicates on the rightmost table, but it currently fails to do so.
```sql
create table t1(a int, b int);
create table t2(a int, b int);
create table t3(a int, b int);

insert into t1 values(1,2);
insert into t2 values(1,2);
insert into t3 values(1,2);
insert into t3 values(null,2);

explain logical plan
select * from t1 left join t2 on t1.a=t2.a left join t3 on t2.a=t3.a where t1.a=1;

LogicalResultSink[110] ( outputExprs=[a#0, b#1, a#2, b#3, a#4, b#5] )
+--LogicalProject[109] ( distinct=false, projects=[a#0, b#1, a#2, b#3, a#4, b#5] )
   +--LogicalJoin[108] ( type=LEFT_OUTER_JOIN, markJoinSlotReference=Optional.empty, hashJoinConjuncts=[(a#2 = a#4)], otherJoinConjuncts=[], markJoinConjuncts=[] )
      |--LogicalProject[105] ( distinct=false, projects=[a#0, b#1, a#2, b#3] )
      |  +--LogicalJoin[104] ( type=LEFT_OUTER_JOIN, markJoinSlotReference=Optional.empty, hashJoinConjuncts=[(a#0 = a#2)], otherJoinConjuncts=[], markJoinConjuncts=[] )
      |     |--LogicalFilter[101] ( predicates=(a#0 = 1) )
      |     |  +--LogicalOlapScan ( qualified=internal.maldb.t1, indexName=<index_not_selected>, selectedIndexId=1764043369852, preAgg=ON, operativeCol=[a#0], virtualColumns=[] )
      |     +--LogicalFilter[103] ( predicates=(a#2 = 1) )
      |        +--LogicalOlapScan ( qualified=internal.maldb.t2, indexName=<index_not_selected>, selectedIndexId=1764043369875, preAgg=ON, operativeCol=[a#2], virtualColumns=[] )
     +--LogicalOlapScan ( qualified=internal.maldb.t3, indexName=<index_not_selected>, selectedIndexId=1764043369898, preAgg=ON, operativeCol=[a#4], virtualColumns=[] )
```
The optimizer should derive t3.a=1 from t1.a=1 and the join conditions, but it currently doesn't.

The root cause is that the PullUpPredicates rule doesn't properly handle predicate pull-up from the right side of LEFT JOINs. This PR fixes this by generating null-tolerant predicates when pulling up from RIGHT JOIN's right table and strengthening them when possible based on upper-level join conditions.
after this pr:
```sql
LogicalResultSink[110] ( outputExprs=[a#0, b#1, a#2, b#3, a#4, b#5] )
+--LogicalProject[109] ( distinct=false, projects=[a#0, b#1, a#2, b#3, a#4, b#5] )
   +--LogicalJoin[108] ( type=LEFT_OUTER_JOIN, markJoinSlotReference=Optional.empty, hashJoinConjuncts=[(a#2 = a#4)], otherJoinConjuncts=[], markJoinConjuncts=[] )
      |--LogicalProject[105] ( distinct=false, projects=[a#0, b#1, a#2, b#3] )
      |  +--LogicalJoin[104] ( type=LEFT_OUTER_JOIN, markJoinSlotReference=Optional.empty, hashJoinConjuncts=[(a#0 = a#2)], otherJoinConjuncts=[], markJoinConjuncts=[] )
      |     |--LogicalFilter[101] ( predicates=(a#0 = 1) )
      |     |  +--LogicalOlapScan ( qualified=internal.maldb.t1, indexName=<index_not_selected>, selectedIndexId=1764043369852, preAgg=ON, operativeCol=[a#0], virtualColumns=[] )
      |     +--LogicalFilter[103] ( predicates=(a#2 = 1) )
      |        +--LogicalOlapScan ( qualified=internal.maldb.t2, indexName=<index_not_selected>, selectedIndexId=1764043369875, preAgg=ON, operativeCol=[a#2], virtualColumns=[] )
      +--LogicalFilter[107] ( predicates=(a#4 = 1) )
         +--LogicalOlapScan ( qualified=internal.maldb.t3, indexName=<index_not_selected>, selectedIndexId=1764043369898, preAgg=ON, operativeCol=[a#4], virtualColumns=[] )
```

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

