### PR TITLE
[fix](packed-file) improve packed file trailer tooling and recycler robustness

### DIFF
--- a/be/src/io/fs/packed_file_trailer.cpp
+++ b/be/src/io/fs/packed_file_trailer.cpp
@@ -1,0 +1,152 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "io/fs/packed_file_trailer.h"
+
+#include <array>
+#include <fstream>
+
+#include "common/status.h"
+#include "util/coding.h"
+
+namespace doris::io {
+
+Status parse_packed_file_trailer(std::string_view data, cloud::PackedFileDebugInfoPB* debug_pb,
+                                 uint32_t* version) {
+    if (debug_pb == nullptr || version == nullptr) {
+        return Status::InvalidArgument("Output parameters must not be null");
+    }
+    if (data.size() < kPackedFileTrailerSuffixSize) {
+        return Status::InternalError("Packed file too small to contain trailer");
+    }
+
+    const size_t suffix_offset = data.size() - kPackedFileTrailerSuffixSize;
+    const auto* suffix_ptr = reinterpret_cast<const uint8_t*>(data.data() + suffix_offset);
+    const uint32_t trailer_size = decode_fixed32_le(suffix_ptr);
+    const uint32_t trailer_version = decode_fixed32_le(suffix_ptr + sizeof(uint32_t));
+
+    // Preferred format: [PackedFileDebugInfoPB][length][version]
+    if (trailer_size > 0 && trailer_size <= data.size() - kPackedFileTrailerSuffixSize) {
+        const size_t payload_offset = data.size() - kPackedFileTrailerSuffixSize - trailer_size;
+        std::string_view payload(data.data() + payload_offset, trailer_size);
+        if (payload.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
+            return Status::InternalError("Packed file trailer payload too large");
+        }
+        cloud::PackedFileDebugInfoPB parsed_pb;
+        if (parsed_pb.ParseFromArray(payload.data(), static_cast<int>(payload.size()))) {
+            debug_pb->Swap(&parsed_pb);
+            *version = trailer_version;
+            return Status::OK();
+        }
+    }
+
+    // Legacy format fallback: [PackedFileInfoPB][length]
+    if (data.size() < sizeof(uint32_t)) {
+        return Status::InternalError("Packed file trailer corrupted");
+    }
+    const size_t legacy_suffix_offset = data.size() - sizeof(uint32_t);
+    const auto* legacy_ptr = reinterpret_cast<const uint8_t*>(data.data() + legacy_suffix_offset);
+    const uint32_t legacy_size = decode_fixed32_le(legacy_ptr);
+    if (legacy_size == 0 || legacy_size > data.size() - sizeof(uint32_t)) {
+        return Status::InternalError("Packed file trailer corrupted");
+    }
+    const size_t legacy_payload_offset = data.size() - sizeof(uint32_t) - legacy_size;
+    std::string_view legacy_payload(data.data() + legacy_payload_offset, legacy_size);
+    cloud::PackedFileInfoPB packed_info;
+    if (legacy_payload.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
+        return Status::InternalError("Packed file legacy trailer payload too large");
+    }
+    if (!packed_info.ParseFromArray(legacy_payload.data(),
+                                    static_cast<int>(legacy_payload.size()))) {
+        return Status::InternalError("Failed to parse packed file trailer");
+    }
+    debug_pb->Clear();
+    debug_pb->mutable_packed_file_info()->Swap(&packed_info);
+    *version = 0;
+    return Status::OK();
+}
+
+Status read_packed_file_trailer(const std::string& file_path,
+                                cloud::PackedFileDebugInfoPB* debug_pb, uint32_t* version) {
+    if (debug_pb == nullptr || version == nullptr) {
+        return Status::InvalidArgument("Output parameters must not be null");
+    }
+
+    std::ifstream file(file_path, std::ios::binary);
+    if (!file.is_open()) {
+        return Status::IOError("Failed to open packed file {}", file_path);
+    }
+
+    file.seekg(0, std::ios::end);
+    const std::streamoff file_size = file.tellg();
+    if (file_size < static_cast<std::streamoff>(sizeof(uint32_t))) {
+        return Status::InternalError("Packed file {} is too small", file_path);
+    }
+
+    auto read_tail = [&](std::streamoff count, std::string* out) -> Status {
+        out->assign(static_cast<size_t>(count), '\0');
+        file.seekg(file_size - count);
+        file.read(out->data(), count);
+        if (!file) {
+            return Status::IOError("Failed to read last {} bytes from {}", count, file_path);
+        }
+        return Status::OK();
+    };
+
+    // Try new format first.
+    if (file_size >= static_cast<std::streamoff>(kPackedFileTrailerSuffixSize)) {
+        std::array<char, kPackedFileTrailerSuffixSize> suffix {};
+        file.seekg(file_size - static_cast<std::streamoff>(suffix.size()));
+        file.read(suffix.data(), suffix.size());
+        if (file) {
+            const uint32_t trailer_size =
+                    decode_fixed32_le(reinterpret_cast<uint8_t*>(suffix.data()));
+            const uint32_t trailer_version =
+                    decode_fixed32_le(reinterpret_cast<uint8_t*>(suffix.data()) + sizeof(uint32_t));
+            const std::streamoff required =
+                    static_cast<std::streamoff>(kPackedFileTrailerSuffixSize + trailer_size);
+            if (trailer_size > 0 && file_size >= required) {
+                std::string tail;
+                RETURN_IF_ERROR(read_tail(required, &tail));
+                Status st = parse_packed_file_trailer(tail, debug_pb, version);
+                if (st.ok() && *version == trailer_version) {
+                    return st;
+                }
+            }
+        }
+        file.clear();
+    }
+
+    // Legacy fallback: PackedFileInfoPB + length.
+    std::array<char, sizeof(uint32_t)> legacy_suffix {};
+    file.seekg(file_size - static_cast<std::streamoff>(legacy_suffix.size()));
+    file.read(legacy_suffix.data(), legacy_suffix.size());
+    if (!file) {
+        return Status::IOError("Failed to read legacy trailer length from {}", file_path);
+    }
+    const uint32_t legacy_size =
+            decode_fixed32_le(reinterpret_cast<uint8_t*>(legacy_suffix.data()));
+    const std::streamoff required = static_cast<std::streamoff>(sizeof(uint32_t) + legacy_size);
+    if (legacy_size == 0 || file_size < required) {
+        return Status::InternalError("Packed file trailer corrupted for {}", file_path);
+    }
+    std::string tail;
+    RETURN_IF_ERROR(read_tail(required, &tail));
+    return parse_packed_file_trailer(tail, debug_pb, version);
+}
+
+} // namespace doris::io

