### PR TITLE
[check](column)Columns must be created only via their corresponding create methods.

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_writer.h
+++ b/be/src/olap/rowset/segment_v2/column_writer.h
@@ -36,6 +36,7 @@
 #include "olap/rowset/segment_v2/inverted_index_writer.h"
 #include "util/bitmap.h" // for BitmapChange
 #include "util/slice.h"  // for OwnedSlice
+#include "vec/columns/column_variant.h"
 
 namespace doris {
 
@@ -605,7 +606,7 @@ private:
     bool _is_finalized = false;
     ordinal_t _next_rowid = 0;
     size_t none_null_size = 0;
-    vectorized::MutableColumnPtr _column;
+    vectorized::ColumnVariant::MutablePtr _column;
     const TabletColumn* _tablet_column = nullptr;
     ColumnWriterOptions _opts;
     std::unique_ptr<ColumnWriter> _writer;

--- a/be/src/olap/rowset/segment_v2/variant/variant_column_writer_impl.h
+++ b/be/src/olap/rowset/segment_v2/variant/variant_column_writer_impl.h
@@ -137,8 +137,8 @@ private:
                                vectorized::OlapBlockDataConvertor* converter, size_t num_rows,
                                int& column_id);
     // prepare a column for finalize
-    doris::vectorized::MutableColumnPtr _column;
-    doris::vectorized::ColumnUInt8 _null_column;
+    doris::vectorized::ColumnVariant::MutablePtr _column;
+    doris::vectorized::ColumnUInt8::MutablePtr _null_column;
     ColumnWriterOptions _opts;
     const TabletColumn* _tablet_column = nullptr;
     bool _is_finalized = false;

--- a/be/src/pipeline/exec/join/process_hash_table_probe.h
+++ b/be/src/pipeline/exec/join/process_hash_table_probe.h
@@ -20,9 +20,9 @@
 #include <vector>
 
 #include "vec/columns/column.h"
+#include "vec/columns/column_vector.h"
 #include "vec/common/arena.h"
 #include "vec/common/custom_allocator.h"
