### PR TITLE
[fix](hive) Fix StackOverflowError in insert overwrite on S3-compatible storage

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
@@ -213,7 +213,10 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
         try {
             S3URI s3Uri = S3URI.create(remotePath, isUsePathStyle, forceParsingByStandardUri);
             String bucket = s3Uri.getBucket();
-            String prefix = s3Uri.getKey();
+            String key = s3Uri.getKey();
+            String schemeAndBucket = remotePath.substring(0, remotePath.length() - key.length());
+
+            String prefix = key.endsWith("/") ? key : key + "/";
             ListObjectsV2Request.Builder requestBuilder = ListObjectsV2Request.builder()
                     .bucket(bucket)
                     .prefix(prefix)
@@ -228,7 +231,7 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
                 ListObjectsV2Response response = getClient().listObjectsV2(requestBuilder.build());
 
                 for (CommonPrefix dir : response.commonPrefixes()) {
-                    result.add("s3://" + bucket + "/" + dir.prefix());
+                    result.add(schemeAndBucket + dir.prefix());
                 }
                 continuationToken = response.nextContinuationToken();
             } while (continuationToken != null);


### PR DESCRIPTION
Fix StackOverflowError when executing insert overwrite on Hive tables stored in S3-compatible object storage (OBS, COS, OSS, etc.). The root cause is that
  S3ObjStorage.listDirectories hardcoded "s3://" scheme when constructing directory paths, causing scheme mismatch (e.g., obs:// becomes s3://) which leads to
  infinite recursion in HMSTransaction.doRecursiveDeleteFiles. This PR preserves the original scheme from input path。