### PR TITLE
[fix](build) fix macOS build

### DIFF
--- a/be/src/exprs/hybrid_set.h
+++ b/be/src/exprs/hybrid_set.h
@@ -417,7 +417,7 @@ public:
         std::vector<ElementType> elems(_set.begin(), _set.end());
         std::sort(elems.begin(), elems.end());
         if constexpr (std::is_same<ElementType, bool>::value) {
-            for (const auto& v : elems) {
+            for (bool v : elems) {
                 seed = HashUtil::crc_hash64(&v, sizeof(v), seed);
             }
         } else {


### PR DESCRIPTION
Related PR: #58458
Fix macOS compilation error in HybridSet::get_digest(). std::vector<bool> uses proxy objects for iteration, so `const auto& v` cannot be addressed with `&v` in libc++. Changed to `bool v` to copy the value to a real bool variable.