-#include "vec/columns/column_vector.h"
 
 namespace doris {
 namespace vectorized {

--- a/be/src/pipeline/exec/join/process_hash_table_probe.h
+++ b/be/src/pipeline/exec/join/process_hash_table_probe.h
@@ -22,6 +22,7 @@
 #include "vec/columns/column.h"
 #include "vec/common/arena.h"
 #include "vec/common/custom_allocator.h"
+#include "vec/columns/column_vector.h"
 
 namespace doris {
 namespace vectorized {

--- a/be/src/vec/columns/column_varbinary.h
+++ b/be/src/vec/columns/column_varbinary.h
@@ -41,10 +41,10 @@ private:
 public:
     using value_type = typename PrimitiveTypeTraits<TYPE_VARBINARY>::ColumnItemType;
     using Container = PaddedPODArray<doris::StringView>;
-    ColumnVarbinary() = default;
-    ColumnVarbinary(const size_t n) : _data(n) {}
 
 private:
+    ColumnVarbinary() = default;
+    ColumnVarbinary(const size_t n) : _data(n) {}
     ColumnVarbinary(const ColumnVarbinary& src) : _data(src._data.begin(), src._data.end()) {}
 
 public:

--- a/be/src/vec/columns/column_variant.h
+++ b/be/src/vec/columns/column_variant.h
@@ -291,6 +291,8 @@ private:
 public:
     static constexpr auto COLUMN_NAME_DUMMY = "_dummy";
 
+private:
+    friend class COWHelper<IColumn, ColumnVariant>;
     // always create root: data type nothing
     explicit ColumnVariant(int32_t max_subcolumns_count);
 
@@ -302,6 +304,7 @@ public:
 
     explicit ColumnVariant(int32_t max_subcolumns_count, Subcolumns&& subcolumns_);
 
+public:
     ~ColumnVariant() override = default;
 
     /// Checks that all subcolumns have consistent sizes.

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -52,6 +52,11 @@
 
 class SipHash;
 
+namespace doris::pipeline {
+template <int JoinOpType>
+struct ProcessHashTableProbe;
+}
+
 namespace doris::vectorized {
 class Arena;
 class ColumnSorter;
@@ -72,6 +77,9 @@ private:
     using Self = ColumnVector;
     friend class COWHelper<IColumn, Self>;
 
+    template <int JoinOpType>
+    friend struct doris::pipeline::ProcessHashTableProbe;
+
     struct less;
     struct greater;
 
@@ -79,6 +87,7 @@ public:
     using value_type = typename PrimitiveTypeTraits<T>::ColumnItemType;
     using Container = PaddedPODArray<value_type>;
 
+private:
     ColumnVector() = default;
     explicit ColumnVector(const size_t n) : data(n) {}
     explicit ColumnVector(const size_t n, const value_type x) : data(n, x) {}
@@ -87,6 +96,7 @@ public:
     /// Sugar constructor.
     ColumnVector(std::initializer_list<value_type> il) : data {il} {}
 
+public:
     size_t size() const override { return data.size(); }
 
     StringRef get_data_at(size_t n) const override {

--- a/be/src/vec/functions/function_date_or_datetime_computation.h
+++ b/be/src/vec/functions/function_date_or_datetime_computation.h
@@ -758,13 +758,13 @@ public:
             // vector-const
             if (const auto* nest_col1_const = check_and_get_column<ColumnConst>(*nest_col1)) {
                 rconst = true;
-                const auto col1_inside_const =
+                const auto& col1_inside_const =
                         assert_cast<const ColumnVector<Transform::ArgPType>&>(
                                 nest_col1_const->get_data_column());
                 Op::vector_constant(sources->get_data(), res_col->get_data(),
                                     col1_inside_const.get_data()[0], nullmap0, nullmap1);
             } else { // vector-vector
-                const auto concrete_col1 =
+                const auto& concrete_col1 =
                         assert_cast<const ColumnVector<Transform::ArgPType>&>(*nest_col1);
                 Op::vector_vector(sources->get_data(), concrete_col1.get_data(),
                                   res_col->get_data(), nullmap0, nullmap1);
@@ -789,10 +789,10 @@ public:
                            check_and_get_column_const<ColumnVector<Transform::ArgPType>>(
                                    src_nested_col.get())) {
             // const-vector
-            const auto col0_inside_const = assert_cast<const ColumnVector<Transform::ArgPType>&>(
+            const auto& col0_inside_const = assert_cast<const ColumnVector<Transform::ArgPType>&>(
                     sources_const->get_data_column());
             const ColumnPtr nested_col1 = remove_nullable(col1);
-            const auto concrete_col1 =
+            const auto& concrete_col1 =
                     assert_cast<const ColumnVector<Transform::ArgPType>&>(*nested_col1);
             Op::constant_vector(col0_inside_const.get_data()[0], res_col->get_data(),
                                 concrete_col1.get_data(), nullmap0, nullmap1);
@@ -887,14 +887,14 @@ public:
                                         nest_col1_const->get_data_at(0).to_string(), nullmap0,
                                         nullmap1);
                 } else {
-                    const auto col1_inside_const = assert_cast<const IntervalColumnType&>(
+                    const auto& col1_inside_const = assert_cast<const IntervalColumnType&>(
                             nest_col1_const->get_data_column());
                     Op::vector_constant(sources->get_data(), res_col->get_data(),
                                         col1_inside_const.get_data()[0], nullmap0, nullmap1);
                 }
             } else { // vector-vector
                 if constexpr (Transform::IntervalPType != TYPE_STRING) {
-                    const auto concrete_col1 = assert_cast<const IntervalColumnType&>(*nest_col1);
+                    const auto& concrete_col1 = assert_cast<const IntervalColumnType&>(*nest_col1);
                     Op::vector_vector(sources->get_data(), concrete_col1.get_data(),
                                       res_col->get_data(), nullmap0, nullmap1);
                 } else {
@@ -930,11 +930,11 @@ public:
                                    src_nested_col.get())) {
             if constexpr (Transform::IntervalPType != TYPE_STRING) {
                 // const-vector
-                const auto col0_inside_const =
+                const auto& col0_inside_const =
                         assert_cast<const ColumnVector<Transform::ArgPType>&>(
                                 sources_const->get_data_column());
                 const ColumnPtr nested_col1 = remove_nullable(col1);
-                const auto concrete_col1 = assert_cast<const IntervalColumnType&>(*nested_col1);
+                const auto& concrete_col1 = assert_cast<const IntervalColumnType&>(*nested_col1);
                 Op::constant_vector(col0_inside_const.get_data()[0], res_col->get_data(),
                                     concrete_col1.get_data(), nullmap0, nullmap1);
 


### PR DESCRIPTION
### What problem does this PR solve?

Previously some Column constructors were public. That caused issues, for example:

```cpp
const auto col1_inside_const =
        assert_cast<const ColumnVector<Transform::ArgPType>&>(
                nest_col1_const->get_data_column());
```

This code omitted a reference, which caused an extra copy of the data. It should be changed to:

```cpp
const auto& col1_inside_const =
        assert_cast<const ColumnVector<Transform::ArgPType>&>(
                nest_col1_const->get_data_column());
```

There are other issues as well.

If you now write:

```cpp
ColumnInt32 col;
```

you will get an error:

Calling a private constructor of class 'doris::vectorized::ColumnVector<doris::TYPE_INT>'

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

