### PR TITLE
[refine](exec)Provide an execute_filter interface in expr to execute execute_conjuncts.

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1010,7 +1010,7 @@ DEFINE_mInt64(big_column_size_buffer, "65535");
 DEFINE_mInt64(small_column_size_buffer, "100");
 
 // Perform the always_true check at intervals determined by runtime_filter_sampling_frequency
-DEFINE_mInt32(runtime_filter_sampling_frequency, "64");
+DEFINE_mInt32(runtime_filter_sampling_frequency, "32");
 DEFINE_mInt32(execution_max_rpc_timeout_sec, "3600");
 DEFINE_mBool(execution_ignore_eovercrowded, "true");
 // cooldown task configs

--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -24,6 +24,7 @@
 #include "olap/rowset/segment_v2/bloom_filter.h"
 #include "olap/rowset/segment_v2/inverted_index_iterator.h"
 #include "runtime/define_primitive_type.h"
+#include "runtime_filter/runtime_filter_selectivity.h"
 #include "util/defer_op.h"
 #include "util/runtime_profile.h"
 #include "vec/columns/column.h"
@@ -419,8 +420,8 @@ protected:
         if (!_always_true) {
             _judge_filter_rows += filter_rows;
             _judge_input_rows += input_rows;
-            vectorized::VRuntimeFilterWrapper::judge_selectivity(
-                    get_ignore_threshold(), _judge_filter_rows, _judge_input_rows, _always_true);
+            RuntimeFilterSelectivity::judge_selectivity(get_ignore_threshold(), _judge_filter_rows,
+                                                        _judge_input_rows, _always_true);
         }
     }
 

--- a/be/src/runtime_filter/runtime_filter_selectivity.h
+++ b/be/src/runtime_filter/runtime_filter_selectivity.h
@@ -1,0 +1,96 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdint>
+
+#include "common/config.h"
+#include "common/logging.h"
+
+namespace doris {
+
+// Used to track the selectivity of runtime filters
+// If the selectivity of a runtime filter is very low, it is considered ineffective and can be ignored
+// Considering that the selectivity of runtime filters may change with data variations
+// A dynamic selectivity tracking mechanism is needed
+// Note: this is not a thread-safe class
+
+class RuntimeFilterSelectivity {
+public:
+    RuntimeFilterSelectivity() = default;
+
+    RuntimeFilterSelectivity(const RuntimeFilterSelectivity&) = delete;
+    void update_judge_counter() {
+        if ((_judge_counter++) >= config::runtime_filter_sampling_frequency) {
+            reset_judge_selectivity();
+        }
+    }
+
+    void update_judge_selectivity(int filter_id, uint64_t filter_rows, uint64_t input_rows,
+                                  double ignore_thredhold) {
+        if (!_always_true) {
+            _judge_filter_rows += filter_rows;
+            _judge_input_rows += input_rows;
+            judge_selectivity(ignore_thredhold, _judge_filter_rows, _judge_input_rows,
+                              _always_true);
+        }
+
+        VLOG_ROW << fmt::format(
+                "Runtime filter[{}] selectivity update: filter_rows: {}, input_rows: {},  filter "
+                "rate: {}, "
+                "ignore_thredhold: {}, counter: {} , always_true: {}",
+                filter_id, _judge_filter_rows, _judge_input_rows,
+                static_cast<double>(_judge_filter_rows) / static_cast<double>(_judge_input_rows),
+                ignore_thredhold, _judge_counter, _always_true);
+    }
+
+    bool maybe_always_true_can_ignore() const {
+        /// TODO: maybe we can use session variable to control this behavior ?
+        if (config::runtime_filter_sampling_frequency <= 0) {
+            return false;
+        } else {
+            return _always_true;
+        }
+    }
+
+    static void judge_selectivity(double ignore_threshold, int64_t filter_rows, int64_t input_rows,
+                                  bool& always_true) {
+        // if the judged input rows is too small, we think the selectivity is not reliable
+        if (input_rows > min_judge_input_rows) {
+            always_true = (static_cast<double>(filter_rows) / static_cast<double>(input_rows)) <
+                          ignore_threshold;
+        }
+    }
+
+private:
+    void reset_judge_selectivity() {
+        _always_true = false;
+        _judge_counter = 0;
+        _judge_input_rows = 0;
+        _judge_filter_rows = 0;
+    }
+
+    int64_t _judge_input_rows = 0;
+    int64_t _judge_filter_rows = 0;
+    int _judge_counter = 0;
+    bool _always_true = false;
+
+    constexpr static int64_t min_judge_input_rows = 4096 * 10;
+};
+
+} // namespace doris

