### PR TITLE
[chore](json) Use const to qualify related functions when possible

### DIFF
--- a/be/src/util/jsonb_document.cpp
+++ b/be/src/util/jsonb_document.cpp
@@ -147,7 +147,7 @@ JsonbFindResult JsonbValue::findValue(JsonbPath& path) const {
             }
             result.writer->writeEndArray();
 
-            JsonbDocument* doc = nullptr;
+            const JsonbDocument* doc = nullptr;
             THROW_IF_ERROR(JsonbDocument::checkAndCreateDocument(
                     result.writer->getOutput()->getBuffer(), result.writer->getOutput()->getSize(),
                     &doc));

--- a/be/src/util/jsonb_utils.h
+++ b/be/src/util/jsonb_utils.h
@@ -38,7 +38,7 @@ public:
 
     // get json string
     std::string to_json_string(const char* data, size_t size) {
-        JsonbDocument* pdoc;
+        const JsonbDocument* pdoc;
         THROW_IF_ERROR(doris::JsonbDocument::checkAndCreateDocument(data, size, &pdoc));
         return to_json_string(pdoc->getValue());
     }

--- a/be/src/util/jsonb_writer.h
+++ b/be/src/util/jsonb_writer.h
@@ -550,16 +550,19 @@ public:
     }
 
     OS_TYPE* getOutput() { return os_; }
