### PR TITLE
[improvement](editlog) Skip edit log writing when global variable value unchanged

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -416,7 +416,12 @@ public class VariableMgr {
         // global variable will make effect when is set immediately.
         wlock.lock();
         try {
-
+            // Check if the value has actually changed before writing edit log
+            String currentValue = getValue(ctx.getObj(), ctx.getField());
+            if (value.equals(currentValue)) {
+                // Value unchanged, skip setValue and edit log writing
+                return;
+            }
             setValue(ctx.getObj(), new SessionVariableField(ctx.getField()), value);
             // write edit log
             GlobalVarPersistInfo info = new GlobalVarPersistInfo(defaultSessionVariable, Lists.newArrayList(name));


### PR DESCRIPTION
[improvement] (deitlog) Skip edit log writing when global variable value unchanged

Avoid unnecessary edit log writes when setting global variable to the same value. This reduces disk I/O and prevents edit log bloat.

The optimization adds a value comparison check before setting the variable and writing edit log, maintaining thread safety under existing wlock.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)

- Behavior changed:
    - [ ] No.

- Does this need documentation?
    - [ ] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

