### PR TITLE
[fix](ann index) fix omp threads limit can not be assigned manually

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1609,14 +1609,15 @@ DEFINE_mInt64(max_csv_line_reader_output_buffer_size, "4294967296");
 // -1 means auto: use 80% of the available CPU cores.
 DEFINE_Int32(omp_threads_limit, "-1");
 DEFINE_Validator(omp_threads_limit, [](const int config) -> bool {
+    if (config > 0) {
+        omp_threads_limit = config;
+        return true;
+    }
     CpuInfo::init();
     int core_cap = config::num_cores > 0 ? config::num_cores : CpuInfo::num_cores();
     core_cap = std::max(1, core_cap);
-    int limit = config;
-    if (limit < 0) {
-        limit = std::max(1, core_cap * 4 / 5);
-    }
-    omp_threads_limit = std::max(1, std::min(limit, core_cap));
+    // Use at most 80% of the available CPU cores.
+    omp_threads_limit = std::max(1, core_cap * 4 / 5);
     return true;
 });
 // The capacity of segment partial column cache, used to cache column readers for each segment.

--- a/be/test/common/config_validator_test.cpp
+++ b/be/test/common/config_validator_test.cpp
@@ -17,8 +17,11 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+
 #include "common/config.h"
 #include "common/status.h"
+#include "util/cpu_info.h"
 
 namespace doris {
 using namespace config;
@@ -45,5 +48,48 @@ TEST(ConfigValidatorTest, Validator) {
     s = config::set_config("cfg_validator_2", "8");
     EXPECT_TRUE(s.ok());
     EXPECT_EQ(cfg_validator_2, 8);
+}
+
+// When a positive value is specified, validator should use it directly.
+TEST(ConfigValidatorTest, OmpThreadsLimitExplicitValue) {
+    int32_t original_limit = config::omp_threads_limit;
+
+    Status st = config::set_config("omp_threads_limit", "7", false, true);
+    ASSERT_TRUE(st.ok());
+    EXPECT_EQ(7, config::omp_threads_limit);
+
+    config::omp_threads_limit = original_limit;
+}
+
+// When value is -1 and config::num_cores is set,
+// validator should pick 80% of that core count.
+TEST(ConfigValidatorTest, OmpThreadsLimitAutoUsesConfiguredNumCores) {
+    int32_t original_limit = config::omp_threads_limit;
+    int32_t original_num_cores = config::num_cores;
+
+    config::num_cores = 20;
+    Status st = config::set_config("omp_threads_limit", "-1", false, true);
+    ASSERT_TRUE(st.ok());
+    EXPECT_EQ(16, config::omp_threads_limit);
+
+    config::num_cores = original_num_cores;
+    config::omp_threads_limit = original_limit;
+}
+
+// When value is -1 and config::num_cores is 0,
+// validator should fall back to CpuInfo::num_cores().
+TEST(ConfigValidatorTest, OmpThreadsLimitAutoFallsBackToCpuInfo) {
+    int32_t original_limit = config::omp_threads_limit;
+    int32_t original_num_cores = config::num_cores;
+
+    config::num_cores = 0;
+    Status st = config::set_config("omp_threads_limit", "-1", false, true);
+    ASSERT_TRUE(st.ok());
+    CpuInfo::init();
+    int expected = std::max(1, CpuInfo::num_cores() * 4 / 5);
+    EXPECT_EQ(expected, config::omp_threads_limit);
+
+    config::num_cores = original_num_cores;
+    config::omp_threads_limit = original_limit;
 }
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Make sure user specified omp_threads_limit is working.

Related PR: https://github.com/apache/doris/pull/56796

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