--- a/be/src/io/fs/packed_file_trailer.h
+++ b/be/src/io/fs/packed_file_trailer.h
@@ -1,0 +1,38 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include "common/status.h"
+#include "gen_cpp/cloud.pb.h"
+
+namespace doris::io {
+
+constexpr uint32_t kPackedFileTrailerVersion = 1;
+constexpr size_t kPackedFileTrailerSuffixSize = sizeof(uint32_t) * 2;
+
+Status parse_packed_file_trailer(std::string_view data, cloud::PackedFileDebugInfoPB* debug_pb,
+                                 uint32_t* version);
+
+Status read_packed_file_trailer(const std::string& file_path,
+                                cloud::PackedFileDebugInfoPB* debug_pb, uint32_t* version);
+
+} // namespace doris::io

--- a/be/src/tools/CMakeLists.txt
+++ b/be/src/tools/CMakeLists.txt
@@ -53,3 +53,32 @@ add_custom_command(TARGET meta_tool POST_BUILD
     COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=$<TARGET_FILE:meta_tool>.dbg $<TARGET_FILE:meta_tool>
     )
 endif()
+
+add_executable(packed_file_tool
+    packed_file_tool.cpp
+)
+
+pch_reuse(packed_file_tool)
+
+set_target_properties(packed_file_tool PROPERTIES ENABLE_EXPORTS 1)
+
+if (COMPILER_CLANG)
+    target_compile_options(packed_file_tool PRIVATE
+    -Wno-implicit-int-conversion
+    -Wno-shorten-64-to-32
+    )
+endif()
+
+target_link_libraries(packed_file_tool
+    ${DORIS_LINK_LIBS}
+)
+
+install(TARGETS packed_file_tool DESTINATION ${OUTPUT_DIR}/lib/)
+
+if (NOT OS_MACOSX)
+add_custom_command(TARGET packed_file_tool POST_BUILD
+    COMMAND ${CMAKE_OBJCOPY} --only-keep-debug $<TARGET_FILE:packed_file_tool> $<TARGET_FILE:packed_file_tool>.dbg
+    COMMAND ${CMAKE_STRIP} --strip-debug --strip-unneeded $<TARGET_FILE:packed_file_tool>
+    COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=$<TARGET_FILE:packed_file_tool>.dbg $<TARGET_FILE:packed_file_tool>
+    )
+endif()

--- a/be/src/tools/packed_file_tool.cpp
+++ b/be/src/tools/packed_file_tool.cpp
@@ -38,7 +38,7 @@ int main(int argc, char** argv) {
         return -1;
     }
 
