### PR TITLE
branch-3.1: [fix](load)Fix object storage protocol validation to exclude non-S3 compatible services like Azure

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LoadStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LoadStmt.java
@@ -626,8 +626,8 @@ public class LoadStmt extends DdlStmt implements NotFallbackInParser {
     }
 
     public void checkS3Param() throws UserException {
-        if (brokerDesc.getFileType() != null && brokerDesc.getFileType().equals(TFileType.FILE_S3)) {
-
+        if (brokerDesc.getFileType() != null && brokerDesc.getFileType().equals(TFileType.FILE_S3)
+                && brokerDesc.getStorageProperties() instanceof ObjectStorageProperties) {
             ObjectStorageProperties storageProperties = (ObjectStorageProperties) brokerDesc.getStorageProperties();
             String endpoint = storageProperties.getEndpoint();
             checkEndpoint(endpoint);


### PR DESCRIPTION
### changes 
Based on the error message, there's a ClassCastException occurring in the LoadStmt class: 

`Error: AzureProperties cannot be cast to ObjectStorageProperties `

The current LoadStmt.checkS3Param() method has a protocol classification issue:
Over-generalized scope: The method checks all storage types using ObjectStorageProperties
Protocol confusion: Azure is an object storage service but not S3-compatible, so it shouldn't use S3-specific validation logic
Type casting error: As shown in the error, AzureProperties cannot be cast to ObjectStorageProperties

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

