### PR TITLE
[Chore](profile) adjust some profile

### DIFF
--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -540,7 +540,6 @@ Status PipelineTask::execute(bool* done) {
             SCOPED_TIMER(_sink_timer);
             Status status = Status::OK();
             DEFER_RELEASE_RESERVED();
-            COUNTER_UPDATE(_memory_reserve_times, 1);
             if (_state->get_query_ctx()
                         ->resource_ctx()
                         ->task_controller()

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -138,10 +138,6 @@ Status Channel::add_rows(Block* block, const uint32_t* data, const uint32_t offs
     if (_pblock == nullptr) {
         _pblock = std::make_unique<PBlock>();
     }
-    int64_t old_channel_mem_usage = mem_usage();
-    Defer update_mem([&]() {
-        COUNTER_UPDATE(_parent->memory_used_counter(), mem_usage() - old_channel_mem_usage);
-    });
     RETURN_IF_ERROR(_serializer.next_serialized_block(block, _pblock.get(), 1, &serialized, eos,
                                                       data, offset, size));
     if (serialized) {


### PR DESCRIPTION
### What problem does this PR solve?
This pull request makes minor cleanup changes to memory usage tracking in the pipeline and data stream sender components. The main focus is on removing redundant or unnecessary memory counter updates.

Memory tracking cleanup:

* Removed a redundant call to `COUNTER_UPDATE(_memory_reserve_times, 1)` in `PipelineTask::execute`, simplifying memory reservation tracking. (This was deleted because it was counted twice)
* Eliminated the deferred memory usage update logic in `Channel::add_rows`, streamlining memory counter management for channel operations. (Remove this because it will slightly affect performance)

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

