### PR TITLE
[fix](enforcer) shuffle if has continuous project or filter on cte consumer

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulatorTest.java
@@ -1,0 +1,167 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.properties;
+
+import org.apache.doris.common.Pair;
+import org.apache.doris.nereids.CascadesContext;
+import org.apache.doris.nereids.cost.Cost;
+import org.apache.doris.nereids.cost.CostCalculator;
+import org.apache.doris.nereids.jobs.JobContext;
+import org.apache.doris.nereids.memo.Group;
+import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.trees.plans.GroupPlan;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalFilter;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalLimit;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class ChildrenPropertiesRegulatorTest {
+
+    private List<GroupExpression> children;
+    private JobContext mockedJobContext;
+    private List<PhysicalProperties> originOutputChildrenProperties
+            = Lists.newArrayList(PhysicalProperties.MUST_SHUFFLE);
+
+    @BeforeEach
+    public void setUp() {
+        Group childGroup = Mockito.mock(Group.class);
+        Mockito.when(childGroup.getLogicalProperties()).thenReturn(Mockito.mock(LogicalProperties.class));
+        GroupExpression child = Mockito.mock(GroupExpression.class);
+        Mockito.when(child.getOutputProperties(Mockito.any())).thenReturn(PhysicalProperties.MUST_SHUFFLE);
+        Mockito.when(child.getOwnerGroup()).thenReturn(childGroup);
+        Map<PhysicalProperties, Pair<Cost, List<PhysicalProperties>>> lct = Maps.newHashMap();
+        lct.put(PhysicalProperties.MUST_SHUFFLE, Pair.of(Cost.zero(), Lists.newArrayList()));
+        Mockito.when(child.getLowestCostTable()).thenReturn(lct);
+        children = Lists.newArrayList(child);
+
+        mockedJobContext = Mockito.mock(JobContext.class);
+        Mockito.when(mockedJobContext.getCascadesContext()).thenReturn(Mockito.mock(CascadesContext.class));
+
+    }
+
+    @Test
+    public void testMustShuffleProjectProjectCanNotMerge() {
+        testMustShuffleProject(PhysicalProject.class, DistributionSpecExecutionAny.class, false);
+
+    }
+
+    @Test
+    public void testMustShuffleProjectProjectCanMerge() {
+        testMustShuffleProject(PhysicalProject.class, DistributionSpecMustShuffle.class, true);
+
+    }
+
+    @Test
+    public void testMustShuffleProjectFilter() {
+        testMustShuffleProject(PhysicalFilter.class, DistributionSpecMustShuffle.class, true);
+
+    }
+
+    @Test
+    public void testMustShuffleProjectLimit() {
+        testMustShuffleProject(PhysicalLimit.class, DistributionSpecExecutionAny.class, true);
+    }
+
+    public void testMustShuffleProject(Class<? extends Plan> childClazz,
+            Class<? extends DistributionSpec> distributeClazz,
+            boolean canMergeChildProject) {
+        try (MockedStatic<CostCalculator> mockedCostCalculator = Mockito.mockStatic(CostCalculator.class)) {
+            mockedCostCalculator.when(() -> CostCalculator.calculateCost(Mockito.any(), Mockito.any(),
+                    Mockito.anyList())).thenReturn(Cost.zero());
+            mockedCostCalculator.when(() -> CostCalculator.addChildCost(Mockito.any(), Mockito.any(), Mockito.any(),
+                    Mockito.any(), Mockito.anyInt())).thenReturn(Cost.zero());
+
+            // project, cannot merge
+            Plan mockedChild = Mockito.mock(childClazz);
+            Mockito.when(mockedChild.withGroupExpression(Mockito.any())).thenReturn(mockedChild);
+            Group mockedGroup = Mockito.mock(Group.class);
+            List<GroupExpression> physicalExpressions = Lists.newArrayList(new GroupExpression(mockedChild));
+            Mockito.when(mockedGroup.getPhysicalExpressions()).thenReturn(physicalExpressions);
+            GroupPlan mockedGroupPlan = Mockito.mock(GroupPlan.class);
+            Mockito.when(mockedGroupPlan.getGroup()).thenReturn(mockedGroup);
+            // let AbstractTreeNode's init happy
+            Mockito.when(mockedGroupPlan.getAllChildrenTypes()).thenReturn(new BitSet());
+            PhysicalProject parentPlan = new PhysicalProject<>(Lists.newArrayList(), null, mockedGroupPlan);
+            GroupExpression parent = new GroupExpression(parentPlan);
+            parentPlan = parentPlan.withGroupExpression(Optional.of(parent));
+            parentPlan = Mockito.spy(parentPlan);
+            Mockito.doReturn(canMergeChildProject).when(parentPlan).canMergeChildProjections(Mockito.any());
+            parent = Mockito.spy(parent);
+            Mockito.doReturn(parentPlan).when(parent).getPlan();
+            ChildrenPropertiesRegulator regulator = new ChildrenPropertiesRegulator(parent, children,
+                    new ArrayList<>(originOutputChildrenProperties), null, mockedJobContext);
+            PhysicalProperties result = regulator.adjustChildrenProperties().get(0).get(0);
+            Assertions.assertInstanceOf(distributeClazz, result.getDistributionSpec());
+        }
+    }
+
+    @Test
+    public void testMustShuffleFilterProject() {
+        testMustShuffleFilter(PhysicalProject.class);
+    }
+
+    @Test
+    public void testMustShuffleFilterFilter() {
+        testMustShuffleFilter(PhysicalFilter.class);
+    }
+
+    @Test
+    public void testMustShuffleFilterLimit() {
+        testMustShuffleFilter(PhysicalLimit.class);
+    }
+
+    private void testMustShuffleFilter(Class<? extends Plan> childClazz) {
+        try (MockedStatic<CostCalculator> mockedCostCalculator = Mockito.mockStatic(CostCalculator.class)) {
+            mockedCostCalculator.when(() -> CostCalculator.calculateCost(Mockito.any(), Mockito.any(),
+                    Mockito.anyList())).thenReturn(Cost.zero());
+            mockedCostCalculator.when(() -> CostCalculator.addChildCost(Mockito.any(), Mockito.any(), Mockito.any(),
+                    Mockito.any(), Mockito.anyInt())).thenReturn(Cost.zero());
+
+            // project, cannot merge
+            Plan mockedChild = Mockito.mock(childClazz);
+            Mockito.when(mockedChild.withGroupExpression(Mockito.any())).thenReturn(mockedChild);
+            Group mockedGroup = Mockito.mock(Group.class);
+            List<GroupExpression> physicalExpressions = Lists.newArrayList(new GroupExpression(mockedChild));
+            Mockito.when(mockedGroup.getPhysicalExpressions()).thenReturn(physicalExpressions);
+            GroupPlan mockedGroupPlan = Mockito.mock(GroupPlan.class);
+            Mockito.when(mockedGroupPlan.getGroup()).thenReturn(mockedGroup);
+            // let AbstractTreeNode's init happy
+            Mockito.when(mockedGroupPlan.getAllChildrenTypes()).thenReturn(new BitSet());
+            GroupExpression parent = new GroupExpression(new PhysicalFilter<>(Sets.newHashSet(), null, mockedGroupPlan));
+            ChildrenPropertiesRegulator regulator = new ChildrenPropertiesRegulator(parent, children,
+                    new ArrayList<>(originOutputChildrenProperties), null, mockedJobContext);
+            PhysicalProperties result = regulator.adjustChildrenProperties().get(0).get(0);
+            Assertions.assertInstanceOf(DistributionSpecExecutionAny.class, result.getDistributionSpec());
+        }
+    }
+}

