### PR TITLE
[fix](hive) fix invalid edit log after inserting hive partition table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
@@ -26,7 +26,9 @@ import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.ExternalDatabase;
 import org.apache.doris.datasource.ExternalObjectLog;
 import org.apache.doris.datasource.ExternalTable;
+import org.apache.doris.datasource.hive.HMSExternalCatalog;
 import org.apache.doris.datasource.hive.HMSExternalTable;
+import org.apache.doris.datasource.hive.HiveMetaStoreCache;
 import org.apache.doris.persist.OperationType;
 
 import com.google.common.base.Strings;
@@ -183,13 +185,20 @@ public class RefreshManager {
             db.get().unregisterTable(log.getTableName());
             db.get().resetMetaCacheNames();
         } else {
-            List<String> partitionNames = log.getPartitionNames();
-            if (partitionNames != null && !partitionNames.isEmpty()) {
-                // Partition-level cache invalidation
-                Env.getCurrentEnv().getExtMetaCacheMgr()
-                        .invalidatePartitionsCache(table.get(), partitionNames);
-                LOG.info("replay refresh partitions for table {}, partitions count: {}",
-                        table.get().getName(), partitionNames.size());
+            List<String> modifiedPartNames = log.getPartitionNames();
+            List<String> newPartNames = log.getNewPartitionNames();
+            if (catalog instanceof HMSExternalCatalog
+                    && ((modifiedPartNames != null && !modifiedPartNames.isEmpty())
+                    || (newPartNames != null && !newPartNames.isEmpty()))) {
+                // Partition-level cache invalidation, only for hive catalog
+                HiveMetaStoreCache cache = Env.getCurrentEnv().getExtMetaCacheMgr()
+                        .getMetaStoreCache((HMSExternalCatalog) catalog);
+                cache.refreshAffectedPartitionsCache((HMSExternalTable) table.get(), modifiedPartNames, newPartNames);
+                LOG.info("replay refresh partitions for table {}, "
+                                + "modified partitions count: {}, "
+                                + "new partitions count: {}",
+                        table.get().getName(), modifiedPartNames == null ? 0 : modifiedPartNames.size(),
+                        newPartNames == null ? 0 : newPartNames.size());
             } else {
                 // Full table cache invalidation
                 refreshTableInternal(db.get(), table.get(), log.getLastUpdateTime());

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalObjectLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalObjectLog.java
@@ -58,6 +58,9 @@ public class ExternalObjectLog implements Writable {
     @SerializedName(value = "partitionNames")
     private List<String> partitionNames;
 
+    @SerializedName(value = "newPartitionNames")
+    private List<String> newPartitionNames;
+
     @SerializedName(value = "lastUpdateTime")
     private long lastUpdateTime;
 
@@ -81,12 +84,13 @@ public class ExternalObjectLog implements Writable {
     }
 
     public static ExternalObjectLog createForRefreshPartitions(long catalogId, String dbName, String tblName,
-            List<String> partitionNames) {
+            List<String> modifiedPartNames, List<String> newPartNames) {
         ExternalObjectLog externalObjectLog = new ExternalObjectLog();
         externalObjectLog.setCatalogId(catalogId);
         externalObjectLog.setDbName(dbName);
         externalObjectLog.setTableName(tblName);
-        externalObjectLog.setPartitionNames(partitionNames);
+        externalObjectLog.setPartitionNames(modifiedPartNames);
+        externalObjectLog.setNewPartitionNames(newPartNames);
         return externalObjectLog;
     }
 
@@ -133,6 +137,12 @@ public class ExternalObjectLog implements Writable {
             sb.append("tableName: " + tableName + "]");
         } else {
             sb.append("tableId: " + tableId + "]");
+        }
+        if (partitionNames != null && !partitionNames.isEmpty()) {
+            sb.append(", partitionNames: " + partitionNames);
+        }
+        if (newPartitionNames != null && !newPartitionNames.isEmpty()) {
+            sb.append(", newPartitionNames: " + newPartitionNames);
         }
         return sb.toString();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/HiveInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/HiveInsertExecutor.java
@@ -34,10 +34,10 @@ import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.transaction.TransactionType;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -86,20 +86,12 @@ public class HiveInsertExecutor extends BaseExternalTableInsertExecutor {
 
         // For partitioned tables, do selective partition refresh
         // For non-partitioned tables, do full table cache invalidation
-        List<String> affectedPartitionNames = null;
+        List<String> modifiedPartNames = Lists.newArrayList();
+        List<String> newPartNames = Lists.newArrayList();
         if (hmsTable.isPartitionedTable() && partitionUpdates != null && !partitionUpdates.isEmpty()) {
             HiveMetaStoreCache cache = Env.getCurrentEnv().getExtMetaCacheMgr()
                     .getMetaStoreCache((HMSExternalCatalog) hmsTable.getCatalog());
-            cache.refreshAffectedPartitions(hmsTable, partitionUpdates);
-
-            // Collect partition names for edit log
-            affectedPartitionNames = new ArrayList<>();
-            for (THivePartitionUpdate update : partitionUpdates) {
-                String partitionName = update.getName();
-                if (partitionName != null && !partitionName.isEmpty()) {
-                    affectedPartitionNames.add(partitionName);
-                }
-            }
+            cache.refreshAffectedPartitions(hmsTable, partitionUpdates, modifiedPartNames, newPartNames);
         } else {
             // Non-partitioned table or no partition updates, do full table refresh
             Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTableCache(hmsTable);
@@ -107,13 +99,14 @@ public class HiveInsertExecutor extends BaseExternalTableInsertExecutor {
 
         // Write edit log to notify other FEs
         ExternalObjectLog log;
-        if (affectedPartitionNames != null && !affectedPartitionNames.isEmpty()) {
+        if (!modifiedPartNames.isEmpty() || !newPartNames.isEmpty()) {
             // Partition-level refresh for other FEs
             log = ExternalObjectLog.createForRefreshPartitions(
                     hmsTable.getCatalog().getId(),
                     table.getDatabase().getFullName(),
                     table.getName(),
-                    affectedPartitionNames);
+                    modifiedPartNames,
+                    newPartNames);
         } else {
             // Full table refresh for other FEs
             log = ExternalObjectLog.createForRefreshTable(


### PR DESCRIPTION
### What problem does this PR solve?

Followup #58166
In #58166, the edit log need record "modified partitions" and "new partitions" separately,
so that non-master FE can correctly update the partition cache.
Otherwise, some new partitions can not be queried in non-master FE after inserting.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

