### PR TITLE
[fix](mtmv) Fix mv rewrite failed when mv is rewritten by LimitAggToTopNAgg but query is not

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PreMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PreMaterializedViewRewriter.java
@@ -69,8 +69,6 @@ public class PreMaterializedViewRewriter {
         NEED_PRE_REWRITE_RULE_TYPES.set(RuleType.PROCESS_SCALAR_AGG_MUST_USE_MULTI_DISTINCT.ordinal());
         NEED_PRE_REWRITE_RULE_TYPES.set(RuleType.ELIMINATE_GROUP_BY_KEY_BY_UNIFORM.ordinal());
         NEED_PRE_REWRITE_RULE_TYPES.set(RuleType.SALT_JOIN.ordinal());
-        // this would add extra order keys in topN, which may cause mv rewrite fail, so need pre rewrite
-        NEED_PRE_REWRITE_RULE_TYPES.set(RuleType.LIMIT_AGG_TO_TOPN_AGG.ordinal());
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PreMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/PreMaterializedViewRewriter.java
@@ -69,6 +69,8 @@ public class PreMaterializedViewRewriter {
         NEED_PRE_REWRITE_RULE_TYPES.set(RuleType.PROCESS_SCALAR_AGG_MUST_USE_MULTI_DISTINCT.ordinal());
         NEED_PRE_REWRITE_RULE_TYPES.set(RuleType.ELIMINATE_GROUP_BY_KEY_BY_UNIFORM.ordinal());
         NEED_PRE_REWRITE_RULE_TYPES.set(RuleType.SALT_JOIN.ordinal());
+        // this would add extra order keys in topN, which may cause mv rewrite fail, so need pre rewrite
+        NEED_PRE_REWRITE_RULE_TYPES.set(RuleType.LIMIT_AGG_TO_TOPN_AGG.ordinal());
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -3285,8 +3285,11 @@ public class SessionVariable implements Serializable, Writable {
         }
         this.runtimeFilterWaitInfinitely = random.nextBoolean();
 
-        // set random 1, 10, 100, 1000, 10000
-        this.topnOptLimitThreshold = (int) Math.pow(10, random.nextInt(5));
+        // set random 101, 100, 1000, 10000, should be greater than 100, because small limit may lead
+        // some test case failed, e.g. topN with limit 100 may not hit the LimitAggToTopNAgg rule
+        // optimization when fuzzy
+        int randomLimitThreshold = (int) Math.pow(10, random.nextInt(5));
+        this.topnOptLimitThreshold = randomLimitThreshold <= 100 ? 101 : randomLimitThreshold;
 
         // for spill to disk
         if (Config.fuzzy_test_type.equals("p0")) {

--- a/regression-test/suites/nereids_rules_p0/mv/agg_optimize_when_uniform/agg_optimize_when_uniform.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/agg_optimize_when_uniform/agg_optimize_when_uniform.groovy
@@ -379,6 +379,10 @@ suite("agg_optimize_when_uniform") {
     def plan_6 = sql """explain verbose ${query6_0}"""
     logger.info("plan_6 is " + plan_6)
 
+    // This line of code is modified to position the occasional error: "null value is not in not null slot".
+    def query_mv6 = sql """select sum(__bin_4 is null) from mv6_0"""
+    logger.info("query_mv6 is " + query_mv6)
+
     order_qt_query6_0_after "${query6_0}"
     sql """ DROP MATERIALIZED VIEW IF EXISTS mv6_0"""
 


### PR DESCRIPTION
### What problem does this PR solve?

Fix mv rewrite failed when mv is rewritten by LimitAggToTopNAgg but query is not
such as query and mv def sql is as fllowing:

```sql
SELECT
              c_name,
              c_custkey,
              o_orderkey,
              o_orderdate,
              o_totalprice,
              sum(l_quantity)
            FROM
              customer,
              orders,
              lineitem
            WHERE
              o_orderkey IN (
                SELECT l_orderkey
                FROM
                  lineitem
                GROUP BY
                  l_orderkey
                HAVING
                  sum(l_quantity) > 300
              )
              AND c_custkey = o_custkey
              AND o_orderkey = l_orderkey
            GROUP BY
              c_name,
              c_custkey,
              o_orderkey,
              o_orderdate,
              o_totalprice
            ORDER BY
              o_totalprice DESC,
              o_orderdate
            LIMIT 100
```

if query plan is rewrtten by rule `LimitAggToTopNAgg`， plan would be like as following, tonN contains all goup by key
```sql
 LogicalResultSink[812] ( outputExprs=[c_name#1, c_custkey#0, o_orderkey#8, o_orderdate#12, o_totalprice#11, __sum_5#50] )                                                                                                                                                                                                                                                        
**| +--LogicalTopN ( limit=100, offset=0, orderKeys=[o_totalprice#11 desc, o_orderdate#12 asc null first, c_name#1 asc, c_custkey#0 asc, o_orderkey#8 asc] )**                                                                                                                                                                                                                         

```

if mv plan is not rewrtten by rule `LimitAggToTopNAgg`， plan would be like as following, tonN not contain all goup by key
```sql
LogicalResultSink[801] ( outputExprs=[c_name#1, c_custkey#0, o_orderkey#8, o_orderdate#12, o_totalprice#11, __sum_5#50] )
    **+--LogicalTopN ( limit=100, offset=0, orderKeys=[o_totalprice#11 desc, o_orderdate#12 asc null first] )**
```

this would cause `doris/regression-test/suites/nereids_rules_p0/mv/tpch/mv_tpch_test.groovy` mv18 rewrite fail, the pr fix this


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

