### PR TITLE
[fix](rf)Fix ColumnPredicate rf may not reset judge

### DIFF
--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -355,7 +355,7 @@ protected:
     }
 
     void try_reset_judge_selectivity() const {
-        if (_can_ignore() && (_judge_counter == 0)) {
+        if (_can_ignore() && ((_judge_counter--) == 0)) {
             reset_judge_selectivity();
         }
     }

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -417,6 +417,7 @@ public:
         Defer defer([&]() {
             update_filter_info(current_evaluated_rows - current_passed_rows,
                                current_evaluated_rows);
+            try_reset_judge_selectivity();
         });
 
         if (column.is_nullable()) {

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -2267,7 +2267,7 @@ uint16_t SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_
     }
     if (all_pred_always_true) {
         for (const auto& pred : _pre_eval_block_predicate) {
-            pred->always_true();
+            DCHECK(pred->always_true());
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?
Previously, if always_true() returned true, judge would not be reset.
it was reset inside do_judge_selectivity.

```
        if (always_true()) {
            return size;
        }

        uint16_t new_size = _evaluate_inner(column, sel, size);
        if (_can_ignore()) {
            do_judge_selectivity(size - new_size, size);
        }
        update_filter_info(size - new_size, size);
        return new_size;
```


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

