### PR TITLE
fix flight sql when contains &

### DIFF
--- a/be/src/service/arrow_flight/flight_sql_service.cpp
+++ b/be/src/service/arrow_flight/flight_sql_service.cpp
@@ -28,6 +28,7 @@
 #include "service/backend_options.h"
 #include "util/arrow/utils.h"
 #include "util/uid_util.h"
+#include "util/url_coding.h"
 
 namespace doris::flight {
 
@@ -60,7 +61,9 @@ private:
         TNetworkAddress result_addr;
         result_addr.hostname = fields[1];
         result_addr.port = std::stoi(fields[2]);
-        std::string sql = fields[3];
+        const std::string& sql_base64 = fields[3];
+        std::string sql;
+        base64_decode(sql_base64, &sql);
         std::shared_ptr<QueryStatement> statement =
                 std::make_shared<QueryStatement>(queryid, result_addr, sql);
         return statement;

--- a/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/DorisFlightSqlProducer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/DorisFlightSqlProducer.java
@@ -85,7 +85,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -240,7 +242,8 @@ public class DorisFlightSqlProducer implements FlightSqlProducer, AutoCloseable 
                         // Ticket contains the IP and Brpc Port of the Doris BE node where the query result is located.
                         final ByteString handle = ByteString.copyFromUtf8(
                                 DebugUtil.printId(tid) + "&" + endpointLoc.getResultInternalServiceAddr().hostname + "&"
-                                        + endpointLoc.getResultInternalServiceAddr().port + "&" + query);
+                                        + endpointLoc.getResultInternalServiceAddr().port + "&"
+                                        + Base64.getEncoder().encodeToString(query.getBytes(StandardCharsets.UTF_8)));
                         TicketStatementQuery ticketStatement = TicketStatementQuery.newBuilder()
                                 .setStatementHandle(handle).build();
                         Ticket ticket = new Ticket(Any.pack(ticketStatement).toByteArray());


### PR DESCRIPTION
### What problem does this PR solve?

fix flight sql when contains &, such as:
select 'a&b' as c

error message:
error org.apache.arrow.adbc.core.AdbcException: Malformed ticket, size: 5