### PR TITLE
[fix](simplify range) fix simplify range with null

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/RangeInference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/RangeInference.java
@@ -324,12 +324,14 @@ public class RangeInference extends ExpressionVisitor<RangeInference.ValueDesc, 
             resultValues.add(new EmptyValue(context, reference));
         }
 
+        // RangeAll = (a is not null or null), only a is not nullable, then RangeAll equals IsNotNull
         // process is null and is not null
         // for non-nullable a: EmptyValue(a) = a is null and null
         boolean hasIsNullValue = collector.hasIsNullValue || collector.hasEmptyValue && reference.nullable();
         boolean hasIsNotNullValue = collector.isNotNullValueOpt.isPresent()
                 || collector.isGenerateNotNullValueOpt.isPresent()
-                || mergeRangeValue != null && !mergeRangeValue.hasLowerBound() && !mergeRangeValue.hasUpperBound();
+                || (!reference.nullable() && mergeRangeValue != null
+                    && !mergeRangeValue.hasLowerBound() && !mergeRangeValue.hasUpperBound());
         if (hasIsNullValue && hasIsNotNullValue) {
             return new UnknownValue(context, BooleanLiteral.FALSE);
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
@@ -385,8 +385,53 @@ public class SimplifyRangeTest extends ExpressionRewrite {
 
         assertRewrite("(TA is not null or null) and TA > 10", "TA > 10");
         assertRewrite("(TA is not null or null) or TA > 10", "TA is not null or null");
+
+        assertRewrite("(TA is null and null) and TA is null", "TA is null and null");
+        assertRewrite("(TA is null and null) or TA is null", "TA is null");
+        // can simplify to 'TA is null', but not supported yet
+        assertRewrite("(TA is null or null) and TA is null", "(TA is null or null) and TA is null");
+        assertRewrite("(TA is null or null) or TA is null", "TA is null or null");
+        assertRewrite("(TA is not null and null) and TA is null", "FALSE");
+        assertRewrite("(TA is not null and null) or TA is null", "TA is not null and null or TA is null");
+        // can simplify to 'TA is null and null', but not supported yet, because it treat 'TA is not null or null' to RangeAll
+        assertRewrite("(TA is not null or null) and TA is null", "(TA is not null or null) and TA is null");
         assertRewrite("(TA is not null or null) or TA is null", "TRUE");
-        assertRewrite("TA is not null or null or TA is not null", "TA is not null or null");
+        assertRewrite("(TA is null and null) and TA is not null", "FALSE");
+        assertRewrite("(TA is null and null) or TA is not null", "TA is not null or TA is null and null");
+        assertRewrite("(TA is null or null) and TA is not null", "(TA is null or null) and TA is not null");
+        assertRewrite("(TA is null or null) or TA is not null", "TRUE");
+        assertRewrite("(TA is not null and null) and TA is not null", "TA is not null and null");
+        // can simplify to 'TA is not null', but not supported yet
+        assertRewrite("(TA is not null and null) or TA is not null", "TA is not null and null or TA is not null");
+        // can simplify to 'TA is not null', but not supported yet
+        assertRewrite("(TA is not null or null) and TA is not null", "(TA is not null or null) and TA is not null");
+        assertRewrite("(TA is not null or null) or TA is not null", "TA is not null or null");
+
+        assertRewrite("(XA is null and null) and XA is null", "FALSE");
+        // can simplify to 'FALSE', but not supported yet
+        assertRewrite("(XA is null and null) or XA is null", "XA is null");
+        // can simplify to 'FALSE', but not supported yet
+        assertRewrite("(XA is null or null) and XA is null", "(XA is null or null) and XA is null");
+        // can simplify to 'null', but not supported yet
+        assertRewrite("(XA is null or null) or XA is null", "XA is null or null");
+        assertRewrite("(XA is not null and null) and XA is null", "FALSE");
+        // can simplify to 'null', but not supported yet
+        assertRewrite("(XA is not null and null) or XA is null", "(XA is not null and null) or XA is null");
+        assertRewrite("(XA is not null or null) and XA is null", "FALSE");
+        assertRewrite("(XA is not null or null) or XA is null", "TRUE");
+        assertRewrite("(XA is null and null) and XA is not null", "FALSE");
+        // can simplify to 'TRUE', but not supported yet
+        assertRewrite("(XA is null and null) or XA is not null", "XA is not null");
+        // can simplify to 'NULL', but not supported yet
+        assertRewrite("(XA is null or null) and XA is not null", "(XA is null or null) and XA is not null");
+        assertRewrite("(XA is null or null) or XA is not null", "TRUE");
+        // can simplify to 'NULL', but not supported yet
+        assertRewrite("(XA is not null and null) and XA is not null", "XA is not null and null");
+        // can simplify to 'NULL', but not supported yet
+        assertRewrite("(XA is not null and null) or XA is not null", "XA is not null and null or XA is not null");
+        // can simplify to 'TRUE', but not supported yet
+        assertRewrite("(XA is not null or null) and XA is not null", "XA is not null");
+        assertRewrite("(XA is not null or null) or XA is not null", "TRUE");
 
         assertRewrite("TA + TC", "TA + TC");
         assertRewrite("(TA + TC >= 1 and TA + TC <=3 ) or (TA + TC > 5 and TA + TC < 7)", "(TA + TC >= 1 and TA + TC <=3 ) or (TA + TC > 5 and TA + TC < 7)");


### PR DESCRIPTION
### What problem does this PR solve?

for RangeAll(a) intersect IsNull(a),  cann't simplify it to FALSE because when a is null, the result is null.  Only when a is not null, can simplify it to FALSE.

introduce by #57537

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

