### PR TITLE
[fix](parquet)fix hudi parquet read hoodie.datasource.write.drop.partition.columns prop table cause be core.

### DIFF
--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -357,6 +357,7 @@ Status ParquetReader::init_reader(
         if (required_file_columns.find(name) != required_file_columns.end()) {
             _read_file_columns.emplace_back(name);
             _read_table_columns.emplace_back(required_file_columns[name]);
+            _read_table_columns_set.insert(required_file_columns[name]);
         }
     }
     // build column predicates for column lazy read
@@ -365,7 +366,13 @@ Status ParquetReader::init_reader(
 }
 
 bool ParquetReader::_exists_in_file(const VSlotRef* slot_ref) const {
-    return _table_info_node_ptr->children_column_exists(slot_ref->expr_name());
+    // `_read_table_columns_set` is used to ensure that only columns actually read are subject to min-max filtering.
+    // This primarily handles cases where partition columns also exist in a file. The reason it's not modified
+    // in `_table_info_node_ptr` is that Iceberg、Hudi has inconsistent requirements for this node;
+    // Iceberg partition evolution need read partition columns from a file.
+    // hudi set `hoodie.datasource.write.drop.partition.columns=false` not need read partition columns from a file.
+    return _table_info_node_ptr->children_column_exists(slot_ref->expr_name()) &&
+           _read_table_columns_set.contains(slot_ref->expr_name());
 }
 
 bool ParquetReader::_type_matches(const VSlotRef* slot_ref) const {
@@ -946,6 +953,12 @@ Status ParquetReader::_process_page_index_filter(
             // complex type, not support page index yet.
             return false;
         }
+        if (!_col_offsets.contains(parquet_col_id)) {
+            // If the file contains partition columns and the query applies filters on those
+            // partition columns, then reading the page index is unnecessary.
+            return false;
+        }
+
         auto& column_chunk = row_group.columns[parquet_col_id];
         if (column_chunk.column_index_length == 0 || column_chunk.offset_index_length == 0) {
             // column no page index.

--- a/be/src/vec/exec/format/parquet/vparquet_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.h
@@ -289,7 +289,8 @@ private:
     //sequence in file, need to read
     std::vector<std::string> _read_table_columns;
     std::vector<std::string> _read_file_columns;
-
+    // The set of file columns to be read; only columns within this set will be filtered using the min-max predicate.
+    std::set<std::string> _read_table_columns_set;
     // Deleted rows will be marked by Iceberg/Paimon. So we should filter deleted rows when reading it.
     const std::vector<int64_t>* _delete_rows = nullptr;
     int64_t _delete_rows_index = 0;

--- a/be/test/vec/exec/format/parquet/parquet_expr_test.cpp
+++ b/be/test/vec/exec/format/parquet/parquet_expr_test.cpp
@@ -399,6 +399,7 @@ TEST_F(ParquetExprTest, test_ne) {
     auto const_val = std::make_shared<MockLiteral>(
             ColumnHelper::create_column_with_name<DataTypeInt64>({100}));
 
+    slot_ref->set_expr_name("int32_all_null_col");
     fn_eq->add_child(slot_ref);
     fn_eq->add_child(const_val);
     fn_eq->_node_type = TExprNodeType::BINARY_PRED;
@@ -417,7 +418,7 @@ TEST_F(ParquetExprTest, test_eq) {
     auto fn_eq = MockFnCall::create("eq");
     auto const_val = std::make_shared<MockLiteral>(
             ColumnHelper::create_column_with_name<DataTypeInt32>({100}));
-
+    slot_ref->set_expr_name("int32_all_null_col");
     fn_eq->add_child(slot_ref);
     fn_eq->add_child(const_val);
     fn_eq->_node_type = TExprNodeType::BINARY_PRED;
@@ -437,7 +438,7 @@ TEST_F(ParquetExprTest, test_le) {
     auto fn_eq = MockFnCall::create("le");
     auto const_val = std::make_shared<MockLiteral>(
             ColumnHelper::create_column_with_name<DataTypeInt32>({100}));
-
+    slot_ref->set_expr_name("int32_all_null_col");
     fn_eq->add_child(slot_ref);
     fn_eq->add_child(const_val);
     fn_eq->_node_type = TExprNodeType::BINARY_PRED;
@@ -457,7 +458,7 @@ TEST_F(ParquetExprTest, test_ge) {
     auto fn_eq = MockFnCall::create("ge");
     auto const_val = std::make_shared<MockLiteral>(
             ColumnHelper::create_column_with_name<DataTypeInt32>({100}));
-
+    slot_ref->set_expr_name("int32_all_null_col");
     fn_eq->add_child(slot_ref);
     fn_eq->add_child(const_val);
     fn_eq->_node_type = TExprNodeType::BINARY_PRED;
@@ -477,7 +478,7 @@ TEST_F(ParquetExprTest, test_gt) {
     auto fn_eq = MockFnCall::create("gt");
     auto const_val = std::make_shared<MockLiteral>(
             ColumnHelper::create_column_with_name<DataTypeInt32>({100}));
-
+    slot_ref->set_expr_name("int32_all_null_col");
     fn_eq->add_child(slot_ref);
     fn_eq->add_child(const_val);
     fn_eq->_node_type = TExprNodeType::BINARY_PRED;
@@ -497,7 +498,7 @@ TEST_F(ParquetExprTest, test_lt) {
     auto fn_eq = MockFnCall::create("lt");
     auto const_val = std::make_shared<MockLiteral>(
             ColumnHelper::create_column_with_name<DataTypeInt32>({100}));
-
+    slot_ref->set_expr_name("int32_all_null_col");
     fn_eq->add_child(slot_ref);
     fn_eq->add_child(const_val);
     fn_eq->_node_type = TExprNodeType::BINARY_PRED;
@@ -1170,6 +1171,7 @@ TEST_F(ParquetExprTest, test_expr_push_down_and) {
         auto fn_le = MockFnCall::create("le");
         auto const_val = std::make_shared<MockLiteral>(
                 ColumnHelper::create_column_with_name<DataTypeInt64>({10000000002}));
+        slot_ref->set_expr_name("int64_col");
         fn_le->add_child(slot_ref);
         fn_le->add_child(const_val);
         fn_le->_node_type = TExprNodeType::BINARY_PRED;
@@ -1189,7 +1191,7 @@ TEST_F(ParquetExprTest, test_expr_push_down_and) {
         auto fn_le = MockFnCall::create("gt");
         auto const_val = std::make_shared<MockLiteral>(
                 ColumnHelper::create_column_with_name<DataTypeInt64>({100}));
-
+        slot_ref->set_expr_name("int64_col");
         fn_le->add_child(slot_ref);
         fn_le->add_child(const_val);
         fn_le->_node_type = TExprNodeType::BINARY_PRED;
@@ -1209,7 +1211,7 @@ TEST_F(ParquetExprTest, test_expr_push_down_and) {
         auto fn_le = MockFnCall::create("ge");
         auto const_val = std::make_shared<MockLiteral>(
                 ColumnHelper::create_column_with_name<DataTypeInt64>({900}));
-
+        slot_ref->set_expr_name("int64_col");
         fn_le->add_child(slot_ref);
         fn_le->add_child(const_val);
         fn_le->_node_type = TExprNodeType::BINARY_PRED;
@@ -1271,7 +1273,7 @@ TEST_F(ParquetExprTest, test_expr_push_down_or_string) {
         auto fn_lt = MockFnCall::create("lt");
         auto const_val = std::make_shared<MockLiteral>(
                 ColumnHelper::create_column_with_name<DataTypeString>({"name_1"}));
-
+        slot_ref->set_expr_name("string_col");
         fn_lt->add_child(slot_ref);
         fn_lt->add_child(const_val);
         fn_lt->_node_type = TExprNodeType::BINARY_PRED;
@@ -1290,6 +1292,7 @@ TEST_F(ParquetExprTest, test_expr_push_down_or_string) {
     {
         auto slot_ref = std::make_shared<MockSlotRef>(5, std::make_shared<DataTypeString>());
         auto fn_is_not_null = MockFnCall::create("is_not_null_pred");
+        slot_ref->set_expr_name("string_col");
 
         fn_is_not_null->add_child(slot_ref);
         fn_is_not_null->_node_type = TExprNodeType::FUNCTION_CALL;


### PR DESCRIPTION
### What problem does this PR solve?
Related PR: #57771
Problem Summary:
Fixed a core issue when reading Hudi Parquet format tables with the `hoodie.properties`  `hoodie.datasource.write.drop.partition.columns=false`.

```
*** SIGSEGV address not mapped to object (@0x18) received by PID 12234 (TID 38368 OR 0x7f0bd279e640) from PID 24; stack trace: ***
11:01:31    0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:420
11:01:31    1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
11:01:31    2# JVM_handle_linux_signal in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
11:01:31    3# 0x00007F18963FB520 in /lib/x86_64-linux-gnu/libc.so.6
11:01:31    4# std::_Function_handler<bool (doris::vectorized::ParquetPredicate::PageIndexStat**, int), doris::vectorized::ParquetReader::_process_page_index_filter(tparquet::RowGroup const&, doris::vectorized::RowGroupReader::RowGroupIndex const&, std::vector<std::unique_ptr<doris::MutilColumnBlockPredicate, std::default_delete<doris::MutilColumnBlockPredicate> >, std::allocator<std::unique_ptr<doris::MutilColumnBlockPredicate, std::default_delete<doris::MutilColumnBlockPredicate> > > > const&, doris::segment_v2::RowRanges*)::$_1>::_M_invoke(std::_Any_data const&, doris::vectorized::ParquetPredicate::PageIndexStat**&&, int&&) at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:292
11:01:31    5# doris::InListPredicateBase<(doris::PrimitiveType)2, (doris::PredicateType)7, doris::HybridSet<(doris::PrimitiveType)2, doris::FixedContainer<bool, 1ul>, doris::vectorized::PredicateColumnType<(doris::PrimitiveType)2> > >::evaluate_and(doris::vectorized::ParquetPredicate::CachedPageIndexStat*, doris::segment_v2::RowRanges*) const at /home/zcp/repo_center/doris_master/doris/be/src/olap/in_list_predicate.h:345
11:01:31    6# doris::AndBlockColumnPredicate::evaluate_and(doris::vectorized::ParquetPredicate::CachedPageIndexStat*, doris::segment_v2::RowRanges*) const at /home/zcp/repo_center/doris_master/doris/be/src/olap/block_column_predicate.cpp:148
11:01:31    7# doris::vectorized::ParquetReader::_process_page_index_filter(tparquet::RowGroup const&, doris::vectorized::RowGroupReader::RowGroupIndex const&, std::vector<std::unique_ptr<doris::MutilColumnBlockPredicate, std::default_delete<doris::MutilColumnBlockPredicate> >, std::allocator<std::unique_ptr<doris::MutilColumnBlockPredicate, std::default_delete<doris::MutilColumnBlockPredicate> > > > const&, doris::segment_v2::RowRanges*) in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
11:01:31    8# doris::vectorized::ParquetReader::_process_min_max_bloom_filter(doris::vectorized::RowGroupReader::RowGroupIndex const&, tparquet::RowGroup const&, std::vector<std::unique_ptr<doris::MutilColumnBlockPredicate, std::default_delete<doris::MutilColumnBlockPredicate> >, std::allocator<std::unique_ptr<doris::MutilColumnBlockPredicate, std::default_delete<doris::MutilColumnBlockPredicate> > > > const&, doris::segment_v2::RowRanges*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exec/format/parquet/vparquet_reader.cpp:1082
11:01:31    9# doris::vectorized::ParquetReader::_next_row_group_reader() in /mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be
11:01:31   10# doris::vectorized::ParquetReader::get_next_block(doris::vectorized::Block*, unsigned long*, bool*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exec/format/parquet/vparquet_reader.cpp:598
11:01:31   11# doris::vectorized::HudiReader::get_next_block_inner(doris::vectorized::Block*, unsigned long*, bool*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exec/format/table/hudi_reader.cpp:29
11:01:31   12# doris::vectorized::TableFormatReader::get_next_block(doris::vectorized::Block*, unsigned long*, bool*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exec/format/table/table_format_reader.h:82
11:01:31   13# doris::vectorized::FileScanner::_get_block_wrapped(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exec/scan/file_scanner.cpp:472
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

