### PR TITLE
[fix](hudi) Fix Hudi query error "do not support DLA type HUDI"

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -655,6 +655,13 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
                                 fileScan.getTableSample().get().sampleValue, fileScan.getTableSample().get().seek));
                     }
                     break;
+                case HUDI:
+                    // HUDI table should be handled by visitPhysicalHudiScan, not here.
+                    // If we reach here, it means LogicalHudiScan was incorrectly converted to
+                    // PhysicalFileScan.
+                    throw new RuntimeException("HUDI table should use PhysicalHudiScan instead of PhysicalFileScan. "
+                            + "This indicates a bug in the optimizer rules. "
+                            + "FileScan class: " + fileScan.getClass().getSimpleName());
                 default:
                     throw new RuntimeException("do not support DLA type " + ((HMSExternalTable) table).getDlaType());
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHudiScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHudiScan.java
@@ -78,12 +78,29 @@ public class LogicalHudiScan extends LogicalFileScan {
             List<NamedExpression> virtualColumns,
             Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties,
+            String tableAlias,
             Optional<List<Slot>> cachedOutputs) {
         super(id, table, qualifier, selectedPartitions, operativeSlots, virtualColumns,
-                tableSample, tableSnapshot, scanParams, groupExpression, logicalProperties, "", cachedOutputs);
+                tableSample, tableSnapshot, scanParams, groupExpression, logicalProperties, tableAlias, cachedOutputs);
         Objects.requireNonNull(scanParams, "scanParams should not null");
         Objects.requireNonNull(incrementalRelation, "incrementalRelation should not null");
         this.incrementalRelation = incrementalRelation;
+    }
+
+    /**
+     * Constructor for LogicalHudiScan (backward compatibility without tableAlias).
+     */
+    protected LogicalHudiScan(RelationId id, ExternalTable table, List<String> qualifier,
+            SelectedPartitions selectedPartitions, Optional<TableSample> tableSample,
+            Optional<TableSnapshot> tableSnapshot,
+            Optional<TableScanParams> scanParams, Optional<IncrementalRelation> incrementalRelation,
+            Collection<Slot> operativeSlots,
+            List<NamedExpression> virtualColumns,
+            Optional<GroupExpression> groupExpression,
+            Optional<LogicalProperties> logicalProperties,
+            Optional<List<Slot>> cachedOutputs) {
+        this(id, table, qualifier, selectedPartitions, tableSample, tableSnapshot, scanParams, incrementalRelation,
+                operativeSlots, virtualColumns, groupExpression, logicalProperties, "", cachedOutputs);
     }
 
     public LogicalHudiScan(RelationId id, ExternalTable table, List<String> qualifier,
@@ -142,7 +159,8 @@ public class LogicalHudiScan extends LogicalFileScan {
     public LogicalHudiScan withGroupExpression(Optional<GroupExpression> groupExpression) {
         return new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
                 selectedPartitions, tableSample, tableSnapshot, scanParams, incrementalRelation,
-                operativeSlots, virtualColumns, groupExpression, Optional.of(getLogicalProperties()), cachedOutputs);
+                operativeSlots, virtualColumns, groupExpression, Optional.of(getLogicalProperties()),
+                tableAlias, cachedOutputs);
     }
 
     @Override
@@ -150,20 +168,23 @@ public class LogicalHudiScan extends LogicalFileScan {
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         return new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
             selectedPartitions, tableSample, tableSnapshot, scanParams, incrementalRelation,
-            operativeSlots, virtualColumns, groupExpression, logicalProperties, cachedOutputs);
+                operativeSlots, virtualColumns, groupExpression, logicalProperties,
+                tableAlias, cachedOutputs);
     }
 
     public LogicalHudiScan withSelectedPartitions(SelectedPartitions selectedPartitions) {
         return new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
             selectedPartitions, tableSample, tableSnapshot, scanParams, incrementalRelation,
-            operativeSlots, virtualColumns, groupExpression, Optional.of(getLogicalProperties()), cachedOutputs);
+                operativeSlots, virtualColumns, groupExpression, Optional.of(getLogicalProperties()),
+                tableAlias, cachedOutputs);
     }
 
     @Override
     public LogicalHudiScan withRelationId(RelationId relationId) {
         return new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
             selectedPartitions, tableSample, tableSnapshot, scanParams, incrementalRelation,
-            operativeSlots, virtualColumns, groupExpression, Optional.of(getLogicalProperties()), cachedOutputs);
+                operativeSlots, virtualColumns, groupExpression, Optional.of(getLogicalProperties()),
+                tableAlias, cachedOutputs);
     }
 
     @Override
@@ -172,10 +193,27 @@ public class LogicalHudiScan extends LogicalFileScan {
     }
 
     @Override
-    public LogicalFileScan withOperativeSlots(Collection<Slot> operativeSlots) {
+    public LogicalHudiScan withOperativeSlots(Collection<Slot> operativeSlots) {
+        return new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
+                selectedPartitions, tableSample, tableSnapshot, scanParams, incrementalRelation,
+                operativeSlots, virtualColumns, groupExpression, Optional.of(getLogicalProperties()),
+                tableAlias, cachedOutputs);
+    }
+
+    @Override
+    public LogicalHudiScan withTableAlias(String tableAlias) {
+        return new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
+                selectedPartitions, tableSample, tableSnapshot, scanParams, incrementalRelation,
+                operativeSlots, virtualColumns, Optional.empty(), Optional.of(getLogicalProperties()),
+                tableAlias, cachedOutputs);
+    }
+
+    @Override
+    public LogicalHudiScan withCachedOutput(List<Slot> cachedOutputs) {
         return new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
             selectedPartitions, tableSample, tableSnapshot, scanParams, incrementalRelation,
-            operativeSlots, virtualColumns, groupExpression, Optional.of(getLogicalProperties()), cachedOutputs);
+                operativeSlots, virtualColumns, groupExpression, Optional.empty(),
+                tableAlias, Optional.of(cachedOutputs));
     }
 
     /**
@@ -228,6 +266,7 @@ public class LogicalHudiScan extends LogicalFileScan {
         }
         return new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
             selectedPartitions, tableSample, tableSnapshot, scanParams, newIncrementalRelation,
-            operativeSlots, virtualColumns, groupExpression, Optional.of(getLogicalProperties()), cachedOutputs);
+                operativeSlots, virtualColumns, groupExpression, Optional.of(getLogicalProperties()),
+                tableAlias, cachedOutputs);
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #56802

Problem Summary:

`LogicalHudiScan` did not override `withTableAlias()` and `withCachedOutput()` methods,  causing HUDI table type information to be lost during optimization,  and the table was incorrectly processed as `PhysicalFileScan`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

