### PR TITLE
[Chore](profile) attach always true counter to column predicate

### DIFF
--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -210,7 +210,8 @@ public:
             if (null_pred.condition_values.size() != 0) {
                 filters.emplace_back(_column_name, null_pred, _runtime_filter_id,
                                      _predicate_filtered_rows_counter,
-                                     _predicate_input_rows_counter);
+                                     _predicate_input_rows_counter,
+                                     _predicate_always_true_rows_counter);
                 return;
             }
 
@@ -223,9 +224,9 @@ public:
             }
 
             if (low.condition_values.size() != 0) {
-                filters.emplace_back(_column_name, low, _runtime_filter_id,
-                                     _predicate_filtered_rows_counter,
-                                     _predicate_input_rows_counter);
+                filters.emplace_back(
+                        _column_name, low, _runtime_filter_id, _predicate_filtered_rows_counter,
+                        _predicate_input_rows_counter, _predicate_always_true_rows_counter);
             }
 
             TCondition high;
@@ -237,9 +238,9 @@ public:
             }
 
             if (high.condition_values.size() != 0) {
-                filters.emplace_back(_column_name, high, _runtime_filter_id,
-                                     _predicate_filtered_rows_counter,
-                                     _predicate_input_rows_counter);
+                filters.emplace_back(
+                        _column_name, high, _runtime_filter_id, _predicate_filtered_rows_counter,
+                        _predicate_input_rows_counter, _predicate_always_true_rows_counter);
             }
         } else {
             // 3. convert to is null and is not null filter condition
@@ -254,7 +255,8 @@ public:
             if (null_pred.condition_values.size() != 0) {
                 filters.emplace_back(_column_name, null_pred, _runtime_filter_id,
                                      _predicate_filtered_rows_counter,
-                                     _predicate_input_rows_counter);
+                                     _predicate_input_rows_counter,
+                                     _predicate_always_true_rows_counter);
             }
         }
     }
@@ -272,7 +274,8 @@ public:
 
         if (condition.condition_values.size() != 0) {
             filters.emplace_back(_column_name, condition, _runtime_filter_id,
-                                 _predicate_filtered_rows_counter, _predicate_input_rows_counter);
+                                 _predicate_filtered_rows_counter, _predicate_input_rows_counter,
+                                 _predicate_always_true_rows_counter);
         }
     }
 
@@ -312,7 +315,8 @@ public:
     void attach_profile_counter(
             int runtime_filter_id,
             std::shared_ptr<RuntimeProfile::Counter> predicate_filtered_rows_counter,
-            std::shared_ptr<RuntimeProfile::Counter> predicate_input_rows_counter) {
+            std::shared_ptr<RuntimeProfile::Counter> predicate_input_rows_counter,
+            std::shared_ptr<RuntimeProfile::Counter> predicate_always_true_rows_counter) {
         DCHECK(predicate_filtered_rows_counter != nullptr);
         DCHECK(predicate_input_rows_counter != nullptr);
 
@@ -323,6 +327,9 @@ public:
         }
         if (predicate_input_rows_counter != nullptr) {
             _predicate_input_rows_counter = predicate_input_rows_counter;
+        }
+        if (predicate_always_true_rows_counter != nullptr) {
+            _predicate_always_true_rows_counter = predicate_always_true_rows_counter;
         }
     }
 
@@ -397,6 +404,8 @@ private:
     std::shared_ptr<RuntimeProfile::Counter> _predicate_filtered_rows_counter =
             std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0);
     std::shared_ptr<RuntimeProfile::Counter> _predicate_input_rows_counter =
+            std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0);
+    std::shared_ptr<RuntimeProfile::Counter> _predicate_always_true_rows_counter =
             std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0);
 };
 template <>

--- a/be/src/olap/bitmap_filter_predicate.h
+++ b/be/src/olap/bitmap_filter_predicate.h
@@ -111,7 +111,7 @@ uint16_t BitmapFilterColumnPredicate<T>::_evaluate_inner(const vectorized::IColu
     } else {
         new_size = evaluate<false>(column, nullptr, sel, size);
     }
