### PR TITLE
[refine](block)Ensure mem_reuse_block always calls set_columns at the end.

### DIFF
--- a/be/src/pipeline/exec/repeat_operator.cpp
+++ b/be/src/pipeline/exec/repeat_operator.cpp
@@ -114,9 +114,9 @@ Status RepeatLocalState::get_repeated_block(vectorized::Block* input_block, int 
     size_t input_column_size = input_block->columns();
     size_t output_column_size = p._output_slots.size();
     DCHECK_LT(input_column_size, output_column_size);
-    auto m_block = vectorized::VectorizedUtils::build_mutable_mem_reuse_block(output_block,
-                                                                              p._output_slots);
-    auto& output_columns = m_block.mutable_columns();
+    auto mem_reuse_block = vectorized::VectorizedUtils::build_mutable_mem_reuse_block(
+            output_block, p._output_slots);
+    auto& output_columns = mem_reuse_block.mutable_block.mutable_columns();
     /* Fill all slots according to child, for example:select tc1,tc2,sum(tc3) from t1 group by grouping sets((tc1),(tc2));
      * insert into t1 values(1,2,1),(1,3,1),(2,1,1),(3,1,1);
      * slot_id_set_list=[[0],[1]],repeat_id_idx=0,
@@ -238,10 +238,10 @@ Status RepeatOperatorX::pull(doris::RuntimeState* state, vectorized::Block* outp
                 _repeat_id_idx = 0;
             }
         } else if (local_state._expr_ctxs.empty()) {
-            auto m_block = vectorized::VectorizedUtils::build_mutable_mem_reuse_block(
+            auto mem_reuse_block = vectorized::VectorizedUtils::build_mutable_mem_reuse_block(
                     output_block, _output_slots);
             auto rows = _child_block.rows();
-            auto& columns = m_block.mutable_columns();
+            auto& columns = mem_reuse_block.mutable_block.mutable_columns();
 
             std::size_t cur_col = 0;
             RETURN_IF_ERROR(

--- a/be/src/pipeline/exec/union_sink_operator.h
+++ b/be/src/pipeline/exec/union_sink_operator.h
@@ -149,12 +149,11 @@ private:
         DCHECK_LT(child_id, _child_size);
         DCHECK(!is_child_passthrough(child_id));
         if (input_block->rows() > 0) {
-            vectorized::MutableBlock mblock =
-                    vectorized::VectorizedUtils::build_mutable_mem_reuse_block(output_block,
-                                                                               row_descriptor());
+            auto mem_reuse_block = vectorized::VectorizedUtils::build_mutable_mem_reuse_block(
+                    output_block, row_descriptor());
             vectorized::Block res;
             RETURN_IF_ERROR(materialize_block(state, input_block, child_id, &res));
-            RETURN_IF_ERROR(mblock.merge(res));
+            RETURN_IF_ERROR(mem_reuse_block.mutable_block.merge(res));
         }
         return Status::OK();
     }

--- a/be/src/vec/common/sort/sorter.cpp
+++ b/be/src/vec/common/sort/sorter.cpp
@@ -99,8 +99,8 @@ void MergeSorterState::_merge_sort_read_impl(int batch_size, doris::vectorized::
                                              bool* eos) {
     size_t num_columns = unsorted_block()->columns();
 
-    MutableBlock m_block = VectorizedUtils::build_mutable_mem_reuse_block(block, *unsorted_block());
-    MutableColumns& merged_columns = m_block.mutable_columns();
+    auto mem_reuse_block = VectorizedUtils::build_mutable_mem_reuse_block(block, *unsorted_block());
+    MutableColumns& merged_columns = mem_reuse_block.mutable_block.mutable_columns();
 
     /// Take rows from queue in right order and push to 'merged'.
     size_t merged_rows = 0;
@@ -127,8 +127,6 @@ void MergeSorterState::_merge_sort_read_impl(int batch_size, doris::vectorized::
             _queue.remove_top();
         }
     }
-
-    block->set_columns(std::move(merged_columns));
     *eos = merged_rows == 0;
 }
 

--- a/be/src/vec/exec/scan/file_scanner.cpp
+++ b/be/src/vec/exec/scan/file_scanner.cpp
@@ -735,9 +735,8 @@ Status FileScanner::_convert_to_output_block(Block* block) {
 
     // After convert, the column_ptr should be copied into output block.
     // Can not use block->insert() because it may cause use_count() non-zero bug
-    MutableBlock mutable_output_block =
-            VectorizedUtils::build_mutable_mem_reuse_block(block, *_dest_row_desc);
-    auto& mutable_output_columns = mutable_output_block.mutable_columns();
+    auto mem_reuse_block = VectorizedUtils::build_mutable_mem_reuse_block(block, *_dest_row_desc);
+    auto& mutable_output_columns = mem_reuse_block.mutable_block.mutable_columns();
 
     std::vector<BitmapValue>* skip_bitmaps {nullptr};
     if (_should_process_skip_bitmap_col()) {
@@ -835,6 +834,9 @@ Status FileScanner::_convert_to_output_block(Block* block) {
     _src_block_ptr->clear();
 
     size_t dest_size = block->columns();
+
+    mem_reuse_block.set_columns();
+
     // do filter
     block->insert(vectorized::ColumnWithTypeAndName(std::move(filter_column),
                                                     std::make_shared<vectorized::DataTypeUInt8>(),

--- a/be/src/vec/exec/scan/scanner.cpp
+++ b/be/src/vec/exec/scan/scanner.cpp
@@ -165,10 +165,10 @@ Status Scanner::_do_projections(vectorized::Block* origin_block, vectorized::Blo
     }
 
     DCHECK_EQ(rows, input_block.rows());
-    MutableBlock mutable_block =
+    auto mem_reuse_block =
             VectorizedUtils::build_mutable_mem_reuse_block(output_block, *_output_row_descriptor);
 
-    auto& mutable_columns = mutable_block.mutable_columns();
+    auto& mutable_columns = mem_reuse_block.mutable_block.mutable_columns();
 
     DCHECK_EQ(mutable_columns.size(), _projections.size());
 
@@ -181,9 +181,7 @@ Status Scanner::_do_projections(vectorized::Block* origin_block, vectorized::Blo
         }
         mutable_columns[i]->insert_range_from(*column_ptr, 0, rows);
     }
-    DCHECK(mutable_block.rows() == rows);
-    output_block->set_columns(std::move(mutable_columns));
-
+    DCHECK(mem_reuse_block.mutable_block.rows() == rows);
     return Status::OK();
 }
 

--- a/be/src/vec/runtime/vsorted_run_merger.cpp
+++ b/be/src/vec/runtime/vsorted_run_merger.cpp
@@ -151,9 +151,9 @@ Status VSortedRunMerger::get_next(Block* output_block, bool* eos) {
         return Status::OK();
     } else {
         size_t num_columns = _priority_queue.top().impl->block->columns();
-        MutableBlock m_block = VectorizedUtils::build_mutable_mem_reuse_block(
+        auto mem_reuse_block = VectorizedUtils::build_mutable_mem_reuse_block(
                 output_block, *_priority_queue.top().impl->block);
-        MutableColumns& merged_columns = m_block.mutable_columns();
+        MutableColumns& merged_columns = mem_reuse_block.mutable_block.mutable_columns();
 
         if (num_columns != merged_columns.size()) {
             throw Exception(
@@ -199,8 +199,6 @@ Status VSortedRunMerger::get_next(Block* output_block, bool* eos) {
             }
         }
         do_insert();
-        output_block->set_columns(std::move(merged_columns));
-
         if (merged_rows == 0) {
             *eos = true;
             return Status::OK();


### PR DESCRIPTION
### What problem does this PR solve?
In our previous code we sometimes forgot to call set_columns.
```C++
        MutableBlock m_block = VectorizedUtils::build_mutable_mem_reuse_block(
                output_block, *_priority_queue.top().impl->block);
        MutableColumns& merged_columns = m_block.mutable_columns();
       //....
        while (merged_rows != _batch_size && !_priority_queue.empty()) {
            if (_need_more_data(current)) {
                do_insert();
                return Status::OK();
            }
        }
        do_insert();
        output_block->set_columns(std::move(merged_columns));
```


If a block's use count was always 1 this wasn't an issue, but we can no longer assume use count is 1 (the original check was removed), so we must ensure set_columns is called every time.



### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

