### PR TITLE
[fix](load) Fix the sensitivity issue of load column mapping with expressions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadScanProvider.java
@@ -62,11 +62,11 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * process column mapping expressions, delete conditions and sequence columns
@@ -165,7 +165,7 @@ public class NereidsLoadScanProvider {
         //          (k1, k2, tmpk3 = k1 + k2, k3 = k1 + k2)
         //     so "tmpk3 = k1 + k2" is not needed anymore, we can skip it.
         List<NereidsImportColumnDesc> copiedColumnExprs = new ArrayList<>(columnDescs.size());
-        Set<String> constantMappingColumns = new HashSet<>();
+        Set<String> constantMappingColumns = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
         for (NereidsImportColumnDesc importColumnDesc : columnDescs) {
             String mappingColumnName = importColumnDesc.getColumnName();
             if (importColumnDesc.isColumn()) {

--- a/regression-test/suites/load_p0/broker_load/test_s3_load_with_set.groovy
+++ b/regression-test/suites/load_p0/broker_load/test_s3_load_with_set.groovy
@@ -49,7 +49,7 @@ suite("test_s3_load_with_set", "load_p0") {
             kd01 DATE           NOT NULL,
             kd02 INT            NULL,
             kd03 VARCHAR(256)   NULL,
-            kd04 DATE           NOT NULL
+            KD04 DATE           NOT NULL
         )
         DUPLICATE KEY(k00)
         DISTRIBUTED BY HASH(k00) BUCKETS 1


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #58353 #56041

Problem Summary:

```
CREATE TABLE t (
    c1 INT,
    c2 VARCHAR(256),
    DATA_DT DATETIME
)
DUPLICATE KEY(c1)
DISTRIBUTED BY HASH(c1) BUCKETS 3
PROPERTIES("replication_num" = "1");
```

```
LOAD LABEL load
(
   SET (data_dt = now())
)
```

The column names in the `SET (data_dt = now())` statement here should be case-insensitive.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

