### PR TITLE
[Exec](cache) condition cache digest error in runtime filter in and add debug log

### DIFF
--- a/be/src/exprs/hybrid_set.h
+++ b/be/src/exprs/hybrid_set.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <gen_cpp/internal_service.pb.h>
+#include <pdqsort.h>
 
 #include "common/object_pool.h"
 #include "exprs/filter_base.h"
@@ -415,7 +416,7 @@ public:
 
     uint64_t get_digest(uint64_t seed) override {
         std::vector<ElementType> elems(_set.begin(), _set.end());
-        std::sort(elems.begin(), elems.end());
+        pdqsort(elems.begin(), elems.end());
         if constexpr (std::is_same<ElementType, bool>::value) {
             for (const auto& v : elems) {
                 seed = HashUtil::crc_hash64(&v, sizeof(v), seed);
@@ -607,7 +608,7 @@ public:
 
     uint64_t get_digest(uint64_t seed) override {
         std::vector<StringRef> elems(_set.begin(), _set.end());
-        std::sort(elems.begin(), elems.end());
+        pdqsort(elems.begin(), elems.end());
 
         for (const auto& v : elems) {
             seed = HashUtil::crc_hash64(v.data, (uint32_t)v.size, seed);
@@ -795,7 +796,7 @@ public:
 
     uint64_t get_digest(uint64_t seed) override {
         std::vector<StringRef> elems(_set.begin(), _set.end());
-        std::sort(elems.begin(), elems.end());
+        pdqsort(elems.begin(), elems.end());
 
         for (const auto& v : elems) {
             seed = HashUtil::crc_hash64(v.data, (uint32_t)v.size, seed);

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -129,6 +129,13 @@ void SegmentIterator::_init_row_bitmap_by_condition_cache() {
             // Increment hit count if cache lookup is successful
             if (_find_condition_cache) {
                 DorisMetrics::instance()->condition_cache_hit_count->increment(1);
+                if (_opts.runtime_state) {
+                    VLOG_DEBUG << "Condition cache hit, query id: "
+                               << print_id(_opts.runtime_state->query_id())
+                               << ", segment id: " << _segment->id()
+                               << ", cache digest: " << _opts.condition_cache_digest
+                               << ", rowset id: " << _opts.rowset_id.to_string();
+                }
             }
 
             auto num_rows = _segment->num_rows();
@@ -2372,6 +2379,11 @@ Status SegmentIterator::next_batch(vectorized::Block* block) {
                     auto* condition_cache = ConditionCache::instance();
                     ConditionCache::CacheKey cache_key(_opts.rowset_id, _segment->id(),
                                                        _opts.condition_cache_digest);
+                    VLOG_DEBUG << "Condition cache insert, query id: "
+                               << print_id(_opts.runtime_state->query_id())
+                               << ", rowset id: " << _opts.rowset_id.to_string()
+                               << ", segment id: " << _segment->id()
+                               << ", cache digest: " << _opts.condition_cache_digest;
                     condition_cache->insert(cache_key, std::move(_condition_cache));
                 }
                 return res;

--- a/be/src/vec/exprs/vdirect_in_predicate.h
+++ b/be/src/vec/exprs/vdirect_in_predicate.h
@@ -106,7 +106,13 @@ public:
         return true;
     }
 
-    uint64_t get_digest(uint64_t seed) const override { return _filter->get_digest(seed); }
+    uint64_t get_digest(uint64_t seed) const override {
+        seed = _children[0]->get_digest(seed);
+        if (seed) {
+            return _filter->get_digest(seed);
+        }
+        return seed;
+    }
 
 private:
     Status _do_execute(VExprContext* context, const Block* block, size_t count,


### PR DESCRIPTION
### What problem does this PR solve?

## Overview

This pull request (authored by HappenLee) focuses on **performance optimization** (via sorting algorithm replacement) and **observability enhancement** (via logging expansion) for Apache Doris, along with a critical fix to ensure accurate digest calculation in predicate expressions. The changes span core data structure handling, segment iteration, and vectorized expression logic.

## Key Changes

### 1. Performance: Replace `std::sort` with `pdqsort` for Faster Set Sorting

- **File**: `be/src/exprs/hybrid_set.h`

- Modifications

  :

  - Added `#include <pdqsort.h>` to enable the pdqsort algorithm (a fast, adaptive quicksort variant optimized for real-world data).

  - Replaced

     

    ```
    std::sort(elems.begin(), elems.end())
    ```

     

    with

     

    ```
    pdqsort(elems.begin(), elems.end())
    ```

     

    in three set classes:

    - `HybridSet`: For generic element type sets.
    - `StringSet`: For string reference (`StringRef`) sets.
    - `StringValueSet`: For string value-based sets.

- **Purpose**: pdqsort outperforms `std::sort` in most practical scenarios (e.g., partially sorted data, duplicate values), reducing the time to sort elements during digest calculation for set-based operations.

### 2. Observability: Add Debug Logs for Condition Cache Operations

- **File**: `be/src/olap/rowset/segment_v2/segment_iterator.cpp`

- Modifications

  :

  - Cache Hit Logging

     

    (Line 132-138): Added

     

    ```
    VLOG_DEBUG
    ```

     

    output when a condition cache hit occurs, including:

    - Query ID (from `_opts.runtime_state->query_id()`).
    - Segment ID (`_segment->id()`).
    - Cache digest (`_opts.condition_cache_digest`).
    - Rowset ID (`_opts.rowset_id.to_string()`).

  - **Cache Insert Logging** (Line 2379-2383): Added `VLOG_DEBUG` output when inserting data into the condition cache, including the same fields as the hit log.

- **Purpose**: Improve debuggability for cache-related issues (e.g., false misses, incorrect cache entries) by linking cache events to specific queries and data segments.

### 3. Correctness: Fix Digest Calculation for `VDirectInPredicate`

- **File**: `be/src/vec/exprs/vdirect_in_predicate.h`

- Modifications

  :

  - Updated the

     

    ```
    get_digest(uint64_t seed)
    ```

     

    method to:

    1. First incorporate the digest of the predicate’s child expression (`_children[0]->get_digest(seed)`).
    2. Only propagate the filter’s digest (`_filter->get_digest(seed)`) if the child digest is non-zero; otherwise, return the original seed.

  - Replaced the previous implementation (which directly returned `_filter->get_digest(seed)` without including the child expression).

- **Purpose**: Ensure the digest uniquely identifies the full predicate logic (including both the child expression and the filter), preventing hash collisions that could lead to incorrect cache lookups or data processing.

## Impact

- **Performance**: Faster sorting for set-based digest calculations may reduce latency in query operations involving `IN` predicates or set comparisons.
- **Debuggability**: Detailed cache logs enable quicker diagnosis of cache performance issues.
- **Correctness**: Fixes a potential source of incorrect digest values, improving the reliability of cache-dependent features (e.g., condition cache, query result caching).

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

