### PR TITLE
[fix](variant) function element at compute signature

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ComputeSignature.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ComputeSignature.java
@@ -114,7 +114,6 @@ public interface ComputeSignature extends FunctionTrait, ImplicitCastInputTypes 
                 .then(ComputeSignatureHelper::implementFollowToArgumentReturnType)
                 .then(ComputeSignatureHelper::normalizeDecimalV2)
                 .then(ComputeSignatureHelper::ensureNestedNullableOfArray)
-                .then(ComputeSignatureHelper::dynamicComputeVariantArgs)
                 .get();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ComputeSignatureHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ComputeSignatureHelper.java
@@ -33,7 +33,6 @@ import org.apache.doris.nereids.types.MapType;
 import org.apache.doris.nereids.types.NullType;
 import org.apache.doris.nereids.types.StructType;
 import org.apache.doris.nereids.types.TimeV2Type;
-import org.apache.doris.nereids.types.VariantType;
 import org.apache.doris.nereids.types.coercion.AnyDataType;
 import org.apache.doris.nereids.types.coercion.ComplexDataType;
 import org.apache.doris.nereids.types.coercion.FollowToAnyDataType;
@@ -556,58 +555,6 @@ public class ComputeSignatureHelper {
             signature = signature.withReturnType(
                     TypeCoercionUtils.replaceTimesWithTargetPrecision(signature.returnType, finalTypeScale));
         }
