### PR TITLE
[fix](nullable) set SlotRef's nullable to right value

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadPlanInfoCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadPlanInfoCollector.java
@@ -423,17 +423,6 @@ public class NereidsLoadPlanInfoCollector extends DefaultPlanVisitor<Void, PlanT
         List<Slot> slots = oneRowRelation.getLogicalProperties().getOutput();
         TupleDescriptor oneRowTuple = generateTupleDesc(slots, null, context);
 
-        List<Expr> legacyExprs = oneRowRelation.getProjects()
-                .stream()
-                .map(expr -> ExpressionTranslator.translate(expr, context))
-                .collect(Collectors.toList());
-
-        for (int i = 0; i < legacyExprs.size(); i++) {
-            SlotDescriptor slotDescriptor = oneRowTuple.getSlots().get(i);
-            Expr expr = legacyExprs.get(i);
-            slotDescriptor.setSourceExpr(expr);
-            slotDescriptor.setIsNullable(slots.get(i).nullable());
-        }
         loadPlanInfo.srcTupleId = oneRowTuple.getId();
         loadPlanInfo.srcSlotIds = new ArrayList<>(oneRowTuple.getAllSlotIds());
         loadPlanInfo.srcSlotIdToDefaultValueMap = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/AssertNumRowsNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/AssertNumRowsNode.java
@@ -36,17 +36,14 @@ public class AssertNumRowsNode extends PlanNode {
     private String subqueryString;
     private AssertNumRowsElement.Assertion assertion;
 
-    private boolean shouldConvertOutputToNullable = false;
-
     public AssertNumRowsNode(PlanNodeId id, PlanNode input, AssertNumRowsElement assertNumRowsElement,
-                             boolean convertToNullable, TupleDescriptor tupleDescriptor) {
+            TupleDescriptor tupleDescriptor) {
         super(id, "ASSERT NUMBER OF ROWS");
         this.desiredNumOfRows = assertNumRowsElement.getDesiredNumOfRows();
         this.subqueryString = assertNumRowsElement.getSubqueryString();
         this.assertion = assertNumRowsElement.getAssertion();
         this.children.add(input);
         this.tupleIds.add(tupleDescriptor.getId());
-        this.shouldConvertOutputToNullable = convertToNullable;
     }
 
     @Override
@@ -72,7 +69,7 @@ public class AssertNumRowsNode extends PlanNode {
         msg.assert_num_rows_node.setDesiredNumRows(desiredNumOfRows);
         msg.assert_num_rows_node.setSubqueryString(subqueryString);
         msg.assert_num_rows_node.setAssertion(assertion.toThrift());
-        msg.assert_num_rows_node.setShouldConvertOutputToNullable(shouldConvertOutputToNullable);
+        msg.assert_num_rows_node.setShouldConvertOutputToNullable(true);
     }
 
     @Override


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #57862

Problem Summary:

This pull request refactors how constant and result expressions are handled in set operations and one-row relations, simplifies the logic for handling nullable outputs in joins and assertions, and removes some legacy or redundant code. The changes improve code clarity, maintainability, and correctness, especially around expression translation and output slot nullability.

**Set Operation and Expression Handling Improvements:**

- Refactored set operation node construction to directly generate and assign materialized constant and result expression lists (`setMaterializedConstExprLists` and `setMaterializedResultExprLists`), removing the `finalizeForSetOperationNode` method and simplifying the logic in `visitPhysicalSetOperation`. This ensures expressions are translated and assigned more explicitly and consistently. [[1]](diffhunk://#diff-f363369b49ec5af5a087420f31ec3d9a8c5147eacabdf051792017cfab289dacL2281-R2265) [[2]](diffhunk://#diff-f363369b49ec5af5a087420f31ec3d9a8c5147eacabdf051792017cfab289dacL3154-L3192)
- Updated the handling of `PhysicalOneRowRelation` to directly assign materialized constant expressions to the `UnionNode`, streamlining the process and removing unnecessary slot descriptor assignments.

**Nullability and Join Output Adjustments:**

- Improved the logic for setting output slots as nullable in hash joins, ensuring that for outer joins, corresponding slot references are created and mapped in the translation context, which enhances correctness for downstream processing.
- Simplified the construction of `AssertNumRowsNode` by always generating a new tuple descriptor based on the output, removing redundant code for slot mapping and nullability, and ensuring output nullability is always set in the Thrift conversion. [[1]](diffhunk://#diff-f363369b49ec5af5a087420f31ec3d9a8c5147eacabdf051792017cfab289dacL1321-L1351) [[2]](diffhunk://#diff-5c9560e7d6a4205917e6dd98375c41fbae4ad32e1ae077b77d51e8de47158f44L39-L50) [[3]](diffhunk://#diff-5c9560e7d6a4205917e6dd98375c41fbae4ad32e1ae077b77d51e8de47158f44L76-R73)

**Code Cleanup and Removal of Legacy Logic:**

- Removed temporary/legacy code for handling special cases like `ROWID_COL` in join slot descriptor creation, making the codebase more maintainable and focused.
- Cleaned up unused or redundant code in the load plan info collector and set operation node handling, reducing complexity. [[1]](diffhunk://#diff-90672d2ab7c4423ec99eae798eec14e4566164691ad9afd2102ce83386a78182L426-L436) [[2]](diffhunk://#diff-f363369b49ec5af5a087420f31ec3d9a8c5147eacabdf051792017cfab289dacL2265)

**Dependency and Import Updates:**

- Added necessary imports for `AssertNumRowsElement` to support the refactored assertion handling.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

