### PR TITLE
[chore](planner) remove useless NullableTuples in PlanNode

### DIFF
--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -584,8 +584,7 @@ Status PushBrokerReader::_init_expr_ctxes() {
         _src_slot_descs.emplace_back(it->second);
     }
     _row_desc.reset(new RowDescriptor(_runtime_state->desc_tbl(),
-                                      std::vector<TupleId>({_params.src_tuple_id}),
-                                      std::vector<bool>({false})));
+                                      std::vector<TupleId>({_params.src_tuple_id})));
 
     if (!_pre_filter_texprs.empty()) {
         DCHECK(_pre_filter_texprs.size() == 1);

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -321,7 +321,7 @@ Status BlockChanger::change_block(vectorized::Block* ref_block,
     _state->set_desc_tbl(&_desc_tbl);
     _state->set_be_exec_version(_fe_compatible_version);
     RowDescriptor row_desc =
-            RowDescriptor(_desc_tbl.get_tuple_descriptor(_desc_tbl.get_row_tuples()[0]), false);
+            RowDescriptor(_desc_tbl.get_tuple_descriptor(_desc_tbl.get_row_tuples()[0]));
 
     if (_where_expr != nullptr) {
         vectorized::VExprContextSPtr ctx = nullptr;

--- a/be/src/pipeline/exec/aggregation_sink_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_sink_operator.cpp
@@ -752,7 +752,7 @@ AggSinkOperatorX::AggSinkOperatorX(ObjectPool* pool, int operator_id, int dest_i
                           : tnode.agg_node.grouping_exprs),
           _is_colocate(tnode.agg_node.__isset.is_colocate && tnode.agg_node.is_colocate),
           _require_bucket_distribution(require_bucket_distribution),
-          _agg_fn_output_row_descriptor(descs, tnode.row_tuples, tnode.nullable_tuples) {}
+          _agg_fn_output_row_descriptor(descs, tnode.row_tuples) {}
 
 Status AggSinkOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(DataSinkOperatorX<AggSinkLocalState>::init(tnode, state));

--- a/be/src/pipeline/exec/analytic_sink_operator.cpp
+++ b/be/src/pipeline/exec/analytic_sink_operator.cpp
@@ -709,7 +709,7 @@ Status AnalyticSinkOperatorX::prepare(RuntimeState* state) {
         std::vector<TTupleId> tuple_ids;
         tuple_ids.push_back(_child->row_desc().tuple_descriptors()[0]->id());
         tuple_ids.push_back(_buffered_tuple_id);
-        RowDescriptor cmp_row_desc(state->desc_tbl(), tuple_ids, std::vector<bool>(2, false));
+        RowDescriptor cmp_row_desc(state->desc_tbl(), tuple_ids);
         if (!_partition_by_eq_expr_ctxs.empty()) {
             RETURN_IF_ERROR(
                     vectorized::VExpr::prepare(_partition_by_eq_expr_ctxs, state, cmp_row_desc));

--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -330,7 +330,7 @@ Status ExchangeSinkOperatorX::prepare(RuntimeState* state) {
                     vectorized::VExpr::prepare(_tablet_sink_expr_ctxs, state, _child->row_desc()));
         } else {
             auto* output_tuple_desc = state->desc_tbl().get_tuple_descriptor(_output_tuple_id);
-            auto* output_row_desc = _pool->add(new RowDescriptor(output_tuple_desc, false));
+            auto* output_row_desc = _pool->add(new RowDescriptor(output_tuple_desc));
             RETURN_IF_ERROR(
                     vectorized::VExpr::prepare(_tablet_sink_expr_ctxs, state, *output_row_desc));
         }

--- a/be/src/pipeline/exec/join_probe_operator.cpp
+++ b/be/src/pipeline/exec/join_probe_operator.cpp
@@ -118,13 +118,11 @@ JoinProbeOperatorX<LocalStateType>::JoinProbeOperatorX(ObjectPool* pool, const T
                                                 !_is_mark_join) {
     if (tnode.__isset.hash_join_node) {
         _intermediate_row_desc = std::make_unique<RowDescriptor>(
-                descs, tnode.hash_join_node.vintermediate_tuple_id_list,
-                std::vector<bool>(tnode.hash_join_node.vintermediate_tuple_id_list.size()));
+                descs, tnode.hash_join_node.vintermediate_tuple_id_list);
         DCHECK_NE(Base::_output_row_descriptor, nullptr);
     } else if (tnode.__isset.nested_loop_join_node) {
         _intermediate_row_desc = std::make_unique<RowDescriptor>(
-                descs, tnode.nested_loop_join_node.vintermediate_tuple_id_list,
-                std::vector<bool>(tnode.nested_loop_join_node.vintermediate_tuple_id_list.size()));
+                descs, tnode.nested_loop_join_node.vintermediate_tuple_id_list);
         DCHECK_NE(Base::_output_row_descriptor, nullptr);
     } else {
         // Iff BE has been upgraded and FE has not yet, we should keep origin logics for CROSS JOIN.

--- a/be/src/pipeline/exec/nested_loop_join_build_operator.cpp
+++ b/be/src/pipeline/exec/nested_loop_join_build_operator.cpp
@@ -68,7 +68,7 @@ NestedLoopJoinBuildSinkOperatorX::NestedLoopJoinBuildSinkOperatorX(ObjectPool* p
                                                                     tnode, descs),
           _is_output_left_side_only(tnode.nested_loop_join_node.__isset.is_output_left_side_only &&
                                     tnode.nested_loop_join_node.is_output_left_side_only),
-          _row_descriptor(descs, tnode.row_tuples, tnode.nullable_tuples) {}
+          _row_descriptor(descs, tnode.row_tuples) {}
 
 Status NestedLoopJoinBuildSinkOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(JoinBuildSinkOperatorX<NestedLoopJoinBuildSinkLocalState>::init(tnode, state));

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -841,13 +841,13 @@ public:
               _type(tnode.node_type),
               _pool(pool),
               _tuple_ids(tnode.row_tuples),
-              _row_descriptor(descs, tnode.row_tuples, tnode.nullable_tuples),
+              _row_descriptor(descs, tnode.row_tuples),
               _resource_profile(tnode.resource_profile),
               _limit(tnode.limit) {
         if (tnode.__isset.output_tuple_id) {
-            _output_row_descriptor.reset(new RowDescriptor(descs, {tnode.output_tuple_id}, {true}));
-            _output_row_descriptor = std::make_unique<RowDescriptor>(
-                    descs, std::vector {tnode.output_tuple_id}, std::vector {true});
+            _output_row_descriptor.reset(new RowDescriptor(descs, {tnode.output_tuple_id}));
+            _output_row_descriptor =
+                    std::make_unique<RowDescriptor>(descs, std::vector {tnode.output_tuple_id});
         }
         if (!tnode.intermediate_output_tuple_id_list.empty()) {
             // common subexpression elimination
@@ -855,7 +855,7 @@ public:
                     tnode.intermediate_output_tuple_id_list.size());
             for (auto output_tuple_id : tnode.intermediate_output_tuple_id_list) {
                 _intermediate_output_row_descriptor.push_back(
-                        RowDescriptor(descs, std::vector {output_tuple_id}, std::vector {true}));
+                        RowDescriptor(descs, std::vector {output_tuple_id}));
             }
         }
     }

--- a/be/src/pipeline/exec/partition_sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/partition_sort_sink_operator.cpp
@@ -70,7 +70,7 @@ PartitionSortSinkOperatorX::PartitionSortSinkOperatorX(ObjectPool* pool, int ope
                                                        const DescriptorTbl& descs)
         : DataSinkOperatorX(operator_id, tnode.node_id, dest_id),
           _pool(pool),
-          _row_descriptor(descs, tnode.row_tuples, tnode.nullable_tuples),
+          _row_descriptor(descs, tnode.row_tuples),
           _limit(tnode.limit),
           _partition_exprs_num(static_cast<int>(tnode.partition_sort_node.partition_exprs.size())),
           _topn_phase(tnode.partition_sort_node.ptopn_phase),

--- a/be/src/pipeline/exec/result_file_sink_operator.cpp
+++ b/be/src/pipeline/exec/result_file_sink_operator.cpp
@@ -50,7 +50,7 @@ ResultFileSinkOperatorX::ResultFileSinkOperatorX(
           _row_desc(row_desc),
           _t_output_expr(t_output_expr),
           _dests(destinations),
-          _output_row_descriptor(descs.get_tuple_descriptor(sink.output_tuple_id), false) {
+          _output_row_descriptor(descs.get_tuple_descriptor(sink.output_tuple_id)) {
     CHECK_EQ(destinations.size(), 1);
 }
 

--- a/be/src/pipeline/exec/sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/sort_sink_operator.cpp
@@ -91,7 +91,7 @@ SortSinkOperatorX::SortSinkOperatorX(ObjectPool* pool, int operator_id, int dest
           _offset(tnode.sort_node.__isset.offset ? tnode.sort_node.offset : 0),
           _pool(pool),
           _limit(tnode.limit),
-          _row_descriptor(descs, tnode.row_tuples, tnode.nullable_tuples),
+          _row_descriptor(descs, tnode.row_tuples),
           _merge_by_exchange(tnode.sort_node.merge_by_exchange),
           _is_colocate(tnode.sort_node.__isset.is_colocate && tnode.sort_node.is_colocate),
           _require_bucket_distribution(require_bucket_distribution),

--- a/be/src/pipeline/exec/streaming_aggregation_operator.cpp
+++ b/be/src/pipeline/exec/streaming_aggregation_operator.cpp
@@ -620,7 +620,7 @@ StreamingAggOperatorX::StreamingAggOperatorX(ObjectPool* pool, int operator_id,
           _is_merge(false),
           _is_first_phase(tnode.agg_node.__isset.is_first_phase && tnode.agg_node.is_first_phase),
           _have_conjuncts(tnode.__isset.vconjunct && !tnode.vconjunct.nodes.empty()),
-          _agg_fn_output_row_descriptor(descs, tnode.row_tuples, tnode.nullable_tuples),
+          _agg_fn_output_row_descriptor(descs, tnode.row_tuples),
           _partition_exprs(
                   tnode.__isset.distribute_expr_lists &&
                                   (require_bucket_distribution ||

--- a/be/src/pipeline/exec/union_sink_operator.cpp
+++ b/be/src/pipeline/exec/union_sink_operator.cpp
@@ -58,7 +58,7 @@ UnionSinkOperatorX::UnionSinkOperatorX(int child_id, int sink_id, int dest_id, O
         : Base(sink_id, tnode.node_id, dest_id),
           _first_materialized_child_idx(
                   cast_set<int>(tnode.union_node.first_materialized_child_idx)),
-          _row_descriptor(descs, tnode.row_tuples, tnode.nullable_tuples),
+          _row_descriptor(descs, tnode.row_tuples),
           _cur_child_id(child_id),
           _child_size(tnode.num_children),
           _distribute_exprs(tnode.__isset.distribute_expr_lists

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -1130,8 +1130,7 @@ Status PipelineFragmentContext::_create_data_sink(ObjectPool* pool, const TDataS
                         !thrift_sink.multi_cast_stream_sink.sinks[i].output_exprs.empty()
                                 ? RowDescriptor(state->desc_tbl(),
                                                 {thrift_sink.multi_cast_stream_sink.sinks[i]
-                                                         .output_tuple_id},
-                                                {false})
+                                                         .output_tuple_id})
                                 : row_desc;
                 exchange_row_desc = pool->add(new RowDescriptor(tmp_row_desc));
             }

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -457,12 +457,8 @@ std::string TupleDescriptor::debug_string() const {
     return out.str();
 }
 
-RowDescriptor::RowDescriptor(const DescriptorTbl& desc_tbl, const std::vector<TTupleId>& row_tuples,
-                             const std::vector<bool>& nullable_tuples)
-        : _tuple_idx_nullable_map(nullable_tuples) {
-    DCHECK(nullable_tuples.size() == row_tuples.size())
-            << "nullable_tuples size " << nullable_tuples.size() << " != row_tuples size "
-            << row_tuples.size();
+RowDescriptor::RowDescriptor(const DescriptorTbl& desc_tbl,
+                             const std::vector<TTupleId>& row_tuples) {
     DCHECK_GT(row_tuples.size(), 0);
     _num_materialized_slots = 0;
     _num_slots = 0;
@@ -479,8 +475,7 @@ RowDescriptor::RowDescriptor(const DescriptorTbl& desc_tbl, const std::vector<TT
     init_has_varlen_slots();
 }
 
-RowDescriptor::RowDescriptor(TupleDescriptor* tuple_desc, bool is_nullable)
-        : _tuple_desc_map(1, tuple_desc), _tuple_idx_nullable_map(1, is_nullable) {
+RowDescriptor::RowDescriptor(TupleDescriptor* tuple_desc) : _tuple_desc_map(1, tuple_desc) {
     init_tuple_idx_map();
     init_has_varlen_slots();
     _num_slots = static_cast<int32_t>(tuple_desc->slots().size());
@@ -491,12 +486,6 @@ RowDescriptor::RowDescriptor(const RowDescriptor& lhs_row_desc, const RowDescrip
                            lhs_row_desc._tuple_desc_map.end());
     _tuple_desc_map.insert(_tuple_desc_map.end(), rhs_row_desc._tuple_desc_map.begin(),
                            rhs_row_desc._tuple_desc_map.end());
-    _tuple_idx_nullable_map.insert(_tuple_idx_nullable_map.end(),
-                                   lhs_row_desc._tuple_idx_nullable_map.begin(),
-                                   lhs_row_desc._tuple_idx_nullable_map.end());
-    _tuple_idx_nullable_map.insert(_tuple_idx_nullable_map.end(),
-                                   rhs_row_desc._tuple_idx_nullable_map.begin(),
-                                   rhs_row_desc._tuple_idx_nullable_map.end());
     init_tuple_idx_map();
     init_has_varlen_slots();
 
@@ -597,15 +586,6 @@ std::string RowDescriptor::debug_string() const {
     for (int i = 0; i < _tuple_idx_map.size(); ++i) {
         ss << _tuple_idx_map[i];
         if (i != _tuple_idx_map.size() - 1) {
-            ss << ", ";
-        }
-    }
-    ss << "] ";
-
-    ss << "tuple_is_nullable: [";
-    for (int i = 0; i < _tuple_idx_nullable_map.size(); ++i) {
-        ss << _tuple_idx_nullable_map[i];
-        if (i != _tuple_idx_nullable_map.size() - 1) {
             ss << ", ";
         }
     }

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -456,13 +456,11 @@ private:
 // case)
 class RowDescriptor {
 public:
-    RowDescriptor(const DescriptorTbl& desc_tbl, const std::vector<TTupleId>& row_tuples,
-                  const std::vector<bool>& nullable_tuples);
+    RowDescriptor(const DescriptorTbl& desc_tbl, const std::vector<TTupleId>& row_tuples);
 
     // standard copy c'tor, made explicit here
     RowDescriptor(const RowDescriptor& desc)
             : _tuple_desc_map(desc._tuple_desc_map),
-              _tuple_idx_nullable_map(desc._tuple_idx_nullable_map),
               _tuple_idx_map(desc._tuple_idx_map),
               _has_varlen_slots(desc._has_varlen_slots) {
         auto it = desc._tuple_desc_map.begin();
@@ -472,7 +470,7 @@ public:
         }
     }
 
-    RowDescriptor(TupleDescriptor* tuple_desc, bool is_nullable);
+    RowDescriptor(TupleDescriptor* tuple_desc);
 
     RowDescriptor(const RowDescriptor& lhs_row_desc, const RowDescriptor& rhs_row_desc);
 
@@ -522,9 +520,6 @@ private:
 
     // map from position of tuple w/in row to its descriptor
     std::vector<TupleDescriptor*> _tuple_desc_map;
-
-    // _tuple_idx_nullable_map[i] is true if tuple i can be null
-    std::vector<bool> _tuple_idx_nullable_map;
 
     // map from TupleId to position of tuple w/in row
     std::vector<int> _tuple_idx_map;

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -145,7 +145,7 @@ Status Reusable::init(const TDescriptorTable& t_desc_tbl, const std::vector<TExp
     }
 
     RETURN_IF_ERROR(vectorized::VExpr::create_expr_trees(output_exprs, _output_exprs_ctxs));
-    RowDescriptor row_desc(tuple_desc(), false);
+    RowDescriptor row_desc(tuple_desc());
     // Prepare the exprs to run.
     RETURN_IF_ERROR(vectorized::VExpr::prepare(_output_exprs_ctxs, _runtime_state.get(), row_desc));
     RETURN_IF_ERROR(vectorized::VExpr::open(_output_exprs_ctxs, _runtime_state.get()));

--- a/be/src/vec/exec/scan/file_scanner.cpp
+++ b/be/src/vec/exec/scan/file_scanner.cpp
@@ -175,8 +175,7 @@ Status FileScanner::init(RuntimeState* state, const VExprContextSPtrs& conjuncts
 
     if (_is_load) {
         _src_row_desc.reset(new RowDescriptor(_state->desc_tbl(),
-                                              std::vector<TupleId>({_input_tuple_desc->id()}),
-                                              std::vector<bool>({false})));
+                                              std::vector<TupleId>({_input_tuple_desc->id()})));
         // prepare pre filters
         if (_params->__isset.pre_filter_exprs_list) {
             RETURN_IF_ERROR(doris::vectorized::VExpr::create_expr_trees(
@@ -194,13 +193,11 @@ Status FileScanner::init(RuntimeState* state, const VExprContextSPtrs& conjuncts
         }
 
         _dest_row_desc.reset(new RowDescriptor(_state->desc_tbl(),
-                                               std::vector<TupleId>({_output_tuple_desc->id()}),
-                                               std::vector<bool>({false})));
+                                               std::vector<TupleId>({_output_tuple_desc->id()})));
     }
 
-    _default_val_row_desc.reset(new RowDescriptor(_state->desc_tbl(),
-                                                  std::vector<TupleId>({_real_tuple_desc->id()}),
-                                                  std::vector<bool>({false})));
+    _default_val_row_desc.reset(
+            new RowDescriptor(_state->desc_tbl(), std::vector<TupleId>({_real_tuple_desc->id()})));
 
     return Status::OK();
 }
@@ -1488,7 +1485,7 @@ Status FileScanner::prepare_for_read_lines(const TFileRangeDesc& range) {
     RETURN_IF_ERROR(_init_io_ctx());
     _io_ctx->file_cache_stats = _file_cache_statistics.get();
     _io_ctx->file_reader_stats = _file_reader_stats.get();
-    _default_val_row_desc.reset(new RowDescriptor((TupleDescriptor*)_real_tuple_desc, false));
+    _default_val_row_desc.reset(new RowDescriptor((TupleDescriptor*)_real_tuple_desc));
     RETURN_IF_ERROR(_init_expr_ctxes());
 
     // Since only one column is read from the file, there is no need to filter, so set these variables to empty.

--- a/be/src/vec/sink/tablet_sink_hash_partitioner.cpp
+++ b/be/src/vec/sink/tablet_sink_hash_partitioner.cpp
@@ -51,8 +51,7 @@ Status TabletSinkHashPartitioner::open(RuntimeState* state) {
     _tablet_finder =
             std::make_unique<vectorized::OlapTabletFinder>(_vpartition.get(), find_tablet_mode);
     _tablet_sink_tuple_desc = state->desc_tbl().get_tuple_descriptor(_tablet_sink_tuple_id);
-    _tablet_sink_row_desc =
-            state->obj_pool()->add(new RowDescriptor(_tablet_sink_tuple_desc, false));
+    _tablet_sink_row_desc = state->obj_pool()->add(new RowDescriptor(_tablet_sink_tuple_desc));
     auto& ctxs =
             _local_state->parent()->cast<pipeline::ExchangeSinkOperatorX>().tablet_sink_expr_ctxs();
     _tablet_sink_expr_ctxs.resize(ctxs.size());

--- a/be/src/vec/sink/writer/vtablet_writer.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer.cpp
@@ -547,7 +547,7 @@ Status VNodeChannel::init(RuntimeState* state) {
     _load_info = "load_id=" + print_id(_parent->_load_id) +
                  ", txn_id=" + std::to_string(_parent->_txn_id);
 
-    _row_desc = std::make_unique<RowDescriptor>(_tuple_desc, false);
+    _row_desc = std::make_unique<RowDescriptor>(_tuple_desc);
     _batch_size = state->batch_size();
 
     _stub = state->exec_env()->brpc_internal_client_cache()->get_client(_node_info.host,
@@ -1576,7 +1576,7 @@ Status VTabletWriter::_init(RuntimeState* state, RuntimeProfile* profile) {
             _schema->db_id(), _schema->table_id(), _state->batch_size(),
             _schema->is_fixed_partial_update() && !_schema->auto_increment_coulumn().empty(),
             _schema->auto_increment_column_unique_id());
-    _output_row_desc = _pool->add(new RowDescriptor(_output_tuple_desc, false));
+    _output_row_desc = _pool->add(new RowDescriptor(_output_tuple_desc));
 
     // add all counter
     _input_rows_counter = ADD_COUNTER(profile, "RowsRead", TUnit::UNIT);

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -225,7 +225,7 @@ Status VTabletWriterV2::_init(RuntimeState* state, RuntimeProfile* profile) {
             _schema->db_id(), _schema->table_id(), _state->batch_size(),
             _schema->is_fixed_partial_update() && !_schema->auto_increment_coulumn().empty(),
             _schema->auto_increment_column_unique_id());
-    _output_row_desc = _pool->add(new RowDescriptor(_output_tuple_desc, false));
+    _output_row_desc = _pool->add(new RowDescriptor(_output_tuple_desc));
 
     // add all counter
     _input_rows_counter = ADD_COUNTER(_operator_profile, "RowsRead", TUnit::UNIT);

--- a/be/test/olap/vector_search/ann_range_search_test.cpp
+++ b/be/test/olap/vector_search/ann_range_search_test.cpp
@@ -65,7 +65,7 @@ TEST_F(VectorSearchTest, TestPrepareAnnRangeSearch) {
     auto desc_tbl = std::make_unique<DescriptorTbl>();
     DescriptorTbl* desc_tbl_ptr = desc_tbl.get();
     ASSERT_TRUE(DescriptorTbl::create(pool.get(), table1, &(desc_tbl_ptr)).ok());
-    RowDescriptor row_desc = RowDescriptor(*desc_tbl_ptr, {0}, {false});
+    RowDescriptor row_desc = RowDescriptor(*desc_tbl_ptr, {0});
     std::unique_ptr<doris::RuntimeState> state = std::make_unique<doris::RuntimeState>();
     state->set_desc_tbl(desc_tbl_ptr);
 
@@ -101,7 +101,7 @@ TEST_F(VectorSearchTest, TestEvaluateAnnRangeSearch) {
     auto desc_tbl = std::make_unique<DescriptorTbl>();
     DescriptorTbl* desc_tbl_ptr = desc_tbl.get();
     ASSERT_TRUE(DescriptorTbl::create(pool.get(), table1, &(desc_tbl_ptr)).ok());
-    RowDescriptor row_desc = RowDescriptor(*desc_tbl_ptr, {0}, {false});
+    RowDescriptor row_desc = RowDescriptor(*desc_tbl_ptr, {0});
     std::unique_ptr<doris::RuntimeState> state = std::make_unique<doris::RuntimeState>();
     state->set_desc_tbl(desc_tbl_ptr);
 
@@ -198,7 +198,7 @@ TEST_F(VectorSearchTest, TestEvaluateAnnRangeSearch2) {
     auto desc_tbl = std::make_unique<DescriptorTbl>();
     DescriptorTbl* desc_tbl_ptr = desc_tbl.get();
     ASSERT_TRUE(DescriptorTbl::create(pool.get(), table1, &(desc_tbl_ptr)).ok());
-    RowDescriptor row_desc = RowDescriptor(*desc_tbl_ptr, {0}, {false});
+    RowDescriptor row_desc = RowDescriptor(*desc_tbl_ptr, {0});
     std::unique_ptr<doris::RuntimeState> state = std::make_unique<doris::RuntimeState>();
     state->set_desc_tbl(desc_tbl_ptr);
 
@@ -709,7 +709,7 @@ TEST_F(VectorSearchTest, TestEvaluateAnnRangeSearch_DimensionMismatch) {
     auto desc_tbl = std::make_unique<DescriptorTbl>();
     DescriptorTbl* desc_tbl_ptr = desc_tbl.get();
     ASSERT_TRUE(DescriptorTbl::create(pool.get(), table1, &(desc_tbl_ptr)).ok());
-    RowDescriptor row_desc = RowDescriptor(*desc_tbl_ptr, {0}, {false});
+    RowDescriptor row_desc = RowDescriptor(*desc_tbl_ptr, {0});
     std::unique_ptr<doris::RuntimeState> state = std::make_unique<doris::RuntimeState>();
     state->set_desc_tbl(desc_tbl_ptr);
 
@@ -832,7 +832,7 @@ TEST_F(VectorSearchTest, TestPrepareAnnRangeSearch_EarlyReturn_WrongOpcode) {
     auto desc_tbl = std::make_unique<DescriptorTbl>();
     DescriptorTbl* desc_tbl_ptr = desc_tbl.get();
     ASSERT_TRUE(DescriptorTbl::create(pool.get(), table1, &(desc_tbl_ptr)).ok());
-    RowDescriptor row_desc = RowDescriptor(*desc_tbl_ptr, {0}, {false});
+    RowDescriptor row_desc = RowDescriptor(*desc_tbl_ptr, {0});
     std::unique_ptr<doris::RuntimeState> state = std::make_unique<doris::RuntimeState>();
     state->set_desc_tbl(desc_tbl_ptr);
 
@@ -878,7 +878,7 @@ TEST_F(VectorSearchTest, TestPrepareAnnRangeSearch_EarlyReturn_NonLiteralRight) 
     auto desc_tbl = std::make_unique<DescriptorTbl>();
     DescriptorTbl* desc_tbl_ptr = desc_tbl.get();
     ASSERT_TRUE(DescriptorTbl::create(pool.get(), table1, &(desc_tbl_ptr)).ok());
-    RowDescriptor row_desc = RowDescriptor(*desc_tbl_ptr, {0}, {false});
+    RowDescriptor row_desc = RowDescriptor(*desc_tbl_ptr, {0});
     std::unique_ptr<doris::RuntimeState> state = std::make_unique<doris::RuntimeState>();
     state->set_desc_tbl(desc_tbl_ptr);
 

--- a/be/test/olap/vector_search/ann_topn_runtime_negative_test.cpp
+++ b/be/test/olap/vector_search/ann_topn_runtime_negative_test.cpp
@@ -85,7 +85,7 @@ TEST_F(VectorSearchTest, AnnTopNRuntimePrepare_NoFunctionCall) {
 
     doris::DescriptorTbl* desc_tbl_local = nullptr;
     ASSERT_TRUE(DescriptorTbl::create(&obj_pool_local, thrift_tbl, &desc_tbl_local).ok());
-    RowDescriptor row_desc_local(*desc_tbl_local, {2000}, {false});
+    RowDescriptor row_desc_local(*desc_tbl_local, {2000});
 
     // Create a VirtualSlotRef root expr that points to the local descriptor's slot id (3000)
     doris::TExpr local_virtual_slot_ref_expr = _virtual_slot_ref_expr;

--- a/be/test/olap/vector_search/vector_search_utils.h
+++ b/be/test/olap/vector_search/vector_search_utils.h
@@ -253,7 +253,7 @@ protected:
         _virtual_slot_ref_expr.nodes.push_back(virtual_slot_ref_node);
         _ann_index_iterator = std::make_unique<vector_search_utils::MockAnnIndexIterator>();
 
-        _row_desc = RowDescriptor(*_desc_tbl, {0}, {false});
+        _row_desc = RowDescriptor(*_desc_tbl, {0});
 
         // Create CLucene RAM directory instead of mock
         _ram_dir = std::make_shared<lucene::store::RAMDirectory>();

--- a/be/test/olap/wal/wal_manager_test.cpp
+++ b/be/test/olap/wal/wal_manager_test.cpp
@@ -268,7 +268,6 @@ void WalManagerTest::init() {
     _tnode.num_children = 0;
     _tnode.limit = -1;
     _tnode.row_tuples.push_back(0);
-    _tnode.nullable_tuples.push_back(false);
     _tnode.file_scan_node.tuple_id = 0;
     _tnode.__isset.file_scan_node = true;
 

--- a/be/test/pipeline/operator/hash_join_test_helper.cpp
+++ b/be/test/pipeline/operator/hash_join_test_helper.cpp
@@ -172,8 +172,6 @@ TPlanNode HashJoinTestHelper::create_test_plan_node(
 
     tnode.row_tuples.push_back(0);
     tnode.row_tuples.push_back(1);
-    tnode.nullable_tuples.push_back(false);
-    tnode.nullable_tuples.push_back(false);
     tnode.__isset.hash_join_node = true;
 
     tnode.hash_join_node.vintermediate_tuple_id_list.emplace_back(2);
@@ -605,10 +603,10 @@ HashJoinTestHelper::create_operators(const TPlanNode& tnode) {
     auto probe_side_source_operator = std::make_shared<MockSourceOperator>();
     auto probe_side_sink_operator = std::make_shared<MockSinkOperator>();
 
-    RowDescriptor row_desc(runtime_state->desc_tbl(), {1}, {false});
+    RowDescriptor row_desc(runtime_state->desc_tbl(), {1});
     child_operator->_row_descriptor = row_desc;
 
-    RowDescriptor probe_side_row_desc(runtime_state->desc_tbl(), {0}, {false});
+    RowDescriptor probe_side_row_desc(runtime_state->desc_tbl(), {0});
     probe_side_source_operator->_row_descriptor = probe_side_row_desc;
 
     EXPECT_TRUE(sink_operator->set_child(child_operator));

--- a/be/test/pipeline/operator/partitioned_aggregation_test_helper.cpp
+++ b/be/test/pipeline/operator/partitioned_aggregation_test_helper.cpp
@@ -97,7 +97,6 @@ TPlanNode PartitionedAggregationTestHelper::create_test_plan_node() {
     fn_child_node.type.types.emplace_back(type_node);
 
     tnode.row_tuples.push_back(0);
-    tnode.nullable_tuples.push_back(false);
 
     return tnode;
 }
@@ -175,7 +174,7 @@ PartitionedAggregationTestHelper::create_operators() {
     auto [source_pipeline, _] = generate_agg_pipeline(source_operator, source_side_sink_operator,
                                                       sink_operator, child_operator);
 
-    RowDescriptor row_desc(runtime_state->desc_tbl(), {0}, {false});
+    RowDescriptor row_desc(runtime_state->desc_tbl(), {0});
     child_operator->_row_descriptor = row_desc;
 
     EXPECT_TRUE(sink_operator->set_child(child_operator));

--- a/be/test/pipeline/operator/partitioned_hash_join_probe_operator_test.cpp
+++ b/be/test/pipeline/operator/partitioned_hash_join_probe_operator_test.cpp
@@ -83,7 +83,7 @@ TEST_F(PartitionedHashJoinProbeOperatorTest, InitAndOpen) {
     // before opening, should setup probe_operator's partitioner.
     const auto& tnode = probe_operator->_tnode;
     auto child = std::make_shared<MockChildOperator>();
-    RowDescriptor row_desc(_helper.runtime_state->desc_tbl(), {0}, {false});
+    RowDescriptor row_desc(_helper.runtime_state->desc_tbl(), {0});
     child->_row_descriptor = row_desc;
 
     probe_operator->_inner_sink_operator->_child = nullptr;
@@ -165,7 +165,7 @@ TEST_F(PartitionedHashJoinProbeOperatorTest, spill_probe_blocks) {
     auto local_state = _helper.create_probe_local_state(_helper.runtime_state.get(),
                                                         probe_operator.get(), shared_state);
 
-    RowDescriptor row_desc(_helper.runtime_state->desc_tbl(), {0}, {false});
+    RowDescriptor row_desc(_helper.runtime_state->desc_tbl(), {0});
     const auto& tnode = probe_operator->_tnode;
     local_state->_partitioner = create_spill_partitioner(
             _helper.runtime_state.get(), PartitionedHashJoinTestHelper::TEST_PARTITION_COUNT,
@@ -794,7 +794,7 @@ TEST_F(PartitionedHashJoinProbeOperatorTest, PushPartitionData) {
     auto local_state = _helper.create_probe_local_state(_helper.runtime_state.get(),
                                                         probe_operator.get(), shared_state);
     // Setup row descriptor and partitioner
-    RowDescriptor row_desc(_helper.runtime_state->desc_tbl(), {0}, {false});
+    RowDescriptor row_desc(_helper.runtime_state->desc_tbl(), {0});
     const auto& tnode = probe_operator->_tnode;
     local_state->_partitioner = create_spill_partitioner(
             _helper.runtime_state.get(), PartitionedHashJoinTestHelper::TEST_PARTITION_COUNT,
@@ -828,7 +828,7 @@ TEST_F(PartitionedHashJoinProbeOperatorTest, PushWithEOS) {
                                                         probe_operator.get(), shared_state);
 
     // Setup row descriptor and partitioner
-    RowDescriptor row_desc(_helper.runtime_state->desc_tbl(), {0}, {false});
+    RowDescriptor row_desc(_helper.runtime_state->desc_tbl(), {0});
     const auto& tnode = probe_operator->_tnode;
     local_state->_partitioner = create_spill_partitioner(
             _helper.runtime_state.get(), PartitionedHashJoinTestHelper::TEST_PARTITION_COUNT,
@@ -870,7 +870,7 @@ TEST_F(PartitionedHashJoinProbeOperatorTest, PushLargeBlock) {
                                                         probe_operator.get(), shared_state);
 
     // Setup row descriptor and partitioner
-    RowDescriptor row_desc(_helper.runtime_state->desc_tbl(), {0}, {false});
+    RowDescriptor row_desc(_helper.runtime_state->desc_tbl(), {0});
     const auto& tnode = probe_operator->_tnode;
     local_state->_partitioner = create_spill_partitioner(
             _helper.runtime_state.get(), PartitionedHashJoinTestHelper::TEST_PARTITION_COUNT,

--- a/be/test/pipeline/operator/partitioned_hash_join_sink_operator_test.cpp
+++ b/be/test/pipeline/operator/partitioned_hash_join_sink_operator_test.cpp
@@ -67,14 +67,13 @@ TEST_F(PartitionedHashJoinSinkOperatorTest, Init) {
     ASSERT_EQ(desc_tbl.get_tuple_descs().size(), 2);
 
     tnode.row_tuples.push_back(desc_tbl.get_tuple_descs().front()->id());
-    tnode.nullable_tuples.push_back(false);
 
     PartitionedHashJoinSinkOperatorX operator_x(
             _helper.obj_pool.get(), 0, 0, tnode, desc_tbl,
             PartitionedHashJoinTestHelper::TEST_PARTITION_COUNT);
 
     auto child = std::make_shared<MockChildOperator>();
-    child->_row_descriptor = RowDescriptor(_helper.runtime_state->desc_tbl(), {1}, {false});
+    child->_row_descriptor = RowDescriptor(_helper.runtime_state->desc_tbl(), {1});
     EXPECT_TRUE(operator_x.set_child(child));
 
     ASSERT_TRUE(operator_x.init(tnode, _helper.runtime_state.get()));
@@ -306,7 +305,7 @@ TEST_F(PartitionedHashJoinSinkOperatorTest, RevokeMemory) {
     // prepare & set child operator
     auto child = std::dynamic_pointer_cast<MockChildOperator>(sink_operator->child());
 
-    RowDescriptor row_desc(_helper.runtime_state->desc_tbl(), {1}, {false});
+    RowDescriptor row_desc(_helper.runtime_state->desc_tbl(), {1});
     child->_row_descriptor = row_desc;
     EXPECT_EQ(child->row_desc().num_slots(), 1);
 

--- a/be/test/pipeline/operator/partitioned_hash_join_test_helper.cpp
+++ b/be/test/pipeline/operator/partitioned_hash_join_test_helper.cpp
@@ -46,8 +46,6 @@ TPlanNode PartitionedHashJoinTestHelper::create_test_plan_node() {
 
     tnode.row_tuples.push_back(0);
     tnode.row_tuples.push_back(1);
-    tnode.nullable_tuples.push_back(false);
-    tnode.nullable_tuples.push_back(false);
     tnode.node_type = TPlanNodeType::HASH_JOIN_NODE;
     tnode.hash_join_node.join_op = TJoinOp::INNER_JOIN;
     tnode.__isset.hash_join_node = true;
@@ -125,10 +123,10 @@ PartitionedHashJoinTestHelper::create_operators() {
     auto [probe_pipeline, _] = generate_hash_join_pipeline(probe_operator, probe_side_sink_operator,
                                                            sink_operator, child_operator);
 
-    RowDescriptor row_desc(runtime_state->desc_tbl(), {1}, {false});
+    RowDescriptor row_desc(runtime_state->desc_tbl(), {1});
     child_operator->_row_descriptor = row_desc;
 
-    RowDescriptor row_desc_probe(runtime_state->desc_tbl(), {0}, {false});
+    RowDescriptor row_desc_probe(runtime_state->desc_tbl(), {0});
     probe_side_source_operator->_row_descriptor = row_desc_probe;
 
     EXPECT_TRUE(probe_operator->set_child(probe_side_source_operator));

--- a/be/test/pipeline/operator/spill_sort_test_helper.cpp
+++ b/be/test/pipeline/operator/spill_sort_test_helper.cpp
@@ -42,7 +42,6 @@ TPlanNode SpillSortTestHelper::create_test_plan_node() {
     tnode.num_children = 0;
     tnode.node_type = TPlanNodeType::SORT_NODE;
     tnode.row_tuples.emplace_back(1);
-    tnode.nullable_tuples.emplace_back(false);
     tnode.limit = -1;
 
     tnode.sort_node.sort_info.is_asc_order.emplace_back(true);
@@ -153,7 +152,7 @@ SpillSortTestHelper::create_operators() {
     auto [source_pipeline, _] = generate_sort_pipeline(source_operator, source_side_sink_operator,
                                                        sink_operator, child_operator);
 
-    RowDescriptor row_desc(runtime_state->desc_tbl(), {0}, {false});
+    RowDescriptor row_desc(runtime_state->desc_tbl(), {0});
     child_operator->_row_descriptor = row_desc;
 
     EXPECT_TRUE(sink_operator->set_child(child_operator));

--- a/be/test/pipeline/thrift_builder.h
+++ b/be/test/pipeline/thrift_builder.h
@@ -131,7 +131,6 @@ public:
     }
     TPlanNodeBuilder& append_row_tuples(TTupleId tuple_id, bool nullable) {
         _plan_node.row_tuples.emplace_back(tuple_id);
-        _plan_node.nullable_tuples.emplace_back(nullable);
         return *this;
     }
 

--- a/be/test/scan/scanner_context_test.cpp
+++ b/be/test/scan/scanner_context_test.cpp
@@ -49,8 +49,6 @@ public:
         // First one is input tuple, second one is output tuple.
         tnode.row_tuples.push_back(TTupleId(0));
         tnode.row_tuples.push_back(TTupleId(1));
-        std::vector<bool> null_map {false, false};
-        tnode.nullable_tuples = null_map;
         tbl_desc.tableType = TTableType::OLAP_TABLE;
 
         tuple_desc.id = 0;

--- a/be/test/util/profile_spec_test.cpp
+++ b/be/test/util/profile_spec_test.cpp
@@ -58,7 +58,7 @@ public:
         thrift_tbl.slotDescriptors = slot_descs;
         std::ignore = DescriptorTbl::create(obj_pool.get(), thrift_tbl, &descs);
 
-        row_desc = RowDescriptor(*descs, {0, 1}, {true, true});
+        row_desc = RowDescriptor(*descs, {0, 1});
         sink.__set_dest_node_id(1);
     }
 
@@ -105,8 +105,6 @@ TEST_F(ProfileSpecTest, SourceOperatorNameSuffixTest1) {
     tnode.__set_node_type(TPlanNodeType::AGGREGATION_NODE);
     tnode.row_tuples.push_back(TTupleId(0));
     tnode.row_tuples.push_back(TTupleId(1));
-    std::vector<bool> null_map {false, false};
-    tnode.nullable_tuples = null_map;
 
     MockOperatorX op(obj_pool.get(), tnode, 1, *descs);
 
@@ -122,8 +120,6 @@ TEST_F(ProfileSpecTest, SourceOperatorNameSuffixTest2) {
     tnode.__set_node_type(TPlanNodeType::AGGREGATION_NODE);
     tnode.row_tuples.push_back(TTupleId(0));
     tnode.row_tuples.push_back(TTupleId(1));
-    std::vector<bool> null_map {false, false};
-    tnode.nullable_tuples = null_map;
 
     MockOperatorX op(obj_pool.get(), tnode, 1, *descs);
     op._nereids_id = 100;
@@ -158,8 +154,6 @@ TEST_F(ProfileSpecTest, CommonCountersCustomCounters) {
     tnode.__set_node_type(TPlanNodeType::AGGREGATION_NODE);
     tnode.row_tuples.push_back(TTupleId(0));
     tnode.row_tuples.push_back(TTupleId(1));
-    std::vector<bool> null_map {false, false};
-    tnode.nullable_tuples = null_map;
 
     MockOperatorX op(obj_pool.get(), tnode, 1, *descs);
 

--- a/be/test/vec/data_types/serde/data_type_serde_mysql_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_serde_mysql_test.cpp
@@ -313,7 +313,7 @@ void serialize_and_deserialize_mysql_test() {
         builder.declare_tuple() << type_desc;
         doris::DescriptorTbl* desc_tbl = builder.build();
         auto tuple_desc = const_cast<doris::TupleDescriptor*>(desc_tbl->get_tuple_descriptor(0));
-        doris::RowDescriptor row_desc(tuple_desc, false);
+        doris::RowDescriptor row_desc(tuple_desc);
         runtime_stat.set_desc_tbl(desc_tbl);
         st = ctx->prepare(&runtime_stat, row_desc);
         std::cout << st.to_string() << std::endl;

--- a/be/test/vec/exec/orc/orc_read_lines.cpp
+++ b/be/test/vec/exec/orc/orc_read_lines.cpp
@@ -108,7 +108,7 @@ static void read_orc_line(int64_t line, std::string block_dump) {
                                        "col9");
     DescriptorTbl* desc_tbl = builder.build();
     auto* tuple_desc = const_cast<TupleDescriptor*>(desc_tbl->get_tuple_descriptor(0));
-    RowDescriptor row_desc(tuple_desc, false);
+    RowDescriptor row_desc(tuple_desc);
     TFileScanRangeParams params;
     params.file_type = TFileType::FILE_LOCAL;
     TFileRangeDesc range;

--- a/be/test/vec/exec/orc_reader_test.cpp
+++ b/be/test/vec/exec/orc_reader_test.cpp
@@ -77,7 +77,7 @@ private:
                                    "o_comment");
         DescriptorTbl* desc_tbl = builder.build();
         auto* tuple_desc = const_cast<TupleDescriptor*>(desc_tbl->get_tuple_descriptor(0));
-        RowDescriptor row_desc(tuple_desc, false);
+        RowDescriptor row_desc(tuple_desc);
         TFileScanRangeParams params;
         TFileRangeDesc range;
         range.path = "./be/test/exec/test_data/orc_scanner/orders.orc";

--- a/be/test/vec/exec/scan_operator_test.cpp
+++ b/be/test/vec/exec/scan_operator_test.cpp
@@ -61,8 +61,6 @@ TEST_F(ScanOperatorTest, adaptive_pipeline_task_serial_read_on_limit) {
     TPlanNode tnode;
     tnode.row_tuples.push_back(TTupleId(0));
     tnode.row_tuples.push_back(TTupleId(1));
-    std::vector<bool> null_map {false, false};
-    tnode.nullable_tuples = null_map;
 
     // Scan with conjuncts
     TExpr conjunct;

--- a/be/test/vec/exec/vfile_scanner_exception_test.cpp
+++ b/be/test/vec/exec/vfile_scanner_exception_test.cpp
@@ -237,7 +237,6 @@ void VfileScannerExceptionTest::init() {
     _tnode.num_children = 0;
     _tnode.limit = -1;
     _tnode.row_tuples.push_back(0);
-    _tnode.nullable_tuples.push_back(false);
     _tnode.file_scan_node.tuple_id = 0;
     _tnode.__isset.file_scan_node = true;
 

--- a/be/test/vec/exprs/vexpr_test.cpp
+++ b/be/test/vec/exprs/vexpr_test.cpp
@@ -65,7 +65,7 @@ TEST(TEST_VEXPR, ABSTEST) {
     doris::DescriptorTbl* desc_tbl = builder.build();
 
     auto tuple_desc = const_cast<doris::TupleDescriptor*>(desc_tbl->get_tuple_descriptor(0));
-    doris::RowDescriptor row_desc(tuple_desc, false);
+    doris::RowDescriptor row_desc(tuple_desc);
     std::string expr_json =
             R"|({"1":{"lst":["rec",2,{"1":{"i32":20},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":6}}}}]}}},"4":{"i32":1},"20":{"i32":-1},"26":{"rec":{"1":{"rec":{"2":{"str":"abs"}}},"2":{"i32":0},"3":{"lst":["rec",1,{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":5}}}}]}}]},"4":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":6}}}}]}}},"5":{"tf":0},"7":{"str":"abs(INT)"},"9":{"rec":{"1":{"str":"_ZN5doris13MathFunctions3absEPN9doris_udf15FunctionContextERKNS1_6IntValE"}}},"11":{"i64":0}}}},{"1":{"i32":16},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":5}}}}]}}},"4":{"i32":0},"15":{"rec":{"1":{"i32":0},"2":{"i32":0}}},"20":{"i32":-1},"23":{"i32":-1}}]}})|";
     doris::TExpr exprx = apache::thrift::from_json_string<doris::TExpr>(expr_json);
@@ -156,7 +156,7 @@ TEST(TEST_VEXPR, ABSTEST2) {
             {"k1", TYPE_INT, sizeof(int32_t), false}};
     ObjectPool object_pool;
     doris::TupleDescriptor* tuple_desc = create_tuple_desc(&object_pool, column_descs);
-    RowDescriptor row_desc(tuple_desc, false);
+    RowDescriptor row_desc(tuple_desc);
     std::string expr_json =
             R"|({"1":{"lst":["rec",2,{"1":{"i32":20},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":6}}}}]}}},"4":{"i32":1},"20":{"i32":-1},"26":{"rec":{"1":{"rec":{"2":{"str":"abs"}}},"2":{"i32":0},"3":{"lst":["rec",1,{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":5}}}}]}}]},"4":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":6}}}}]}}},"5":{"tf":0},"7":{"str":"abs(INT)"},"9":{"rec":{"1":{"str":"_ZN5doris13MathFunctions3absEPN9doris_udf15FunctionContextERKNS1_6IntValE"}}},"11":{"i64":0}}}},{"1":{"i32":16},"2":{"rec":{"1":{"lst":["rec",1,{"1":{"i32":0},"2":{"rec":{"1":{"i32":5}}}}]}}},"4":{"i32":0},"15":{"rec":{"1":{"i32":0},"2":{"i32":0}}},"20":{"i32":-1},"23":{"i32":-1}}]}})|";
     TExpr exprx = apache::thrift::from_json_string<TExpr>(expr_json);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/AnalyticEvalNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/AnalyticEvalNode.java
@@ -32,7 +32,6 @@ import org.apache.doris.thrift.TPlanNodeType;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 import java.util.List;
 
@@ -70,7 +69,6 @@ public class AnalyticEvalNode extends PlanNode {
         this.analyticWindow = analyticWindow;
         this.outputTupleDesc = outputTupleDesc;
         children.add(input);
-        nullableTupleIds = Sets.newHashSet(input.getNullableTupleIds());
     }
 
     public void setColocate(boolean colocate) {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/AssertNumRowsNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/AssertNumRowsNode.java
@@ -46,7 +46,6 @@ public class AssertNumRowsNode extends PlanNode {
         this.assertion = assertNumRowsElement.getAssertion();
         this.children.add(input);
         this.tupleIds.add(tupleDescriptor.getId());
-        this.nullableTupleIds.addAll(input.getNullableTupleIds());
         this.shouldConvertOutputToNullable = convertToNullable;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ExchangeNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ExchangeNode.java
@@ -81,11 +81,9 @@ public class ExchangeNode extends PlanNode {
         if (outputTupleDesc != null) {
             clearTupleIds();
             tupleIds.add(outputTupleDesc.getId());
-            nullableTupleIds.add(outputTupleDesc.getId());
         } else {
             clearTupleIds();
             tupleIds.addAll(getChild(0).getOutputTupleIds());
-            nullableTupleIds.addAll(getChild(0).getNullableTupleIds());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -93,19 +93,6 @@ public class HashJoinNode extends JoinNodeBase {
         this.markJoinConjuncts = markJoinConjuncts;
         children.add(outer);
         children.add(inner);
-
-        // Inherits all the nullable tuple from the children
-        // Mark tuples that form the "nullable" side of the outer join as nullable.
-        nullableTupleIds.addAll(inner.getNullableTupleIds());
-        nullableTupleIds.addAll(outer.getNullableTupleIds());
-        if (joinOp.equals(JoinOperator.FULL_OUTER_JOIN)) {
-            nullableTupleIds.addAll(outer.getOutputTupleIds());
-            nullableTupleIds.addAll(inner.getOutputTupleIds());
-        } else if (joinOp.equals(JoinOperator.LEFT_OUTER_JOIN)) {
-            nullableTupleIds.addAll(inner.getOutputTupleIds());
-        } else if (joinOp.equals(JoinOperator.RIGHT_OUTER_JOIN)) {
-            nullableTupleIds.addAll(outer.getOutputTupleIds());
-        }
         this.vIntermediateTupleDescList = Lists.newArrayList();
         this.outputTupleDesc = null;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/NestedLoopJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/NestedLoopJoinNode.java
@@ -72,18 +72,6 @@ public class NestedLoopJoinNode extends JoinNodeBase {
         this.tupleIds.addAll(tupleIds);
         children.add(outer);
         children.add(inner);
-        // Inherits all the nullable tuple from the children
-        // Mark tuples that form the "nullable" side of the outer join as nullable.
-        nullableTupleIds.addAll(outer.getNullableTupleIds());
-        nullableTupleIds.addAll(inner.getNullableTupleIds());
-        if (joinOp.equals(JoinOperator.FULL_OUTER_JOIN)) {
-            nullableTupleIds.addAll(outer.getOutputTupleIds());
-            nullableTupleIds.addAll(inner.getOutputTupleIds());
-        } else if (joinOp.equals(JoinOperator.LEFT_OUTER_JOIN)) {
-            nullableTupleIds.addAll(inner.getOutputTupleIds());
-        } else if (joinOp.equals(JoinOperator.RIGHT_OUTER_JOIN)) {
-            nullableTupleIds.addAll(outer.getOutputTupleIds());
-        }
     }
 
     public void setOutputLeftSideOnly(boolean outputLeftSideOnly) {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PartitionSortNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PartitionSortNode.java
@@ -62,7 +62,6 @@ public class PartitionSortNode extends PlanNode {
         this.partitionLimit = partitionLimit;
         this.phase = phase;
         this.tupleIds.addAll(Lists.newArrayList(info.getSortTupleDescriptor().getId()));
-        this.nullableTupleIds.addAll(input.getNullableTupleIds());
         this.children.add(input);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -47,12 +47,12 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -87,11 +87,6 @@ public abstract class PlanNode extends TreeNode<PlanNode> {
 
     // ids materialized by the tree rooted at this node
     protected ArrayList<TupleId> tupleIds;
-
-    // A set of nullable TupleId produced by this node. It is a subset of tupleIds.
-    // A tuple is nullable within a particular plan tree if it's the "nullable" side of
-    // an outer join, which has nothing to do with the schema.
-    protected Set<TupleId> nullableTupleIds = Sets.newHashSet();
 
     protected List<Expr> conjuncts = Lists.newArrayList();
 
@@ -174,7 +169,6 @@ public abstract class PlanNode extends TreeNode<PlanNode> {
         this.limit = node.limit;
         this.offset = node.offset;
         this.tupleIds = Lists.newArrayList(node.tupleIds);
-        this.nullableTupleIds = Sets.newHashSet(node.nullableTupleIds);
         this.conjuncts = Expr.cloneList(node.conjuncts, null);
 
         this.cardinality = -1;
@@ -191,7 +185,6 @@ public abstract class PlanNode extends TreeNode<PlanNode> {
      */
     protected void clearTupleIds() {
         tupleIds.clear();
-        nullableTupleIds.clear();
     }
 
     protected void setPlanNodeName(String s) {
@@ -282,11 +275,6 @@ public abstract class PlanNode extends TreeNode<PlanNode> {
             return Lists.newArrayList(outputTupleDesc.getId());
         }
         return tupleIds;
-    }
-
-    public Set<TupleId> getNullableTupleIds() {
-        Preconditions.checkState(nullableTupleIds != null);
-        return nullableTupleIds;
     }
 
     public List<Expr> getConjuncts() {
@@ -412,8 +400,7 @@ public abstract class PlanNode extends TreeNode<PlanNode> {
         if (detailLevel.equals(TExplainLevel.VERBOSE)) {
             expBuilder.append(detailPrefix + "tuple ids: ");
             for (TupleId tupleId : tupleIds) {
-                String nullIndicator = nullableTupleIds.contains(tupleId) ? "N" : "";
-                expBuilder.append(tupleId.asInt() + nullIndicator + " ");
+                expBuilder.append(tupleId.asInt() + " ");
             }
             expBuilder.append("\n");
         }
@@ -482,8 +469,8 @@ public abstract class PlanNode extends TreeNode<PlanNode> {
         msg.limit = limit;
         for (TupleId tid : tupleIds) {
             msg.addToRowTuples(tid.asInt());
-            msg.addToNullableTuples(nullableTupleIds.contains(tid));
         }
+        msg.setNullableTuples(Collections.emptyList());
 
         for (Expr e : conjuncts) {
             msg.addToConjuncts(e.treeToThrift());
@@ -571,14 +558,6 @@ public abstract class PlanNode extends TreeNode<PlanNode> {
                 .collect(Collectors.toSet());
         normalizedPlan.setTupleIds(
                 tupleIds.stream()
-                    .map(normalizer::normalizeTupleId)
-                    .collect(Collectors.toSet())
-        );
-        normalizedPlan.setNullableTuples(
-                nullableTupleIds
-                    .stream()
-                    .map(Id::asInt)
-                    .filter(tupleIds::contains)
                     .map(normalizer::normalizeTupleId)
                     .collect(Collectors.toSet())
         );

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SelectNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SelectNode.java
@@ -36,7 +36,6 @@ public class SelectNode extends PlanNode {
     public SelectNode(PlanNodeId id, PlanNode child) {
         super(id, new ArrayList<>(child.getOutputTupleIds()), "SELECT");
         addChild(child);
-        this.nullableTupleIds = child.nullableTupleIds;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SortNode.java
@@ -73,7 +73,6 @@ public class SortNode extends PlanNode {
         this.info = info;
         this.useTopN = useTopN;
         this.tupleIds.addAll(Lists.newArrayList(info.getSortTupleDescriptor().getId()));
-        this.nullableTupleIds.addAll(input.getNullableTupleIds());
         this.children.add(input);
         this.offset = 0;
         Preconditions.checkArgument(info.getOrderingExprs().size() == info.getIsAscOrder().size());

--- a/gensrc/thrift/Normalization.thrift
+++ b/gensrc/thrift/Normalization.thrift
@@ -51,6 +51,7 @@ struct TNormalizedPlanNode {
   2: optional PlanNodes.TPlanNodeType node_type
   3: optional i32 num_children
   5: optional set<Types.TTupleId> tuple_ids
+  // Deprecated
   6: optional set<Types.TTupleId> nullable_tuples
   7: optional list<Exprs.TExpr> conjuncts
   8: optional list<Exprs.TExpr> projects

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1402,7 +1402,7 @@ struct TPlanNode {
   4: required i64 limit
   5: required list<Types.TTupleId> row_tuples
 
-  // nullable_tuples[i] is true if row_tuples[i] is nullable
+  // Deprecated
   6: required list<bool> nullable_tuples
   7: optional list<Exprs.TExpr> conjuncts
 

--- a/regression-test/suites/nereids_p0/join/translate_tuple_id/join_input_tuple_id.groovy
+++ b/regression-test/suites/nereids_p0/join/translate_tuple_id/join_input_tuple_id.groovy
@@ -38,7 +38,7 @@ suite("join_input_tuple_id") {
                 join t3 on u.k+1 = t3.k
         """
         // verify that join's input tuple is union's output tuple id (5) not input tuple (4)
-        contains "tuple ids: 5 1N"
+        contains "tuple ids: 5 1"
 
 //   7:VHASH JOIN(293)
 //   |  join op: INNER JOIN(BROADCAST)[]
@@ -53,12 +53,12 @@ suite("join_input_tuple_id") {
 //   |  final project output tuple id: 7
 //   |  distribute expr lists: 
 //   |  distribute expr lists: 
-//   |  tuple ids: 5 1N 
+//   |  tuple ids: 5 1
 //   |  
 //   |----1:VEXCHANGE
 //   |       offset: 0
 //   |       distribute expr lists: 
-//   |       tuple ids: 1N 
+//   |       tuple ids: 1
 //   |    
 //   6:VUNION(276)
 //   |  child exprs: 


### PR DESCRIPTION
This pull request refactors the construction and usage of the `RowDescriptor` class throughout the codebase. The main change is the removal of the `nullable_tuples` parameter from `RowDescriptor` constructors and related data structures, simplifying the interface and internal state. This affects many operator and utility classes, as well as the implementation and debug output of `RowDescriptor`.

**RowDescriptor API and Implementation Simplification:**

* The `RowDescriptor` class no longer takes a `nullable_tuples` parameter in its constructors, and the internal `_tuple_idx_nullable_map` is removed. All related code and debug output referencing tuple nullability are deleted. [[1]](diffhunk://#diff-9ca2d7b56242bdb590e5ca112e78db5f91dce8d0e0ca4fad1ff0acfdd9177457L460-R461) [[2]](diffhunk://#diff-9ca2d7b56242bdb590e5ca112e78db5f91dce8d0e0ca4fad1ff0acfdd9177457L482-R478) [[3]](diffhunk://#diff-9ca2d7b56242bdb590e5ca112e78db5f91dce8d0e0ca4fad1ff0acfdd9177457L494-L499) [[4]](diffhunk://#diff-9ca2d7b56242bdb590e5ca112e78db5f91dce8d0e0ca4fad1ff0acfdd9177457L605-L613) [[5]](diffhunk://#diff-7de33f6a478f1f1d79ef409ceb6f3ae3919cebe3080294d25c38effe348d787cL459-L465) [[6]](diffhunk://#diff-7de33f6a478f1f1d79ef409ceb6f3ae3919cebe3080294d25c38effe348d787cL475-R473) [[7]](diffhunk://#diff-7de33f6a478f1f1d79ef409ceb6f3ae3919cebe3080294d25c38effe348d787cL526-L528)

**Operator and Utility Class Refactoring:**

* All instantiations of `RowDescriptor` in pipeline operators, scan/file scanners, and utility classes are updated to use the new constructor signature that omits the `nullable_tuples` argument. This includes classes such as `OperatorXBase`, `AggSinkOperatorX`, `StreamingAggOperatorX`, `JoinProbeOperatorX`, `NestedLoopJoinBuildSinkOperatorX`, `PartitionSortSinkOperatorX`, `SortSinkOperatorX`, `UnionSinkOperatorX`, `ResultFileSinkOperatorX`, and various scanner and sink operators. [[1]](diffhunk://#diff-043b378f55274208f7f4c1bf8b0d55745fb284ff0dff1fd26626e6f07a312d3fL844-R858) [[2]](diffhunk://#diff-df21df88282293d1bbe3223e0d95dcc5afc01da571e3a7c1d9dc9377a758d5daL755-R755) [[3]](diffhunk://#diff-5f2882c1f711fc0954459c6b98a1dcde9b688bb5634be71ce6f585332d8b6497L623-R623) [[4]](diffhunk://#diff-e6ac6c06aa08e51ed16e5949d228820d1f9aad0729ceea2f120bbc64d2568beaL121-R125) [[5]](diffhunk://#diff-41bf2d0887482c737060b81be10f308f586d91038ebf7e30c695f3d1197643ebL71-R71) [[6]](diffhunk://#diff-a720dfa6dfe95ee2b2805c1d3b150d0525df79083e837d15f2361bcc8814848cL73-R73) [[7]](diffhunk://#diff-6b22371546b44afb1cb510d34731b466f0f4b84cd4ddb7e17ce44ac416461744L94-R94) [[8]](diffhunk://#diff-dc070b360f07cfa32cbe858a7170f94e2691751afd61e424c26aa6254648b2eaL61-R61) [[9]](diffhunk://#diff-d3f219dbd844b02877c76b342b2b5011b9c5857f8fbe6063339f93a92d49f80aL53-R53) [[10]](diffhunk://#diff-aa97e616efca2638565e6a58aa9295252714265fcc1ed904d503425ef4930ce7L587-R587) [[11]](diffhunk://#diff-8ed52fcd40d49be70d3aa98b911d9ddc7b0366cf0a1110d45763da9be74f3834L324-R324) [[12]](diffhunk://#diff-70038347289359e40966cf399f9a4165f6423f3634ceb13d496da4d4627ce073L335-R335) [[13]](diffhunk://#diff-ecf0aa986b80b6f57a595b8c01add26a475b38677bfdb4887419635f58b2d276L712-R712) [[14]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617L1133-R1133) [[15]](diffhunk://#diff-018248672effda60a37074032505e76c1441447246e936df6b3bbf52f54160a2L148-R148) [[16]](diffhunk://#diff-6afbc092caa913a8775be9772777060161de5608b9aae939202e963e8aaf4e8bL178-R178) [[17]](diffhunk://#diff-6afbc092caa913a8775be9772777060161de5608b9aae939202e963e8aaf4e8bL197-R200) [[18]](diffhunk://#diff-6afbc092caa913a8775be9772777060161de5608b9aae939202e963e8aaf4e8bL1491-R1488) [[19]](diffhunk://#diff-ffdcb53fc7553e312f711f317af86ea75c99af2e5af446b6b95e1b92ff7368d2L54-R54)

This change unifies and simplifies the handling of row descriptors across the codebase, reducing complexity and potential sources of bugs related to tuple nullability handling.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

