### PR TITLE
[chore](load) Not log unnecessary stack information

### DIFF
--- a/be/src/runtime/stream_load/stream_load_recorder.cpp
+++ b/be/src/runtime/stream_load/stream_load_recorder.cpp
@@ -113,7 +113,7 @@ Status StreamLoadRecorder::get(const std::string& key, std::string* value, bool 
     rocksdb::ReadOptions read_options;
     rocksdb::Status s = _db->Get(read_options, handle, rocksdb::Slice(key), value);
     if (s.IsNotFound()) {
-        return Status::NotFound("Key not found: {}", key);
+        return Status::NotFound<false>("Key not found: {}", key);
     }
     if (!s.ok()) {
         LOG(WARNING) << "rocks db get key:" << key << " failed, reason:" << s.ToString();


### PR DESCRIPTION
### What problem does this PR solve?

`stream_load_recorder_manager_last_fetch_key` key not found is not a fatal issue here, no need to log the following stack information

```
W20251126 17:32:35.140445 2054603 status.h:439] meet error status: [NOT_FOUND]Key not found: stream_load_recorder_manager_last_fetch_key

        0#  doris::StreamLoadRecorder::get(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, bool) at /data11/chen/doris-la
test/be/src/common/status.h:494
        1#  doris::StreamLoadRecorderManager::_load_last_fetch_key() at /opt/ldb_toolchain/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/basic_string.h:239
        2#  doris::StreamLoadRecorderManager::start() at /opt/ldb_toolchain/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_thread.h:103
        3#  doris::ExecEnv::_init(std::vector<doris::StorePath, std::allocator<doris::StorePath> > const&, std::vector<doris::StorePath, std::allocator<doris::StorePath> > const&, std::set<std::__cxx11::basic_string<char, std::char_traits<char
>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) at /data11/chen/
doris-latest/be/src/runtime/exec_env_init.cpp:406
        4#  doris::ExecEnv::init(doris::ExecEnv*, std::vector<doris::StorePath, std::allocator<doris::StorePath> > const&, std::vector<doris::StorePath, std::allocator<doris::StorePath> > const&, std::set<std::__cxx11::basic_string<char, std::
char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) at /data11/chen/doris-latest/be/src/runtime/exec_env_init.cpp:188
        5#  main at /data11/chen/doris-latest/be/src/service/doris_main.cpp:0
        6#  __libc_start_main
        7#  _start
I20251126 17:32:35.140537 2054603 stream_load_recorder_manager.cpp:75] No stream load recorder manager last fetch key found in RocksDB, starting from beginning
```

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

