### PR TITLE
branch-4.0:[opt](nereids) Add planWithUnknownColumnStats to QueryState to prevent queries from analysis tasks from polluting the column stats cache. (#57850)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -568,10 +568,11 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
 
         StatisticsBuilder builder = new StatisticsBuilder();
 
-        // for system table or FeUt, use ColumnStatistic.UNKNOWN
+        // query for system table or FeUt or analysis, use ColumnStatistic.UNKNOWN
+
         if (StatisticConstants.isSystemTable(olapTable) || !FeConstants.enableInternalSchemaDb
                 || ConnectContext.get() == null
-                || ConnectContext.get().getState().isInternal()) {
+                || ConnectContext.get().getState().isPlanWithUnKnownColumnStats()) {
             for (Slot slot : ((Plan) olapScan).getOutput()) {
                 builder.putColumnStatistics(slot, ColumnStatistic.UNKNOWN);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QueryState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QueryState.java
@@ -53,6 +53,7 @@ public class QueryState {
     private boolean isNereids = true;
     private boolean isInternal = false;
     private ShowResultSet rs = null;
+    private boolean planWithUnKnownColumnStats = false;
 
     public QueryState() {
     }
@@ -69,6 +70,7 @@ public class QueryState {
         warningRows = 0;
         isNereids = false;
         rs = null;
+        planWithUnKnownColumnStats = false;
     }
 
     public MysqlStateType getStateType() {
@@ -193,5 +195,13 @@ public class QueryState {
     @Override
     public String toString() {
         return String.valueOf(stateType);
+    }
+
+    public boolean isPlanWithUnKnownColumnStats() {
+        return planWithUnKnownColumnStats;
+    }
+
+    public void setPlanWithUnKnownColumnStats(boolean planWithUnKnownColumnStats) {
+        this.planWithUnKnownColumnStats = planWithUnKnownColumnStats;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
@@ -511,6 +511,7 @@ public abstract class BaseAnalysisTask {
         long startTime = System.currentTimeMillis();
         String queryId = "";
         try (AutoCloseConnectContext a  = StatisticsUtil.buildConnectContext(false)) {
+            a.connectContext.getState().setPlanWithUnKnownColumnStats(true);
             stmtExecutor = new StmtExecutor(a.connectContext, sql);
             ColStatsData colStatsData = new ColStatsData(stmtExecutor.executeInternalQuery().get(0));
             if (!colStatsData.isValid()) {


### PR DESCRIPTION
commitId: e10e29d7
pr: #57850