--- a/regression-test/suites/nereids_syntax_p0/cte.groovy
+++ b/regression-test/suites/nereids_syntax_p0/cte.groovy
@@ -334,5 +334,10 @@ suite("cte") {
     sql """
         WITH cte_0 AS ( SELECT 1 AS a ), cte_1 AS ( SELECT 1 AS a ) select * from cte_0, cte_1 union select * from cte_0, cte_1
     """
+
+    // test more than one project on cte consumer
+    sql """
+        with a as (select 1 c1) select *, uuid() from a union all select c2, c2 from (select c1 + 1, uuid() c2 from a) x ;
+    """
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #21412

Problem Summary:

This pull request improves the handling of distribution properties (specifically "must shuffle") for `PhysicalProject` and `PhysicalFilter` nodes in the query planner, and adds comprehensive unit tests to ensure correctness. The main logic ensures that when certain child nodes require shuffling, the planner correctly adjusts the distribution requirements, especially in the presence of `Project`, `Filter`, and `Limit` nodes.

Key changes include:

**Distribution Property Handling Enhancements:**

* Added logic in `ChildrenPropertiesRegulator` to check if a child node under a `PhysicalProject` or `PhysicalFilter` requires a "must shuffle" distribution, and to adjust the children’s properties accordingly. This is done via the new `mustShuffleUnderProjectOrFilter` method. [[1]](diffhunk://#diff-79d8abdb9d7855b95a985ffa9b4ddbe1c646b58245fc2d0c02bef33374743777R281-R288) [[2]](diffhunk://#diff-79d8abdb9d7855b95a985ffa9b4ddbe1c646b58245fc2d0c02bef33374743777R605-R612) [[3]](diffhunk://#diff-79d8abdb9d7855b95a985ffa9b4ddbe1c646b58245fc2d0c02bef33374743777R320-R338)
* Included `PhysicalLimit` in the set of nodes that can trigger a shuffle requirement, by updating imports and logic. [[1]](diffhunk://#diff-79d8abdb9d7855b95a985ffa9b4ddbe1c646b58245fc2d0c02bef33374743777R40) [[2]](diffhunk://#diff-79d8abdb9d7855b95a985ffa9b4ddbe1c646b58245fc2d0c02bef33374743777R320-R338)

**Testing Improvements:**

* Added a new test class `ChildrenPropertiesRegulatorTest.java` with detailed unit tests for the handling of "must shuffle" properties under `Project`, `Filter`, and `Limit` nodes. These tests use mocks to simulate various plan trees and assert correct distribution specification propagation.

**Regression Test Coverage:**

* Added a new regression test in `cte.groovy` to verify correct behavior when multiple `Project` nodes are present on a CTE consumer, ensuring the planner handles such cases as expected.

These changes collectively make the planner more robust in handling complex plan trees with respect to distribution requirements, and ensure correctness through thorough testing.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

