### PR TITLE
[bugfix](be) should not use cpu init in config's valadator

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -301,21 +301,10 @@ DEFINE_mInt32(pipeline_task_exec_time_slice, "100");
 DEFINE_Int32(task_executor_min_concurrency_per_task, "1");
 // task executor max concurrency per task
 DEFINE_Int32(task_executor_max_concurrency_per_task, "-1");
-DEFINE_Validator(task_executor_max_concurrency_per_task, [](const int config) -> bool {
-    if (config == -1) {
-        task_executor_max_concurrency_per_task = std::numeric_limits<int>::max();
-    }
-    return true;
-});
+
 // task task executor inital split max concurrency per task, later concurrency may be adjusted dynamically
 DEFINE_Int32(task_executor_initial_max_concurrency_per_task, "-1");
-DEFINE_Validator(task_executor_initial_max_concurrency_per_task, [](const int config) -> bool {
-    if (config == -1) {
-        CpuInfo::init();
-        task_executor_initial_max_concurrency_per_task = std::max(48, CpuInfo::num_cores() * 2);
-    }
-    return true;
-});
+
 // Enable task executor in internal table scan.
 DEFINE_Bool(enable_task_executor_in_internal_table, "false");
 // Enable task executor in external table scan.
@@ -324,13 +313,7 @@ DEFINE_Bool(enable_task_executor_in_external_table, "true");
 // number of scanner thread pool size for olap table
 // and the min thread num of remote scanner thread pool
 DEFINE_Int32(doris_scanner_thread_pool_thread_num, "-1");
-DEFINE_Validator(doris_scanner_thread_pool_thread_num, [](const int config) -> bool {
-    if (config == -1) {
-        CpuInfo::init();
-        doris_scanner_thread_pool_thread_num = std::max(48, CpuInfo::num_cores() * 2);
-    }
-    return true;
-});
+
 DEFINE_Int32(doris_scanner_min_thread_pool_thread_num, "8");
 DEFINE_Int32(remote_split_source_batch_size, "1000");
 DEFINE_Int32(doris_max_remote_scanner_thread_pool_thread_num, "-1");
@@ -371,21 +354,6 @@ DEFINE_String(storage_root_path, "${DORIS_HOME}/storage");
 DEFINE_mString(broken_storage_path, "");
 DEFINE_Int32(min_active_scan_threads, "-1");
 DEFINE_Int32(min_active_file_scan_threads, "-1");
-
-DEFINE_Validator(min_active_scan_threads, [](const int config) -> bool {
-    if (config == -1) {
-        CpuInfo::init();
-        min_active_scan_threads = CpuInfo::num_cores() * 2;
-    }
-    return true;
-});
-DEFINE_Validator(min_active_file_scan_threads, [](const int config) -> bool {
-    if (config == -1) {
-        CpuInfo::init();
-        min_active_file_scan_threads = CpuInfo::num_cores() * 8;
-    }
-    return true;
-});
 
 // Config is used to check incompatible old format hdr_ format
 // whether doris uses strict way. When config is true, process will log fatal

--- a/be/src/olap/rowset/segment_v2/ann_index/faiss_ann_index.cpp
+++ b/be/src/olap/rowset/segment_v2/ann_index/faiss_ann_index.cpp
@@ -78,7 +78,7 @@ public:
         omp_set_num_threads(_reserved_threads);
         VLOG_DEBUG << fmt::format(
                 "ScopedOmpThreadBudget reserve threads reserved={}, in_use={}, limit={}",
-                _reserved_threads, g_index_threads_in_use, config::omp_threads_limit);
+                _reserved_threads, g_index_threads_in_use, get_omp_threads_limit());
     }
 
     ~ScopedOmpThreadBudget() {
@@ -90,7 +90,16 @@ public:
         }
         VLOG_DEBUG << fmt::format(
                 "ScopedOmpThreadBudget release threads reserved={}, remaining_in_use={}, limit={}",
-                _reserved_threads, g_index_threads_in_use, config::omp_threads_limit);
+                _reserved_threads, g_index_threads_in_use, get_omp_threads_limit());
+    }
+
+    static int get_omp_threads_limit() {
+        if (config::omp_threads_limit > 0) {
+            return config::omp_threads_limit;
+        }
+        int core_cap = std::max(1, CpuInfo::num_cores());
+        // Use at most 80% of the available CPU cores.
+        return std::max(1, core_cap * 4 / 5);
     }
 
 private:

