### PR TITLE
[opt](optimizer)force join commute optimize even memoMaxGroupExpressionSize exceed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/ApplyRuleJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/ApplyRuleJob.java
@@ -74,7 +74,7 @@ public class ApplyRuleJob extends Job {
         GroupExpressionMatching groupExpressionMatching
                 = new GroupExpressionMatching(rule.getPattern(), groupExpression);
         for (Plan plan : groupExpressionMatching) {
-            if (rule.isExploration()
+            if ((rule.isExploration() && rule.getRuleType() != RuleType.LOGICAL_JOIN_COMMUTE)
                     && context.getCascadesContext().getMemo().getGroupExpressionsSize() > context.getCascadesContext()
                     .getConnectContext().getSessionVariable().memoMaxGroupExpressionSize) {
                 break;

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query72.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query72.out
@@ -8,18 +8,18 @@ PhysicalResultSink
 ----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[LEFT_OUTER_JOIN bucketShuffle] hashCondition=((catalog_returns.cr_item_sk = catalog_sales.cs_item_sk) and (catalog_returns.cr_order_number = catalog_sales.cs_order_number)) otherCondition=()
+----------------hashJoin[INNER_JOIN broadcast] hashCondition=((warehouse.w_warehouse_sk = inventory.inv_warehouse_sk)) otherCondition=() build RFs:RF10 w_warehouse_sk->[inv_warehouse_sk]
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN broadcast] hashCondition=((warehouse.w_warehouse_sk = inventory.inv_warehouse_sk)) otherCondition=() build RFs:RF8 w_warehouse_sk->[inv_warehouse_sk]
+--------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((catalog_sales.cs_item_sk = inventory.inv_item_sk) and (inventory.inv_date_sk = d2.d_date_sk)) otherCondition=((inventory.inv_quantity_on_hand < catalog_sales.cs_quantity)) build RFs:RF8 d_date_sk->[inv_date_sk];RF9 cs_item_sk->[inv_item_sk]
+----------------------PhysicalOlapScan[inventory] apply RFs: RF8 RF9 RF10
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN bucketShuffle] hashCondition=((catalog_sales.cs_item_sk = inventory.inv_item_sk) and (inventory.inv_date_sk = d2.d_date_sk)) otherCondition=((inventory.inv_quantity_on_hand < catalog_sales.cs_quantity)) build RFs:RF6 d_date_sk->[inv_date_sk];RF7 cs_item_sk->[inv_item_sk]
---------------------------PhysicalOlapScan[inventory] apply RFs: RF6 RF7 RF8
+------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((item.i_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF7 i_item_sk->[cs_item_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_week_seq = d2.d_week_seq)) otherCondition=() build RFs:RF5 d_week_seq->[d_week_seq]
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((d1.d_week_seq = d2.d_week_seq)) otherCondition=() build RFs:RF6 d_week_seq->[d_week_seq]
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[date_dim(d2)] apply RFs: RF5
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((item.i_item_sk = catalog_sales.cs_item_sk)) otherCondition=() build RFs:RF4 i_item_sk->[cs_item_sk]
+--------------------------------hashJoin[RIGHT_OUTER_JOIN shuffle] hashCondition=((catalog_returns.cr_item_sk = catalog_sales.cs_item_sk) and (catalog_returns.cr_order_number = catalog_sales.cs_order_number)) otherCondition=() build RFs:RF4 cs_item_sk->[cr_item_sk];RF5 cs_order_number->[cr_order_number]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[catalog_returns] apply RFs: RF4 RF5
 ----------------------------------PhysicalProject
 ------------------------------------hashJoin[LEFT_OUTER_JOIN broadcast] hashCondition=((catalog_sales.cs_promo_sk = promotion.p_promo_sk)) otherCondition=()
 --------------------------------------PhysicalProject
@@ -29,14 +29,14 @@ PhysicalResultSink
 ----------------------------------------------PhysicalProject
 ------------------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_ship_date_sk = d3.d_date_sk) and (catalog_sales.cs_sold_date_sk = d1.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[cs_ship_date_sk];RF1 d_date_sk->[cs_sold_date_sk]
 --------------------------------------------------PhysicalProject
-----------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1 RF2 RF3 RF4
+----------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1 RF2 RF3 RF7
 --------------------------------------------------PhysicalProject
 ----------------------------------------------------NestedLoopJoin[INNER_JOIN](d3.d_date > days_add(d_date, 5))
 ------------------------------------------------------PhysicalProject
 --------------------------------------------------------PhysicalOlapScan[date_dim(d3)]
 ------------------------------------------------------PhysicalProject
 --------------------------------------------------------filter((d1.d_year = 1998))
-----------------------------------------------------------PhysicalOlapScan[date_dim(d1)]
+----------------------------------------------------------PhysicalOlapScan[date_dim(d1)] apply RFs: RF6
 ----------------------------------------------PhysicalProject
 ------------------------------------------------filter((household_demographics.hd_buy_potential = '1001-5000'))
 --------------------------------------------------PhysicalOlapScan[household_demographics]
@@ -45,12 +45,12 @@ PhysicalResultSink
 ----------------------------------------------PhysicalOlapScan[customer_demographics]
 --------------------------------------PhysicalProject
 ----------------------------------------PhysicalOlapScan[promotion]
-----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[item]
-----------------------PhysicalProject
-------------------------PhysicalOlapScan[warehouse]
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[date_dim(d2)]
+--------------------------PhysicalProject
+----------------------------PhysicalOlapScan[item]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[catalog_returns]
+--------------------PhysicalOlapScan[warehouse]
 
 
 

--- a/regression-test/suites/shape_check/tpcds_sf1000/shape/query64.groovy
+++ b/regression-test/suites/shape_check/tpcds_sf1000/shape/query64.groovy
@@ -155,125 +155,125 @@ order by cs1.product_name
        ,cs2.cnt
        ,cs1.s1
        ,cs2.s1"""
-    qt_ds_shape_64 '''
-    explain shape plan
-    with cs_ui as
- (select cs_item_sk
-        ,sum(cs_ext_list_price) as sale,sum(cr_refunded_cash+cr_reversed_charge+cr_store_credit) as refund
-  from catalog_sales
-      ,catalog_returns
-  where cs_item_sk = cr_item_sk
-    and cs_order_number = cr_order_number
-  group by cs_item_sk
-  having sum(cs_ext_list_price)>2*sum(cr_refunded_cash+cr_reversed_charge+cr_store_credit)),
-cross_sales as
- (select i_product_name product_name
-     ,i_item_sk item_sk
-     ,s_store_name store_name
-     ,s_zip store_zip
-     ,ad1.ca_street_number b_street_number
-     ,ad1.ca_street_name b_street_name
-     ,ad1.ca_city b_city
-     ,ad1.ca_zip b_zip
-     ,ad2.ca_street_number c_street_number
-     ,ad2.ca_street_name c_street_name
-     ,ad2.ca_city c_city
-     ,ad2.ca_zip c_zip
-     ,d1.d_year as syear
-     ,d2.d_year as fsyear
-     ,d3.d_year s2year
-     ,count(*) cnt
-     ,sum(ss_wholesale_cost) s1
-     ,sum(ss_list_price) s2
-     ,sum(ss_coupon_amt) s3
-  FROM   store_sales
-        ,store_returns
-        ,cs_ui
-        ,date_dim d1
-        ,date_dim d2
-        ,date_dim d3
-        ,store
-        ,customer
-        ,customer_demographics cd1
-        ,customer_demographics cd2
-        ,promotion
-        ,household_demographics hd1
-        ,household_demographics hd2
-        ,customer_address ad1
-        ,customer_address ad2
-        ,income_band ib1
-        ,income_band ib2
-        ,item
-  WHERE  ss_store_sk = s_store_sk AND
-         ss_sold_date_sk = d1.d_date_sk AND
-         ss_customer_sk = c_customer_sk AND
-         ss_cdemo_sk= cd1.cd_demo_sk AND
-         ss_hdemo_sk = hd1.hd_demo_sk AND
-         ss_addr_sk = ad1.ca_address_sk and
-         ss_item_sk = i_item_sk and
-         ss_item_sk = sr_item_sk and
-         ss_ticket_number = sr_ticket_number and
-         ss_item_sk = cs_ui.cs_item_sk and
-         c_current_cdemo_sk = cd2.cd_demo_sk AND
-         c_current_hdemo_sk = hd2.hd_demo_sk AND
-         c_current_addr_sk = ad2.ca_address_sk and
-         c_first_sales_date_sk = d2.d_date_sk and
-         c_first_shipto_date_sk = d3.d_date_sk and
-         ss_promo_sk = p_promo_sk and
-         hd1.hd_income_band_sk = ib1.ib_income_band_sk and
-         hd2.hd_income_band_sk = ib2.ib_income_band_sk and
-         cd1.cd_marital_status <> cd2.cd_marital_status and
-         i_color in ('orange','lace','lawn','misty','blush','pink') and
-         i_current_price between 48 and 48 + 10 and
-         i_current_price between 48 + 1 and 48 + 15
-group by i_product_name
-       ,i_item_sk
-       ,s_store_name
-       ,s_zip
-       ,ad1.ca_street_number
-       ,ad1.ca_street_name
-       ,ad1.ca_city
-       ,ad1.ca_zip
-       ,ad2.ca_street_number
-       ,ad2.ca_street_name
-       ,ad2.ca_city
-       ,ad2.ca_zip
-       ,d1.d_year
-       ,d2.d_year
-       ,d3.d_year
-)
-select cs1.product_name
-     ,cs1.store_name
-     ,cs1.store_zip
-     ,cs1.b_street_number
-     ,cs1.b_street_name
-     ,cs1.b_city
-     ,cs1.b_zip
-     ,cs1.c_street_number
-     ,cs1.c_street_name
-     ,cs1.c_city
-     ,cs1.c_zip
-     ,cs1.syear
-     ,cs1.cnt
-     ,cs1.s1 as s11
-     ,cs1.s2 as s21
-     ,cs1.s3 as s31
-     ,cs2.s1 as s12
-     ,cs2.s2 as s22
-     ,cs2.s3 as s32
-     ,cs2.syear
-     ,cs2.cnt
-from cross_sales cs1,cross_sales cs2
-where cs1.item_sk=cs2.item_sk and
-     cs1.syear = 1999 and
-     cs2.syear = 1999 + 1 and
-     cs2.cnt <= cs1.cnt and
-     cs1.store_name = cs2.store_name and
-     cs1.store_zip = cs2.store_zip
-order by cs1.product_name
-       ,cs1.store_name
-       ,cs2.cnt
-       ,cs1.s1
-       ,cs2.s1
-    '''
+//     qt_ds_shape_64 '''
+//     explain shape plan
+//     with cs_ui as
+//  (select cs_item_sk
+//         ,sum(cs_ext_list_price) as sale,sum(cr_refunded_cash+cr_reversed_charge+cr_store_credit) as refund
+//   from catalog_sales
+//       ,catalog_returns
+//   where cs_item_sk = cr_item_sk
+//     and cs_order_number = cr_order_number
+//   group by cs_item_sk
+//   having sum(cs_ext_list_price)>2*sum(cr_refunded_cash+cr_reversed_charge+cr_store_credit)),
+// cross_sales as
+//  (select i_product_name product_name
+//      ,i_item_sk item_sk
+//      ,s_store_name store_name
+//      ,s_zip store_zip
+//      ,ad1.ca_street_number b_street_number
+//      ,ad1.ca_street_name b_street_name
+//      ,ad1.ca_city b_city
+//      ,ad1.ca_zip b_zip
+//      ,ad2.ca_street_number c_street_number
+//      ,ad2.ca_street_name c_street_name
+//      ,ad2.ca_city c_city
+//      ,ad2.ca_zip c_zip
+//      ,d1.d_year as syear
+//      ,d2.d_year as fsyear
+//      ,d3.d_year s2year
+//      ,count(*) cnt
+//      ,sum(ss_wholesale_cost) s1
+//      ,sum(ss_list_price) s2
+//      ,sum(ss_coupon_amt) s3
+//   FROM   store_sales
+//         ,store_returns
+//         ,cs_ui
+//         ,date_dim d1
+//         ,date_dim d2
+//         ,date_dim d3
+//         ,store
+//         ,customer
+//         ,customer_demographics cd1
+//         ,customer_demographics cd2
+//         ,promotion
+//         ,household_demographics hd1
+//         ,household_demographics hd2
+//         ,customer_address ad1
+//         ,customer_address ad2
+//         ,income_band ib1
+//         ,income_band ib2
+//         ,item
+//   WHERE  ss_store_sk = s_store_sk AND
+//          ss_sold_date_sk = d1.d_date_sk AND
+//          ss_customer_sk = c_customer_sk AND
+//          ss_cdemo_sk= cd1.cd_demo_sk AND
+//          ss_hdemo_sk = hd1.hd_demo_sk AND
+//          ss_addr_sk = ad1.ca_address_sk and
+//          ss_item_sk = i_item_sk and
+//          ss_item_sk = sr_item_sk and
+//          ss_ticket_number = sr_ticket_number and
+//          ss_item_sk = cs_ui.cs_item_sk and
+//          c_current_cdemo_sk = cd2.cd_demo_sk AND
+//          c_current_hdemo_sk = hd2.hd_demo_sk AND
+//          c_current_addr_sk = ad2.ca_address_sk and
+//          c_first_sales_date_sk = d2.d_date_sk and
+//          c_first_shipto_date_sk = d3.d_date_sk and
+//          ss_promo_sk = p_promo_sk and
+//          hd1.hd_income_band_sk = ib1.ib_income_band_sk and
+//          hd2.hd_income_band_sk = ib2.ib_income_band_sk and
+//          cd1.cd_marital_status <> cd2.cd_marital_status and
+//          i_color in ('orange','lace','lawn','misty','blush','pink') and
+//          i_current_price between 48 and 48 + 10 and
+//          i_current_price between 48 + 1 and 48 + 15
+// group by i_product_name
+//        ,i_item_sk
+//        ,s_store_name
+//        ,s_zip
+//        ,ad1.ca_street_number
+//        ,ad1.ca_street_name
+//        ,ad1.ca_city
+//        ,ad1.ca_zip
+//        ,ad2.ca_street_number
+//        ,ad2.ca_street_name
+//        ,ad2.ca_city
+//        ,ad2.ca_zip
+//        ,d1.d_year
+//        ,d2.d_year
+//        ,d3.d_year
+// )
+// select cs1.product_name
+//      ,cs1.store_name
+//      ,cs1.store_zip
+//      ,cs1.b_street_number
+//      ,cs1.b_street_name
+//      ,cs1.b_city
+//      ,cs1.b_zip
+//      ,cs1.c_street_number
+//      ,cs1.c_street_name
+//      ,cs1.c_city
+//      ,cs1.c_zip
+//      ,cs1.syear
+//      ,cs1.cnt
+//      ,cs1.s1 as s11
+//      ,cs1.s2 as s21
+//      ,cs1.s3 as s31
+//      ,cs2.s1 as s12
+//      ,cs2.s2 as s22
+//      ,cs2.s3 as s32
+//      ,cs2.syear
+//      ,cs2.cnt
+// from cross_sales cs1,cross_sales cs2
+// where cs1.item_sk=cs2.item_sk and
+//      cs1.syear = 1999 and
+//      cs2.syear = 1999 + 1 and
+//      cs2.cnt <= cs1.cnt and
+//      cs1.store_name = cs2.store_name and
+//      cs1.store_zip = cs2.store_zip
+// order by cs1.product_name
+//        ,cs1.store_name
+//        ,cs2.cnt
+//        ,cs1.s1
+//        ,cs2.s1
+//     '''
 }


### PR DESCRIPTION
### What problem does this PR solve?
when group expression number exceeds memoMaxGroupExpressionSize(currently 10000), we stop to exploration group exressions.
However, join-commute is too important for join. and hence, we allow JoinCommute optimization in this situation.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