-    JsonbDocument* getDocument() {
-        JsonbDocument* doc = nullptr;
+
+#ifdef BE_TEST
+    const JsonbDocument* getDocument() {
+        const JsonbDocument* doc = nullptr;
         THROW_IF_ERROR(JsonbDocument::checkAndCreateDocument(getOutput()->getBuffer(),
                                                              getOutput()->getSize(), &doc));
         return doc;
     }
 
-    JsonbValue* getValue() {
+    const JsonbValue* getValue() {
         return JsonbDocument::createValue(getOutput()->getBuffer(), getOutput()->getSize());
     }
+#endif
 
     bool writeEnd() {
         while (!stack_.empty()) {

--- a/be/src/vec/data_types/convert_field_to_type.cpp
+++ b/be/src/vec/data_types/convert_field_to_type.cpp
@@ -94,7 +94,7 @@ public:
         writer->writeEndString();
     }
     void operator()(const JsonbField& x, JsonbWriter* writer) const {
-        JsonbDocument* doc;
+        const JsonbDocument* doc;
         THROW_IF_ERROR(JsonbDocument::checkAndCreateDocument(x.get_value(), x.get_size(), &doc));
         writer->writeValue(doc->getValue());
     }

--- a/be/src/vec/data_types/serde/data_type_jsonb_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_jsonb_serde.cpp
@@ -267,7 +267,7 @@ void convert_jsonb_to_rapidjson(const JsonbValue& val, rapidjson::Value& target,
 Status DataTypeJsonbSerDe::serialize_column_to_jsonb(const IColumn& from_column, int64_t row_num,
                                                      JsonbWriter& writer) const {
     const auto& jsonb_binary = assert_cast<const ColumnString&>(from_column).get_data_at(row_num);
-    JsonbDocument* doc = nullptr;
+    const JsonbDocument* doc = nullptr;
     RETURN_IF_ERROR(
             JsonbDocument::checkAndCreateDocument(jsonb_binary.data, jsonb_binary.size, &doc));
 

--- a/be/src/vec/data_types/serde/data_type_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_serde.cpp
@@ -97,7 +97,7 @@ Status DataTypeSerDe::deserialize_column_from_jsonb_vector(ColumnNullable& colum
     const bool is_strict = castParms.is_strict;
     for (size_t i = 0; i < size; ++i) {
         const auto& val = col_from_json.get_data_at(i);
-        auto* value = handle_jsonb_value(val);
+        const auto* value = handle_jsonb_value(val);
         if (!value) {
             column_to.insert_default();
             continue;

--- a/be/src/vec/data_types/serde/data_type_serde.h
+++ b/be/src/vec/data_types/serde/data_type_serde.h
@@ -393,7 +393,7 @@ public:
     // if jsonb is invalid, return nullptr
     // if josnb is null json , return nullptr
     // else return jsonb_value
-    static JsonbValue* handle_jsonb_value(const StringRef& val);
+    static const JsonbValue* handle_jsonb_value(const StringRef& val);
 
     virtual Status deserialize_column_from_jsonb_vector(ColumnNullable& column_to,
                                                         const ColumnString& from_column,
@@ -500,8 +500,8 @@ inline Status checkArrowStatus(const arrow::Status& status, const std::string& c
     return Status::OK();
 }
 
-inline JsonbValue* DataTypeSerDe::handle_jsonb_value(const StringRef& val) {
-    JsonbDocument* doc = nullptr;
+inline const JsonbValue* DataTypeSerDe::handle_jsonb_value(const StringRef& val) {
+    const JsonbDocument* doc = nullptr;
     if (val.size == 0) {
         return nullptr;
     }
@@ -509,7 +509,7 @@ inline JsonbValue* DataTypeSerDe::handle_jsonb_value(const StringRef& val) {
     if (!st.ok() || !doc || !doc->getValue()) [[unlikely]] {
         return nullptr;
     }
-    JsonbValue* value = doc->getValue();
+    const JsonbValue* value = doc->getValue();
     if (UNLIKELY(!value)) {
         return nullptr;
     }

--- a/be/src/vec/exprs/table_function/vexplode_json_object.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_json_object.cpp
@@ -57,25 +57,25 @@ void VExplodeJsonObjectTableFunction::process_row(size_t row_idx) {
 
     StringRef text = _json_object_column->get_data_at(row_idx);
     if (text.data != nullptr) {
-        JsonbDocument* doc = nullptr;
+        const JsonbDocument* doc = nullptr;
         auto st = JsonbDocument::checkAndCreateDocument(text.data, text.size, &doc);
         if (!st.ok() || !doc || !doc->getValue()) [[unlikely]] {
             // error jsonb, put null into output, cur_size = 0 , we will insert_default
             return;
         }
         // value is NOT necessary to be deleted since JsonbValue will not allocate memory
-        JsonbValue* value = doc->getValue();
+        const JsonbValue* value = doc->getValue();
         auto writer = std::make_unique<JsonbWriter>();
         if (value->isObject()) {
             _cur_size = value->numElements();
-            auto* obj = value->unpack<ObjectVal>();
+            const auto* obj = value->unpack<ObjectVal>();
             _object_pairs.first =
                     ColumnNullable::create(ColumnString::create(), ColumnUInt8::create());
             _object_pairs.second =
                     ColumnNullable::create(ColumnString::create(), ColumnUInt8::create());
             _object_pairs.first->reserve(_cur_size);
             _object_pairs.second->reserve(_cur_size);
-            for (auto& it : *obj) {
+            for (const auto& it : *obj) {
                 _object_pairs.first->insert_data(it.getKeyStr(), it.klen());
                 writer->reset();
                 writer->writeValue(it.value());

--- a/be/src/vec/functions/cast/cast_to_jsonb.h
+++ b/be/src/vec/functions/cast/cast_to_jsonb.h
@@ -56,7 +56,7 @@ struct ConvertImplGenericFromJsonb {
             const bool is_dst_string = is_string_type(data_type_to->get_primitive_type());
             for (size_t i = 0; i < size; ++i) {
                 const auto& val = col_from_string->get_data_at(i);
-                JsonbDocument* doc = nullptr;
+                const JsonbDocument* doc = nullptr;
                 auto st = JsonbDocument::checkAndCreateDocument(val.data, val.size, &doc);
                 if (!st.ok() || !doc || !doc->getValue()) [[unlikely]] {
                     (*vec_null_map_to)[i] = 1;
@@ -65,7 +65,7 @@ struct ConvertImplGenericFromJsonb {
                 }
 
                 // value is NOT necessary to be deleted since JsonbValue will not allocate memory
-                JsonbValue* value = doc->getValue();
+                const JsonbValue* value = doc->getValue();
                 if (UNLIKELY(!value)) {
                     (*vec_null_map_to)[i] = 1;
                     col_to->insert_default();

--- a/be/src/vec/functions/function_json.cpp
+++ b/be/src/vec/functions/function_json.cpp
@@ -320,7 +320,7 @@ struct JsonParser<'7'> {
     static void update_value(StringParser::ParseResult& result, rapidjson::Value& value,
                              StringRef data, rapidjson::Document::AllocatorType& allocator) {
         rapidjson::Document document;
-        JsonbValue* json_val = JsonbDocument::createValue(data.data, data.size);
+        const JsonbValue* json_val = JsonbDocument::createValue(data.data, data.size);
         convert_jsonb_to_rapidjson(*json_val, document, allocator);
         value.CopyFrom(document, allocator);
     }
@@ -509,13 +509,13 @@ public:
                     vec_to[i] = 0;
                     continue;
                 }
-                JsonbDocument* doc = nullptr;
+                const JsonbDocument* doc = nullptr;
                 auto st = JsonbDocument::checkAndCreateDocument(val.data, val.size, &doc);
                 if (!st.ok() || !doc || !doc->getValue()) [[unlikely]] {
                     vec_to[i] = 0;
                     continue;
                 }
-                JsonbValue* value = doc->getValue();
+                const JsonbValue* value = doc->getValue();
                 if (UNLIKELY(!value)) {
                     vec_to[i] = 0;
                     continue;

--- a/be/src/vec/functions/function_json_hash.cpp
+++ b/be/src/vec/functions/function_json_hash.cpp
@@ -77,7 +77,7 @@ public:
 
         for (size_t i = 0; i < size; ++i) {
             StringRef val = input_jsonb_column.get_data_at(i);
-            JsonbDocument* doc = nullptr;
+            const JsonbDocument* doc = nullptr;
             auto st = JsonbDocument::checkAndCreateDocument(val.data, val.size, &doc);
             if (!st.ok() || !doc || !doc->getValue()) [[unlikely]] {
                 // mayby be invalid jsonb, just insert default

--- a/be/src/vec/functions/function_jsonb.cpp
+++ b/be/src/vec/functions/function_jsonb.cpp
@@ -252,7 +252,7 @@ public:
                 std::tie(default_value_col, default_value_const) =
                         unpack_if_const(block.get_by_position(arguments[1]).column);
                 if (default_value_const) {
-                    JsonbDocument* default_value_doc = nullptr;
+                    const JsonbDocument* default_value_doc = nullptr;
                     if (default_value_col->is_null_at(0)) {
                         default_value_null_const = true;
                     } else {
@@ -595,7 +595,7 @@ private:
             }
 
             auto json_data = col_from_string.get_data_at(index);
-            JsonbDocument* doc = nullptr;
+            const JsonbDocument* doc = nullptr;
             auto st = JsonbDocument::checkAndCreateDocument(json_data.data, json_data.size, &doc);
             if (!st.ok() || !doc || !doc->getValue()) [[unlikely]] {
                 dst_arr.clear();
@@ -775,7 +775,7 @@ private:
     static ALWAYS_INLINE void inner_loop_impl(size_t i, Container& res, const char* l_raw_str,
                                               size_t l_str_size, JsonbPath& path) {
         // doc is NOT necessary to be deleted since JsonbDocument will not allocate memory
-        JsonbDocument* doc = nullptr;
+        const JsonbDocument* doc = nullptr;
         auto st = JsonbDocument::checkAndCreateDocument(l_raw_str, l_str_size, &doc);
         if (!st.ok() || !doc || !doc->getValue()) [[unlikely]] {
             return;
@@ -876,7 +876,7 @@ private:
                                               std::unique_ptr<JsonbToJson>& formater,
                                               const char* l_raw, size_t l_size, JsonbPath& path) {
         // doc is NOT necessary to be deleted since JsonbDocument will not allocate memory
-        JsonbDocument* doc = nullptr;
+        const JsonbDocument* doc = nullptr;
         auto st = JsonbDocument::checkAndCreateDocument(l_raw, l_size, &doc);
         if (!st.ok() || !doc || !doc->getValue()) [[unlikely]] {
             StringOP::push_null_string(i, res_data, res_offsets, null_map);
@@ -1005,7 +1005,7 @@ public:
                 bool has_value = false;
 
                 // doc is NOT necessary to be deleted since JsonbDocument will not allocate memory
-                JsonbDocument* doc = nullptr;
+                const JsonbDocument* doc = nullptr;
                 auto st = JsonbDocument::checkAndCreateDocument(l_raw, l_size, &doc);
 
                 for (size_t pi = 0; pi < rdata_columns.size(); ++pi) {
@@ -1184,7 +1184,7 @@ private:
         }
 
         // doc is NOT necessary to be deleted since JsonbDocument will not allocate memory
-        JsonbDocument* doc = nullptr;
+        const JsonbDocument* doc = nullptr;
         auto st = JsonbDocument::checkAndCreateDocument(l_raw_str, l_str_size, &doc);
         if (!st.ok() || !doc || !doc->getValue()) [[unlikely]] {
             null_map[i] = 1;
@@ -1425,7 +1425,7 @@ struct JsonbLengthUtil {
             }
             auto jsonb_value = jsonb_data_column->get_data_at(i);
             // doc is NOT necessary to be deleted since JsonbDocument will not allocate memory
-            JsonbDocument* doc = nullptr;
+            const JsonbDocument* doc = nullptr;
             RETURN_IF_ERROR(JsonbDocument::checkAndCreateDocument(jsonb_value.data,
                                                                   jsonb_value.size, &doc));
             auto find_result = doc->getValue()->findValue(path);
@@ -1547,16 +1547,16 @@ struct JsonbContainsUtil {
                 continue;
             }
             // doc is NOT necessary to be deleted since JsonbDocument will not allocate memory
-            JsonbDocument* doc1 = nullptr;
+            const JsonbDocument* doc1 = nullptr;
             RETURN_IF_ERROR(JsonbDocument::checkAndCreateDocument(jsonb_value1.data,
                                                                   jsonb_value1.size, &doc1));
-            JsonbDocument* doc2 = nullptr;
+            const JsonbDocument* doc2 = nullptr;
             RETURN_IF_ERROR(JsonbDocument::checkAndCreateDocument(jsonb_value2.data,
                                                                   jsonb_value2.size, &doc2));
 
             auto find_result = doc1->getValue()->findValue(path);
             const auto* value1 = find_result.value;
-            JsonbValue* value2 = doc2->getValue();
+            const JsonbValue* value2 = doc2->getValue();
             if (!value1 || !value2) {
                 null_map->get_data()[i] = 1;
                 res->insert_data(nullptr, 0);
@@ -1622,7 +1622,7 @@ public:
                         }
                     } else {
                         auto jsonb_binary = jsonb_column.get_data_at(index);
-                        JsonbDocument* doc = nullptr;
+                        const JsonbDocument* doc = nullptr;
                         auto st = JsonbDocument::checkAndCreateDocument(jsonb_binary.data,
                                                                         jsonb_binary.size, &doc);
                         if (!st.ok() || !doc || !doc->getValue()) [[unlikely]] {
@@ -1642,7 +1642,7 @@ public:
 
                     auto index = index_check_const(i, is_const);
                     auto jsonb_binary = jsonb_column.get_data_at(index);
-                    JsonbDocument* doc = nullptr;
+                    const JsonbDocument* doc = nullptr;
                     auto st = JsonbDocument::checkAndCreateDocument(jsonb_binary.data,
                                                                     jsonb_binary.size, &doc);
                     if (!st.ok() || !doc || !doc->getValue()) [[unlikely]] {
@@ -1726,7 +1726,7 @@ public:
             }
 
             auto value_string = value_col.get_data_at(index);
-            JsonbDocument* doc = nullptr;
+            const JsonbDocument* doc = nullptr;
             RETURN_IF_ERROR(JsonbDocument::checkAndCreateDocument(value_string.data,
                                                                   value_string.size, &doc));
             writer.writeValue(doc->getValue());
@@ -1956,10 +1956,10 @@ public:
             }
         }
 
-        DorisVector<JsonbDocument*> json_documents(input_rows_count);
+        DorisVector<const JsonbDocument*> json_documents(input_rows_count);
         if (json_data_const) {
             auto json_data_string = json_data_column->get_data_at(0);
-            JsonbDocument* doc = nullptr;
+            const JsonbDocument* doc = nullptr;
             RETURN_IF_ERROR(JsonbDocument::checkAndCreateDocument(json_data_string.data,
                                                                   json_data_string.size, &doc));
             if (!doc || !doc->getValue()) [[unlikely]] {
@@ -1977,7 +1977,7 @@ public:
                 }
 
                 auto json_data_string = json_data_column->get_data_at(i);
-                JsonbDocument* doc = nullptr;
+                const JsonbDocument* doc = nullptr;
                 RETURN_IF_ERROR(JsonbDocument::checkAndCreateDocument(json_data_string.data,
                                                                       json_data_string.size, &doc));
                 if (!doc || !doc->getValue()) [[unlikely]] {
@@ -1989,7 +1989,7 @@ public:
         }
 
         DorisVector<DorisVector<JsonbPath>> json_paths(keys_count);
-        DorisVector<DorisVector<JsonbValue*>> json_values(keys_count);
+        DorisVector<DorisVector<const JsonbValue*>> json_values(keys_count);
 
         RETURN_IF_ERROR(parse_paths_and_values(json_paths, json_values, arguments, input_rows_count,
                                                json_path_columns, json_path_constant,
@@ -2115,7 +2115,7 @@ public:
             if (!null_map[row_idx]) {
                 auto* ptr = res_chars.data() + res_offsets[row_idx - 1];
                 auto size = res_offsets[row_idx] - res_offsets[row_idx - 1];
-                JsonbDocument* doc = nullptr;
+                const JsonbDocument* doc = nullptr;
                 THROW_IF_ERROR(JsonbDocument::checkAndCreateDocument(
                         reinterpret_cast<const char*>(ptr), size, &doc));
             }
@@ -2272,7 +2272,7 @@ public:
     }
 
     Status parse_paths_and_values(DorisVector<DorisVector<JsonbPath>>& json_paths,
-                                  DorisVector<DorisVector<JsonbValue*>>& json_values,
+                                  DorisVector<DorisVector<const JsonbValue*>>& json_values,
                                   const ColumnNumbers& arguments, const size_t input_rows_count,
                                   const std::vector<const ColumnString*>& json_path_columns,
                                   const std::vector<bool>& json_path_constant,
@@ -2316,7 +2316,7 @@ public:
                 }
 
                 auto value_string = value_column->get_data_at(row_idx);
-                JsonbDocument* doc = nullptr;
+                const JsonbDocument* doc = nullptr;
                 RETURN_IF_ERROR(JsonbDocument::checkAndCreateDocument(value_string.data,
                                                                       value_string.size, &doc));
                 if (doc) {
@@ -2477,7 +2477,7 @@ private:
                 continue;
             }
             const auto& json_doc_str = col_json_string(i);
-            JsonbDocument* json_doc = nullptr;
+            const JsonbDocument* json_doc = nullptr;
             auto st = JsonbDocument::checkAndCreateDocument(json_doc_str.data, json_doc_str.size,
                                                             &json_doc);
             if (!st.ok()) {
@@ -2810,7 +2810,7 @@ public:
 
             // Parse JSON document
             const auto& json_data = json_data_column->get_data_at(json_idx);
-            JsonbDocument* json_doc = nullptr;
+            const JsonbDocument* json_doc = nullptr;
             Status parse_status = JsonbDocument::checkAndCreateDocument(json_data.data,
                                                                         json_data.size, &json_doc);
 
@@ -2889,7 +2889,7 @@ public:
                            writer_output->getSize());
                     tmp_buffer.size = writer_output->getSize();
 
-                    JsonbDocument* new_doc = nullptr;
+                    const JsonbDocument* new_doc = nullptr;
                     RETURN_IF_ERROR(JsonbDocument::checkAndCreateDocument(
                             tmp_buffer.ptr.get(), tmp_buffer.size, &new_doc));
 
@@ -2897,7 +2897,7 @@ public:
                 }
             }
 
-            JsonbDocument* modified_doc = nullptr;
+            const JsonbDocument* modified_doc = nullptr;
             if (current_value != json_doc->getValue()) {
                 RETURN_IF_ERROR(JsonbDocument::checkAndCreateDocument(
                         tmp_buffer.ptr.get(), tmp_buffer.size, &modified_doc));
@@ -3070,7 +3070,7 @@ public:
                 result_data_col.insert_default();
                 continue;
             }
-            JsonbDocument* json_doc = nullptr;
+            const JsonbDocument* json_doc = nullptr;
             const auto& json_str = json_column->get_data_at(i);
             RETURN_IF_ERROR(
                     JsonbDocument::checkAndCreateDocument(json_str.data, json_str.size, &json_doc));

--- a/be/src/vec/functions/function_jsonb_transform.cpp
+++ b/be/src/vec/functions/function_jsonb_transform.cpp
@@ -124,7 +124,7 @@ public:
         JsonbWriter writer;
         for (size_t i = 0; i < size; ++i) {
             StringRef val = input_jsonb_column.get_data_at(i);
-            JsonbDocument* doc = nullptr;
+            const JsonbDocument* doc = nullptr;
             auto st = JsonbDocument::checkAndCreateDocument(val.data, val.size, &doc);
             if (!st.ok() || !doc || !doc->getValue()) [[unlikely]] {
                 // mayby be invalid jsonb, just insert default
@@ -133,7 +133,7 @@ public:
                 to_column->insert_default();
                 continue;
             }
-            JsonbValue* value = doc->getValue();
+            const JsonbValue* value = doc->getValue();
             if (UNLIKELY(!value)) {
                 // mayby be invalid jsonb, just insert default
                 // invalid jsonb value may be caused by the default null processing

--- a/be/src/vec/jsonb/serialize.cpp
+++ b/be/src/vec/jsonb/serialize.cpp
@@ -91,9 +91,9 @@ Status JsonbSerializeUtil::jsonb_to_block(
         const std::unordered_map<uint32_t, uint32_t>& col_id_to_idx, Block& dst,
         const std::vector<std::string>& default_values,
         const std::unordered_set<int>& include_cids) {
-    JsonbDocument* pdoc = nullptr;
+    const JsonbDocument* pdoc = nullptr;
     RETURN_IF_ERROR(JsonbDocument::checkAndCreateDocument(data, size, &pdoc));
-    JsonbDocument& doc = *pdoc;
+    const JsonbDocument& doc = *pdoc;
     size_t num_rows = dst.rows();
     size_t filled_columns = 0;
     for (auto it = doc->begin(); it != doc->end(); ++it) {

--- a/be/src/vec/olap/olap_data_convertor.cpp
+++ b/be/src/vec/olap/olap_data_convertor.cpp
@@ -603,7 +603,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorVarChar::convert_to_olap(
                 }
                 // Make sure that the json binary data written in is the correct jsonb value.
                 if (_is_jsonb) {
-                    JsonbDocument* doc = nullptr;
+                    const JsonbDocument* doc = nullptr;
                     RETURN_IF_ERROR(doris::JsonbDocument::checkAndCreateDocument(
                             slice->data, slice->size, &doc));
                 }
@@ -630,7 +630,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorVarChar::convert_to_olap(
             }
             // Make sure that the json binary data written in is the correct jsonb value.
             if (_is_jsonb) {
-                JsonbDocument* doc = nullptr;
+                const JsonbDocument* doc = nullptr;
                 RETURN_IF_ERROR(doris::JsonbDocument::checkAndCreateDocument(slice->data,
                                                                              slice->size, &doc));
             }

--- a/be/test/util/jsonb_serialize_test.cpp
+++ b/be/test/util/jsonb_serialize_test.cpp
@@ -124,7 +124,7 @@ TEST_F(JsonbSerializeTest, serialize) {
     ASSERT_EQ(memcmp(output->getBuffer(), serialized_data.data(), serialized_data.size()), 0)
             << "Serialized data does not match expected data";
 
-    JsonbDocument* jsonb_doc = nullptr;
+    const JsonbDocument* jsonb_doc = nullptr;
     st = JsonbDocument::checkAndCreateDocument(output->getBuffer(), output->getSize(), &jsonb_doc);
     ASSERT_TRUE(st.ok()) << "Failed to create JsonbDocument: " << st.to_string();
 }

--- a/be/test/vec/data_types/common_data_type_serder_test.h
+++ b/be/test/vec/data_types/common_data_type_serder_test.h
@@ -288,11 +288,11 @@ public:
         EXPECT_EQ(jsonb_column->size(), load_cols[0]->size());
         for (size_t r = 0; r < jsonb_column->size(); ++r) {
             StringRef jsonb_data = jsonb_column->get_data_at(r);
-            JsonbDocument* pdoc = nullptr;
+            const JsonbDocument* pdoc = nullptr;
             auto st =
                     JsonbDocument::checkAndCreateDocument(jsonb_data.data, jsonb_data.size, &pdoc);
             ASSERT_TRUE(st.ok()) << "checkAndCreateDocument failed: " << st.to_string();
-            JsonbDocument& doc = *pdoc;
+            const JsonbDocument& doc = *pdoc;
             size_t cIdx = 0;
             for (auto it = doc->begin(); it != doc->end(); ++it) {
                 serders[cIdx]->read_one_cell_from_jsonb(*assert_cols[cIdx], it->value());

--- a/be/test/vec/data_types/serde/data_type_jsonb_serde_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_jsonb_serde_test.cpp
@@ -171,12 +171,12 @@ TEST_F(DataTypeJsonbSerDeTest, serdes) {
             ser_col->reserve(row_count);
             MutableColumnPtr deser_column = source_column->clone_empty();
             const auto* deser_col_with_type = assert_cast<const ColumnType*>(deser_column.get());
-            JsonbDocument* pdoc = nullptr;
+            const JsonbDocument* pdoc = nullptr;
             auto st = JsonbDocument::checkAndCreateDocument(jsonb_writer.getOutput()->getBuffer(),
                                                             jsonb_writer.getOutput()->getSize(),
                                                             &pdoc);
             EXPECT_TRUE(st.ok()) << "Failed to check and create jsonb document: " << st;
-            JsonbDocument& doc = *pdoc;
+            const JsonbDocument& doc = *pdoc;
             for (auto it = doc->begin(); it != doc->end(); ++it) {
                 serde.read_one_cell_from_jsonb(*deser_column, it->value());
             }

--- a/be/test/vec/data_types/serde/data_type_serde_agg_state_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_serde_agg_state_test.cpp
@@ -58,10 +58,10 @@ TEST_F(AggStateSerdeTest, writeOneCellToJsonb) {
     jsonb_column->insert_data(jsonb_writer.getOutput()->getBuffer(),
                               jsonb_writer.getOutput()->getSize());
     StringRef jsonb_data = jsonb_column->get_data_at(0);
-    JsonbDocument* pdoc = nullptr;
+    const JsonbDocument* pdoc = nullptr;
     auto st = JsonbDocument::checkAndCreateDocument(jsonb_data.data, jsonb_data.size, &pdoc);
     ASSERT_TRUE(st.ok()) << "checkAndCreateDocument failed: " << st.to_string();
-    JsonbDocument& doc = *pdoc;
+    const JsonbDocument& doc = *pdoc;
     for (auto it = doc->begin(); it != doc->end(); ++it) {
         datatype_agg_state_serde_count->read_one_cell_from_jsonb(*column_fixed_length, it->value());
     }
@@ -86,10 +86,10 @@ TEST_F(AggStateSerdeTest, writeOneCellToJsonb2) {
     jsonb_column->insert_data(jsonb_writer.getOutput()->getBuffer(),
                               jsonb_writer.getOutput()->getSize());
     StringRef jsonb_data = jsonb_column->get_data_at(0);
-    JsonbDocument* pdoc = nullptr;
+    const JsonbDocument* pdoc = nullptr;
     auto st = JsonbDocument::checkAndCreateDocument(jsonb_data.data, jsonb_data.size, &pdoc);
     ASSERT_TRUE(st.ok()) << "checkAndCreateDocument failed: " << st.to_string();
-    JsonbDocument& doc = *pdoc;
+    const JsonbDocument& doc = *pdoc;
     for (auto it = doc->begin(); it != doc->end(); ++it) {
         datatype_agg_state_serde_hll_union->read_one_cell_from_jsonb(*column_string, it->value());
     }

--- a/be/test/vec/data_types/serde/data_type_serde_bitmap_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_serde_bitmap_test.cpp
@@ -41,10 +41,10 @@ TEST(BitmapSerdeTest, writeOneCellToJsonb) {
     jsonb_column->insert_data(jsonb_writer.getOutput()->getBuffer(),
                               jsonb_writer.getOutput()->getSize());
     StringRef jsonb_data = jsonb_column->get_data_at(0);
-    JsonbDocument* pdoc = nullptr;
+    const JsonbDocument* pdoc = nullptr;
     auto st = JsonbDocument::checkAndCreateDocument(jsonb_data.data, jsonb_data.size, &pdoc);
     ASSERT_TRUE(st.ok()) << "checkAndCreateDocument failed: " << st.to_string();
-    JsonbDocument& doc = *pdoc;
+    const JsonbDocument& doc = *pdoc;
     for (auto it = doc->begin(); it != doc->end(); ++it) {
         bitmap_serde->read_one_cell_from_jsonb(*column_bitmap, it->value());
     }

--- a/be/test/vec/data_types/serde/data_type_serde_datetime_v1_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_serde_datetime_v1_test.cpp
@@ -164,12 +164,12 @@ TEST_F(DataTypeDateTimeV1SerDeTest, serdes) {
             ser_col->reserve(row_count);
             MutableColumnPtr deser_column = source_column->clone_empty();
             const auto* deser_col_with_type = assert_cast<const ColumnType*>(deser_column.get());
-            JsonbDocument* pdoc = nullptr;
+            const JsonbDocument* pdoc = nullptr;
             auto st = JsonbDocument::checkAndCreateDocument(jsonb_writer.getOutput()->getBuffer(),
                                                             jsonb_writer.getOutput()->getSize(),
                                                             &pdoc);
             ASSERT_TRUE(st.ok()) << "checkAndCreateDocument failed: " << st.to_string();
-            JsonbDocument& doc = *pdoc;
+            const JsonbDocument& doc = *pdoc;
             for (auto it = doc->begin(); it != doc->end(); ++it) {
                 serde.read_one_cell_from_jsonb(*deser_column, it->value());
             }

--- a/be/test/vec/data_types/serde/data_type_serde_datetime_v2_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_serde_datetime_v2_test.cpp
@@ -191,12 +191,12 @@ TEST_F(DataTypeDateTimeV2SerDeTest, serdes) {
             ser_col->reserve(row_count);
             MutableColumnPtr deser_column = source_column->clone_empty();
             const auto* deser_col_with_type = assert_cast<const ColumnType*>(deser_column.get());
-            JsonbDocument* pdoc = nullptr;
+            const JsonbDocument* pdoc = nullptr;
             auto st = JsonbDocument::checkAndCreateDocument(jsonb_writer.getOutput()->getBuffer(),
                                                             jsonb_writer.getOutput()->getSize(),
                                                             &pdoc);
             EXPECT_TRUE(st.ok()) << "Failed to create JsonbDocument: " << st;
-            JsonbDocument& doc = *pdoc;
+            const JsonbDocument& doc = *pdoc;
             for (auto it = doc->begin(); it != doc->end(); ++it) {
                 serde.read_one_cell_from_jsonb(*deser_column, it->value());
             }

--- a/be/test/vec/data_types/serde/data_type_serde_decimal_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_serde_decimal_test.cpp
@@ -250,12 +250,12 @@ TEST_F(DataTypeDecimalSerDeTest, serdes) {
             ser_col->reserve(row_count);
             MutableColumnPtr deser_column = source_column->clone_empty();
             const auto* deser_col_with_type = assert_cast<const ColumnType*>(deser_column.get());
-            JsonbDocument* pdoc = nullptr;
+            const JsonbDocument* pdoc = nullptr;
             auto st = JsonbDocument::checkAndCreateDocument(jsonb_writer.getOutput()->getBuffer(),
                                                             jsonb_writer.getOutput()->getSize(),
                                                             &pdoc);
             EXPECT_TRUE(st.ok()) << "Failed to create JsonbDocument: " << st;
-            JsonbDocument& doc = *pdoc;
+            const JsonbDocument& doc = *pdoc;
             for (auto it = doc->begin(); it != doc->end(); ++it) {
                 serde.read_one_cell_from_jsonb(*deser_column, it->value());
             }

--- a/be/test/vec/data_types/serde/data_type_serde_fixed_length_object_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_serde_fixed_length_object_test.cpp
@@ -41,10 +41,10 @@ TEST(FixedLengthObjectSerdeTest, writeOneCellToJsonb) {
     jsonb_column->insert_data(jsonb_writer.getOutput()->getBuffer(),
                               jsonb_writer.getOutput()->getSize());
     StringRef jsonb_data = jsonb_column->get_data_at(0);
-    JsonbDocument* pdoc = nullptr;
+    const JsonbDocument* pdoc = nullptr;
     auto st = JsonbDocument::checkAndCreateDocument(jsonb_data.data, jsonb_data.size, &pdoc);
     ASSERT_TRUE(st.ok()) << "checkAndCreateDocument failed: " << st.to_string();
-    JsonbDocument& doc = *pdoc;
+    const JsonbDocument& doc = *pdoc;
     for (auto it = doc->begin(); it != doc->end(); ++it) {
         fixed_length_serde->read_one_cell_from_jsonb(*column_fixed_length, it->value());
     }

--- a/be/test/vec/data_types/serde/data_type_serde_hll_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_serde_hll_test.cpp
@@ -44,10 +44,10 @@ TEST(HLLSerdeTest, writeOneCellToJsonb) {
     jsonb_column->insert_data(jsonb_writer.getOutput()->getBuffer(),
                               jsonb_writer.getOutput()->getSize());
     StringRef jsonb_data = jsonb_column->get_data_at(0);
-    JsonbDocument* pdoc = nullptr;
+    const JsonbDocument* pdoc = nullptr;
     auto st = JsonbDocument::checkAndCreateDocument(jsonb_data.data, jsonb_data.size, &pdoc);
     ASSERT_TRUE(st.ok()) << "checkAndCreateDocument failed: " << st.to_string();
-    JsonbDocument& doc = *pdoc;
+    const JsonbDocument& doc = *pdoc;
     for (auto it = doc->begin(); it != doc->end(); ++it) {
         hll_serde->read_one_cell_from_jsonb(*column_hll, it->value());
     }

--- a/be/test/vec/data_types/serde/data_type_serde_number_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_serde_number_test.cpp
@@ -247,12 +247,12 @@ TEST_F(DataTypeNumberSerDeTest, serdes) {
             ser_col->reserve(row_count);
             MutableColumnPtr deser_column = source_column->clone_empty();
             const auto* deser_col_with_type = assert_cast<const ColumnType*>(deser_column.get());
-            JsonbDocument* pdoc = nullptr;
+            const JsonbDocument* pdoc = nullptr;
             auto st = JsonbDocument::checkAndCreateDocument(jsonb_writer.getOutput()->getBuffer(),
                                                             jsonb_writer.getOutput()->getSize(),
                                                             &pdoc);
             ASSERT_TRUE(st.ok()) << "checkAndCreateDocument failed: " << st.to_string();
-            JsonbDocument& doc = *pdoc;
+            const JsonbDocument& doc = *pdoc;
             for (auto it = doc->begin(); it != doc->end(); ++it) {
                 serde.read_one_cell_from_jsonb(*deser_column, it->value());
             }

--- a/be/test/vec/data_types/serde/data_type_serde_quantile_state_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_serde_quantile_state_test.cpp
@@ -42,10 +42,10 @@ TEST(QuantileStateSerdeTest, writeOneCellToJsonb) {
     jsonb_column->insert_data(jsonb_writer.getOutput()->getBuffer(),
                               jsonb_writer.getOutput()->getSize());
     StringRef jsonb_data = jsonb_column->get_data_at(0);
-    JsonbDocument* pdoc = nullptr;
+    const JsonbDocument* pdoc = nullptr;
     auto st = JsonbDocument::checkAndCreateDocument(jsonb_data.data, jsonb_data.size, &pdoc);
     ASSERT_TRUE(st.ok()) << "checkAndCreateDocument failed: " << st.to_string();
-    JsonbDocument& doc = *pdoc;
+    const JsonbDocument& doc = *pdoc;
     for (auto it = doc->begin(); it != doc->end(); ++it) {
         quantile_state_serde->read_one_cell_from_jsonb(*column_quantile_state, it->value());
     }

--- a/be/test/vec/data_types/serde/data_type_serde_string_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_serde_string_test.cpp
@@ -173,12 +173,12 @@ TEST_F(DataTypeStringSerDeTest, serdes) {
             ser_col->reserve(row_count);
             MutableColumnPtr deser_column = source_column->clone_empty();
             const auto* deser_col_with_type = assert_cast<const ColumnType*>(deser_column.get());
-            JsonbDocument* pdoc = nullptr;
+            const JsonbDocument* pdoc = nullptr;
             auto st = JsonbDocument::checkAndCreateDocument(jsonb_writer.getOutput()->getBuffer(),
                                                             jsonb_writer.getOutput()->getSize(),
                                                             &pdoc);
             ASSERT_TRUE(st.ok()) << "checkAndCreateDocument failed: " << st.to_string();
-            JsonbDocument& doc = *pdoc;
+            const JsonbDocument& doc = *pdoc;
             for (auto it = doc->begin(); it != doc->end(); ++it) {
                 serde.read_one_cell_from_jsonb(*deser_column, it->value());
             }

--- a/be/test/vec/data_types/serde/data_type_serde_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_serde_test.cpp
@@ -227,10 +227,10 @@ TEST(DataTypeSerDeTest, DataTypeRowStoreSerDeTest) {
         jsonb_column->insert_data(jsonb_writer.getOutput()->getBuffer(),
                                   jsonb_writer.getOutput()->getSize());
         StringRef jsonb_data = jsonb_column->get_data_at(0);
-        JsonbDocument* pdoc = nullptr;
+        const JsonbDocument* pdoc = nullptr;
         auto st = JsonbDocument::checkAndCreateDocument(jsonb_data.data, jsonb_data.size, &pdoc);
         ASSERT_TRUE(st.ok()) << "checkAndCreateDocument failed: " << st.to_string();
-        JsonbDocument& doc = *pdoc;
+        const JsonbDocument& doc = *pdoc;
         for (auto it = doc->begin(); it != doc->end(); ++it) {
             serde->read_one_cell_from_jsonb(*vec, it->value());
         }
@@ -259,10 +259,10 @@ TEST(DataTypeSerDeTest, DataTypeRowStoreSerDeTest) {
         jsonb_column->insert_data(jsonb_writer.getOutput()->getBuffer(),
                                   jsonb_writer.getOutput()->getSize());
         StringRef jsonb_data = jsonb_column->get_data_at(0);
-        JsonbDocument* pdoc = nullptr;
+        const JsonbDocument* pdoc = nullptr;
         auto st = JsonbDocument::checkAndCreateDocument(jsonb_data.data, jsonb_data.size, &pdoc);
         ASSERT_TRUE(st.ok()) << "checkAndCreateDocument failed: " << st.to_string();
-        JsonbDocument& doc = *pdoc;
+        const JsonbDocument& doc = *pdoc;
         for (auto it = doc->begin(); it != doc->end(); ++it) {
             serde->read_one_cell_from_jsonb(*vec, it->value());
         }

--- a/be/test/vec/jsonb/convert_field_to_type_test.cpp
+++ b/be/test/vec/jsonb/convert_field_to_type_test.cpp
@@ -53,7 +53,7 @@ TEST_F(ConvertFieldToTypeTest, FieldVisitorToJsonb_Null) {
     ASSERT_GT(output->getSize(), 0);
 
     // Verify the output is valid JSONB
-    JsonbDocument* doc = nullptr;
+    const JsonbDocument* doc = nullptr;
     auto status =
             JsonbDocument::checkAndCreateDocument(output->getBuffer(), output->getSize(), &doc);
     ASSERT_TRUE(status.ok()) << "Failed to create JsonbDocument: " << status.to_string();
@@ -77,7 +77,7 @@ TEST_F(ConvertFieldToTypeTest, FieldVisitorToJsonb_Int64) {
     ASSERT_GT(output->getSize(), 0);
 
     // Verify the output is valid JSONB
-    JsonbDocument* doc = nullptr;
+    const JsonbDocument* doc = nullptr;
     auto status =
             JsonbDocument::checkAndCreateDocument(output->getBuffer(), output->getSize(), &doc);
     ASSERT_TRUE(status.ok()) << "Failed to create JsonbDocument: " << status.to_string();
@@ -102,7 +102,7 @@ TEST_F(ConvertFieldToTypeTest, FieldVisitorToJsonb_UInt64) {
     ASSERT_GT(output->getSize(), 0);
 
     // Verify the output is valid JSONB
-    JsonbDocument* doc = nullptr;
+    const JsonbDocument* doc = nullptr;
     auto status =
             JsonbDocument::checkAndCreateDocument(output->getBuffer(), output->getSize(), &doc);
     ASSERT_TRUE(status.ok()) << "Failed to create JsonbDocument: " << status.to_string();
@@ -127,7 +127,7 @@ TEST_F(ConvertFieldToTypeTest, FieldVisitorToJsonb_Float64) {
     ASSERT_GT(output->getSize(), 0);
 
     // Verify the output is valid JSONB
-    JsonbDocument* doc = nullptr;
+    const JsonbDocument* doc = nullptr;
     auto status =
             JsonbDocument::checkAndCreateDocument(output->getBuffer(), output->getSize(), &doc);
     ASSERT_TRUE(status.ok()) << "Failed to create JsonbDocument: " << status.to_string();
@@ -152,7 +152,7 @@ TEST_F(ConvertFieldToTypeTest, FieldVisitorToJsonb_String) {
     ASSERT_GT(output->getSize(), 0);
 
     // Verify the output is valid JSONB
-    JsonbDocument* doc = nullptr;
+    const JsonbDocument* doc = nullptr;
     auto status =
             JsonbDocument::checkAndCreateDocument(output->getBuffer(), output->getSize(), &doc);
     ASSERT_TRUE(status.ok()) << "Failed to create JsonbDocument: " << status.to_string();
@@ -182,7 +182,7 @@ TEST_F(ConvertFieldToTypeTest, FieldVisitorToJsonb_JsonbField) {
     ASSERT_GT(output->getSize(), 0);
 
     // Verify the output is valid JSONB
-    JsonbDocument* doc = nullptr;
+    const JsonbDocument* doc = nullptr;
     auto status =
             JsonbDocument::checkAndCreateDocument(output->getBuffer(), output->getSize(), &doc);
     ASSERT_TRUE(status.ok()) << "Failed to create JsonbDocument: " << status.to_string();
@@ -212,7 +212,7 @@ TEST_F(ConvertFieldToTypeTest, FieldVisitorToJsonb_Array) {
     ASSERT_GT(output->getSize(), 0);
 
     // Verify the output is valid JSONB
-    JsonbDocument* doc = nullptr;
+    const JsonbDocument* doc = nullptr;
     auto status =
             JsonbDocument::checkAndCreateDocument(output->getBuffer(), output->getSize(), &doc);
     ASSERT_TRUE(status.ok()) << "Failed to create JsonbDocument: " << status.to_string();
@@ -246,7 +246,7 @@ TEST_F(ConvertFieldToTypeTest, FieldVisitorToJsonb_NestedArray) {
     ASSERT_GT(output->getSize(), 0);
 
     // Verify the output is valid JSONB
-    JsonbDocument* doc = nullptr;
+    const JsonbDocument* doc = nullptr;
     auto status =
             JsonbDocument::checkAndCreateDocument(output->getBuffer(), output->getSize(), &doc);
     ASSERT_TRUE(status.ok()) << "Failed to create JsonbDocument: " << status.to_string();
@@ -271,7 +271,7 @@ TEST_F(ConvertFieldToTypeTest, FieldVisitorToJsonb_LargeInt) {
     ASSERT_GT(output->getSize(), 0);
 
     // Verify the output is valid JSONB
-    JsonbDocument* doc = nullptr;
+    const JsonbDocument* doc = nullptr;
     auto status =
             JsonbDocument::checkAndCreateDocument(output->getBuffer(), output->getSize(), &doc);
     ASSERT_TRUE(status.ok()) << "Failed to create JsonbDocument: " << status.to_string();
@@ -296,7 +296,7 @@ TEST_F(ConvertFieldToTypeTest, FieldVisitorToJsonb_UInt128) {
     ASSERT_GT(output->getSize(), 0);
 
     // Verify the output is valid JSONB
-    JsonbDocument* doc = nullptr;
+    const JsonbDocument* doc = nullptr;
     auto status =
             JsonbDocument::checkAndCreateDocument(output->getBuffer(), output->getSize(), &doc);
     ASSERT_TRUE(status.ok()) << "Failed to create JsonbDocument: " << status.to_string();
@@ -327,7 +327,7 @@ TEST_F(ConvertFieldToTypeTest, ConvertFieldToType_ToJsonb) {
         ASSERT_GT(jsonb_result.get_size(), 0);
 
         // Verify the JSONB content
-        JsonbDocument* doc = nullptr;
+        const JsonbDocument* doc = nullptr;
         auto status = JsonbDocument::checkAndCreateDocument(jsonb_result.get_value(),
                                                             jsonb_result.get_size(), &doc);
         ASSERT_TRUE(status.ok()) << "Failed to create JsonbDocument: " << status.to_string();
@@ -352,7 +352,7 @@ TEST_F(ConvertFieldToTypeTest, ConvertFieldToType_ToJsonb) {
         ASSERT_GT(jsonb_result.get_size(), 0);
 
         // Verify the JSONB content
-        JsonbDocument* doc = nullptr;
+        const JsonbDocument* doc = nullptr;
         auto status = JsonbDocument::checkAndCreateDocument(jsonb_result.get_value(),
                                                             jsonb_result.get_size(), &doc);
         ASSERT_TRUE(status.ok()) << "Failed to create JsonbDocument: " << status.to_string();
@@ -383,7 +383,7 @@ TEST_F(ConvertFieldToTypeTest, ConvertFieldToType_ToJsonb) {
         ASSERT_GT(jsonb_result.get_size(), 0);
 
         // Verify the JSONB content
-        JsonbDocument* doc = nullptr;
+        const JsonbDocument* doc = nullptr;
         auto status = JsonbDocument::checkAndCreateDocument(jsonb_result.get_value(),
                                                             jsonb_result.get_size(), &doc);
         ASSERT_TRUE(status.ok()) << "Failed to create JsonbDocument: " << status.to_string();
@@ -450,7 +450,7 @@ TEST_F(ConvertFieldToTypeTest, ConvertFieldToType_ToNullableJsonb) {
         ASSERT_GT(jsonb_result.get_size(), 0);
 
         // Verify the JSONB content
-        JsonbDocument* doc = nullptr;
+        const JsonbDocument* doc = nullptr;
         auto status = JsonbDocument::checkAndCreateDocument(jsonb_result.get_value(),
                                                             jsonb_result.get_size(), &doc);
         ASSERT_TRUE(status.ok()) << "Failed to create JsonbDocument: " << status.to_string();
@@ -493,7 +493,7 @@ TEST_F(ConvertFieldToTypeTest, ConvertFieldToType_ArrayToJsonb) {
         ASSERT_GT(jsonb_element.get_size(), 0);
 
         // Verify the JSONB content
-        JsonbDocument* doc = nullptr;
+        const JsonbDocument* doc = nullptr;
         auto status = JsonbDocument::checkAndCreateDocument(jsonb_element.get_value(),
                                                             jsonb_element.get_size(), &doc);
         ASSERT_TRUE(status.ok()) << "Failed to create JsonbDocument for element " << i << ": "

--- a/be/test/vec/jsonb/jsonb_document_cast_test.cpp
+++ b/be/test/vec/jsonb/jsonb_document_cast_test.cpp
@@ -133,100 +133,100 @@ protected:
 };
 
 TEST_F(JsonbDocumentCastTest, test_to_bool) {
-    auto get_json_value = [&](int idx) -> JsonbValue* {
+    auto get_json_value = [&](int idx) -> const JsonbValue* {
         auto& val = jsonbs[idx];
-        JsonbDocument* doc = nullptr;
+        const JsonbDocument* doc = nullptr;
         auto st = JsonbDocument::checkAndCreateDocument(val.data(), val.size(), &doc);
-        JsonbValue* value = doc->getValue();
+        const JsonbValue* value = doc->getValue();
         return value;
     };
 
     {
-        JsonbValue* jsonb_value = get_json_value(0); // true
+        const JsonbValue* jsonb_value = get_json_value(0); // true
         UInt8 to = false;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_boolean(jsonb_value, to, params));
         EXPECT_TRUE(to);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(1); // false
+        const JsonbValue* jsonb_value = get_json_value(1); // false
         UInt8 to = true;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_boolean(jsonb_value, to, params));
         EXPECT_FALSE(to);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(2); // Int8 123
+        const JsonbValue* jsonb_value = get_json_value(2); // Int8 123
         UInt8 to = false;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_boolean(jsonb_value, to, params));
         EXPECT_TRUE(to);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(3); // Int16 12345
+        const JsonbValue* jsonb_value = get_json_value(3); // Int16 12345
         UInt8 to = false;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_boolean(jsonb_value, to, params));
         EXPECT_TRUE(to);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(4); // Int32 1234567890
+        const JsonbValue* jsonb_value = get_json_value(4); // Int32 1234567890
         UInt8 to = false;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_boolean(jsonb_value, to, params));
         EXPECT_TRUE(to);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(5); // Int64 1234567890123456789
+        const JsonbValue* jsonb_value = get_json_value(5); // Int64 1234567890123456789
         UInt8 to = false;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_boolean(jsonb_value, to, params));
         EXPECT_TRUE(to);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(6); // Int128 1234567890123456789
+        const JsonbValue* jsonb_value = get_json_value(6); // Int128 1234567890123456789
         UInt8 to = false;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_boolean(jsonb_value, to, params));
         EXPECT_TRUE(to);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(7); // Float 123.456F
+        const JsonbValue* jsonb_value = get_json_value(7); // Float 123.456F
         UInt8 to = false;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_boolean(jsonb_value, to, params));
         EXPECT_TRUE(to);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(8); // Double 123.4567890123456789
+        const JsonbValue* jsonb_value = get_json_value(8); // Double 123.4567890123456789
         UInt8 to = false;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_boolean(jsonb_value, to, params));
         EXPECT_TRUE(to);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(9); // Decimal32 12345678
+        const JsonbValue* jsonb_value = get_json_value(9); // Decimal32 12345678
         UInt8 to = false;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_boolean(jsonb_value, to, params));
         EXPECT_TRUE(to);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(10); // Decimal64 1234567890123456789
+        const JsonbValue* jsonb_value = get_json_value(10); // Decimal64 1234567890123456789
         UInt8 to = false;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_boolean(jsonb_value, to, params));
         EXPECT_TRUE(to);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(11); // Decimal128V3 1234567890123456789
+        const JsonbValue* jsonb_value = get_json_value(11); // Decimal128V3 1234567890123456789
         UInt8 to = false;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_boolean(jsonb_value, to, params));
         EXPECT_TRUE(to);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(12); // Decimal256 1234567890123456789
+        const JsonbValue* jsonb_value = get_json_value(12); // Decimal256 1234567890123456789
         UInt8 to = false;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_boolean(jsonb_value, to, params));
         EXPECT_TRUE(to);
@@ -234,100 +234,100 @@ TEST_F(JsonbDocumentCastTest, test_to_bool) {
 }
 
 TEST_F(JsonbDocumentCastTest, test_to_int) {
-    auto get_json_value = [&](int idx) -> JsonbValue* {
+    auto get_json_value = [&](int idx) -> const JsonbValue* {
         auto& val = jsonbs[idx];
-        JsonbDocument* doc = nullptr;
+        const JsonbDocument* doc = nullptr;
         auto st = JsonbDocument::checkAndCreateDocument(val.data(), val.size(), &doc);
-        JsonbValue* value = doc->getValue();
+        const JsonbValue* value = doc->getValue();
         return value;
     };
 
     {
-        JsonbValue* jsonb_value = get_json_value(0); // true
+        const JsonbValue* jsonb_value = get_json_value(0); // true
         Int8 to = 0;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_int(jsonb_value, to, params));
         EXPECT_EQ(to, 1);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(1); // false
+        const JsonbValue* jsonb_value = get_json_value(1); // false
         Int8 to = 0;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_int(jsonb_value, to, params));
         EXPECT_EQ(to, 0);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(2); // Int8 123
+        const JsonbValue* jsonb_value = get_json_value(2); // Int8 123
         Int8 to = 0;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_int(jsonb_value, to, params));
         EXPECT_EQ(to, 123);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(3); // Int16 12345
+        const JsonbValue* jsonb_value = get_json_value(3); // Int16 12345
         Int16 to = 0;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_int(jsonb_value, to, params));
         EXPECT_EQ(to, 12345);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(4); // Int32 1234567890
+        const JsonbValue* jsonb_value = get_json_value(4); // Int32 1234567890
         Int32 to = 0;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_int(jsonb_value, to, params));
         EXPECT_EQ(to, 1234567890);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(5); // Int64 1234567890123456789
+        const JsonbValue* jsonb_value = get_json_value(5); // Int64 1234567890123456789
         Int64 to = 0;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_int(jsonb_value, to, params));
         EXPECT_EQ(to, 1234567890123456789LL);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(6); // Int128 1234567890123456789
+        const JsonbValue* jsonb_value = get_json_value(6); // Int128 1234567890123456789
         Int128 to = 0;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_int(jsonb_value, to, params));
         EXPECT_EQ(to, 1234567890123456789LL);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(7); // Float 123.456F
+        const JsonbValue* jsonb_value = get_json_value(7); // Float 123.456F
         Int32 to = 0;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_int(jsonb_value, to, params));
         EXPECT_EQ(to, 123);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(8); // Double 123.4567890123456789
+        const JsonbValue* jsonb_value = get_json_value(8); // Double 123.4567890123456789
         Int64 to = 0;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_int(jsonb_value, to, params));
         EXPECT_EQ(to, 123);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(9); // Decimal32 12345678
+        const JsonbValue* jsonb_value = get_json_value(9); // Decimal32 12345678
         Int32 to = 0;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_int(jsonb_value, to, params));
         EXPECT_EQ(to, 1234567);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(10); // Decimal64 1234567890123456789
+        const JsonbValue* jsonb_value = get_json_value(10); // Decimal64 1234567890123456789
         Int64 to = 0;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_int(jsonb_value, to, params));
         EXPECT_EQ(to, 12345678901234567);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(11); // Decimal128V3 1234567890123456789
+        const JsonbValue* jsonb_value = get_json_value(11); // Decimal128V3 1234567890123456789
         Int128 to = 0;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_int(jsonb_value, to, params));
         EXPECT_EQ(to, 1234567890123456);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(12); // Decimal256 1234567890123456789
+        const JsonbValue* jsonb_value = get_json_value(12); // Decimal256 1234567890123456789
         Int128 to = 0;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_int(jsonb_value, to, params));
         EXPECT_EQ(to, 1234567890123456);
@@ -335,100 +335,100 @@ TEST_F(JsonbDocumentCastTest, test_to_int) {
 }
 
 TEST_F(JsonbDocumentCastTest, test_to_float) {
-    auto get_json_value = [&](int idx) -> JsonbValue* {
+    auto get_json_value = [&](int idx) -> const JsonbValue* {
         auto& val = jsonbs[idx];
-        JsonbDocument* doc = nullptr;
+        const JsonbDocument* doc = nullptr;
         auto st = JsonbDocument::checkAndCreateDocument(val.data(), val.size(), &doc);
-        JsonbValue* value = doc->getValue();
+        const JsonbValue* value = doc->getValue();
         return value;
     };
 
     {
-        JsonbValue* jsonb_value = get_json_value(0); // true
+        const JsonbValue* jsonb_value = get_json_value(0); // true
         Float32 to = 0.0F;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_float(jsonb_value, to, params));
         EXPECT_EQ(to, 1.0F);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(1); // false
+        const JsonbValue* jsonb_value = get_json_value(1); // false
         Float32 to = 0.0F;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_float(jsonb_value, to, params));
         EXPECT_EQ(to, 0.0F);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(2); // Int8 123
+        const JsonbValue* jsonb_value = get_json_value(2); // Int8 123
         Float32 to = 0.0F;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_float(jsonb_value, to, params));
         EXPECT_EQ(to, 123.0F);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(3); // Int16 12345
+        const JsonbValue* jsonb_value = get_json_value(3); // Int16 12345
         Float32 to = 0.0F;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_float(jsonb_value, to, params));
         EXPECT_EQ(to, 12345.0F);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(4); // Int32 1234567890
+        const JsonbValue* jsonb_value = get_json_value(4); // Int32 1234567890
         Float32 to = 0.0F;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_float(jsonb_value, to, params));
         EXPECT_EQ(to, 1234567890.0F);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(5); // Int64 1234567890123456789
+        const JsonbValue* jsonb_value = get_json_value(5); // Int64 1234567890123456789
         Float32 to = 0.0F;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_float(jsonb_value, to, params));
         EXPECT_EQ(to, 1234567890123456789LL);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(6); // Int128 1234567890123456789
+        const JsonbValue* jsonb_value = get_json_value(6); // Int128 1234567890123456789
         Float32 to = 0.0F;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_float(jsonb_value, to, params));
         EXPECT_EQ(to, 1234567890123456789LL);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(7); // Float 123.456F
+        const JsonbValue* jsonb_value = get_json_value(7); // Float 123.456F
         Float32 to = 0.0F;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_float(jsonb_value, to, params));
         EXPECT_EQ(to, 123.456F);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(8); // Double 123.4567890123456789
+        const JsonbValue* jsonb_value = get_json_value(8); // Double 123.4567890123456789
         Float32 to = 0.0F;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_float(jsonb_value, to, params));
         EXPECT_EQ(to, 123.456789F);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(9); // Decimal32 12345678
+        const JsonbValue* jsonb_value = get_json_value(9); // Decimal32 12345678
         Float32 to = 0.0F;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_float(jsonb_value, to, params));
         EXPECT_EQ(to, 1234567.8F);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(10); // Decimal64 1234567890123456789
+        const JsonbValue* jsonb_value = get_json_value(10); // Decimal64 1234567890123456789
         Float32 to = 0.0F;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_float(jsonb_value, to, params));
         EXPECT_EQ(to, 12345678901234567.89F);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(11); // Decimal128V3 1234567890123456789
+        const JsonbValue* jsonb_value = get_json_value(11); // Decimal128V3 1234567890123456789
         Float32 to = 0.0F;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_float(jsonb_value, to, params));
         EXPECT_EQ(to, 1234567890123456.789F);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(12); // Decimal256 1234567890123456789
+        const JsonbValue* jsonb_value = get_json_value(12); // Decimal256 1234567890123456789
         Float32 to = 0.0F;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_float(jsonb_value, to, params));
         EXPECT_EQ(to, 1234567890123456.789F);
@@ -436,94 +436,94 @@ TEST_F(JsonbDocumentCastTest, test_to_float) {
 }
 
 TEST_F(JsonbDocumentCastTest, test_to_decimal) {
-    auto get_json_value = [&](int idx) -> JsonbValue* {
+    auto get_json_value = [&](int idx) -> const JsonbValue* {
         auto& val = jsonbs[idx];
-        JsonbDocument* doc = nullptr;
+        const JsonbDocument* doc = nullptr;
         auto st = JsonbDocument::checkAndCreateDocument(val.data(), val.size(), &doc);
-        JsonbValue* value = doc->getValue();
+        const JsonbValue* value = doc->getValue();
         return value;
     };
 
     {
-        JsonbValue* jsonb_value = get_json_value(0); // true
+        const JsonbValue* jsonb_value = get_json_value(0); // true
         Decimal32 to = 0;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_decimal(jsonb_value, to, 4, 1, params));
         EXPECT_EQ(to.value, 10);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(1); // false
+        const JsonbValue* jsonb_value = get_json_value(1); // false
         Decimal32 to = 0;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_decimal(jsonb_value, to, 4, 1, params));
         EXPECT_EQ(to.value, 0);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(2); // Int8 123
+        const JsonbValue* jsonb_value = get_json_value(2); // Int8 123
         Decimal32 to = 0;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_decimal(jsonb_value, to, 4, 1, params));
         EXPECT_EQ(to.value, 1230);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(3); // Int16 12345
+        const JsonbValue* jsonb_value = get_json_value(3); // Int16 12345
         Decimal32 to = 0;
         EXPECT_FALSE(JsonbCast::cast_from_json_to_decimal(jsonb_value, to, 4, 1, params));
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(4); // Int32 1234567890
+        const JsonbValue* jsonb_value = get_json_value(4); // Int32 1234567890
         Decimal32 to = 0;
         EXPECT_FALSE(JsonbCast::cast_from_json_to_decimal(jsonb_value, to, 4, 1, params));
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(5); // Int64 1234567890123456789
+        const JsonbValue* jsonb_value = get_json_value(5); // Int64 1234567890123456789
         Decimal32 to = 0;
         EXPECT_FALSE(JsonbCast::cast_from_json_to_decimal(jsonb_value, to, 4, 1, params));
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(6); // Int128 1234567890123456789
+        const JsonbValue* jsonb_value = get_json_value(6); // Int128 1234567890123456789
         Decimal32 to = 0;
         EXPECT_FALSE(JsonbCast::cast_from_json_to_decimal(jsonb_value, to, 4, 1, params));
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(7); // Float 123.456F
+        const JsonbValue* jsonb_value = get_json_value(7); // Float 123.456F
         Decimal32 to = 0;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_decimal(jsonb_value, to, 4, 1, params));
         EXPECT_EQ(to.value, 1235);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(8); // Double 123.4567890123456789
+        const JsonbValue* jsonb_value = get_json_value(8); // Double 123.4567890123456789
         Decimal32 to = 0;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_decimal(jsonb_value, to, 4, 1, params));
         EXPECT_EQ(to.value, 1235);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(9); // Decimal32 12345678
+        const JsonbValue* jsonb_value = get_json_value(9); // Decimal32 12345678
         Decimal32 to = 0;
         EXPECT_TRUE(JsonbCast::cast_from_json_to_decimal(jsonb_value, to, 4, 1, params));
         EXPECT_EQ(to.value, 12345678);
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(10); // Decimal64 1234567890123456789
+        const JsonbValue* jsonb_value = get_json_value(10); // Decimal64 1234567890123456789
         Decimal32 to = 0;
         EXPECT_FALSE(JsonbCast::cast_from_json_to_decimal(jsonb_value, to, 4, 1, params));
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(11); // Decimal128V3 1234567890123456789
+        const JsonbValue* jsonb_value = get_json_value(11); // Decimal128V3 1234567890123456789
         Decimal32 to = 0;
         EXPECT_FALSE(JsonbCast::cast_from_json_to_decimal(jsonb_value, to, 4, 1, params));
     }
 
     {
-        JsonbValue* jsonb_value = get_json_value(12); // Decimal256 1234567890123456789
+        const JsonbValue* jsonb_value = get_json_value(12); // Decimal256 1234567890123456789
         Decimal32 to = 0;
         EXPECT_FALSE(JsonbCast::cast_from_json_to_decimal(jsonb_value, to, 4, 1, params));
     }

--- a/be/test/vec/jsonb/jsonb_document_test.cpp
+++ b/be/test/vec/jsonb/jsonb_document_test.cpp
@@ -93,8 +93,8 @@ TEST_F(JsonbDocumentTest, writer) {
 
     writer.writeEndObject();
 
-    JsonbDocument* doc = writer.getDocument();
-    auto* root = doc->getValue();
+    const JsonbDocument* doc = writer.getDocument();
+    const auto* root = doc->getValue();
     ASSERT_TRUE(root->type == JsonbType::T_Object)
             << "invalid root type:" << static_cast<JsonbTypeUnder>(root->type);
 
@@ -242,8 +242,8 @@ TEST_F(JsonbDocumentTest, forobject) {
 
     writer.writeEndObject();
 
-    JsonbDocument* doc = writer.getDocument();
-    auto* root = doc->getValue();
+    const JsonbDocument* doc = writer.getDocument();
+    const auto* root = doc->getValue();
     std::cout << JsonbToJson {}.to_json_string(root) << std::endl;
     EXPECT_EQ(
             JsonbToJson {}.to_json_string(root),


### PR DESCRIPTION
### What problem does this PR solve?

The `JsonbDocument` and `JsonbValue` should be read-only, so this PR make related functions const.

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

