### PR TITLE
[fix](build) fix macOS build

### DIFF
--- a/be/src/runtime/stream_load/stream_load_recorder_manager.cpp
+++ b/be/src/runtime/stream_load/stream_load_recorder_manager.cpp
@@ -19,6 +19,7 @@
 
 #include <fmt/format.h>
 #include <glog/logging.h>
+#include <inttypes.h>
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
 
@@ -176,9 +177,9 @@ std::string StreamLoadRecorderManager::_parse_and_format_record(const std::strin
         struct tm tm_buf;
         localtime_r(&ts_sec, &tm_buf);
         char buf[64];
-        snprintf(buf, sizeof(buf), "%04d-%02d-%02d %02d:%02d:%02d.%03ld", tm_buf.tm_year + 1900,
-                 tm_buf.tm_mon + 1, tm_buf.tm_mday, tm_buf.tm_hour, tm_buf.tm_min, tm_buf.tm_sec,
-                 ms_part);
+        snprintf(buf, sizeof(buf), "%04d-%02d-%02d %02d:%02d:%02d.%03" PRId64,
+                 tm_buf.tm_year + 1900, tm_buf.tm_mon + 1, tm_buf.tm_mday, tm_buf.tm_hour,
+                 tm_buf.tm_min, tm_buf.tm_sec, ms_part);
         return {buf};
     };
 


### PR DESCRIPTION
Use PRId64 macro instead of %lld for int64_t to fix compilation