### PR TITLE
[fix](exec)Fix execute_conjuncts not correctly handling Const (Nullable) columns when accept_null is enabled.

### DIFF
--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -266,8 +266,11 @@ Status VExprContext::execute_conjuncts(const VExprContextSPtrs& ctxs,
                 }
             }
         } else if (const auto* const_column = check_and_get_column<ColumnConst>(*filter_column)) {
-            // filter all
-            if (!const_column->get_bool(0)) {
+            const bool result =
+                    accept_null ? (const_column->is_null_at(0) || const_column->get_bool(0))
+                                : (!const_column->is_null_at(0) && const_column->get_bool(0));
+            if (!result) {
+                // filter all
                 *can_filter_all = true;
                 memset(result_filter_data, 0, result_filter->size());
                 return Status::OK();

--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -266,6 +266,11 @@ Status VExprContext::execute_conjuncts(const VExprContextSPtrs& ctxs,
                 }
             }
         } else if (const auto* const_column = check_and_get_column<ColumnConst>(*filter_column)) {
+            // if colum not nullable column
+            // const bool result =
+            // accept_null ? (false || const_column->get_bool(0))
+            //             : (!false && const_column->get_bool(0));
+            // same as directly use const_column->get_bool(0)
             const bool result =
                     accept_null ? (const_column->is_null_at(0) || const_column->get_bool(0))
                                 : (!const_column->is_null_at(0) && const_column->get_bool(0));


### PR DESCRIPTION
### What problem does this PR solve?

If the input column is a Const (Nullable), enumerate the possible outcomes:
```
            // accept_null = false;
            // is null  , true ==>  res = false , get_bool = false
            // not null , true ==>  res = true  , get_bool = true
            // is null  , false ==> res = false , get_bool = false
            // not null , false ==> res = false , get_bool = false

            // accept_null = true;
            // is null  , true ==>  res = true , get_bool = false
            // not null , true ==>  res = true , get_bool = true
            // is null  , false ==> res = true , get_bool = false
            // not null , false ==> res = false, get_bool = false
```
When accept_null = true and the column is null, this can produce an incorrect result. Here we replace the logic with the same code used for non-const columns.

```C++
                if (accept_null) {
                    for (size_t i = 0; i < rows; ++i) {
                        result_filter_data[i] &= (null_map_data[i]) || filter_data[i];
                    }
                } else {
                    for (size_t i = 0; i < rows; ++i) {
                        result_filter_data[i] &= (!null_map_data[i]) & filter_data[i];
                    }
                }

            const bool result =
                    accept_null ? (const_column->is_null_at(0) || const_column->get_bool(0))
                                : (!const_column->is_null_at(0) && const_column->get_bool(0));

```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

