### PR TITLE
[fix](filecache) fix benchmark varification problem

### DIFF
--- a/be/src/io/tools/file_cache_microbench.cpp
+++ b/be/src/io/tools/file_cache_microbench.cpp
@@ -1088,13 +1088,17 @@ private:
 
                     std::vector<doris::Slice> slices;
                     slices.reserve(4);
+                    std::vector<std::string> slice_buffers;
+                    slice_buffers.reserve(4);
                     size_t accumulated_size = 0;
 
                     // Stream data writing
                     while (data_generator.has_more()) {
                         doris::Slice chunk = data_generator.next_chunk(key);
-                        slices.push_back(chunk);
-                        accumulated_size += chunk.size;
+                        slice_buffers.emplace_back(chunk.data, chunk.size);
+                        const std::string& stored_chunk = slice_buffers.back();
+                        slices.emplace_back(stored_chunk.data(), stored_chunk.size());
+                        accumulated_size += stored_chunk.size();
 
                         if (accumulated_size >= config.write_batch_size ||
                             !data_generator.has_more()) {
@@ -1105,6 +1109,7 @@ private:
                                                          status.to_string());
                             }
                             slices.clear();
+                            slice_buffers.clear();
                             accumulated_size = 0;
                         }
                     }
@@ -1319,15 +1324,12 @@ private:
                                 file_size = exist_job_perfile_size;
                             }
 
-// TODO(dengxin): fix verify
-#if 0
-        // Verify read data
+                            // Verify read data
                             if (!DataVerifier::verify_data(key, file_size, read_offset, read_buffer,
                                                            read_length)) {
                                 throw std::runtime_error("Data verification failed for key: " +
                                                          key);
                             }
-#endif
 
                             LOG(INFO)
                                     << "read_offset=" << read_offset


### PR DESCRIPTION
Cause of the the problem:
The generator reused one 1 MB buffer, but the writer batched up to 5 MB before calling appendv, so every pending Slice pointed at the same buffer that kept being overwritten; the uploaded data no longer matched the key/offset tags, making DataVerifier fail.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

