### PR TITLE
[fix](nereids) deduplicate scope slots

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
@@ -290,7 +290,9 @@ public class ExpressionAnalyzer extends SubExprAnalyzer<ExpressionRewriteContext
         if (bindSlotInOuterScope && !foundInThisScope && outerScope.isPresent()) {
             boundedOpt = Optional.of(bindSlotByScope(unboundSlot, outerScope.get()));
         }
-        List<? extends Expression> bounded = boundedOpt.get();
+        // it is heavy to deduplicate slots in scope. So we deduplicates bounded here
+        List<? extends Expression> bounded =
+                boundedOpt.get().stream().distinct().collect(Collectors.toList());
         switch (bounded.size()) {
             case 0:
                 String tableName = StringUtils.join(unboundSlot.getQualifier(), ".");

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
@@ -291,8 +291,10 @@ public class ExpressionAnalyzer extends SubExprAnalyzer<ExpressionRewriteContext
             boundedOpt = Optional.of(bindSlotByScope(unboundSlot, outerScope.get()));
         }
         // it is heavy to deduplicate slots in scope. So we deduplicates bounded here
-        List<? extends Expression> bounded =
-                boundedOpt.get().stream().distinct().collect(Collectors.toList());
+        List<? extends Expression> bounded = boundedOpt.get();
+        if (bounded.size() > 1) {
+            bounded = bounded.stream().distinct().collect(Collectors.toList());
+        }
         switch (bounded.size()) {
             case 0:
                 String tableName = StringUtils.join(unboundSlot.getQualifier(), ".");

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/copier/LogicalPlanDeepCopier.java
@@ -188,7 +188,7 @@ public class LogicalPlanDeepCopier extends DefaultPlanRewriter<DeepCopierContext
                 .collect(ImmutableList.toImmutableList());
         LogicalAggregate<Plan> copiedAggregate = aggregate.withChildGroupByAndOutput(groupByExpressions,
                 outputExpressions, child);
-        Optional<LogicalRepeat<? extends Plan>> childRepeat =
+        Optional<LogicalRepeat<?>> childRepeat =
                 copiedAggregate.collectFirst(LogicalRepeat.class::isInstance);
         return childRepeat.isPresent() ? aggregate.withChildGroupByAndOutputAndSourceRepeat(
                 groupByExpressions, outputExpressions, child, childRepeat)

--- a/regression-test/suites/nereids_p0/slot_bind/test_bind_slot.groovy
+++ b/regression-test/suites/nereids_p0/slot_bind/test_bind_slot.groovy
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+suite("test_bind_slot") {
+    sql """
+      drop table if exists t; 
+       CREATE TABLE t (
+      `id` int COMMENT '',
+      `status` string COMMENT '',
+      `time_created` string COMMENT '',
+    )  properties("replication_num" = "1");
+
+  """
+  // if scope is not deduplicated, time_created wil be bound twice, causing a slot ambigious error
+  sql """select
+          from_unixtime(time_created / 1000, 'yyyyMMdd') as date1,
+          status,
+          count(distinct id) as cnt
+          from
+            (
+              select
+                from_unixtime(time_created / 1001) as created_date,
+                time_created,
+                *
+              from
+                t
+            ) t1
+          group by
+          from_unixtime(time_created / 1000, 'yyyyMMdd'),
+          status;
+  """
+}


### PR DESCRIPTION
If the slots in the scope are not deduplicated, some slots will be bounded twice, and optimizer throw exception because of ambigious.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

