### PR TITLE
Add wait mechanism for TPCH data loading to prevent token competition

### DIFF
--- a/tools/tpch-tools/bin/load-tpch-data.sh
+++ b/tools/tpch-tools/bin/load-tpch-data.sh
@@ -274,7 +274,7 @@ for file in "${TPCH_DATA_DIR}"/lineitem.tbl*; do
         echo >&3
     } &
 done
-
+wait
 date
 for file in "${TPCH_DATA_DIR}"/orders.tbl*; do
     read -r -u3
@@ -285,7 +285,7 @@ for file in "${TPCH_DATA_DIR}"/orders.tbl*; do
         echo >&3
     } &
 done
-
+wait
 date
 for file in "${TPCH_DATA_DIR}"/partsupp.tbl*; do
     read -r -u3


### PR DESCRIPTION
Add wait mechanism for TPCH data loading to prevent token competition

Fix token competition issue in load-tpch-data.sh where lineitem occupies all tokens, blocking orders and partsupp imports. Add wait commands after each table's import loop to ensure sequential processing of large tables.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Manual test (add detailed scripts or steps below)

- Behavior changed:
    - [ ] No.

- Does this need documentation?
    - [ ] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

