### PR TITLE
[fix](nereids)StatementContext must be created before creating stream load plan

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadUtils.java
@@ -24,7 +24,6 @@ import org.apache.doris.catalog.Table;
 import org.apache.doris.common.UserException;
 import org.apache.doris.info.PartitionNamesInfo;
 import org.apache.doris.nereids.CascadesContext;
-import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.analyzer.UnboundAlias;
 import org.apache.doris.nereids.analyzer.UnboundOneRowRelation;
 import org.apache.doris.nereids.analyzer.UnboundSlot;
@@ -199,8 +198,8 @@ public class NereidsLoadUtils {
                 partitionNamesInfo != null ? partitionNamesInfo.getPartitionNames() : ImmutableList.of(),
                 isPartialUpdate, partialUpdateNewKeyPolicy, DMLCommandType.LOAD, currentRootPlan);
 
-        CascadesContext cascadesContext = CascadesContext.initContext(new StatementContext(), currentRootPlan,
-                PhysicalProperties.ANY);
+        CascadesContext cascadesContext = CascadesContext.initContext(ConnectContext.get().getStatementContext(),
+                currentRootPlan, PhysicalProperties.ANY);
         ConnectContext ctx = cascadesContext.getConnectContext();
         // we force convert nullable column to non-nullable column for load
         // so set feDebug to false to avoid AdjustNullableRule report error

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadingTaskPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadingTaskPlanner.java
@@ -28,6 +28,7 @@ import org.apache.doris.common.LoadException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.info.PartitionNamesInfo;
+import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.planner.DataPartition;
 import org.apache.doris.planner.FileLoadScanNode;
@@ -145,6 +146,14 @@ public class NereidsLoadingTaskPlanner {
         }
 
         Preconditions.checkState(!fileGroups.isEmpty() && fileGroups.size() == fileStatusesList.size());
+
+        // make sure StatementContext is set in ConnectContext
+        ConnectContext connectContext = ConnectContext.get();
+        if (connectContext != null && connectContext.getStatementContext() == null) {
+            StatementContext statementContext = new StatementContext();
+            connectContext.setStatementContext(statementContext);
+            statementContext.setConnectContext(connectContext);
+        }
 
         PartitionNamesInfo partitionNamesInfo = getPartitionNamesInfo();
         long txnTimeout = timeoutS == 0 ? ConnectContext.get().getExecTimeoutS() : timeoutS;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsStreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsStreamLoadPlanner.java
@@ -31,6 +31,7 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.load.loadv2.LoadTask;
+import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.planner.DataPartition;
 import org.apache.doris.planner.FileLoadScanNode;
@@ -38,6 +39,7 @@ import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.planner.PlanFragmentId;
 import org.apache.doris.planner.PlanNodeId;
 import org.apache.doris.planner.ScanNode;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.service.FrontendOptions;
 import org.apache.doris.thrift.PaloInternalServiceVersion;
 import org.apache.doris.thrift.TBrokerFileStatus;
@@ -217,6 +219,15 @@ public class NereidsStreamLoadPlanner {
                 throw new DdlException("Column is not SUM AggregateType. column:" + col.getName());
             }
         }
+
+        // make sure StatementContext is set in ConnectContext
+        ConnectContext connectContext = ConnectContext.get();
+        if (connectContext != null && connectContext.getStatementContext() == null) {
+            StatementContext statementContext = new StatementContext();
+            connectContext.setStatementContext(statementContext);
+            statementContext.setConnectContext(connectContext);
+        }
+
         // 1. create file group
         NereidsDataDescription dataDescription = new NereidsDataDescription(destTable.getName(), taskInfo);
         dataDescription.analyzeWithoutCheckPriv(db.getFullName());

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/StreamLoadPlannerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/StreamLoadPlannerTest.java
@@ -17,8 +17,12 @@
 
 package org.apache.doris.planner;
 
+import org.apache.doris.common.IdGenerator;
+import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.load.NereidsLoadUtils;
+import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -31,5 +35,14 @@ public class StreamLoadPlannerTest {
         String sql = new String("k1, k2, k3=abc(), k4=default_value()");
         List<Expression> expressions = NereidsLoadUtils.parseExpressionSeq(sql);
         Assert.assertEquals(4, expressions.size());
+    }
+
+    @Test
+    public void testExprIdGenerator() {
+        IdGenerator<ExprId> exprIdGenerator1 = StatementScopeIdGenerator.getExprIdGenerator();
+        CascadesContext context = CascadesContext.initTempContext();
+        IdGenerator<ExprId> exprIdGenerator2 = context.getStatementContext().getExprIdGenerator();
+        // we get different IdGenerator instance
+        Assert.assertTrue(exprIdGenerator1 != exprIdGenerator2);
     }
 }


### PR DESCRIPTION
In NereidsLoadScanProvider, we call StatementScopeIdGenerator.getExprIdGenerator() to generate ExprId for column mapping exprs. But the StatementContext is not set in ConnectContext at this point. So it will use ExprIdGenerator from default StatementContext. Later when createLoadPlan for stream load, we create a new StatementContext and use a new ExprIdGenerator then. We should only use 1 ExprIdGenerator during stream load process. This pr fix it.
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: (https://github.com/apache/doris/pull/49116)

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

