### PR TITLE
[opt](hive) use binary search to prune hive partitions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/cache/NereidsSortedPartitionsCacheManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/cache/NereidsSortedPartitionsCacheManager.java
@@ -127,6 +127,9 @@ public class NereidsSortedPartitionsCacheManager {
         }
 
         Map<?, PartitionItem> unsortedMap = table.getOriginPartitions(scan);
+        if (unsortedMap == null || unsortedMap.isEmpty()) {
+            return null;
+        }
         List<Entry<?, PartitionItem>> unsortedList = Lists.newArrayList(unsortedMap.entrySet());
         List<PartitionItemAndRange<?>> sortedRanges = Lists.newArrayListWithCapacity(unsortedMap.size());
         List<PartitionItemAndId<?>> defaultPartitions = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalTable.java
@@ -33,6 +33,8 @@ import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.ExternalSchemaCache.SchemaCacheKey;
 import org.apache.doris.datasource.mvcc.MvccSnapshot;
+import org.apache.doris.nereids.rules.expression.rules.SortedPartitionRanges;
+import org.apache.doris.nereids.trees.plans.algebra.CatalogRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFileScan.SelectedPartitions;
 import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.persist.gson.GsonUtils;
@@ -451,6 +453,18 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
      */
     public boolean supportInternalPartitionPruned() {
         return false;
+    }
+
+    /**
+     * Get sorted partition ranges for binary search filtering.
+     * Subclasses can override this method to provide sorted partition ranges
+     * for efficient partition pruning.
+     *
+     * @param scan the catalog relation
+     * @return sorted partition ranges, or empty if not supported
+     */
+    public Optional<SortedPartitionRanges<String>> getSortedPartitionRanges(CatalogRelation scan) {
+        return Optional.empty();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PruneFileScanPartition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PruneFileScanPartition.java
@@ -17,11 +17,8 @@
 
 package org.apache.doris.nereids.rules.rewrite;
 
-import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.PartitionItem;
-import org.apache.doris.catalog.SupportBinarySearchFilteringPartitions;
 import org.apache.doris.common.Pair;
-import org.apache.doris.common.cache.NereidsSortedPartitionsCacheManager;
 import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.rules.Rule;
@@ -96,11 +93,10 @@ public class PruneFileScanPartition extends OneRewriteRuleFactory {
 
         Map<String, PartitionItem> nameToPartitionItem = scan.getSelectedPartitions().selectedPartitions;
         Optional<SortedPartitionRanges<String>> sortedPartitionRanges = Optional.empty();
-        if (externalTable instanceof SupportBinarySearchFilteringPartitions) {
-            NereidsSortedPartitionsCacheManager partitionsCacheManager = Env.getCurrentEnv()
-                    .getSortedPartitionsCacheManager();
-            sortedPartitionRanges = (Optional) partitionsCacheManager.get(
-                            (SupportBinarySearchFilteringPartitions) externalTable, scan);
+        boolean enableBinarySearch = ctx.getConnectContext() == null
+                || ctx.getConnectContext().getSessionVariable().enableBinarySearchFilteringPartitions;
+        if (enableBinarySearch) {
+            sortedPartitionRanges = (Optional) externalTable.getSortedPartitionRanges(scan);
         }
         Pair<List<String>, Optional<Expression>> res = PartitionPruner.prune(
                 partitionSlots, filter.getPredicate(), nameToPartitionItem, ctx,


### PR DESCRIPTION
Followup #44586
Enable binary search partition pruning optimization for Hive external tables.

  This PR adds binary search partition pruning support for Hive tables by:
  - Adding `getSortedPartitionRanges()` method to `ExternalTable` base class
  - Maintaining sorted partition ranges directly in `HivePartitionValues` for cache lifecycle consistency
  - Overriding `getSortedPartitionRanges()` in `HMSExternalTable` to provide sorted ranges

  **Performance improvement (20000 partitions, 1000 queries):**
  - Binary search enabled: **4.548 seconds**
  - Binary search disabled: **12.849 seconds**
  - **~2.8x faster**