### PR TITLE
[performance](exec) fix zone map in effective in column preidate

### DIFF
--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -119,8 +119,8 @@ public:
     }
 
     bool evaluate_and(const std::pair<WrapperField*, WrapperField*>& statistic) const override {
-        if (statistic.first->is_null()) {
-            return true;
+        if (statistic.first->is_null() && statistic.second->is_null()) {
+            return false;
         }
 
         T tmp_min_value = get_zone_map_value<Type, T>(statistic.first->cell_ptr());

--- a/be/src/olap/in_list_predicate.h
+++ b/be/src/olap/in_list_predicate.h
@@ -233,8 +233,8 @@ public:
     }
 
     bool evaluate_and(const std::pair<WrapperField*, WrapperField*>& statistic) const override {
-        if (statistic.first->is_null()) {
-            return true;
+        if (statistic.first->is_null() && statistic.second->is_null()) {
+            return false;
         }
         if constexpr (PT == PredicateType::IN_LIST) {
             return Compare::less_equal(get_zone_map_value<Type, T>(statistic.first->cell_ptr()),

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -545,10 +545,6 @@ bool ColumnReader::_zone_map_match_condition(const ZoneMapPB& zone_map,
                                              WrapperField* min_value_container,
                                              WrapperField* max_value_container,
                                              const AndBlockColumnPredicate* col_predicates) const {
-    if (!zone_map.has_not_null() && !zone_map.has_null()) {
-        return false; // no data in this zone
-    }
-
     if (zone_map.pass_all() || min_value_container == nullptr || max_value_container == nullptr) {
         return true;
     }


### PR DESCRIPTION
### What problem does this PR solve?

When a page contains some NULL values, we set both the min value and its associated flag to NULL for filtering purposes in IN and comparison operations. In such cases, we can directly compare the min/max values to determine whether the zone map is effective, without needing to handle the scenario where the min value is NULL. However, if all values in the page are NULL, the entire page can be directly filtered out.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

