### PR TITLE
[fix](cloud) fix inverted index file error when inverted_index_ram_dir_enable is set to false for packed file

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_fs_directory.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_fs_directory.cpp
@@ -905,8 +905,8 @@ DorisFSDirectory* DorisFSDirectoryFactory::getDirectory(const io::FileSystemSPtr
     if (config::inverted_index_ram_dir_enable && can_use_ram_dir) {
         dir = _CLNEW DorisRAMFSDirectory();
     } else {
-        // cloud mode does not need to create directory
-        if (!config::is_cloud_mode()) {
+        // local and HDFS file systems need to create directories explicitly
+        if (_fs->type() == io::FileSystemType::LOCAL || _fs->type() == io::FileSystemType::HDFS) {
             bool exists = false;
             auto st = _fs->exists(file, &exists);
             DBUG_EXECUTE_IF("DorisFSDirectoryFactory::getDirectory_exists_status_is_not_ok", {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #57770 

Problem Summary:

Changed the directory creation condition to check if the filesystem type is `LOCAL` (`_fs->type() == io::FileSystemType::LOCAL`) instead of using the `is_cloud_mode` configuration, ensuring that directories are only created for local filesystems.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

