### PR TITLE
[test](mv) Remove 'set enable_stats=false' in sync mv regression test to make mv regression test case stable

### DIFF
--- a/regression-test/suites/mv_p0/agg_have_dup_base/agg_have_dup_base.groovy
+++ b/regression-test/suites/mv_p0/agg_have_dup_base/agg_have_dup_base.groovy
@@ -46,7 +46,6 @@ suite ("agg_have_dup_base") {
 
     sql "analyze table d_table with sync;"
     sql """alter table d_table modify column k4 set stats ('row_count'='5');"""
-    sql """set enable_stats=false;"""
 
     qt_select_star "select * from d_table order by k1;"
 
@@ -62,13 +61,4 @@ suite ("agg_have_dup_base") {
     mv_rewrite_success("select unix_timestamp(k1) tmp,sum(k2) from d_table group by tmp;", "k12s3m")
     qt_select_mv "select unix_timestamp(k1) tmp,sum(k2) from d_table group by tmp order by tmp;"
 
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_success("select k1,sum(k2),max(k2) from d_table group by k1;", "k12s3m")
-
-    mv_rewrite_success("select k1,sum(k2) from d_table group by k1;", "k12s3m")
-
-    mv_rewrite_success("select k1,max(k2) from d_table group by k1;", "k12s3m")
-
-    mv_rewrite_success("select unix_timestamp(k1) tmp,sum(k2) from d_table group by tmp;", "k12s3m")
 }

--- a/regression-test/suites/mv_p0/agg_state/test_agg_state_max_by.groovy
+++ b/regression-test/suites/mv_p0/agg_state/test_agg_state_max_by.groovy
@@ -69,7 +69,6 @@ suite ("test_agg_state_max_by") {
 
     sql "analyze table d_table with sync;"
     sql """alter table d_table modify column k4 set stats ('row_count'='8');"""
-    sql """set enable_stats=false;"""
 
     qt_select_star "select * from d_table order by 1,2;"
     mv_rewrite_success("select k1,max_by(k2,k3) from d_table group by k1 order by 1,2;", "k1mb")
@@ -109,11 +108,10 @@ suite ("test_agg_state_max_by") {
 
     qt_select_star "select * from d_table order by 1,2;"
 
-    sql """set enable_stats=true;"""
     sql """alter table d_table modify column k4 set stats ('row_count'='8');"""
     sql "analyze table d_table with sync;"
-    sql """set enable_stats=false;"""
 
+    sql """alter table d_table modify column k4 set stats ('row_count'='8');"""
     mv_rewrite_success("select k1,max_by(k2+k3,abs(k3)) from d_table group by k1 order by 1,2;", "k1mbcp1")
     qt_select_mv "select k1,max_by(k2+k3,k3) from d_table group by k1 order by 1,2;"
 
@@ -122,10 +120,4 @@ suite ("test_agg_state_max_by") {
 
     mv_rewrite_success("select k1,max_by(k2,abs(k3)) from d_table group by k1 order by 1,2;", "k1mbcp3")
     qt_select_mv "select k1,max_by(k2,abs(k3)) from d_table group by k1 order by 1,2;"
-
-    sql """set enable_stats=true;"""
-    sql """alter table d_table modify column k4 set stats ('row_count'='8');"""
-    mv_rewrite_success("select k1,max_by(k2+k3,abs(k3)) from d_table group by k1 order by 1,2;", "k1mbcp1")
-    mv_rewrite_success("select k1,max_by(k2+k3,k3) from d_table group by k1 order by 1,2;", "k1mbcp2")
-    mv_rewrite_success("select k1,max_by(k2,abs(k3)) from d_table group by k1 order by 1,2;", "k1mbcp3")
 }

--- a/regression-test/suites/mv_p0/case_ignore/case_ignore.groovy
+++ b/regression-test/suites/mv_p0/case_ignore/case_ignore.groovy
@@ -47,20 +47,12 @@ suite ("case_ignore") {
     sql "insert into d_table select -4,-4,-4,'d';"
 
     sql "analyze table d_table with sync;"
-        sql """alter table d_table modify column k4 set stats ('row_count'='8');"""
-    sql """set enable_stats=false;"""
+    sql """alter table d_table modify column k4 set stats ('row_count'='8');"""
 
-    qt_select_star "select * from d_table order by k1;"
-
+    sql """alter table d_table modify column k4 set stats ('row_count'='8');"""
     mv_rewrite_success("select k1,abs(k2) from d_table order by k1;", "k12a")
     qt_select_mv "select k1,abs(k2) from d_table order by k1;"
 
     mv_rewrite_success("select K1,abs(K2) from d_table order by K1;", "k12a")
     qt_select_mv "select K1,abs(K2) from d_table order by K1;"
-
-    sql """set enable_stats=true;"""
-    sql """alter table d_table modify column k4 set stats ('row_count'='8');"""
-    mv_rewrite_success("select k1,abs(k2) from d_table order by k1;", "k12a")
-    mv_rewrite_success("select K1,abs(K2) from d_table order by K1;", "k12a")
-
 }

--- a/regression-test/suites/mv_p0/count_star/count_star.groovy
+++ b/regression-test/suites/mv_p0/count_star/count_star.groovy
@@ -46,8 +46,6 @@ suite ("count_star") {
     sql "insert into d_table select 3,2,null,'c';"
     sql "insert into d_table values(2,1,1,'a'),(2,1,1,'a');"
 
-
-    sql """set enable_stats=true;"""
     sql "analyze table d_table with sync;"
     sql """alter table d_table modify column k4 set stats ('row_count'='8');"""
 
@@ -66,16 +64,4 @@ suite ("count_star") {
 
     mv_rewrite_fail("select count(*) from d_table where k3=1;", "kstar")
     qt_select_mv "select count(*) from d_table where k3=1;"
-
-    sql """set enable_stats=false;"""
-
-
-    mv_rewrite_success_without_check_chosen("select k1,k4,count(*) from d_table group by k1,k4;", "kstar")
-
-    mv_rewrite_success_without_check_chosen("select k1,k4,count(*) from d_table where k1=1 group by k1,k4;", "kstar")
-
-    mv_rewrite_fail("select k1,k4,count(*) from d_table where k3=1 group by k1,k4;", "kstar")
-
-    mv_rewrite_fail("select count(*) from d_table where k3=1;", "kstar")
-
 }

--- a/regression-test/suites/mv_p0/dis_26495/dis_26495.groovy
+++ b/regression-test/suites/mv_p0/dis_26495/dis_26495.groovy
@@ -27,12 +27,8 @@ suite ("dis_26495") {
         create table doris_test (a int,b int, agg_st_1 agg_state<max_by(int ,int)> generic)
             DISTRIBUTED BY HASH(a) BUCKETS 1 properties("replication_num" = "1");
         """
-
     sql """insert into doris_test values (1,2,max_by_state(1,2));"""
-
     sql """alter table doris_test modify column agg_st_1 set stats ('row_count'='1');"""
-
-    sql """set enable_stats=false;"""
 
     streamLoad {
         table "doris_test"

--- a/regression-test/suites/mv_p0/k1ap2spa/k1ap2spa.groovy
+++ b/regression-test/suites/mv_p0/k1ap2spa/k1ap2spa.groovy
@@ -50,10 +50,7 @@ suite ("k1ap2spa") {
 
     sql "analyze table d_table with sync;"
     sql """set enable_stats=true;"""
-    mv_rewrite_success_without_check_chosen("select abs(k1)+1 t,sum(abs(k2+1)) from d_table group by t order by t;", "k1ap2spa")
-
     sql """alter table d_table modify column k1 set stats ('row_count'='6');"""
-    sql """set enable_stats=false;"""
     mv_rewrite_success_without_check_chosen("select abs(k1)+1 t,sum(abs(k2+1)) from d_table group by t order by t;", "k1ap2spa")
     qt_select_mv "select abs(k1)+1 t,sum(abs(k2+1)) from d_table group by t order by t;"
 }

--- a/regression-test/suites/mv_p0/k1s2m3_auto_inc/k1s2m3_auto_inc.groovy
+++ b/regression-test/suites/mv_p0/k1s2m3_auto_inc/k1s2m3_auto_inc.groovy
@@ -55,11 +55,8 @@ suite ("k1s2m3_auto_inc") {
 
     sql "analyze table d_table with sync;"
     sql """alter table d_table modify column k1 set stats ('row_count'='2');"""
-    sql """set enable_stats=false;"""
-
-    mv_rewrite_success("select k3,sum(abs(k2+1)) from d_table group by k3 order by 1;", "k3ap2spa")
-    qt_select_mv "select k3,sum(abs(k2+1)) from d_table group by k3 order by 1;"
 
     sql """set enable_stats=true;"""
+    qt_select_mv "select k3,sum(abs(k2+1)) from d_table group by k3 order by 1;"
     mv_rewrite_success("select k3,sum(abs(k2+1)) from d_table group by k3 order by 1;", "k3ap2spa")
 }

--- a/regression-test/suites/mv_p0/multi_agg_with_same_slot/multi_agg_with_same_slot.groovy
+++ b/regression-test/suites/mv_p0/multi_agg_with_same_slot/multi_agg_with_same_slot.groovy
@@ -50,19 +50,8 @@ suite ("multi_agg_with_same_slot") {
 
     sql "analyze table d_table with sync;"
     sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
-    sql """set enable_stats=false;"""
 
     qt_select_star "select * from d_table order by k1;"
-
-    mv_rewrite_success_without_check_chosen("select k1,k2,avg(k3),max(k3) from d_table group by k1,k2 order by 1,2;", "kmv")
-
-    mv_rewrite_success_without_check_chosen("select k1,k2,avg(k3)+max(k3) from d_table group by k1,k2 order by 1,2;", "kmv")
-
-    mv_rewrite_success_without_check_chosen("select k1,k2,avg(k3)+max(k3) from d_table group by grouping sets((k1),(k1,k2),()) order by 1,2;", "kmv")
-
-    mv_rewrite_success_without_check_chosen("select k1,k2,max(k5) from d_table group by grouping sets((k1),(k1,k2),()) order by 1,2;", "kmv2")
-
-    sql """set enable_stats=true;"""
 
     mv_rewrite_success("select k1,k2,avg(k3),max(k3) from d_table group by k1,k2 order by 1,2;", "kmv")
     qt_select_mv "select k1,k2,avg(k3),max(k3) from d_table group by k1,k2 order by 1,2;"

--- a/regression-test/suites/mv_p0/multi_slot_k123p/multi_slot_k123p.groovy
+++ b/regression-test/suites/mv_p0/multi_slot_k123p/multi_slot_k123p.groovy
@@ -55,7 +55,7 @@ suite ("multi_slot_k123p") {
     sql """sync"""
     sql "analyze table d_table with sync;"
     sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
-    sql """set enable_stats=false;"""
+
     qt_select_star "select * from d_table order by k1,k4;"
 
     mv_rewrite_success("select k1,k2+k3 from d_table order by k1;", "k123p")
@@ -64,7 +64,4 @@ suite ("multi_slot_k123p") {
     qt_select_mv "select lhs.k1,rhs.k2 from d_table as lhs right join d_table as rhs on lhs.k1=rhs.k1 order by lhs.k1;"
 
     qt_select_mv "select k1,version() from d_table order by k1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select k1,k2+k3 from d_table order by k1;", "k123p")
 }

--- a/regression-test/suites/mv_p0/multi_slot_k1a2p2ap3p/multi_slot_k1a2p2ap3p.groovy
+++ b/regression-test/suites/mv_p0/multi_slot_k1a2p2ap3p/multi_slot_k1a2p2ap3p.groovy
@@ -49,11 +49,7 @@ suite ("multi_slot_k1a2p2ap3p") {
 
     sql "analyze table d_table with sync;"
     sql """alter table d_table modify column k1 set stats ('row_count'='7');"""
-    sql """set enable_stats=false;"""
 
-    mv_rewrite_success_without_check_chosen("select abs(k1)+k2+1,abs(k2+2)+k3+3 from d_table order by abs(k1)+k2+1,abs(k2+2)+k3+3", "k1a2p2ap3p")
-
-    sql """set enable_stats=true;"""
     mv_rewrite_success_without_check_chosen("select abs(k1)+k2+1,abs(k2+2)+k3+3 from d_table order by abs(k1)+k2+1,abs(k2+2)+k3+3", "k1a2p2ap3p")
     qt_select_mv "select abs(k1)+k2+1,abs(k2+2)+k3+3 from d_table order by abs(k1)+k2+1,abs(k2+2)+k3+3;"
 

--- a/regression-test/suites/mv_p0/multi_slot_k1a2p2ap3ps/multi_slot_k1a2p2ap3ps.groovy
+++ b/regression-test/suites/mv_p0/multi_slot_k1a2p2ap3ps/multi_slot_k1a2p2ap3ps.groovy
@@ -63,10 +63,4 @@ suite ("multi_slot_k1a2p2ap3ps") {
 
     mv_rewrite_fail("select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from d_table group by abs(k1)+k2 order by abs(k1)+k2", "k1a2p2ap3ps")
     qt_select_base "select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from d_table group by abs(k1)+k2 order by abs(k1)+k2;"
-
-    sql """set enable_stats=false;"""
-    mv_rewrite_success_without_check_chosen("select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from d_table group by abs(k1)+k2+1 order by abs(k1)+k2+1", "k1a2p2ap3ps")
-
-    mv_rewrite_fail("select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from d_table group by abs(k1)+k2 order by abs(k1)+k2", "k1a2p2ap3ps")
-
 }

--- a/regression-test/suites/mv_p0/multi_slot_k1p2ap3p/multi_slot_k1p2ap3p.groovy
+++ b/regression-test/suites/mv_p0/multi_slot_k1p2ap3p/multi_slot_k1p2ap3p.groovy
@@ -46,13 +46,9 @@ suite ("multi_slot_k1p2ap3p") {
 
     sql "analyze table d_table with sync;"
     sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
-    sql """set enable_stats=false;"""
 
     qt_select_star "select * from d_table order by k1;"
 
     mv_rewrite_success_without_check_chosen("select k1+1,abs(k2+2)+k3+3 from d_table order by k1+1;", "k1p2ap3p")
     qt_select_mv "select k1+1,abs(k2+2)+k3+3 from d_table order by k1+1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success_without_check_chosen("select k1+1,abs(k2+2)+k3+3 from d_table order by k1+1;", "k1p2ap3p")
 }

--- a/regression-test/suites/mv_p0/multi_slot_k1p2ap3ps/multi_slot_k1p2ap3ps.groovy
+++ b/regression-test/suites/mv_p0/multi_slot_k1p2ap3ps/multi_slot_k1p2ap3ps.groovy
@@ -51,13 +51,9 @@ suite ("multi_slot_k1p2ap3ps") {
 
     sql "analyze table d_table with sync;"
     sql """alter table d_table modify column k1 set stats ('row_count'='11');"""
-    sql """set enable_stats=false;"""
 
     qt_select_star "select * from d_table order by k1;"
 
     mv_rewrite_success("select k1+1,sum(abs(k2+2)+k3+3) from d_table group by k1+1 order by k1+1;", "k1p2ap3ps")
     qt_select_mv "select k1+1,sum(abs(k2+2)+k3+3) from d_table group by k1+1 order by k1+1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select k1+1,sum(abs(k2+2)+k3+3) from d_table group by k1+1 order by k1+1;", "k1p2ap3ps")
 }

--- a/regression-test/suites/mv_p0/multi_slot_multi_mv/multi_slot_multi_mv.groovy
+++ b/regression-test/suites/mv_p0/multi_slot_multi_mv/multi_slot_multi_mv.groovy
@@ -49,7 +49,6 @@ suite ("multi_slot_multi_mv") {
 
     sql "analyze table d_table with sync;"
     sql """alter table d_table modify column k1 set stats ('row_count'='5');"""
-    sql """set enable_stats=false;"""
 
     def retry_times = 60
     for (def i = 0; i < retry_times; ++i) {
@@ -84,37 +83,4 @@ suite ("multi_slot_multi_mv") {
 
     mv_rewrite_success_without_check_chosen("select abs(k1)+k2+1,abs(k2+2)+k3+3 from d_table order by abs(k1)+k2+1,abs(k2+2)+k3+3", "k1a2p2ap3p")
     qt_select_mv "select abs(k1)+k2+1,abs(k2+2)+k3+3 from d_table order by abs(k1)+k2+1,abs(k2+2)+k3+3;"
-
-    sql """set enable_stats=true;"""
-    for (def i = 0; i < retry_times; ++i) {
-        boolean is_k1a2p2ap3p = false
-        boolean is_k1a2p2ap3ps = false
-        boolean is_d_table = false
-        explain {
-            sql("select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from d_table group by abs(k1)+k2+1 order by abs(k1)+k2+1")
-            check { explainStr, ex, startTime, endTime ->
-                if (ex != null) {
-                    throw ex;
-                }
-                logger.info("explain result: ${explainStr}".toString())
-                is_k1a2p2ap3p = explainStr.contains"(k1a2p2ap3p)"
-                is_k1a2p2ap3ps = explainStr.contains("(k1a2p2ap3ps)")
-                is_d_table = explainStr.contains("(d_table)")
-                assert is_k1a2p2ap3p || is_k1a2p2ap3ps || is_d_table
-            }
-        }
-        // FIXME: the mv selector maybe select base table forever when exist multi mv,
-        //        so this pr just treat as success if select base table.
-        //        we should remove is_d_table in the future
-        if (is_d_table || is_k1a2p2ap3p || is_k1a2p2ap3ps) {
-            break
-        }
-        if (i + 1 == retry_times) {
-            throw new IllegalStateException("retry and failed too much")
-        }
-        sleep(1000)
-    }
-
-    mv_rewrite_success_without_check_chosen("select abs(k1)+k2+1,abs(k2+2)+k3+3 from d_table order by abs(k1)+k2+1,abs(k2+2)+k3+3", "k1a2p2ap3p")
-
 }

--- a/regression-test/suites/mv_p0/mv_ignore_predicate/mv_ignore_predicate.groovy
+++ b/regression-test/suites/mv_p0/mv_ignore_predicate/mv_ignore_predicate.groovy
@@ -48,24 +48,9 @@ suite ("mv_ignore_predicate") {
     sql "insert into d_table select 5,null,null,null;"
 
     sql "analyze table d_table with sync;"
-    sql """set enable_stats=false;"""
 
     qt_select_star "select * from d_table order by k1;"
 
     mv_rewrite_success("select count(k2) from d_table;", "kign")
     qt_select_mv "select count(k2) from d_table;"
-
-//    explain {
-//         sql("select count(k2) from d_table where k2 is not null;")
-//         contains "(kign)"
-//     }
-//     qt_select_mv "select count(k2) from d_table where k2 is not null;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select count(k2) from d_table;", "kign")
-
-//     explain {
-//         sql("select count(k2) from d_table where k2 is not null;")
-//         contains "(kign)"
-//     }
 }

--- a/regression-test/suites/mv_p0/mv_percentile/mv_percentile.groovy
+++ b/regression-test/suites/mv_p0/mv_percentile/mv_percentile.groovy
@@ -64,7 +64,6 @@ suite ("mv_percentile") {
 
     sql "analyze table d_table with sync;"
     sql """alter table d_table modify column k1 set stats ('row_count'='15');"""
-    sql """set enable_stats=false;"""
 
     qt_select_star "select * from d_table order by k1;"
 
@@ -82,18 +81,4 @@ suite ("mv_percentile") {
 
     mv_rewrite_success("select percentile(k3, 0.1) from d_table group by grouping sets((k1),()) order by 1;", "kp")
     qt_select_mv "select percentile(k3, 0.1) from d_table group by grouping sets((k1),()) order by 1;"
-
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_success("select k1,k2,percentile(k3, 0.1),percentile(k3, 0.9) from d_table group by k1,k2 order by k1,k2;",
-            "kp", true, [TRY_IN_RBO, FORCE_IN_RBO])
-    mv_rewrite_fail("select k1,k2,percentile(k3, 0.1),percentile(k3, 0.9) from d_table group by k1,k2 order by k1,k2;",
-            "kp", [NOT_IN_RBO])
-
-    mv_rewrite_success("select k1,k2,percentile(k3, 0.1),percentile(k3, 0.9) from d_table group by grouping sets((k1),(k1,k2),()) order by 1,2;",
-            "kp", true, [TRY_IN_RBO, FORCE_IN_RBO])
-    mv_rewrite_fail("select k1,k2,percentile(k3, 0.1),percentile(k3, 0.9) from d_table group by grouping sets((k1),(k1,k2),()) order by 1,2;",
-            "kp", [NOT_IN_RBO])
-
-    mv_rewrite_success("select percentile(k3, 0.1) from d_table group by grouping sets((k1),()) order by 1;", "kp")
 }

--- a/regression-test/suites/mv_p0/mv_with_view/mv_with_view.groovy
+++ b/regression-test/suites/mv_p0/mv_with_view/mv_with_view.groovy
@@ -45,29 +45,7 @@ suite ("mv_with_view") {
 
     sql "analyze table d_table with sync;"
     sql """alter table d_table modify column k1 set stats ('row_count'='3');"""
-    sql """set enable_stats=false;"""
 
-    mv_rewrite_fail("select * from d_table order by k1;", "k312")
-
-    sql """
-        drop view if exists v_k312;
-    """
-
-    sql """
-        create view v_k312 as select k1,k3,k2 from d_table where k3 = 1;
-    """
-    mv_rewrite_success_without_check_chosen("select * from v_k312 order by k1;", "k312")
-
-    sql """
-        drop view if exists v_k124;
-    """
-
-    sql """
-        create view v_k124 as select k1,k2,k4 from d_table where k1 = 1;
-    """
-    mv_rewrite_fail("select * from v_k124 order by k1;", "k312")
-
-    sql """set enable_stats=true;"""
     mv_rewrite_fail("select * from d_table order by k1;", "k312")
     qt_select_star "select * from d_table order by k1;"
 

--- a/regression-test/suites/mv_p0/null_insert/null_insert.groovy
+++ b/regression-test/suites/mv_p0/null_insert/null_insert.groovy
@@ -67,7 +67,7 @@ suite ("null_insert") {
     }
 
     sql "analyze table test with sync;"
-    sql """set enable_stats=false;"""
+    sql """alter table test modify column date set stats ('row_count'='3');"""
 
     mv_rewrite_success("""SELECT date, vid, os, ver, ip_country, hll_union(hll_hash(uid))
                 FROM test
@@ -76,10 +76,4 @@ suite ("null_insert") {
     qt_select_mv """SELECT date, vid, os, ver, ip_country, hll_union(hll_hash(uid))
                     FROM test
                     GROUP BY date,vid,os,ver,ip_country;"""
-
-    sql """set enable_stats=true;"""
-    sql """alter table test modify column date set stats ('row_count'='3');"""
-    mv_rewrite_success("""SELECT date, vid, os, ver, ip_country, hll_union(hll_hash(uid))
-                FROM test
-                GROUP BY date,vid,os,ver,ip_country;""", "mv_test")
 }

--- a/regression-test/suites/mv_p0/routine_load_hll/routine_load_hll.groovy
+++ b/regression-test/suites/mv_p0/routine_load_hll/routine_load_hll.groovy
@@ -54,11 +54,7 @@ suite ("routine_load_hll") {
 
     sql "analyze table test with sync;"
     sql """alter table test modify column mv_event_id set stats ('row_count'='2');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_success("select mv_time_stamp, hll_union_agg(mv_device_id) from test group by mv_time_stamp order by 1;", "m_view")
     qt_select_mv "select mv_time_stamp, hll_union_agg(mv_device_id) from test group by mv_time_stamp order by 1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select mv_time_stamp, hll_union_agg(mv_device_id) from test group by mv_time_stamp order by 1;", "m_view")
 }

--- a/regression-test/suites/mv_p0/ssb/multiple_no_where/multiple_no_where.groovy
+++ b/regression-test/suites/mv_p0/ssb/multiple_no_where/multiple_no_where.groovy
@@ -109,7 +109,6 @@ suite ("multiple_no_where") {
     sql """analyze table lineorder_flat with sync;"""
     sql """alter table lineorder_flat modify column C_CITY set stats ('row_count'='7');"""
     sql """alter table lineorder_flat modify column a3 set stats ('row_count'='1');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_success("""SELECT SUM(LO_EXTENDEDPRICE * LO_DISCOUNT) AS revenue
                 FROM lineorder_flat

--- a/regression-test/suites/mv_p0/ssb/multiple_ssb/multiple_ssb.groovy
+++ b/regression-test/suites/mv_p0/ssb/multiple_ssb/multiple_ssb.groovy
@@ -158,7 +158,6 @@ suite ("multiple_ssb") {
     sql """alter table lineorder_flat modify column a4 set stats ('row_count'='1');"""
     sql """alter table lineorder_flat modify column a6 set stats ('row_count'='1');"""
     sql """alter table lineorder_flat modify column x2 set stats ('row_count'='1');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_success("""SELECT SUM(LO_EXTENDEDPRICE * LO_DISCOUNT) AS revenue
                 FROM lineorder_flat
@@ -243,50 +242,4 @@ suite ("multiple_ssb") {
     mv_rewrite_success("""select LO_ORDERPRIORITY, count(1) from lineorder_flat where LO_ORDERPRIORITY in ('1','2','3') group by LO_ORDERPRIORITY;""",
             "count_LO_ORDERPRIORITY_3")
     qt_select_count_3 "select LO_ORDERPRIORITY, count(1) from lineorder_flat where LO_ORDERPRIORITY in ('1','2','3') group by LO_ORDERPRIORITY order by 1,2;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("""SELECT SUM(LO_EXTENDEDPRICE * LO_DISCOUNT) AS revenue
-                FROM lineorder_flat
-                WHERE
-                    LO_ORDERDATE >= 19930101
-                    AND LO_ORDERDATE <= 19931231
-                    AND LO_DISCOUNT >= 1 AND LO_DISCOUNT <= 3
-                    AND LO_QUANTITY < 25;""", "lineorder_q_1_1")
-
-    mv_rewrite_success("""SELECT
-                SUM(LO_REVENUE), (LO_ORDERDATE DIV 10000) AS YEAR,
-                P_BRAND
-            FROM lineorder_flat
-            WHERE P_CATEGORY = 'MFGR#12' AND S_REGION = 'AMERICA'
-            GROUP BY (LO_ORDERDATE DIV 10000), P_BRAND
-            ORDER BY YEAR, P_BRAND;""", "lineorder_q_2_1")
-
-    mv_rewrite_success("""SELECT
-                C_NATION,
-                S_NATION, (LO_ORDERDATE DIV 10000) AS YEAR,
-                SUM(LO_REVENUE) AS revenue
-            FROM lineorder_flat
-            WHERE
-                C_REGION = 'ASIA'
-                AND S_REGION = 'ASIA'
-                AND LO_ORDERDATE >= 19920101
-                AND LO_ORDERDATE <= 19971231
-            GROUP BY C_NATION, S_NATION, YEAR
-            ORDER BY YEAR ASC, revenue DESC;""", "lineorder_q_3_1")
-
-    mv_rewrite_success("""SELECT (LO_ORDERDATE DIV 10000) AS YEAR,
-                C_NATION,
-                SUM(LO_REVENUE - LO_SUPPLYCOST) AS profit
-                FROM lineorder_flat
-                WHERE
-                C_REGION = 'AMERICA'
-                AND S_REGION = 'AMERICA'
-                AND P_MFGR IN ('MFGR#1', 'MFGR#2')
-                GROUP BY YEAR, C_NATION
-                ORDER BY YEAR ASC, C_NATION ASC;""", "lineorder_q_4_1")
-
-    mv_rewrite_success("""select LO_ORDERDATE, sum(LO_ORDERDATE) from lineorder_flat where LO_ORDERDATE in (1,2,3) group by LO_ORDERDATE;""",
-            "count_LO_ORDERPRIORITY_1")
-    mv_rewrite_success("""select LO_ORDERPRIORITY, count(1) from lineorder_flat where LO_ORDERPRIORITY in ('1','2','3') group by LO_ORDERPRIORITY;""",
-            "count_LO_ORDERPRIORITY_3")
 }

--- a/regression-test/suites/mv_p0/ssb/q_4_1_r1/q_4_1_r1.groovy
+++ b/regression-test/suites/mv_p0/ssb/q_4_1_r1/q_4_1_r1.groovy
@@ -97,8 +97,9 @@ suite ("q_4_1_r1") {
     sql """analyze table lineorder_flat with sync;"""
     sql """alter table lineorder_flat modify column LO_ORDERDATE set stats ('row_count'='8');"""
     sql """alter table lineorder_flat modify column a1 set stats ('row_count'='1');"""
-    sql """set enable_stats=false;"""
 
+
+    sql """set enable_stats=true;"""
     mv_rewrite_success("""SELECT (LO_ORDERDATE DIV 10000) AS YEAR,
             C_NATION,
             SUM(LO_REVENUE - LO_SUPPLYCOST) AS profit
@@ -120,15 +121,4 @@ suite ("q_4_1_r1") {
                 AND P_MFGR IN ('MFGR#1', 'MFGR#2')
                 GROUP BY YEAR, C_NATION
                 ORDER BY YEAR ASC, C_NATION ASC;"""
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("""SELECT (LO_ORDERDATE DIV 10000) AS YEAR,
-            C_NATION,
-            SUM(LO_REVENUE - LO_SUPPLYCOST) AS profit
-            FROM lineorder_flat
-            WHERE
-            C_REGION = 'AMERICA'
-            AND S_REGION = 'AMERICA'
-            AND P_MFGR IN ('MFGR#1', 'MFGR#2')
-            GROUP BY YEAR, C_NATION
-            ORDER BY YEAR ASC, C_NATION ASC;""", "lineorder_mv")
 }

--- a/regression-test/suites/mv_p0/sum_divede_count/sum_devide_count.groovy
+++ b/regression-test/suites/mv_p0/sum_divede_count/sum_devide_count.groovy
@@ -57,8 +57,6 @@ suite ("sum_devide_count") {
 
     sql """analyze table d_table with sync;"""
     sql """alter table d_table modify column k3 set stats ('row_count'='15');"""
-    sql """set enable_stats=false;"""
-
 
     mv_rewrite_success("select k1,k4,sum(k2)/count(k2) from d_table group by k1,k4 order by k1,k4;", "kavg")
     qt_select_mv "select k1,k4,sum(k2)/count(k2) from d_table group by k1,k4 order by k1,k4;"
@@ -71,13 +69,4 @@ suite ("sum_devide_count") {
 
     mv_rewrite_success("select sum(k2)/count(k2) from d_table;", "kavg")
     qt_select_mv "select sum(k2)/count(k2) from d_table;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select k1,k4,sum(k2)/count(k2) from d_table group by k1,k4 order by k1,k4;", "kavg")
-
-    mv_rewrite_success("select k1,sum(k2)/count(k2) from d_table group by k1 order by k1;", "kavg")
-
-    mv_rewrite_success("select k4,sum(k2)/count(k2) from d_table group by k4 order by k4;", "kavg")
-
-    mv_rewrite_success("select sum(k2)/count(k2) from d_table;", "kavg")
 }

--- a/regression-test/suites/mv_p0/test_28741/test_28741.groovy
+++ b/regression-test/suites/mv_p0/test_28741/test_28741.groovy
@@ -69,10 +69,6 @@ suite ("test_28741") {
 
     sql """analyze table test with sync;"""
     sql """alter table test modify column a set stats ('row_count'='2');"""
-    sql """set enable_stats=false;"""
 
-    mv_rewrite_fail("select b1 from test where t >= '2023-12-20 17:21:00'", "mv_test")
-
-    sql """set enable_stats=true;"""
     mv_rewrite_fail("select b1 from test where t >= '2023-12-20 17:21:00'", "mv_test")
 }

--- a/regression-test/suites/mv_p0/test_approx_count_distinct/test_approx_count_distinct.groovy
+++ b/regression-test/suites/mv_p0/test_approx_count_distinct/test_approx_count_distinct.groovy
@@ -41,13 +41,7 @@ suite ("test_approx_count_distinct") {
 
     sql """analyze table user_tags with sync;"""
 
-    sql """set enable_stats=true;"""
-    mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
-    mv_rewrite_success("select user_id, ndv(tag_id) a from user_tags group by user_id order by user_id;", "user_tags_mv")
-    mv_rewrite_success("select user_id, approx_count_distinct(tag_id) a from user_tags group by user_id order by user_id;", "user_tags_mv")
-
     sql """alter table user_tags modify column time_col set stats ('row_count'='4');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
     qt_select_star "select * from user_tags order by time_col,tag_id;"

--- a/regression-test/suites/mv_p0/test_base/test_base.groovy
+++ b/regression-test/suites/mv_p0/test_base/test_base.groovy
@@ -47,7 +47,6 @@ suite ("test_base") {
 
     sql "analyze table dwd with sync;"
     sql """alter table dwd modify column id set stats ('row_count'='2');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_success("SELECT created_at, id  FROM dwd where created_at = '2020-09-09 00:00:00' order by 1, 2;", "dwd_mv")
     qt_select_mv "SELECT created_at, id FROM dwd order by 1, 2;"
@@ -55,7 +54,6 @@ suite ("test_base") {
     mv_rewrite_success("SELECT id,created_at  FROM dwd where id is not null order by 1, 2;", "dwd_mv")
     qt_select_mv "SELECT id,created_at FROM dwd order by 1, 2;"
 
-    sql """set enable_stats=true;"""
     mv_rewrite_success_without_check_chosen("SELECT created_at, id  FROM dwd where created_at = '2020-09-09 00:00:00' order by 1, 2;",
             "dwd_mv", [TRY_IN_RBO, NOT_IN_RBO])
     mv_rewrite_success_without_check_chosen("SELECT created_at, id  FROM dwd where created_at = '2020-09-09 00:00:00' order by 1, 2;",

--- a/regression-test/suites/mv_p0/test_casewhen/test_casewhen.groovy
+++ b/regression-test/suites/mv_p0/test_casewhen/test_casewhen.groovy
@@ -36,13 +36,9 @@ suite ("test_casewhen") {
 
     sql """analyze table sales_records with sync;"""
     sql """alter table sales_records modify column record_id set stats ('row_count'='4');"""
-    sql """set enable_stats=false;"""
 
     qt_select_star "select * from sales_records order by 1,2;"
 
     mv_rewrite_success("select store_id, sum(case when sale_amt>10 then 1 else 2 end) from sales_records group by store_id order by 1;", "store_amt")
     qt_select_mv "select store_id, sum(case when sale_amt>10 then 1 else 2 end) from sales_records group by store_id order by 1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select store_id, sum(case when sale_amt>10 then 1 else 2 end) from sales_records group by store_id order by 1;", "store_amt")
 }

--- a/regression-test/suites/mv_p0/test_doc_e4/test_doc_e4.groovy
+++ b/regression-test/suites/mv_p0/test_doc_e4/test_doc_e4.groovy
@@ -46,7 +46,6 @@ suite ("test_doc_e4") {
 
     sql """analyze table d_table with sync;"""
     sql """alter table d_table modify column k1 set stats ('row_count'='3');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_success("select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from d_table group by abs(k1)+k2+1 order by 1,2;", "k1a2p2ap3ps")
     qt_select_mv "select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from d_table group by abs(k1)+k2+1 order by 1,2;"
@@ -59,13 +58,4 @@ suite ("test_doc_e4") {
 
     mv_rewrite_success("select year(k4)+month(k4) from d_table where year(k4) = 2020;", "kymd")
     qt_select_mv "select year(k4)+month(k4) from d_table where year(k4) = 2020 order by 1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from d_table group by abs(k1)+k2+1 order by 1,2;", "k1a2p2ap3ps")
-
-    mv_rewrite_success("select bin(abs(k1)+k2+1),sum(abs(k2+2)+k3+3) from d_table group by bin(abs(k1)+k2+1);", "k1a2p2ap3ps")
-
-    mv_rewrite_all_fail("select year(k4),month(k4) from d_table;", ["k1a2p2ap3ps", "kymd"])
-
-    mv_rewrite_success("select year(k4)+month(k4) from d_table where year(k4) = 2020;", "kymd")
 }

--- a/regression-test/suites/mv_p0/test_dup_group_by_mv_abs/test_dup_group_by_mv_abs.groovy
+++ b/regression-test/suites/mv_p0/test_dup_group_by_mv_abs/test_dup_group_by_mv_abs.groovy
@@ -46,7 +46,6 @@ suite ("test_dup_group_by_mv_abs") {
 
     sql """analyze table d_table with sync;"""
     sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
-    sql """set enable_stats=false;"""
 
     qt_select_star "select * from d_table order by k1;"
 
@@ -55,8 +54,4 @@ suite ("test_dup_group_by_mv_abs") {
 
     mv_rewrite_success("select sum(abs(k2)) from d_table group by k1;", "k12sa")
     qt_select_mv_sub "select sum(abs(k2)) from d_table group by k1 order by k1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select k1,sum(abs(k2)) from d_table group by k1;", "k12sa")
-    mv_rewrite_success("select sum(abs(k2)) from d_table group by k1;", "k12sa")
 }

--- a/regression-test/suites/mv_p0/test_dup_group_by_mv_plus/test_dup_group_by_mv_plus.groovy
+++ b/regression-test/suites/mv_p0/test_dup_group_by_mv_plus/test_dup_group_by_mv_plus.groovy
@@ -53,7 +53,6 @@ suite ("test_dup_group_by_mv_plus") {
 
     sql """analyze table d_table with sync;"""
     sql """alter table d_table modify column k1 set stats ('row_count'='8');"""
-    sql """set enable_stats=false;"""
 
     qt_select_star "select * from d_table order by k1;"
 
@@ -62,10 +61,6 @@ suite ("test_dup_group_by_mv_plus") {
 
     mv_rewrite_success("select sum(k2+1) from d_table group by k1;", "k12sp")
     qt_select_mv_sub "select sum(k2+1) from d_table group by k1 order by k1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select k1,sum(k2+1) from d_table group by k1;", "k12sp")
-    mv_rewrite_success("select sum(k2+1) from d_table group by k1;", "k12sp")
 
     sql """drop materialized view k12sp on d_table"""
     create_sync_mv(db, "d_table", "k12sp_multi",

--- a/regression-test/suites/mv_p0/test_dup_mv_abs/test_dup_mv_abs.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_abs/test_dup_mv_abs.groovy
@@ -45,7 +45,6 @@ suite ("test_dup_mv_abs") {
 
     sql """analyze table d_table with sync;"""
     sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
-    sql """set enable_stats=false;"""
 
     qt_select_star "select * from d_table order by k1;"
 
@@ -66,23 +65,4 @@ suite ("test_dup_mv_abs") {
 
     mv_rewrite_fail("select sum(abs(k2)) from d_table group by k3;", "k12a")
     qt_select_group_mv_not "select sum(abs(k2)) from d_table group by k3 order by k3;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select k1,abs(k2) from d_table order by k1;", "k12a")
-
-    mv_rewrite_success("select abs(k2) from d_table order by k1;", "k12a")
-
-    mv_rewrite_success("select abs(k2)+1 from d_table order by k1;", "k12a")
-
-    mv_rewrite_success("select sum(abs(k2)) from d_table group by k1 order by k1;", "k12a",
-     true, [TRY_IN_RBO, NOT_IN_RBO])
-    mv_rewrite_success_without_check_chosen("select sum(abs(k2)) from d_table group by k1 order by k1;", "k12a",
-             [FORCE_IN_RBO])
-
-    mv_rewrite_success("select sum(abs(k2)+1) from d_table group by k1 order by k1;", "k12a",
-     true, [TRY_IN_RBO, NOT_IN_RBO])
-    mv_rewrite_success_without_check_chosen("select sum(abs(k2)+1) from d_table group by k1 order by k1;", "k12a",
-             [FORCE_IN_RBO])
-
-    mv_rewrite_fail("select sum(abs(k2)) from d_table group by k3;", "k12a")
 }

--- a/regression-test/suites/mv_p0/test_dup_mv_bin/test_dup_mv_bin.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_bin/test_dup_mv_bin.groovy
@@ -45,23 +45,8 @@ suite ("test_dup_mv_bin") {
 
     sql "analyze table d_table with sync;"
     sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
-    sql """set enable_stats=false;"""
 
     qt_select_star "select * from d_table order by k1;"
-
-    mv_rewrite_success_without_check_chosen("select k1,bin(k2) from d_table order by k1;", "k12b")
-
-    mv_rewrite_success_without_check_chosen("select bin(k2) from d_table order by k1;", "k12b")
-
-    mv_rewrite_success_without_check_chosen("select bin(k2)+1 from d_table order by k1;", "k12b")
-
-    mv_rewrite_success_without_check_chosen("select group_concat(bin(k2)) from d_table group by k1 order by k1;", "k12b")
-
-    mv_rewrite_success_without_check_chosen("select group_concat(concat(bin(k2),'a')) from d_table group by k1 order by k1;", "k12b")
-
-    mv_rewrite_fail("select group_concat(bin(k2)) from d_table group by k3;", "k12b")
-
-    sql """set enable_stats=true;"""
 
     mv_rewrite_success("select k1,bin(k2) from d_table order by k1;", "k12b")
     qt_select_mv "select k1,bin(k2) from d_table order by k1;"

--- a/regression-test/suites/mv_p0/test_dup_mv_bitmap_hash/test_dup_mv_bitmap_hash.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_bitmap_hash/test_dup_mv_bitmap_hash.groovy
@@ -45,13 +45,9 @@ suite ("test_dup_mv_bitmap_hash") {
 
     sql """analyze table d_table with sync;"""
     sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_success("select bitmap_union_count(to_bitmap(k2)) from d_table group by k1 order by k1;", "k1g2bm")
     qt_select_mv "select bitmap_union_count(to_bitmap(k2)) from d_table group by k1 order by k1;"
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select bitmap_union_count(to_bitmap(k2)) from d_table group by k1 order by k1;", "k1g2bm")
-
     createMV "create materialized view k1g3bm as select k1 as x3,bitmap_union(bitmap_hash(k3)) as x4 from d_table group by k1;"
 
     sql "insert into d_table select 2,2,'bb';"
@@ -61,15 +57,10 @@ suite ("test_dup_mv_bitmap_hash") {
 
     qt_select_star "select * from d_table order by k1,k2,k3;"
 
-    sql """set enable_stats=true;"""
     sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
     sql """analyze table d_table with sync;"""
     sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_success("select k1,bitmap_union_count(bitmap_hash(k3)) from d_table group by k1;", "k1g3bm")
     qt_select_mv_sub "select k1,bitmap_union_count(bitmap_hash(k3)) from d_table group by k1 order by k1;"
-    sql """set enable_stats=true;"""
-    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
-    mv_rewrite_success("select k1,bitmap_union_count(bitmap_hash(k3)) from d_table group by k1;", "k1g3bm")
 }

--- a/regression-test/suites/mv_p0/test_dup_mv_expr_priority/test_dup_mv_expr_priority.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_expr_priority/test_dup_mv_expr_priority.groovy
@@ -42,16 +42,9 @@ suite ("test_dup_mv_expr_priority") {
     sql """insert into table_ngrambf values(1,1,"123_def_美国");"""
 
     sql """analyze table table_ngrambf with sync;"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_success("""select  element_at(split_by_string(username,"_"),1) ,element_at(split_by_string(username,"_"),2) ,element_at(split_by_string(username,"_"),3)  ,siteid,citycode from table_ngrambf order by citycode;""",
     "test_mv_1")
 
     qt_select_mv """select  element_at(split_by_string(username,"_"),1) ,element_at(split_by_string(username,"_"),2) ,element_at(split_by_string(username,"_"),3)  ,siteid,citycode from table_ngrambf order by citycode;"""
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("""select  element_at(split_by_string(username,"_"),1) ,element_at(split_by_string(username,"_"),2) ,element_at(split_by_string(username,"_"),3)  ,siteid,citycode from table_ngrambf order by citycode;""",
-            "test_mv_1")
-
-
 }

--- a/regression-test/suites/mv_p0/test_dup_mv_plus/test_dup_mv_plus.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_plus/test_dup_mv_plus.groovy
@@ -49,27 +49,9 @@ suite ("test_dup_mv_plus") {
 
     sql "analyze table d_table with sync;"
     sql """alter table d_table modify column k4 set stats ('row_count'='8');"""
-    sql """set enable_stats=false;"""
 
     qt_select_star "select * from d_table order by k1;"
 
-    mv_rewrite_success_without_check_chosen("select k1,k2+1 from d_table order by k1;", "k12p")
-
-    mv_rewrite_success_without_check_chosen("select k2+1 from d_table order by k1;", "k12p")
-
-    mv_rewrite_success_without_check_chosen("select k2+1 from d_table order by k1+1-1;", "k12p")
-
-    mv_rewrite_success_without_check_chosen("select sum(k2+1) from d_table group by k1 order by k1;", "k12p")
-
-    mv_rewrite_success_without_check_chosen("select sum(k1) from d_table group by k2+1 order by k2+1;", "k12p")
-
-    mv_rewrite_success_without_check_chosen("select sum(k1+1-1) from d_table group by k2+1 order by k2+1;", "k12p")
-
-    mv_rewrite_fail("select sum(k2) from d_table group by k3;", "k12p")
-
-    mv_rewrite_fail("select k1,k2+1 from d_table order by k2;", "k12p")
-
-    sql """set enable_stats=true;"""
     mv_rewrite_success("select k1,k2+1 from d_table order by k1;", "k12p")
     qt_select_mv "select k1,k2+1 from d_table order by k1;"
 

--- a/regression-test/suites/mv_p0/test_dup_mv_repeat/test_dup_mv_repeat.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_repeat/test_dup_mv_repeat.groovy
@@ -52,14 +52,9 @@ suite ("test_dup_mv_repeat") {
     createMV ("create materialized view dbviwe as select dt as a1,s as a2 ,sum(n) as n1 from db1 group by dt,s;")
 
     sql "analyze table db1 with sync;"
-    sql """set enable_stats=false;"""
+    sql """alter table db1 modify column dt set stats ('row_count'='2');"""
 
     mv_rewrite_success("SELECT s AS s, sum(n) / count(DISTINCT dt) AS n FROM  db1 GROUP BY  GROUPING SETS((s)) order by 1;",
             "dbviwe")
     qt_select_mv "SELECT s AS s, sum(n) / count(DISTINCT dt) AS n FROM  db1 GROUP BY  GROUPING SETS((s)) order by 1;"
-
-    sql """set enable_stats=true;"""
-    sql """alter table db1 modify column dt set stats ('row_count'='2');"""
-    mv_rewrite_success("SELECT s AS s, sum(n) / count(DISTINCT dt) AS n FROM  db1 GROUP BY  GROUPING SETS((s)) order by 1;",
-            "dbviwe")
 }

--- a/regression-test/suites/mv_p0/test_dup_mv_year/test_dup_mv_year.groovy
+++ b/regression-test/suites/mv_p0/test_dup_mv_year/test_dup_mv_year.groovy
@@ -42,13 +42,9 @@ suite ("test_dup_mv_year") {
 
     sql """analyze table d_table with sync;"""
     sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_success("select k1,year(k2) from d_table order by k1;", "k12y")
     qt_select_mv "select k1,year(k2) from d_table order by k1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select k1,year(k2) from d_table order by k1;", "k12y")
 
     createMV "create materialized view k13y as select k1 as a3,year(k3) as a4 from d_table;"
 
@@ -58,8 +54,4 @@ suite ("test_dup_mv_year") {
 
     mv_rewrite_success("select year(k3) from d_table order by k1;", "k13y")
     qt_select_mv_sub "select year(k3) from d_table order by k1;"
-
-    sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
-    sql """set enable_stats=false;"""
-    mv_rewrite_success("select year(k3) from d_table order by k1;", "k13y")
 }

--- a/regression-test/suites/mv_p0/test_insert_multi/test_insert_multi.groovy
+++ b/regression-test/suites/mv_p0/test_insert_multi/test_insert_multi.groovy
@@ -44,12 +44,7 @@ suite ("test_insert_multi") {
     qt_select_star "select * from sales_records order by 1,2;"
 
     sql """analyze table sales_records with sync;"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_success(" SELECT store_id, sum(sale_amt) FROM sales_records GROUP BY store_id order by 1;", "store_amt")
     qt_select_mv " SELECT store_id, sum(sale_amt) FROM sales_records GROUP BY store_id order by 1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success(" SELECT store_id, sum(sale_amt) FROM sales_records GROUP BY store_id order by 1;", "store_amt")
-
 }

--- a/regression-test/suites/mv_p0/test_mv_dp/test_mv_dp.groovy
+++ b/regression-test/suites/mv_p0/test_mv_dp/test_mv_dp.groovy
@@ -47,18 +47,8 @@ suite ("test_mv_dp") {
 
     sql """INSERT INTO `dp` VALUES (1,'success',["3","4"]),(2,'success',["5"]);"""
     sql "analyze table dp with sync;"
-    sql """set enable_stats=false;"""
-/*
-    streamLoad {
-        table "test"
 
-        set 'columns', 'date'
-
-        file './test'
-        time 10000 // limit inflight 10s
-    }
-*/
-
+    sql """alter table dp modify column d set stats ('row_count'='4');"""
     mv_rewrite_success("""select d,
                         bitmap_union_count(bitmap_from_array(cast(uid_list as array<bigint>))),
                         bitmap_union_count(bitmap_from_array(if(status='success', cast(uid_list as array<bigint>), array())))
@@ -70,11 +60,4 @@ suite ("test_mv_dp") {
                         bitmap_union_count(bitmap_from_array(if(status='success', cast(uid_list as array<bigint>), array())))
                     from dp
                     group by d order by 1;"""
-    sql """set enable_stats=true;"""
-    sql """alter table dp modify column d set stats ('row_count'='4');"""
-    mv_rewrite_success("""select d,
-                        bitmap_union_count(bitmap_from_array(cast(uid_list as array<bigint>))),
-                        bitmap_union_count(bitmap_from_array(if(status='success', cast(uid_list as array<bigint>), array())))
-                    from dp
-                    group by d;""", "view_2")
 }

--- a/regression-test/suites/mv_p0/test_mv_mow/test_mv_mow.groovy
+++ b/regression-test/suites/mv_p0/test_mv_mow/test_mv_mow.groovy
@@ -45,14 +45,10 @@ suite ("test_mv_mow") {
 
     sql """alter table u_table modify column k1 set stats ('row_count'='2');"""
 
-    sql """set enable_stats=false;"""
-
     mv_rewrite_success("select k1,k2+k3 from u_table order by k1;", "k123p")
     qt_select_mv "select k1,k2+k3 from u_table order by k1;"
 
     qt_select_mv "select * from `u_table` index `k123p` order by 1,2;"
     qt_select_mv "select a1 from `u_table` index `k123p` order by 1;"
     qt_select_mv "select `__add_3` from `u_table` index `k123p` order by 1;"
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select k1,k2+k3 from u_table order by k1;", "k123p")
 }

--- a/regression-test/suites/mv_p0/test_ndv/test_ndv.groovy
+++ b/regression-test/suites/mv_p0/test_ndv/test_ndv.groovy
@@ -40,13 +40,7 @@ suite ("test_ndv") {
     sql """insert into user_tags values("2020-01-01",1,"a",2);"""
 
     sql """analyze table user_tags with sync;"""
-    sql """set enable_stats=true;"""
-    mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
-    mv_rewrite_success("select user_id, ndv(tag_id) a from user_tags group by user_id order by user_id;", "user_tags_mv")
-    mv_rewrite_success("select user_id, approx_count_distinct(tag_id) a from user_tags group by user_id order by user_id;", "user_tags_mv")
-
     sql """alter table user_tags modify column time_col set stats ('row_count'='4');"""
-    sql """set enable_stats=false;"""
     mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
     qt_select_star "select * from user_tags order by time_col,tag_id;"
 
@@ -55,5 +49,4 @@ suite ("test_ndv") {
 
     mv_rewrite_success("select user_id, approx_count_distinct(tag_id) a from user_tags group by user_id order by user_id;", "user_tags_mv")
     qt_select_mv "select user_id, approx_count_distinct(tag_id) a from user_tags group by user_id order by user_id;"
-
 }

--- a/regression-test/suites/mv_p0/test_nvl/test_nvl.groovy
+++ b/regression-test/suites/mv_p0/test_nvl/test_nvl.groovy
@@ -45,20 +45,12 @@ suite ("test_nvl") {
 
     sql """analyze table dwd with sync;"""
     sql """alter table dwd modify column id set stats ('row_count'='2');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_success("select nvl(id,0) from dwd order by 1;", "dwd_mv")
     qt_select_mv "select nvl(id,0) from dwd order by 1;"
 
     mv_rewrite_success("select ifnull(id,0) from dwd order by 1;", "dwd_mv")
     qt_select_mv "select ifnull(id,0) from dwd order by 1;"
-
-    sql """set enable_stats=true;"""
-    sql """alter table dwd modify column id set stats ('row_count'='2');"""
-    mv_rewrite_success("select nvl(id,0) from dwd order by 1;", "dwd_mv")
-
-    mv_rewrite_success("select ifnull(id,0) from dwd order by 1;", "dwd_mv")
-
 
     sql """ drop materialized view dwd_mv on dwd;
     """
@@ -72,9 +64,4 @@ suite ("test_nvl") {
 
     mv_rewrite_success("select ifnull(id,0) from dwd order by 1;", "dwd_mv")
     qt_select_mv "select ifnull(id,0) from dwd order by 1;"
-
-    sql """set enable_stats=false;"""
-    mv_rewrite_success("select nvl(id,0) from dwd order by 1;", "dwd_mv")
-
-    mv_rewrite_success("select ifnull(id,0) from dwd order by 1;", "dwd_mv")
 }

--- a/regression-test/suites/mv_p0/test_o2/test_o2.groovy
+++ b/regression-test/suites/mv_p0/test_o2/test_o2.groovy
@@ -58,13 +58,9 @@ suite ("test_o2") {
 
     sql """analyze table o2_order_events with sync;"""
     sql """alter table o2_order_events modify column ts set stats ('row_count'='2');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_success("select ts,metric_name,platform,sum(count_value) from o2_order_events group by ts,metric_name,platform;",
             "o2_order_events_mv")
     qt_select_mv "select ts,metric_name,platform,sum(count_value) from o2_order_events group by ts,metric_name,platform;"
 
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select ts,metric_name,platform,sum(count_value) from o2_order_events group by ts,metric_name,platform;",
-            "o2_order_events_mv")
 }

--- a/regression-test/suites/mv_p0/test_substr/test_substr.groovy
+++ b/regression-test/suites/mv_p0/test_substr/test_substr.groovy
@@ -52,13 +52,8 @@ suite ("test_substr") {
 
     sql """analyze table dwd with sync;"""
     sql """alter table dwd modify column id set stats ('row_count'='2');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_success("SELECT substr(created_at,1,10) as statistic_date, max(dt) as dt FROM dwd  group by substr(created_at,1,10);",
             "dwd_mv")
     qt_select_mv "SELECT substr(created_at,1,10) as statistic_date, max(dt) as dt FROM dwd  group by substr(created_at,1,10);"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("SELECT substr(created_at,1,10) as statistic_date, max(dt) as dt FROM dwd  group by substr(created_at,1,10);",
-            "dwd_mv")
 }

--- a/regression-test/suites/mv_p0/test_tbl_name/test_tbl_name.groovy
+++ b/regression-test/suites/mv_p0/test_tbl_name/test_tbl_name.groovy
@@ -43,7 +43,6 @@ suite ("test_tbl_name") {
 
     sql """analyze table functionality_olap with sync;"""
     sql """alter table functionality_olap modify column id set stats ('row_count'='2');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_success("""select 
             functionality_olap.id as id,
@@ -68,17 +67,4 @@ suite ("test_tbl_name") {
         from functionality_olap
         group by id order by 1,2;
         """
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("""select 
-            functionality_olap.id as id,
-            sum(functionality_olap.score) as score_max
-            from functionality_olap
-            group by functionality_olap.id order by 1,2; """, "MV_OLAP_SUM")
-
-    mv_rewrite_success("""select 
-            id,
-            sum(score) as score_max
-            from functionality_olap
-            group by id order by 1,2;
-            """, "MV_OLAP_SUM")
 }

--- a/regression-test/suites/mv_p0/test_upper_alias/test_upper_alias.groovy
+++ b/regression-test/suites/mv_p0/test_upper_alias/test_upper_alias.groovy
@@ -54,8 +54,6 @@ suite ("test_upper_alias") {
     sql "analyze table test_0401 with sync;"
     sql """alter table test_0401 modify column d_b set stats ('row_count'='3');"""
 
-    sql """set enable_stats=false;"""
-
     mv_rewrite_success("SELECT upper(d_b) AS d_b FROM test_0401 GROUP BY upper(d_b) order by 1;", "test_0401_mv");
     qt_select_mv "SELECT upper(d_b) AS d_b FROM test_0401 GROUP BY upper(d_b) order by 1;"
 
@@ -65,15 +63,4 @@ suite ("test_upper_alias") {
     mv_rewrite_success("SELECT d_a AS d_b FROM test_0401 where d_a = 'xx' order by 1;", "test_0401_mv2")
     qt_select_mv "SELECT d_a AS d_b FROM test_0401 order by 1;"
 
-    sql """set enable_stats=true;"""
-    mv_rewrite_any_success("SELECT upper(d_b) AS d_b FROM test_0401 GROUP BY upper(d_b) order by 1;",
-            ["test_0401_mv", "test_0401_mv2"])
-
-    mv_rewrite_any_success("SELECT upper(d_b) AS d_bb FROM test_0401 GROUP BY upper(d_b) order by 1;",
-            ["test_0401_mv", "test_0401_mv2"])
-
-    mv_rewrite_success("SELECT d_a AS d_b FROM test_0401 where d_a = 'xx' order by 1;", "test_0401_mv2",
-            true, [TRY_IN_RBO, NOT_IN_RBO])
-    mv_rewrite_success_without_check_chosen("SELECT d_a AS d_b FROM test_0401 where d_a = 'xx' order by 1;",
-            "test_0401_mv2", [FORCE_IN_RBO])
 }

--- a/regression-test/suites/mv_p0/test_user_activity/test_user_activity.groovy
+++ b/regression-test/suites/mv_p0/test_user_activity/test_user_activity.groovy
@@ -48,14 +48,9 @@ suite ("test_user_activity") {
     qt_select_star "select * from u_axx order by 1;"
 
     sql """analyze table u_axx with sync;"""
-    sql """set enable_stats=false;"""
+    sql """alter table u_axx modify column r_xx set stats ('row_count'='3');"""
 
     mv_rewrite_success("select n_dx, percentile_approx(n_duration, 0.5) as p50, percentile_approx(n_duration, 0.90) as p90 FROM u_axx GROUP BY n_dx;",
             "session_distribution_2")
     qt_select_group_mv "select n_dx, percentile_approx(n_duration, 0.5) as p50, percentile_approx(n_duration, 0.90) as p90 FROM u_axx GROUP BY n_dx;"
-
-    sql """set enable_stats=true;"""
-    sql """alter table u_axx modify column r_xx set stats ('row_count'='3');"""
-    mv_rewrite_success("select n_dx, percentile_approx(n_duration, 0.5) as p50, percentile_approx(n_duration, 0.90) as p90 FROM u_axx GROUP BY n_dx;",
-            "session_distribution_2")
 }

--- a/regression-test/suites/mv_p0/unique/unique.groovy
+++ b/regression-test/suites/mv_p0/unique/unique.groovy
@@ -62,10 +62,9 @@ suite ("unique") {
     sql "insert into u_table select 300,-3,null,'c';"
 
     sql """analyze table u_table with sync;"""
-    sql """set enable_stats=false;"""
+    sql """alter table u_table modify column k1 set stats ('row_count'='3');"""
     mv_rewrite_success("select k3,length(k1),k2 from u_table order by 1,2,3;", "k31l42")
     qt_select "select k3,length(k1),k2 from u_table order by 1,2,3;"
-
 
     test {
         sql """create materialized view kadp as select k4 as xx from u_table group by k4;"""
@@ -73,10 +72,4 @@ suite ("unique") {
     }
 
     qt_select_star "select * from u_table order by k1;"
-
-    sql """set enable_stats=true;"""
-    sql """alter table u_table modify column k1 set stats ('row_count'='3');"""
-    mv_rewrite_success("select k3,length(k1),k2 from u_table order by 1,2,3;", "k31l42")
-
-    // todo: support match query
 }

--- a/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV10/testAggQueryOnAggMV10.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV10/testAggQueryOnAggMV10.groovy
@@ -48,7 +48,6 @@ suite ("testAggQueryOnAggMV10") {
 
     sql "analyze table emps with sync;"
     sql """alter table emps modify column time_col set stats ('row_count'='8');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
@@ -56,10 +55,4 @@ suite ("testAggQueryOnAggMV10") {
     mv_rewrite_success("select deptno, commission, sum(salary) + 1 from emps group by rollup (deptno, commission);",
             "emps_mv")
     qt_select_mv "select deptno, commission, sum(salary) + 1 from emps group by rollup (deptno, commission) order by 1,2;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
-
-    mv_rewrite_success("select deptno, commission, sum(salary) + 1 from emps group by rollup (deptno, commission);",
-            "emps_mv")
 }

--- a/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV11/testAggQueryOnAggMV11.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV11/testAggQueryOnAggMV11.groovy
@@ -49,18 +49,10 @@ suite ("testAggQueryOnAggMV11") {
 
     sql "analyze table emps with sync;"
     sql """alter table emps modify column time_col set stats ('row_count'='8');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
 
     mv_rewrite_fail("select deptno, count(salary) + count(1) from emps group by deptno;", "emps_mv")
     qt_select_mv "select deptno, count(salary) + count(1) from emps group by deptno order by 1;"
-
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
-
-    mv_rewrite_fail("select deptno, count(salary) + count(1) from emps group by deptno;", "emps_mv")
-
 }

--- a/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV2/testAggQueryOnAggMV2.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV2/testAggQueryOnAggMV2.groovy
@@ -51,7 +51,6 @@ suite ("testAggQueryOnAggMV2") {
 
     sql "analyze table emps with sync;"
     sql """alter table emps modify column time_col set stats ('row_count'='6');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid, salary;"
@@ -59,10 +58,4 @@ suite ("testAggQueryOnAggMV2") {
     mv_rewrite_success("select * from (select deptno, sum(salary) as sum_salary from emps group by deptno) a where (sum_salary * 2) > 3 order by deptno ;",
             "emps_mv")
     qt_select_mv "select * from (select deptno, sum(salary) as sum_salary from emps group by deptno) a where (sum_salary * 2) > 3 order by deptno ;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
-
-    mv_rewrite_success("select * from (select deptno, sum(salary) as sum_salary from emps group by deptno) a where (sum_salary * 2) > 3 order by deptno ;",
-            "emps_mv")
 }

--- a/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV3/testAggQueryOnAggMV3.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQueryOnAggMV3/testAggQueryOnAggMV3.groovy
@@ -50,7 +50,6 @@ suite ("testAggQueryOnAggMV3") {
 
     sql "analyze table emps with sync;"
     sql """alter table emps modify column time_col set stats ('row_count'='8');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
@@ -62,13 +61,4 @@ suite ("testAggQueryOnAggMV3") {
     mv_rewrite_success("select commission, sum(salary) from emps where deptno > 0 and  commission = 100 group by commission order by commission;",
             "emps_mv")
     qt_select_mv "select commission, sum(salary) from emps where commission = 100 group by commission order by commission;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
-
-    mv_rewrite_success("select commission, sum(salary) from emps where deptno > 0 and commission * (deptno + commission) = 100 group by commission order by commission;",
-            "emps_mv")
-
-    mv_rewrite_success("select commission, sum(salary) from emps where deptno > 0 and  commission = 100 group by commission order by commission;",
-            "emps_mv")
 }

--- a/regression-test/suites/mv_p0/ut/testAggQuqeryOnAggMV5/testAggQuqeryOnAggMV5.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQuqeryOnAggMV5/testAggQuqeryOnAggMV5.groovy
@@ -48,7 +48,6 @@ suite ("testAggQuqeryOnAggMV5") {
 
     sql """analyze table emps with sync;"""
     sql """alter table emps modify column time_col set stats ('row_count'='8');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
@@ -57,10 +56,4 @@ suite ("testAggQuqeryOnAggMV5") {
             "emps_mv")
     qt_select_mv "select * from (select deptno, sum(salary) as sum_salary from emps group by deptno) a where sum_salary>10 order by 1;"
 
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
-
-    mv_rewrite_success("select * from (select deptno, sum(salary) as sum_salary from emps group by deptno) a where sum_salary>0;",
-            "emps_mv")
 }

--- a/regression-test/suites/mv_p0/ut/testAggQuqeryOnAggMV6/testAggQuqeryOnAggMV6.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQuqeryOnAggMV6/testAggQuqeryOnAggMV6.groovy
@@ -59,7 +59,6 @@ suite ("testAggQuqeryOnAggMV6") {
     sql """analyze table emps with sync;"""
     sql """alter table emps modify column time_col set stats ('row_count'='18');"""
 
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
@@ -67,10 +66,4 @@ suite ("testAggQuqeryOnAggMV6") {
     mv_rewrite_success("select * from (select deptno, sum(salary) as sum_salary from emps where deptno>=4 group by deptno) a where sum_salary>10;",
             "emps_mv")
     qt_select_mv "select * from (select deptno, sum(salary) as sum_salary from emps where deptno>=20 group by deptno) a where sum_salary>10 order by 1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
-
-    mv_rewrite_success("select * from (select deptno, sum(salary) as sum_salary from emps where deptno>=4 group by deptno) a where sum_salary>10;",
-            "emps_mv")
 }

--- a/regression-test/suites/mv_p0/ut/testAggQuqeryOnAggMV7/testAggQuqeryOnAggMV7.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggQuqeryOnAggMV7/testAggQuqeryOnAggMV7.groovy
@@ -48,17 +48,10 @@ suite ("testAggQuqeryOnAggMV7") {
 
     sql """analyze table emps with sync;"""
     sql """alter table emps modify column time_col set stats ('row_count'='8');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
 
     mv_rewrite_success("select deptno, sum(salary) from emps where deptno>=20 group by deptno;", "emps_mv")
     qt_select_mv "select deptno, sum(salary) from emps where deptno>=20 group by deptno order by 1;"
-
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
-
-    mv_rewrite_success("select deptno, sum(salary) from emps where deptno>=20 group by deptno;", "emps_mv")
 }

--- a/regression-test/suites/mv_p0/ut/testAggTableCountDistinctInBitmapType/testAggTableCountDistinctInBitmapType.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggTableCountDistinctInBitmapType/testAggTableCountDistinctInBitmapType.groovy
@@ -36,22 +36,12 @@ suite ("testAggTableCountDistinctInBitmapType") {
 
     sql "analyze table test_tb with sync;"
     sql """alter table test_tb modify column k1 set stats ('row_count'='6');"""
-    sql """set enable_stats=false;"""
 
     qt_select_star "select * from test_tb order by 1;"
-
 
     explain {
         sql("select k1, count(distinct v1) from test_tb group by k1;")
         contains "bitmap_union_count"
     }
     qt_select_mv "select k1, count(distinct v1) from test_tb group by k1 order by k1;"
-
-    sql """set enable_stats=true;"""
-
-    explain {
-        sql("select k1, count(distinct v1) from test_tb group by k1;")
-        contains "bitmap_union_count"
-    }
-
 }

--- a/regression-test/suites/mv_p0/ut/testAggregateMVCalcAggFunctionQuery/testAggregateMVCalcAggFunctionQuery.groovy
+++ b/regression-test/suites/mv_p0/ut/testAggregateMVCalcAggFunctionQuery/testAggregateMVCalcAggFunctionQuery.groovy
@@ -48,16 +48,10 @@ suite ("testAggregateMVCalcAggFunctionQuery") {
 
     sql "analyze table emps with sync;"
     sql """alter table emps modify column time_col set stats ('row_count'='8');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
 
     mv_rewrite_fail("select deptno, sum(salary + 1) from emps where deptno > 10 group by deptno;", "emps_mv")
     qt_select_mv "select deptno, sum(salary + 1) from emps where deptno > 10 group by deptno order by deptno;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
-
-    mv_rewrite_fail("select deptno, sum(salary + 1) from emps where deptno > 10 group by deptno;", "emps_mv")
 }

--- a/regression-test/suites/mv_p0/ut/testBitmapUnionInQuery/testBitmapUnionInQuery.groovy
+++ b/regression-test/suites/mv_p0/ut/testBitmapUnionInQuery/testBitmapUnionInQuery.groovy
@@ -43,13 +43,6 @@ suite ("testBitmapUnionInQuery") {
 
     sql "analyze table user_tags with sync;"
     sql """alter table user_tags modify column time_col set stats ('row_count'='6');"""
-    sql """set enable_stats=false;"""
-
-    mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
-    mv_rewrite_success_without_check_chosen("select user_id, bitmap_union_count(to_bitmap(tag_id)) a from user_tags group by user_id having a>1 order by a;",
-            "user_tags_mv")
-    mv_rewrite_success_without_check_chosen("select user_id, bitmap_count(bitmap_union(to_bitmap(tag_id))) a from user_tags group by user_id having a>1 order by a;",
-            "user_tags_mv")
 
     sql """set enable_stats=true;"""
 

--- a/regression-test/suites/mv_p0/ut/testCountDistinctToBitmap/testCountDistinctToBitmap.groovy
+++ b/regression-test/suites/mv_p0/ut/testCountDistinctToBitmap/testCountDistinctToBitmap.groovy
@@ -45,14 +45,7 @@ suite ("testCountDistinctToBitmap") {
 
     sql "analyze table user_tags with sync;"
     sql """alter table user_tags modify column time_col set stats ('row_count'='6');"""
-    sql """set enable_stats=false;"""
 
-    mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
-
-    mv_rewrite_success_without_check_chosen("select user_id, count(distinct tag_id) a from user_tags group by user_id having a>1 order by a;",
-            "user_tags_mv")
-
-    sql """set enable_stats=true;"""
     mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
     qt_select_star "select * from user_tags order by time_col,tag_id;"
 
@@ -88,10 +81,4 @@ suite ("testCountDistinctToBitmap") {
     mv_rewrite_success("select user_id, count(distinct tag_id) a from user_tags2 group by user_id having a>1 order by a;",
             "user_tags_mv")
     qt_select_mv "select user_id, count(distinct tag_id) a from user_tags2 group by user_id having a>1 order by a;"
-
-    sql """set enable_stats=false;"""
-    mv_rewrite_fail("select * from user_tags2 order by time_col;", "user_tags_mv")
-
-    mv_rewrite_success_without_check_chosen("select user_id, count(distinct tag_id) a from user_tags2 group by user_id having a>1 order by a;",
-            "user_tags_mv")
 }

--- a/regression-test/suites/mv_p0/ut/testIncorrectMVRewriteInSubquery/testIncorrectMVRewriteInSubquery.groovy
+++ b/regression-test/suites/mv_p0/ut/testIncorrectMVRewriteInSubquery/testIncorrectMVRewriteInSubquery.groovy
@@ -42,7 +42,6 @@ suite ("testIncorrectMVRewriteInSubquery") {
 
     sql "analyze table user_tags with sync;"
     sql """alter table user_tags modify column time_col set stats ('row_count'='6');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
     qt_select_star "select * from user_tags order by time_col, tag_id;"
@@ -51,11 +50,4 @@ suite ("testIncorrectMVRewriteInSubquery") {
     "user_tags_mv")
 
     qt_select_mv "select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags where user_name in (select user_name from user_tags group by user_name having bitmap_union_count(to_bitmap(tag_id)) >1 ) group by user_id order by user_id;"
-
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
-
-    mv_rewrite_fail("select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags where user_name in (select user_name from user_tags group by user_name having bitmap_union_count(to_bitmap(tag_id)) >1 ) group by user_id order by user_id;",
-            "user_tags_mv")
 }

--- a/regression-test/suites/mv_p0/ut/testIncorrectRewriteCountDistinct/testIncorrectRewriteCountDistinct.groovy
+++ b/regression-test/suites/mv_p0/ut/testIncorrectRewriteCountDistinct/testIncorrectRewriteCountDistinct.groovy
@@ -42,17 +42,10 @@ suite ("testIncorrectRewriteCountDistinct") {
 
     sql "analyze table user_tags with sync;"
     sql """alter table user_tags modify column time_col set stats ('row_count'='6');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
     qt_select_star "select * from user_tags order by time_col,tag_id;"
 
     mv_rewrite_fail("select user_name, count(distinct tag_id) from user_tags group by user_name;", "user_tags_mv")
     qt_select_mv "select user_name, count(distinct tag_id) from user_tags group by user_name order by user_name;"
-
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
-
-    mv_rewrite_fail("select user_name, count(distinct tag_id) from user_tags group by user_name;", "user_tags_mv")
 }

--- a/regression-test/suites/mv_p0/ut/testJoinOnLeftProjectToJoin/testJoinOnLeftProjectToJoin.groovy
+++ b/regression-test/suites/mv_p0/ut/testJoinOnLeftProjectToJoin/testJoinOnLeftProjectToJoin.groovy
@@ -63,12 +63,6 @@ suite ("testJoinOnLeftProjectToJoin") {
     sql "analyze table emps with sync;"
     sql """alter table emps modify column time_col set stats ('row_count'='6');"""
 
-    sql """set enable_stats=false;"""
-
-    mv_rewrite_all_success_without_check_chosen("select * from (select deptno , sum(salary) from emps group by deptno) A join (select deptno, max(cost) from depts group by deptno ) B on A.deptno = B.deptno;",
-            ["emps_mv", "depts_mv"])
-
-    sql """set enable_stats=true;"""
     mv_rewrite_all_success("select * from (select deptno , sum(salary) from emps group by deptno) A join (select deptno, max(cost) from depts group by deptno ) B on A.deptno = B.deptno;",
             ["emps_mv", "depts_mv"])
     qt_select_mv "select * from (select deptno , sum(salary) from emps group by deptno) A join (select deptno, max(cost) from depts group by deptno ) B on A.deptno = B.deptno order by A.deptno;"

--- a/regression-test/suites/mv_p0/ut/testNDVToHll/testNDVToHll.groovy
+++ b/regression-test/suites/mv_p0/ut/testNDVToHll/testNDVToHll.groovy
@@ -45,15 +45,6 @@ suite ("testNDVToHll") {
 
     sql "analyze table user_tags with sync;"
     sql """alter table user_tags modify column time_col set stats ('row_count'='7');"""
-    sql """set enable_stats=false;"""
-
-    mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
-
-    mv_rewrite_success_without_check_chosen("select user_id, ndv(tag_id) a from user_tags group by user_id order by user_id;", "user_tags_mv")
-
-    mv_rewrite_success_without_check_chosen("select user_id, approx_count_distinct(tag_id) a from user_tags group by user_id order by user_id;", "user_tags_mv")
-
-    sql """set enable_stats=true;"""
 
     mv_rewrite_fail("select * from user_tags order by time_col;", "user_tags_mv")
     order_qt_select_star "select * from user_tags order by time_col,tag_id;"

--- a/regression-test/suites/mv_p0/ut/testProjectionMV1/testProjectionMV1.groovy
+++ b/regression-test/suites/mv_p0/ut/testProjectionMV1/testProjectionMV1.groovy
@@ -46,20 +46,9 @@ suite ("testProjectionMV1") {
 
     sql "analyze table emps with sync;"
     sql """alter table emps modify column time_col set stats ('row_count'='6');"""
-    sql """set enable_stats=false;"""
 
-    mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
+
     qt_select_star "select * from emps order by empid;"
-
-    mv_rewrite_success_without_check_chosen("select empid, deptno from emps where deptno > 0 order by empid;", "emps_mv")
-
-    mv_rewrite_success_without_check_chosen("select empid, sum(deptno) from emps where deptno > 0 group by empid order by empid;",
-            "emps_mv")
-
-    mv_rewrite_success_without_check_chosen("select deptno, sum(empid) from emps where deptno > 0 group by deptno order by deptno;",
-            "emps_mv")
-
-    sql """set enable_stats=true;"""
 
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
 

--- a/regression-test/suites/mv_p0/ut/testProjectionMV2/testProjectionMV2.groovy
+++ b/regression-test/suites/mv_p0/ut/testProjectionMV2/testProjectionMV2.groovy
@@ -45,15 +45,6 @@ suite ("testProjectionMV2") {
 
     sql "analyze table emps with sync;"
     sql """alter table emps modify column time_col set stats ('row_count'='6');"""
-    sql """set enable_stats=false;"""
-
-    mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
-
-    mv_rewrite_success_without_check_chosen("select empid + 1 from emps where deptno = 1 order by empid;", "emps_mv")
-
-    mv_rewrite_fail("select name from emps where deptno -1 = 0 order by empid;", "emps_mv")
-
-    sql """set enable_stats=true;"""
 
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"

--- a/regression-test/suites/mv_p0/ut/testProjectionMV3/testProjectionMV3.groovy
+++ b/regression-test/suites/mv_p0/ut/testProjectionMV3/testProjectionMV3.groovy
@@ -47,7 +47,6 @@ suite ("testProjectionMV3") {
 
     sql """analyze table emps with sync;"""
     sql """alter table emps modify column time_col set stats ('row_count'='6');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
@@ -57,12 +56,4 @@ suite ("testProjectionMV3") {
 
     mv_rewrite_success("select name from emps where deptno = 1 order by empid;", "emps_mv")
     qt_select_mv2 "select name from emps where deptno = 1 order by empid;"
-
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
-
-    mv_rewrite_success("select empid + 1, name from emps where deptno = 1 order by empid;", "emps_mv")
-
-    mv_rewrite_success("select name from emps where deptno = 1 order by empid;", "emps_mv")
 }

--- a/regression-test/suites/mv_p0/ut/testProjectionMV4/testProjectionMV4.groovy
+++ b/regression-test/suites/mv_p0/ut/testProjectionMV4/testProjectionMV4.groovy
@@ -47,7 +47,6 @@ suite ("testProjectionMV4") {
 
     sql "analyze table emps with sync;"
     sql """alter table emps modify column time_col set stats ('row_count'='6');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
@@ -56,10 +55,4 @@ suite ("testProjectionMV4") {
 
     mv_rewrite_fail("select empid from emps where deptno > 1 and empid > 1 order by empid;", "emps_mv")
     qt_select_base "select empid from emps where deptno > 1 and empid > 1 order by empid;"
-
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
-
-    mv_rewrite_fail("select empid from emps where deptno > 1 and empid > 1 order by empid;", "emps_mv")
 }

--- a/regression-test/suites/mv_p0/ut/testSingleMVMultiUsage/testSingleMVMultiUsage.groovy
+++ b/regression-test/suites/mv_p0/ut/testSingleMVMultiUsage/testSingleMVMultiUsage.groovy
@@ -47,7 +47,6 @@ suite ("testSingleMVMultiUsage") {
 
     sql "analyze table emps with sync;"
     sql """alter table emps modify column time_col set stats ('row_count'='8');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
@@ -57,13 +56,4 @@ suite ("testSingleMVMultiUsage") {
             "emps_mv")
 
     qt_select_mv "select * from (select deptno, empid from emps where deptno>100) A join (select deptno, empid from emps where deptno >200) B using (deptno) order by 1;"
-    sql """set enable_stats=true;"""
-    mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
-
-
-    mv_rewrite_success("select * from (select deptno, empid from emps where deptno>100) A join (select deptno, empid from emps where deptno >200) B using (deptno);",
-    "emps_mv", true, [TRY_IN_RBO, NOT_IN_RBO])
-    mv_rewrite_success_without_check_chosen("select * from (select deptno, empid from emps where deptno>100) A join (select deptno, empid from emps where deptno >200) B using (deptno);",
-            "emps_mv", [FORCE_IN_RBO])
-
 }

--- a/regression-test/suites/mv_p0/ut/testSubQuery/testSubQuery.groovy
+++ b/regression-test/suites/mv_p0/ut/testSubQuery/testSubQuery.groovy
@@ -50,14 +50,9 @@ suite ("testSubQuery") {
 
     sql "analyze table emps with sync;"
     sql """alter table emps modify column time_col set stats ('row_count'='8');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
 
     qt_select_mv "select empid, deptno, salary from emps e1 where empid = (select max(empid) from emps where deptno = e1.deptno) order by deptno;"
-
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
 }

--- a/regression-test/suites/mv_p0/ut/testUnionDistinct/testUnionDistinct.groovy
+++ b/regression-test/suites/mv_p0/ut/testUnionDistinct/testUnionDistinct.groovy
@@ -48,23 +48,13 @@ suite ("testUnionDistinct") {
 
     sql "analyze table emps with sync;"
     sql """alter table emps modify column time_col set stats ('row_count'='8');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
     qt_select_star "select * from emps order by empid;"
 
-    mv_rewrite_success_without_check_chosen(
+    mv_rewrite_success(
             "select empid, deptno from emps where empid >1 union select empid, deptno from emps where empid <0 order by empid;",
             "emps_mv"
     )
-
     qt_select_mv "select * from (select empid, deptno from emps where empid >1 union select empid, deptno from emps where empid <0) t order by 1;"
-    sql """set enable_stats=true;"""
-    mv_rewrite_fail("select * from emps order by empid;", "emps_mv")
-
-    explain {
-        sql("select empid, deptno from emps where empid >1 union select empid, deptno from emps where empid <0 order by empid;")
-        contains "(emps_mv)"
-        notContains "(emps)"
-    }
 }

--- a/regression-test/suites/mv_p0/where/k123/k123.groovy
+++ b/regression-test/suites/mv_p0/where/k123/k123.groovy
@@ -45,7 +45,6 @@ suite ("k123p") {
     sql "insert into d_table select 3,-3,null,'c';"
 
     sql "analyze table d_table with sync;"
-    sql """set enable_stats=false;"""
 
     qt_select_star "select * from d_table order by k1;"
 
@@ -71,20 +70,4 @@ suite ("k123p") {
     qt_select_mv """select k1,k2+k3 from d_table where k1 = 2 and k4 = "b" order by k1;"""
 
     qt_select_mv_constant """select bitmap_empty() from d_table where true;"""
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_all_fail("select k1,k2+k3 from d_table order by k1;", ["k123p1w", "k123p4w"])
-
-    mv_rewrite_success_without_check_chosen("select k1,k2+k3 from d_table where k1 = 1 order by k1;", "k123p1w")
-
-    mv_rewrite_all_fail("select k1,k2+k3 from d_table where k1 = 2 order by k1;", ["k123p1w", "k123p4w"])
-
-    mv_rewrite_success_without_check_chosen("select k1,k2+k3 from d_table where k1 = '1' order by k1;", "k123p1w")
-
-    mv_rewrite_success_without_check_chosen("select k1,k2+k3 from d_table where k4 = 'b' order by k1;", "k123p4w")
-
-    mv_rewrite_all_fail("select k1,k2+k3 from d_table where k4 = 'a' order by k1;", ["k123p1w", "k123p4w"])
-
-    mv_rewrite_success_without_check_chosen("""select k1,k2+k3 from d_table where k1 = 2 and k4 = "b";""", "k123p4w")
-
 }

--- a/regression-test/suites/mv_p0/where/mvljc/mvljc.groovy
+++ b/regression-test/suites/mv_p0/where/mvljc/mvljc.groovy
@@ -45,7 +45,6 @@ suite ("mvljc") {
     sql "insert into d_table select 3,-3,null,'c';"
 
     sql "analyze table d_table with sync;"
-    sql """set enable_stats=false;"""
 
     mv_rewrite_success("SELECT k1, SUM(k2) FROM d_table WHERE k3 < 2 or k2 < 0 GROUP BY k1 order by 1,2;",
             "mvljc")
@@ -54,11 +53,4 @@ suite ("mvljc") {
     mv_rewrite_success("SELECT a.k1 + 1 FROM ( SELECT k1, SUM(k2) FROM d_table WHERE k3 < 2 or k2 < 0 GROUP BY k1 ) a, d_table order by 1;",
             "mvljc")
     qt_select_mv "SELECT a.k1 + 1 FROM ( SELECT k1, SUM(k2) FROM d_table WHERE k3 < 2 or k2 < 0 GROUP BY k1 ) a, d_table order by 1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("SELECT k1, SUM(k2) FROM d_table WHERE k3 < 2 or k2 < 0 GROUP BY k1 order by 1,2;",
-            "mvljc")
-
-    mv_rewrite_success("SELECT a.k1 + 1 FROM ( SELECT k1, SUM(k2) FROM d_table WHERE k3 < 2 or k2 < 0 GROUP BY k1 ) a, d_table order by 1;",
-            "mvljc")
 }

--- a/regression-test/suites/nereids_rules_p0/mv/single_table_without_agg/single_table_without_aggregate.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/single_table_without_agg/single_table_without_aggregate.groovy
@@ -63,7 +63,6 @@ suite("single_table_without_aggregate") {
 
     sql "analyze table orders with sync;"
     sql """alter table orders modify column O_COMMENT set stats ('row_count'='6');"""
-    sql """set enable_stats=false;"""
 
     def check_rewrite = { mv_sql, query_sql, mv_name ->
 

--- a/regression-test/suites/nereids_syntax_p0/advance_mv.groovy
+++ b/regression-test/suites/nereids_syntax_p0/advance_mv.groovy
@@ -90,7 +90,6 @@ suite("advance_mv") {
     sql "analyze table ${tbName1} with sync;"
     sql "analyze table ${tbName2} with sync;"
     sql "analyze table ${tbName3} with sync;"
-    sql """set enable_stats=false;"""
 
     create_sync_mv(db, tbName1, "mv1", "SELECT k1 as a1, sum(v2) as a2 FROM ${tbName1} GROUP BY k1;")
 
@@ -99,7 +98,6 @@ suite("advance_mv") {
         contains "(mv1)"
     }
 
-    sql """set enable_stats=true;"""
     explain {
         sql("select k1, sum(v2) from ${tbName1} group by k1 order by k1;")
         contains "(mv1)"
@@ -112,7 +110,6 @@ suite("advance_mv") {
         sql("SELECT abs(k1)+k2+1 tmp, sum(abs(k2+2)+k3+3) FROM ${tbName2} GROUP BY tmp;")
         contains "(mv2)"
     }
-    sql """set enable_stats=false;"""
     explain {
         sql("SELECT abs(k1)+k2+1 tmp, sum(abs(k2+2)+k3+3) FROM ${tbName2} GROUP BY tmp;")
         contains "(mv2)"
@@ -127,7 +124,6 @@ suite("advance_mv") {
     }
     order_qt_select_star "SELECT abs(k1)+k2+1 tmp, abs(k2+2)+k3+3 FROM ${tbName2};"
 
-    sql """set enable_stats=true;"""
     explain {
         sql("SELECT abs(k1)+k2+1 tmp, abs(k2+2)+k3+3 FROM ${tbName2};")
         contains "(mv3)"
@@ -140,10 +136,4 @@ suite("advance_mv") {
         contains "(mv4)"
     }
     order_qt_select_star "select sum(age) from ${tbName3};"
-
-    sql """set enable_stats=false;"""
-    explain {
-        sql("select sum(age) from ${tbName3};")
-        contains "(mv4)"
-    }
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/aggregate/agg_sync_mv.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/aggregate/agg_sync_mv.groovy
@@ -20,7 +20,6 @@ suite("agg_sync_mv") {
     sql """ SET enable_nereids_planner=true """
     sql """ SET enable_fallback_to_original_planner=false """
     sql """ analyze table agg_mv_test with sync"""
-    sql """ set enable_stats=false"""
     // this mv rewrite would not be rewritten in RBO phase, so set TRY_IN_RBO explicitly to make case stable
     sql "set pre_materialized_view_rewrite_strategy = TRY_IN_RBO"
 

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/case_ignore.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/case_ignore.groovy
@@ -50,7 +50,6 @@ suite ("case_ignore") {
     sql "analyze table case_ignore with sync;"
     sql """alter table case_ignore modify column k1 set stats ('row_count'='4');"""
 
-    sql """set enable_stats=false;"""
 
     qt_select_star "select * from case_ignore order by k1;"
 
@@ -59,10 +58,4 @@ suite ("case_ignore") {
 
     mv_rewrite_success("select K1,abs(K2) from case_ignore order by K1;", "k12a")
     order_qt_select_mv "select K1,abs(K2) from case_ignore order by K1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select k1,abs(k2) from case_ignore order by k1;", "k12a")
-
-    mv_rewrite_success("select K1,abs(K2) from case_ignore order by K1;", "k12a")
-
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_gb_mv_abs.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_gb_mv_abs.groovy
@@ -50,9 +50,6 @@ suite ("dup_gb_mv_abs") {
     sql "analyze table dup_gb_mv_abs with sync;"
     sql """alter table dup_gb_mv_abs modify column k1 set stats ('row_count'='4');"""
 
-    sql """set enable_stats=false;"""
-
-
     order_qt_select_star "select * from dup_gb_mv_abs order by k1;"
 
     mv_rewrite_success("select k1,sum(abs(k2)) from dup_gb_mv_abs group by k1;", "k12sa")
@@ -60,9 +57,4 @@ suite ("dup_gb_mv_abs") {
 
     mv_rewrite_success("select sum(abs(k2)) from dup_gb_mv_abs group by k1;", "k12sa")
     order_qt_select_mv_sub "select sum(abs(k2)) from dup_gb_mv_abs group by k1 order by k1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select k1,sum(abs(k2)) from dup_gb_mv_abs group by k1;", "k12sa")
-
-    mv_rewrite_success("select sum(abs(k2)) from dup_gb_mv_abs group by k1;", "k12sa")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_gb_mv_plus.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_gb_mv_plus.groovy
@@ -51,9 +51,6 @@ suite ("dup_gb_mv_plus") {
     sql "analyze table dup_gb_mv_plus with sync;"
     sql """alter table dup_gb_mv_plus modify column k1 set stats ('row_count'='4');"""
 
-    sql """set enable_stats=false;"""
-
-
     order_qt_select_star "select * from dup_gb_mv_plus order by k1;"
 
     mv_rewrite_success("select k1,sum(k2+1) from dup_gb_mv_plus group by k1;", "k12sp")
@@ -61,9 +58,4 @@ suite ("dup_gb_mv_plus") {
 
     mv_rewrite_success("select sum(k2+1) from dup_gb_mv_plus group by k1;", "k12sp")
     order_qt_select_mv_sub "select sum(k2+1) from dup_gb_mv_plus group by k1 order by k1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select k1,sum(k2+1) from dup_gb_mv_plus group by k1;", "k12sp")
-
-    mv_rewrite_success("select sum(k2+1) from dup_gb_mv_plus group by k1;", "k12sp")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_abs.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_abs.groovy
@@ -49,9 +49,6 @@ suite ("dup_mv_abs") {
     sql "analyze table dup_mv_abs with sync;"
     sql """alter table dup_mv_abs modify column k1 set stats ('row_count'='4');"""
 
-    sql """set enable_stats=false;"""
-
-
     order_qt_select_star "select * from dup_mv_abs order by k1;"
 
     mv_rewrite_success("select k1,abs(k2) from dup_mv_abs order by k1;", "k12a")
@@ -71,17 +68,4 @@ suite ("dup_mv_abs") {
 
     mv_rewrite_fail("select sum(abs(k2)) from dup_mv_abs group by k3;", "k12a")
     order_qt_select_group_mv_not "select sum(abs(k2)) from dup_mv_abs group by k3 order by k3;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select k1,abs(k2) from dup_mv_abs order by k1;", "k12a")
-
-    mv_rewrite_success("select abs(k2) from dup_mv_abs order by k1;", "k12a")
-
-    mv_rewrite_success("select abs(k2)+1 from dup_mv_abs order by k1;", "k12a")
-
-    mv_rewrite_success("select sum(abs(k2)) from dup_mv_abs group by k1 order by k1;", "k12a")
-
-    mv_rewrite_success("select sum(abs(k2)+1) from dup_mv_abs group by k1 order by k1;", "k12a")
-
-    mv_rewrite_fail("select sum(abs(k2)) from dup_mv_abs group by k3;", "k12a")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_bin.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_bin.groovy
@@ -50,9 +50,6 @@ suite ("dup_mv_bin") {
     sql "analyze table dup_mv_bin with sync;"
     sql """alter table dup_mv_bin modify column k1 set stats ('row_count'='4');"""
 
-    sql """set enable_stats=false;"""
-
-
     order_qt_select_star "select * from dup_mv_bin order by k1;"
 
     mv_rewrite_success("select k1,bin(k2) from dup_mv_bin order by k1;", "k12b")
@@ -73,16 +70,4 @@ suite ("dup_mv_bin") {
     mv_rewrite_fail("select group_concat(bin(k2)) from dup_mv_bin group by k3;", "k12b")
     order_qt_select_group_mv_not "select group_concat(bin(k2)) from dup_mv_bin group by k3 order by k3;"
 
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select k1,bin(k2) from dup_mv_bin order by k1;", "k12b")
-
-    mv_rewrite_success("select bin(k2) from dup_mv_bin order by k1;", "k12b")
-
-    mv_rewrite_success("select bin(k2)+1 from dup_mv_bin order by k1;", "k12b")
-
-    mv_rewrite_success("select group_concat(bin(k2)) from dup_mv_bin group by k1 order by k1;", "k12b")
-
-    mv_rewrite_success("select group_concat(concat(bin(k2),'a')) from dup_mv_bin group by k1 order by k1;", "k12b")
-
-    mv_rewrite_fail("select group_concat(bin(k2)) from dup_mv_bin group by k3;", "k12b")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_bm_hash.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_bm_hash.groovy
@@ -45,12 +45,9 @@ suite ("dup_mv_bm_hash") {
     sql "analyze table dup_mv_bm_hash with sync;"
     sql """alter table dup_mv_bm_hash modify column k1 set stats ('row_count'='5');"""
 
-    sql """set enable_stats=false;"""
-
     mv_rewrite_success("select bitmap_union_count(to_bitmap(k2)) from dup_mv_bm_hash group by k1 order by k1;", "dup_mv_bm_hash_mv1")
     order_qt_select_mv "select bitmap_union_count(to_bitmap(k2)) from dup_mv_bm_hash group by k1 order by k1;"
 
-    sql """set enable_stats=true;"""
     mv_rewrite_success("select bitmap_union_count(to_bitmap(k2)) from dup_mv_bm_hash group by k1 order by k1;", "dup_mv_bm_hash_mv1")
 
     create_sync_mv(db, "dup_mv_bm_hash", "dup_mv_bm_hash_mv2", "select k1 as a3,bitmap_union(bitmap_hash(k3)) as a4 from dup_mv_bm_hash group by k1;")
@@ -64,7 +61,4 @@ suite ("dup_mv_bm_hash") {
 
     mv_rewrite_success("select k1,bitmap_union_count(bitmap_hash(k3)) from dup_mv_bm_hash group by k1;", "dup_mv_bm_hash_mv2")
     order_qt_select_mv_sub "select k1,bitmap_union_count(bitmap_hash(k3)) from dup_mv_bm_hash group by k1 order by k1;"
-
-    sql """set enable_stats=false;"""
-    mv_rewrite_success("select k1,bitmap_union_count(bitmap_hash(k3)) from dup_mv_bm_hash group by k1;", "dup_mv_bm_hash_mv2")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_plus.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_plus.groovy
@@ -49,7 +49,6 @@ suite ("dup_mv_plus") {
     sql "analyze table dup_mv_plus with sync;"
     sql """alter table dup_mv_plus modify column k1 set stats ('row_count'='4');"""
 
-    sql """set enable_stats=false;"""
 
     order_qt_select_star "select * from dup_mv_plus order by k1;"
 
@@ -88,18 +87,4 @@ suite ("dup_mv_plus") {
 
     mv_rewrite_fail("select k1,k2+1 from dup_mv_plus order by k2;", "k12p")
     order_qt_select_mv "select k1,k2+1 from dup_mv_plus order by k2;"
-
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_success("select k1,k2+1 from dup_mv_plus order by k1;", "k12p")
-
-    mv_rewrite_success("select k2+1 from dup_mv_plus order by k1;", "k12p")
-
-    mv_rewrite_success("select sum(k2+1) from dup_mv_plus group by k1 order by k1;", "k12p")
-
-    mv_rewrite_success("select sum(k1) from dup_mv_plus group by k2+1 order by k2+1;", "k12p")
-
-    mv_rewrite_success("select sum(k2+1) from dup_mv_plus group by k1 order by k1;", "k12p")
-
-    mv_rewrite_success("select sum(k1) from dup_mv_plus group by k2+1 order by k2+1;", "k12p")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_year.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/dup_mv_year.groovy
@@ -44,14 +44,8 @@ suite ("dup_mv_year") {
     sql "analyze table dup_mv_year with sync;"
     sql """alter table dup_mv_year modify column k1 set stats ('row_count'='4');"""
 
-    sql """set enable_stats=false;"""
-
-
     mv_rewrite_success("select k1,year(k2) from dup_mv_year order by k1;", "k12y")
     order_qt_select_mv "select k1,year(k2) from dup_mv_year order by k1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select k1,year(k2) from dup_mv_year order by k1;", "k12y")
 
     create_sync_mv(db, "dup_mv_year", "k13y", "select k1 as a3,year(k3) as a4 from dup_mv_year;")
 
@@ -63,6 +57,4 @@ suite ("dup_mv_year") {
     mv_rewrite_success("select year(k3) from dup_mv_year order by k1;", "k13y")
     order_qt_select_mv_sub "select year(k3) from dup_mv_year order by k1;"
 
-    sql """set enable_stats=false;"""
-    mv_rewrite_success("select year(k3) from dup_mv_year order by k1;", "k13y")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot1.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot1.groovy
@@ -49,13 +49,8 @@ suite ("multi_slot1") {
     sql "analyze table multi_slot1 with sync;"
     sql """alter table multi_slot1 modify column k1 set stats ('row_count'='4');"""
 
-    sql """set enable_stats=false;"""
-
     order_qt_select_star "select * from multi_slot1 order by k1;"
 
     mv_rewrite_success("select abs(k1)+k2+1,abs(k2+2)+k3+3 from multi_slot1 order by abs(k1)+k2+1,abs(k2+2)+k3+3", "k1a2p2ap3p")
     order_qt_select_mv "select abs(k1)+k2+1,abs(k2+2)+k3+3 from multi_slot1 order by abs(k1)+k2+1,abs(k2+2)+k3+3;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select abs(k1)+k2+1,abs(k2+2)+k3+3 from multi_slot1 order by abs(k1)+k2+1,abs(k2+2)+k3+3", "k1a2p2ap3p")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot2.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot2.groovy
@@ -57,9 +57,6 @@ suite ("multi_slot2") {
     sql "analyze table multi_slot2 with sync;"
     sql """alter table multi_slot2 modify column k1 set stats ('row_count'='4');"""
 
-    sql """set enable_stats=false;"""
-
-
     order_qt_select_star "select * from multi_slot2 order by k1;"
 
     mv_rewrite_success("select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from multi_slot2 group by abs(k1)+k2+1 order by abs(k1)+k2+1",
@@ -68,11 +65,4 @@ suite ("multi_slot2") {
 
     mv_rewrite_fail("select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from multi_slot2 group by abs(k1)+k2 order by abs(k1)+k2", "k1a2p2ap3ps")
     order_qt_select_base "select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from multi_slot2 group by abs(k1)+k2 order by abs(k1)+k2;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from multi_slot2 group by abs(k1)+k2+1 order by abs(k1)+k2+1",
-            "k1a2p2ap3ps")
-
-    mv_rewrite_fail("select abs(k1)+k2+1,sum(abs(k2+2)+k3+3) from multi_slot2 group by abs(k1)+k2 order by abs(k1)+k2", "k1a2p2ap3ps")
-
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot3.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot3.groovy
@@ -49,13 +49,8 @@ suite ("multi_slot3") {
     sql "analyze table multi_slot3 with sync;"
     sql """alter table multi_slot3 modify column k1 set stats ('row_count'='4');"""
 
-    sql """set enable_stats=false;"""
-
     order_qt_select_star "select * from multi_slot3 order by k1;"
 
     mv_rewrite_success("select k1+1,abs(k2+2)+k3+3 from multi_slot3 order by k1+1;", "k1p2ap3p")
     order_qt_select_mv "select k1+1,abs(k2+2)+k3+3 from multi_slot3 order by k1+1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select k1+1,abs(k2+2)+k3+3 from multi_slot3 order by k1+1;", "k1p2ap3p")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot4.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot4.groovy
@@ -59,14 +59,8 @@ suite ("multi_slot4") {
     sql "analyze table multi_slot4 with sync;"
     sql """alter table multi_slot4 modify column k1 set stats ('row_count'='13');"""
 
-    sql """set enable_stats=false;"""
-
-
     order_qt_select_star "select * from multi_slot4 order by k1;"
 
     mv_rewrite_success("select k1+1,sum(abs(k2+2)+k3+3) from multi_slot4 group by k1+1 order by k1+1;", "k1p2ap3ps")
     order_qt_select_mv "select k1+1,sum(abs(k2+2)+k3+3) from multi_slot4 group by k1+1 order by k1+1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select k1+1,sum(abs(k2+2)+k3+3) from multi_slot4 group by k1+1 order by k1+1;", "k1p2ap3ps")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot5.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot5.groovy
@@ -50,8 +50,6 @@ suite ("multi_slot5") {
     sql "analyze table multi_slot5 with sync;"
     sql """alter table multi_slot5 modify column k1 set stats ('row_count'='5');"""
 
-    sql """set enable_stats=false;"""
-
     order_qt_select_star "select * from multi_slot5 order by k1,k4;"
 
     mv_rewrite_success("select k1,k2+k3 from multi_slot5 order by k1;", "k123p")
@@ -60,7 +58,4 @@ suite ("multi_slot5") {
     order_qt_select_mv "select lhs.k1,rhs.k2 from multi_slot5 as lhs right join multi_slot5 as rhs on lhs.k1=rhs.k1 order by lhs.k1;"
 
     order_qt_select_mv "select k1,version() from multi_slot5 order by k1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select k1,k2+k3 from multi_slot5 order by k1;", "k123p")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot6.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/multi_slot6.groovy
@@ -50,9 +50,6 @@ suite ("multi_slot6") {
     sql "analyze table multi_slot6 with sync;"
     sql """alter table multi_slot6 modify column k1 set stats ('row_count'='4');"""
 
-    sql """set enable_stats=false;"""
-
-
     order_qt_select_star "select * from multi_slot6 order by k1;"
 
     def retry_times = 60

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/mv_with_view.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/mv_with_view.groovy
@@ -46,7 +46,6 @@ suite ("mv_with_view") {
     sql "analyze table d_table with sync;"
     sql """alter table d_table modify column k1 set stats ('row_count'='4');"""
 
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from d_table order by k1;", "k312")
     qt_select_star "select * from d_table order by k1;"
@@ -70,25 +69,4 @@ suite ("mv_with_view") {
     """
     mv_rewrite_fail("select * from v_k124 order by k1;", "k312")
     qt_select_mv "select * from v_k124 order by k1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_fail("select * from d_table order by k1;", "k312")
-
-    sql """
-        drop view if exists v_k312;
-    """
-
-    sql """
-        create view v_k312 as select k1,k3,k2 from d_table where k3 = 1;
-    """
-    mv_rewrite_success("select * from v_k312 order by k1;", "k312")
-
-    sql """
-        drop view if exists v_k124;
-    """
-
-    sql """
-        create view v_k124 as select k1,k2,k4 from d_table where k1 = 1;
-    """
-    mv_rewrite_fail("select * from v_k124 order by k1;", "k312")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/rollback1.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/rollback1.groovy
@@ -47,8 +47,6 @@ suite ("rollback1") {
     sql "SET enable_fallback_to_original_planner=false"
 
     sql "analyze table rollback1 with sync;"
-    sql """set enable_stats=false;"""
-
 
     order_qt_select_star "select * from rollback1 order by k1;"
 

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/single_slot.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/single_slot.groovy
@@ -50,8 +50,6 @@ suite ("single_slot") {
     sql "analyze table single_slot with sync;"
     sql """alter table single_slot modify column k1 set stats ('row_count'='4');"""
 
-    sql """set enable_stats=false;"""
-
     order_qt_select_star "select * from single_slot order by k1;"
 
     mv_rewrite_success("select abs(k1)+1 t,sum(abs(k2+1)) from single_slot group by t order by t;",
@@ -64,10 +62,4 @@ suite ("single_slot") {
     mv_rewrite_success_without_check_chosen("select abs(k1)+1 t,sum(abs(k2+1)) from single_slot group by t order by t;",
             "k1ap2spa", [FORCE_IN_RBO])
     order_qt_select_mv "select abs(k1)+1 t,sum(abs(k2+1)) from single_slot group by t order by t;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select abs(k1)+1 t,sum(abs(k2+1)) from single_slot group by t order by t;",
-            "k1ap2spa", true, [TRY_IN_RBO, NOT_IN_RBO])
-    mv_rewrite_success_without_check_chosen("select abs(k1)+1 t,sum(abs(k2+1)) from single_slot group by t order by t;",
-            "k1ap2spa", [FORCE_IN_RBO])
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/sum_devide_count.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/sum_devide_count.groovy
@@ -65,8 +65,6 @@ suite ("sum_devide_count") {
     sql "analyze table sum_devide_count with sync;"
     sql """alter table sum_devide_count modify column k1 set stats ('row_count'='20');"""
 
-    sql """set enable_stats=false;"""
-
     qt_select_star "select * from sum_devide_count order by k1,k2,k3,k4;"
 
     mv_rewrite_success("select k1,k4,sum(k2)/count(k2) from sum_devide_count group by k1,k4 order by k1,k4;", "kavg")
@@ -80,13 +78,4 @@ suite ("sum_devide_count") {
 
     mv_rewrite_success("select sum(k2)/count(k2) from sum_devide_count;", "kavg")
     order_qt_select_mv "select sum(k2)/count(k2) from sum_devide_count;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("select k1,k4,sum(k2)/count(k2) from sum_devide_count group by k1,k4 order by k1,k4;", "kavg")
-
-    mv_rewrite_success("select k1,sum(k2)/count(k2) from sum_devide_count group by k1 order by k1;", "kavg")
-
-    mv_rewrite_success("select k4,sum(k2)/count(k2) from sum_devide_count group by k4 order by k4;", "kavg")
-
-    mv_rewrite_success("select sum(k2)/count(k2) from sum_devide_count;", "kavg")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/newMv/unique_mv.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/newMv/unique_mv.groovy
@@ -48,11 +48,5 @@ suite ("unique_mv") {
     sql "analyze table c5816_t with sync;"
     sql """alter table c5816_t modify column org_id set stats ('row_count'='1');"""
 
-    sql """set enable_stats=false;"""
-
     mv_rewrite_success("SELECT * FROM c5816_t WHERE call_uuid='adc';", "mv_1")
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("SELECT * FROM c5816_t WHERE call_uuid='adc';", "mv_1")
-
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/MVMultiUsage.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/MVMultiUsage.groovy
@@ -52,8 +52,6 @@ suite ("MVMultiUsage") {
     sql "analyze table MVMultiUsage with sync;"
     sql """alter table MVMultiUsage modify column time_col set stats ('row_count'='4');"""
 
-    sql """set enable_stats=false;"""
-
     mv_rewrite_fail("select * from MVMultiUsage order by empid;", "MVMultiUsage_mv")
     order_qt_select_star "select * from MVMultiUsage order by empid;"
 
@@ -64,14 +62,4 @@ suite ("MVMultiUsage") {
         notContains "(MVMultiUsage)"
     }
     order_qt_select_mv "select * from (select deptno, empid from MVMultiUsage where deptno>100) A join (select deptno, empid from MVMultiUsage where deptno >200) B using (deptno) order by 1;"
-
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_fail("select * from MVMultiUsage order by empid;", "MVMultiUsage_mv")
-    explain {
-        sql("select * from (select deptno, empid from MVMultiUsage where deptno>100) A join (select deptno, empid from MVMultiUsage where deptno >200) B using (deptno);")
-        contains "(MVMultiUsage_mv)"
-        notContains "(MVMultiUsage)"
-    }
-
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/MVWithAs.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/MVWithAs.groovy
@@ -48,15 +48,10 @@ suite ("MVWithAs") {
 
     sql "analyze table MVWithAs with sync;"
     sql """alter table MVWithAs modify column time_col set stats ('row_count'='7');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from MVWithAs order by time_col;", "MVWithAs_mv")
     order_qt_select_star "select * from MVWithAs order by time_col;"
 
     mv_rewrite_success("select count(tag_id) from MVWithAs t;", "MVWithAs_mv")
     order_qt_select_mv "select count(tag_id) from MVWithAs t;"
-
-    mv_rewrite_fail("select * from MVWithAs order by time_col;", "MVWithAs_mv")
-
-    mv_rewrite_success("select count(tag_id) from MVWithAs t;", "MVWithAs_mv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggCDInBitmap.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggCDInBitmap.groovy
@@ -35,21 +35,12 @@ suite ("aggCDInBitmap") {
 
     sql "analyze table aggCDInBitmap with sync;"
     sql """alter table aggCDInBitmap modify column k1 set stats ('row_count'='3');"""
-    sql """set enable_stats=false;"""
 
     order_qt_select_star "select * from aggCDInBitmap order by 1;"
-
 
     explain {
         sql("select k1, count(distinct v1) from aggCDInBitmap group by k1;")
         contains "bitmap_union_count"
     }
     order_qt_select_mv "select k1, count(distinct v1) from aggCDInBitmap group by k1 order by k1;"
-
-    sql """set enable_stats=true;"""
-    explain {
-        sql("select k1, count(distinct v1) from aggCDInBitmap group by k1;")
-        contains "bitmap_union_count"
-    }
-    
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggMVCalcAggFun.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggMVCalcAggFun.groovy
@@ -48,15 +48,10 @@ suite ("aggMVCalcAggFun") {
 
     sql "analyze table aggMVCalcAggFun with sync;"
     sql """alter table aggMVCalcAggFun modify column time_col set stats ('row_count'='4');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from aggMVCalcAggFun order by empid;", "aggMVCalcAggFunMv")
     order_qt_select_star "select * from aggMVCalcAggFun order by empid;"
 
     mv_rewrite_fail("select deptno, sum(salary + 1) from aggMVCalcAggFun where deptno > 10 group by deptno;", "aggMVCalcAggFunMv")
     order_qt_select_mv "select deptno, sum(salary + 1) from aggMVCalcAggFun where deptno > 10 group by deptno order by deptno;"
-
-    mv_rewrite_fail("select * from aggMVCalcAggFun order by empid;", "aggMVCalcAggFunMv")\
-
-    mv_rewrite_fail("select deptno, sum(salary + 1) from aggMVCalcAggFun where deptno > 10 group by deptno;", "aggMVCalcAggFunMv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV1.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV1.groovy
@@ -55,16 +55,9 @@ suite ("aggOnAggMV1") {
     sql "analyze table aggOnAggMV1 with sync;"
     sql """alter table aggOnAggMV1 modify column time_col set stats ('row_count'='9');"""
 
-    sql """set enable_stats=false;"""
-
     mv_rewrite_fail("select * from aggOnAggMV1 order by empid;", "aggOnAggMV1_mv")
     order_qt_select_star "select * from aggOnAggMV1 order by empid;"
 
     mv_rewrite_success("select sum(salary), deptno from aggOnAggMV1 group by deptno order by deptno;", "aggOnAggMV1_mv")
     order_qt_select_mv "select sum(salary), deptno from aggOnAggMV1 group by deptno order by deptno;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_fail("select * from aggOnAggMV1 order by empid;", "aggOnAggMV1_mv")
-
-    mv_rewrite_success("select sum(salary), deptno from aggOnAggMV1 group by deptno order by deptno;", "aggOnAggMV1_mv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV10.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV10.groovy
@@ -53,18 +53,10 @@ suite ("aggOnAggMV10") {
     sql "analyze table aggOnAggMV10 with sync;"
     sql """alter table aggOnAggMV10 modify column time_col set stats ('row_count'='7');"""
 
-    sql """set enable_stats=false;"""
-
     mv_rewrite_fail("select * from aggOnAggMV10 order by empid;", "aggOnAggMV10_mv")
     order_qt_select_star "select * from aggOnAggMV10 order by empid;"
 
     mv_rewrite_success("select deptno, commission, sum(salary) + 1 from aggOnAggMV10 group by rollup (deptno, commission);",
             "aggOnAggMV10_mv")
     order_qt_select_mv "select deptno, commission, sum(salary) + 1 from aggOnAggMV10 group by rollup (deptno, commission) order by 1,2;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_fail("select * from aggOnAggMV10 order by empid;", "aggOnAggMV10_mv")
-
-    mv_rewrite_success("select deptno, commission, sum(salary) + 1 from aggOnAggMV10 group by rollup (deptno, commission);",
-            "aggOnAggMV10_mv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV11.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV11.groovy
@@ -52,19 +52,10 @@ suite ("aggOnAggMV11") {
     sql "analyze table aggOnAggMV11 with sync;"
     sql """alter table aggOnAggMV11 modify column time_col set stats ('row_count'='7');"""
 
-    sql """set enable_stats=false;"""
-
     mv_rewrite_fail("select * from aggOnAggMV11 order by empid;", "aggOnAggMV11_mv")
     order_qt_select_star "select * from aggOnAggMV11 order by empid;"
 
     mv_rewrite_fail("select deptno, count(salary) + count(1) from aggOnAggMV11 group by deptno;",
             "aggOnAggMV11_mv")
     order_qt_select_mv "select deptno, count(salary) + count(1) from aggOnAggMV11 group by deptno order by 1;"
-
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_fail("select * from aggOnAggMV11 order by empid;", "aggOnAggMV11_mv")
-
-    mv_rewrite_fail("select deptno, count(salary) + count(1) from aggOnAggMV11 group by deptno;",
-            "aggOnAggMV11_mv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV2.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV2.groovy
@@ -55,7 +55,6 @@ suite ("aggOnAggMV2") {
     sql "analyze table aggOnAggMV2 with sync;"
     sql """alter table aggOnAggMV2 modify column time_col set stats ('row_count'='8');"""
 
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from aggOnAggMV2 order by empid;", "aggOnAggMV2_mv")
     order_qt_select_star "select * from aggOnAggMV2 order by empid, salary;"
@@ -63,9 +62,4 @@ suite ("aggOnAggMV2") {
     mv_rewrite_success("select * from (select deptno, sum(salary) as sum_salary from aggOnAggMV2 group by deptno) a where (sum_salary * 2) > 3 order by deptno ;", "aggOnAggMV2_mv")
 
     order_qt_select_mv "select * from (select deptno, sum(salary) as sum_salary from aggOnAggMV2 group by deptno) a where (sum_salary * 2) > 3 order by deptno ;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_fail("select * from aggOnAggMV2 order by empid;", "aggOnAggMV2_mv")
-
-    mv_rewrite_success("select * from (select deptno, sum(salary) as sum_salary from aggOnAggMV2 group by deptno) a where (sum_salary * 2) > 3 order by deptno ;", "aggOnAggMV2_mv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV3.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV3.groovy
@@ -53,7 +53,6 @@ suite ("aggOnAggMV3") {
     sql "analyze table aggOnAggMV3 with sync;"
     sql """alter table aggOnAggMV3 modify column time_col set stats ('row_count'='8');"""
 
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from aggOnAggMV3 order by empid;", "aggOnAggMV3_mv")
     order_qt_select_star "select * from aggOnAggMV3 order by empid;"
@@ -61,10 +60,4 @@ suite ("aggOnAggMV3") {
     mv_rewrite_success("select commission, sum(salary) from aggOnAggMV3 where commission * (deptno + commission) = 100 group by commission order by commission;",
             "aggOnAggMV3_mv")
     order_qt_select_mv "select commission, sum(salary) from aggOnAggMV3 where commission * (deptno + commission) = 100 group by commission order by commission;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_fail("select * from aggOnAggMV3 order by empid;", "aggOnAggMV3_mv")
-
-    mv_rewrite_success("select commission, sum(salary) from aggOnAggMV3 where commission * (deptno + commission) = 100 group by commission order by commission;",
-            "aggOnAggMV3_mv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV6.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV6.groovy
@@ -51,18 +51,10 @@ suite ("aggOnAggMV6") {
     sql "analyze table aggOnAggMV6 with sync;"
     sql """alter table aggOnAggMV6 modify column time_col set stats ('row_count'='6');"""
 
-    sql """set enable_stats=false;"""
-
     mv_rewrite_fail("select * from aggOnAggMV6 order by empid;", "aggOnAggMV6_mv")
     order_qt_select_star "select * from aggOnAggMV6 order by empid;"
 
     mv_rewrite_success("select * from (select deptno, sum(salary) as sum_salary from aggOnAggMV6 where deptno>=20 group by deptno) a where sum_salary>10;",
             "aggOnAggMV6_mv")
     order_qt_select_mv "select * from (select deptno, sum(salary) as sum_salary from aggOnAggMV6 where deptno>=20 group by deptno) a where sum_salary>10 order by 1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_fail("select * from aggOnAggMV6 order by empid;", "aggOnAggMV6_mv")
-
-    mv_rewrite_success("select * from (select deptno, sum(salary) as sum_salary from aggOnAggMV6 where deptno>=20 group by deptno) a where sum_salary>10;",
-            "aggOnAggMV6_mv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV7.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/aggOnAggMV7.groovy
@@ -50,7 +50,6 @@ suite ("aggOnAggMV7") {
 
     sql "analyze table aggOnAggMV7 with sync;"
     sql """alter table aggOnAggMV7 modify column time_col set stats ('row_count'='7');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from aggOnAggMV7 order by empid;", "aggOnAggMV7_mv")
     order_qt_select_star "select * from aggOnAggMV7 order by empid;"
@@ -58,10 +57,4 @@ suite ("aggOnAggMV7") {
     mv_rewrite_success("select deptno, sum(salary) from aggOnAggMV7 where deptno>=20 group by deptno;",
             "aggOnAggMV7_mv")
     order_qt_select_mv "select deptno, sum(salary) from aggOnAggMV7 where deptno>=20 group by deptno order by 1;"
-
-    sql """set enable_stats=true;"""
-    mv_rewrite_fail("select * from aggOnAggMV7 order by empid;", "aggOnAggMV7_mv")
-
-    mv_rewrite_success("select deptno, sum(salary) from aggOnAggMV7 where deptno>=20 group by deptno;",
-            "aggOnAggMV7_mv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/bitmapUnionIn.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/bitmapUnionIn.groovy
@@ -44,7 +44,6 @@ suite ("bitmapUnionIn") {
 
     sql "analyze table bitmapUnionIn with sync;"
     sql """alter table bitmapUnionIn modify column time_col set stats ('row_count'='3');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from bitmapUnionIn order by time_col;", "bitmapUnionIn_mv")
     order_qt_select_star "select * from bitmapUnionIn order by time_col,tag_id;"
@@ -52,11 +51,4 @@ suite ("bitmapUnionIn") {
     mv_rewrite_success("select user_id, bitmap_union_count(to_bitmap(tag_id)) a from bitmapUnionIn group by user_id having a>1 order by a;",
             "bitmapUnionIn_mv")
     order_qt_select_mv "select user_id, bitmap_union_count(to_bitmap(tag_id)) a from bitmapUnionIn group by user_id having a>1 order by a;"
-
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_fail("select * from bitmapUnionIn order by time_col;", "bitmapUnionIn_mv")
-
-    mv_rewrite_success("select user_id, bitmap_union_count(to_bitmap(tag_id)) a from bitmapUnionIn group by user_id having a>1 order by a;",
-            "bitmapUnionIn_mv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/incMVReInSub.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/incMVReInSub.groovy
@@ -46,7 +46,6 @@ suite ("incMVReInSub") {
     sql "analyze table incMVReInSub with sync;"
     sql """alter table incMVReInSub modify column time_col set stats ('row_count'='3');"""
 
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from incMVReInSub order by time_col;", "incMVReInSub_mv")
     order_qt_select_star "select * from incMVReInSub order by time_col, user_id, user_name, tag_id;"
@@ -55,11 +54,4 @@ suite ("incMVReInSub") {
             "incMVReInSub_mv")
 
     order_qt_select_mv "select user_id, bitmap_union(to_bitmap(tag_id)) from incMVReInSub where user_name in (select user_name from incMVReInSub group by user_name having bitmap_union_count(to_bitmap(tag_id)) >1 ) group by user_id order by user_id;"
-
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_fail("select * from incMVReInSub order by time_col;", "incMVReInSub_mv")
-
-    mv_rewrite_fail("select user_id, bitmap_union(to_bitmap(tag_id)) from incMVReInSub where user_name in (select user_name from incMVReInSub group by user_name having bitmap_union_count(to_bitmap(tag_id)) >1 ) group by user_id order by user_id;",
-            "incMVReInSub_mv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/incRewriteCD.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/incRewriteCD.groovy
@@ -45,17 +45,9 @@ suite ("incRewriteCD") {
     sql "analyze table incRewriteCD with sync;"
     sql """alter table incRewriteCD modify column time_col set stats ('row_count'='3');"""
 
-    sql """set enable_stats=false;"""
-
     mv_rewrite_fail("select * from incRewriteCD order by time_col;", "incRewriteCD_mv")
     order_qt_select_star "select * from incRewriteCD order by time_col,tag_id;"
 
     mv_rewrite_fail("select user_name, count(distinct tag_id) from incRewriteCD group by user_name;", "incRewriteCD_mv")
     order_qt_select_mv "select user_name, count(distinct tag_id) from incRewriteCD group by user_name order by user_name;"
-
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_fail("select * from incRewriteCD order by time_col;", "incRewriteCD_mv")
-
-    mv_rewrite_fail("select user_name, count(distinct tag_id) from incRewriteCD group by user_name;", "incRewriteCD_mv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/joinOnCalcToJoin.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/joinOnCalcToJoin.groovy
@@ -63,13 +63,6 @@ suite ("joinOnCalcToJoin") {
     sql "analyze table joinOnCalcToJoin_1 with sync;"
     sql """alter table joinOnCalcToJoin_1 modify column time_col set stats ('row_count'='3');"""
 
-    sql """set enable_stats=false;"""
-
-    mv_rewrite_all_success("select * from (select empid, deptno from joinOnCalcToJoin where empid = 0) A join (select deptno, cost from joinOnCalcToJoin_1 where deptno > 0) B on A.deptno = B.deptno;",
-            ["joinOnLeftPToJoin_mv", "joinOnLeftPToJoin_1_mv"])
-
-    sql """set enable_stats=true;"""
-
     mv_rewrite_all_success("select * from (select empid, deptno from joinOnCalcToJoin where empid = 0) A join (select deptno, cost from joinOnCalcToJoin_1 where deptno > 0) B on A.deptno = B.deptno;",
             ["joinOnLeftPToJoin_mv", "joinOnLeftPToJoin_1_mv"])
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/joinOnLeftPToJoin.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/joinOnLeftPToJoin.groovy
@@ -64,15 +64,9 @@ suite ("joinOnLeftPToJoin") {
     sql "analyze table joinOnLeftPToJoin_1 with sync;"
     sql """alter table joinOnLeftPToJoin_1 modify column time_col set stats ('row_count'='3');"""
 
-    sql """set enable_stats=false;"""
 
     mv_rewrite_all_success("select * from (select deptno , sum(salary) from joinOnLeftPToJoin group by deptno) A join (select deptno, max(cost) from joinOnLeftPToJoin_1 group by deptno ) B on A.deptno = B.deptno;",
     ["joinOnLeftPToJoin_mv", "joinOnLeftPToJoin_1_mv"])
 
     order_qt_select_mv "select * from (select deptno , sum(salary) from joinOnLeftPToJoin group by deptno) A join (select deptno, max(cost) from joinOnLeftPToJoin_1 group by deptno ) B on A.deptno = B.deptno order by A.deptno;"
-
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_all_success("select * from (select deptno , sum(salary) from joinOnLeftPToJoin group by deptno) A join (select deptno, max(cost) from joinOnLeftPToJoin_1 group by deptno ) B on A.deptno = B.deptno;",
-            ["joinOnLeftPToJoin_mv", "joinOnLeftPToJoin_1_mv"])
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/onStar.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/onStar.groovy
@@ -45,7 +45,6 @@ suite ("onStar") {
     sql """insert into onStar values("2020-01-01",1,"a",1,1,1);"""
 
     sql "analyze table onStar with sync;"
-    sql """set enable_stats=false;"""
 
     order_qt_select_star "select * from onStar order by empid;"
     order_qt_select_mv "select * from onStar where deptno = 1 order by empid;"

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/onlyGroupBy.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/onlyGroupBy.groovy
@@ -53,10 +53,6 @@ suite ("onlyGroupBy") {
 
     sql "analyze table onlyGroupBy with sync;"
     sql """alter table onlyGroupBy modify column time_col set stats ('row_count'='9');"""
-    sql """set enable_stats=false;"""
 
-    mv_rewrite_success("select deptno from onlyGroupBy group by deptno;", "onlyGroupBy_mv")
-
-    sql """set enable_stats=true;"""
     mv_rewrite_success("select deptno from onlyGroupBy group by deptno;", "onlyGroupBy_mv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/orderByOnPView.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/orderByOnPView.groovy
@@ -49,17 +49,9 @@ suite ("orderByOnPView") {
     sql "analyze table orderByOnPView with sync;"
     sql """alter table orderByOnPView modify column time_col set stats ('row_count'='4');"""
 
-    sql """set enable_stats=false;"""
-
     mv_rewrite_fail("select * from orderByOnPView where time_col='2020-01-01' order by empid;", "orderByOnPView_mv")
     order_qt_select_star "select * from orderByOnPView order by empid;"
 
     mv_rewrite_success("select empid from orderByOnPView where deptno = 0 order by deptno;", "orderByOnPView_mv")
     order_qt_select_mv "select empid from orderByOnPView order by deptno;"
-
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_fail("select * from orderByOnPView where time_col='2020-01-01' order by empid;", "orderByOnPView_mv")
-
-    mv_rewrite_success("select empid from orderByOnPView where deptno = 0 order by deptno;", "orderByOnPView_mv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV1.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV1.groovy
@@ -50,17 +50,10 @@ suite ("projectMV1") {
     sql "analyze table projectMV1 with sync;"
     sql """alter table projectMV1 modify column time_col set stats ('row_count'='3');"""
 
-    sql """set enable_stats=false;"""
-
     mv_rewrite_fail("select * from projectMV1 where time_col='2020-01-01' order by empid;", "projectMV1_mv")
     order_qt_select_star "select * from projectMV1 order by empid;"
 
     mv_rewrite_success("select empid, deptno from projectMV1 where deptno=0 order by empid;", "projectMV1_mv")
     order_qt_select_mv "select empid, deptno from projectMV1 order by empid;"
 
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_fail("select * from projectMV1 where time_col='2020-01-01' order by empid;", "projectMV1_mv")
-
-    mv_rewrite_success("select empid, deptno from projectMV1 where deptno=0 order by empid;", "projectMV1_mv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV2.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV2.groovy
@@ -48,8 +48,6 @@ suite ("projectMV2") {
     sql "analyze table projectMV2 with sync;"
     sql """alter table projectMV2 modify column time_col set stats ('row_count'='3');"""
 
-    sql """set enable_stats=false;"""
-
     mv_rewrite_fail("select * from projectMV2 order by empid;", "projectMV2_mv")
     order_qt_select_star "select * from projectMV2 order by empid;"
 
@@ -58,12 +56,4 @@ suite ("projectMV2") {
 
     mv_rewrite_fail("select name from projectMV2 where deptno -1 = 0 order by empid;", "projectMV2_mv")
     order_qt_select_base "select name from projectMV2 where deptno -1 = 0 order by empid;"
-
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_fail("select * from projectMV2 order by empid;", "projectMV2_mv")
-
-    mv_rewrite_success("select empid + 1 from projectMV2 where deptno = 1 order by empid;", "projectMV2_mv")
-
-    mv_rewrite_fail("select name from projectMV2 where deptno -1 = 0 order by empid;", "projectMV2_mv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV3.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV3.groovy
@@ -50,7 +50,6 @@ suite ("projectMV3") {
 
     sql "analyze table projectMV3 with sync;"
     sql """alter table projectMV3 modify column time_col set stats ('row_count'='3');"""
-    sql """set enable_stats=false;"""
 
     mv_rewrite_fail("select * from projectMV3 order by empid;", "projectMV3_mv")
     order_qt_select_star "select * from projectMV3 order by empid;"
@@ -60,13 +59,4 @@ suite ("projectMV3") {
 
     mv_rewrite_success("select name from projectMV3 where deptno = 0 order by empid;", "projectMV3_mv")
     order_qt_select_mv2 "select name from projectMV3 where deptno -1 = 0 order by empid;"
-
-    sql """set enable_stats=true;"""
-    sql """alter table projectMV3 modify column time_col set stats ('row_count'='3');"""
-
-    mv_rewrite_fail("select * from projectMV3 order by empid;", "projectMV3_mv")
-
-    mv_rewrite_success("select empid + 1, name from projectMV3 where deptno = 1 order by empid;", "projectMV3_mv")
-
-    mv_rewrite_success("select name from projectMV3 where deptno = 0 order by empid;", "projectMV3_mv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV4.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/projectMV4.groovy
@@ -50,8 +50,6 @@ suite ("projectMV4") {
     sql "analyze table projectMV4 with sync;"
     sql """alter table projectMV4 modify column time_col set stats ('row_count'='3');"""
 
-    sql """set enable_stats=false;"""
-
     mv_rewrite_fail("select * from projectMV4 order by empid;", "projectMV4_mv")
     order_qt_select_star "select * from projectMV4 order by empid;"
 
@@ -60,12 +58,4 @@ suite ("projectMV4") {
 
     mv_rewrite_fail("select empid from projectMV4 where deptno > 1 and empid > 1 and time_col = '2020-01-01' order by empid;", "projectMV4_mv")
     order_qt_select_base "select empid from projectMV4 where deptno > 1 and empid > 1 order by empid;"
-
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_fail("select * from projectMV4 order by empid;", "projectMV4_mv")
-
-    mv_rewrite_success("select name from projectMV4 where deptno > 1 and salary > 1 and name = 'a' order by name;", "projectMV4_mv")
-
-    mv_rewrite_fail("select empid from projectMV4 where deptno > 1 and empid > 1 and time_col = '2020-01-01' order by empid;", "projectMV4_mv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/subQuery.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/subQuery.groovy
@@ -48,21 +48,6 @@ suite ("subQuery") {
     sql "analyze table subQuery with sync;"
     sql """alter table subQuery modify column time_col set stats ('row_count'='4');"""
 
-    sql """set enable_stats=false;"""
-
     mv_rewrite_fail("select * from subQuery order by empid;", "subQuery_mv")
     order_qt_select_star "select * from subQuery order by empid;"
-
-    /*
-    explain {
-        sql("select empid, deptno, salary from subQuery e1 where empid = (select max(empid) from subQuery where deptno = e1.deptno);")
-        contains "(subQuery_mv)"
-        contains "(subQuery)"
-    }
-    qt_select_mv "select empid, deptno, salary from subQuery e1 where empid = (select max(empid) from subQuery where deptno = e1.deptno) order by deptno;"
-     */
-
-     sql """set enable_stats=true;"""
-
-    mv_rewrite_fail("select * from subQuery order by empid;", "subQuery_mv")
 }

--- a/regression-test/suites/nereids_syntax_p0/mv/ut/unionDis.groovy
+++ b/regression-test/suites/nereids_syntax_p0/mv/ut/unionDis.groovy
@@ -48,8 +48,6 @@ suite ("unionDis") {
     sql "analyze table unionDis with sync;"
     sql """alter table unionDis modify column time_col set stats ('row_count'='4');"""
 
-    sql """set enable_stats=false;"""
-
     mv_rewrite_fail("select * from unionDis order by empid;", "unionDis_mv")
     order_qt_select_star "select * from unionDis order by empid;"
 
@@ -60,14 +58,4 @@ suite ("unionDis") {
         notContains "(unionDis)"
     }
     order_qt_select_mv "select * from (select empid, deptno from unionDis where empid >1 union select empid, deptno from unionDis where empid <0) t order by 1;"
-
-    sql """set enable_stats=true;"""
-
-    mv_rewrite_fail("select * from unionDis order by empid;", "unionDis_mv")
-
-    explain {
-        sql("select empid, deptno from unionDis where empid >1 union select empid, deptno from unionDis where empid <0 order by empid;")
-        contains "(unionDis_mv)"
-        notContains "(unionDis)"
-    }
 }

--- a/regression-test/suites/nereids_syntax_p0/rollup/agg.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup/agg.groovy
@@ -76,10 +76,7 @@ suite("agg") {
     sql "insert into ${tbName} values(2, 1, 'test2', 100,100,100);"
 
     sql "analyze table ${tbName} with sync;"
-    sql """set enable_stats=false;"""
 
-    mv_rewrite_success("SELECT citycode,SUM(pv) FROM ${tbName} GROUP BY citycode", "rollup_city")
-    sql """set enable_stats=true;"""
     mv_rewrite_success("SELECT citycode,SUM(pv) FROM ${tbName} GROUP BY citycode", "rollup_city")
 
     qt_sql "SELECT citycode,SUM(pv) FROM ${tbName} GROUP BY citycode"

--- a/regression-test/suites/nereids_syntax_p0/rollup/agg_date.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup/agg_date.groovy
@@ -84,11 +84,7 @@ suite("agg_date", "rollup") {
     sql "insert into ${tbName} values('2022-08-23', '2022-08-23 11:11:11.111111', '2022-08-23 11:11:11.111111', '2022-08-23 11:11:11.111111', '2022-08-23', '2022-08-23 11:11:11.111111', '2022-08-23 11:11:11.111111', '2022-08-23 11:11:11.111111', '2022-08-23 11:11:11.111111');"
 
     sql "analyze table ${tbName} with sync;"
-    sql """set enable_stats=false;"""
 
-    mv_rewrite_success("SELECT datek1,datetimek1,datetimek2,datetimek3,max(datev1),max(datetimev1),max(datetimev2),max(datetimev3) FROM ${tbName} GROUP BY datek1,datetimek1,datetimek2,datetimek3",
-            "rollup_date")
-    sql """set enable_stats=true;"""
     mv_rewrite_success("SELECT datek1,datetimek1,datetimek2,datetimek3,max(datev1),max(datetimev1),max(datetimev2),max(datetimev3) FROM ${tbName} GROUP BY datek1,datetimek1,datetimek2,datetimek3",
             "rollup_date")
 

--- a/regression-test/suites/nereids_syntax_p0/rollup/date.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup/date.groovy
@@ -51,17 +51,8 @@ suite("date", "rollup") {
     Thread.sleep(2000)
 
     sql "analyze table ${tbName1} with sync;"
-    sql """set enable_stats=false;"""
-
-    mv_rewrite_success("SELECT store_id, max(sale_date1) FROM ${tbName1} GROUP BY store_id", "amt_max1")
-
-    mv_rewrite_success("SELECT store_id, max(sale_datetime1) FROM ${tbName1} GROUP BY store_id", "amt_max2")
-
-    mv_rewrite_success("SELECT store_id, max(sale_datetime2) FROM ${tbName1} GROUP BY store_id", "amt_max3")
-
-    mv_rewrite_success("SELECT store_id, max(sale_datetime3) FROM ${tbName1} GROUP BY store_id", "amt_max4")
-    sql """set enable_stats=true;"""
     sql """alter table test_materialized_view_date1 modify column record_id set stats ('row_count'='2');"""
+
     mv_rewrite_success("SELECT store_id, max(sale_date1) FROM ${tbName1} GROUP BY store_id", "amt_max1")
 
     mv_rewrite_success("SELECT store_id, max(sale_datetime1) FROM ${tbName1} GROUP BY store_id", "amt_max2")

--- a/regression-test/suites/nereids_syntax_p0/rollup/hll/hll.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup/hll/hll.groovy
@@ -38,16 +38,11 @@ suite("hll", "rollup") {
     sql "analyze table test_materialized_view_hll1 with sync;"
     sql """alter table test_materialized_view_hll1 modify column record_id set stats ('row_count'='2');"""
 
-    sql """set enable_stats=false;"""
 
     explain {
         sql("SELECT store_id, hll_union_agg(hll_hash(sale_amt)) FROM test_materialized_view_hll1 GROUP BY store_id;")
         contains "(amt_count)"
     }
-    mv_rewrite_success("SELECT store_id, hll_union_agg(hll_hash(sale_amt)) FROM test_materialized_view_hll1 GROUP BY store_id;",
-            "amt_count")
-
-    sql """set enable_stats=true;"""
     mv_rewrite_success("SELECT store_id, hll_union_agg(hll_hash(sale_amt)) FROM test_materialized_view_hll1 GROUP BY store_id;",
             "amt_count")
 }

--- a/regression-test/suites/nereids_syntax_p0/rollup/hll_with_light_sc/hll_with_light_sc.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup/hll_with_light_sc/hll_with_light_sc.groovy
@@ -39,12 +39,7 @@ suite("hll_with_light_sc", "rollup") {
     sql "analyze table test_materialized_view_hll_with_light_sc1 with sync;"
     sql """alter table test_materialized_view_hll_with_light_sc1 modify column record_id set stats ('row_count'='2');"""
 
-    sql """set enable_stats=false;"""
-
     mv_rewrite_success("SELECT store_id, hll_union_agg(hll_hash(sale_amt)) FROM test_materialized_view_hll_with_light_sc1 GROUP BY store_id;",
             "amt_count1")
 
-    sql """set enable_stats=true;"""
-    mv_rewrite_success("SELECT store_id, hll_union_agg(hll_hash(sale_amt)) FROM test_materialized_view_hll_with_light_sc1 GROUP BY store_id;",
-            "amt_count1")
 }

--- a/regression-test/suites/nereids_syntax_p1/mv/aggregate/agg_sync_mv.groovy
+++ b/regression-test/suites/nereids_syntax_p1/mv/aggregate/agg_sync_mv.groovy
@@ -134,7 +134,6 @@ suite("agg_sync_mv") {
     sql """ SET enable_nereids_planner=true """
     sql """ SET enable_fallback_to_original_planner=false """
     sql """ analyze table agg_mv_test with sync"""
-    sql """ set enable_stats=false"""
 
     qt_select_any_value """select id, any_value(kint) from agg_mv_test group by id order by id;"""
     sql """drop materialized view if exists mv_sync1 on agg_mv_test;"""

--- a/regression-test/suites/rollup_p0/test_rollup_agg.groovy
+++ b/regression-test/suites/rollup_p0/test_rollup_agg.groovy
@@ -78,12 +78,6 @@ suite("test_rollup_agg") {
     sql "insert into ${tbName} values(2, 1, 'test2', 100,100,100);"
 
     sql "analyze table ${tbName} with sync;"
-    sql """set enable_stats=false;"""
-    explain {
-        sql("SELECT citycode,SUM(pv) FROM ${tbName} GROUP BY citycode")
-        contains("(rollup_city)")
-    }
-    sql """set enable_stats=true;"""
     explain {
         sql("SELECT citycode,SUM(pv) FROM ${tbName} GROUP BY citycode")
         contains("(rollup_city)")


### PR DESCRIPTION
### What problem does this PR solve?
In the regression testing for synchronous materialized views, many cases specify` set enable_stats=false.` This can result in row counts being reported as unknown, causing the Cost-Based Optimizer (CBO) to inconsistently choose query plans that include materialized views. In real‑world environments, enable_statsdefaults to true. Therefore, to stabilize the pipeline and fix the flakiness of synchronous materialized view test cases, we are removing `set enable_stats=false `from the tests.


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