-        return signature;
-    }
-
-    /**
-     * Dynamically compute function signature for variant type arguments.
-     * This method handles cases where the function signature contains variant types
-     * and needs to be adjusted based on the actual argument types.
-     *
-     * @param signature Original function signature
-     * @param arguments List of actual arguments passed to the function
-     * @return Updated function signature with resolved variant types
-     */
-    public static FunctionSignature dynamicComputeVariantArgs(
-            FunctionSignature signature, List<Expression> arguments) {
-
-        List<DataType> newArgTypes = Lists.newArrayListWithCapacity(arguments.size());
-        boolean findVariantType = false;
-
-        for (int i = 0; i < arguments.size(); i++) {
-            // Get signature type for current argument position
-            DataType sigType;
-            if (i >= signature.argumentsTypes.size()) {
-                sigType = signature.getVarArgType().orElseThrow(
-                        () -> new AnalysisException("function arity not match with signature"));
-            } else {
-                sigType = signature.argumentsTypes.get(i);
-            }
-
-            // Get actual type of the argument expression
-            DataType expressionType = arguments.get(i).getDataType();
-
-            // If both signature type and expression type are variant,
-            // use expression type and update return type
-            if (sigType instanceof VariantType && expressionType instanceof VariantType) {
-                // return type is variant, update return type to expression type
-                if (signature.returnType instanceof VariantType) {
-                    signature = signature.withReturnType(expressionType);
-                    if (findVariantType) {
-                        throw new AnalysisException("variant type is not supported in multiple arguments");
-                    } else {
-                        findVariantType = true;
-                    }
-                }
-                newArgTypes.add(expressionType);
-            } else {
-                // Otherwise keep original signature type
-                newArgTypes.add(sigType);
-            }
-        }
-
-        // Update signature with new argument types
-        signature = signature.withArgumentTypes(signature.hasVarArgs, newArgTypes);
         return signature;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Crc32Internal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Crc32Internal.java
@@ -94,7 +94,6 @@ public class Crc32Internal extends ScalarFunction
         sig = ComputeSignatureHelper.implementFollowToArgumentReturnType(sig, getArguments());
         sig = ComputeSignatureHelper.normalizeDecimalV2(sig, getArguments());
         sig = ComputeSignatureHelper.ensureNestedNullableOfArray(sig, getArguments());
-        sig = ComputeSignatureHelper.dynamicComputeVariantArgs(sig, getArguments());
         return sig;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ElementAt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ElementAt.java
@@ -18,7 +18,6 @@
 package org.apache.doris.nereids.trees.expressions.functions.scalar;
 
 import org.apache.doris.catalog.FunctionSignature;
-import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.PreferPushDownProject;
 import org.apache.doris.nereids.trees.expressions.functions.AlwaysNullable;
@@ -38,7 +37,6 @@ import org.apache.doris.nereids.types.coercion.FollowToAnyDataType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import java.util.List;
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/ComputeSignatureHelperTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/ComputeSignatureHelperTest.java
@@ -18,7 +18,6 @@
 package org.apache.doris.nereids.trees.expressions.functions;
 
 import org.apache.doris.catalog.FunctionSignature;
-import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.literal.ArrayLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.BigIntLiteral;
@@ -26,18 +25,15 @@ import org.apache.doris.nereids.trees.expressions.literal.DateLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeV2Literal;
 import org.apache.doris.nereids.trees.expressions.literal.DecimalV3Literal;
-import org.apache.doris.nereids.trees.expressions.literal.DoubleLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.literal.MapLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.SmallIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.TimeV2Literal;
-import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.ArrayType;
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.BooleanType;
-import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.DateTimeType;
 import org.apache.doris.nereids.types.DateTimeV2Type;
 import org.apache.doris.nereids.types.DateType;
@@ -50,7 +46,6 @@ import org.apache.doris.nereids.types.MapType;
 import org.apache.doris.nereids.types.NullType;
 import org.apache.doris.nereids.types.SmallIntType;
 import org.apache.doris.nereids.types.TimeV2Type;
-import org.apache.doris.nereids.types.VariantType;
 import org.apache.doris.nereids.types.coercion.AnyDataType;
 import org.apache.doris.nereids.types.coercion.FollowToAnyDataType;
 import org.apache.doris.nereids.types.coercion.FollowToArgumentType;
@@ -535,199 +530,6 @@ public class ComputeSignatureHelperTest {
         Assertions.assertTrue(((MapType) signature.returnType).getValueType() instanceof ArrayType);
         Assertions.assertEquals(TimeV2Type.of(4),
                         ((ArrayType) ((MapType) signature.returnType).getValueType()).getItemType());
-    }
-
-    @Test
-    void testNoDynamicComputeVariantArgs() {
-        FunctionSignature signature = FunctionSignature.ret(DoubleType.INSTANCE).args(IntegerType.INSTANCE);
-        signature = ComputeSignatureHelper.dynamicComputeVariantArgs(signature, Collections.emptyList());
-        Assertions.assertTrue(signature.returnType instanceof DoubleType);
-    }
-
-    @Test
-    void testDynamicComputeVariantArgsSingleVariant() {
-        VariantType variantType = new VariantType(100);
-        FunctionSignature signature = FunctionSignature.ret(VariantType.INSTANCE)
-                .args(VariantType.INSTANCE, IntegerType.INSTANCE);
-
-        List<Expression> arguments = Lists.newArrayList(
-                new MockVariantExpression(variantType),
-                new IntegerLiteral(42));
-
-        signature = ComputeSignatureHelper.dynamicComputeVariantArgs(signature, arguments);
-
-        Assertions.assertTrue(signature.returnType instanceof VariantType);
-        Assertions.assertEquals(100, ((VariantType) signature.returnType).getVariantMaxSubcolumnsCount());
-        Assertions.assertEquals(10000, ((VariantType) signature.returnType).getVariantMaxSparseColumnStatisticsSize());
-
-        Assertions.assertTrue(signature.getArgType(0) instanceof VariantType);
-        Assertions.assertEquals(100, ((VariantType) signature.getArgType(0)).getVariantMaxSubcolumnsCount());
-        Assertions.assertEquals(10000, ((VariantType) signature.getArgType(0)).getVariantMaxSparseColumnStatisticsSize());
-
-        Assertions.assertTrue(signature.getArgType(1) instanceof IntegerType);
-    }
-
-    @Test
-    void testDynamicComputeVariantArgsMultipleVariants() {
-        VariantType variantType1 = new VariantType(150);
-        VariantType variantType2 = new VariantType(250);
-        FunctionSignature signature = FunctionSignature.ret(IntegerType.INSTANCE)
-                .args(VariantType.INSTANCE, VariantType.INSTANCE);
-
-        List<Expression> arguments = Lists.newArrayList(
-                new MockVariantExpression(variantType1),
-                new MockVariantExpression(variantType2));
-
-        signature = ComputeSignatureHelper.dynamicComputeVariantArgs(signature, arguments);
-
-        Assertions.assertTrue(signature.getArgType(0) instanceof VariantType);
-        Assertions.assertEquals(150, ((VariantType) signature.getArgType(0)).getVariantMaxSubcolumnsCount());
-        Assertions.assertEquals(10000, ((VariantType) signature.getArgType(0)).getVariantMaxSparseColumnStatisticsSize());
-        Assertions.assertTrue(signature.getArgType(1) instanceof VariantType);
-        Assertions.assertEquals(250, ((VariantType) signature.getArgType(1)).getVariantMaxSubcolumnsCount());
-        Assertions.assertEquals(10000, ((VariantType) signature.getArgType(1)).getVariantMaxSparseColumnStatisticsSize());
-        Assertions.assertTrue(signature.returnType instanceof IntegerType);
-    }
-
-    @Test
-    void testDynamicComputeVariantArgsMixedTypesWithSingleVariant() {
-        VariantType variantType = new VariantType(75);
-        FunctionSignature signature = FunctionSignature.ret(BooleanType.INSTANCE)
-                .args(VariantType.INSTANCE, IntegerType.INSTANCE, DoubleType.INSTANCE);
-
-        List<Expression> arguments = Lists.newArrayList(
-                new MockVariantExpression(variantType),
-                new IntegerLiteral(10),
-                new DoubleLiteral(3.14));
-
-        signature = ComputeSignatureHelper.dynamicComputeVariantArgs(signature, arguments);
-
-        Assertions.assertTrue(signature.getArgType(0) instanceof VariantType);
-        Assertions.assertEquals(75, ((VariantType) signature.getArgType(0)).getVariantMaxSubcolumnsCount());
-        Assertions.assertEquals(10000, ((VariantType) signature.getArgType(0)).getVariantMaxSparseColumnStatisticsSize());
-        Assertions.assertTrue(signature.getArgType(1) instanceof IntegerType);
-        Assertions.assertTrue(signature.getArgType(2) instanceof DoubleType);
-
-        Assertions.assertTrue(signature.returnType instanceof BooleanType);
-    }
-
-    @Test
-    void testDynamicComputeVariantArgsWithNullLiteral() {
-        FunctionSignature signature = FunctionSignature.ret(BooleanType.INSTANCE)
-                .args(VariantType.INSTANCE, IntegerType.INSTANCE);
-
-        List<Expression> arguments = Lists.newArrayList(
-                new NullLiteral(),
-                new IntegerLiteral(10));
-
-        signature = ComputeSignatureHelper.dynamicComputeVariantArgs(signature, arguments);
-
-        Assertions.assertTrue(signature.getArgType(0) instanceof VariantType);
-        Assertions.assertEquals(0, ((VariantType) signature.getArgType(0)).getVariantMaxSubcolumnsCount());
-        Assertions.assertEquals(10000, ((VariantType) signature.getArgType(0)).getVariantMaxSparseColumnStatisticsSize());
-        Assertions.assertTrue(signature.getArgType(1) instanceof IntegerType);
-    }
-
-    @Test
-    void testDynamicComputeVariantArgsNoVariantReturnType() {
-        VariantType variantType = new VariantType(300);
-        FunctionSignature signature = FunctionSignature.ret(IntegerType.INSTANCE)
-                .args(VariantType.INSTANCE);
-
-        List<Expression> arguments = Lists.newArrayList(
-                new MockVariantExpression(variantType));
-
-        signature = ComputeSignatureHelper.dynamicComputeVariantArgs(signature, arguments);
-
-        Assertions.assertTrue(signature.returnType instanceof IntegerType);
-
-        Assertions.assertTrue(signature.getArgType(0) instanceof VariantType);
-        Assertions.assertEquals(300, ((VariantType) signature.getArgType(0)).getVariantMaxSubcolumnsCount());
-        Assertions.assertEquals(10000, ((VariantType) signature.getArgType(0)).getVariantMaxSparseColumnStatisticsSize());
-    }
-
-    @Test
-    void testDynamicComputeVariantArgsWithVarArgsThrowsException() {
-        VariantType variantType1 = new VariantType(150);
-        VariantType variantType2 = new VariantType(250);
-        FunctionSignature signature = FunctionSignature.ret(VariantType.INSTANCE)
-                .args(VariantType.INSTANCE, VariantType.INSTANCE);
-
-        List<Expression> arguments = Lists.newArrayList(
-                new MockVariantExpression(variantType1),
-                new MockVariantExpression(variantType2));
-
-        AnalysisException exception = Assertions.assertThrows(AnalysisException.class, () -> {
-            ComputeSignatureHelper.dynamicComputeVariantArgs(signature, arguments);
-        });
-
-        Assertions.assertEquals("variant type is not supported in multiple arguments", exception.getMessage());
-    }
-
-    @Test
-    void testDynamicComputeVariantArgsWithComputeSignature() {
-        VariantType variantType = new VariantType(200);
-        FunctionSignature signature = FunctionSignature.ret(VariantType.INSTANCE)
-                .args(VariantType.INSTANCE);
-
-        List<Expression> arguments = Lists.newArrayList(
-                new MockVariantExpression(variantType));
-
-        signature = ComputeSignatureHelper.dynamicComputeVariantArgs(signature, arguments);
-
-        Assertions.assertTrue(signature.returnType instanceof VariantType);
-        Assertions.assertEquals(200, ((VariantType) signature.returnType).getVariantMaxSubcolumnsCount());
-        Assertions.assertEquals(10000, ((VariantType) signature.returnType).getVariantMaxSparseColumnStatisticsSize());
-        Assertions.assertTrue(signature.getArgType(0) instanceof VariantType);
-        Assertions.assertEquals(200, ((VariantType) signature.getArgType(0)).getVariantMaxSubcolumnsCount());
-        Assertions.assertEquals(10000, ((VariantType) signature.getArgType(0)).getVariantMaxSparseColumnStatisticsSize());
-    }
-
-    /**
-     * Mock Expression class for testing VariantType
-     */
-    private static class MockVariantExpression extends Expression {
-        private final VariantType variantType;
-
-        public MockVariantExpression(VariantType variantType) {
-            super(Collections.emptyList());
-            this.variantType = variantType;
-        }
-
-        @Override
-        public DataType getDataType() {
-            return variantType;
-        }
-
-        @Override
-        public boolean nullable() {
-            return true;
-        }
-
-        @Override
-        public Expression withChildren(List<Expression> children) {
-            return this;
-        }
-
-        @Override
-        public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
-            return visitor.visit(this, context);
-        }
-
-        @Override
-        public int arity() {
-            return 0;
-        }
-
-        @Override
-        public Expression child(int index) {
-            throw new IndexOutOfBoundsException("MockVariantExpression has no children");
-        }
-
-        @Override
-        public List<Expression> children() {
-            return Collections.emptyList();
-        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ElementAtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ElementAtTest.java
@@ -23,7 +23,6 @@ import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
-import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.nereids.types.VarcharType;
 import org.apache.doris.nereids.types.VariantType;
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ElementAtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ElementAtTest.java
@@ -1,0 +1,158 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.expressions.functions.scalar;
+
+import org.apache.doris.catalog.FunctionSignature;
+import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
+import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
+import org.apache.doris.nereids.types.DataType;
+import org.apache.doris.nereids.types.IntegerType;
+import org.apache.doris.nereids.types.VarcharType;
+import org.apache.doris.nereids.types.VariantType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Unit tests for ElementAt scalar function computeSignature behavior on VariantType.
+ */
+public class ElementAtTest {
+
+    @Test
+    public void testComputeSignatureSingleVariant() {
+        VariantType variantType = new VariantType(100);
+        ElementAt elementAt = new ElementAt(new MockVariantExpression(variantType), new VarcharLiteral("k"));
+        FunctionSignature signature = FunctionSignature.ret(VariantType.INSTANCE)
+                .args(VariantType.INSTANCE, VarcharType.SYSTEM_DEFAULT);
+
+        signature = elementAt.computeSignature(signature);
+
+        Assertions.assertTrue(signature.returnType instanceof VariantType);
+        Assertions.assertEquals(100, ((VariantType) signature.returnType).getVariantMaxSubcolumnsCount());
+        Assertions.assertEquals(10000, ((VariantType) signature.returnType).getVariantMaxSparseColumnStatisticsSize());
+
+        Assertions.assertTrue(signature.getArgType(0) instanceof VariantType);
+        Assertions.assertEquals(100, ((VariantType) signature.getArgType(0)).getVariantMaxSubcolumnsCount());
+        Assertions.assertEquals(10000,
+                ((VariantType) signature.getArgType(0)).getVariantMaxSparseColumnStatisticsSize());
+
+        Assertions.assertTrue(signature.getArgType(1) instanceof VarcharType);
+    }
+
+    @Test
+    public void testComputeSignatureNoVariantReturnType() {
+        VariantType variantType = new VariantType(300);
+        ElementAt elementAt = new ElementAt(new MockVariantExpression(variantType), new VarcharLiteral("k"));
+        FunctionSignature signature = FunctionSignature.ret(IntegerType.INSTANCE)
+                .args(VariantType.INSTANCE, VarcharType.SYSTEM_DEFAULT);
+
+        signature = elementAt.computeSignature(signature);
+
+        Assertions.assertTrue(signature.returnType instanceof IntegerType);
+        Assertions.assertTrue(signature.getArgType(0) instanceof VariantType);
+        Assertions.assertEquals(300, ((VariantType) signature.getArgType(0)).getVariantMaxSubcolumnsCount());
+        Assertions.assertEquals(10000,
+                ((VariantType) signature.getArgType(0)).getVariantMaxSparseColumnStatisticsSize());
+    }
+
+    @Test
+    public void testComputeSignatureWithNullLiteral() {
+        ElementAt elementAt = new ElementAt(new NullLiteral(), new VarcharLiteral("k"));
+        FunctionSignature signature = FunctionSignature.ret(VariantType.INSTANCE)
+                .args(VariantType.INSTANCE, VarcharType.SYSTEM_DEFAULT);
+
+        signature = elementAt.computeSignature(signature);
+
+        Assertions.assertTrue(signature.returnType instanceof VariantType);
+        Assertions.assertTrue(signature.getArgType(0) instanceof VariantType);
+        Assertions.assertEquals(0, ((VariantType) signature.getArgType(0)).getVariantMaxSubcolumnsCount());
+        Assertions.assertEquals(10000,
+                ((VariantType) signature.getArgType(0)).getVariantMaxSparseColumnStatisticsSize());
+    }
+
+    @Test
+    public void testComputeSignatureMultipleVariantsThrowsException() {
+        VariantType variantType1 = new VariantType(150);
+        VariantType variantType2 = new VariantType(250);
+        ElementAt elementAt = new ElementAt(new MockVariantExpression(variantType1),
+                new MockVariantExpression(variantType2));
+        FunctionSignature signature = FunctionSignature.ret(VariantType.INSTANCE)
+                .args(VariantType.INSTANCE, VariantType.INSTANCE);
+
+        AnalysisException exception = Assertions.assertThrows(AnalysisException.class, () -> {
+            elementAt.computeSignature(signature);
+        });
+
+        Assertions.assertEquals("variant type is not supported in multiple arguments", exception.getMessage());
+    }
+
+    /**
+     * Mock Expression class for providing VariantType in computeSignature tests.
+     */
+    private static class MockVariantExpression extends Expression {
+        private final VariantType variantType;
+
+        public MockVariantExpression(VariantType variantType) {
+            super(Collections.emptyList());
+            this.variantType = variantType;
+        }
+
+        @Override
+        public DataType getDataType() {
+            return variantType;
+        }
+
+        @Override
+        public boolean nullable() {
+            return true;
+        }
+
+        @Override
+        public Expression withChildren(List<Expression> children) {
+            return this;
+        }
+
+        @Override
+        public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
+            return visitor.visit(this, context);
+        }
+
+        @Override
+        public int arity() {
+            return 0;
+        }
+
+        @Override
+        public Expression child(int index) {
+            throw new IndexOutOfBoundsException("MockVariantExpression has no children");
+        }
+
+        @Override
+        public List<Expression> children() {
+            return Collections.emptyList();
+        }
+    }
+}
+
+

--- a/regression-test/suites/variant_p0/test_sub_path_pruning.groovy
+++ b/regression-test/suites/variant_p0/test_sub_path_pruning.groovy
@@ -17,6 +17,9 @@
 
 suite("variant_sub_path_pruning", "variant_type"){
 
+    sql """ set default_variant_enable_typed_paths_to_sparse = false """
+    sql """ set default_variant_max_sparse_column_statistics_size = 10000 """
+    sql """ set default_variant_sparse_hash_shard_count = 0 """
     sql "DROP TABLE IF EXISTS pruning_test"
 
     sql """


### PR DESCRIPTION
The `ELEMENTAT` function should override the `computeSignature` method to determine the return value type for variant.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