--- a/be/src/pipeline/exec/file_scan_operator.cpp
+++ b/be/src/pipeline/exec/file_scan_operator.cpp
@@ -83,7 +83,7 @@ Status FileScanLocalState::_init_scanners(std::list<vectorized::ScannerSPtr>* sc
     auto& p = _parent->cast<FileScanOperatorX>();
     // There's only one scan range for each backend in batch split mode. Each backend only starts up one ScanNode instance.
     uint32_t shard_num = std::min(
-            vectorized::ScannerScheduler::get_remote_scan_thread_num() / p.parallelism(state()),
+            vectorized::ScannerScheduler::default_remote_scan_thread_num() / p.parallelism(state()),
             _max_scanners);
     shard_num = std::max(shard_num, 1U);
     _kv_cache.reset(new vectorized::ShardedKVCache(shard_num));
@@ -108,8 +108,8 @@ void FileScanLocalState::set_scan_ranges(RuntimeState* state,
     auto& p = _parent->cast<FileScanOperatorX>();
 
     auto calc_max_scanners = [&](int parallel_instance_num) -> int {
-        int max_scanners =
-                vectorized::ScannerScheduler::get_remote_scan_thread_num() / parallel_instance_num;
+        int max_scanners = vectorized::ScannerScheduler::default_remote_scan_thread_num() /
+                           parallel_instance_num;
         if (should_run_serial()) {
             max_scanners = 1;
         }

--- a/be/src/runtime/workload_group/workload_group.cpp
+++ b/be/src/runtime/workload_group/workload_group.cpp
@@ -389,13 +389,14 @@ WorkloadGroupInfo WorkloadGroupInfo::parse_topic_info(
     }
 
     // 9 scan thread num
-    int scan_thread_num = ScannerScheduler::default_local_scan_thread_num();
+    int scan_thread_num = vectorized::ScannerScheduler::default_local_scan_thread_num();
     if (tworkload_group_info.__isset.scan_thread_num && tworkload_group_info.scan_thread_num > 0) {
         scan_thread_num = tworkload_group_info.scan_thread_num;
     }
 
     // 10 max remote scan thread num
-    int max_remote_scan_thread_num = vectorized::ScannerScheduler::default_remote_scan_thread_num();
+    int max_remote_scan_thread_num =
+            vectorized::vectorized::ScannerScheduler::default_remote_scan_thread_num();
     if (tworkload_group_info.__isset.max_remote_scan_thread_num &&
         tworkload_group_info.max_remote_scan_thread_num > 0) {
         max_remote_scan_thread_num = tworkload_group_info.max_remote_scan_thread_num;
@@ -559,9 +560,9 @@ Status WorkloadGroup::upsert_thread_pool_no_lock(WorkloadGroupInfo* wg_info,
                     "ls_" + wg_name, cg_cpu_ctl_ptr, wg_name);
         }
 
-        Status ret = scan_scheduler->start(scan_thread_num, scan_thread_num,
-                                           config::doris_scanner_thread_pool_queue_size,
-                                           ScannerScheduler::default_min_active_scan_threads());
+        Status ret = scan_scheduler->start(
+                scan_thread_num, scan_thread_num, config::doris_scanner_thread_pool_queue_size,
+                vectorized::ScannerScheduler::default_min_active_scan_threads());
         if (ret.ok()) {
             _scan_task_sched = std::move(scan_scheduler);
         } else {
@@ -572,7 +573,7 @@ Status WorkloadGroup::upsert_thread_pool_no_lock(WorkloadGroupInfo* wg_info,
 
     if (_remote_scan_task_sched == nullptr) {
         int remote_scan_thread_queue_size =
-                vectorized::ScannerScheduler::get_remote_scan_thread_queue_size();
+                vectorized::vectorized::ScannerScheduler::get_remote_scan_thread_queue_size();
         std::unique_ptr<vectorized::ScannerScheduler> remote_scan_scheduler;
         if (config::enable_task_executor_in_external_table) {
             remote_scan_scheduler =
@@ -585,7 +586,7 @@ Status WorkloadGroup::upsert_thread_pool_no_lock(WorkloadGroupInfo* wg_info,
         Status ret = remote_scan_scheduler->start(
                 max_remote_scan_thread_num, min_remote_scan_thread_num,
                 remote_scan_thread_queue_size,
-                ScannerScheduler::default_min_active_file_scan_threads());
+                vectorized::ScannerScheduler::default_min_active_file_scan_threads());
         if (ret.ok()) {
             _remote_scan_task_sched = std::move(remote_scan_scheduler);
         } else {
@@ -616,14 +617,15 @@ Status WorkloadGroup::upsert_thread_pool_no_lock(WorkloadGroupInfo* wg_info,
 
     // 2 update thread pool
     if (scan_thread_num > 0 && _scan_task_sched) {
-        _scan_task_sched->reset_thread_num(scan_thread_num, scan_thread_num,
-                                           ScannerScheduler::default_min_active_scan_threads());
+        _scan_task_sched->reset_thread_num(
+                scan_thread_num, scan_thread_num,
+                vectorized::ScannerScheduler::default_min_active_scan_threads());
     }
 
     if (max_remote_scan_thread_num >= min_remote_scan_thread_num && _remote_scan_task_sched) {
         _remote_scan_task_sched->reset_thread_num(
                 max_remote_scan_thread_num, min_remote_scan_thread_num,
-                ScannerScheduler::default_min_active_file_scan_threads());
+                vectorized::ScannerScheduler::default_min_active_file_scan_threads());
     }
 
     return upsert_ret;

--- a/be/src/runtime/workload_group/workload_group.cpp
+++ b/be/src/runtime/workload_group/workload_group.cpp
@@ -389,13 +389,13 @@ WorkloadGroupInfo WorkloadGroupInfo::parse_topic_info(
     }
 
     // 9 scan thread num
-    int scan_thread_num = ScannerScheduler::get_local_scan_thread_num();
+    int scan_thread_num = ScannerScheduler::default_local_scan_thread_num();
     if (tworkload_group_info.__isset.scan_thread_num && tworkload_group_info.scan_thread_num > 0) {
         scan_thread_num = tworkload_group_info.scan_thread_num;
     }
 
     // 10 max remote scan thread num
-    int max_remote_scan_thread_num = vectorized::ScannerScheduler::get_remote_scan_thread_num();
+    int max_remote_scan_thread_num = vectorized::ScannerScheduler::default_remote_scan_thread_num();
     if (tworkload_group_info.__isset.max_remote_scan_thread_num &&
         tworkload_group_info.max_remote_scan_thread_num > 0) {
         max_remote_scan_thread_num = tworkload_group_info.max_remote_scan_thread_num;

--- a/be/src/runtime/workload_group/workload_group.cpp
+++ b/be/src/runtime/workload_group/workload_group.cpp
@@ -395,8 +395,7 @@ WorkloadGroupInfo WorkloadGroupInfo::parse_topic_info(
     }
 
     // 10 max remote scan thread num
-    int max_remote_scan_thread_num =
-            vectorized::vectorized::ScannerScheduler::default_remote_scan_thread_num();
+    int max_remote_scan_thread_num = vectorized::ScannerScheduler::default_remote_scan_thread_num();
     if (tworkload_group_info.__isset.max_remote_scan_thread_num &&
         tworkload_group_info.max_remote_scan_thread_num > 0) {
         max_remote_scan_thread_num = tworkload_group_info.max_remote_scan_thread_num;
@@ -573,7 +572,7 @@ Status WorkloadGroup::upsert_thread_pool_no_lock(WorkloadGroupInfo* wg_info,
 
     if (_remote_scan_task_sched == nullptr) {
         int remote_scan_thread_queue_size =
-                vectorized::vectorized::ScannerScheduler::get_remote_scan_thread_queue_size();
+                vectorized::ScannerScheduler::get_remote_scan_thread_queue_size();
         std::unique_ptr<vectorized::ScannerScheduler> remote_scan_scheduler;
         if (config::enable_task_executor_in_external_table) {
             remote_scan_scheduler =

--- a/be/src/runtime/workload_group/workload_group.cpp
+++ b/be/src/runtime/workload_group/workload_group.cpp
@@ -389,7 +389,7 @@ WorkloadGroupInfo WorkloadGroupInfo::parse_topic_info(
     }
 
     // 9 scan thread num
-    int scan_thread_num = config::doris_scanner_thread_pool_thread_num;
+    int scan_thread_num = ScannerScheduler::get_local_scan_thread_num();
     if (tworkload_group_info.__isset.scan_thread_num && tworkload_group_info.scan_thread_num > 0) {
         scan_thread_num = tworkload_group_info.scan_thread_num;
     }
@@ -561,7 +561,7 @@ Status WorkloadGroup::upsert_thread_pool_no_lock(WorkloadGroupInfo* wg_info,
 
         Status ret = scan_scheduler->start(scan_thread_num, scan_thread_num,
                                            config::doris_scanner_thread_pool_queue_size,
-                                           config::min_active_scan_threads);
+                                           ScannerScheduler::default_min_active_scan_threads());
         if (ret.ok()) {
             _scan_task_sched = std::move(scan_scheduler);
         } else {
@@ -584,7 +584,8 @@ Status WorkloadGroup::upsert_thread_pool_no_lock(WorkloadGroupInfo* wg_info,
         }
         Status ret = remote_scan_scheduler->start(
                 max_remote_scan_thread_num, min_remote_scan_thread_num,
-                remote_scan_thread_queue_size, config::min_active_file_scan_threads);
+                remote_scan_thread_queue_size,
+                ScannerScheduler::default_min_active_file_scan_threads());
         if (ret.ok()) {
             _remote_scan_task_sched = std::move(remote_scan_scheduler);
         } else {
@@ -616,13 +617,13 @@ Status WorkloadGroup::upsert_thread_pool_no_lock(WorkloadGroupInfo* wg_info,
     // 2 update thread pool
     if (scan_thread_num > 0 && _scan_task_sched) {
         _scan_task_sched->reset_thread_num(scan_thread_num, scan_thread_num,
-                                           config::min_active_scan_threads);
+                                           ScannerScheduler::default_min_active_scan_threads());
     }
 
     if (max_remote_scan_thread_num >= min_remote_scan_thread_num && _remote_scan_task_sched) {
-        _remote_scan_task_sched->reset_thread_num(max_remote_scan_thread_num,
-                                                  min_remote_scan_thread_num,
-                                                  config::min_active_file_scan_threads);
+        _remote_scan_task_sched->reset_thread_num(
+                max_remote_scan_thread_num, min_remote_scan_thread_num,
+                ScannerScheduler::default_min_active_file_scan_threads());
     }
 
     return upsert_ret;

--- a/be/src/util/async_io.h
+++ b/be/src/util/async_io.h
@@ -35,7 +35,9 @@ struct AsyncIOCtx {
 class AsyncIO {
 public:
     AsyncIO() {
-        _io_thread_pool = new PriorityThreadPool(config::doris_scanner_thread_pool_thread_num,
+        _io_thread_pool = new PriorityThreadPool(config::doris_scan_thread_pool_thread_num > 0
+                                                         ? config::doris_scan_thread_pool_thread_num
+                                                         : std::max(48, CpuInfo::num_cores() * 2),
                                                  config::doris_scanner_thread_pool_queue_size,
                                                  "async_io_thread_pool");
         _remote_thread_pool = new PriorityThreadPool(

--- a/be/src/util/async_io.h
+++ b/be/src/util/async_io.h
@@ -35,11 +35,11 @@ struct AsyncIOCtx {
 class AsyncIO {
 public:
     AsyncIO() {
-        _io_thread_pool = new PriorityThreadPool(config::doris_scan_thread_pool_thread_num > 0
-                                                         ? config::doris_scan_thread_pool_thread_num
-                                                         : std::max(48, CpuInfo::num_cores() * 2),
-                                                 config::doris_scanner_thread_pool_queue_size,
-                                                 "async_io_thread_pool");
+        _io_thread_pool = new PriorityThreadPool(
+                config::doris_scanner_thread_pool_thread_num > 0
+                        ? config::doris_scanner_thread_pool_thread_num
+                        : std::max(48, CpuInfo::num_cores() * 2),
+                config::doris_scanner_thread_pool_queue_size, "async_io_thread_pool");
         _remote_thread_pool = new PriorityThreadPool(
                 config::doris_remote_scanner_thread_pool_thread_num,
                 config::doris_remote_scanner_thread_pool_queue_size, "async_remote_thread_pool");

--- a/be/src/util/async_io.h
+++ b/be/src/util/async_io.h
@@ -21,6 +21,7 @@
 
 #include "io/fs/file_system.h"
 #include "olap/olap_define.h"
+#include "util/cpu_info.h"
 #include "work_thread_pool.hpp"
 
 namespace doris {

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -126,7 +126,9 @@ Status ScannerContext::init() {
         vectorized::TaskId task_id(fmt::format("{}-{}", print_id(_state->query_id()), ctx_id));
         _task_handle = DORIS_TRY(task_executor->create_task(
                 task_id, []() { return 0.0; },
-                config::task_executor_initial_max_concurrency_per_task,
+                config::task_executor_initial_max_concurrency_per_task > 0
+                        ? config::task_executor_initial_max_concurrency_per_task
+                        : std::max(48, CpuInfo::num_cores() * 2),
                 std::chrono::milliseconds(100), std::nullopt));
     }
 #endif

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -334,19 +334,30 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
 
     ctx->push_back_scan_task(scan_task);
 }
-
+int ScannerScheduler::get_local_scan_thread_num() {
+    return config::doris_scan_thread_pool_thread_num > 0 ? config::doris_scan_thread_pool_thread_num
+                                                         : std::max(48, CpuInfo::num_cores() * 2);
+}
 int ScannerScheduler::get_remote_scan_thread_num() {
-    static int remote_max_thread_num = []() {
-        int num = config::doris_max_remote_scanner_thread_pool_thread_num != -1
-                          ? config::doris_max_remote_scanner_thread_pool_thread_num
-                          : std::max(512, CpuInfo::num_cores() * 10);
-        return std::max(num, config::doris_scanner_thread_pool_thread_num);
-    }();
-    return remote_max_thread_num;
+    int num = config::doris_max_remote_scanner_thread_pool_thread_num > 0
+                      ? config::doris_max_remote_scanner_thread_pool_thread_num
+                      : std::max(512, CpuInfo::num_cores() * 10);
+    return std::max(num, get_local_scan_thread_num());
 }
 
 int ScannerScheduler::get_remote_scan_thread_queue_size() {
     return config::doris_remote_scanner_thread_pool_queue_size;
+}
+
+int ScannerScheduler::default_min_active_scan_threads() {
+    return config::min_active_scan_threads > 0 ? config::min_active_scan_threads
+                                               : min_active_scan_threads = CpuInfo::num_cores() * 2;
+}
+
+int ScannerScheduler::default_min_active_file_scan_threads() {
+    return config::min_active_file_scan_threads > 0
+                   ? config::min_active_file_scan_threads
+                   : min_active_file_scan_threads = CpuInfo::num_cores() * 8;
 }
 
 void ScannerScheduler::_make_sure_virtual_col_is_materialized(

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -334,16 +334,16 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
 
     ctx->push_back_scan_task(scan_task);
 }
-int ScannerScheduler::get_local_scan_thread_num() {
+int ScannerScheduler::default_local_scan_thread_num() {
     return config::doris_scanner_thread_pool_thread_num > 0
                    ? config::doris_scanner_thread_pool_thread_num
                    : std::max(48, CpuInfo::num_cores() * 2);
 }
-int ScannerScheduler::get_remote_scan_thread_num() {
+int ScannerScheduler::default_remote_scan_thread_num() {
     int num = config::doris_max_remote_scanner_thread_pool_thread_num > 0
                       ? config::doris_max_remote_scanner_thread_pool_thread_num
                       : std::max(512, CpuInfo::num_cores() * 10);
-    return std::max(num, get_local_scan_thread_num());
+    return std::max(num, default_local_scan_thread_num());
 }
 
 int ScannerScheduler::get_remote_scan_thread_queue_size() {

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -351,14 +351,15 @@ int ScannerScheduler::get_remote_scan_thread_queue_size() {
 }
 
 int ScannerScheduler::default_min_active_scan_threads() {
-    return config::min_active_scan_threads > 0 ? config::min_active_scan_threads
-                                               : min_active_scan_threads = CpuInfo::num_cores() * 2;
+    return config::min_active_scan_threads > 0
+                   ? config::min_active_scan_threads
+                   : config::min_active_scan_threads = CpuInfo::num_cores() * 2;
 }
 
 int ScannerScheduler::default_min_active_file_scan_threads() {
     return config::min_active_file_scan_threads > 0
                    ? config::min_active_file_scan_threads
-                   : min_active_file_scan_threads = CpuInfo::num_cores() * 8;
+                   : config::min_active_file_scan_threads = CpuInfo::num_cores() * 8;
 }
 
 void ScannerScheduler::_make_sure_virtual_col_is_materialized(

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -335,8 +335,9 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
     ctx->push_back_scan_task(scan_task);
 }
 int ScannerScheduler::get_local_scan_thread_num() {
-    return config::doris_scan_thread_pool_thread_num > 0 ? config::doris_scan_thread_pool_thread_num
-                                                         : std::max(48, CpuInfo::num_cores() * 2);
+    return config::doris_scanner_thread_pool_thread_num > 0
+                   ? config::doris_scanner_thread_pool_thread_num
+                   : std::max(48, CpuInfo::num_cores() * 2);
 }
 int ScannerScheduler::get_remote_scan_thread_num() {
     int num = config::doris_max_remote_scanner_thread_pool_thread_num > 0

--- a/be/src/vec/exec/scan/scanner_scheduler.h
+++ b/be/src/vec/exec/scan/scanner_scheduler.h
@@ -108,9 +108,9 @@ public:
 
     Status submit(std::shared_ptr<ScannerContext> ctx, std::shared_ptr<ScanTask> scan_task);
 
-    static int get_local_scan_thread_num();
+    static int default_local_scan_thread_num();
 
-    static int get_remote_scan_thread_num();
+    static int default_remote_scan_thread_num();
 
     static int get_remote_scan_thread_queue_size();
 

--- a/be/src/vec/exec/scan/scanner_scheduler.h
+++ b/be/src/vec/exec/scan/scanner_scheduler.h
@@ -108,9 +108,15 @@ public:
 
     Status submit(std::shared_ptr<ScannerContext> ctx, std::shared_ptr<ScanTask> scan_task);
 
+    static int get_local_scan_thread_num();
+
     static int get_remote_scan_thread_num();
 
     static int get_remote_scan_thread_queue_size();
+
+    static int default_min_active_scan_threads();
+
+    static int default_min_active_file_scan_threads();
 
     virtual Status start(int max_thread_num, int min_thread_num, int queue_size,
                          int min_active_scan_threads) = 0;
@@ -276,8 +282,10 @@ public:
         thread_config.cgroup_cpu_ctl = _cgroup_cpu_ctl;
         _task_executor = TimeSharingTaskExecutor::create_shared(
                 thread_config, max_thread_num * 2, config::task_executor_min_concurrency_per_task,
-                config::task_executor_max_concurrency_per_task, std::make_shared<SystemTicker>(),
-                nullptr, false);
+                config::task_executor_max_concurrency_per_task > 0
+                        ? config::task_executor_max_concurrency_per_task
+                        : std::numeric_limits<int>::max(),
+                std::make_shared<SystemTicker>(), nullptr, false);
         RETURN_IF_ERROR(_task_executor->init());
         RETURN_IF_ERROR(_task_executor->start());
         return Status::OK();
@@ -321,7 +329,9 @@ public:
             vectorized::TaskId task_id(task_id_string);
             std::shared_ptr<TaskHandle> task_handle = DORIS_TRY(_task_executor->create_task(
                     task_id, []() { return 0.0; },
-                    config::task_executor_initial_max_concurrency_per_task,
+                    config::task_executor_initial_max_concurrency_per_task > 0
+                            ? config::task_executor_initial_max_concurrency_per_task
+                            : std::max(48, CpuInfo::num_cores() * 2),
                     std::chrono::milliseconds(100), std::nullopt));
 
             auto wrapped_scan_func = [this, task_handle, scan_func = scan_task.scan_func]() {

--- a/be/test/common/config_validator_test.cpp
+++ b/be/test/common/config_validator_test.cpp
@@ -50,46 +50,4 @@ TEST(ConfigValidatorTest, Validator) {
     EXPECT_EQ(cfg_validator_2, 8);
 }
 
-// When a positive value is specified, validator should use it directly.
-TEST(ConfigValidatorTest, OmpThreadsLimitExplicitValue) {
-    int32_t original_limit = config::omp_threads_limit;
-
-    Status st = config::set_config("omp_threads_limit", "7", false, true);
-    ASSERT_TRUE(st.ok());
-    EXPECT_EQ(7, config::omp_threads_limit);
-
-    config::omp_threads_limit = original_limit;
-}
-
-// When value is -1 and config::num_cores is set,
-// validator should pick 80% of that core count.
-TEST(ConfigValidatorTest, OmpThreadsLimitAutoUsesConfiguredNumCores) {
-    int32_t original_limit = config::omp_threads_limit;
-    int32_t original_num_cores = config::num_cores;
-
-    config::num_cores = 20;
-    Status st = config::set_config("omp_threads_limit", "-1", false, true);
-    ASSERT_TRUE(st.ok());
-    EXPECT_EQ(16, config::omp_threads_limit);
-
-    config::num_cores = original_num_cores;
-    config::omp_threads_limit = original_limit;
-}
-
-// When value is -1 and config::num_cores is 0,
-// validator should fall back to CpuInfo::num_cores().
-TEST(ConfigValidatorTest, OmpThreadsLimitAutoFallsBackToCpuInfo) {
-    int32_t original_limit = config::omp_threads_limit;
-    int32_t original_num_cores = config::num_cores;
-
-    config::num_cores = 0;
-    Status st = config::set_config("omp_threads_limit", "-1", false, true);
-    ASSERT_TRUE(st.ok());
-    CpuInfo::init();
-    int expected = std::max(1, CpuInfo::num_cores() * 4 / 5);
-    EXPECT_EQ(expected, config::omp_threads_limit);
-
-    config::num_cores = original_num_cores;
-    config::omp_threads_limit = original_limit;
-}
 } // namespace doris


### PR DESCRIPTION
When call cpuinfo.init in validator, the num_cores config maybe not inited, so that the cpu cores number is not correct.
Should not do any compute logic in the validator, it should be "const".

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

