### PR TITLE
[fix](information_schema) Fix timezone format incompatibility when using offset timezone

### DIFF
--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -162,6 +162,7 @@ Status SchemaScanner::init(RuntimeState* state, SchemaScannerParam* param, Objec
     }
 
     _param = param;
+    _timezone = state->timezone();
     _timezone_obj = state->timezone_obj();
     _is_init = true;
 

--- a/be/src/exec/schema_scanner.h
+++ b/be/src/exec/schema_scanner.h
@@ -145,6 +145,7 @@ protected:
     std::atomic<bool> _eos = false;
     std::atomic<bool> _opened = false;
     std::atomic<bool> _async_thread_running = false;
+    std::string _timezone;
     cctz::time_zone _timezone_obj;
 };
 

--- a/be/src/exec/schema_scanner/schema_active_queries_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_active_queries_scanner.cpp
@@ -63,7 +63,7 @@ Status SchemaActiveQueriesScanner::_get_active_queries_block_from_fe() {
     }
     schema_table_params.replay_to_other_fe = true;
     schema_table_params.__isset.replay_to_other_fe = true;
-    schema_table_params.__set_time_zone(_timezone_obj.name());
+    schema_table_params.__set_time_zone(_timezone);
 
     TFetchSchemaTableDataRequest request;
     request.__set_schema_table_name(TSchemaTableName::ACTIVE_QUERIES);

--- a/be/src/exec/schema_scanner/schema_partitions_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_partitions_scanner.cpp
@@ -126,7 +126,7 @@ Status SchemaPartitionsScanner::get_onedb_info_from_fe(int64_t dbId) {
     schema_table_request_params.__set_current_user_ident(*_param->common_param->current_user_ident);
     schema_table_request_params.__set_catalog(*_param->common_param->catalog);
     schema_table_request_params.__set_dbId(dbId);
-    schema_table_request_params.__set_time_zone(_timezone_obj.name());
+    schema_table_request_params.__set_time_zone(_timezone);
 
     TFetchSchemaTableDataRequest request;
     request.__set_schema_table_name(TSchemaTableName::PARTITIONS);

--- a/be/src/exec/schema_scanner/schema_processlist_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_processlist_scanner.cpp
@@ -57,7 +57,7 @@ SchemaProcessListScanner::~SchemaProcessListScanner() = default;
 Status SchemaProcessListScanner::start(RuntimeState* state) {
     TShowProcessListRequest request;
     request.__set_show_full_sql(true);
-    request.__set_time_zone(state->timezone_obj().name());
+    request.__set_time_zone(state->timezone());
 
     for (const auto& fe_addr : _param->common_param->fe_addr_list) {
         TShowProcessListResult tmp_ret;

--- a/regression-test/suites/external_table_p0/info_schema_db/test_information_schema_timezone.groovy
+++ b/regression-test/suites/external_table_p0/info_schema_db/test_information_schema_timezone.groovy
@@ -225,4 +225,15 @@ suite("test_information_schema_timezone", "p0,external,hive,kerberos,external_do
 
     // set time_zone back
     sql """ SET time_zone = "Asia/Shanghai" """
+
+    // 8. Test offset format timezone (e.g. +08:00)
+    // This tests the fix for cctz returning "Fixed/UTC+08:00:00" format
+    sql """ SET time_zone = '+08:00' """
+    sql """
+        select a.*, b.*, c.NAME as WORKLOAD_GROUP_NAME
+        from information_schema.active_queries a
+        left join information_schema.backend_active_tasks b on a.QUERY_ID = b.QUERY_ID
+        left join information_schema.workload_groups c on a.WORKLOAD_GROUP_ID = c.ID
+    """
+    sql """ SET time_zone = "Asia/Shanghai" """
 }


### PR DESCRIPTION

Related PR: #48462

  When `time_zone` is set to offset format like `+08:00`, `cctz::time_zone::name()`
  returns internal format `Fixed/UTC+08:00:00` which Java `ZoneId.of()` cannot parse.

  Use the original timezone string instead of `_timezone_obj.name()` when passing
  timezone to FE via thrift RPC.