-    cloud::PackedFileDebugInfoPB debug_info;
+    doris::cloud::PackedFileDebugInfoPB debug_info;
     uint32_t version = 0;
     doris::Status st = doris::io::read_packed_file_trailer(FLAGS_file, &debug_info, &version);
     if (!st.ok()) {

--- a/be/src/tools/packed_file_tool.cpp
+++ b/be/src/tools/packed_file_tool.cpp
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gen_cpp/cloud.pb.h>
+#include <gflags/gflags.h>
+
+#include <iostream>
+#include <string>
+
+#include "common/status.h"
+#include "io/fs/packed_file_trailer.h"
+#include "json2pb/pb_to_json.h"
+
+DEFINE_string(file, "", "Path to a local merge/packed file");
+
+int main(int argc, char** argv) {
+    google::SetUsageMessage(
+            "Dump packed file trailer for debugging.\n"
+            "Usage: packed_file_tool --file=/path/to/merge_file");
+    google::ParseCommandLineFlags(&argc, &argv, true);
+
+    if (FLAGS_file.empty()) {
+        std::cerr << "Flag --file is required\n";
+        return -1;
+    }
+
+    cloud::PackedFileDebugInfoPB debug_info;
+    uint32_t version = 0;
+    doris::Status st = doris::io::read_packed_file_trailer(FLAGS_file, &debug_info, &version);
+    if (!st.ok()) {
+        std::cerr << "Failed to read packed file trailer: " << st.to_string() << std::endl;
+        return -1;
+    }
+
+    json2pb::Pb2JsonOptions options;
+    options.pretty_json = true;
+    std::string json;
+    json2pb::ProtoMessageToJson(debug_info, &json, options);
+
+    std::cout << "trailer_version: " << version << "\n" << json << std::endl;
+    return 0;
+}

--- a/be/test/io/packed_file_trailer_test.cpp
+++ b/be/test/io/packed_file_trailer_test.cpp
@@ -18,6 +18,7 @@
 #include "io/fs/packed_file_trailer.h"
 
 #include <gtest/gtest.h>
+#include <unistd.h>
 
 #include <filesystem>
 #include <fstream>
@@ -32,8 +33,13 @@ using doris::Status;
 
 namespace {
 std::string unique_temp_file() {
-    auto path = std::filesystem::temp_directory_path() / std::filesystem::unique_path();
-    return path.string();
+    auto dir = std::filesystem::temp_directory_path();
+    std::string pattern = (dir / "packed_file_XXXXXX").string();
+    int fd = mkstemp(pattern.data());
+    if (fd != -1) {
+        close(fd);
+    }
+    return pattern;
 }
 
 void write_file(const std::string& path, const std::string& data) {

--- a/be/test/io/packed_file_trailer_test.cpp
+++ b/be/test/io/packed_file_trailer_test.cpp
@@ -1,0 +1,110 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "io/fs/packed_file_trailer.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include "common/status.h"
+#include "util/coding.h"
+
+namespace doris::io {
+
+using doris::Status;
+
+namespace {
+std::string unique_temp_file() {
+    auto path = std::filesystem::temp_directory_path() / std::filesystem::unique_path();
+    return path.string();
+}
+
+void write_file(const std::string& path, const std::string& data) {
+    std::ofstream ofs(path, std::ios::binary | std::ios::trunc);
+    ofs.write(data.data(), data.size());
+}
+} // namespace
+
+TEST(PackedFileTrailerTest, ReadNewFormatTrailer) {
+    cloud::PackedFileInfoPB info;
+    info.set_resource_id("resource");
+    info.set_total_slice_num(1);
+    auto* slice = info.add_slices();
+    slice->set_path("a");
+    slice->set_offset(10);
+    slice->set_size(20);
+
+    cloud::PackedFileDebugInfoPB debug_pb;
+    debug_pb.mutable_packed_file_info()->CopyFrom(info);
+
+    std::string serialized_debug;
+    ASSERT_TRUE(debug_pb.SerializeToString(&serialized_debug));
+
+    std::string file_content = "data";
+    file_content.append(serialized_debug);
+    put_fixed32_le(&file_content, static_cast<uint32_t>(serialized_debug.size()));
+    put_fixed32_le(&file_content, kPackedFileTrailerVersion);
+
+    auto path = unique_temp_file();
+    write_file(path, file_content);
+
+    cloud::PackedFileDebugInfoPB parsed;
+    uint32_t version = 0;
+    Status st = read_packed_file_trailer(path, &parsed, &version);
+    ASSERT_TRUE(st.ok()) << st;
+    EXPECT_EQ(version, kPackedFileTrailerVersion);
+    ASSERT_TRUE(parsed.has_packed_file_info());
+    EXPECT_EQ(parsed.packed_file_info().resource_id(), info.resource_id());
+    ASSERT_EQ(parsed.packed_file_info().slices_size(), 1);
+    EXPECT_EQ(parsed.packed_file_info().slices(0).path(), "a");
+    EXPECT_EQ(parsed.packed_file_info().slices(0).offset(), 10);
+    EXPECT_EQ(parsed.packed_file_info().slices(0).size(), 20);
+
+    std::filesystem::remove(path);
+}
+
+TEST(PackedFileTrailerTest, ReadLegacyTrailer) {
+    cloud::PackedFileInfoPB info;
+    info.set_total_slice_num(2);
+    info.set_remaining_slice_bytes(100);
+
+    std::string serialized_info;
+    ASSERT_TRUE(info.SerializeToString(&serialized_info));
+
+    std::string file_content = "legacy_payload";
+    file_content.append(serialized_info);
+    put_fixed32_le(&file_content, static_cast<uint32_t>(serialized_info.size()));
+
+    auto path = unique_temp_file();
+    write_file(path, file_content);
+
+    cloud::PackedFileDebugInfoPB parsed;
+    uint32_t version = 0;
+    Status st = read_packed_file_trailer(path, &parsed, &version);
+    ASSERT_TRUE(st.ok()) << st;
+    EXPECT_EQ(version, 0);
+    ASSERT_TRUE(parsed.has_packed_file_info());
+    EXPECT_EQ(parsed.packed_file_info().total_slice_num(), info.total_slice_num());
+    EXPECT_EQ(parsed.packed_file_info().remaining_slice_bytes(), info.remaining_slice_bytes());
+
+    std::filesystem::remove(path);
+}
+
+} // namespace doris::io

--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -115,6 +115,7 @@ CONF_mInt64(check_recycle_task_interval_seconds, "600"); // 10min
 CONF_mInt64(recycler_sleep_before_scheduling_seconds, "60");
 // log a warning if a recycle task takes longer than this duration
 CONF_mInt64(recycle_task_threshold_seconds, "10800"); // 3h
+CONF_mInt32(decrement_packed_file_ref_counts_retry_times, "3");
 
 // force recycler to recycle all useless object.
 // **just for TEST**

--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -115,7 +115,11 @@ CONF_mInt64(check_recycle_task_interval_seconds, "600"); // 10min
 CONF_mInt64(recycler_sleep_before_scheduling_seconds, "60");
 // log a warning if a recycle task takes longer than this duration
 CONF_mInt64(recycle_task_threshold_seconds, "10800"); // 3h
-CONF_mInt32(decrement_packed_file_ref_counts_retry_times, "3");
+CONF_mInt32(decrement_packed_file_ref_counts_retry_times, "10");
+CONF_mInt32(packed_file_txn_retry_times, "10");
+// randomized interval to reduce conflict storms in FoundationDB, default 5-50ms
+CONF_mInt64(packed_file_txn_retry_sleep_min_ms, "5");
+CONF_mInt64(packed_file_txn_retry_sleep_max_ms, "50");
 
 // force recycler to recycle all useless object.
 // **just for TEST**

--- a/cloud/src/recycler/recycler.h
+++ b/cloud/src/recycler/recycler.h
@@ -434,6 +434,7 @@ private:
 
     // return 0 for success otherwise error
     int decrement_packed_file_ref_counts(const doris::RowsetMetaCloudPB& rs_meta_pb);
+    friend class RecyclerTest_delete_rowset_data_packed_file_respects_recycled_tablet_Test;
 
     int delete_packed_file_and_kv(const std::string& packed_file_path,
                                   const std::string& packed_key,

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -2157,6 +2157,12 @@ message PackedFileInfoPB {
     optional string resource_id = 9;
 }
 
+// Wrapper for packed file debug information. It keeps PackedFileInfoPB extensible for tools
+// reading packed file trailers.
+message PackedFileDebugInfoPB {
+    optional PackedFileInfoPB packed_file_info = 1;
+}
+
 message UpdatePackedFileInfoRequest {
     optional string cloud_unique_id = 1; // For auth
     optional string request_ip = 2;


### PR DESCRIPTION

Debug & tooling: write/parse versioned PackedFileDebugInfoPB trailer, add packed_file_tool and unit tests for easier debugging
Recycler retries: make packed file ref-count updates retryable/configurable to handle TXN_CONFLICTs
Prevent leak on recycle timing: ensure rowsets with packed slices are processed even when the tablet is already marked recycled
Trim logs: downgrade noisy state transition logs to VLOG_DEBUG while keeping upload completion details
