### PR TITLE
[improvement](ann index): Add serial thread pool for ANN index building

### DIFF
--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -356,6 +356,10 @@ Status StorageEngine::start_bg_threads(std::shared_ptr<WorkloadGroup> wg_sptr) {
             &_check_delete_bitmap_score_thread));
     LOG(INFO) << "check tablet delete bitmap score thread started";
 
+    RETURN_IF_ERROR(ThreadPoolBuilder("AnnBuildThreadPool")
+                            .set_max_threads(1)
+                            .build(&_ann_build_thread_pool));
+
     LOG(INFO) << "all storage engine's background threads are started.";
     return Status::OK();
 }

--- a/be/src/olap/rowset/segment_v2/ann_index/faiss_ann_index.h
+++ b/be/src/olap/rowset/segment_v2/ann_index/faiss_ann_index.h
@@ -31,6 +31,7 @@
 
 #include "common/status.h"
 #include "olap/rowset/segment_v2/ann_index/ann_index.h"
+#include "util/threadpool.h"
 #include "vec/core/types.h"
 
 namespace doris::segment_v2 {
@@ -278,6 +279,7 @@ private:
     std::unique_ptr<faiss::Index> _index = nullptr; ///< Underlying FAISS index instance
     std::unique_ptr<faiss::Index> _quantizer = nullptr;
     FaissBuildParameter _params; ///< Build parameters for the index
+    ThreadPool* _ann_threadpool = nullptr;
 };
 #include "common/compile_check_end.h"
 } // namespace doris::segment_v2

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -186,6 +186,7 @@ protected:
 
     std::unique_ptr<ThreadPool> _base_compaction_thread_pool;
     std::unique_ptr<ThreadPool> _cumu_compaction_thread_pool;
+    std::unique_ptr<ThreadPool> _ann_build_thread_pool;
     int _cumu_compaction_thread_pool_used_threads {0};
     int _cumu_compaction_thread_pool_small_tasks_running {0};
 };
@@ -334,6 +335,7 @@ public:
                                       SegCompactionCandidatesSharedPtr segments);
 
     ThreadPool* tablet_publish_txn_thread_pool() { return _tablet_publish_txn_thread_pool.get(); }
+    ThreadPool* ann_build_thread_pool() const { return _ann_build_thread_pool.get(); }
     bool stopped() override { return _stopped; }
 
     Status process_index_change_task(const TAlterInvertedIndexReq& reqest);

--- a/be/src/olap/task/index_builder.cpp
+++ b/be/src/olap/task/index_builder.cpp
@@ -586,7 +586,7 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
                         })
                 if (!status.ok()) {
                     return Status::Error<ErrorCode::SCHEMA_CHANGE_INFO_INVALID>(
-                            "failed to write block.");
+                            "failed to write block: {}", status.msg());
                 }
                 block->clear_column_data();
             }


### PR DESCRIPTION
### What problem does this PR solve?

Remove ScopedOmpThreadBudget to resolve resource imbalance issues when building ann index. 
We introduced a serial thread pool to manage ANN index building tasks, each indexing task now utilizes the configured maximum OMP threads, subsequent tasks are queued and executed sequentially.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

