### PR TITLE
[Enhancement](Snapshot)Add toggle to strip recycle rowset key bounds in compaction op logs

### DIFF
--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -119,6 +119,9 @@ CONF_Bool(force_immediate_recycle, "false");
 
 CONF_mBool(enable_mow_job_key_check, "false");
 
+// Strip key bounds in recycle rowset meta emitted by compaction to shrink op log size
+CONF_Bool(enable_recycle_rowset_strip_key_bounds, "true");
+
 CONF_mBool(enable_restore_job_check, "false");
 
 CONF_mBool(enable_tablet_stats_key_check, "false");

--- a/cloud/src/meta-service/meta_service_job.cpp
+++ b/cloud/src/meta-service/meta_service_job.cpp
@@ -1109,6 +1109,11 @@ void process_compaction_job(MetaServiceCode& code, std::string& msg, std::string
         RecycleRowsetPB recycle_rowset;
         recycle_rowset.set_creation_time(now);
         recycle_rowset.mutable_rowset_meta()->CopyFrom(rs);
+        if (config::enable_recycle_rowset_strip_key_bounds) {
+            // Strip key bounds to shrink operation log for ts compaction recycle entries
+            recycle_rowset.mutable_rowset_meta()->clear_segments_key_bounds();
+            recycle_rowset.mutable_rowset_meta()->clear_segments_key_bounds_truncated();
+        }
         recycle_rowset.set_type(RecycleRowsetPB::COMPACT);
 
         if (is_versioned_write) {
@@ -1657,6 +1662,11 @@ void process_schema_change_job(MetaServiceCode& code, std::string& msg, std::str
         RecycleRowsetPB recycle_rowset;
         recycle_rowset.set_creation_time(now);
         recycle_rowset.mutable_rowset_meta()->CopyFrom(rs);
+        if (config::enable_recycle_rowset_strip_key_bounds) {
+            // Strip key bounds to shrink schema change recycle operation log entries
+            recycle_rowset.mutable_rowset_meta()->clear_segments_key_bounds();
+            recycle_rowset.mutable_rowset_meta()->clear_segments_key_bounds_truncated();
+        }
         recycle_rowset.set_type(RecycleRowsetPB::DROP);
         if (is_versioned_write) {
             schema_change_log.add_recycle_rowsets()->Swap(&recycle_rowset);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

