### PR TITLE
[bugfix](memory_profile) should split memtable memory from task's memory profile

### DIFF
--- a/be/src/runtime/memory/memory_profile.h
+++ b/be/src/runtime/memory/memory_profile.h
@@ -102,11 +102,14 @@ private:
 
     // tasks memory counter
     RuntimeProfile::HighWaterMarkCounter* _tasks_memory_usage_counter;
+
+    // Memtable memory counter
+    RuntimeProfile::HighWaterMarkCounter* _memtable_memory_usage_counter;
+
     // reserved memory is the sum of all task reserved memory, is duplicated with all task memory counter.
     RuntimeProfile::HighWaterMarkCounter* _reserved_memory_usage_counter;
     RuntimeProfile::HighWaterMarkCounter* _query_usage_counter;
     RuntimeProfile::HighWaterMarkCounter* _load_usage_counter;
-    RuntimeProfile::HighWaterMarkCounter* _load_all_memtables_usage_counter;
     RuntimeProfile::HighWaterMarkCounter* _compaction_usage_counter;
     RuntimeProfile::HighWaterMarkCounter* _schema_change_usage_counter;
     RuntimeProfile::HighWaterMarkCounter* _other_usage_counter;


### PR DESCRIPTION
### What problem does this PR solve?
Current：
<img width="977" height="876" alt="image" src="https://github.com/user-attachments/assets/4c3c5dc3-779c-4877-9f24-b251e3fd10b1" />

Actually, the memtable's memory not included in the load memtracker. So that memtable's memory should be a single catagory. Like this:
<img width="887" height="884" alt="image" src="https://github.com/user-attachments/assets/5a1cc198-e9a1-4a26-b2e6-9fceb7562bd2" />

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

