### PR TITLE
[opt](cloud) optimize load performance for inverted index when pack small files

### DIFF
--- a/be/src/index-tools/index_tool.cpp
+++ b/be/src/index-tools/index_tool.cpp
@@ -621,9 +621,14 @@ int main(int argc, char** argv) {
         _CLLDELETE(analyzer);
         _CLLDELETE(char_string_reader);
 
-        auto ret = index_file_writer->close();
+        auto ret = index_file_writer->close_async();
         if (!ret.ok()) {
             std::cerr << "IndexFileWriter close error:" << ret.msg() << std::endl;
+            return -1;
+        }
+        ret = index_file_writer->wait_close();
+        if (!ret.ok()) {
+            std::cerr << "IndexFileWriter wait close error:" << ret.msg() << std::endl;
             return -1;
         }
     } else if (FLAGS_operation == "show_nested_files_v2") {

--- a/be/src/index-tools/index_tool.cpp
+++ b/be/src/index-tools/index_tool.cpp
@@ -621,12 +621,12 @@ int main(int argc, char** argv) {
         _CLLDELETE(analyzer);
         _CLLDELETE(char_string_reader);
 
-        auto ret = index_file_writer->close_async();
+        auto ret = index_file_writer->begin_close();
         if (!ret.ok()) {
             std::cerr << "IndexFileWriter close error:" << ret.msg() << std::endl;
             return -1;
         }
-        ret = index_file_writer->wait_close();
+        ret = index_file_writer->finish_close();
         if (!ret.ok()) {
             std::cerr << "IndexFileWriter wait close error:" << ret.msg() << std::endl;
             return -1;

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -206,13 +206,21 @@ Status InvertedIndexFileCollection::add(int seg_id, IndexFileWriterPtr&& index_w
     return Status::OK();
 }
 
-Status InvertedIndexFileCollection::close() {
+Status InvertedIndexFileCollection::close_async() {
     std::lock_guard lock(_lock);
     for (auto&& [id, writer] : _inverted_index_file_writers) {
-        RETURN_IF_ERROR(writer->close());
+        RETURN_IF_ERROR(writer->close_async());
         _total_size += writer->get_index_file_total_size();
     }
 
+    return Status::OK();
+}
+
+Status InvertedIndexFileCollection::wait_close() {
+    std::lock_guard lock(_lock);
+    for (auto&& [id, writer] : _inverted_index_file_writers) {
+        RETURN_IF_ERROR(writer->wait_close());
+    }
     return Status::OK();
 }
 
@@ -1097,7 +1105,7 @@ Status BetaRowsetWriter::create_segment_writer_for_segcompaction(
     _segcompaction_worker->get_file_writer().reset(file_writer.release());
     if (auto& idx_file_writer = _segcompaction_worker->get_inverted_index_file_writer();
         idx_file_writer != nullptr) {
-        RETURN_IF_ERROR(idx_file_writer->close());
+        RETURN_IF_ERROR(idx_file_writer->close_async());
     }
     _segcompaction_worker->get_inverted_index_file_writer().reset(index_file_writer.release());
     return Status::OK();

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -91,7 +91,10 @@ public:
 
     // Close all file writers
     // If the inverted index file writer is not closed, an error will be thrown during destruction
-    Status close();
+    Status close_async();
+
+    // Wait for all inverted index file writers to be closed
+    Status wait_close();
 
     // Get inverted index file info in segment id order.
     // `seg_id_offset` is the offset of the segment id relative to the subscript of `_inverted_index_file_writers`,
@@ -214,9 +217,11 @@ protected:
     // Some index files are written during normal compaction and some files are written during index compaction.
     // After all index writes are completed, call this method to write the final compound index file.
     Status _close_inverted_index_file_writers() {
-        RETURN_NOT_OK_STATUS_WITH_WARN(_idx_files.close(),
+        RETURN_NOT_OK_STATUS_WITH_WARN(_idx_files.close_async(),
                                        "failed to close index file when build new rowset");
         this->_total_index_size += _idx_files.get_total_index_size();
+        RETURN_NOT_OK_STATUS_WITH_WARN(_idx_files.wait_close(),
+                                       "failed to wait close index file when build new rowset");
         return Status::OK();
     }
 

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -91,10 +91,10 @@ public:
 
     // Close all file writers
     // If the inverted index file writer is not closed, an error will be thrown during destruction
-    Status close_async();
+    Status begin_close();
 
     // Wait for all inverted index file writers to be closed
-    Status wait_close();
+    Status finish_close();
 
     // Get inverted index file info in segment id order.
     // `seg_id_offset` is the offset of the segment id relative to the subscript of `_inverted_index_file_writers`,
@@ -217,10 +217,10 @@ protected:
     // Some index files are written during normal compaction and some files are written during index compaction.
     // After all index writes are completed, call this method to write the final compound index file.
     Status _close_inverted_index_file_writers() {
-        RETURN_NOT_OK_STATUS_WITH_WARN(_idx_files.close_async(),
+        RETURN_NOT_OK_STATUS_WITH_WARN(_idx_files.begin_close(),
                                        "failed to close index file when build new rowset");
         this->_total_index_size += _idx_files.get_total_index_size();
-        RETURN_NOT_OK_STATUS_WITH_WARN(_idx_files.wait_close(),
+        RETURN_NOT_OK_STATUS_WITH_WARN(_idx_files.finish_close(),
                                        "failed to wait close index file when build new rowset");
         return Status::OK();
     }

--- a/be/src/olap/rowset/segment_creator.cpp
+++ b/be/src/olap/rowset/segment_creator.cpp
@@ -111,7 +111,9 @@ Status SegmentFlusher::_internal_parse_variant_columns(vectorized::Block& block)
 }
 
 Status SegmentFlusher::close() {
-    return _seg_files.close();
+    RETURN_IF_ERROR(_seg_files.close());
+    RETURN_IF_ERROR(_idx_files.wait_close());
+    return Status::OK();
 }
 
 Status SegmentFlusher::_add_rows(std::unique_ptr<segment_v2::SegmentWriter>& segment_writer,

--- a/be/src/olap/rowset/segment_creator.cpp
+++ b/be/src/olap/rowset/segment_creator.cpp
@@ -112,7 +112,7 @@ Status SegmentFlusher::_internal_parse_variant_columns(vectorized::Block& block)
 
 Status SegmentFlusher::close() {
     RETURN_IF_ERROR(_seg_files.close());
-    RETURN_IF_ERROR(_idx_files.wait_close());
+    RETURN_IF_ERROR(_idx_files.finish_close());
     return Status::OK();
 }
 

--- a/be/src/olap/rowset/segment_v2/index_file_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/index_file_writer.cpp
@@ -229,6 +229,15 @@ Status IndexFileWriter::close_async() {
 
 Status IndexFileWriter::wait_close() {
     DCHECK(_closed) << debug_string();
+    if (_indices_dirs.empty()) {
+        // An empty file must still be created even if there are no indexes to write
+        if (dynamic_cast<io::StreamSinkFileWriter*>(_idx_v2_writer.get()) != nullptr ||
+            dynamic_cast<io::S3FileWriter*>(_idx_v2_writer.get()) != nullptr ||
+            dynamic_cast<io::PackedFileWriter*>(_idx_v2_writer.get()) != nullptr) {
+            return _idx_v2_writer->close(false);
+        }
+        return Status::OK();
+    }
     if (_idx_v2_writer != nullptr && _idx_v2_writer->state() != io::FileWriter::State::CLOSED) {
         RETURN_IF_ERROR(_idx_v2_writer->close(false));
     }

--- a/be/src/olap/rowset/segment_v2/index_file_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/index_file_writer.cpp
@@ -184,7 +184,7 @@ Result<std::unique_ptr<IndexSearcherBuilder>> IndexFileWriter::_construct_index_
     return IndexSearcherBuilder::create_index_searcher_builder(reader_type);
 }
 
-Status IndexFileWriter::close_async() {
+Status IndexFileWriter::begin_close() {
     DCHECK(!_closed) << debug_string();
     _closed = true;
     if (_indices_dirs.empty()) {
@@ -227,7 +227,7 @@ Status IndexFileWriter::close_async() {
     return Status::OK();
 }
 
-Status IndexFileWriter::wait_close() {
+Status IndexFileWriter::finish_close() {
     DCHECK(_closed) << debug_string();
     if (_indices_dirs.empty()) {
         // An empty file must still be created even if there are no indexes to write
@@ -241,7 +241,7 @@ Status IndexFileWriter::wait_close() {
     if (_idx_v2_writer != nullptr && _idx_v2_writer->state() != io::FileWriter::State::CLOSED) {
         RETURN_IF_ERROR(_idx_v2_writer->close(false));
     }
-    LOG_INFO("IndexFileWriter wait_close, enable_write_index_searcher_cache: {}",
+    LOG_INFO("IndexFileWriter finish_close, enable_write_index_searcher_cache: {}",
              config::enable_write_index_searcher_cache);
     Status st = Status::OK();
     if (config::enable_write_index_searcher_cache) {

--- a/be/src/olap/rowset/segment_v2/index_file_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/index_file_writer.cpp
@@ -248,7 +248,7 @@ Status IndexFileWriter::wait_close() {
         st = add_into_searcher_cache();
     }
     _indices_dirs.clear();
-    return Status::OK();
+    return st;
 }
 
 std::vector<std::string> IndexFileWriter::get_index_file_names() const {

--- a/be/src/olap/rowset/segment_v2/index_file_writer.h
+++ b/be/src/olap/rowset/segment_v2/index_file_writer.h
@@ -57,7 +57,8 @@ public:
     Status delete_index(const TabletIndex* index_meta);
     Status initialize(InvertedIndexDirectoryMap& indices_dirs);
     Status add_into_searcher_cache();
-    Status close();
+    Status close_async();
+    Status wait_close();
     const InvertedIndexFileInfo* get_index_file_info() const {
         DCHECK(_closed) << debug_string();
         return &_file_info;

--- a/be/src/olap/rowset/segment_v2/index_file_writer.h
+++ b/be/src/olap/rowset/segment_v2/index_file_writer.h
@@ -57,8 +57,13 @@ public:
     Status delete_index(const TabletIndex* index_meta);
     Status initialize(InvertedIndexDirectoryMap& indices_dirs);
     Status add_into_searcher_cache();
-    Status close_async();
-    Status wait_close();
+    // Begin the close process. This mainly triggers the asynchronous close operation of
+    // _idx_v2_writer by calling close(true), which starts the close process but returns
+    // immediately without waiting for completion.
+    Status begin_close();
+    // Finish the close process. This waits for the close operation to complete by calling
+    // _idx_v2_writer->close(false), which blocks until the close is fully done.
+    Status finish_close();
     const InvertedIndexFileInfo* get_index_file_info() const {
         DCHECK(_closed) << debug_string();
         return &_file_info;

--- a/be/src/olap/rowset/segment_v2/inverted_index_fs_directory.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_fs_directory.cpp
@@ -433,7 +433,7 @@ void DorisFSDirectory::FSIndexOutputV2::close() {
         _index_v2_file_writer = nullptr;
     })
     if (_index_v2_file_writer) {
-        auto ret = _index_v2_file_writer->close();
+        auto ret = _index_v2_file_writer->close(true);
         DBUG_EXECUTE_IF("DorisFSDirectory::FSIndexOutput._set_writer_close_status_error",
                         { ret = Status::Error<INTERNAL_ERROR>("writer close status error"); })
         if (!ret.ok()) {

--- a/be/src/olap/rowset/segment_v2/segment_writer.h
+++ b/be/src/olap/rowset/segment_v2/segment_writer.h
@@ -148,7 +148,7 @@ public:
             *inverted_index_file_size = 0;
             return Status::OK();
         }
-        RETURN_IF_ERROR(_index_file_writer->close_async());
+        RETURN_IF_ERROR(_index_file_writer->begin_close());
         *inverted_index_file_size = _index_file_writer->get_index_file_total_size();
         return Status::OK();
     }

--- a/be/src/olap/rowset/segment_v2/segment_writer.h
+++ b/be/src/olap/rowset/segment_v2/segment_writer.h
@@ -148,7 +148,7 @@ public:
             *inverted_index_file_size = 0;
             return Status::OK();
         }
-        RETURN_IF_ERROR(_index_file_writer->close());
+        RETURN_IF_ERROR(_index_file_writer->close_async());
         *inverted_index_file_size = _index_file_writer->get_index_file_total_size();
         return Status::OK();
     }

--- a/be/src/olap/rowset/segment_v2/vertical_segment_writer.h
+++ b/be/src/olap/rowset/segment_v2/vertical_segment_writer.h
@@ -125,7 +125,7 @@ public:
             *inverted_index_file_size = 0;
             return Status::OK();
         }
-        RETURN_IF_ERROR(_index_file_writer->close_async());
+        RETURN_IF_ERROR(_index_file_writer->begin_close());
         *inverted_index_file_size = _index_file_writer->get_index_file_total_size();
         return Status::OK();
     }

--- a/be/src/olap/rowset/segment_v2/vertical_segment_writer.h
+++ b/be/src/olap/rowset/segment_v2/vertical_segment_writer.h
@@ -125,7 +125,7 @@ public:
             *inverted_index_file_size = 0;
             return Status::OK();
         }
-        RETURN_IF_ERROR(_index_file_writer->close());
+        RETURN_IF_ERROR(_index_file_writer->close_async());
         *inverted_index_file_size = _index_file_writer->get_index_file_total_size();
         return Status::OK();
     }

--- a/be/src/olap/task/index_builder.cpp
+++ b/be/src/olap/task/index_builder.cpp
@@ -368,12 +368,19 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
                 _index_file_writers.emplace(seg_ptr->id(), std::move(index_file_writer));
             }
             for (auto&& [seg_id, index_file_writer] : _index_file_writers) {
-                auto st = index_file_writer->close();
+                auto st = index_file_writer->close_async();
                 if (!st.ok()) {
                     LOG(ERROR) << "close index_file_writer error:" << st;
                     return st;
                 }
                 inverted_index_size += index_file_writer->get_index_file_total_size();
+            }
+            for (auto&& [seg_id, index_file_writer] : _index_file_writers) {
+                auto st = index_file_writer->wait_close();
+                if (!st.ok()) {
+                    LOG(ERROR) << "wait close index_file_writer error:" << st;
+                    return st;
+                }
             }
             _index_file_writers.clear();
             output_rowset_meta->set_data_disk_size(output_rowset_meta->data_disk_size());
@@ -610,7 +617,7 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
             _olap_data_convertor->reset();
         }
         for (auto&& [seg_id, index_file_writer] : _index_file_writers) {
-            auto st = index_file_writer->close();
+            auto st = index_file_writer->close_async();
             DBUG_EXECUTE_IF("IndexBuilder::handle_single_rowset_file_writer_close_error", {
                 st = Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
                         "debug point: handle_single_rowset_file_writer_close_error");
@@ -620,6 +627,13 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
                 return st;
             }
             inverted_index_size += index_file_writer->get_index_file_total_size();
+        }
+        for (auto&& [seg_id, index_file_writer] : _index_file_writers) {
+            auto st = index_file_writer->wait_close();
+            if (!st.ok()) {
+                LOG(ERROR) << "wait close index_file_writer error:" << st;
+                return st;
+            }
         }
         _index_column_writers.clear();
         _index_file_writers.clear();

--- a/be/src/olap/task/index_builder.cpp
+++ b/be/src/olap/task/index_builder.cpp
@@ -368,7 +368,7 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
                 _index_file_writers.emplace(seg_ptr->id(), std::move(index_file_writer));
             }
             for (auto&& [seg_id, index_file_writer] : _index_file_writers) {
-                auto st = index_file_writer->close_async();
+                auto st = index_file_writer->begin_close();
                 if (!st.ok()) {
                     LOG(ERROR) << "close index_file_writer error:" << st;
                     return st;
@@ -376,7 +376,7 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
                 inverted_index_size += index_file_writer->get_index_file_total_size();
             }
             for (auto&& [seg_id, index_file_writer] : _index_file_writers) {
-                auto st = index_file_writer->wait_close();
+                auto st = index_file_writer->finish_close();
                 if (!st.ok()) {
                     LOG(ERROR) << "wait close index_file_writer error:" << st;
                     return st;
@@ -617,7 +617,7 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
             _olap_data_convertor->reset();
         }
         for (auto&& [seg_id, index_file_writer] : _index_file_writers) {
-            auto st = index_file_writer->close_async();
+            auto st = index_file_writer->begin_close();
             DBUG_EXECUTE_IF("IndexBuilder::handle_single_rowset_file_writer_close_error", {
                 st = Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
                         "debug point: handle_single_rowset_file_writer_close_error");
@@ -629,7 +629,7 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
             inverted_index_size += index_file_writer->get_index_file_total_size();
         }
         for (auto&& [seg_id, index_file_writer] : _index_file_writers) {
-            auto st = index_file_writer->wait_close();
+            auto st = index_file_writer->finish_close();
             if (!st.ok()) {
                 LOG(ERROR) << "wait close index_file_writer error:" << st;
                 return st;

--- a/be/test/io/fs/s3_file_writer_test.cpp
+++ b/be/test/io/fs/s3_file_writer_test.cpp
@@ -1492,8 +1492,8 @@ TEST_F(S3FileWriterTest, test_empty_file) {
     auto index_file_writer = std::make_unique<segment_v2::IndexFileWriter>(
             fs, index_path, rowset_id, seg_id, InvertedIndexStorageFormatPB::V2,
             std::move(file_writer), false);
-    EXPECT_TRUE(index_file_writer->close_async().ok());
-    EXPECT_TRUE(index_file_writer->wait_close().ok());
+    EXPECT_TRUE(index_file_writer->begin_close().ok());
+    EXPECT_TRUE(index_file_writer->finish_close().ok());
 }
 
 } // namespace doris

--- a/be/test/io/fs/s3_file_writer_test.cpp
+++ b/be/test/io/fs/s3_file_writer_test.cpp
@@ -1492,7 +1492,8 @@ TEST_F(S3FileWriterTest, test_empty_file) {
     auto index_file_writer = std::make_unique<segment_v2::IndexFileWriter>(
             fs, index_path, rowset_id, seg_id, InvertedIndexStorageFormatPB::V2,
             std::move(file_writer), false);
-    EXPECT_TRUE(index_file_writer->close().ok());
+    EXPECT_TRUE(index_file_writer->close_async().ok());
+    EXPECT_TRUE(index_file_writer->wait_close().ok());
 }
 
 } // namespace doris

--- a/be/test/olap/rowset/segment_v2/inverted_index/empty_index_file_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index/empty_index_file_test.cpp
@@ -86,7 +86,8 @@ TEST_F(EmptyIndexFileTest, test_empty_index_file) {
     auto index_file_writer = std::make_unique<segment_v2::IndexFileWriter>(
             fs, index_path, rowset_id, seg_id, InvertedIndexStorageFormatPB::V2,
             std::move(file_writer), false);
-    EXPECT_TRUE(index_file_writer->close().ok());
+    EXPECT_TRUE(index_file_writer->close_async().ok());
+    EXPECT_TRUE(index_file_writer->wait_close().ok());
 }
 
 } // namespace doris

--- a/be/test/olap/rowset/segment_v2/inverted_index/empty_index_file_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index/empty_index_file_test.cpp
@@ -86,8 +86,8 @@ TEST_F(EmptyIndexFileTest, test_empty_index_file) {
     auto index_file_writer = std::make_unique<segment_v2::IndexFileWriter>(
             fs, index_path, rowset_id, seg_id, InvertedIndexStorageFormatPB::V2,
             std::move(file_writer), false);
-    EXPECT_TRUE(index_file_writer->close_async().ok());
-    EXPECT_TRUE(index_file_writer->wait_close().ok());
+    EXPECT_TRUE(index_file_writer->begin_close().ok());
+    EXPECT_TRUE(index_file_writer->finish_close().ok());
 }
 
 } // namespace doris

--- a/be/test/olap/rowset/segment_v2/inverted_index/query/phrase_edge_query_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index/query/phrase_edge_query_test.cpp
@@ -150,7 +150,9 @@ public:
         // Finish and close
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->close();
+        status = index_file_writer->close_async();
+        EXPECT_TRUE(status.ok()) << status;
+        status = index_file_writer->wait_close();
         EXPECT_TRUE(status.ok()) << status;
     }
 

--- a/be/test/olap/rowset/segment_v2/inverted_index/query/phrase_edge_query_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index/query/phrase_edge_query_test.cpp
@@ -150,9 +150,9 @@ public:
         // Finish and close
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->close_async();
+        status = index_file_writer->begin_close();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->wait_close();
+        status = index_file_writer->finish_close();
         EXPECT_TRUE(status.ok()) << status;
     }
 

--- a/be/test/olap/rowset/segment_v2/inverted_index/query/phrase_prefix_query_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index/query/phrase_prefix_query_test.cpp
@@ -149,9 +149,9 @@ public:
         // Finish and close
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->close_async();
+        status = index_file_writer->begin_close();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->wait_close();
+        status = index_file_writer->finish_close();
         EXPECT_TRUE(status.ok()) << status;
     }
 

--- a/be/test/olap/rowset/segment_v2/inverted_index/query/phrase_prefix_query_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index/query/phrase_prefix_query_test.cpp
@@ -149,7 +149,9 @@ public:
         // Finish and close
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->close();
+        status = index_file_writer->close_async();
+        EXPECT_TRUE(status.ok()) << status;
+        status = index_file_writer->wait_close();
         EXPECT_TRUE(status.ok()) << status;
     }
 

--- a/be/test/olap/rowset/segment_v2/inverted_index/query/phrase_query_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index/query/phrase_query_test.cpp
@@ -150,7 +150,9 @@ public:
         // Finish and close
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->close();
+        status = index_file_writer->close_async();
+        EXPECT_TRUE(status.ok()) << status;
+        status = index_file_writer->wait_close();
         EXPECT_TRUE(status.ok()) << status;
     }
 

--- a/be/test/olap/rowset/segment_v2/inverted_index/query/phrase_query_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index/query/phrase_query_test.cpp
@@ -150,9 +150,9 @@ public:
         // Finish and close
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->close_async();
+        status = index_file_writer->begin_close();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->wait_close();
+        status = index_file_writer->finish_close();
         EXPECT_TRUE(status.ok()) << status;
     }
 

--- a/be/test/olap/rowset/segment_v2/inverted_index_array_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_array_test.cpp
@@ -279,8 +279,8 @@ public:
         EXPECT_EQ(st, Status::OK());
 
         EXPECT_EQ(_inverted_index_builder->finish(), Status::OK());
-        EXPECT_EQ(index_file_writer->close_async(), Status::OK());
-        EXPECT_EQ(index_file_writer->wait_close(), Status::OK());
+        EXPECT_EQ(index_file_writer->begin_close(), Status::OK());
+        EXPECT_EQ(index_file_writer->finish_close(), Status::OK());
 
         ExpectedDocMap expected = {{"amory", {0, 1}}, {"doris", {0}}, {"commiter", {1}}};
         check_terms_stats(index_path_prefix, &expected, {}, InvertedIndexStorageFormatPB::V1,
@@ -366,8 +366,8 @@ public:
         st = _inverted_index_builder->add_array_nulls(null_map, block.rows());
         EXPECT_EQ(st, Status::OK());
         EXPECT_EQ(_inverted_index_builder->finish(), Status::OK());
-        EXPECT_EQ(index_file_writer->close_async(), Status::OK());
-        EXPECT_EQ(index_file_writer->wait_close(), Status::OK());
+        EXPECT_EQ(index_file_writer->begin_close(), Status::OK());
+        EXPECT_EQ(index_file_writer->finish_close(), Status::OK());
 
         ExpectedDocMap expected = {{"amory", {0, 1}}, {"doris", {0}}, {"commiter", {1}}};
         check_terms_stats(index_path_prefix, &expected, {}, InvertedIndexStorageFormatPB::V1,
@@ -479,8 +479,8 @@ public:
         st = _inverted_index_builder->add_array_nulls(null_map, block.rows());
         EXPECT_EQ(st, Status::OK());
         EXPECT_EQ(_inverted_index_builder->finish(), Status::OK());
-        EXPECT_EQ(index_file_writer->close_async(), Status::OK());
-        EXPECT_EQ(index_file_writer->wait_close(), Status::OK());
+        EXPECT_EQ(index_file_writer->begin_close(), Status::OK());
+        EXPECT_EQ(index_file_writer->finish_close(), Status::OK());
 
         // Expected inverted index result: only index non-null elements
         // Row 1: non-null in a2 is "test"
@@ -594,8 +594,8 @@ public:
         st = _inverted_index_builder->add_array_nulls(null_map, block.rows());
         EXPECT_EQ(st, Status::OK());
         EXPECT_EQ(_inverted_index_builder->finish(), Status::OK());
-        EXPECT_EQ(index_file_writer->close_async(), Status::OK());
-        EXPECT_EQ(index_file_writer->wait_close(), Status::OK());
+        EXPECT_EQ(index_file_writer->begin_close(), Status::OK());
+        EXPECT_EQ(index_file_writer->finish_close(), Status::OK());
 
         // Expected inverted index result: only index non-null elements
         // Row 1: non-null in a2 is "test"
@@ -797,8 +797,8 @@ public:
         }
 
         EXPECT_EQ(_inverted_index_builder->finish(), Status::OK());
-        EXPECT_EQ(index_file_writer->close_async(), Status::OK());
-        EXPECT_EQ(index_file_writer->wait_close(), Status::OK());
+        EXPECT_EQ(index_file_writer->begin_close(), Status::OK());
+        EXPECT_EQ(index_file_writer->finish_close(), Status::OK());
 
         std::vector<int> expected_null_bitmap = {0, 3, 5, 7};
         check_terms_stats(index_path_prefix, &merged_expected, expected_null_bitmap,
@@ -901,8 +901,8 @@ public:
         st = _inverted_index_builder->add_array_nulls(null_map, block.rows());
         EXPECT_EQ(st, Status::OK());
         EXPECT_EQ(_inverted_index_builder->finish(), Status::OK());
-        EXPECT_EQ(index_file_writer->close_async(), Status::OK());
-        EXPECT_EQ(index_file_writer->wait_close(), Status::OK());
+        EXPECT_EQ(index_file_writer->begin_close(), Status::OK());
+        EXPECT_EQ(index_file_writer->finish_close(), Status::OK());
 
         // expected inverted index: row0 contains "123" and "456" (doc id 0), row1 is null, row2 contains "789" and "101112" (doc id 2)
         ExpectedDocMap expected = {{"123", {0}}, {"456", {0}}, {"789", {2}}, {"101112", {2}}};
@@ -1013,8 +1013,8 @@ public:
         EXPECT_EQ(st, Status::OK());
 
         EXPECT_EQ(_inverted_index_builder->finish(), Status::OK());
-        EXPECT_EQ(index_file_writer->close_async(), Status::OK());
-        EXPECT_EQ(index_file_writer->wait_close(), Status::OK());
+        EXPECT_EQ(index_file_writer->begin_close(), Status::OK());
+        EXPECT_EQ(index_file_writer->finish_close(), Status::OK());
 
         std::vector<int> expected_null_bitmap = {0, 1};
         ExpectedDocMap expected {};

--- a/be/test/olap/rowset/segment_v2/inverted_index_array_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_array_test.cpp
@@ -279,7 +279,8 @@ public:
         EXPECT_EQ(st, Status::OK());
 
         EXPECT_EQ(_inverted_index_builder->finish(), Status::OK());
-        EXPECT_EQ(index_file_writer->close(), Status::OK());
+        EXPECT_EQ(index_file_writer->close_async(), Status::OK());
+        EXPECT_EQ(index_file_writer->wait_close(), Status::OK());
 
         ExpectedDocMap expected = {{"amory", {0, 1}}, {"doris", {0}}, {"commiter", {1}}};
         check_terms_stats(index_path_prefix, &expected, {}, InvertedIndexStorageFormatPB::V1,
@@ -365,7 +366,8 @@ public:
         st = _inverted_index_builder->add_array_nulls(null_map, block.rows());
         EXPECT_EQ(st, Status::OK());
         EXPECT_EQ(_inverted_index_builder->finish(), Status::OK());
-        EXPECT_EQ(index_file_writer->close(), Status::OK());
+        EXPECT_EQ(index_file_writer->close_async(), Status::OK());
+        EXPECT_EQ(index_file_writer->wait_close(), Status::OK());
 
         ExpectedDocMap expected = {{"amory", {0, 1}}, {"doris", {0}}, {"commiter", {1}}};
         check_terms_stats(index_path_prefix, &expected, {}, InvertedIndexStorageFormatPB::V1,
@@ -477,7 +479,8 @@ public:
         st = _inverted_index_builder->add_array_nulls(null_map, block.rows());
         EXPECT_EQ(st, Status::OK());
         EXPECT_EQ(_inverted_index_builder->finish(), Status::OK());
-        EXPECT_EQ(index_file_writer->close(), Status::OK());
+        EXPECT_EQ(index_file_writer->close_async(), Status::OK());
+        EXPECT_EQ(index_file_writer->wait_close(), Status::OK());
 
         // Expected inverted index result: only index non-null elements
         // Row 1: non-null in a2 is "test"
@@ -591,7 +594,8 @@ public:
         st = _inverted_index_builder->add_array_nulls(null_map, block.rows());
         EXPECT_EQ(st, Status::OK());
         EXPECT_EQ(_inverted_index_builder->finish(), Status::OK());
-        EXPECT_EQ(index_file_writer->close(), Status::OK());
+        EXPECT_EQ(index_file_writer->close_async(), Status::OK());
+        EXPECT_EQ(index_file_writer->wait_close(), Status::OK());
 
         // Expected inverted index result: only index non-null elements
         // Row 1: non-null in a2 is "test"
@@ -793,7 +797,8 @@ public:
         }
 
         EXPECT_EQ(_inverted_index_builder->finish(), Status::OK());
-        EXPECT_EQ(index_file_writer->close(), Status::OK());
+        EXPECT_EQ(index_file_writer->close_async(), Status::OK());
+        EXPECT_EQ(index_file_writer->wait_close(), Status::OK());
 
         std::vector<int> expected_null_bitmap = {0, 3, 5, 7};
         check_terms_stats(index_path_prefix, &merged_expected, expected_null_bitmap,
@@ -896,7 +901,8 @@ public:
         st = _inverted_index_builder->add_array_nulls(null_map, block.rows());
         EXPECT_EQ(st, Status::OK());
         EXPECT_EQ(_inverted_index_builder->finish(), Status::OK());
-        EXPECT_EQ(index_file_writer->close(), Status::OK());
+        EXPECT_EQ(index_file_writer->close_async(), Status::OK());
+        EXPECT_EQ(index_file_writer->wait_close(), Status::OK());
 
         // expected inverted index: row0 contains "123" and "456" (doc id 0), row1 is null, row2 contains "789" and "101112" (doc id 2)
         ExpectedDocMap expected = {{"123", {0}}, {"456", {0}}, {"789", {2}}, {"101112", {2}}};
@@ -1007,7 +1013,8 @@ public:
         EXPECT_EQ(st, Status::OK());
 
         EXPECT_EQ(_inverted_index_builder->finish(), Status::OK());
-        EXPECT_EQ(index_file_writer->close(), Status::OK());
+        EXPECT_EQ(index_file_writer->close_async(), Status::OK());
+        EXPECT_EQ(index_file_writer->wait_close(), Status::OK());
 
         std::vector<int> expected_null_bitmap = {0, 1};
         ExpectedDocMap expected {};

--- a/be/test/olap/rowset/segment_v2/inverted_index_compound_reader_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_compound_reader_test.cpp
@@ -375,9 +375,9 @@ TEST_F(DorisCompoundReaderTest, IntegrationWithFileWriter) {
         out->close();
         _CLLDELETE(out);
 
-        auto st = index_file_writer->close_async();
+        auto st = index_file_writer->begin_close();
         ASSERT_TRUE(st.ok()) << st;
-        st = index_file_writer->wait_close();
+        st = index_file_writer->finish_close();
         ASSERT_TRUE(st.ok()) << st;
 
         auto file_reader = std::make_unique<IndexFileReader>(
@@ -424,9 +424,9 @@ TEST_F(DorisCompoundReaderTest, IntegrationWithFileWriter) {
         out->close();
         _CLLDELETE(out);
 
-        st = index_file_writer->close_async();
+        st = index_file_writer->begin_close();
         ASSERT_TRUE(st.ok()) << st;
-        st = index_file_writer->wait_close();
+        st = index_file_writer->finish_close();
         ASSERT_TRUE(st.ok()) << st;
 
         auto file_reader = std::make_unique<IndexFileReader>(

--- a/be/test/olap/rowset/segment_v2/inverted_index_compound_reader_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_compound_reader_test.cpp
@@ -375,7 +375,9 @@ TEST_F(DorisCompoundReaderTest, IntegrationWithFileWriter) {
         out->close();
         _CLLDELETE(out);
 
-        auto st = index_file_writer->close();
+        auto st = index_file_writer->close_async();
+        ASSERT_TRUE(st.ok()) << st;
+        st = index_file_writer->wait_close();
         ASSERT_TRUE(st.ok()) << st;
 
         auto file_reader = std::make_unique<IndexFileReader>(
@@ -422,7 +424,9 @@ TEST_F(DorisCompoundReaderTest, IntegrationWithFileWriter) {
         out->close();
         _CLLDELETE(out);
 
-        st = index_file_writer->close();
+        st = index_file_writer->close_async();
+        ASSERT_TRUE(st.ok()) << st;
+        st = index_file_writer->wait_close();
         ASSERT_TRUE(st.ok()) << st;
 
         auto file_reader = std::make_unique<IndexFileReader>(

--- a/be/test/olap/rowset/segment_v2/inverted_index_file_reader_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_file_reader_test.cpp
@@ -202,10 +202,10 @@ public:
 
         dir->close();
 
-        // Write and close the file - only call close_async() and wait_close(), not write()
-        st = writer->close_async();
+        // Write and close the file - only call begin_close() and finish_close(), not write()
+        st = writer->begin_close();
         ASSERT_TRUE(st.ok()) << st.msg();
-        st = writer->wait_close();
+        st = writer->finish_close();
         ASSERT_TRUE(st.ok()) << st.msg();
     }
 

--- a/be/test/olap/rowset/segment_v2/inverted_index_file_reader_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_file_reader_test.cpp
@@ -202,8 +202,10 @@ public:
 
         dir->close();
 
-        // Write and close the file - only call close(), not write()
-        st = writer->close();
+        // Write and close the file - only call close_async() and wait_close(), not write()
+        st = writer->close_async();
+        ASSERT_TRUE(st.ok()) << st.msg();
+        st = writer->wait_close();
         ASSERT_TRUE(st.ok()) << st.msg();
     }
 

--- a/be/test/olap/rowset/segment_v2/inverted_index_file_writer_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_file_writer_test.cpp
@@ -247,9 +247,14 @@ TEST_F(IndexFileWriterTest, WriteV1Test) {
     out_file->close();
     dir->close();
 
-    Status close_status = writer.close();
+    Status close_status = writer.close_async();
     if (!close_status.ok()) {
-        std::cout << "close error:" << close_status.msg() << std::endl;
+        std::cout << "close_async error:" << close_status.msg() << std::endl;
+    }
+    ASSERT_TRUE(close_status.ok());
+    close_status = writer.wait_close();
+    if (!close_status.ok()) {
+        std::cout << "wait_close error:" << close_status.msg() << std::endl;
     }
     ASSERT_TRUE(close_status.ok());
 
@@ -302,7 +307,9 @@ TEST_F(IndexFileWriterTest, WriteV2Test) {
     out_file_2->writeString("test2");
     out_file_2->close();
     dir_2->close();
-    Status close_status = writer.close();
+    Status close_status = writer.close_async();
+    ASSERT_TRUE(close_status.ok());
+    close_status = writer.wait_close();
     ASSERT_TRUE(close_status.ok());
 
     const InvertedIndexFileInfo* file_info = writer.get_index_file_info();
@@ -620,7 +627,7 @@ TEST_F(IndexFileWriterTest, WriteV1ExceptionHandlingTest) {
                                       ::testing::_))
             .WillOnce(::testing::Throw(CLuceneError(CL_ERR_IO, "Simulated exception", false)));
 
-    Status status = writer_mock.close();
+    Status status = writer_mock.close_async();
     ASSERT_FALSE(status.ok());
     ASSERT_EQ(status.code(), ErrorCode::INVERTED_INDEX_CLUCENE_ERROR);
 }
@@ -673,7 +680,7 @@ TEST_F(IndexFileWriterTest, WriteV2ExceptionHandlingTest) {
                 write_index_headers_and_metadata(::testing::_, ::testing::_))
             .WillOnce(::testing::Throw(CLuceneError(CL_ERR_IO, "Simulated exception", false)));
 
-    Status status = writer_mock.close();
+    Status status = writer_mock.close_async();
     ASSERT_FALSE(status.ok());
     ASSERT_EQ(status.code(), ErrorCode::INVERTED_INDEX_CLUCENE_ERROR);
 }
@@ -780,7 +787,7 @@ TEST_F(IndexFileWriterTest, WriteV1OutputTest) {
     out_file->close();
     dir->close();
 
-    Status status = writer_mock.close();
+    Status status = writer_mock.close_async();
     ASSERT_FALSE(status.ok());
     ASSERT_EQ(status.code(), ErrorCode::INVERTED_INDEX_CLUCENE_ERROR);
 }
@@ -829,7 +836,7 @@ TEST_F(IndexFileWriterTest, WriteV2OutputTest) {
     out_file->close();
     dir->close();
 
-    Status status = writer_mock.close();
+    Status status = writer_mock.close_async();
     ASSERT_FALSE(status.ok());
     ASSERT_EQ(status.code(), ErrorCode::INVERTED_INDEX_CLUCENE_ERROR);
 }
@@ -892,7 +899,7 @@ TEST_F(IndexFileWriterTest, WriteV2OutputCloseErrorTest) {
     out_file->close();
     dir->close();
 
-    Status status = writer_mock.close();
+    Status status = writer_mock.close_async();
     ASSERT_FALSE(status.ok());
     ASSERT_EQ(status.code(), ErrorCode::INVERTED_INDEX_CLUCENE_ERROR);
 }
@@ -942,7 +949,7 @@ TEST_F(IndexFileWriterTest, WriteV1OutputCloseErrorTest) {
     out_file->close();
     dir->close();
 
-    Status status = writer_mock.close();
+    Status status = writer_mock.close_async();
     ASSERT_FALSE(status.ok());
     ASSERT_EQ(status.code(), ErrorCode::INVERTED_INDEX_CLUCENE_ERROR);
 }
@@ -1005,7 +1012,9 @@ TEST_F(IndexFileWriterTest, AddIntoSearcherCacheTest) {
     EXPECT_CALL(writer, _construct_index_searcher_builder(testing::_))
             .WillOnce(testing::Return(testing::ByMove(std::move(mock_builder))));
 
-    Status close_status = writer.close();
+    Status close_status = writer.close_async();
+    ASSERT_TRUE(close_status.ok());
+    close_status = writer.wait_close();
     ASSERT_TRUE(close_status.ok());
 
     auto index_file_key = InvertedIndexDescriptor::get_index_file_cache_key(_index_path_prefix,
@@ -1065,7 +1074,9 @@ TEST_F(IndexFileWriterTest, CacheEvictionTest) {
     EXPECT_CALL(writer1, _construct_index_searcher_builder(testing::_))
             .WillOnce(testing::Return(testing::ByMove(std::move(mock_builder1))));
 
-    Status close_status1 = writer1.close();
+    Status close_status1 = writer1.close_async();
+    ASSERT_TRUE(close_status1.ok());
+    close_status1 = writer1.wait_close();
     ASSERT_TRUE(close_status1.ok());
 
     MockIndexFileWriter writer2(_fs, _index_path_prefix + "_2", "rowset2", 2,
@@ -1096,7 +1107,9 @@ TEST_F(IndexFileWriterTest, CacheEvictionTest) {
     EXPECT_CALL(writer2, _construct_index_searcher_builder(testing::_))
             .WillOnce(testing::Return(testing::ByMove(std::move(mock_builder2))));
 
-    Status close_status2 = writer2.close();
+    Status close_status2 = writer2.close_async();
+    ASSERT_TRUE(close_status2.ok());
+    close_status2 = writer2.wait_close();
     ASSERT_TRUE(close_status2.ok());
 
     MockIndexFileWriter writer3(_fs, _index_path_prefix + "_3", "rowset3", 3,
@@ -1126,7 +1139,9 @@ TEST_F(IndexFileWriterTest, CacheEvictionTest) {
     EXPECT_CALL(writer3, _construct_index_searcher_builder(testing::_))
             .WillOnce(testing::Return(testing::ByMove(std::move(mock_builder3))));
 
-    Status close_status3 = writer3.close();
+    Status close_status3 = writer3.close_async();
+    ASSERT_TRUE(close_status3.ok());
+    close_status3 = writer3.wait_close();
     ASSERT_TRUE(close_status3.ok());
 
     InvertedIndexCacheHandle cache_handle1;
@@ -1196,7 +1211,9 @@ TEST_F(IndexFileWriterTest, CacheUpdateTest) {
     EXPECT_CALL(writer, _construct_index_searcher_builder(testing::_))
             .WillOnce(testing::Return(testing::ByMove(std::move(mock_builder))));
 
-    Status close_status = writer.close();
+    Status close_status = writer.close_async();
+    ASSERT_TRUE(close_status.ok());
+    close_status = writer.wait_close();
     ASSERT_TRUE(close_status.ok());
 
     auto index_file_key = InvertedIndexDescriptor::get_index_file_cache_key(
@@ -1234,7 +1251,9 @@ TEST_F(IndexFileWriterTest, CacheUpdateTest) {
     EXPECT_CALL(writer_new, _construct_index_searcher_builder(testing::_))
             .WillOnce(testing::Return(testing::ByMove(std::move(mock_builder_new))));
 
-    Status close_status_new = writer_new.close();
+    Status close_status_new = writer_new.close_async();
+    ASSERT_TRUE(close_status_new.ok());
+    close_status_new = writer_new.wait_close();
     ASSERT_TRUE(close_status_new.ok());
 
     InvertedIndexCacheHandle cache_handle_new;
@@ -1280,7 +1299,9 @@ TEST_F(IndexFileWriterTest, AddIntoSearcherCacheV1Test) {
                     }));
     EXPECT_CALL(writer, _construct_index_searcher_builder(testing::_))
             .WillOnce(testing::Return(testing::ByMove(std::move(mock_builder))));
-    Status close_status = writer.close();
+    Status close_status = writer.close_async();
+    ASSERT_TRUE(close_status.ok());
+    close_status = writer.wait_close();
     ASSERT_TRUE(close_status.ok());
 
     auto index_file_key = InvertedIndexDescriptor::get_index_file_cache_key(
@@ -1392,7 +1413,9 @@ TEST_F(IndexFileWriterTest, RowsetWriterCreateIndexFileWriterWithoutRamDir) {
 
     // Cleanup
     dir->close();
-    status = index_file_writer->close();
+    status = index_file_writer->close_async();
+    ASSERT_TRUE(status.ok());
+    status = index_file_writer->wait_close();
     ASSERT_TRUE(status.ok());
 }
 
@@ -1441,7 +1464,9 @@ TEST_F(IndexFileWriterTest, RowsetWriterCreateIndexFileWriterWithRamDir) {
 
     // Cleanup
     dir->close();
-    status = index_file_writer->close();
+    status = index_file_writer->close_async();
+    ASSERT_TRUE(status.ok());
+    status = index_file_writer->wait_close();
     ASSERT_TRUE(status.ok());
 }
 
@@ -1490,7 +1515,9 @@ TEST_F(IndexFileWriterTest, RowsetWriterCreateIndexFileWriterNonBaseCompaction) 
 
     // Cleanup
     dir->close();
-    status = index_file_writer->close();
+    status = index_file_writer->close_async();
+    ASSERT_TRUE(status.ok());
+    status = index_file_writer->wait_close();
     ASSERT_TRUE(status.ok());
 }
 
@@ -1568,7 +1595,7 @@ TEST_F(IndexFileWriterTest, MultipleIndicesCreateOutputStreamException) {
             .WillOnce(::testing::Throw(CLuceneError(CL_ERR_IO, "Simulated exception", false)));
 
     // When we call close(), it should process both indices and fail on the second one
-    Status status = writer_mock.close();
+    Status status = writer_mock.close_async();
     ASSERT_FALSE(status.ok());
     ASSERT_EQ(status.code(), ErrorCode::INVERTED_INDEX_CLUCENE_ERROR);
 }
@@ -1908,7 +1935,9 @@ TEST_F(IndexFileWriterTest, CloseV1DirectoryDeletionTest) {
     dir->close();
 
     // Close should handle directory cleanup
-    Status status = writer.close();
+    Status status = writer.close_async();
+    ASSERT_TRUE(status.ok());
+    status = writer.wait_close();
     ASSERT_TRUE(status.ok());
 }
 
@@ -1939,9 +1968,12 @@ TEST_F(IndexFileWriterTest, CloseV2CLuceneExceptionTest) {
     dir->close();
 
     // The test should verify that CLucene exceptions are properly caught and handled
-    Status status = writer.close();
+    Status status = writer.close_async();
     // Even if there are CLucene errors, the status should still indicate completion
     // The error handling should log the error but not crash
+    if (status.ok()) {
+        status = writer.wait_close();
+    }
 }
 
 // Test for compound directory deletion error handling
@@ -1973,7 +2005,9 @@ TEST_F(IndexFileWriterTest, CompoundDirectoryDeletionTest) {
     if (std::strcmp(dir->getObjectName(), "DorisFSDirectory") == 0) {
         // This path should trigger the compound directory deletion code
         dir->close();
-        Status status = writer.close();
+        Status status = writer.close_async();
+        ASSERT_TRUE(status.ok());
+        status = writer.wait_close();
         ASSERT_TRUE(status.ok());
     }
 }
@@ -2068,7 +2102,9 @@ TEST_F(IndexFileWriterTest, WriteIndexHeadersAndMetadataTest) {
     ASSERT_TRUE(insert_st.ok());
 
     // Test close which should trigger write_index_headers_and_metadata
-    Status close_status = writer.close();
+    Status close_status = writer.close_async();
+    ASSERT_TRUE(close_status.ok());
+    close_status = writer.wait_close();
     ASSERT_TRUE(close_status.ok());
 
     // Clean up
@@ -2145,7 +2181,9 @@ TEST_F(IndexFileWriterTest, EmptyIndexV2Test) {
                            InvertedIndexStorageFormatPB::V2, std::move(file_writer));
 
     // Close without adding any indices - should handle empty case
-    Status close_status = writer.close();
+    Status close_status = writer.close_async();
+    ASSERT_TRUE(close_status.ok());
+    close_status = writer.wait_close();
     ASSERT_TRUE(close_status.ok());
 }
 
@@ -2156,7 +2194,9 @@ TEST_F(IndexFileWriterTest, StreamSinkFileWriterCloseTest) {
                            InvertedIndexStorageFormatPB::V2);
 
     // Close should handle the case where _idx_v2_writer is not a StreamSinkFileWriter
-    Status close_status = writer.close();
+    Status close_status = writer.close_async();
+    ASSERT_TRUE(close_status.ok());
+    close_status = writer.wait_close();
     ASSERT_TRUE(close_status.ok());
 }
 

--- a/be/test/olap/rowset/segment_v2/inverted_index_reader_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_reader_test.cpp
@@ -153,9 +153,9 @@ public:
         // Finish and close
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->close_async();
+        status = index_file_writer->begin_close();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->wait_close();
+        status = index_file_writer->finish_close();
         EXPECT_TRUE(status.ok()) << status;
     }
 
@@ -217,9 +217,9 @@ public:
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
 
-        status = index_file_writer->close_async();
+        status = index_file_writer->begin_close();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->wait_close();
+        status = index_file_writer->finish_close();
         EXPECT_TRUE(status.ok()) << status;
     }
 
@@ -276,9 +276,9 @@ public:
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
 
-        status = index_file_writer->close_async();
+        status = index_file_writer->begin_close();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->wait_close();
+        status = index_file_writer->finish_close();
         EXPECT_TRUE(status.ok()) << status;
     }
 
@@ -2672,9 +2672,9 @@ public:
 
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->close_async();
+        status = index_file_writer->begin_close();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->wait_close();
+        status = index_file_writer->finish_close();
         EXPECT_TRUE(status.ok()) << status;
     }
 
@@ -3144,9 +3144,9 @@ public:
 
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->close_async();
+        status = index_file_writer->begin_close();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->wait_close();
+        status = index_file_writer->finish_close();
         EXPECT_TRUE(status.ok()) << status;
     }
 
@@ -3621,9 +3621,9 @@ public:
         if (status.ok()) {
             status = column_writer->finish();
             EXPECT_TRUE(status.ok()) << status;
-            status = index_file_writer->close_async();
+            status = index_file_writer->begin_close();
             EXPECT_TRUE(status.ok()) << status;
-            status = index_file_writer->wait_close();
+            status = index_file_writer->finish_close();
             EXPECT_TRUE(status.ok()) << status;
 
             // Try to create reader and test unsupported query

--- a/be/test/olap/rowset/segment_v2/inverted_index_reader_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_reader_test.cpp
@@ -153,7 +153,9 @@ public:
         // Finish and close
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->close();
+        status = index_file_writer->close_async();
+        EXPECT_TRUE(status.ok()) << status;
+        status = index_file_writer->wait_close();
         EXPECT_TRUE(status.ok()) << status;
     }
 
@@ -215,7 +217,9 @@ public:
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
 
-        status = index_file_writer->close();
+        status = index_file_writer->close_async();
+        EXPECT_TRUE(status.ok()) << status;
+        status = index_file_writer->wait_close();
         EXPECT_TRUE(status.ok()) << status;
     }
 
@@ -272,7 +276,9 @@ public:
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
 
-        status = index_file_writer->close();
+        status = index_file_writer->close_async();
+        EXPECT_TRUE(status.ok()) << status;
+        status = index_file_writer->wait_close();
         EXPECT_TRUE(status.ok()) << status;
     }
 
@@ -2666,7 +2672,9 @@ public:
 
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->close();
+        status = index_file_writer->close_async();
+        EXPECT_TRUE(status.ok()) << status;
+        status = index_file_writer->wait_close();
         EXPECT_TRUE(status.ok()) << status;
     }
 
@@ -3136,7 +3144,9 @@ public:
 
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->close();
+        status = index_file_writer->close_async();
+        EXPECT_TRUE(status.ok()) << status;
+        status = index_file_writer->wait_close();
         EXPECT_TRUE(status.ok()) << status;
     }
 
@@ -3611,7 +3621,9 @@ public:
         if (status.ok()) {
             status = column_writer->finish();
             EXPECT_TRUE(status.ok()) << status;
-            status = index_file_writer->close();
+            status = index_file_writer->close_async();
+            EXPECT_TRUE(status.ok()) << status;
+            status = index_file_writer->wait_close();
             EXPECT_TRUE(status.ok()) << status;
 
             // Try to create reader and test unsupported query

--- a/be/test/olap/rowset/segment_v2/inverted_index_writer_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_writer_test.cpp
@@ -357,7 +357,9 @@ public:
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
 
-        status = index_file_writer->close();
+        status = index_file_writer->close_async();
+        EXPECT_TRUE(status.ok()) << status;
+        status = index_file_writer->wait_close();
         EXPECT_TRUE(status.ok()) << status;
 
         // Verify the terms stats
@@ -425,7 +427,9 @@ public:
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
 
-        status = index_file_writer->close();
+        status = index_file_writer->close_async();
+        EXPECT_TRUE(status.ok()) << status;
+        status = index_file_writer->wait_close();
         EXPECT_TRUE(status.ok()) << status;
 
         // Verify the terms stats
@@ -491,7 +495,9 @@ public:
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
 
-        status = index_file_writer->close();
+        status = index_file_writer->close_async();
+        EXPECT_TRUE(status.ok()) << status;
+        status = index_file_writer->wait_close();
         EXPECT_TRUE(status.ok()) << status;
 
         // For BKD index, we need to verify using BkdIndexReader instead of check_terms_stats
@@ -567,7 +573,9 @@ public:
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
 
-        status = index_file_writer->close();
+        status = index_file_writer->close_async();
+        EXPECT_TRUE(status.ok()) << status;
+        status = index_file_writer->wait_close();
         EXPECT_TRUE(status.ok()) << status;
 
         // Restore original config value
@@ -756,12 +764,16 @@ TEST_F(InvertedIndexWriterTest, CompareUnicodeStringWriteResults) {
     // Finish and close both writers
     status = column_writer_enabled->finish();
     EXPECT_TRUE(status.ok()) << status;
-    status = index_file_writer_enabled->close();
+    status = index_file_writer_enabled->close_async();
+    EXPECT_TRUE(status.ok()) << status;
+    status = index_file_writer_enabled->wait_close();
     EXPECT_TRUE(status.ok()) << status;
 
     status = column_writer_disabled->finish();
     EXPECT_TRUE(status.ok()) << status;
-    status = index_file_writer_disabled->close();
+    status = index_file_writer_disabled->close_async();
+    EXPECT_TRUE(status.ok()) << status;
+    status = index_file_writer_disabled->wait_close();
     EXPECT_TRUE(status.ok()) << status;
 
     // Restore original config value
@@ -899,7 +911,9 @@ TEST_F(InvertedIndexWriterTest, ErrorHandlingInFileWriter) {
     status = column_writer->finish();
     EXPECT_TRUE(status.ok()) << status;
 
-    status = index_file_writer->close();
+    status = index_file_writer->close_async();
+    EXPECT_TRUE(status.ok()) << status;
+    status = index_file_writer->wait_close();
     EXPECT_TRUE(status.ok()) << status;
 }
 
@@ -1023,7 +1037,9 @@ TEST_F(InvertedIndexWriterTest, ArrayValuesWithNulls) {
     status = column_writer->finish();
     EXPECT_TRUE(status.ok()) << status;
 
-    status = index_file_writer->close();
+    status = index_file_writer->close_async();
+    EXPECT_TRUE(status.ok()) << status;
+    status = index_file_writer->wait_close();
     EXPECT_TRUE(status.ok()) << status;
 }
 
@@ -1157,7 +1173,9 @@ TEST_F(InvertedIndexWriterTest, NumericArrayWithErrorConditions) {
     status = column_writer->finish();
     EXPECT_TRUE(status.ok()) << status;
 
-    status = index_file_writer->close();
+    status = index_file_writer->close_async();
+    EXPECT_TRUE(status.ok()) << status;
+    status = index_file_writer->wait_close();
     EXPECT_TRUE(status.ok()) << status;
 }
 
@@ -1211,7 +1229,9 @@ TEST_F(InvertedIndexWriterTest, CopyFileErrorHandling) {
     status = column_writer->finish();
     EXPECT_TRUE(status.ok()) << status;
 
-    status = index_file_writer->close();
+    status = index_file_writer->close_async();
+    EXPECT_TRUE(status.ok()) << status;
+    status = index_file_writer->wait_close();
     EXPECT_TRUE(status.ok()) << status;
 }
 
@@ -1280,7 +1300,9 @@ TEST_F(InvertedIndexWriterTest, CollectionValueProcessing) {
     status = column_writer->finish();
     EXPECT_TRUE(status.ok()) << status;
 
-    status = index_file_writer->close();
+    status = index_file_writer->close_async();
+    EXPECT_TRUE(status.ok()) << status;
+    status = index_file_writer->wait_close();
     EXPECT_TRUE(status.ok()) << status;
 }
 
@@ -1344,7 +1366,9 @@ TEST_F(InvertedIndexWriterTest, BKDWriterErrorConditions) {
     status = column_writer->finish();
     EXPECT_TRUE(status.ok()) << status;
 
-    status = index_file_writer->close();
+    status = index_file_writer->close_async();
+    EXPECT_TRUE(status.ok()) << status;
+    status = index_file_writer->wait_close();
     EXPECT_TRUE(status.ok()) << status;
 }
 

--- a/be/test/olap/rowset/segment_v2/inverted_index_writer_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_writer_test.cpp
@@ -357,9 +357,9 @@ public:
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
 
-        status = index_file_writer->close_async();
+        status = index_file_writer->begin_close();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->wait_close();
+        status = index_file_writer->finish_close();
         EXPECT_TRUE(status.ok()) << status;
 
         // Verify the terms stats
@@ -427,9 +427,9 @@ public:
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
 
-        status = index_file_writer->close_async();
+        status = index_file_writer->begin_close();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->wait_close();
+        status = index_file_writer->finish_close();
         EXPECT_TRUE(status.ok()) << status;
 
         // Verify the terms stats
@@ -495,9 +495,9 @@ public:
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
 
-        status = index_file_writer->close_async();
+        status = index_file_writer->begin_close();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->wait_close();
+        status = index_file_writer->finish_close();
         EXPECT_TRUE(status.ok()) << status;
 
         // For BKD index, we need to verify using BkdIndexReader instead of check_terms_stats
@@ -573,9 +573,9 @@ public:
         status = column_writer->finish();
         EXPECT_TRUE(status.ok()) << status;
 
-        status = index_file_writer->close_async();
+        status = index_file_writer->begin_close();
         EXPECT_TRUE(status.ok()) << status;
-        status = index_file_writer->wait_close();
+        status = index_file_writer->finish_close();
         EXPECT_TRUE(status.ok()) << status;
 
         // Restore original config value
@@ -764,16 +764,16 @@ TEST_F(InvertedIndexWriterTest, CompareUnicodeStringWriteResults) {
     // Finish and close both writers
     status = column_writer_enabled->finish();
     EXPECT_TRUE(status.ok()) << status;
-    status = index_file_writer_enabled->close_async();
+    status = index_file_writer_enabled->begin_close();
     EXPECT_TRUE(status.ok()) << status;
-    status = index_file_writer_enabled->wait_close();
+    status = index_file_writer_enabled->finish_close();
     EXPECT_TRUE(status.ok()) << status;
 
     status = column_writer_disabled->finish();
     EXPECT_TRUE(status.ok()) << status;
-    status = index_file_writer_disabled->close_async();
+    status = index_file_writer_disabled->begin_close();
     EXPECT_TRUE(status.ok()) << status;
-    status = index_file_writer_disabled->wait_close();
+    status = index_file_writer_disabled->finish_close();
     EXPECT_TRUE(status.ok()) << status;
 
     // Restore original config value
@@ -911,9 +911,9 @@ TEST_F(InvertedIndexWriterTest, ErrorHandlingInFileWriter) {
     status = column_writer->finish();
     EXPECT_TRUE(status.ok()) << status;
 
-    status = index_file_writer->close_async();
+    status = index_file_writer->begin_close();
     EXPECT_TRUE(status.ok()) << status;
-    status = index_file_writer->wait_close();
+    status = index_file_writer->finish_close();
     EXPECT_TRUE(status.ok()) << status;
 }
 
@@ -1037,9 +1037,9 @@ TEST_F(InvertedIndexWriterTest, ArrayValuesWithNulls) {
     status = column_writer->finish();
     EXPECT_TRUE(status.ok()) << status;
 
-    status = index_file_writer->close_async();
+    status = index_file_writer->begin_close();
     EXPECT_TRUE(status.ok()) << status;
-    status = index_file_writer->wait_close();
+    status = index_file_writer->finish_close();
     EXPECT_TRUE(status.ok()) << status;
 }
 
@@ -1173,9 +1173,9 @@ TEST_F(InvertedIndexWriterTest, NumericArrayWithErrorConditions) {
     status = column_writer->finish();
     EXPECT_TRUE(status.ok()) << status;
 
-    status = index_file_writer->close_async();
+    status = index_file_writer->begin_close();
     EXPECT_TRUE(status.ok()) << status;
-    status = index_file_writer->wait_close();
+    status = index_file_writer->finish_close();
     EXPECT_TRUE(status.ok()) << status;
 }
 
@@ -1229,9 +1229,9 @@ TEST_F(InvertedIndexWriterTest, CopyFileErrorHandling) {
     status = column_writer->finish();
     EXPECT_TRUE(status.ok()) << status;
 
-    status = index_file_writer->close_async();
+    status = index_file_writer->begin_close();
     EXPECT_TRUE(status.ok()) << status;
-    status = index_file_writer->wait_close();
+    status = index_file_writer->finish_close();
     EXPECT_TRUE(status.ok()) << status;
 }
 
@@ -1300,9 +1300,9 @@ TEST_F(InvertedIndexWriterTest, CollectionValueProcessing) {
     status = column_writer->finish();
     EXPECT_TRUE(status.ok()) << status;
 
-    status = index_file_writer->close_async();
+    status = index_file_writer->begin_close();
     EXPECT_TRUE(status.ok()) << status;
-    status = index_file_writer->wait_close();
+    status = index_file_writer->finish_close();
     EXPECT_TRUE(status.ok()) << status;
 }
 
@@ -1366,9 +1366,9 @@ TEST_F(InvertedIndexWriterTest, BKDWriterErrorConditions) {
     status = column_writer->finish();
     EXPECT_TRUE(status.ok()) << status;
 
-    status = index_file_writer->close_async();
+    status = index_file_writer->begin_close();
     EXPECT_TRUE(status.ok()) << status;
-    status = index_file_writer->wait_close();
+    status = index_file_writer->finish_close();
     EXPECT_TRUE(status.ok()) << status;
 }
 

--- a/be/test/olap/rowset/segment_v2/segment_corruption_test.cpp
+++ b/be/test/olap/rowset/segment_v2/segment_corruption_test.cpp
@@ -249,9 +249,9 @@ public:
         EXPECT_TRUE(file_writer->close().ok());
 
         // Close the index file writer (it was already written by SegmentWriter during finalize)
-        st = index_file_writer->close_async();
+        st = index_file_writer->begin_close();
         EXPECT_TRUE(st.ok()) << st;
-        st = index_file_writer->wait_close();
+        st = index_file_writer->finish_close();
         EXPECT_TRUE(st.ok()) << st;
 
         return seg_path;

--- a/be/test/olap/rowset/segment_v2/segment_corruption_test.cpp
+++ b/be/test/olap/rowset/segment_v2/segment_corruption_test.cpp
@@ -249,7 +249,9 @@ public:
         EXPECT_TRUE(file_writer->close().ok());
 
         // Close the index file writer (it was already written by SegmentWriter during finalize)
-        st = index_file_writer->close();
+        st = index_file_writer->close_async();
+        EXPECT_TRUE(st.ok()) << st;
+        st = index_file_writer->wait_close();
         EXPECT_TRUE(st.ok()) << st;
 
         return seg_path;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #57770 

Problem Summary:

When merging small files with inverted indexes, the segment close operation was synchronously waiting for inverted index files to be uploaded to S3. This blocking behavior significantly impacted the memtable flush thread performance, causing bottlenecks in the data loading pipeline.

Solution:

The solution introduces a two-phase close mechanism for inverted index file writers:

1. **Asynchronous Close Phase**: During segment close, inverted index files are closed asynchronously and the S3 upload task is submitted immediately without waiting for completion.

2. **Wait Phase**: When the load channel closes, the system waits for all pending S3 upload tasks to complete, ensuring data consistency.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

