### PR TITLE
[fix](remote) Endpoint contains `http://` will result in `UnknownHostException`

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/DefaultRemote.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/DefaultRemote.java
@@ -158,7 +158,11 @@ public class DefaultRemote extends RemoteBase {
                 credentials = AwsBasicCredentials.create(obj.getAk(), obj.getSk());
             }
             StaticCredentialsProvider scp = StaticCredentialsProvider.create(credentials);
-            URI endpointUri = URI.create("http://" + obj.getEndpoint());
+            String endpointStr = obj.getEndpoint();
+            if (!endpointStr.contains("://")) {
+                endpointStr = "http://" + endpointStr;
+            }
+            URI endpointUri = URI.create(endpointStr);
             s3Client = S3Client.builder().endpointOverride(endpointUri).credentialsProvider(scp)
                     .region(Region.of(obj.getRegion()))
                     .serviceConfiguration(S3Configuration.builder().chunkedEncodingEnabled(false).build())


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:

endponit maybe contains `http://`, incorrect splicing will lead to `UnknownHostException`

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

