### PR TITLE
[[fix](rest-s3)Set AWS Request Checksum Calculation only if not set void issues on non-S3 storage

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/AbstractS3CompatibleProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/AbstractS3CompatibleProperties.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.SdkSystemSetting;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -250,6 +251,7 @@ public abstract class AbstractS3CompatibleProperties extends StorageProperties i
         // storage is OSS, OBS, etc., users may still configure the schema as "s3://".
         // To ensure backward compatibility, we append S3-related properties by default.
         appendS3HdfsProperties(hadoopStorageConfig);
+        setDefaultRequestChecksum();
     }
 
     private void appendS3HdfsProperties(Configuration hadoopStorageConfig) {
@@ -273,6 +275,34 @@ public abstract class AbstractS3CompatibleProperties extends StorageProperties i
         hadoopStorageConfig.set("fs.s3a.connection.request.timeout", getRequestTimeoutS());
         hadoopStorageConfig.set("fs.s3a.connection.timeout", getConnectionTimeoutS());
         hadoopStorageConfig.set("fs.s3a.path.style.access", getUsePathStyle());
+    }
+
+    /**
+     * Sets the AWS request checksum calculation property to "WHEN_REQUIRED"
+     * only if it has not been explicitly set by the user.
+     *
+     * <p>
+     * Background:
+     * AWS SDK for Java v2 uses the system property
+     * {@link SdkSystemSetting#AWS_REQUEST_CHECKSUM_CALCULATION} to determine
+     * whether request payloads should have a checksum calculated.
+     * <p>
+     * According to the official AWS discussion:
+     * https://github.com/aws/aws-sdk-java-v2/discussions/5802
+     * - Default SDK behavior may calculate checksums automatically if the property is not set.
+     * - Automatic calculation can affect performance or cause unexpected behavior for large requests.
+     * <p>
+     * This method ensures:
+     * 1. The property is set to "WHEN_REQUIRED" only if the user has not already set it.
+     * 2. User-specified settings are never overridden.
+     * 3. Aligns with AWS SDK recommended best practices.
+     * </p>
+     */
+    public static void setDefaultRequestChecksum() {
+        String key = SdkSystemSetting.AWS_REQUEST_CHECKSUM_CALCULATION.property();
+        if (System.getProperty(key) == null) {
+            System.setProperty(key, "WHEN_REQUIRED");
+        }
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSPropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSPropertiesTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.SdkSystemSetting;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -266,6 +267,15 @@ public class OSSPropertiesTest {
         props.put("fs.oss.impl.disable.cache", "null");
         s3Properties = (OSSProperties) StorageProperties.createPrimary(props);
         Assertions.assertFalse(s3Properties.hadoopStorageConfig.getBoolean("fs.oss.impl.disable.cache", false));
+    }
+
+    @Test
+    public void testResuestCheckSum() throws UserException {
+        Map<String, String> props = Maps.newHashMap();
+        props.put("oss.endpoint", "oss-cn-hangzhou.aliyuncs.com");
+        Assertions.assertEquals("WHEN_REQUIRED", System.getProperty(SdkSystemSetting.AWS_REQUEST_CHECKSUM_CALCULATION.property()));
+        System.setProperty("aws.requestChecksumCalculation", "ALWAYS");
+        Assertions.assertEquals("ALWAYS", System.getProperty(SdkSystemSetting.AWS_REQUEST_CHECKSUM_CALCULATION.property()));
     }
 
 }


### PR DESCRIPTION
AWS SDK for Java v2 uses the system property AwsSystemSetting.AWS_REQUEST_CHECKSUM_CALCULATION to control request payload checksum calculation.


According to the official discussion AWS SDK v2 Discussion https://github.com/aws/aws-sdk-java-v2/discussions/5802 


By default, the SDK may automatically calculate checksums when required.


For AWS S3, setting the default value "WHEN_REQUIRED" ensures checksums are calculated only when necessary, providing both compatibility and performance benefits.


For non-S3 object storage (such as COS, OSS, OBS), using this default value may cause errors, for example:


`aws-chunked encoding is not supported with the specified x-amz-content-sha256 value`

because these services do not support AWS-specific chunked encoding or SHA256 checksum.