### PR TITLE
[fix](deploy) Fix incorrect user group configuration in fdb_ctl.sh

### DIFF
--- a/tools/fdb/fdb_ctl.sh
+++ b/tools/fdb/fdb_ctl.sh
@@ -265,10 +265,12 @@ function deploy_fdb() {
 ${CLUSTER_DESC}:${FDB_CLUSTER_ID}@$(get_coordinators)
 EOF
 
+    GROUP_NAME="$(id -gn 2>/dev/null || echo "${USER}")"
+
     cat >"${FDB_HOME}/conf/fdb.conf" <<EOF
 [fdbmonitor]
 user = ${USER}
-group = ${USER}
+group = ${GROUP_NAME}
 
 [general]
 restart-delay = 60


### PR DESCRIPTION
The previous implementation set `group = ${USER}`, which is incorrect in environments where the primary group name differs from the user name.

This patch resolves the group dynamically using:
    GROUP_NAME="$(id -gn 2>/dev/null || echo "${USER}")"

Impact:
- Correct group assignment in fdb_ctl.sh
- Avoids permission/ownership issues on some systems
- Backward compatible when primary group equals user name


