### PR TITLE
[Feature](Iceberg) Implement ancestors_of procedure for Iceberg tables

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergAncestorsOfAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergAncestorsOfAction.java
@@ -1,0 +1,158 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.action;
+
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.TableIf;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.common.ArgumentParsers;
+import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.iceberg.IcebergExternalTable;
+import org.apache.doris.info.PartitionNamesInfo;
+import org.apache.doris.nereids.trees.expressions.Expression;
+
+import com.google.common.collect.Lists;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.util.SnapshotUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Iceberg ancestors_of action implementation.
+ * This action reports the live snapshot IDs and timestamps of the ancestors of a specified snapshot.
+ * If no snapshot ID is provided, it uses the current snapshot.
+ * This procedure helps trace the snapshot lineage and understand the commit history of a table.
+ *
+ * <p>Use cases:
+ * <ul>
+ *   <li>Locate rollback targets</li>
+ *   <li>Debug commit relationships in multi-branch/multi-tag scenarios</li>
+ *   <li>Understand table evolution history</li>
+ * </ul>
+ *
+ * <p>Syntax:
+ * <pre>
+ * ALTER TABLE table_name EXECUTE ancestors_of();
+ * ALTER TABLE table_name EXECUTE ancestors_of("snapshot_id" = "123456789");
+ * </pre>
+ *
+ * <p>Output:
+ * <ul>
+ *   <li>snapshot_id: The ancestor snapshot ID</li>
+ *   <li>timestamp: The snapshot creation timestamp in milliseconds</li>
+ * </ul>
+ */
+public class IcebergAncestorsOfAction extends BaseIcebergAction {
+    public static final String SNAPSHOT_ID = "snapshot_id";
+
+    public IcebergAncestorsOfAction(Map<String, String> properties,
+            Optional<PartitionNamesInfo> partitionNamesInfo,
+            Optional<Expression> whereCondition) {
+        super("ancestors_of", properties, partitionNamesInfo, whereCondition);
+    }
+
+    @Override
+    protected void registerIcebergArguments() {
+        // Register snapshot_id as an optional parameter
+        // If not provided, the current snapshot will be used
+        namedArguments.registerOptionalArgument(SNAPSHOT_ID,
+                "Snapshot ID to find ancestors for. If not provided, uses the current snapshot.",
+                null,
+                ArgumentParsers.positiveLong(SNAPSHOT_ID));
+    }
+
+    @Override
+    protected void validateIcebergAction() throws UserException {
+        // ancestors_of procedure doesn't support partitions or where conditions
+        validateNoPartitions();
+        validateNoWhereCondition();
+    }
+
+    /**
+     * Execute the ancestors_of action to return multiple rows (one per ancestor snapshot).
+     */
+    @Override
+    protected List<List<String>> executeAction(TableIf table) throws UserException {
+        Table icebergTable = ((IcebergExternalTable) table).getIcebergTable();
+        Long targetSnapshotId = namedArguments.getLong(SNAPSHOT_ID);
+
+        try {
+            // If no snapshot ID is provided, use the current snapshot
+            if (targetSnapshotId == null) {
+                Snapshot currentSnapshot = icebergTable.currentSnapshot();
+                if (currentSnapshot == null) {
+                    // Return empty result if no snapshots exist
+                    return new ArrayList<>();
+                }
+                targetSnapshotId = currentSnapshot.snapshotId();
+            } else {
+                // Validate that the specified snapshot exists
+                Snapshot targetSnapshot = icebergTable.snapshot(targetSnapshotId);
+                if (targetSnapshot == null) {
+                    throw new UserException(
+                            "Snapshot " + targetSnapshotId + " not found in table " + icebergTable.name());
+                }
+            }
+
+            // Get all ancestor snapshot IDs using Iceberg's SnapshotUtil
+            // ancestorIdsBetween returns IDs from targetSnapshotId to the oldest ancestor (null means no limit)
+            List<Long> ancestorIds = Lists.newArrayList(
+                    SnapshotUtil.ancestorIdsBetween(targetSnapshotId, null, icebergTable::snapshot));
+
+            // Build result rows
+            List<List<String>> resultRows = new ArrayList<>();
+            for (Long ancestorId : ancestorIds) {
+                Snapshot snapshot = icebergTable.snapshot(ancestorId);
+                if (snapshot != null) {
+                    List<String> row = Lists.newArrayList(
+                            String.valueOf(ancestorId),
+                            String.valueOf(snapshot.timestampMillis())
+                    );
+                    resultRows.add(row);
+                }
+            }
+
+            return resultRows;
+
+        } catch (UserException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new UserException("Failed to get ancestors of snapshot " + targetSnapshotId
+                    + ": " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    protected List<Column> getResultSchema() {
+        return Lists.newArrayList(
+                new Column("snapshot_id", Type.BIGINT, false,
+                        "ID of an ancestor snapshot in the lineage chain, "
+                                + "ordered from the specified snapshot to the oldest ancestor"),
+                new Column("timestamp", Type.BIGINT, false,
+                        "Snapshot creation timestamp in milliseconds"));
+    }
+
+    @Override
+    public String getDescription() {
+        return "Report the ancestor snapshot IDs and timestamps of a specified snapshot or the current snapshot";
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergCherrypickSnapshotAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergCherrypickSnapshotAction.java
@@ -69,7 +69,7 @@ public class IcebergCherrypickSnapshotAction extends BaseIcebergAction {
     }
 
     @Override
-    protected List<String> executeAction(TableIf table) throws UserException {
+    protected List<List<String>> executeAction(TableIf table) throws UserException {
         Table icebergTable = ((IcebergExternalTable) table).getIcebergTable();
         Long sourceSnapshotId = namedArguments.getLong(SNAPSHOT_ID);
 
@@ -84,11 +84,11 @@ public class IcebergCherrypickSnapshotAction extends BaseIcebergAction {
 
             // invalid iceberg catalog table cache.
             Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTableCache((ExternalTable) table);
-            return Lists.newArrayList(
+            return Lists.newArrayList(Lists.newArrayList(
                     String.valueOf(sourceSnapshotId),
                     String.valueOf(currentSnapshot.snapshotId()
                     )
-            );
+            ));
 
         } catch (Exception e) {
             throw new UserException("Failed to cherry-pick snapshot " + sourceSnapshotId + ": " + e.getMessage(), e);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergExecuteActionFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergExecuteActionFactory.java
@@ -40,6 +40,7 @@ public class IcebergExecuteActionFactory {
     public static final String EXPIRE_SNAPSHOTS = "expire_snapshots";
     public static final String REWRITE_DATA_FILES = "rewrite_data_files";
     public static final String PUBLISH_CHANGES = "publish_changes";
+    public static final String ANCESTORS_OF = "ancestors_of";
 
     /**
      * Create an Iceberg-specific ExecuteAction instance.
@@ -84,6 +85,9 @@ public class IcebergExecuteActionFactory {
             case PUBLISH_CHANGES:
                 return new IcebergPublishChangesAction(properties, partitionNamesInfo,
                         whereCondition);
+            case ANCESTORS_OF:
+                return new IcebergAncestorsOfAction(properties, partitionNamesInfo,
+                        whereCondition);
             default:
                 throw new DdlException("Unsupported Iceberg procedure: " + actionType
                         + ". Supported procedures: " + String.join(", ", getSupportedActions()));
@@ -104,7 +108,8 @@ public class IcebergExecuteActionFactory {
                 FAST_FORWARD,
                 EXPIRE_SNAPSHOTS,
                 REWRITE_DATA_FILES,
-                PUBLISH_CHANGES
+                PUBLISH_CHANGES,
+                ANCESTORS_OF
         };
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergExpireSnapshotsAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergExpireSnapshotsAction.java
@@ -114,7 +114,7 @@ public class IcebergExpireSnapshotsAction extends BaseIcebergAction {
     }
 
     @Override
-    protected List<String> executeAction(TableIf table) throws UserException {
+    protected List<List<String>> executeAction(TableIf table) throws UserException {
         throw new DdlException("Iceberg expire_snapshots procedure is not implemented yet");
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergFastForwardAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergFastForwardAction.java
@@ -69,7 +69,7 @@ public class IcebergFastForwardAction extends BaseIcebergAction {
     }
 
     @Override
-    protected List<String> executeAction(TableIf table) throws UserException {
+    protected List<List<String>> executeAction(TableIf table) throws UserException {
         Table icebergTable = ((IcebergExternalTable) table).getIcebergTable();
 
         String sourceBranch = namedArguments.getString(BRANCH);
@@ -83,11 +83,11 @@ public class IcebergFastForwardAction extends BaseIcebergAction {
             long snapshotAfter = icebergTable.snapshot(sourceBranch).snapshotId();
             // invalid iceberg catalog table cache.
             Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTableCache((ExternalTable) table);
-            return Lists.newArrayList(
+            return Lists.newArrayList(Lists.newArrayList(
                     sourceBranch.trim(),
                     String.valueOf(snapshotBefore),
                     String.valueOf(snapshotAfter)
-            );
+            ));
 
         } catch (Exception e) {
             throw new UserException(

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergPublishChangesAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergPublishChangesAction.java
@@ -65,7 +65,7 @@ public class IcebergPublishChangesAction extends BaseIcebergAction {
     }
 
     @Override
-    protected List<String> executeAction(TableIf table) throws UserException {
+    protected List<List<String>> executeAction(TableIf table) throws UserException {
         Table icebergTable = ((IcebergExternalTable) table).getIcebergTable();
         String targetWapId = namedArguments.getString(WAP_ID);
 
@@ -102,10 +102,10 @@ public class IcebergPublishChangesAction extends BaseIcebergAction {
             String previousSnapshotIdString = previousSnapshotId != null ? String.valueOf(previousSnapshotId) : "null";
             String currentSnapshotIdString = currentSnapshotId != null ? String.valueOf(currentSnapshotId) : "null";
 
-            return Lists.newArrayList(
+            return Lists.newArrayList(Lists.newArrayList(
                     previousSnapshotIdString,
                     currentSnapshotIdString
-            );
+            ));
 
         } catch (Exception e) {
             throw new UserException("Failed to publish changes for wap.id " + targetWapId + ": " + e.getMessage(), e);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergRewriteDataFilesAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergRewriteDataFilesAction.java
@@ -165,14 +165,14 @@ public class IcebergRewriteDataFilesAction extends BaseIcebergAction {
     }
 
     @Override
-    protected List<String> executeAction(TableIf table) throws UserException {
+    protected List<List<String>> executeAction(TableIf table) throws UserException {
         try {
             Table icebergTable = IcebergUtils.getIcebergTable((IcebergExternalTable) table);
 
             if (icebergTable.currentSnapshot() == null) {
                 LOG.info("Table {} has no data, skipping rewrite", table.getName());
                 // return empty result
-                return Lists.newArrayList("0", "0", "0", "0");
+                return Lists.newArrayList(Lists.newArrayList("0", "0", "0", "0"));
             }
 
             RewriteDataFilePlanner.Parameters parameters = buildRewriteParameters();
@@ -194,7 +194,7 @@ public class IcebergRewriteDataFilesAction extends BaseIcebergAction {
                     (IcebergExternalTable) table, connectContext);
             long targetFileSizeBytes = namedArguments.getLong(TARGET_FILE_SIZE_BYTES);
             RewriteResult totalResult = executor.executeGroupsConcurrently(groupsList, targetFileSizeBytes);
-            return totalResult.toStringList();
+            return Lists.newArrayList(totalResult.toStringList());
         } catch (Exception e) {
             LOG.warn("Failed to rewrite data files for table: " + table.getName(), e);
             throw new UserException("Rewrite data files failed: " + e.getMessage());

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergRollbackToSnapshotAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergRollbackToSnapshotAction.java
@@ -67,7 +67,7 @@ public class IcebergRollbackToSnapshotAction extends BaseIcebergAction {
     }
 
     @Override
-    protected List<String> executeAction(TableIf table) throws UserException {
+    protected List<List<String>> executeAction(TableIf table) throws UserException {
         Table icebergTable = ((IcebergExternalTable) table).getIcebergTable();
         Long targetSnapshotId = namedArguments.getLong(SNAPSHOT_ID);
 
@@ -80,18 +80,18 @@ public class IcebergRollbackToSnapshotAction extends BaseIcebergAction {
             Snapshot previousSnapshot = icebergTable.currentSnapshot();
             Long previousSnapshotId = previousSnapshot != null ? previousSnapshot.snapshotId() : null;
             if (previousSnapshot != null && previousSnapshot.snapshotId() == targetSnapshotId) {
-                return Lists.newArrayList(
+                return Lists.newArrayList(Lists.newArrayList(
                         String.valueOf(previousSnapshotId),
                         String.valueOf(targetSnapshotId)
-                );
+                ));
             }
             icebergTable.manageSnapshots().rollbackTo(targetSnapshotId).commit();
             // invalid iceberg catalog table cache.
             Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTableCache((ExternalTable) table);
-            return Lists.newArrayList(
+            return Lists.newArrayList(Lists.newArrayList(
                     String.valueOf(previousSnapshotId),
                     String.valueOf(targetSnapshotId)
-            );
+            ));
 
         } catch (Exception e) {
             throw new UserException("Failed to rollback to snapshot " + targetSnapshotId + ": " + e.getMessage(), e);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergRollbackToTimestampAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergRollbackToTimestampAction.java
@@ -94,7 +94,7 @@ public class IcebergRollbackToTimestampAction extends BaseIcebergAction {
     }
 
     @Override
-    protected List<String> executeAction(TableIf table) throws UserException {
+    protected List<List<String>> executeAction(TableIf table) throws UserException {
         Table icebergTable = ((IcebergExternalTable) table).getIcebergTable();
 
         String timestampStr = namedArguments.getString(TIMESTAMP);
@@ -110,10 +110,10 @@ public class IcebergRollbackToTimestampAction extends BaseIcebergAction {
             Long currentSnapshotId = currentSnapshot != null ? currentSnapshot.snapshotId() : null;
             // invalid iceberg catalog table cache.
             Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTableCache((ExternalTable) table);
-            return Lists.newArrayList(
+            return Lists.newArrayList(Lists.newArrayList(
                     String.valueOf(previousSnapshotId),
                     String.valueOf(currentSnapshotId)
-            );
+            ));
 
         } catch (Exception e) {
             throw new UserException("Failed to rollback to timestamp " + timestampStr + ": " + e.getMessage(), e);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergSetCurrentSnapshotAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergSetCurrentSnapshotAction.java
@@ -86,7 +86,7 @@ public class IcebergSetCurrentSnapshotAction extends BaseIcebergAction {
     }
 
     @Override
-    protected List<String> executeAction(TableIf table) throws UserException {
+    protected List<List<String>> executeAction(TableIf table) throws UserException {
         Table icebergTable = ((IcebergExternalTable) table).getIcebergTable();
 
         Snapshot previousSnapshot = icebergTable.currentSnapshot();
@@ -104,10 +104,10 @@ public class IcebergSetCurrentSnapshotAction extends BaseIcebergAction {
                 }
 
                 if (previousSnapshot != null && previousSnapshot.snapshotId() == targetSnapshotId) {
-                    return Lists.newArrayList(
+                    return Lists.newArrayList(Lists.newArrayList(
                             String.valueOf(previousSnapshotId),
                             String.valueOf(targetSnapshotId)
-                    );
+                    ));
                 }
 
                 icebergTable.manageSnapshots().setCurrentSnapshot(targetSnapshotId).commit();
@@ -120,10 +120,10 @@ public class IcebergSetCurrentSnapshotAction extends BaseIcebergAction {
                 targetSnapshotId = refSnapshot.snapshotId();
 
                 if (previousSnapshot != null && previousSnapshot.snapshotId() == targetSnapshotId) {
-                    return Lists.newArrayList(
+                    return Lists.newArrayList(Lists.newArrayList(
                             String.valueOf(previousSnapshotId),
                             String.valueOf(targetSnapshotId)
-                    );
+                    ));
                 }
 
                 icebergTable.manageSnapshots().setCurrentSnapshot(targetSnapshotId).commit();
@@ -131,10 +131,10 @@ public class IcebergSetCurrentSnapshotAction extends BaseIcebergAction {
 
             // invalid iceberg catalog table cache.
             Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTableCache((ExternalTable) table);
-            return Lists.newArrayList(
+            return Lists.newArrayList(Lists.newArrayList(
                     String.valueOf(previousSnapshotId),
                     String.valueOf(targetSnapshotId)
-            );
+            ));
 
         } catch (Exception e) {
             String target = targetSnapshotId != null ? "snapshot " + targetSnapshotId : "reference '" + ref + "'";

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/execute/BaseExecuteAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/execute/BaseExecuteAction.java
@@ -99,15 +99,14 @@ public abstract class BaseExecuteAction implements ExecuteAction {
 
     @Override
     public final ResultSet execute(TableIf table) throws UserException {
-        List<String> resultRow = executeAction(table);
-        if (resultSetMetaData == null || resultRow == null) {
+        List<List<String>> resultRows = executeAction(table);
+        if (resultSetMetaData == null || resultRows == null) {
             return null;
         }
-        Preconditions.checkState(resultSetMetaData.getColumnCount() == resultRow.size(),
-                "Result row size does not match metadata column count");
-        // the result should be just one row, so we wrap it in a list
-        List<List<String>> resultRows = Lists.newArrayList();
-        resultRows.add(resultRow);
+        for (List<String> row : resultRows) {
+            Preconditions.checkState(resultSetMetaData.getColumnCount() == row.size(),
+                    "Result row size does not match metadata column count");
+        }
         return new CommonResultSet(resultSetMetaData, resultRows);
     }
 
@@ -141,10 +140,10 @@ public abstract class BaseExecuteAction implements ExecuteAction {
      * Subclasses must implement this method to perform the actual action.
      *
      * @param table the table to operate on
-     * @return list of result if the action produces results, null otherwise
+     * @return list of result rows if the action produces results, null otherwise
      * @throws UserException if execution fails
      */
-    protected abstract List<String> executeAction(TableIf table) throws UserException;
+    protected abstract List<List<String>> executeAction(TableIf table) throws UserException;
 
     @Override
     public String getActionType() {


### PR DESCRIPTION
### What problem does this PR solve?

- **Issue Number**: part of #58199
- **Related PR**: N/A

**Problem Summary:**

This PR implements the `ancestors_of` procedure for Iceberg tables. The procedure reports the live snapshot IDs and timestamps of the ancestors of a specified snapshot, helping users trace snapshot lineage and understand the commit history of a table.

**Syntax:**

```sql
ALTER TABLE catalog.db.table_name EXECUTE ancestors_of();
ALTER TABLE catalog.db.table_name EXECUTE ancestors_of("snapshot_id" = "123456789");
```

**Output:**
Returns `snapshot_id` (BIGINT) and `timestamp` (BIGINT) for each ancestor snapshot.

**Use cases:**
- Locate rollback targets
- Debug commit relationships
- Understand table evolution history

### Release note

Support `ancestors_of` procedure for Iceberg tables to report snapshot ancestry chain.

### Check List (For Author)

**Test**

- [x] Regression test
- [ ] Unit Test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No need to test or manual test. Explain why:
  - [ ] This is a refactor/code format and no logic has been changed.
  - [ ] Previous test can cover this change.
  - [ ] No code files have been changed.
  - [ ] Other reason

**Behavior changed:**

- [x] No.
- [ ] Yes.

**Does this need documentation?**

- [x] No.
- [ ] Yes. 

### Check List (For Reviewer who merge this PR)
- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label