### PR TITLE
[fix](Hive) Fix insert failure for non-partitioned object storage tables

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HiveTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HiveTableSink.java
@@ -48,12 +48,10 @@ import org.apache.doris.thrift.THiveSerDeProperties;
 import org.apache.doris.thrift.THiveTableSink;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -203,7 +201,7 @@ public class HiveTableSink extends BaseExternalTableDataSink {
 
         List<THivePartition> partitions = new ArrayList<>();
 
-        List<HivePartition> hivePartitions;
+        List<HivePartition> hivePartitions = new ArrayList<>();
         if (targetTable.isPartitionedTable()) {
             // Get partitions from cache instead of HMS client (similar to HiveScanNode)
             HiveMetaStoreCache cache = Env.getCurrentEnv().getExtMetaCacheMgr()
@@ -213,14 +211,6 @@ public class HiveTableSink extends BaseExternalTableDataSink {
             List<List<String>> partitionValuesList =
                     new ArrayList<>(partitionValues.getPartitionValuesMap().values());
             hivePartitions = cache.getAllPartitionsWithCache(targetTable, partitionValuesList);
-        } else {
-            // Non-partitioned table, create dummy partition
-            hivePartitions = Lists.newArrayList();
-            StorageDescriptor sd = targetTable.getRemoteTable().getSd();
-            HivePartition dummyPartition = new HivePartition(targetTable.getOrBuildNameMapping(), true,
-                    sd.getInputFormat(), sd.getLocation(), Lists.newArrayList(),
-                    sd.getParameters() != null ? sd.getParameters() : new HashMap<>());
-            hivePartitions.add(dummyPartition);
         }
 
         // Convert HivePartition to THivePartition (same logic as before)


### PR DESCRIPTION
### Problem

Reproduction Steps: Create a Hive Catalog, create an unpartitioned table, then insert data. The following failure occurs.

```
copy file failed: software.amazon.awssdk.services.s3.model.NoSuchKeyException: The specified key does not exist. (Service: S3, Status Code: 404,
```

The BE mistakenly treats non-partitioned tables as partitioned ones. For partitioned tables, the system always appends a folder suffix for each partition, organizing data into partition directories. However, non-partitioned tables do not require partition information. In this case, the BE incorrectly added a partition folder suffix for non-partitioned tables, causing the insert operation to fail.

### Solution
- Skip setting partition information for non-partitioned tables in the BE.
- Maintain current behavior for partitioned tables, including folder suffix handling.

### Result
- Inserts into non-partitioned object storage tables succeed.
- Partitioned tables continue to work as expected.

This issue was introduced in #58166