--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -1055,7 +1055,7 @@ Status VExpr::execute_filter(VExprContext* context, const Block* block,
             }
         }
 
-        if ((memchr(result_filter_data, 0x1, rows) == nullptr)) {
+        if (!simd::contain_one(result_filter_data, rows)) {
             *can_filter_all = true;
             return Status::OK();
         }
@@ -1068,7 +1068,7 @@ Status VExpr::execute_filter(VExprContext* context, const Block* block,
             result_filter_data[i] &= filter_data[i];
         }
 
-        if (memchr(result_filter_data, 0x1, rows) == nullptr) {
+        if (!simd::contain_one(result_filter_data, rows)) {
             *can_filter_all = true;
             return Status::OK();
         }

--- a/be/src/vec/exprs/vexpr.h
+++ b/be/src/vec/exprs/vexpr.h
@@ -153,6 +153,10 @@ public:
     // Therefore we need a function like this to return the actual type produced by execution.
     virtual DataTypePtr execute_type(const Block* block) const { return _data_type; }
 
+    virtual Status execute_filter(VExprContext* context, const Block* block,
+                                  uint8_t* __restrict result_filter_data, size_t rows,
+                                  bool accept_null, bool* can_filter_all) const;
+
     // `is_blockable` means this expr will be blocked in `execute` (e.g. AI Function, Remote Function)
     [[nodiscard]] virtual bool is_blockable() const {
         return std::any_of(_children.begin(), _children.end(),
@@ -210,12 +214,6 @@ public:
                                    [](VExprSPtr child) { return child->is_rf_wrapper(); });
     }
     virtual bool is_topn_filter() const { return false; }
-
-    virtual void do_judge_selectivity(uint64_t filter_rows, uint64_t input_rows) {
-        for (auto child : _children) {
-            child->do_judge_selectivity(filter_rows, input_rows);
-        }
-    }
 
     static Status create_expr_tree(const TExpr& texpr, VExprContextSPtr& ctx);
 

--- a/be/src/vec/exprs/vexpr_context.h
+++ b/be/src/vec/exprs/vexpr_context.h
@@ -33,6 +33,7 @@
 #include "olap/rowset/segment_v2/inverted_index_reader.h"
 #include "runtime/runtime_state.h"
 #include "runtime/types.h"
+#include "runtime_filter/runtime_filter_selectivity.h"
 #include "udf/udf.h"
 #include "vec/columns/column.h"
 #include "vec/core/block.h"
@@ -233,6 +234,9 @@ public:
 
     bool all_expr_inverted_index_evaluated();
 
+    Status execute_filter(const Block* block, uint8_t* __restrict result_filter_data, size_t rows,
+                          bool accept_null, bool* can_filter_all);
+
     [[nodiscard]] static Status filter_block(VExprContext* vexpr_ctx, Block* block);
 
     [[nodiscard]] static Status filter_block(const VExprContextSPtrs& expr_contexts, Block* block,
@@ -268,6 +272,8 @@ public:
         DCHECK(_last_result_column_id != -1);
         return _last_result_column_id;
     }
+
+    RuntimeFilterSelectivity& get_runtime_filter_selectivity() { return *_rf_selectivity; }
 
     FunctionContext::FunctionStateScope get_function_state_scope() const {
         return _is_clone ? FunctionContext::THREAD_LOCAL : FunctionContext::FRAGMENT_LOCAL;
@@ -360,5 +366,8 @@ private:
 
     segment_v2::AnnRangeSearchRuntime _ann_range_search_runtime;
     bool _suitable_for_ann_index = true;
+
+    std::unique_ptr<RuntimeFilterSelectivity> _rf_selectivity =
+            std::make_unique<RuntimeFilterSelectivity>();
 };
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/vruntimefilter_wrapper.cpp
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.cpp
@@ -62,9 +62,7 @@ VRuntimeFilterWrapper::VRuntimeFilterWrapper(const TExprNode& node, VExprSPtr im
           _impl(std::move(impl)),
           _ignore_thredhold(ignore_thredhold),
           _null_aware(null_aware),
-          _filter_id(filter_id) {
-    reset_judge_selectivity();
-}
+          _filter_id(filter_id) {}
 
 Status VRuntimeFilterWrapper::prepare(RuntimeState* state, const RowDescriptor& desc,
                                       VExprContext* context) {
@@ -89,31 +87,106 @@ void VRuntimeFilterWrapper::close(VExprContext* context,
 
 Status VRuntimeFilterWrapper::execute_column(VExprContext* context, const Block* block,
                                              size_t count, ColumnPtr& result_column) const {
-    DCHECK(_open_finished || block == nullptr);
-    if (_judge_counter.fetch_sub(1) == 0) {
-        reset_judge_selectivity();
-    }
-    if (_always_true) {
-        size_t size = count;
-        result_column = create_always_true_column(size, _data_type->is_nullable());
-        COUNTER_UPDATE(_always_true_filter_rows, size);
-        return Status::OK();
-    } else {
-        ColumnPtr arg_column = nullptr;
-        RETURN_IF_ERROR(
-                _impl->execute_runtime_filter(context, block, count, result_column, &arg_column));
-        // bloom filter will handle null aware inside itself
-        if (_null_aware && TExprNodeType::BLOOM_PRED != node_type()) {
-            DCHECK(arg_column);
-            change_null_to_true(result_column->assume_mutable(), arg_column);
-        }
-
-        return Status::OK();
-    }
+    return Status::InternalError("Not implement VRuntimeFilterWrapper::execute_column");
 }
 
 const std::string& VRuntimeFilterWrapper::expr_name() const {
     return _expr_name;
+}
+
+Status VRuntimeFilterWrapper::execute_filter(VExprContext* context, const Block* block,
+                                             uint8_t* __restrict result_filter_data, size_t rows,
+                                             bool accept_null, bool* can_filter_all) const {
+    DCHECK(_open_finished);
+    if (accept_null) {
+        return Status::InternalError(
+                "Runtime filter does not support accept_null in execute_filter");
+    }
+
+    auto& rf_selectivity = context->get_runtime_filter_selectivity();
+    Defer auto_update_judge_counter = [&]() { rf_selectivity.update_judge_counter(); };
+
+    // if always true, skip evaluate runtime filter
+    if (rf_selectivity.maybe_always_true_can_ignore()) {
+        COUNTER_UPDATE(_always_true_filter_rows, rows);
+        return Status::OK();
+    }
+
+    ColumnPtr filter_column;
+    ColumnPtr arg_column = nullptr;
+    RETURN_IF_ERROR(
+            _impl->execute_runtime_filter(context, block, rows, filter_column, &arg_column));
+
+    // bloom filter will handle null aware inside itself
+    if (_null_aware && TExprNodeType::BLOOM_PRED != node_type()) {
+        DCHECK(arg_column);
+        change_null_to_true(filter_column->assume_mutable(), arg_column);
+    }
+
+    if (const auto* const_column = check_and_get_column<ColumnConst>(*filter_column)) {
+        // const(nullable) or const(bool)
+        if (!const_column->get_bool(0)) {
+            // filter all
+            COUNTER_UPDATE(_rf_filter_rows, rows);
+            COUNTER_UPDATE(_rf_input_rows, rows);
+            rf_selectivity.update_judge_selectivity(_filter_id, rows, rows, _ignore_thredhold);
+            *can_filter_all = true;
+            memset(result_filter_data, 0, rows);
+            return Status::OK();
+        } else {
+            // filter none
+            COUNTER_UPDATE(_rf_input_rows, rows);
+            rf_selectivity.update_judge_selectivity(_filter_id, 0, rows, _ignore_thredhold);
+            return Status::OK();
+        }
+    } else if (const auto* nullable_column = check_and_get_column<ColumnNullable>(*filter_column)) {
+        // nullable(bool)
+        const ColumnPtr& nested_column = nullable_column->get_nested_column_ptr();
+        const IColumn::Filter& filter = assert_cast<const ColumnUInt8&>(*nested_column).get_data();
+        const auto* __restrict filter_data = filter.data();
+        const auto* __restrict null_map_data = nullable_column->get_null_map_data().data();
+
+        const size_t input_rows = rows - simd::count_zero_num((int8_t*)result_filter_data, rows);
+
+        for (size_t i = 0; i < rows; ++i) {
+            result_filter_data[i] &= (!null_map_data[i]) & filter_data[i];
+        }
+
+        const size_t output_rows = rows - simd::count_zero_num((int8_t*)result_filter_data, rows);
+
+        COUNTER_UPDATE(_rf_filter_rows, input_rows - output_rows);
+        COUNTER_UPDATE(_rf_input_rows, input_rows);
+        rf_selectivity.update_judge_selectivity(_filter_id, input_rows - output_rows, input_rows,
+                                                _ignore_thredhold);
+
+        if (output_rows == 0) {
+            *can_filter_all = true;
+            return Status::OK();
+        }
+    } else {
+        // bool
+        const IColumn::Filter& filter = assert_cast<const ColumnUInt8&>(*filter_column).get_data();
+        const auto* __restrict filter_data = filter.data();
+
+        const size_t input_rows = rows - simd::count_zero_num((int8_t*)result_filter_data, rows);
+
+        for (size_t i = 0; i < rows; ++i) {
+            result_filter_data[i] &= filter_data[i];
+        }
+
+        const size_t output_rows = rows - simd::count_zero_num((int8_t*)result_filter_data, rows);
+
+        COUNTER_UPDATE(_rf_filter_rows, input_rows - output_rows);
+        COUNTER_UPDATE(_rf_input_rows, input_rows);
+        rf_selectivity.update_judge_selectivity(_filter_id, input_rows - output_rows, input_rows,
+                                                _ignore_thredhold);
+
+        if (output_rows == 0) {
+            *can_filter_all = true;
+            return Status::OK();
+        }
+    }
+    return Status::OK();
 }
 
 #include "common/compile_check_end.h"

--- a/be/src/vec/exprs/vruntimefilter_wrapper.h
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.h
@@ -64,6 +64,10 @@ public:
     const VExprSPtrs& children() const override { return _impl->children(); }
     TExprNodeType::type node_type() const override { return _impl->node_type(); }
 
+    Status execute_filter(VExprContext* context, const Block* block,
+                          uint8_t* __restrict result_filter_data, size_t rows, bool accept_null,
+                          bool* can_filter_all) const override;
+
     uint64_t get_digest(uint64_t seed) const override {
         seed = _impl->get_digest(seed);
         if (seed) {
@@ -92,32 +96,9 @@ public:
         }
     }
 
-    void update_counters(int64_t filter_rows, int64_t input_rows) {
-        COUNTER_UPDATE(_rf_filter_rows, filter_rows);
-        COUNTER_UPDATE(_rf_input_rows, input_rows);
-    }
-
-    template <typename T>
-    static void judge_selectivity(double ignore_threshold, int64_t filter_rows, int64_t input_rows,
-                                  T& always_true) {
-        always_true = static_cast<double>(filter_rows) / static_cast<double>(input_rows) <
-                      ignore_threshold;
-    }
-
     bool is_rf_wrapper() const override { return true; }
 
     int filter_id() const { return _filter_id; }
-
-    void do_judge_selectivity(uint64_t filter_rows, uint64_t input_rows) override {
-        update_counters(filter_rows, input_rows);
-
-        if (!_always_true) {
-            _judge_filter_rows += filter_rows;
-            _judge_input_rows += input_rows;
-            judge_selectivity(_ignore_thredhold, _judge_filter_rows, _judge_input_rows,
-                              _always_true);
-        }
-    }
 
     std::shared_ptr<RuntimeProfile::Counter> predicate_filtered_rows_counter() const {
         return _rf_filter_rows;
@@ -130,26 +111,7 @@ public:
     }
 
 private:
-    void reset_judge_selectivity() const {
-        _always_true = false;
-        _judge_counter = config::runtime_filter_sampling_frequency;
-        _judge_input_rows = 0;
-        _judge_filter_rows = 0;
-    }
-
     VExprSPtr _impl;
-    // VRuntimeFilterWrapper and ColumnPredicate share the same logic,
-    // but it's challenging to unify them, so the code is duplicated.
-    // _judge_counter, _judge_input_rows, _judge_filter_rows, and _always_true
-    // are variables used to implement the _always_true logic, calculated periodically
-    // based on runtime_filter_sampling_frequency. During each period, if _always_true
-    // is evaluated as true, the logic for always_true is applied for the rest of that period
-    // without recalculating. At the beginning of the next period,
-    // reset_judge_selectivity is used to reset these variables.
-    mutable std::atomic_int _judge_counter = 0;
-    mutable std::atomic_uint64_t _judge_input_rows = 0;
-    mutable std::atomic_uint64_t _judge_filter_rows = 0;
-    mutable std::atomic_int _always_true = false;
 
     std::shared_ptr<RuntimeProfile::Counter> _rf_input_rows =
             std::make_shared<RuntimeProfile::Counter>(TUnit::UNIT, 0);

--- a/be/test/runtime_filter/runtime_filter_selectivity_test.cpp
+++ b/be/test/runtime_filter/runtime_filter_selectivity_test.cpp
@@ -1,0 +1,222 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "runtime_filter/runtime_filter_selectivity.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+namespace doris {
+
+class RuntimeFilterSelectivityTest : public testing::Test {
+protected:
+    void SetUp() override {
+        // Save original config value
+        _original_sampling_frequency = config::runtime_filter_sampling_frequency;
+    }
+
+    void TearDown() override {
+        // Restore original config value
+        config::runtime_filter_sampling_frequency = _original_sampling_frequency;
+    }
+
+    int _original_sampling_frequency;
+};
+
+TEST_F(RuntimeFilterSelectivityTest, basic_initialization) {
+    RuntimeFilterSelectivity selectivity;
+    // Initially should be false (not always_true)
+    EXPECT_FALSE(selectivity.maybe_always_true_can_ignore());
+}
+
+TEST_F(RuntimeFilterSelectivityTest, disabled_sampling_frequency) {
+    RuntimeFilterSelectivity selectivity;
+    config::runtime_filter_sampling_frequency = 0;
+
+    // Even if conditions are met, should return false when sampling is disabled
+    selectivity.update_judge_selectivity(-1, 2000, 50000, 0.1);
+    EXPECT_FALSE(selectivity.maybe_always_true_can_ignore());
+}
+
+TEST_F(RuntimeFilterSelectivityTest, negative_sampling_frequency) {
+    RuntimeFilterSelectivity selectivity;
+    config::runtime_filter_sampling_frequency = -1;
+
+    selectivity.update_judge_selectivity(-1, 2000, 50000, 0.1);
+    EXPECT_FALSE(selectivity.maybe_always_true_can_ignore());
+}
+
+TEST_F(RuntimeFilterSelectivityTest, judge_selectivity_below_threshold) {
+    bool always_true = false;
+    // filter_rows/input_rows = 5/50000 = 0.0001 < 0.1
+    // input_rows (50000) > min_judge_input_rows (40960)
+    RuntimeFilterSelectivity::judge_selectivity(0.1, 5, 50000, always_true);
+    EXPECT_TRUE(always_true);
+}
+
+TEST_F(RuntimeFilterSelectivityTest, judge_selectivity_above_threshold) {
+    bool always_true = false;
+    // filter_rows/input_rows = 25000/50000 = 0.5 >= 0.1
+    RuntimeFilterSelectivity::judge_selectivity(0.1, 25000, 50000, always_true);
+    EXPECT_FALSE(always_true);
+}
+
+TEST_F(RuntimeFilterSelectivityTest, judge_selectivity_insufficient_input_rows) {
+    bool always_true = false;
+    // Even though 5/100 = 0.05 < 0.1, input_rows (100) < min_judge_input_rows (40960)
+    RuntimeFilterSelectivity::judge_selectivity(0.1, 5, 100, always_true);
+    EXPECT_FALSE(always_true);
+}
+
+TEST_F(RuntimeFilterSelectivityTest, update_with_low_selectivity) {
+    config::runtime_filter_sampling_frequency = 100;
+    RuntimeFilterSelectivity selectivity;
+
+    // filter_rows/input_rows = 2000/50000 = 0.04 < 0.1
+    selectivity.update_judge_selectivity(-1, 2000, 50000, 0.1);
+    EXPECT_TRUE(selectivity.maybe_always_true_can_ignore());
+}
+
+TEST_F(RuntimeFilterSelectivityTest, update_with_high_selectivity) {
+    config::runtime_filter_sampling_frequency = 100;
+    RuntimeFilterSelectivity selectivity;
+
+    // filter_rows/input_rows = 45000/50000 = 0.9 >= 0.1
+    selectivity.update_judge_selectivity(-1, 45000, 50000, 0.1);
+    EXPECT_FALSE(selectivity.maybe_always_true_can_ignore());
+}
+
+TEST_F(RuntimeFilterSelectivityTest, once_always_true_stays_true) {
+    config::runtime_filter_sampling_frequency = 100;
+    RuntimeFilterSelectivity selectivity;
+
+    // First update: low selectivity
+    selectivity.update_judge_selectivity(-1, 2000, 50000, 0.1);
+    EXPECT_TRUE(selectivity.maybe_always_true_can_ignore());
+
+    // Second update: high selectivity, but should be ignored
+    selectivity.update_judge_selectivity(-1, 45000, 50000, 0.1);
+    EXPECT_TRUE(selectivity.maybe_always_true_can_ignore());
+}
+
+TEST_F(RuntimeFilterSelectivityTest, accumulated_selectivity_low) {
+    config::runtime_filter_sampling_frequency = 100;
+    RuntimeFilterSelectivity selectivity;
+
+    // First update: 1000/50000 = 0.02
+    selectivity.update_judge_selectivity(-1, 1000, 50000, 0.1);
+    EXPECT_TRUE(selectivity.maybe_always_true_can_ignore());
+}
+
+TEST_F(RuntimeFilterSelectivityTest, accumulated_selectivity_high) {
+    config::runtime_filter_sampling_frequency = 100;
+    RuntimeFilterSelectivity selectivity;
+
+    // First update: 20000/50000 = 0.4
+    selectivity.update_judge_selectivity(-1, 20000, 50000, 0.1);
+    EXPECT_FALSE(selectivity.maybe_always_true_can_ignore());
+
+    // Second update: accumulated (20000+20000)/(50000+50000) = 0.4
+    selectivity.update_judge_selectivity(-1, 20000, 50000, 0.1);
+    EXPECT_FALSE(selectivity.maybe_always_true_can_ignore());
+}
+
+TEST_F(RuntimeFilterSelectivityTest, counter_triggers_reset) {
+    config::runtime_filter_sampling_frequency = 3;
+    RuntimeFilterSelectivity selectivity;
+
+    // Mark as always_true
+    selectivity.update_judge_selectivity(-1, 2000, 50000, 0.1);
+    EXPECT_TRUE(selectivity.maybe_always_true_can_ignore());
+
+    // Update counter to trigger reset
+    selectivity.update_judge_counter(); // counter = 1
+    selectivity.update_judge_counter(); // counter = 2
+    selectivity.update_judge_counter(); // counter = 3, triggers reset
+
+    EXPECT_TRUE(selectivity.maybe_always_true_can_ignore());
+}
+
+TEST_F(RuntimeFilterSelectivityTest, reset_allows_reevaluation) {
+    config::runtime_filter_sampling_frequency = 2;
+    RuntimeFilterSelectivity selectivity;
+
+    // First cycle: mark as always_true
+    selectivity.update_judge_selectivity(-1, 2000, 50000, 0.1);
+    EXPECT_TRUE(selectivity.maybe_always_true_can_ignore());
+
+    // Trigger reset
+    selectivity.update_judge_counter(); // counter = 1
+    selectivity.update_judge_counter(); // counter = 2, triggers reset
+
+    // Second cycle: now with high selectivity
+    selectivity.update_judge_selectivity(-1, 45000, 50000, 0.1);
+    EXPECT_TRUE(selectivity.maybe_always_true_can_ignore());
+}
+
+TEST_F(RuntimeFilterSelectivityTest, edge_case_zero_rows) {
+    bool always_true = false;
+    RuntimeFilterSelectivity::judge_selectivity(0.1, 0, 0, always_true);
+    EXPECT_FALSE(always_true);
+}
+
+TEST_F(RuntimeFilterSelectivityTest, edge_case_exact_threshold) {
+    bool always_true = false;
+    // Exactly at threshold: 5000/50000 = 0.1, NOT less than 0.1
+    RuntimeFilterSelectivity::judge_selectivity(0.1, 5000, 50000, always_true);
+    EXPECT_FALSE(always_true);
+
+    // Just below threshold: 4999/50000 = 0.09998 < 0.1
+    RuntimeFilterSelectivity::judge_selectivity(0.1, 4999, 50000, always_true);
+    EXPECT_TRUE(always_true);
+}
+
+TEST_F(RuntimeFilterSelectivityTest, multiple_updates_before_threshold) {
+    config::runtime_filter_sampling_frequency = 100;
+    RuntimeFilterSelectivity selectivity;
+
+    // Multiple updates with insufficient rows each time
+    selectivity.update_judge_selectivity(-1, 100, 1000, 0.1); // 100/1000, insufficient
+    EXPECT_FALSE(selectivity.maybe_always_true_can_ignore());
+
+    selectivity.update_judge_selectivity(-1, 200, 2000, 0.1); // 300/3000, insufficient
+    EXPECT_FALSE(selectivity.maybe_always_true_can_ignore());
+
+    // Now accumulated rows are sufficient: 300+2000 = 2300, 3000+40000 = 43000
+    selectivity.update_judge_selectivity(-1, 2000, 40000, 0.1); // 2300/43000 = 0.053 < 0.1
+    EXPECT_TRUE(selectivity.maybe_always_true_can_ignore());
+}
+
+TEST_F(RuntimeFilterSelectivityTest, different_thresholds) {
+    config::runtime_filter_sampling_frequency = 100;
+
+    // Test with threshold 0.05
+    {
+        RuntimeFilterSelectivity selectivity;
+        selectivity.update_judge_selectivity(-1, 2000, 50000, 0.05); // 0.04 < 0.05
+        EXPECT_TRUE(selectivity.maybe_always_true_can_ignore());
+    }
+
+    // Test with threshold 0.03
+    {
+        RuntimeFilterSelectivity selectivity;
+        selectivity.update_judge_selectivity(-1, 2000, 50000, 0.03); // 0.04 >= 0.03
+        EXPECT_FALSE(selectivity.maybe_always_true_can_ignore());
+    }
+}
+
+} // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Previously, execute_conjuncts had to check on every operation whether it was an rf wrapper; now that check is encapsulated in a virtual method. 
This has the advantage that in the _always_true case it can return immediately without constructing a column. 
The variables related to the rf check have been moved into VExprContext, so we no longer need to worry about concurrency.

set in be.conf
```
sys_log_verbose_modules = runtime_filter_selectivity
```

output
```
I20251204 18:02:22.102540 3778890 runtime_filter_selectivity.h:53] Runtime filter[1] selectivity update: filter_rows: 144839, input_rows: 145799,  filter rate: 0.9945866141732284, ignore_thredhold: 0.059489920657150065, counter: 35 , always_true: false
```




### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

