### PR TITLE
[fix](mv) Fix stats unknown when calc sync mv plan statistics

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -1149,7 +1149,7 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
     }
 
     private ColumnStatistic getColumnStatistic(TableIf table, String colName, long idxId) {
-        if (connectContext != null && connectContext.getState().isInternal()) {
+        if (connectContext != null && connectContext.getState().isPlanWithUnKnownColumnStats()) {
             return ColumnStatistic.UNKNOWN;
         }
         long catalogId;
@@ -1181,7 +1181,7 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
 
     private ColumnStatistic getColumnStatistic(
             OlapTableStatistics olapTableStatistics, String colName, List<String> partitionNames) {
-        if (connectContext != null && connectContext.getState().isInternal()) {
+        if (connectContext != null && connectContext.getState().isPlanWithUnKnownColumnStats()) {
             return ColumnStatistic.UNKNOWN;
         }
         OlapTable table = olapTableStatistics.olapTable;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -2499,7 +2499,7 @@ public class SessionVariable implements Serializable, Writable {
     public boolean enableMaterializedViewRewrite = true;
 
     @VariableMgr.VarAttr(name = PRE_MATERIALIZED_VIEW_REWRITE_STRATEGY, needForward = true, fuzzy = true,
-            description = {"在 RBO 阶段基于结构信息的物化视图透明改写的策略，FORCE_IN_ROB：强制在 RBO 阶段透明改写，"
+            description = {"在 RBO 阶段基于结构信息的物化视图透明改写的策略，FORCE_IN_RBO：强制在 RBO 阶段透明改写，"
                     + "TRY_IN_RBO：如果在 NEED_PRE_REWRITE_RULE_TYPES 中的规则改写成功了，那么就会尝试在 RBO 阶段透明改写"
                     + "NOT_IN_RBO：不尝试在 RBO 阶段改写，只在 CBO 阶段改写",
                     "Whether to enable pre materialized view rewriting based on struct info,"

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
@@ -93,7 +93,7 @@ public class StatisticsCache {
 
     public ColumnStatistic getColumnStatistics(
             long catalogId, long dbId, long tblId, long idxId, String colName, ConnectContext ctx) {
-        if (ctx != null && ctx.getState().isInternal()) {
+        if (ctx != null && ctx.getState().isPlanWithUnKnownColumnStats()) {
             return ColumnStatistic.UNKNOWN;
         }
         // Need to change base index id to -1 for OlapTable.
@@ -130,7 +130,7 @@ public class StatisticsCache {
 
     public PartitionColumnStatistic getPartitionColumnStatistics(long catalogId, long dbId, long tblId, long idxId,
                                                   String partName, String colName, ConnectContext ctx) {
-        if (ctx != null && ctx.getState().isInternal()) {
+        if (ctx != null && ctx.getState().isPlanWithUnKnownColumnStats()) {
             return PartitionColumnStatistic.UNKNOWN;
         }
         // Need to change base index id to -1 for OlapTable.
@@ -178,7 +178,7 @@ public class StatisticsCache {
 
     private Optional<Histogram> getHistogram(long ctlId, long dbId, long tblId, long idxId, String colName) {
         ConnectContext ctx = ConnectContext.get();
-        if (ctx != null && ctx.getState().isInternal()) {
+        if (ctx != null && ctx.getState().isPlanWithUnKnownColumnStats()) {
             return Optional.empty();
         }
         StatisticsCacheKey k = new StatisticsCacheKey(ctlId, dbId, tblId, idxId, colName);
@@ -398,7 +398,7 @@ public class StatisticsCache {
 
         // this method can avoid compute table and select index id
         public ColumnStatistic getColumnStatistics(String colName, ConnectContext ctx) {
-            if (ctx != null && ctx.getState().isInternal()) {
+            if (ctx != null && ctx.getState().isPlanWithUnKnownColumnStats()) {
                 return ColumnStatistic.UNKNOWN;
             }
             return doGetColumnStatistics(
@@ -408,7 +408,7 @@ public class StatisticsCache {
 
         public PartitionColumnStatistic getPartitionColumnStatistics(
                 String partName, String colName, ConnectContext ctx) {
-            if (ctx != null && ctx.getState().isInternal()) {
+            if (ctx != null && ctx.getState().isPlanWithUnKnownColumnStats()) {
                 return PartitionColumnStatistic.UNKNOWN;
             }
             return doGetPartitionColumnStatistics(

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsCacheTest.java
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.UtFrameUtils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class StatisticsCacheTest {
+
+    private ConnectContext ctx;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        if (ConnectContext.get() == null) {
+            ctx = UtFrameUtils.createDefaultCtx();
+        } else {
+            ctx = ConnectContext.get();
+        }
+    }
+
+    @Test
+    public void testGetColumnStatistics_withPlanWithUnknownColumnStats() {
+        Assumptions.assumeTrue(ConnectContext.get() != null, "ConnectContext not available");
+
+        boolean prevFlag = ConnectContext.get().getState().isPlanWithUnKnownColumnStats();
+        ConnectContext.get().getState().setPlanWithUnKnownColumnStats(true);
+        try {
+            StatisticsCache cache = new StatisticsCache();
+            ColumnStatistic stat = cache.getColumnStatistics(
+                    1L, 1L, 1L, -1L, "col", ConnectContext.get());
+            Assertions.assertEquals(ColumnStatistic.UNKNOWN, stat,
+                    "Expect UNKNOWN when plan has unknown column stats");
+        } finally {
+            ConnectContext.get().getState().setPlanWithUnKnownColumnStats(prevFlag);
+        }
+    }
+
+    @Test
+    public void testGetHistogram_withPlanWithUnknownColumnStats() {
+        Assumptions.assumeTrue(ConnectContext.get() != null, "ConnectContext not available");
+
+        boolean prevFlag = ConnectContext.get().getState().isPlanWithUnKnownColumnStats();
+        ConnectContext.get().getState().setPlanWithUnKnownColumnStats(true);
+        try {
+            StatisticsCache cache = new StatisticsCache();
+            // public getHistogram returns null when underlying optional is empty
+            Histogram hist = cache.getHistogram(1L, 1L, 1L, "col");
+            Assertions.assertNull(hist, "Expect null histogram when plan has unknown column stats");
+        } finally {
+            ConnectContext.get().getState().setPlanWithUnKnownColumnStats(prevFlag);
+        }
+    }
+
+    @Test
+    public void testGetPartitionColumnStatistics_withPlanWithUnknownColumnStats() {
+        Assumptions.assumeTrue(ConnectContext.get() != null, "ConnectContext not available");
+
+        boolean prevFlag = ConnectContext.get().getState().isPlanWithUnKnownColumnStats();
+        ConnectContext.get().getState().setPlanWithUnKnownColumnStats(true);
+        try {
+            StatisticsCache cache = new StatisticsCache();
+            PartitionColumnStatistic pstat = cache.getPartitionColumnStatistics(
+                    1L, 1L, 1L, -1L, "p", "col", ConnectContext.get());
+            Assertions.assertEquals(PartitionColumnStatistic.UNKNOWN, pstat,
+                    "Expect UNKNOWN partition col stat when plan has unknown column stats");
+        } finally {
+            ConnectContext.get().getState().setPlanWithUnKnownColumnStats(prevFlag);
+        }
+    }
+}

--- a/regression-test/suites/nereids_rules_p0/mv/availability/materialized_view_switch.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/availability/materialized_view_switch.groovy
@@ -143,7 +143,10 @@ suite("materialized_view_switch") {
         where o_orderdate = '2023-12-10' order by 1, 2, 3, 4, 5;
     """
 
-    async_mv_rewrite_success(db, mv_name, query, "mv_name_1")
+    async_mv_rewrite_success(db, mv_name, query, "mv_name_1", [NOT_IN_RBO])
+    // because compare total tree, mv fitler can not push down to scan base table in RBO mv rewrite as CBO mv prewrite,
+    // row count would be bigger than before
+    async_mv_rewrite_success_without_check_chosen(db, mv_name, query, "mv_name_1", [TRY_IN_RBO, FORCE_IN_RBO])
     sql """ DROP MATERIALIZED VIEW IF EXISTS mv_name_1"""
 
     sql "SET enable_materialized_view_rewrite=false"
@@ -152,7 +155,10 @@ suite("materialized_view_switch") {
     sql """ DROP MATERIALIZED VIEW IF EXISTS mv_name_2"""
 
     sql "SET enable_materialized_view_rewrite=true"
-    async_mv_rewrite_success(db, mv_name, query, "mv_name_3")
+    async_mv_rewrite_success(db, mv_name, query, "mv_name_3", [NOT_IN_RBO])
+    // because compare total tree, mv fitler can not push down to scan base table in RBO mv rewrite as CBO mv prewrite,
+    // row count would be bigger than before
+    async_mv_rewrite_success_without_check_chosen(db, mv_name, query, "mv_name_3", [TRY_IN_RBO, FORCE_IN_RBO])
     sql """ DROP MATERIALIZED VIEW IF EXISTS mv_name_3"""
 
     // test when materialized_view_relation_mapping_max_count is 8
@@ -167,7 +173,11 @@ suite("materialized_view_switch") {
         inner join lineitem t2 on t1.L_ORDERKEY = t2.L_ORDERKEY;
     """
     order_qt_query1_0_before "${query1_0}"
-    async_mv_rewrite_success(db, mv1_0, query1_0, "mv1_0")
+    async_mv_rewrite_success(db, mv1_0, query1_0, "mv1_0", [NOT_IN_RBO])
+    // because compare total tree, mv fitler can not push down to scan base table in RBO mv rewrite as CBO mv prewrite,
+    // row count would be bigger than before
+    async_mv_rewrite_success_without_check_chosen(db, mv1_0, query1_0, "mv1_0", [TRY_IN_RBO, FORCE_IN_RBO])
+
     order_qt_query1_0_after "${query1_0}"
     sql """ DROP MATERIALIZED VIEW IF EXISTS mv1_0"""
 


### PR DESCRIPTION
### What problem does this PR solve?

 Fix stats unknown when calc sync mv plan statistics

For SQLs that are related to statistics, we should not collect or compute statistics. Previously this was determined by the `isInternal` flag, but `isInternal` is too broad: it covers not only statistics-related SQL but also SQL used to generate materialized view plans. Materialized view plan generation requires statistics, so we introduce a new flag `isPlanWithUnKnownColumnStats` to indicate connections that are used for statistics-only operations (treat column statistics as unknown).

Issue Number: close #xxx

Related PR: 
https://github.com/apache/doris/pull/36760
https://github.com/apache/doris/pull/57850

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

