### PR TITLE
[refine](function)Remove member variables from functions. 

### DIFF
--- a/be/src/vec/functions/binary_arithmetic.h
+++ b/be/src/vec/functions/binary_arithmetic.h
@@ -39,6 +39,7 @@ struct PlusMinusIntegralImpl {
     static constexpr PrimitiveType Type = Impl::PType;
     static constexpr bool result_is_decimal = false;
     static constexpr auto name = Impl::name;
+    constexpr static bool need_replace_null_data_to_default = false;
     using Arg = typename Impl::Arg;
     using ColumnType = typename PrimitiveTypeTraits<Type>::ColumnType;
     using ArgA = Arg;
@@ -116,6 +117,8 @@ struct PlusMinusDecimalImpl {
     using DataTypeB = typename PrimitiveTypeTraits<TypeB>::DataType;
     using ColumnTypeA = typename PrimitiveTypeTraits<TypeA>::ColumnType;
     using ColumnTypeB = typename PrimitiveTypeTraits<TypeB>::ColumnType;
+
+    constexpr static bool need_replace_null_data_to_default = true;
 
     static DataTypes get_variadic_argument_types() {
         return {std::make_shared<typename PrimitiveTypeTraits<TypeA>::DataType>(),
@@ -354,7 +357,6 @@ struct PlusMinusDecimalImpl {
 template <typename Impl>
 class FunctionPlusMinus : public IFunction {
     static constexpr bool result_is_decimal = Impl::result_is_decimal;
-    mutable bool need_replace_null_data_to_default_ = false;
 
 public:
     static constexpr auto name = Impl::name;
@@ -366,7 +368,7 @@ public:
     String get_name() const override { return name; }
 
     bool need_replace_null_data_to_default() const override {
-        return need_replace_null_data_to_default_;
+        return Impl::need_replace_null_data_to_default;
     }
 
     size_t get_number_of_arguments() const override { return 2; }
@@ -376,7 +378,6 @@ public:
     }
 
     DataTypePtr get_return_type_impl(const DataTypes& arguments) const override {
-        need_replace_null_data_to_default_ = is_decimal(arguments[0]->get_primitive_type());
         return arguments[0];
     }
 

--- a/be/src/vec/functions/divide.cpp
+++ b/be/src/vec/functions/divide.cpp
@@ -36,7 +36,6 @@ struct DivideFloatingImpl;
 template <typename Impl>
 class FunctionDiv : public IFunction {
     static constexpr bool result_is_decimal = !std::is_same_v<Impl, DivideFloatingImpl>;
-    mutable bool need_replace_null_data_to_default_ = false;
 
 public:
     static constexpr auto name = "divide";
@@ -48,7 +47,7 @@ public:
     String get_name() const override { return name; }
 
     bool need_replace_null_data_to_default() const override {
-        return need_replace_null_data_to_default_;
+        return Impl::need_replace_null_data_to_default;
     }
 
     size_t get_number_of_arguments() const override { return 2; }
@@ -58,7 +57,6 @@ public:
     }
 
     DataTypePtr get_return_type_impl(const DataTypes& arguments) const override {
-        need_replace_null_data_to_default_ = is_decimal(arguments[0]->get_primitive_type());
         return make_nullable(arguments[0]);
     }
 
@@ -304,6 +302,8 @@ struct DivideFloatingImpl {
     using DataTypeA = typename PrimitiveTypeTraits<TYPE_DOUBLE>::DataType;
     using DataTypeB = typename PrimitiveTypeTraits<TYPE_DOUBLE>::DataType;
 
+    constexpr static bool need_replace_null_data_to_default = false;
+
     static DataTypes get_variadic_argument_types() {
         return {std::make_shared<DataTypeFloat64>(), std::make_shared<DataTypeFloat64>()};
     }
@@ -393,6 +393,8 @@ struct DivideDecimalImpl {
     using DataTypeB = typename PrimitiveTypeTraits<TypeB>::DataType;
     using ColumnTypeA = typename PrimitiveTypeTraits<TypeA>::ColumnType;
     using ColumnTypeB = typename PrimitiveTypeTraits<TypeB>::ColumnType;
+
+    constexpr static bool need_replace_null_data_to_default = true;
 
     static DataTypes get_variadic_argument_types() {
         return {std::make_shared<typename PrimitiveTypeTraits<TypeA>::DataType>(),

--- a/be/src/vec/functions/function_map.cpp
+++ b/be/src/vec/functions/function_map.cpp
@@ -150,7 +150,7 @@ public:
     size_t get_number_of_arguments() const override { return 2; }
 
     bool use_default_implementation_for_nulls() const override {
-        return array_contains.use_default_implementation_for_nulls();
+        return FunctionArrayIndex<ArrayContainsAction> {}.use_default_implementation_for_nulls();
     }
 
     DataTypePtr get_return_type_impl(const DataTypes& arguments) const override {
@@ -227,16 +227,13 @@ public:
             }
         }
 
-        RETURN_IF_ERROR(
-                array_contains.execute_impl(context, block, arguments, result, input_rows_count));
+        RETURN_IF_ERROR(FunctionArrayIndex<ArrayContainsAction> {}.execute_impl(
+                context, block, arguments, result, input_rows_count));
 
         // restore original argument 0
         block.get_by_position(arguments[0]) = orig_arg0;
         return Status::OK();
     }
-
-private:
-    FunctionArrayIndex<ArrayContainsAction> array_contains;
 };
 
 template <bool is_key>

--- a/be/src/vec/functions/functions_multi_string_search.cpp
+++ b/be/src/vec/functions/functions_multi_string_search.cpp
@@ -139,9 +139,9 @@ public:
 private:
     using ResultType = typename Impl::ResultType;
 
-    const bool allow_hyperscan_ = true;
-    const size_t max_hyperscan_regexp_length_ = 0;       // not limited
-    const size_t max_hyperscan_regexp_total_length_ = 0; // not limited
+    constexpr static bool allow_hyperscan_ = true;
+    constexpr static size_t max_hyperscan_regexp_length_ = 0;       // not limited
+    constexpr static size_t max_hyperscan_regexp_total_length_ = 0; // not limited
 
     /// Handles nullable column by setting result to 0 if the input is null
     void handle_nullable_column(const ColumnPtr& column, PaddedPODArray<ResultType>& vec_res,

--- a/be/src/vec/functions/minus.cpp
+++ b/be/src/vec/functions/minus.cpp
@@ -29,6 +29,7 @@ struct MinusDecimalImpl {
     static_assert((TypeA == TYPE_DECIMALV2 && TypeB == TYPE_DECIMALV2) ||
                   (TypeA != TYPE_DECIMALV2 && TypeB != TYPE_DECIMALV2));
 
+    constexpr static bool need_replace_null_data_to_default = true;
     static constexpr auto name = "subtract";
     static constexpr PrimitiveType PTypeA = TypeA;
     static constexpr PrimitiveType PTypeB = TypeA;

--- a/be/src/vec/functions/modulo.cpp
+++ b/be/src/vec/functions/modulo.cpp
@@ -54,7 +54,6 @@ inline void throw_if_division_leads_to_FPE(A a, B b) {
 template <typename Impl>
 class FunctionMod : public IFunction {
     static constexpr bool result_is_decimal = Impl::result_is_decimal;
-    mutable bool need_replace_null_data_to_default_ = false;
 
 public:
     static constexpr auto name = Impl::name;
@@ -66,7 +65,7 @@ public:
     String get_name() const override { return name; }
 
     bool need_replace_null_data_to_default() const override {
-        return need_replace_null_data_to_default_;
+        return Impl::need_replace_null_data_to_default;
     }
 
     size_t get_number_of_arguments() const override { return 2; }
@@ -76,7 +75,6 @@ public:
     }
 
     DataTypePtr get_return_type_impl(const DataTypes& arguments) const override {
-        need_replace_null_data_to_default_ = is_decimal(arguments[0]->get_primitive_type());
         return make_nullable(arguments[0]);
     }
 
@@ -325,6 +323,8 @@ struct ModNumericImpl {
     using DataTypeA = typename Impl::DataTypeA;
     using DataTypeB = typename Impl::DataTypeB;
 
+    constexpr static bool need_replace_null_data_to_default = false;
+
     static DataTypes get_variadic_argument_types() { return Impl::get_variadic_argument_types(); }
 
     static ColumnPtr constant_constant(ArgA a, ArgB b) {
@@ -521,6 +521,8 @@ struct ModDecimalImpl {
     using DataTypeB = typename Impl::DataTypeB;
     using ColumnTypeA = typename Impl::ColumnTypeA;
     using ColumnTypeB = typename Impl::ColumnTypeB;
+
+    constexpr static bool need_replace_null_data_to_default = true;
 
     static DataTypes get_variadic_argument_types() { return Impl::get_variadic_argument_types(); }
 

--- a/be/src/vec/functions/plus.cpp
+++ b/be/src/vec/functions/plus.cpp
@@ -37,6 +37,8 @@ struct PlusDecimalImpl {
     static_assert((TypeA == TYPE_DECIMALV2 && TypeB == TYPE_DECIMALV2) ||
                   (TypeA != TYPE_DECIMALV2 && TypeB != TYPE_DECIMALV2));
 
+    constexpr static bool need_replace_null_data_to_default = true;
+
     static constexpr auto name = "add";
     static constexpr PrimitiveType PTypeA = TypeA;
     static constexpr PrimitiveType PTypeB = TypeA;

--- a/be/src/vec/functions/simple_function_factory.h
+++ b/be/src/vec/functions/simple_function_factory.h
@@ -158,6 +158,7 @@ public:
     template <class Function>
     void register_function() {
         if constexpr (std::is_base_of_v<IFunction, Function>) {
+            static_assert(sizeof(Function) == sizeof(IFunction), "Function must be no member data");
             register_function(Function::name, &createDefaultFunction<Function>);
         } else {
             register_function(Function::name, &Function::create);
@@ -166,6 +167,7 @@ public:
 
     template <class Function>
     void register_function(std::string name) {
+        static_assert(sizeof(Function) == sizeof(IFunction), "Function must be no member data");
         register_function(name, &createDefaultFunction<Function>);
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

If a function inherits from IFunction, it should not have any member variables. Because functions can be shared across multiple threads, any state that needs to be preserved must be placed in FunctionContext.

```
doris/be/src/vec/functions/simple_function_factory.h:161:27: error: static assertion failed due to requirement 'sizeof(doris::vectorized::FunctionMultiply<doris::vectorized::MultiplyDecimalImpl<doris::TYPE_DECIMAL256, doris::TYPE_DECIMAL128I>>) == sizeof(doris::vectorized::IFunction)': Function must be no member data
  161 |             static_assert(sizeof(Function) == sizeof(IFunction), "Function must be no member data");
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

