### PR TITLE
[fix](filecache) using invalid memory crashes clear_need_update_lru_blocks

### DIFF
--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -2356,9 +2356,13 @@ bool BlockFileCache::try_reserve_during_async_load(size_t size,
 }
 
 void BlockFileCache::clear_need_update_lru_blocks() {
-    std::vector<FileBlockSPtr> buffer;
-    buffer.reserve(1024);
-    while (_need_update_lru_blocks.try_dequeue_bulk(buffer.data(), buffer.capacity())) {
+    constexpr size_t kBatchSize = 1024;
+    std::vector<FileBlockSPtr> buffer(kBatchSize);
+    size_t drained = 0;
+    while ((drained = _need_update_lru_blocks.try_dequeue_bulk(buffer.data(), buffer.size())) > 0) {
+        for (size_t i = 0; i < drained; ++i) {
+            buffer[i].reset();
+        }
     }
 }
 


### PR DESCRIPTION
*** SIGSEGV unknown detail explain (@0x0) received by PID 2118050 (TID 2119672 OR 0x7f969ebf3640) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk3/pipeline/repo/selectdb-core_branch-selectdb-doris-3.1/selectdb-core/be/src/common/signal_handler.h:421
 1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 3# 0x00007F9A01EF7520 in /lib/x86_64-linux-gnu/libc.so.6
 4# unsigned long moodycamel::ConcurrentQueue<std::shared_ptr<doris::io::FileBlock>, moodycamel::ConcurrentQueueDefaultTraits>::ImplicitProducer::dequeue_bulk<std::shared_ptr<doris::io::FileBlock>*>(std::shared_ptr<doris::io::FileBlock>*&, unsigned long) at /mnt/disk3/pipeline/repo/selectdb-core_branch-selectdb-doris-3.1/selectdb-core/thirdparty/installed/include/concurrentqueue.h:2802
 5# doris::io::BlockFileCache::clear_need_update_lru_blocks() at /mnt/disk3/pipeline/repo/selectdb-core_branch-selectdb-doris-3.1/selectdb-core/be/src/io/cache/block_file_cache.cpp:2289
 6# doris::io::BlockFileCache::clear_file_cache_directly[abi:cxx11]() at /mnt/disk3/pipeline/repo/selectdb-core_branch-selectdb-doris-3.1/selectdb-core/be/src/io/cache/block_file_cache.cpp:2338
 7# doris::io::FileCacheFactory::clear_file_caches[abi:cxx11](bool) at /mnt/disk3/pipeline/repo/selectdb-core_branch-selectdb-doris-3.1/selectdb-core/be/src/io/cache/block_file_cache_factory.cpp:210