### PR TITLE
[chore](code)Remove the unused member variable _getting_const_col and get_const_col no longer constructs a block.

### DIFF
--- a/be/src/vec/exprs/vbitmap_predicate.cpp
+++ b/be/src/vec/exprs/vbitmap_predicate.cpp
@@ -77,7 +77,7 @@ doris::Status vectorized::VBitmapPredicate::open(doris::RuntimeState* state,
 
 Status VBitmapPredicate::execute_column(VExprContext* context, const Block* block, size_t count,
                                         ColumnPtr& result_column) const {
-    DCHECK(_open_finished || _getting_const_col);
+    DCHECK(_open_finished || block == nullptr);
     DCHECK_EQ(_children.size(), 1);
 
     ColumnPtr argument_column;

--- a/be/src/vec/exprs/vbloom_predicate.cpp
+++ b/be/src/vec/exprs/vbloom_predicate.cpp
@@ -72,7 +72,7 @@ void VBloomPredicate::close(VExprContext* context, FunctionContext::FunctionStat
 
 Status VBloomPredicate::execute_column(VExprContext* context, const Block* block, size_t count,
                                        ColumnPtr& result_column) const {
-    DCHECK(_open_finished || _getting_const_col);
+    DCHECK(_open_finished || block == nullptr);
     DCHECK_EQ(_children.size(), 1);
 
     ColumnPtr argument_column;

--- a/be/src/vec/exprs/vcase_expr.cpp
+++ b/be/src/vec/exprs/vcase_expr.cpp
@@ -82,7 +82,7 @@ Status VCaseExpr::execute_column(VExprContext* context, const Block* block, size
         result_column = get_result_from_const(count);
         return Status::OK();
     }
-    DCHECK(_open_finished || _getting_const_col);
+    DCHECK(_open_finished || block == nullptr);
 
     size_t rows_count = count;
     std::vector<ColumnPtr> when_columns;

--- a/be/src/vec/exprs/vcast_expr.cpp
+++ b/be/src/vec/exprs/vcast_expr.cpp
@@ -146,7 +146,7 @@ DataTypePtr TryCastExpr::original_cast_return_type() const {
 
 Status TryCastExpr::execute_column(VExprContext* context, const Block* block, size_t count,
                                    ColumnPtr& result_column) const {
-    DCHECK(_open_finished) << _open_finished << _expr_name;
+    DCHECK(_open_finished || block == nullptr) << _open_finished << _expr_name;
     if (is_const_and_have_executed()) { // const have executed in open function
         result_column = get_result_from_const(count);
         return Status::OK();

--- a/be/src/vec/exprs/vcast_expr.cpp
+++ b/be/src/vec/exprs/vcast_expr.cpp
@@ -106,8 +106,7 @@ void VCastExpr::close(VExprContext* context, FunctionContext::FunctionStateScope
 
 Status VCastExpr::execute_column(VExprContext* context, const Block* block, size_t count,
                                  ColumnPtr& result_column) const {
-    DCHECK(_open_finished || _getting_const_col)
-            << _open_finished << _getting_const_col << _expr_name;
+    DCHECK(_open_finished || block == nullptr) << _open_finished << _expr_name;
     if (is_const_and_have_executed()) { // const have executed in open function
         result_column = get_result_from_const(count);
         return Status::OK();
@@ -147,8 +146,7 @@ DataTypePtr TryCastExpr::original_cast_return_type() const {
 
 Status TryCastExpr::execute_column(VExprContext* context, const Block* block, size_t count,
                                    ColumnPtr& result_column) const {
-    DCHECK(_open_finished || _getting_const_col)
-            << _open_finished << _getting_const_col << _expr_name;
+    DCHECK(_open_finished) << _open_finished << _expr_name;
     if (is_const_and_have_executed()) { // const have executed in open function
         result_column = get_result_from_const(count);
         return Status::OK();

--- a/be/src/vec/exprs/vcolumn_ref.h
+++ b/be/src/vec/exprs/vcolumn_ref.h
@@ -59,14 +59,14 @@ public:
 
     Status execute_column(VExprContext* context, const Block* block, size_t count,
                           ColumnPtr& result_column) const override {
-        DCHECK(_open_finished || _getting_const_col);
+        DCHECK(_open_finished || block == nullptr);
         result_column = block->get_by_position(_column_id + _gap).column;
         DCHECK_EQ(result_column->size(), count);
         return Status::OK();
     }
 
     DataTypePtr execute_type(const Block* block) const override {
-        DCHECK(_open_finished || _getting_const_col);
+        DCHECK(_open_finished || block == nullptr);
         return block->get_by_position(_column_id + _gap).type;
     }
 

--- a/be/src/vec/exprs/vcondition_expr.cpp
+++ b/be/src/vec/exprs/vcondition_expr.cpp
@@ -447,7 +447,7 @@ Status VectorizedIfExpr::_execute_impl_internal(Block& block, const ColumnNumber
 
 Status VectorizedIfExpr::execute_column(VExprContext* context, const Block* block, size_t count,
                                         ColumnPtr& result_column) const {
-    DCHECK(_open_finished || _getting_const_col) << debug_string();
+    DCHECK(_open_finished || block == nullptr) << debug_string();
     DCHECK_EQ(_children.size(), 3) << "IF expr must have three children";
 
     ColumnPtr cond_column;
@@ -487,7 +487,7 @@ Status VectorizedIfExpr::execute_column(VExprContext* context, const Block* bloc
 
 Status VectorizedIfNullExpr::execute_column(VExprContext* context, const Block* block, size_t count,
                                             ColumnPtr& result_column) const {
-    DCHECK(_open_finished || _getting_const_col) << debug_string();
+    DCHECK(_open_finished || block == nullptr) << debug_string();
     DCHECK_EQ(_children.size(), 2) << "IFNULL expr must have two children";
 
     ColumnPtr first_column;

--- a/be/src/vec/exprs/vdirect_in_predicate.h
+++ b/be/src/vec/exprs/vdirect_in_predicate.h
@@ -111,7 +111,7 @@ public:
 private:
     Status _do_execute(VExprContext* context, const Block* block, size_t count,
                        ColumnPtr& result_column, ColumnPtr* arg_column) const {
-        DCHECK(_open_finished || _getting_const_col);
+        DCHECK(_open_finished || block == nullptr);
 
         ColumnPtr argument_column;
         RETURN_IF_ERROR(_children[0]->execute_column(context, block, count, argument_column));

--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -210,7 +210,7 @@ Status VectorizedFnCall::_do_execute(VExprContext* context, const Block* block, 
             }
         }
     })
-    DCHECK(_open_finished || _getting_const_col) << debug_string();
+    DCHECK(_open_finished || block == nullptr) << debug_string();
 
     Block temp_block;
     ColumnNumbers args(_children.size());

--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -749,19 +749,9 @@ Status VExpr::get_const_col(VExprContext* context,
         return Status::OK();
     }
 
-    int result = -1;
-    Block block;
-    // If block is empty, some functions will produce no result. So we insert a column with
-    // single value here.
-    block.insert({ColumnUInt8::create(1), std::make_shared<DataTypeUInt8>(), ""});
-
-    _getting_const_col = true;
-    RETURN_IF_ERROR(execute(context, &block, &result));
-    _getting_const_col = false;
-
-    DCHECK(result != -1);
-    const auto& column = block.get_by_position(result).column;
-    _constant_col = std::make_shared<ColumnPtrWrapper>(column);
+    ColumnPtr result;
+    RETURN_IF_ERROR(execute_column(context, nullptr, 1, result));
+    _constant_col = std::make_shared<ColumnPtrWrapper>(result);
     if (column_wrapper != nullptr) {
         *column_wrapper = _constant_col;
     }

--- a/be/src/vec/exprs/vexpr.h
+++ b/be/src/vec/exprs/vexpr.h
@@ -145,6 +145,7 @@ public:
     // 'count' indicates the number of rows in the result column returned by this expression.
     // In the future this interface will add an additional parameter, Selector, which specifies
     // which rows in the block should be evaluated.
+    // If expr is executing constant expressions, then block should be nullptr.
     virtual Status execute_column(VExprContext* context, const Block* block, size_t count,
                                   ColumnPtr& result_column) const = 0;
 
@@ -249,8 +250,6 @@ public:
     virtual std::string debug_string() const;
     static std::string debug_string(const VExprSPtrs& exprs);
     static std::string debug_string(const VExprContextSPtrs& ctxs);
-
-    void set_getting_const_col(bool val = true) { _getting_const_col = val; }
 
     bool is_and_expr() const { return _fn.name.function_name == "and"; }
 
@@ -407,8 +406,6 @@ protected:
     // get_const_col()
     std::shared_ptr<ColumnPtrWrapper> _constant_col;
     bool _prepared = false; // for base class VExpr
-    bool _getting_const_col =
-            false; // if true, current execute() is in prepare() (that is, can't check _prepared)
     // for concrete classes
     bool _prepare_finished = false;
     bool _open_finished = false;

--- a/be/src/vec/exprs/vin_predicate.cpp
+++ b/be/src/vec/exprs/vin_predicate.cpp
@@ -122,7 +122,7 @@ Status VInPredicate::execute_column(VExprContext* context, const Block* block, s
     if (fast_execute(context, result_column)) {
         return Status::OK();
     }
-    DCHECK(_open_finished || _getting_const_col);
+    DCHECK(_open_finished || block == nullptr);
 
     // This is an optimization. For expressions like colA IN (1, 2, 3, 4),
     // where all values inside the IN clause are constants,

--- a/be/src/vec/exprs/vlambda_function_call_expr.h
+++ b/be/src/vec/exprs/vlambda_function_call_expr.h
@@ -65,7 +65,7 @@ public:
 
     Status execute_column(VExprContext* context, const Block* block, size_t count,
                           ColumnPtr& result_column) const override {
-        DCHECK(_open_finished || _getting_const_col);
+        DCHECK(_open_finished || block == nullptr);
         return _lambda_function->execute(context, block, count, result_column, _data_type,
                                          _children);
     }

--- a/be/src/vec/exprs/vlambda_function_expr.h
+++ b/be/src/vec/exprs/vlambda_function_expr.h
@@ -44,7 +44,7 @@ public:
 
     Status execute_column(VExprContext* context, const Block* block, size_t count,
                           ColumnPtr& result_column) const override {
-        DCHECK(_open_finished || _getting_const_col);
+        DCHECK(_open_finished || block == nullptr);
         return get_child(0)->execute_column(context, block, count, result_column);
     }
 

--- a/be/src/vec/exprs/vmatch_predicate.cpp
+++ b/be/src/vec/exprs/vmatch_predicate.cpp
@@ -136,7 +136,7 @@ Status VMatchPredicate::evaluate_inverted_index(VExprContext* context, uint32_t 
 
 Status VMatchPredicate::execute_column(VExprContext* context, const Block* block, size_t count,
                                        ColumnPtr& result_column) const {
-    DCHECK(_open_finished || _getting_const_col);
+    DCHECK(_open_finished || block == nullptr);
     if (fast_execute(context, result_column)) {
         return Status::OK();
     }


### PR DESCRIPTION
### What problem does this PR solve?

Currently this variable is only used in DCHECK. Whether to apply the const optimization (is_const_and_have_executed) does not depend on this variable.

```
    bool is_const_and_have_executed() const {
        return (is_constant() && (_constant_col != nullptr));
    }
```

We can determine whether we're currently executing a constant expression by checking if block is nullptr.

get_const_col no longer constructs a block

```
    int result = -1;
    Block block;
    // If block is empty, some functions will produce no result. So we insert a column with
    // single value here.
    block.insert({ColumnUInt8::create(1), std::make_shared<DataTypeUInt8>(), ""});

    RETURN_IF_ERROR(execute(context, &block, &result));
```

now

```
    ColumnPtr result;
    RETURN_IF_ERROR(execute_column(context, nullptr, 1, result));
    _constant_col = std::make_shared<ColumnPtrWrapper>(result);
```



### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

