### PR TITLE
[fix](snapshot) drop index should set db_id

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -826,7 +826,7 @@ public class Alter {
             // not swap, the origin table is not used anymore, need to drop all its tablets.
             // put original table to recycle bin.
             if (isForce) {
-                Env.getCurrentEnv().onEraseOlapTable(origTable, isReplay);
+                Env.getCurrentEnv().onEraseOlapTable(db.getId(), origTable, isReplay);
             } else {
                 Env.getCurrentRecycleBin().recycleTable(db.getId(), origTable, isReplay, isForce, 0);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/CloudRollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/CloudRollupJobV2.java
@@ -128,7 +128,7 @@ public class CloudRollupJobV2 extends RollupJobV2 {
         while (true) {
             try {
                 ((CloudInternalCatalog) Env.getCurrentInternalCatalog())
-                    .dropMaterializedIndex(tableId, rollupIndexList, false);
+                    .dropMaterializedIndex(dbId, tableId, rollupIndexList, false);
                 for (Map.Entry<Long, Map<Long, Long>> partitionEntry : partitionIdToBaseRollupTabletIdMap.entrySet()) {
                     Long partitionId = partitionEntry.getKey();
                     Map<Long, Long> rollupTabletIdToBaseTabletId = partitionEntry.getValue();

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/CloudSchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/CloudSchemaChangeJobV2.java
@@ -149,7 +149,7 @@ public class CloudSchemaChangeJobV2 extends SchemaChangeJobV2 {
         while (true) {
             try {
                 ((CloudInternalCatalog) Env.getCurrentInternalCatalog())
-                    .dropMaterializedIndex(tableId, idxList, false);
+                    .dropMaterializedIndex(dbId, tableId, idxList, false);
                 break;
             } catch (Exception e) {
                 LOG.warn("drop index failed, retry times {}, dbId: {}, tableId: {}, jobId: {}, idxList: {}:",

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
@@ -981,7 +981,7 @@ public class MaterializedViewHandler extends AlterHandler {
         } finally {
             olapTable.writeUnlock();
         }
-        Env.getCurrentInternalCatalog().eraseDroppedIndex(olapTable.getId(), deleteIndexList);
+        Env.getCurrentInternalCatalog().eraseDroppedIndex(db.getId(), olapTable.getId(), deleteIndexList);
     }
 
     public void processDropMaterializedView(DropMaterializedViewCommand dropMaterializedViewCommand, Database db,
@@ -1010,7 +1010,7 @@ public class MaterializedViewHandler extends AlterHandler {
         } finally {
             olapTable.writeUnlock();
         }
-        Env.getCurrentInternalCatalog().eraseDroppedIndex(olapTable.getId(), deleteIndexList);
+        Env.getCurrentInternalCatalog().eraseDroppedIndex(db.getId(), olapTable.getId(), deleteIndexList);
     }
 
     /**
@@ -1101,7 +1101,7 @@ public class MaterializedViewHandler extends AlterHandler {
 
         List<Long> deleteIndexList = new ArrayList<Long>();
         deleteIndexList.add(rollupIndexId);
-        Env.getCurrentInternalCatalog().eraseDroppedIndex(olapTable.getId(), deleteIndexList);
+        Env.getCurrentInternalCatalog().eraseDroppedIndex(db.getId(), olapTable.getId(), deleteIndexList);
         LOG.info("replay drop rollup {}", dropInfo.getIndexId());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -2603,7 +2603,7 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
                     try {
                         LOG.info("drop the origin olap table {}. table={}" + " isAtomicRestore: {}",
                                 originOlapTbl.getName(), originOlapTbl.getId(), isAtomicRestore);
-                        Env.getCurrentEnv().onEraseOlapTable(originOlapTbl, isReplay);
+                        Env.getCurrentEnv().onEraseOlapTable(db.getId(), originOlapTbl, isReplay);
                     } finally {
                         originOlapTbl.writeUnlock();
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -335,7 +335,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
 
             Table table = tableInfo.getTable();
             if (table.isManagedTable()) {
-                Env.getCurrentEnv().onEraseOlapTable((OlapTable) table, false);
+                Env.getCurrentEnv().onEraseOlapTable(dbId, (OlapTable) table, false);
             }
             iterator.remove();
             idToRecycleTime.remove(table.getId());
@@ -366,7 +366,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
 
                 if (isExpire(tableId, currentTimeMs)) {
                     if (table.isManagedTable()) {
-                        Env.getCurrentEnv().onEraseOlapTable((OlapTable) table, false);
+                        Env.getCurrentEnv().onEraseOlapTable(tableInfo.dbId, (OlapTable) table, false);
                     }
 
                     // erase table
@@ -448,7 +448,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             }
             Table table = tableInfo.getTable();
             if (table.isManagedTable()) {
-                Env.getCurrentEnv().onEraseOlapTable((OlapTable) table, false);
+                Env.getCurrentEnv().onEraseOlapTable(dbId, (OlapTable) table, false);
             }
 
             idToTable.remove(tableId);
@@ -469,7 +469,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         }
         Table table = tableInfo.getTable();
         if (table.isManagedTable()) {
-            Env.getCurrentEnv().onEraseOlapTable((OlapTable) table, true);
+            Env.getCurrentEnv().onEraseOlapTable(tableInfo.dbId, (OlapTable) table, true);
         }
         LOG.info("replay erase table[{}]", tableId);
     }
@@ -993,7 +993,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             long dbId = tableInfo.getDbId();
             Table table = tableInfo.getTable();
             if (table.getType() == TableType.OLAP || table.getType() == TableType.MATERIALIZED_VIEW) {
-                Env.getCurrentEnv().onEraseOlapTable((OlapTable) table, false);
+                Env.getCurrentEnv().onEraseOlapTable(dbId, (OlapTable) table, false);
             }
 
             // erase table from idToTable and idToRecycleTime

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -6954,7 +6954,7 @@ public class Env {
         }
     }
 
-    public void onEraseOlapTable(OlapTable olapTable, boolean isReplay) {
+    public void onEraseOlapTable(long dbId, OlapTable olapTable, boolean isReplay) {
         // inverted index
         TabletInvertedIndex invertedIndex = Env.getCurrentInvertedIndex();
         Collection<Partition> allPartitions = olapTable.getAllPartitions();
@@ -6970,7 +6970,7 @@ public class Env {
         // colocation
         Env.getCurrentColocateIndex().removeTable(olapTable.getId());
 
-        getInternalCatalog().eraseTableDropBackendReplicas(olapTable, isReplay);
+        getInternalCatalog().eraseTableDropBackendReplicas(dbId, olapTable, isReplay);
     }
 
     public void onErasePartition(Partition partition) {

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
@@ -737,7 +737,7 @@ public class CloudInternalCatalog extends InternalCatalog {
     // BEGIN DROP TABLE
 
     @Override
-    public void eraseTableDropBackendReplicas(OlapTable olapTable, boolean isReplay) {
+    public void eraseTableDropBackendReplicas(long dbId, OlapTable olapTable, boolean isReplay) {
         if (!Env.getCurrentEnv().isMaster()) {
             return;
         }
@@ -763,7 +763,7 @@ public class CloudInternalCatalog extends InternalCatalog {
                 if (indexs.isEmpty()) {
                     break;
                 }
-                dropMaterializedIndex(olapTable.getId(), indexs, true);
+                dropMaterializedIndex(dbId, olapTable.getId(), indexs, true);
             } catch (Exception e) {
                 LOG.warn("failed to drop index {} of table {}, try cnt {}, execption {}",
                         indexs, olapTable.getId(), tryCnt, e);
@@ -932,7 +932,8 @@ public class CloudInternalCatalog extends InternalCatalog {
         }
     }
 
-    public void dropMaterializedIndex(long tableId, List<Long> indexIds, boolean dropTable) throws DdlException {
+    public void dropMaterializedIndex(long dbId, long tableId, List<Long> indexIds, boolean dropTable)
+            throws DdlException {
         if (Config.enable_check_compatibility_mode) {
             LOG.info("skip dropping materialized index in compatibility checking mode");
             return;
@@ -942,6 +943,7 @@ public class CloudInternalCatalog extends InternalCatalog {
         indexRequestBuilder.setCloudUniqueId(Config.cloud_unique_id);
         indexRequestBuilder.addAllIndexIds(indexIds);
         indexRequestBuilder.setTableId(tableId);
+        indexRequestBuilder.setDbId(dbId);
         final Cloud.IndexRequest indexRequest = indexRequestBuilder.build();
 
         Cloud.IndexResponse response = null;
@@ -972,7 +974,7 @@ public class CloudInternalCatalog extends InternalCatalog {
      * @param tableId
      * @param indexIdList
      */
-    public void eraseDroppedIndex(long tableId, List<Long> indexIdList) {
+    public void eraseDroppedIndex(long dbId, long tableId, List<Long> indexIdList) {
         if (indexIdList == null || indexIdList.size() == 0) {
             LOG.warn("indexIdList is empty");
             return;
@@ -986,7 +988,7 @@ public class CloudInternalCatalog extends InternalCatalog {
             }
 
             try {
-                dropMaterializedIndex(tableId, indexIdList, false);
+                dropMaterializedIndex(dbId, tableId, indexIdList, false);
                 break;
             } catch (Exception e) {
                 LOG.warn("tryCnt:{}, eraseDroppedIndex exception:", tryCnt, e);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1066,7 +1066,7 @@ public class InternalCatalog implements CatalogIf<Database> {
         }
     }
 
-    public void eraseTableDropBackendReplicas(OlapTable olapTable, boolean isReplay) {
+    public void eraseTableDropBackendReplicas(long dbId, OlapTable olapTable, boolean isReplay) {
         if (isReplay || Env.isCheckpointThread()) {
             return;
         }
@@ -1098,7 +1098,7 @@ public class InternalCatalog implements CatalogIf<Database> {
         // no need send be delete task, when be report its tablets, fe will send delete task then.
     }
 
-    public void eraseDroppedIndex(long tableId, List<Long> indexIdList) {
+    public void eraseDroppedIndex(long dbId, long tableId, List<Long> indexIdList) {
         // nothing to do in non cloud mode
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

`recycle_indexes` require `db_id` to recycle multi versioned keys, but drop index does not set db_id

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

