### PR TITLE
[fix](metrics) avoid duplicated # TYPE definitions in Prometheus exporter #57788

### DIFF
--- a/be/src/util/metrics.cpp
+++ b/be/src/util/metrics.cpp
@@ -23,6 +23,7 @@
 #include <rapidjson/writer.h>
 
 #include <initializer_list>
+#include <unordered_set>
 
 #include "common/config.h"
 
@@ -345,13 +346,12 @@ std::string MetricRegistry::to_prometheus(bool with_tablet_metrics) const {
 
     // Output
     std::stringstream ss;
-    std::string last_group_name;
+    std::unordered_set<std::string> exported_types;
     for (const auto& entity_metrics_by_type : entity_metrics_by_types) {
-        if (last_group_name.empty() ||
-            last_group_name != entity_metrics_by_type.first->group_name) {
+        std::string metric_name = entity_metrics_by_type.first->combine_name(_name);
+        if (exported_types.insert(metric_name).second) {
             ss << entity_metrics_by_type.first->to_prometheus(_name); // metric TYPE line
         }
-        last_group_name = entity_metrics_by_type.first->group_name;
         std::string display_name = entity_metrics_by_type.first->combine_name(_name);
         for (const auto& entity_metric : entity_metrics_by_type.second) {
             ss << entity_metric.second->to_prometheus(display_name, // metric key-value line

--- a/be/src/util/metrics.cpp
+++ b/be/src/util/metrics.cpp
@@ -325,11 +325,10 @@ std::string MetricRegistry::to_prometheus(bool with_tablet_metrics) const {
     // Reorder by MetricPrototype
     EntityMetricsByType entity_metrics_by_types;
     std::lock_guard<std::mutex> l1(_lock);
-    
-    // 关键：在这里就确保 _name 不为空
+
     std::string registry_name = _name.empty() ? "unknown" : _name;
     const char* safe_name_ptr = registry_name.c_str();
-    
+
     for (const auto& entity : _entities) {
         if (entity.first->_type == MetricEntityType::kTablet && !with_tablet_metrics) {
             continue;
@@ -359,8 +358,8 @@ std::string MetricRegistry::to_prometheus(bool with_tablet_metrics) const {
             continue;
         }
 
-        const std::string& g_str = proto->group_name;  
-        const std::string& n_str = proto->name;       
+        const std::string& g_str = proto->group_name;
+        const std::string& n_str = proto->name;
 
         std::string metric_name = registry_name + "_" + g_str + "_" + n_str;
 
@@ -372,10 +371,9 @@ std::string MetricRegistry::to_prometheus(bool with_tablet_metrics) const {
             if (entity_metric.second == nullptr || entity_metric.first == nullptr) {
                 continue;
             }
-        
-            ss << entity_metric.second->to_prometheus(metric_name, 
-                                                 entity_metric.first->_labels,
-                                                 proto->labels);
+
+            ss << entity_metric.second->to_prometheus(metric_name, entity_metric.first->_labels,
+                                                      proto->labels);
         }
     }
 

--- a/be/test/util/metrics_test.cpp
+++ b/be/test/util/metrics_test.cpp
@@ -493,14 +493,16 @@ TEST_F(MetricsTest, PrometheusDuplicateTypeFix) {
         // 1. Create the first entity and register a metric with a group name
         auto entity1 = registry.register_entity("entity1");
         // Using MetricPrototype is the "official way" in Doris metrics_test
-        MetricPrototype requests_type(MetricType::COUNTER, MetricUnit::OPERATIONS, "requests_total", "", "engine_requests");
+        MetricPrototype requests_type(MetricType::COUNTER, MetricUnit::OPERATIONS, "requests_total",
+                                      "", "engine_requests");
         IntCounter* m1 = (IntCounter*)entity1->register_metric<IntCounter>(&requests_type);
         m1->increment(1);
 
         // 2. Create the second entity and register a metric with a DIFFERENT name to break continuity
         auto entity2 = registry.register_entity("entity2");
-        MetricPrototype other_type(MetricType::COUNTER, MetricUnit::OPERATIONS, "other_metric", "", "");
-        IntCounter* m2 = (IntCounter*)entity2->register_metric<IntCounter>(&other_type);  // 修复：使用 register_metric
+        MetricPrototype other_type(MetricType::COUNTER, MetricUnit::OPERATIONS, "other_metric", "",
+                                   "");
+        IntCounter* m2 = (IntCounter*)entity2->register_metric<IntCounter>(&other_type);
         m2->increment(5);
 
         // 3. Create the third entity and register the SAME group name metric again
@@ -515,9 +517,9 @@ TEST_F(MetricsTest, PrometheusDuplicateTypeFix) {
         // Verification: Count the occurrences of "# TYPE test_registry_engine_requests counter"
         // In your official snippet, the format is: # TYPE {registry_name}_{group_name} {type}
         std::string target_type_line = "# TYPE test_registry_engine_requests counter";
-        
+
         int occurrences = 0;
-        size_t pos = 0;  // 修复：使用 size_t 而不是 std::string::size_t
+        size_t pos = 0;
         while ((pos = output.find(target_type_line, pos)) != std::string::npos) {
             occurrences++;
             pos += target_type_line.length();
@@ -533,4 +535,3 @@ TEST_F(MetricsTest, PrometheusDuplicateTypeFix) {
     }
 }
 } // namespace doris
-

--- a/be/test/util/metrics_test.cpp
+++ b/be/test/util/metrics_test.cpp
@@ -485,4 +485,52 @@ test_registry_task_duration_standard_deviation{instance="test",type="create_tabl
         registry.deregister_entity(entity);
     }
 }
+TEST_F(MetricsTest, PrometheusDuplicateTypeFix) {
+    MetricRegistry registry("test_registry");
+
+    // We use a specific scope {} to match the official coding style
+    {
+        // 1. Create the first entity and register a metric with a group name
+        auto entity1 = registry.register_entity("entity1");
+        // Using MetricPrototype is the "official way" in Doris metrics_test
+        MetricPrototype requests_type(MetricType::COUNTER, MetricUnit::OPERATIONS, "requests_total", "", "engine_requests");
+        IntCounter* m1 = (IntCounter*)entity1->register_metric<IntCounter>(&requests_type);
+        m1->increment(1);
+
+        // 2. Create the second entity and register a metric with a DIFFERENT name to break continuity
+        auto entity2 = registry.register_entity("entity2");
+        MetricPrototype other_type(MetricType::COUNTER, MetricUnit::OPERATIONS, "other_metric", "", "");
+        IntCounter* m2 = (IntCounter*)entity2->register_metric<IntCounter>(&other_type);  // 修复：使用 register_metric
+        m2->increment(5);
+
+        // 3. Create the third entity and register the SAME group name metric again
+        // In the old logic, this would trigger a duplicate # TYPE line
+        auto entity3 = registry.register_entity("entity3");
+        IntCounter* m3 = (IntCounter*)entity3->register_metric<IntCounter>(&requests_type);
+        m3->increment(10);
+
+        // Execute export
+        std::string output = registry.to_prometheus();
+
+        // Verification: Count the occurrences of "# TYPE test_registry_engine_requests counter"
+        // In your official snippet, the format is: # TYPE {registry_name}_{group_name} {type}
+        std::string target_type_line = "# TYPE test_registry_engine_requests counter";
+        
+        int occurrences = 0;
+        size_t pos = 0;  // 修复：使用 size_t 而不是 std::string::size_t
+        while ((pos = output.find(target_type_line, pos)) != std::string::npos) {
+            occurrences++;
+            pos += target_type_line.length();
+        }
+
+        // Must be exactly 1
+        EXPECT_EQ(1, occurrences) << "Duplicate TYPE line detected for interleaved metrics!";
+
+        // Cleanup: Following the official style to deregister entities
+        registry.deregister_entity(entity1);
+        registry.deregister_entity(entity2);
+        registry.deregister_entity(entity3);
+    }
+}
 } // namespace doris
+


### PR DESCRIPTION
### What problem does this PR solve?
**Issue Number:** close #57788 

**Related PR:** None

**Problem Summary:**
This PR fixes a bug where Prometheus metrics exported duplicated `# TYPE` definition lines. The original logic relied on comparing the `group_name` of adjacent metric entities. However, because metric entities are not strictly ordered within the `entity_metrics_by_types` container, this "adjacent-comparison" approach failed when entities of the same type were separated, resulting in redundant `# TYPE` lines that violate OpenMetrics specifications.

**Key Changes:**
* **Global Deduplication**: Introduced `std::unordered_set<std::string> exported_types` to maintain a global state of already-exported metric names during the output phase.
* **Algorithm Efficiency**: Replaced the local check with a hash-set based lookup, ensuring each `# TYPE` line is printed exactly once with an average time complexity of $O(1)$.
* **Robustness**: Ensured that the metrics output remains valid regardless of the internal storage order of metric entities.



### Release note
None

### Check List (For Author)

* [x] Test
* [x] Regression test (Verified via GitHub Actions CI)
* [x] Unit Test (Verified with backend unit tests related to metrics)
* [ ] Manual test (add detailed scripts or steps below)
* [ ] No need to test or manual test. Explain why:

### Behavior changed:
* [x] No.
* [ ] Yes.

### Does this need documentation?
* [x] No.
* [ ] Yes.

### Check List (For Reviewer who merge this PR)
* [ ] Confirm the release note
* [ ] Commission test cases
* [ ] Confirm document
* [ ] Add branch pick label

<details>
<summary>中文修复逻辑说明</summary>

### 修复逻辑说明：
针对 Prometheus 指标输出中存在重复 `# TYPE` 和 `# HELP` 行的问题（如 `doris_be_engine_requests_total`），本次 PR 进行了以下改进：

1. **引入去重状态机**：在 `to_prometheus` 方法中局部维护一个 `std::unordered_set<std::string>`，用于记录当前请求中已导出的指标元数据。
2. **条件式头部输出**：在遍历各指标实体时，逻辑会先检索该指标名是否已存在于集合中。仅在首次发现时，才按规范输出相应的类型声明和帮助文档。
3. **协议合规化**：此改动消除了 Prometheus 抓取时的 "duplicate metric family" 警告，确保了指标暴露接口严格遵循 OpenMetrics / Prometheus 文本协议标准。

</details>