### PR TITLE
[fix](metrics) resolve deadlock by moving deregister_hook to destructor

### DIFF
--- a/be/src/util/jvm_metrics.h
+++ b/be/src/util/jvm_metrics.h
@@ -105,7 +105,7 @@ public:
 class JvmMetrics {
 public:
     JvmMetrics(MetricRegistry* registry, JNIEnv* env);
-    ~JvmMetrics() = default;
+    ~JvmMetrics();
     void update();
 
     IntGauge* jvm_heap_size_bytes_max = nullptr;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

The deregister_hook function acquires the entity's lock, which is already held by the caller of JvmMetrics::update, leading to a deadlock. Moving deregister_hook to the destructor ensures proper lock acquisition order and resolves the deadlock condition.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

