### PR TITLE
[fix](distribute) fix forward insert statement cause backend core when use local shuffle union

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -703,9 +703,9 @@ public class NereidsPlanner extends Planner {
 
         boolean notNeedBackend = false;
         // if the query can compute without backend, we can skip check cluster privileges
-        if (Config.isCloudMode()
-                && cascadesContext.getConnectContext().supportHandleByFe()
-                && physicalPlan instanceof ComputeResultSet) {
+        if (cascadesContext.getConnectContext().supportHandleByFe()
+                && physicalPlan instanceof ComputeResultSet
+                && !cascadesContext.getConnectContext().getState().isInternal()) {
             Optional<ResultSet> resultSet = ((ComputeResultSet) physicalPlan).computeResultInFe(
                     cascadesContext, Optional.empty(), physicalPlan.getOutput());
             if (resultSet.isPresent()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -702,7 +702,7 @@ public class NereidsPlanner extends Planner {
         }
 
         boolean notNeedBackend = false;
-        // if the query can compute without backend, we can skip check cluster privileges
+        // the internal query not support process Resultset, so must process by backend
         if (cascadesContext.getConnectContext().supportHandleByFe()
                 && physicalPlan instanceof ComputeResultSet
                 && !cascadesContext.getConnectContext().getState().isInternal()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -2313,7 +2313,8 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         // and LocalShuffleUnion need `local` channels to do random local shuffle, so we need check
         // `enable_local_exchange`
         if (setOperation instanceof PhysicalUnion
-                && context.getConnectContext().getSessionVariable().getEnableLocalExchange()) {
+                && context.getConnectContext().getSessionVariable().getEnableLocalExchange()
+                && SessionVariable.canUseNereidsDistributePlanner()) {
             boolean isLocalShuffleUnion = false;
             if (setOperation.getPhysicalProperties().getDistributionSpec() instanceof DistributionSpecExecutionAny) {
                 Map<Integer, ExchangeNode> exchangeIdToExchangeNode = new IdentityHashMap<>();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -500,6 +500,7 @@ import org.apache.doris.nereids.analyzer.UnboundVariable.VariableType;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.exceptions.NotSupportedException;
 import org.apache.doris.nereids.exceptions.ParseException;
+import org.apache.doris.nereids.glue.LogicalPlanAdapter;
 import org.apache.doris.nereids.hint.DistributeHint;
 import org.apache.doris.nereids.hint.JoinSkewInfo;
 import org.apache.doris.nereids.load.NereidsDataDescription;
@@ -2020,8 +2021,10 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
                 connectContext.setStatementContext(statementContext);
                 statementContext.setConnectContext(connectContext);
             }
-            logicalPlans.add(Pair.of(
-                    ParserUtils.withOrigin(ctx, () -> (LogicalPlan) visit(statement)), statementContext));
+            Pair<LogicalPlan, StatementContext> planAndContext = Pair.of(
+                    ParserUtils.withOrigin(ctx, () -> (LogicalPlan) visit(statement)), statementContext);
+            statementContext.setParsedStatement(new LogicalPlanAdapter(planAndContext.first, statementContext));
+            logicalPlans.add(planAndContext);
             List<Placeholder> params = new ArrayList<>(tokenPosToParameters.values());
             statementContext.setPlaceholders(params);
             tokenPosToParameters.clear();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitMaterializationContextHook.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitMaterializationContextHook.java
@@ -198,8 +198,10 @@ public class InitMaterializationContextHook implements PlannerHook {
             return ImmutableList.of();
         }
         if (CollectionUtils.isEmpty(availableMTMVs)) {
-            LOG.info("Enable materialized view rewrite but availableMTMVs is empty, query id "
-                    + "is {}", cascadesContext.getConnectContext().getQueryIdentifier());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Enable materialized view rewrite but availableMTMVs is empty, query id "
+                        + "is {}", cascadesContext.getConnectContext().getQueryIdentifier());
+            }
             return ImmutableList.of();
         }
         List<MaterializationContext> asyncMaterializationContext = new ArrayList<>();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -986,8 +986,11 @@ public class ConnectContext {
     public TUniqueId nextInstanceId() {
         if (loadId != null) {
             return new TUniqueId(loadId.hi, loadId.lo + instanceIdGenerator.incrementAndGet());
-        } else {
+        } else if (queryId != null) {
             return new TUniqueId(queryId.hi, queryId.lo + instanceIdGenerator.incrementAndGet());
+        } else {
+            // for test
+            return new TUniqueId(0, instanceIdGenerator.incrementAndGet());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -18,7 +18,6 @@
 package org.apache.doris.qe;
 
 import org.apache.doris.analysis.SetVar;
-import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
@@ -29,7 +28,6 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.nereids.StatementContext;
-import org.apache.doris.nereids.glue.LogicalPlanAdapter;
 import org.apache.doris.nereids.metrics.Event;
 import org.apache.doris.nereids.metrics.EventSwitchParser;
 import org.apache.doris.nereids.parser.Dialect;
@@ -1921,7 +1919,7 @@ public class SessionVariable implements Serializable, Writable {
     public boolean enableCommonExprPushdown = true;
 
     @VariableMgr.VarAttr(name = ENABLE_LOCAL_EXCHANGE, fuzzy = false, flag = VariableMgr.INVISIBLE,
-            varType = VariableAnnotation.DEPRECATED)
+            varType = VariableAnnotation.DEPRECATED, needForward = true)
     public boolean enableLocalExchange = true;
 
     /**
@@ -4426,15 +4424,7 @@ public class SessionVariable implements Serializable, Writable {
         if (connectContext == null) {
             return true;
         }
-        SessionVariable sessionVariable = connectContext.getSessionVariable();
-        StatementContext statementContext = connectContext.getStatementContext();
-        if (statementContext != null) {
-            StatementBase parsedStatement = statementContext.getParsedStatement();
-            if (!(parsedStatement instanceof LogicalPlanAdapter)) {
-                return false;
-            }
-        }
-        return sessionVariable.enableNereidsDistributePlanner;
+        return connectContext.getSessionVariable().enableNereidsDistributePlanner;
     }
 
     public boolean isEnableNereidsDistributePlanner() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -862,6 +862,9 @@ public class StmtExecutor {
             }
             parsedStmt = statements.get(originStmt.idx);
         }
+        if (parsedStmt != null && statementContext.getParsedStatement() == null) {
+            statementContext.setParsedStatement(parsedStmt);
+        }
     }
 
     public void finalizeQuery() {

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/OlapQueryCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/OlapQueryCacheTest.java
@@ -68,9 +68,11 @@ import org.apache.doris.qe.cache.RowBatchBuilder;
 import org.apache.doris.qe.cache.SqlCache;
 import org.apache.doris.service.FrontendOptions;
 import org.apache.doris.system.Backend;
+import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TStorageType;
 import org.apache.doris.thrift.TUniqueId;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import mockit.Expectations;
@@ -89,6 +91,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 
 public class OlapQueryCacheTest {
     private static final Logger LOG = LogManager.getLogger(OlapQueryCacheTest.class);
@@ -271,6 +274,24 @@ public class OlapQueryCacheTest {
         db.registerTable(view3);
         View view4 = createEventNestedView();
         db.registerTable(view4);
+
+        SystemInfoService clusterInfo = Env.getCurrentEnv().getClusterInfo();
+        Backend be = new Backend(0, "127.0.0.1", 0);
+        be.setAlive(true);
+        ImmutableMap<Long, Backend> backends = ImmutableMap.of(0L, be);
+        new Expectations(clusterInfo) {
+            {
+                clusterInfo.getBackendsByCurrentCluster();
+                minTimes = 0;
+                result = backends;
+            }
+
+            {
+                clusterInfo.getAllBackendsByAllCluster();
+                minTimes = 0;
+                result = backends;
+            }
+        };
     }
 
     private OlapTable createOrderTable() {
@@ -501,6 +522,8 @@ public class OlapQueryCacheTest {
             LogicalPlan plan = new NereidsParser().parseSingle(sql);
             OriginStatement originStatement = new OriginStatement(sql, 0);
             StatementContext statementContext = new StatementContext(ctx, originStatement);
+            UUID uuid = UUID.randomUUID();
+            ctx.setQueryId(new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()));
             ctx.setStatementContext(statementContext);
             NereidsPlanner nereidsPlanner = new NereidsPlanner(statementContext);
             LogicalPlanAdapter adapter = new LogicalPlanAdapter(plan, statementContext);


### PR DESCRIPTION
### What problem does this PR solve?

introduced by #58042

fix forward insert statement cause backend core when use local shuffle union, because the `ConnectContext.get().getStatementContext().getParsedStatement()` is null.

this is a distribute cluster bug so can not add test

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

