### PR TITLE
[opt](partition pruner) add cache_sorted_partition_interval_second

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/cache/NereidsSortedPartitionsCacheManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/cache/NereidsSortedPartitionsCacheManager.java
@@ -31,6 +31,7 @@ import org.apache.doris.nereids.rules.expression.rules.SortedPartitionRanges.Par
 import org.apache.doris.nereids.rules.expression.rules.SortedPartitionRanges.PartitionItemAndRange;
 import org.apache.doris.nereids.trees.plans.algebra.CatalogRelation;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.rpc.RpcException;
 
 import com.github.benmanes.caffeine.cache.Cache;
@@ -80,6 +81,7 @@ public class NereidsSortedPartitionsCacheManager {
             return Optional.empty();
         }
 
+        SessionVariable sessionVariable = connectContext.getSessionVariable();
         DatabaseIf<?> database = table.getDatabase();
         if (database == null) {
             return Optional.empty();
@@ -94,13 +96,13 @@ public class NereidsSortedPartitionsCacheManager {
 
         try {
             if (partitionCacheContext == null) {
-                return Optional.ofNullable(loadCache(key, table, scan));
+                return Optional.ofNullable(loadCache(key, table, scan, sessionVariable));
             }
             if (table.getId() != partitionCacheContext.tableId
                     || !Objects.equals(table.getPartitionMetaVersion(scan),
                     partitionCacheContext.partitionMetaVersion)) {
                 partitionCaches.invalidate(key);
-                return Optional.ofNullable(loadCache(key, table, scan));
+                return Optional.ofNullable(loadCache(key, table, scan, sessionVariable));
             }
         } catch (Throwable t) {
             LOG.warn("Failed to load cache for table {}, key {}.", table.getName(), key, t);
@@ -116,13 +118,18 @@ public class NereidsSortedPartitionsCacheManager {
     }
 
     private SortedPartitionRanges<?> loadCache(
-            TableIdentifier key, SupportBinarySearchFilteringPartitions table, CatalogRelation scan)
+            TableIdentifier key, SupportBinarySearchFilteringPartitions table, CatalogRelation scan,
+            SessionVariable sessionVariable)
             throws RpcException {
         long now = System.currentTimeMillis();
         long partitionMetaLoadTime = table.getPartitionMetaLoadTimeMillis(scan);
 
+        long cacheSortedPartitionIntervalSecond = sessionVariable.cacheSortedPartitionIntervalSecond;
+
         // if insert too frequently, we will skip sort partitions
-        if (now <= partitionMetaLoadTime || (now - partitionMetaLoadTime) <= (10 * 1000)) {
+        if (cacheSortedPartitionIntervalSecond >= 0
+                && (now <= partitionMetaLoadTime
+                || (now - partitionMetaLoadTime) <= (cacheSortedPartitionIntervalSecond * 1000))) {
             return null;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/cache/NereidsSortedPartitionsCacheManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/cache/NereidsSortedPartitionsCacheManager.java
@@ -129,7 +129,7 @@ public class NereidsSortedPartitionsCacheManager {
         // if insert too frequently, we will skip sort partitions
         if (cacheSortedPartitionIntervalSecond >= 0
                 && (now <= partitionMetaLoadTime
-                || (now - partitionMetaLoadTime) <= (cacheSortedPartitionIntervalSecond * 1000))) {
+                    || (now - partitionMetaLoadTime) <= (cacheSortedPartitionIntervalSecond * 1000))) {
             return null;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -183,6 +183,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String ENABLE_REWRITE_ELEMENT_AT_TO_SLOT = "enable_rewrite_element_at_to_slot";
     public static final String ENABLE_ODBC_TRANSCATION = "enable_odbc_transcation";
     public static final String ENABLE_BINARY_SEARCH_FILTERING_PARTITIONS = "enable_binary_search_filtering_partitions";
+    public static final String CACHE_SORTED_PARTITION_INTERVAL_SECOND = "cache_sorted_partition_interval_second";
     public static final String SKIP_PRUNE_PREDICATE = "skip_prune_predicate";
     public static final String ENABLE_SQL_CACHE = "enable_sql_cache";
     public static final String ENABLE_HIVE_SQL_CACHE = "enable_hive_sql_cache";
@@ -1299,6 +1300,17 @@ public class SessionVariable implements Serializable, Writable {
             }
     )
     public boolean enableBinarySearchFilteringPartitions = true;
+
+    @VariableMgr.VarAttr(
+            name = CACHE_SORTED_PARTITION_INTERVAL_SECOND,
+            fuzzy = false,
+            description = {
+                    "表数据更新后，多少秒之内不能使用二分查找分区裁剪",
+                    "After updating table data, within how many seconds can "
+                            + "binary search partitioning and pruning not be used."
+            }
+    )
+    public int cacheSortedPartitionIntervalSecond = 10;
 
     @VariableMgr.VarAttr(name = SKIP_PRUNE_PREDICATE, fuzzy = true,
             description = {


### PR DESCRIPTION
### What problem does this PR solve?

 add cache_sorted_partition_interval_second to control the refresh interval time for the cache of sorted partition

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

