### PR TITLE
[opt](cloud) optimize load performance for mow table when pack small files

### DIFF
--- a/be/src/cloud/cloud_rowset_writer.h
+++ b/be/src/cloud/cloud_rowset_writer.h
@@ -17,13 +17,14 @@
 
 #pragma once
 
+#include "cloud/cloud_storage_engine.h"
 #include "olap/rowset/beta_rowset_writer.h"
 
 namespace doris {
 
 class CloudRowsetWriter : public BaseBetaRowsetWriter {
 public:
-    CloudRowsetWriter();
+    CloudRowsetWriter(CloudStorageEngine& engine);
 
     ~CloudRowsetWriter() override;
 
@@ -38,6 +39,7 @@ private:
 
     Status _collect_packed_slice_location(io::FileWriter* file_writer, const std::string& file_path,
                                           RowsetMeta* rowset_meta);
+    CloudStorageEngine& _engine;
 };
 
 } // namespace doris

--- a/be/src/olap/calc_delete_bitmap_executor.h
+++ b/be/src/olap/calc_delete_bitmap_executor.h
@@ -22,6 +22,7 @@
 #include <atomic>
 #include <iosfwd>
 #include <memory>
+#include <shared_mutex>
 #include <utility>
 #include <vector>
 
@@ -61,6 +62,26 @@ public:
     Status submit(BaseTabletSPtr tablet, TabletSchemaSPtr schema, RowsetId rowset_id,
                   const std::vector<segment_v2::SegmentSharedPtr>& segments,
                   DeleteBitmapPtr delete_bitmap);
+
+    // submit a generic function to the thread pool
+    template <typename Func>
+    Status submit_func(Func&& func) {
+        {
+            std::shared_lock rlock(_lock);
+            RETURN_IF_ERROR(_status);
+            _resource_ctx = thread_context()->resource_ctx();
+        }
+        return _thread_token->submit_func([this, func = std::forward<Func>(func)]() {
+            SCOPED_ATTACH_TASK(_resource_ctx);
+            auto st = func();
+            if (!st.ok()) {
+                std::lock_guard wlock(_lock);
+                if (_status.ok()) {
+                    _status = st;
+                }
+            }
+        });
+    }
 
     // wait all tasks in token to be completed.
     Status wait();

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -338,14 +338,8 @@ Status BaseBetaRowsetWriter::_generate_delete_bitmap(int32_t segment_id) {
             [this, segment_id, specified_rowsets = std::move(specified_rowsets)]() -> Status {
                 Status st = Status::OK();
                 Defer defer([&]() {
-                    if (!st.ok()) {
-                        LOG(WARNING)
-                                << "failed to generate delete bitmap for segment_id=" << segment_id
-                                << ", tablet_id=" << _context.tablet_id
-                                << ", rowset_id=" << _context.rowset_id << ", error=" << st;
-                        auto* task = calc_delete_bitmap_task(segment_id);
-                        task->set_status(st);
-                    }
+                    auto* task = calc_delete_bitmap_task(segment_id);
+                    task->set_status(st);
                 });
                 // Step 1: Close file_writer (must be done before load_segments)
                 auto* file_writer = _seg_files.get(segment_id);
@@ -388,7 +382,6 @@ Status BaseBetaRowsetWriter::_generate_delete_bitmap(int32_t segment_id) {
                         _context.tablet, rowset_ptr, segments, specified_rowsets,
                         _context.mow_context->delete_bitmap, _context.mow_context->max_version,
                         nullptr, nullptr, nullptr);
-
                 if (!st.ok()) {
                     return st;
                 }

--- a/be/src/olap/rowset/rowset_factory.cpp
+++ b/be/src/olap/rowset/rowset_factory.cpp
@@ -74,9 +74,9 @@ Result<std::unique_ptr<RowsetWriter>> RowsetFactory::create_rowset_writer(
     // TODO(plat1ko): cloud vertical rowset writer
     std::unique_ptr<RowsetWriter> writer;
     if (is_vertical) {
-        writer = std::make_unique<VerticalBetaRowsetWriter<CloudRowsetWriter>>();
+        writer = std::make_unique<VerticalBetaRowsetWriter<CloudRowsetWriter>>(engine);
     } else {
-        writer = std::make_unique<CloudRowsetWriter>();
+        writer = std::make_unique<CloudRowsetWriter>(engine);
     }
 
     RETURN_IF_ERROR_RESULT(writer->init(context));


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #57770

Problem Summary:
The main change is to offload the entire delete bitmap calculation process—including file closing, rowset building, segment loading, and bitmap calculation—to a background thread pool. This prevents blocking the memtable flush thread, enhancing performance and concurrency. 

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

