### PR TITLE
[fix](nereids) fix prune map type cause backend core

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathExpressionCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathExpressionCollector.java
@@ -532,7 +532,7 @@ public class AccessPathExpressionCollector extends DefaultExpressionVisitor<Void
     // backend will throw exception because it can not only access the values without the cast keys,
     // so we should check whether the map type is changed, if not changed, we can prune the type.
     private static boolean mapTypeIsChanged(DataType originType, DataType castType, boolean inMap) {
-        if (originType.isMapType() && !originType.equals(castType)) {
+        if (originType.isMapType()) {
             MapType originMapType = (MapType) originType;
             MapType castMapType = (MapType) castType;
             if (mapTypeIsChanged(originMapType.getKeyType(), castMapType.getKeyType(), true)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathExpressionCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathExpressionCollector.java
@@ -528,7 +528,7 @@ public class AccessPathExpressionCollector extends DefaultExpressionVisitor<Void
 
     // if the map type is changed, we can not prune the type, because the map type need distinct the keys,
     // e.g. select map_values(cast(map(3.0, 1, 3.1, 2) as map<int, int>));
-    // the result is [1] because the keys: 3.0 and 3.1 will cast to 3 and the first entry remained.
+    // the result is [2] because the keys: 3.0 and 3.1 will cast to 3 and the second entry remained.
     // backend will throw exception because it can not only access the values without the cast keys,
     // so we should check whether the map type is changed, if not changed, we can prune the type.
     private static boolean mapTypeIsChanged(DataType originType, DataType castType, boolean inMap) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathExpressionCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathExpressionCollector.java
@@ -51,7 +51,9 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.MapValues;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.StructElement;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.visitor.DefaultExpressionVisitor;
+import org.apache.doris.nereids.types.ArrayType;
 import org.apache.doris.nereids.types.DataType;
+import org.apache.doris.nereids.types.MapType;
 import org.apache.doris.nereids.types.NestedColumnPrunable;
 import org.apache.doris.nereids.types.StructField;
 import org.apache.doris.nereids.types.StructType;
@@ -66,6 +68,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Stack;
 
@@ -136,7 +139,8 @@ public class AccessPathExpressionCollector extends DefaultExpressionVisitor<Void
     public Void visitCast(Cast cast, CollectorContext context) {
         if (!context.accessPathBuilder.isEmpty()
                 && cast.getDataType() instanceof NestedColumnPrunable
-                && cast.child().getDataType() instanceof NestedColumnPrunable) {
+                && cast.child().getDataType() instanceof NestedColumnPrunable
+                && !mapTypeIsChanged(cast.child().getDataType(), cast.getDataType(), false)) {
 
             DataTypeAccessTree castTree = DataTypeAccessTree.of(cast.getDataType(), TAccessPathType.DATA);
             DataTypeAccessTree originTree = DataTypeAccessTree.of(cast.child().getDataType(), TAccessPathType.DATA);
@@ -519,6 +523,48 @@ public class AccessPathExpressionCollector extends DefaultExpressionVisitor<Void
         @Override
         public int hashCode() {
             return path.hashCode();
+        }
+    }
+
+    // if the map type is changed, we can not prune the type, because the map type need distinct the keys,
+    // e.g. select map_values(cast(map(3.0, 1, 3.1, 2) as map<int, int>));
+    // the result is [1] because the keys: 3.0 and 3.1 will cast to 3 and the first entry remained.
+    // backend will throw exception because it can not only access the values without the cast keys,
+    // so we should check whether the map type is changed, if not changed, we can prune the type.
+    private static boolean mapTypeIsChanged(DataType originType, DataType castType, boolean inMap) {
+        if (originType.isMapType() && !originType.equals(castType)) {
+            MapType originMapType = (MapType) originType;
+            MapType castMapType = (MapType) castType;
+            if (mapTypeIsChanged(originMapType.getKeyType(), castMapType.getKeyType(), true)
+                    || mapTypeIsChanged(originMapType.getValueType(), castMapType.getValueType(), true)) {
+                return true;
+            }
+            return false;
+        } else if (originType.isStructType()) {
+            StructType originStructType = (StructType) originType;
+            StructType castStructType = (StructType) castType;
+            List<Entry<String, StructField>> originFields
+                    = new ArrayList<>(originStructType.getNameToFields().entrySet());
+            List<Entry<String, StructField>> castFields
+                    = new ArrayList<>(castStructType.getNameToFields().entrySet());
+
+            for (int i = 0; i < originFields.size(); i++) {
+                DataType originFieldType = originFields.get(i).getValue().getDataType();
+                DataType castFieldType = castFields.get(i).getValue().getDataType();
+                if (mapTypeIsChanged(originFieldType, castFieldType, inMap)) {
+                    return true;
+                }
+            }
+            return false;
+        } else if (originType.isArrayType()) {
+            ArrayType originArrayType = (ArrayType) originType;
+            ArrayType castArrayType = (ArrayType) castType;
+            return mapTypeIsChanged(originArrayType.getItemType(), castArrayType.getItemType(), inMap);
+        } else if (inMap) {
+            return !originType.equals(castType);
+        } else {
+            // other type changed which not in map will not affect the map
+            return false;
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneNestedColumnTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneNestedColumnTest.java
@@ -140,13 +140,20 @@ public class PruneNestedColumnTest extends TestWithFeService implements MemoPatt
 
     @Test
     public void testPruneCast() throws Exception {
+        // the map type is changed, so we can not prune type
+        assertColumn("select struct_element(cast(s as struct<k:text,l:array<map<int,struct<x:int,y:int>>>>), 'k') from tbl",
+                "struct<city:text,data:array<map<int,struct<a:int,b:double>>>>",
+                ImmutableList.of(path("s")),
+                ImmutableList.of()
+        );
+
         assertColumn("select struct_element(cast(s as struct<k:text,l:array<map<int,struct<x:int,y:double>>>>), 'k') from tbl",
                 "struct<city:text>",
                 ImmutableList.of(path("s", "city")),
                 ImmutableList.of()
         );
 
-        assertColumn("select struct_element(map_values(struct_element(cast(s as struct<k:text,l:array<map<int,struct<x:double,y:double>>>>), 'l')[0])[0], 'x') from tbl",
+        assertColumn("select struct_element(map_values(struct_element(cast(s as struct<k:text,l:array<map<int,struct<x:int,y:double>>>>), 'l')[0])[0], 'x') from tbl",
                 "struct<data:array<map<int,struct<a:int>>>>",
                 ImmutableList.of(path("s", "data", "*", "VALUES", "a")),
                 ImmutableList.of()


### PR DESCRIPTION
### What problem does this PR solve?

fix prune map type cause backend core, when the map type is changed, we should not prune the nested column type, introduced by #57204

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

