### PR TITLE
[fix](rbo) use wrong child's output of set operation

### DIFF
--- a/regression-test/data/empty_relation/eliminate_empty.out
+++ b/regression-test/data/empty_relation/eliminate_empty.out
@@ -142,22 +142,19 @@ PhysicalResultSink
 
 -- !union_to_onerow_1_shape --
 PhysicalResultSink
---PhysicalDistribute[DistributionSpecGather]
-----hashAgg[GLOBAL]
-------PhysicalDistribute[DistributionSpecHash]
---------hashAgg[LOCAL]
-----------PhysicalOneRowRelation
+--PhysicalLimit[GLOBAL]
+----PhysicalDistribute[DistributionSpecGather]
+------PhysicalProject
+--------PhysicalUnion
 
 -- !union_to_onerow_2 --
 1	2
 
 -- !union_to_onerow_2_shape --
 PhysicalResultSink
---PhysicalDistribute[DistributionSpecGather]
-----hashAgg[GLOBAL]
-------PhysicalDistribute[DistributionSpecHash]
---------hashAgg[LOCAL]
-----------PhysicalOneRowRelation
+--PhysicalLimit[GLOBAL]
+----PhysicalDistribute[DistributionSpecGather]
+------PhysicalUnion
 
 -- !prune_partition1 --
 PhysicalResultSink

--- a/regression-test/data/nereids_rules_p0/infer_predicate/pull_up_predicate_set_op.out
+++ b/regression-test/data/nereids_rules_p0/infer_predicate/pull_up_predicate_set_op.out
@@ -139,8 +139,8 @@ PhysicalResultSink
 
 -- !union_all_const_empty_relation --
 PhysicalResultSink
---hashJoin[INNER_JOIN] hashCondition=((t3.a = expr_cast(a as INT)) and (t3.b = t.b)) otherCondition=()
-----PhysicalOneRowRelation
+--NestedLoopJoin[INNER_JOIN]
+----PhysicalUnion
 ----filter((t3.a = 2) and (t3.b = 'dd'))
 ------PhysicalOlapScan[test_pull_up_predicate_set_op3(t3)]
 


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #22203

Problem Summary:

This pull request refines the logic in the `EliminateEmptyRelation` rewrite rule, focusing on how set operations (`UNION` and `EXCEPT`) handle empty relations in query plans. The changes improve efficiency and code clarity by processing only when necessary, optimizing builder usage, and simplifying project and aggregate node construction.

**Set Operation Handling Improvements:**

* Updated the logic for `UNION` nodes to only process and eliminate empty relation children when at least one is present, reducing unnecessary computation. Builders are now initialized with expected sizes for efficiency, and redundant code for handling constant expressions was removed.
* Improved handling of `EXCEPT` nodes by checking for empty relations only among the right-hand children, and optimizing builder initialization. The construction of aggregate and project nodes now uses the correct outputs directly, streamlining the process.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

