### PR TITLE
[fix](jni) Fix jni.log not printing

### DIFF
--- a/fe/be-java-extensions/java-common/src/main/resources/log4j2.properties
+++ b/fe/be-java-extensions/java-common/src/main/resources/log4j2.properties
@@ -5,9 +5,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -15,12 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
-log4j.rootLogger=INFO, RollingFile
-log4j.appender.RollingFile=org.apache.log4j.RollingFileAppender
-log4j.appender.RollingFile.Threshold=INFO
-log4j.appender.RollingFile.File=${logPath}
-log4j.appender.RollingFile.Append=true
-log4j.appender.RollingFile.MaxFileSize=10MB
-log4j.appender.RollingFile.MaxBackupIndex=5
-log4j.appender.RollingFile.layout=org.apache.log4j.PatternLayout
-log4j.appender.RollingFile.layout.ConversionPattern= %d{yyyy-MM-dd HH:mm:ss} %5p %t %-5l - %m%n
+status = error
+name = JniLog4j2Config
+
+# RollingFile appender
+appender.rolling.type = RollingFile
+appender.rolling.name = RollingFile
+appender.rolling.fileName = ${sys:logPath}
+appender.rolling.filePattern = ${sys:logPath}.%i
+appender.rolling.layout.type = PatternLayout
+appender.rolling.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %5p %t %-5l - %m%n
+appender.rolling.policies.type = Policies
+appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.rolling.policies.size.size = 10MB
+appender.rolling.strategy.type = DefaultRolloverStrategy
+appender.rolling.strategy.max = 5
+
+# Root logger
+rootLogger.level = info
+rootLogger.appenderRef.rolling.ref = RollingFile


### PR DESCRIPTION
Replace `log4j.properties` with `log4j2.properties` using Log4j 2 native configuration format.
Use `${sys:logPath}` instead of `${logPath}` for system property reference