-    update_filter_info(size - new_size, size);
+    update_filter_info(size - new_size, size, 0);
     return new_size;
 }
 } //namespace doris

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -742,8 +742,8 @@ private:
         }
     }
 
-    int32_t __attribute__((flatten)) _find_code_from_dictionary_column(
-            const vectorized::ColumnDictI32& column) const {
+    int32_t __attribute__((flatten))
+    _find_code_from_dictionary_column(const vectorized::ColumnDictI32& column) const {
         int32_t code = 0;
         if (_segment_id_to_cached_code.if_contains(
                     column.get_rowset_segment_id(),

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -396,8 +396,8 @@ public:
     }
 
     template <bool is_and>
-    void __attribute__((flatten)) _evaluate_vec_internal(const vectorized::IColumn& column,
-                                                         uint16_t size, bool* flags) const {
+    void __attribute__((flatten))
+    _evaluate_vec_internal(const vectorized::IColumn& column, uint16_t size, bool* flags) const {
         uint16_t current_evaluated_rows = 0;
         uint16_t current_passed_rows = 0;
         if (_can_ignore()) {
@@ -625,10 +625,9 @@ private:
     }
 
     template <bool is_nullable, bool is_and, typename TArray, typename TValue>
-    void __attribute__((flatten)) _base_loop_vec(uint16_t size, bool* __restrict bflags,
-                                                 const uint8_t* __restrict null_map,
-                                                 const TArray* __restrict data_array,
-                                                 const TValue& value) const {
+    void __attribute__((flatten))
+    _base_loop_vec(uint16_t size, bool* __restrict bflags, const uint8_t* __restrict null_map,
+                   const TArray* __restrict data_array, const TValue& value) const {
         //uint8_t helps compiler to generate vectorized code
         auto* flags = reinterpret_cast<uint8_t*>(bflags);
         if constexpr (is_and) {

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -396,8 +396,8 @@ public:
     }
 
     template <bool is_and>
-    void __attribute__((flatten))
-    _evaluate_vec_internal(const vectorized::IColumn& column, uint16_t size, bool* flags) const {
+    void __attribute__((flatten)) _evaluate_vec_internal(const vectorized::IColumn& column,
+                                                         uint16_t size, bool* flags) const {
         uint16_t current_evaluated_rows = 0;
         uint16_t current_passed_rows = 0;
         if (_can_ignore()) {
@@ -415,8 +415,8 @@ public:
         // so reference here is safe.
         // https://stackoverflow.com/questions/14688285/c-local-variable-destruction-order
         Defer defer([&]() {
-            update_filter_info(current_evaluated_rows - current_passed_rows,
-                               current_evaluated_rows);
+            update_filter_info(current_evaluated_rows - current_passed_rows, current_evaluated_rows,
+                               0);
             try_reset_judge_selectivity();
         });
 
@@ -625,9 +625,10 @@ private:
     }
 
     template <bool is_nullable, bool is_and, typename TArray, typename TValue>
-    void __attribute__((flatten))
-    _base_loop_vec(uint16_t size, bool* __restrict bflags, const uint8_t* __restrict null_map,
-                   const TArray* __restrict data_array, const TValue& value) const {
+    void __attribute__((flatten)) _base_loop_vec(uint16_t size, bool* __restrict bflags,
+                                                 const uint8_t* __restrict null_map,
+                                                 const TArray* __restrict data_array,
+                                                 const TValue& value) const {
         //uint8_t helps compiler to generate vectorized code
         auto* flags = reinterpret_cast<uint8_t*>(bflags);
         if constexpr (is_and) {
@@ -742,8 +743,8 @@ private:
         }
     }
 
-    int32_t __attribute__((flatten))
-    _find_code_from_dictionary_column(const vectorized::ColumnDictI32& column) const {
+    int32_t __attribute__((flatten)) _find_code_from_dictionary_column(
+            const vectorized::ColumnDictI32& column) const {
         int32_t code = 0;
         if (_segment_id_to_cached_code.if_contains(
                     column.get_rowset_segment_id(),

--- a/be/src/olap/filter_olap_param.h
+++ b/be/src/olap/filter_olap_param.h
@@ -25,7 +25,8 @@ template <typename T>
 struct FilterOlapParam {
     FilterOlapParam(std::string column_name, T filter, int runtime_filter_id,
                     std::shared_ptr<RuntimeProfile::Counter> filtered_counter,
-                    std::shared_ptr<RuntimeProfile::Counter> input_counter)
+                    std::shared_ptr<RuntimeProfile::Counter> input_counter,
+                    std::shared_ptr<RuntimeProfile::Counter> always_true_counter)
             : column_name(std::move(column_name)),
               filter(std::move(filter)),
               runtime_filter_id(runtime_filter_id) {
@@ -37,6 +38,9 @@ struct FilterOlapParam {
         if (input_counter != nullptr) {
             input_rows_counter = input_counter;
         }
+        if (always_true_counter != nullptr) {
+            always_true_rows_counter = always_true_counter;
+        }
     }
 
     std::string column_name;
@@ -45,6 +49,8 @@ struct FilterOlapParam {
     std::shared_ptr<RuntimeProfile::Counter> filtered_rows_counter =
             std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0);
     std::shared_ptr<RuntimeProfile::Counter> input_rows_counter =
+            std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0);
+    std::shared_ptr<RuntimeProfile::Counter> always_true_rows_counter =
             std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0);
 };
 

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -2262,12 +2262,8 @@ uint16_t SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_
     for (const auto& pred : _pre_eval_block_predicate) {
         if (!pred->always_true()) {
             all_pred_always_true = false;
-            break;
-        }
-    }
-    if (all_pred_always_true) {
-        for (const auto& pred : _pre_eval_block_predicate) {
-            DCHECK(pred->always_true());
+        } else {
+            pred->update_filter_info(0, 0, selected_size);
         }
     }
 

--- a/be/src/olap/tablet_reader.cpp
+++ b/be/src/olap/tablet_reader.cpp
@@ -527,7 +527,8 @@ Status TabletReader::_init_conditions_param(const ReaderParams& read_params) {
         for (const auto& param : params) {
             ColumnPredicate* predicate = _parse_to_predicate({param.column_name, param.filter});
             predicate->attach_profile_counter(param.runtime_filter_id, param.filtered_rows_counter,
-                                              param.input_rows_counter, param.always_true_rows_counter);
+                                              param.input_rows_counter,
+                                              param.always_true_rows_counter);
             predicates.emplace_back(predicate);
         }
     };

--- a/be/src/olap/tablet_reader.cpp
+++ b/be/src/olap/tablet_reader.cpp
@@ -527,7 +527,7 @@ Status TabletReader::_init_conditions_param(const ReaderParams& read_params) {
         for (const auto& param : params) {
             ColumnPredicate* predicate = _parse_to_predicate({param.column_name, param.filter});
             predicate->attach_profile_counter(param.runtime_filter_id, param.filtered_rows_counter,
-                                              param.input_rows_counter);
+                                              param.input_rows_counter, param.always_true_rows_counter);
             predicates.emplace_back(predicate);
         }
     };
@@ -545,7 +545,7 @@ Status TabletReader::_init_conditions_param(const ReaderParams& read_params) {
         // record condition value into predicate_params in order to pushdown segment_iterator,
         // _gen_predicate_result_sign will build predicate result unique sign with condition value
         predicate->attach_profile_counter(param.runtime_filter_id, param.filtered_rows_counter,
-                                          param.input_rows_counter);
+                                          param.input_rows_counter, param.always_true_rows_counter);
         predicates.emplace_back(predicate);
     }
     parse_and_emplace_predicates(read_params.bloom_filters);

--- a/be/src/vec/exprs/vruntimefilter_wrapper.h
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.h
@@ -124,6 +124,9 @@ public:
     std::shared_ptr<RuntimeProfile::Counter> predicate_input_rows_counter() const {
         return _rf_input_rows;
     }
+    std::shared_ptr<RuntimeProfile::Counter> predicate_always_true_rows_counter() const {
+        return _always_true_filter_rows;
+    }
 
 private:
     void reset_judge_selectivity() const {


### PR DESCRIPTION
### What problem does this PR solve?
attach always true counter to column predicate

This pull request introduces enhancements to the predicate profiling functionality in the OLAP scan and filtering pipeline. The main change is the addition and propagation of a new counter, `predicate_always_true_rows_counter`, which allows for tracking the number of rows for which a predicate is always true. This improves the granularity of predicate statistics and profiling, aiding in performance analysis and debugging.

**Predicate Profiling Enhancements:**

* Added a new counter, `predicate_always_true_rows_counter`, to `ColumnValueRange`, `ColumnPredicate`, and `FilterOlapParam` for tracking rows where predicates are always true. This includes updates to their constructors and member variables. [[1]](diffhunk://#diff-0957bea0469b45011f2b42e782732de5b2a63507dbd44eae3639edd869e6f681L314-R318) [[2]](diffhunk://#diff-0957bea0469b45011f2b42e782732de5b2a63507dbd44eae3639edd869e6f681R407-R408) [[3]](diffhunk://#diff-e9ad21f7dd14427a089c7540d93baef61756985194bd0c48a31cb3e9fee33c27R388-R389) [[4]](diffhunk://#diff-11b7f0ff4b01194182401292cf00e1557cdb50642ac76835d853ab4660f3a500R53-R54)
* Updated methods and logic to propagate the new counter through predicate initialization and attachment, including changes in constructor calls, method parameters, and assignment logic. [[1]](diffhunk://#diff-0957bea0469b45011f2b42e782732de5b2a63507dbd44eae3639edd869e6f681L213-R214) [[2]](diffhunk://#diff-0957bea0469b45011f2b42e782732de5b2a63507dbd44eae3639edd869e6f681L226-R229) [[3]](diffhunk://#diff-0957bea0469b45011f2b42e782732de5b2a63507dbd44eae3639edd869e6f681L240-R243) [[4]](diffhunk://#diff-0957bea0469b45011f2b42e782732de5b2a63507dbd44eae3639edd869e6f681L257-R259) [[5]](diffhunk://#diff-0957bea0469b45011f2b42e782732de5b2a63507dbd44eae3639edd869e6f681L274-R277) [[6]](diffhunk://#diff-e9ad21f7dd14427a089c7540d93baef61756985194bd0c48a31cb3e9fee33c27L276-R277) [[7]](diffhunk://#diff-e9ad21f7dd14427a089c7540d93baef61756985194bd0c48a31cb3e9fee33c27R288-R290) [[8]](diffhunk://#diff-11b7f0ff4b01194182401292cf00e1557cdb50642ac76835d853ab4660f3a500L28-R29) [[9]](diffhunk://#diff-11b7f0ff4b01194182401292cf00e1557cdb50642ac76835d853ab4660f3a500R41-R43)

**Integration with Predicate Initialization:**

* Modified predicate initialization in `TabletReader::_init_conditions_param` to pass and utilize the new `always_true_rows_counter` for both normal and bloom filter predicates. [[1]](diffhunk://#diff-1d300ce472a619557d14f99f3ee8b75fec95186cf70e1f1cdb9eeeb98587079bL530-R530) [[2]](diffhunk://#diff-1d300ce472a619557d14f99f3ee8b75fec95186cf70e1f1cdb9eeeb98587079bL548-R548)
* Updated scan operator logic to ensure the new counter is attached during predicate normalization in the pipeline execution path.

**Runtime Filter Wrapper Support:**

* Added accessor for `predicate_always_true_rows_counter` in `VRuntimeFilterWrapper` to expose the new profiling metric for vectorized runtime filters.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

