### PR TITLE
[chore](exec) BE constant folding no longer needs to construct a temporary block

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
@@ -83,6 +83,7 @@ import org.apache.doris.proto.Types.PTypeDesc;
 import org.apache.doris.proto.Types.PTypeNode;
 import org.apache.doris.proto.Types.PValues;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.rpc.BackendServiceProxy;
 import org.apache.doris.system.Backend;
 import org.apache.doris.thrift.TExpr;
@@ -319,6 +320,7 @@ public class FoldConstantRuleOnBE implements ExpressionPatternRuleFactory {
             tQueryOptions.setBeExecVersion(Config.be_exec_version);
             tQueryOptions.setEnableDecimal256(context.getSessionVariable().isEnableDecimal256());
             tQueryOptions.setNewVersionUnixTimestamp(true);
+            tQueryOptions.setEnableStrictCast(SessionVariable.enableStrictCast());
 
             TFoldConstantParams tParams = new TFoldConstantParams(paramMap, queryGlobals);
             tParams.setVecExec(true);


### PR DESCRIPTION
### What problem does this PR solve?

Also, this PR fixes a bug: previously BE constant folding did not pass whether casts should be performed in strict mode.

```
W20251205 13:32:09.197405 512888 internal_service.cpp:1608] exec fold constant expr failed, errmsg=[INTERNAL_ERROR]ColumnWithTypeAndName check column type failed, column name: (CAST String(String) TO IPv4), type: IPv4,  column: Const(Nullable(IPV4)) , error: [INTERNAL_ERROR]Column type Const(Nullable(IPV4)) is not compatible with data type IPv4        0#  doris::Status doris::vectorized::IDataType::check_column_non_nested_type<doris::vectorized::ColumnVector<(doris::PrimitiveType)36> >(doris::vectorized::IColumn const&) const at /root/doris/be/src/common/status.h:0
        1#  doris::vectorized::DataTypeNumberBase<(doris::PrimitiveType)36>::check_column(doris::vectorized::IColumn const&) const at /root/doris/be/src/vec/data_types/data_type_number_base.cpp:239
        2#  doris::vectorized::ColumnWithTypeAndName::check_type_and_column_match() const at /root/doris/be/src/vec/core/column_with_type_and_name.cpp:0
        3#  doris::vectorized::VExprContext::execute(doris::vectorized::Block*, int*) at /root/doris/be/src/vec/exprs/vexpr_context.cpp:0
        4#  doris::FoldConstantExecutor::fold_constant_vexpr(doris::TFoldConstantParams const&, doris::PConstantExprResult*) at /root/doris/be/src/common/status.h:0
        5#  std::_Function_handler<void (), doris::PInternalService::fold_constant_expr(google::protobuf::RpcController*, doris::PConstantExprRequest const*, doris::PConstantExprResult*, google::protobuf::Closure*)::$_0>::_M_invoke(std::_Any_data const&) at /root/doris/be/src/common/status.h:0
```
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

