### PR TITLE
[fix](profile) sort out parquet reader profile

### DIFF
--- a/be/src/io/fs/buffered_reader.cpp
+++ b/be/src/io/fs/buffered_reader.cpp
@@ -819,12 +819,10 @@ Status BufferedFileStreamReader::read_bytes(const uint8_t** buf, uint64_t offset
     int64_t buf_remaining = _buf_end_offset - _buf_start_offset;
     int64_t to_read = std::min(_buf_size - buf_remaining, _file_end_offset - _buf_end_offset);
     int64_t has_read = 0;
-    SCOPED_RAW_TIMER(&_statistics.read_time);
     while (has_read < to_read) {
         size_t loop_read = 0;
         Slice result(_buf.get() + buf_remaining + has_read, to_read - has_read);
         RETURN_IF_ERROR(_file->read_at(_buf_end_offset + has_read, result, &loop_read, io_ctx));
-        _statistics.read_calls++;
         if (loop_read == 0) {
             break;
         }
@@ -833,7 +831,6 @@ Status BufferedFileStreamReader::read_bytes(const uint8_t** buf, uint64_t offset
     if (has_read != to_read) {
         return Status::Corruption("Try to read {} bytes, but received {} bytes", to_read, has_read);
     }
-    _statistics.read_bytes += to_read;
     _buf_end_offset += to_read;
     *buf = _buf.get();
     return Status::OK();

--- a/be/src/io/fs/tracing_file_reader.h
+++ b/be/src/io/fs/tracing_file_reader.h
@@ -48,6 +48,7 @@ public:
     void _collect_profile_before_close() override { return _inner->collect_profile_before_close(); }
 
     FileReaderStats* stats() const { return _stats; }
+    doris::io::FileReaderSPtr inner_reader() { return _inner; }
 
 private:
     doris::io::FileReaderSPtr _inner;

--- a/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.cpp
@@ -188,8 +188,8 @@ Status ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::load_page_data() {
             // check decompressed buffer size
             _reserve_decompress_buf(uncompressed_size);
             _page_data = Slice(_decompress_buf.get(), uncompressed_size);
-            SCOPED_RAW_TIMER(&_statistics.decompress_time);
-            _statistics.decompress_cnt++;
+            SCOPED_RAW_TIMER(&_chunk_statistics.decompress_time);
+            _chunk_statistics.decompress_cnt++;
             RETURN_IF_ERROR(_block_compress_codec->decompress(compressed_data, &_page_data));
         } else {
             // Don't need decompress
@@ -204,7 +204,7 @@ Status ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::load_page_data() {
 
     // Initialize repetition level and definition level. Skip when level = 0, which means required field.
     if (_max_rep_level > 0) {
-        SCOPED_RAW_TIMER(&_statistics.decode_level_time);
+        SCOPED_RAW_TIMER(&_chunk_statistics.decode_level_time);
         if (header->__isset.data_page_header_v2) {
             RETURN_IF_ERROR(_rep_level_decoder.init_v2(_v2_rep_levels, _max_rep_level,
                                                        _remaining_rep_nums));
@@ -215,7 +215,7 @@ Status ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::load_page_data() {
         }
     }
     if (_max_def_level > 0) {
-        SCOPED_RAW_TIMER(&_statistics.decode_level_time);
+        SCOPED_RAW_TIMER(&_chunk_statistics.decode_level_time);
         if (header->__isset.data_page_header_v2) {
             RETURN_IF_ERROR(_def_level_decoder.init_v2(_v2_def_levels, _max_def_level,
                                                        _remaining_def_nums));
@@ -255,7 +255,7 @@ Status ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::_decode_dict_page() {
     const tparquet::PageHeader* header = nullptr;
     RETURN_IF_ERROR(_page_reader->get_page_header(header));
     DCHECK_EQ(tparquet::PageType::DICTIONARY_PAGE, header->type);
-    SCOPED_RAW_TIMER(&_statistics.decode_dict_time);
+    SCOPED_RAW_TIMER(&_chunk_statistics.decode_dict_time);
 
     // Using the PLAIN_DICTIONARY enum value is deprecated in the Parquet 2.0 specification.
     // Prefer using RLE_DICTIONARY in a data page and PLAIN in a dictionary page for Parquet 2.0+ files.
@@ -314,7 +314,7 @@ Status ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::skip_values(size_t num_va
     }
     _remaining_num_values -= num_values;
     if (skip_data) {
-        SCOPED_RAW_TIMER(&_statistics.decode_value_time);
+        SCOPED_RAW_TIMER(&_chunk_statistics.decode_value_time);
         return _page_decoder->skip_values(num_values);
     } else {
         return Status::OK();
@@ -328,7 +328,7 @@ Status ColumnChunkReader<IN_COLLECTION, OFFSET_INDEX>::decode_values(
     if (select_vector.num_values() == 0) {
         return Status::OK();
     }
-    SCOPED_RAW_TIMER(&_statistics.decode_value_time);
+    SCOPED_RAW_TIMER(&_chunk_statistics.decode_value_time);
     if (UNLIKELY((doris_column->is_column_dictionary() || is_dict_filter) && !_has_dict)) {
         return Status::IOError("Not dictionary coded");
     }

--- a/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
@@ -60,6 +60,7 @@ struct ColumnChunkReaderStatistics {
     int64_t decode_level_time = 0;
     int64_t skip_page_header_num = 0;
     int64_t parse_page_header_num = 0;
+    int64_t read_page_header_time = 0;
 };
 
 /**
@@ -146,11 +147,15 @@ public:
     // Get page decoder
     Decoder* get_page_decoder() { return _page_decoder; }
 
-    ColumnChunkReaderStatistics& statistics() {
-        _statistics.decode_header_time = _page_reader->statistics().decode_header_time;
-        _statistics.skip_page_header_num = _page_reader->statistics().skip_page_header_num;
-        _statistics.parse_page_header_num = _page_reader->statistics().parse_page_header_num;
-        return _statistics;
+    ColumnChunkReaderStatistics& chunk_statistics() {
+        _chunk_statistics.decode_header_time = _page_reader->page_statistics().decode_header_time;
+        _chunk_statistics.skip_page_header_num =
+                _page_reader->page_statistics().skip_page_header_num;
+        _chunk_statistics.parse_page_header_num =
+                _page_reader->page_statistics().parse_page_header_num;
+        _chunk_statistics.read_page_header_time =
+                _page_reader->page_statistics().read_page_header_time;
+        return _chunk_statistics;
     }
 
     Status read_dict_values_to_column(MutableColumnPtr& doris_column) {
@@ -238,7 +243,7 @@ private:
     // Map: encoding -> Decoder
     // Plain or Dictionary encoding. If the dictionary grows too big, the encoding will fall back to the plain encoding
     std::unordered_map<int, std::unique_ptr<Decoder>> _decoders;
-    ColumnChunkReaderStatistics _statistics;
+    ColumnChunkReaderStatistics _chunk_statistics;
 };
 #include "common/compile_check_end.h"
 

--- a/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "io/fs/tracing_file_reader.h"
 #include "runtime/define_primitive_type.h"
 #include "schema_desc.h"
 #include "util/runtime_profile.h"
@@ -255,7 +256,10 @@ Status ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::init(io::FileReaderSPtr 
                                                     : chunk_meta.data_page_offset;
     size_t chunk_len = chunk_meta.total_compressed_size;
     size_t prefetch_buffer_size = std::min(chunk_len, max_buf_size);
-    if (typeid_cast<io::MergeRangeFileReader*>(file.get())) {
+    if ((typeid_cast<doris::io::TracingFileReader*>(file.get()) &&
+         typeid_cast<io::MergeRangeFileReader*>(
+                 ((doris::io::TracingFileReader*)(file.get()))->inner_reader().get())) ||
+        typeid_cast<io::MergeRangeFileReader*>(file.get())) {
         // turn off prefetch data when using MergeRangeFileReader
         prefetch_buffer_size = 0;
     }

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
@@ -1125,10 +1125,10 @@ void RowGroupReader::_convert_dict_cols_to_string_cols(Block* block) {
     }
 }
 
-ParquetColumnReader::Statistics RowGroupReader::statistics() {
-    ParquetColumnReader::Statistics st;
+ParquetColumnReader::ColumnStatistics RowGroupReader::merged_column_statistics() {
+    ParquetColumnReader::ColumnStatistics st;
     for (auto& reader : _column_readers) {
-        auto ost = reader.second->statistics();
+        auto ost = reader.second->column_statistics();
         st.merge(ost);
     }
     return st;

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.h
@@ -166,7 +166,7 @@ public:
     int64_t predicate_filter_time() const { return _predicate_filter_time; }
     int64_t dict_filter_rewrite_time() const { return _dict_filter_rewrite_time; }
 
-    ParquetColumnReader::Statistics statistics();
+    ParquetColumnReader::ColumnStatistics merged_column_statistics();
     void set_remaining_rows(int64_t rows) { _remaining_rows = rows; }
     int64_t get_remaining_rows() { return _remaining_rows; }
 

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -147,13 +147,15 @@ void ParquetReader::_init_profile() {
         ADD_TIMER_WITH_LEVEL(_profile, parquet_profile, 1);
 
         _parquet_profile.filtered_row_groups = ADD_CHILD_COUNTER_WITH_LEVEL(
-                _profile, "FilteredGroups", TUnit::UNIT, parquet_profile, 1);
+                _profile, "RowGroupsFiltered", TUnit::UNIT, parquet_profile, 1);
         _parquet_profile.filtered_row_groups_by_min_max = ADD_CHILD_COUNTER_WITH_LEVEL(
-                _profile, "FilteredGroupsByMinMax", TUnit::UNIT, parquet_profile, 1);
+                _profile, "RowGroupFilteredByMinMax", TUnit::UNIT, parquet_profile, 1);
         _parquet_profile.filtered_row_groups_by_bloom_filter = ADD_CHILD_COUNTER_WITH_LEVEL(
-                _profile, "FilteredGroupsByBloomFilter", TUnit::UNIT, parquet_profile, 1);
+                _profile, "RowGroupFilteredByBloomFilter", TUnit::UNIT, parquet_profile, 1);
         _parquet_profile.to_read_row_groups = ADD_CHILD_COUNTER_WITH_LEVEL(
-                _profile, "ReadGroups", TUnit::UNIT, parquet_profile, 1);
+                _profile, "RowGroupReadNum", TUnit::UNIT, parquet_profile, 1);
+        _parquet_profile.total_row_groups = ADD_CHILD_COUNTER_WITH_LEVEL(
+                _profile, "RowGroupTotalNum", TUnit::UNIT, parquet_profile, 1);
         _parquet_profile.filtered_group_rows = ADD_CHILD_COUNTER_WITH_LEVEL(
                 _profile, "FilteredRowsByGroup", TUnit::UNIT, parquet_profile, 1);
         _parquet_profile.filtered_page_rows = ADD_CHILD_COUNTER_WITH_LEVEL(
@@ -164,16 +166,14 @@ void ParquetReader::_init_profile() {
                 _profile, "FilteredBytes", TUnit::BYTES, parquet_profile, 1);
         _parquet_profile.raw_rows_read = ADD_CHILD_COUNTER_WITH_LEVEL(
                 _profile, "RawRowsRead", TUnit::UNIT, parquet_profile, 1);
-        _parquet_profile.to_read_bytes = ADD_CHILD_COUNTER_WITH_LEVEL(
-                _profile, "ReadBytes", TUnit::BYTES, parquet_profile, 1);
         _parquet_profile.column_read_time =
                 ADD_CHILD_TIMER_WITH_LEVEL(_profile, "ColumnReadTime", parquet_profile, 1);
         _parquet_profile.parse_meta_time =
                 ADD_CHILD_TIMER_WITH_LEVEL(_profile, "ParseMetaTime", parquet_profile, 1);
         _parquet_profile.parse_footer_time =
                 ADD_CHILD_TIMER_WITH_LEVEL(_profile, "ParseFooterTime", parquet_profile, 1);
-        _parquet_profile.open_file_time =
-                ADD_CHILD_TIMER_WITH_LEVEL(_profile, "FileOpenTime", parquet_profile, 1);
+        _parquet_profile.file_reader_create_time =
+                ADD_CHILD_TIMER_WITH_LEVEL(_profile, "FileReaderCreateTime", parquet_profile, 1);
         _parquet_profile.open_file_num =
                 ADD_CHILD_COUNTER_WITH_LEVEL(_profile, "FileNum", TUnit::UNIT, parquet_profile, 1);
         _parquet_profile.page_index_read_calls =
@@ -195,7 +195,9 @@ void ParquetReader::_init_profile() {
         _parquet_profile.decompress_cnt = ADD_CHILD_COUNTER_WITH_LEVEL(
                 _profile, "DecompressCount", TUnit::UNIT, parquet_profile, 1);
         _parquet_profile.decode_header_time =
-                ADD_CHILD_TIMER_WITH_LEVEL(_profile, "DecodeHeaderTime", parquet_profile, 1);
+                ADD_CHILD_TIMER_WITH_LEVEL(_profile, "PageHeaderDecodeTime", parquet_profile, 1);
+        _parquet_profile.read_page_header_time =
+                ADD_CHILD_TIMER_WITH_LEVEL(_profile, "PageHeaderReadTime", parquet_profile, 1);
         _parquet_profile.decode_value_time =
                 ADD_CHILD_TIMER_WITH_LEVEL(_profile, "DecodeValueTime", parquet_profile, 1);
         _parquet_profile.decode_dict_time =
@@ -233,8 +235,8 @@ Status ParquetReader::_open_file() {
         return Status::EndOfFile("stop");
     }
     if (_file_reader == nullptr) {
-        SCOPED_RAW_TIMER(&_statistics.open_file_time);
-        ++_statistics.open_file_num;
+        SCOPED_RAW_TIMER(&_reader_statistics.file_reader_create_time);
+        ++_reader_statistics.open_file_num;
         _file_description.mtime =
                 _scan_range.__isset.modification_time ? _scan_range.modification_time : 0;
         io::FileReaderOptions reader_options =
@@ -248,7 +250,7 @@ Status ParquetReader::_open_file() {
     }
 
     if (_file_metadata == nullptr) {
-        SCOPED_RAW_TIMER(&_statistics.parse_footer_time);
+        SCOPED_RAW_TIMER(&_reader_statistics.parse_footer_time);
         if (_tracing_file_reader->size() <= sizeof(PARQUET_VERSION_NUMBER)) {
             // Some system may generate parquet file with only 4 bytes: PAR1
             // Should consider it as empty file.
@@ -264,9 +266,8 @@ Status ParquetReader::_open_file() {
             RETURN_IF_ERROR(parse_thrift_footer(_tracing_file_reader, &_file_metadata_ptr,
                                                 &meta_size, _io_ctx, enable_mapping_varbinary));
             _file_metadata = _file_metadata_ptr.get();
-            _column_statistics.read_bytes += meta_size;
             // parse magic number & parse meta data
-            _statistics.file_footer_read_calls += 1;
+            _reader_statistics.file_footer_read_calls += 1;
         } else {
             const auto& file_meta_cache_key =
                     FileMetaCache::get_key(_tracing_file_reader, _file_description);
@@ -277,10 +278,9 @@ Status ParquetReader::_open_file() {
                 _meta_cache->insert(file_meta_cache_key, _file_metadata_ptr.release(),
                                     &_meta_cache_handle);
                 _file_metadata = _meta_cache_handle.data<FileMetaData>();
-                _column_statistics.read_bytes += meta_size;
-                _statistics.file_footer_read_calls += 1;
+                _reader_statistics.file_footer_read_calls += 1;
             } else {
-                _statistics.file_footer_hit_cache++;
+                _reader_statistics.file_footer_hit_cache++;
             }
             _file_metadata = _meta_cache_handle.data<FileMetaData>();
         }
@@ -289,9 +289,6 @@ Status ParquetReader::_open_file() {
             return Status::InternalError("failed to get file meta data: {}",
                                          _file_description.path);
         }
-        _column_statistics.read_bytes += meta_size;
-        // parse magic number & parse meta data
-        _column_statistics.read_calls += 1;
     }
     return Status::OK();
 }
@@ -353,7 +350,7 @@ Status ParquetReader::init_reader(
         return Status::InternalError("failed to init parquet reader, please open reader first");
     }
 
-    SCOPED_RAW_TIMER(&_statistics.parse_meta_time);
+    SCOPED_RAW_TIMER(&_reader_statistics.parse_meta_time);
     _total_groups = _t_metadata->row_groups.size();
     if (_total_groups == 0) {
         return Status::EndOfFile("init reader failed, empty parquet file: " + _scan_range.path);
@@ -412,7 +409,7 @@ Status ParquetReader::set_fill_columns(
         const std::unordered_map<std::string, std::tuple<std::string, const SlotDescriptor*>>&
                 partition_columns,
         const std::unordered_map<std::string, VExprContextSPtr>& missing_columns) {
-    SCOPED_RAW_TIMER(&_statistics.parse_meta_time);
+    SCOPED_RAW_TIMER(&_reader_statistics.parse_meta_time);
     // std::unordered_map<column_name, std::pair<col_id, slot_id>>
     std::unordered_map<std::string, std::pair<uint32_t, int>> predicate_columns;
     // visit_slot for lazy mat.
@@ -635,7 +632,7 @@ Status ParquetReader::get_next_block(Block* block, size_t* read_rows, bool* eof)
         return Status::OK();
     }
 
-    SCOPED_RAW_TIMER(&_statistics.column_read_time);
+    SCOPED_RAW_TIMER(&_reader_statistics.column_read_time);
     Status batch_st =
             _current_group_reader->next_batch(block, _batch_size, read_rows, &_row_group_eof);
     if (batch_st.is<ErrorCode::END_OF_FILE>()) {
@@ -652,11 +649,13 @@ Status ParquetReader::get_next_block(Block* block, size_t* read_rows, bool* eof)
     }
 
     if (_row_group_eof) {
-        auto column_st = _current_group_reader->statistics();
+        auto column_st = _current_group_reader->merged_column_statistics();
         _column_statistics.merge(column_st);
-        _statistics.lazy_read_filtered_rows += _current_group_reader->lazy_read_filtered_rows();
-        _statistics.predicate_filter_time += _current_group_reader->predicate_filter_time();
-        _statistics.dict_filter_rewrite_time += _current_group_reader->dict_filter_rewrite_time();
+        _reader_statistics.lazy_read_filtered_rows +=
+                _current_group_reader->lazy_read_filtered_rows();
+        _reader_statistics.predicate_filter_time += _current_group_reader->predicate_filter_time();
+        _reader_statistics.dict_filter_rewrite_time +=
+                _current_group_reader->dict_filter_rewrite_time();
         if (_current_row_group_index.row_group_id + 1 == _total_groups) {
             *eof = true;
         } else {
@@ -741,23 +740,22 @@ Status ParquetReader::_next_row_group_reader() {
             group_size += column_compressed_size(field);
         }
 
-        _statistics.read_rows += candidate_row_ranges.count();
+        _reader_statistics.read_rows += candidate_row_ranges.count();
         if (_io_ctx) {
             _io_ctx->file_reader_stats->read_rows += candidate_row_ranges.count();
         }
 
         if (candidate_row_ranges.count() != 0) {
             // need read this row group.
-            _statistics.read_row_groups++;
-            _statistics.read_bytes += group_size;
-
-            _statistics.filtered_page_rows += row_group.num_rows - candidate_row_ranges.count();
+            _reader_statistics.read_row_groups++;
+            _reader_statistics.filtered_page_rows +=
+                    row_group.num_rows - candidate_row_ranges.count();
             break;
         } else {
             // this row group be filtered.
-            _statistics.filtered_row_groups++;
-            _statistics.filtered_bytes += group_size;
-            _statistics.filtered_group_rows += row_group.num_rows;
+            _reader_statistics.filtered_row_groups++;
+            _reader_statistics.filtered_bytes += group_size;
+            _reader_statistics.filtered_group_rows += row_group.num_rows;
         }
     }
 
@@ -929,11 +927,10 @@ Status ParquetReader::_process_page_index_filter(
         Slice res(off_index_buff.data(), page_index._offset_index_size);
         size_t bytes_read = 0;
         {
-            SCOPED_RAW_TIMER(&_statistics.read_page_index_time);
+            SCOPED_RAW_TIMER(&_reader_statistics.read_page_index_time);
             RETURN_IF_ERROR(_tracing_file_reader->read_at(page_index._offset_index_start, res,
                                                           &bytes_read, _io_ctx));
         }
-        _column_statistics.read_bytes += bytes_read;
         _column_statistics.page_index_read_calls++;
         _col_offsets.clear();
 
@@ -943,7 +940,7 @@ Status ParquetReader::_process_page_index_filter(
                 continue;
             }
             tparquet::OffsetIndex offset_index;
-            SCOPED_RAW_TIMER(&_statistics.parse_page_index_time);
+            SCOPED_RAW_TIMER(&_reader_statistics.parse_page_index_time);
             RETURN_IF_ERROR(
                     page_index.parse_offset_index(chunk, off_index_buff.data(), &offset_index));
             _col_offsets[parquet_col_id] = offset_index;
@@ -965,14 +962,13 @@ Status ParquetReader::_process_page_index_filter(
     size_t bytes_read = 0;
     Slice result(col_index_buff.data(), page_index._column_index_size);
     {
-        SCOPED_RAW_TIMER(&_statistics.read_page_index_time);
+        SCOPED_RAW_TIMER(&_reader_statistics.read_page_index_time);
         RETURN_IF_ERROR(_tracing_file_reader->read_at(page_index._column_index_start, result,
                                                       &bytes_read, _io_ctx));
     }
-    _column_statistics.read_bytes += bytes_read;
     _column_statistics.page_index_read_calls++;
 
-    SCOPED_RAW_TIMER(&_statistics.page_index_filter_time);
+    SCOPED_RAW_TIMER(&_reader_statistics.page_index_filter_time);
 
     // Construct a cacheable page index structure to avoid repeatedly reading the page index of the same column.
     ParquetPredicate::CachedPageIndexStat cached_page_index;
@@ -1015,7 +1011,7 @@ Status ParquetReader::_process_page_index_filter(
 
         tparquet::ColumnIndex column_index;
         {
-            SCOPED_RAW_TIMER(&_statistics.parse_page_index_time);
+            SCOPED_RAW_TIMER(&_reader_statistics.parse_page_index_time);
             RETURN_IF_ERROR(page_index.parse_column_index(column_chunk, col_index_buff.data(),
                                                           &column_index));
         }
@@ -1078,7 +1074,7 @@ Status ParquetReader::_process_min_max_bloom_filter(
         const RowGroupReader::RowGroupIndex& row_group_index, const tparquet::RowGroup& row_group,
         const std::vector<std::unique_ptr<MutilColumnBlockPredicate>>& push_down_pred,
         RowRanges* row_ranges) {
-    SCOPED_RAW_TIMER(&_statistics.row_group_filter_time);
+    SCOPED_RAW_TIMER(&_reader_statistics.row_group_filter_time);
     if (!_filter_groups) {
         // No row group filtering is needed;
         // for example, Iceberg reads position delete files.
@@ -1111,10 +1107,10 @@ Status ParquetReader::_process_min_max_bloom_filter(
         // Update statistics based on filter type
         if (filter_this_row_group) {
             if (filtered_by_min_max) {
-                _statistics.filtered_row_groups_by_min_max++;
+                _reader_statistics.filtered_row_groups_by_min_max++;
             }
             if (filtered_by_bloom_filter) {
-                _statistics.filtered_row_groups_by_bloom_filter++;
+                _reader_statistics.filtered_row_groups_by_bloom_filter++;
             }
         }
 
@@ -1204,7 +1200,7 @@ Status ParquetReader::_process_column_stat_filter(
                     }
 
                     if (!stat->bloom_filter) {
-                        SCOPED_RAW_TIMER(&_statistics.bloom_filter_read_time);
+                        SCOPED_RAW_TIMER(&_reader_statistics.bloom_filter_read_time);
                         auto st = ParquetPredicate::read_bloom_filter(
                                 meta_data, _tracing_file_reader, _io_ctx, stat);
                         if (!st.ok()) {
@@ -1274,41 +1270,53 @@ void ParquetReader::_collect_profile() {
     if (_current_group_reader != nullptr) {
         _current_group_reader->collect_profile_before_close();
     }
-    COUNTER_UPDATE(_parquet_profile.filtered_row_groups, _statistics.filtered_row_groups);
+    COUNTER_UPDATE(_parquet_profile.filtered_row_groups, _reader_statistics.filtered_row_groups);
     COUNTER_UPDATE(_parquet_profile.filtered_row_groups_by_min_max,
-                   _statistics.filtered_row_groups_by_min_max);
+                   _reader_statistics.filtered_row_groups_by_min_max);
     COUNTER_UPDATE(_parquet_profile.filtered_row_groups_by_bloom_filter,
-                   _statistics.filtered_row_groups_by_bloom_filter);
-    COUNTER_UPDATE(_parquet_profile.to_read_row_groups, _statistics.read_row_groups);
-    COUNTER_UPDATE(_parquet_profile.filtered_group_rows, _statistics.filtered_group_rows);
-    COUNTER_UPDATE(_parquet_profile.filtered_page_rows, _statistics.filtered_page_rows);
-    COUNTER_UPDATE(_parquet_profile.lazy_read_filtered_rows, _statistics.lazy_read_filtered_rows);
-    COUNTER_UPDATE(_parquet_profile.filtered_bytes, _statistics.filtered_bytes);
-    COUNTER_UPDATE(_parquet_profile.raw_rows_read, _statistics.read_rows);
-    COUNTER_UPDATE(_parquet_profile.to_read_bytes, _statistics.read_bytes);
-    COUNTER_UPDATE(_parquet_profile.column_read_time, _statistics.column_read_time);
-    COUNTER_UPDATE(_parquet_profile.parse_meta_time, _statistics.parse_meta_time);
-    COUNTER_UPDATE(_parquet_profile.parse_footer_time, _statistics.parse_footer_time);
-    COUNTER_UPDATE(_parquet_profile.open_file_time, _statistics.open_file_time);
-    COUNTER_UPDATE(_parquet_profile.open_file_num, _statistics.open_file_num);
-    COUNTER_UPDATE(_parquet_profile.page_index_filter_time, _statistics.page_index_filter_time);
-    COUNTER_UPDATE(_parquet_profile.read_page_index_time, _statistics.read_page_index_time);
-    COUNTER_UPDATE(_parquet_profile.parse_page_index_time, _statistics.parse_page_index_time);
-    COUNTER_UPDATE(_parquet_profile.row_group_filter_time, _statistics.row_group_filter_time);
-    COUNTER_UPDATE(_parquet_profile.file_footer_read_calls, _statistics.file_footer_read_calls);
-    COUNTER_UPDATE(_parquet_profile.file_footer_hit_cache, _statistics.file_footer_hit_cache);
+                   _reader_statistics.filtered_row_groups_by_bloom_filter);
+    COUNTER_UPDATE(_parquet_profile.to_read_row_groups, _reader_statistics.read_row_groups);
+    COUNTER_UPDATE(_parquet_profile.total_row_groups, _total_groups);
+    COUNTER_UPDATE(_parquet_profile.filtered_group_rows, _reader_statistics.filtered_group_rows);
+    COUNTER_UPDATE(_parquet_profile.filtered_page_rows, _reader_statistics.filtered_page_rows);
+    COUNTER_UPDATE(_parquet_profile.lazy_read_filtered_rows,
+                   _reader_statistics.lazy_read_filtered_rows);
+    COUNTER_UPDATE(_parquet_profile.filtered_bytes, _reader_statistics.filtered_bytes);
+    COUNTER_UPDATE(_parquet_profile.raw_rows_read, _reader_statistics.read_rows);
+    COUNTER_UPDATE(_parquet_profile.column_read_time, _reader_statistics.column_read_time);
+    COUNTER_UPDATE(_parquet_profile.parse_meta_time, _reader_statistics.parse_meta_time);
+    COUNTER_UPDATE(_parquet_profile.parse_footer_time, _reader_statistics.parse_footer_time);
+    COUNTER_UPDATE(_parquet_profile.file_reader_create_time,
+                   _reader_statistics.file_reader_create_time);
+    COUNTER_UPDATE(_parquet_profile.open_file_num, _reader_statistics.open_file_num);
+    COUNTER_UPDATE(_parquet_profile.page_index_filter_time,
+                   _reader_statistics.page_index_filter_time);
+    COUNTER_UPDATE(_parquet_profile.read_page_index_time, _reader_statistics.read_page_index_time);
+    COUNTER_UPDATE(_parquet_profile.parse_page_index_time,
+                   _reader_statistics.parse_page_index_time);
+    COUNTER_UPDATE(_parquet_profile.row_group_filter_time,
+                   _reader_statistics.row_group_filter_time);
+    COUNTER_UPDATE(_parquet_profile.file_footer_read_calls,
+                   _reader_statistics.file_footer_read_calls);
+    COUNTER_UPDATE(_parquet_profile.file_footer_hit_cache,
+                   _reader_statistics.file_footer_hit_cache);
 
     COUNTER_UPDATE(_parquet_profile.skip_page_header_num, _column_statistics.skip_page_header_num);
     COUNTER_UPDATE(_parquet_profile.parse_page_header_num,
                    _column_statistics.parse_page_header_num);
-    COUNTER_UPDATE(_parquet_profile.predicate_filter_time, _statistics.predicate_filter_time);
-    COUNTER_UPDATE(_parquet_profile.dict_filter_rewrite_time, _statistics.dict_filter_rewrite_time);
-    COUNTER_UPDATE(_parquet_profile.bloom_filter_read_time, _statistics.bloom_filter_read_time);
+    COUNTER_UPDATE(_parquet_profile.predicate_filter_time,
+                   _reader_statistics.predicate_filter_time);
+    COUNTER_UPDATE(_parquet_profile.dict_filter_rewrite_time,
+                   _reader_statistics.dict_filter_rewrite_time);
+    COUNTER_UPDATE(_parquet_profile.bloom_filter_read_time,
+                   _reader_statistics.bloom_filter_read_time);
     COUNTER_UPDATE(_parquet_profile.page_index_read_calls,
                    _column_statistics.page_index_read_calls);
     COUNTER_UPDATE(_parquet_profile.decompress_time, _column_statistics.decompress_time);
     COUNTER_UPDATE(_parquet_profile.decompress_cnt, _column_statistics.decompress_cnt);
     COUNTER_UPDATE(_parquet_profile.decode_header_time, _column_statistics.decode_header_time);
+    COUNTER_UPDATE(_parquet_profile.read_page_header_time,
+                   _column_statistics.read_page_header_time);
     COUNTER_UPDATE(_parquet_profile.decode_value_time, _column_statistics.decode_value_time);
     COUNTER_UPDATE(_parquet_profile.decode_dict_time, _column_statistics.decode_dict_time);
     COUNTER_UPDATE(_parquet_profile.decode_level_time, _column_statistics.decode_level_time);

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -149,13 +149,13 @@ void ParquetReader::_init_profile() {
         _parquet_profile.filtered_row_groups = ADD_CHILD_COUNTER_WITH_LEVEL(
                 _profile, "RowGroupsFiltered", TUnit::UNIT, parquet_profile, 1);
         _parquet_profile.filtered_row_groups_by_min_max = ADD_CHILD_COUNTER_WITH_LEVEL(
-                _profile, "RowGroupFilteredByMinMax", TUnit::UNIT, parquet_profile, 1);
+                _profile, "RowGroupsFilteredByMinMax", TUnit::UNIT, parquet_profile, 1);
         _parquet_profile.filtered_row_groups_by_bloom_filter = ADD_CHILD_COUNTER_WITH_LEVEL(
-                _profile, "RowGroupFilteredByBloomFilter", TUnit::UNIT, parquet_profile, 1);
+                _profile, "RowGroupsFilteredByBloomFilter", TUnit::UNIT, parquet_profile, 1);
         _parquet_profile.to_read_row_groups = ADD_CHILD_COUNTER_WITH_LEVEL(
-                _profile, "RowGroupReadNum", TUnit::UNIT, parquet_profile, 1);
+                _profile, "RowGroupsReadNum", TUnit::UNIT, parquet_profile, 1);
         _parquet_profile.total_row_groups = ADD_CHILD_COUNTER_WITH_LEVEL(
-                _profile, "RowGroupTotalNum", TUnit::UNIT, parquet_profile, 1);
+                _profile, "RowGroupsTotalNum", TUnit::UNIT, parquet_profile, 1);
         _parquet_profile.filtered_group_rows = ADD_CHILD_COUNTER_WITH_LEVEL(
                 _profile, "FilteredRowsByGroup", TUnit::UNIT, parquet_profile, 1);
         _parquet_profile.filtered_page_rows = ADD_CHILD_COUNTER_WITH_LEVEL(

--- a/be/src/vec/exec/scan/file_scanner.cpp
+++ b/be/src/vec/exec/scan/file_scanner.cpp
@@ -1768,6 +1768,10 @@ void FileScanner::update_realtime_counters() {
     _state->get_query_ctx()->resource_ctx()->io_context()->update_scan_bytes(
             _file_reader_stats->read_bytes);
 
+    int64_t delta_bytes_read_from_local =
+            _file_cache_statistics->bytes_read_from_local - _last_bytes_read_from_local;
+    int64_t delta_bytes_read_from_remote =
+            _file_cache_statistics->bytes_read_from_remote - _last_bytes_read_from_remote;
     if (_file_cache_statistics->bytes_read_from_local == 0 &&
         _file_cache_statistics->bytes_read_from_remote == 0) {
         _state->get_query_ctx()
@@ -1778,16 +1782,15 @@ void FileScanner::update_realtime_counters() {
                 _file_reader_stats->read_bytes);
     } else {
         _state->get_query_ctx()->resource_ctx()->io_context()->update_scan_bytes_from_local_storage(
-                _file_cache_statistics->bytes_read_from_local);
+                delta_bytes_read_from_local);
         _state->get_query_ctx()
                 ->resource_ctx()
                 ->io_context()
-                ->update_scan_bytes_from_remote_storage(
-                        _file_cache_statistics->bytes_read_from_remote);
+                ->update_scan_bytes_from_remote_storage(delta_bytes_read_from_remote);
         DorisMetrics::instance()->query_scan_bytes_from_local->increment(
-                _file_cache_statistics->bytes_read_from_local);
+                delta_bytes_read_from_local);
         DorisMetrics::instance()->query_scan_bytes_from_remote->increment(
-                _file_cache_statistics->bytes_read_from_remote);
+                delta_bytes_read_from_remote);
     }
 
     COUNTER_UPDATE(_file_read_bytes_counter, _file_reader_stats->read_bytes);
@@ -1797,8 +1800,9 @@ void FileScanner::update_realtime_counters() {
 
     _file_reader_stats->read_bytes = 0;
     _file_reader_stats->read_rows = 0;
-    _file_cache_statistics->bytes_read_from_local = 0;
-    _file_cache_statistics->bytes_read_from_remote = 0;
+
+    _last_bytes_read_from_local = _file_cache_statistics->bytes_read_from_local;
+    _last_bytes_read_from_remote = _file_cache_statistics->bytes_read_from_remote;
 }
 
 void FileScanner::_collect_profile_before_close() {

--- a/be/src/vec/exec/scan/file_scanner.h
+++ b/be/src/vec/exec/scan/file_scanner.h
@@ -232,6 +232,8 @@ private:
 
     std::pair<std::shared_ptr<RowIdColumnIteratorV2>, int> _row_id_column_iterator_pair = {nullptr,
                                                                                            -1};
+    int64_t _last_bytes_read_from_local = 0;
+    int64_t _last_bytes_read_from_remote = 0;
 
 private:
     Status _init_expr_ctxes();


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Refine some metrics in parquet reader profile.
1. Rename some `Statistics` class name to make it readable. (There are too many `Statistics` struct with same name)
2. Add `read page header timer` in parquet reader profile
3. fix issue of invalid check logic for `MergeRangeFileReader` when setting prefetch buffer size
4. fix issue that data cache profile is incorrect for external table can.

After #57204 and #58785

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

