### PR TITLE
[opt](profile) use same metric name as OLAP SCAN NODE for FILE SCAN NODE

### DIFF
--- a/be/src/pipeline/exec/file_scan_operator.cpp
+++ b/be/src/pipeline/exec/file_scan_operator.cpp
@@ -97,10 +97,11 @@ Status FileScanLocalState::_init_scanners(std::list<vectorized::ScannerSPtr>* sc
     return Status::OK();
 }
 
-std::string FileScanLocalState::name_suffix() const {
-    return fmt::format(" (id={}. nereids_id={}. table name = {})",
-                       std::to_string(_parent->node_id()), std::to_string(_parent->nereids_id()),
-                       _parent->cast<FileScanOperatorX>()._table_name);
+std::string FileScanLocalState::name_suffix() const override {
+    return fmt::format("(nereids_id={}. table_name={})" + operator_name_suffix,
+                       std::to_string(_parent->nereids_id()),
+                       _parent->cast<FileScanOperatorX>()._table_name,
+                       std::to_string(_parent->node_id()));
 }
 
 void FileScanLocalState::set_scan_ranges(RuntimeState* state,

--- a/be/src/pipeline/exec/file_scan_operator.cpp
+++ b/be/src/pipeline/exec/file_scan_operator.cpp
@@ -97,7 +97,7 @@ Status FileScanLocalState::_init_scanners(std::list<vectorized::ScannerSPtr>* sc
     return Status::OK();
 }
 
-std::string FileScanLocalState::name_suffix() const override {
+std::string FileScanLocalState::name_suffix() const {
     return fmt::format("(nereids_id={}. table_name={})" + operator_name_suffix,
                        std::to_string(_parent->nereids_id()),
                        _parent->cast<FileScanOperatorX>()._table_name,

--- a/be/src/pipeline/exec/jdbc_scan_operator.cpp
+++ b/be/src/pipeline/exec/jdbc_scan_operator.cpp
@@ -22,8 +22,8 @@
 
 namespace doris::pipeline {
 #include "common/compile_check_begin.h"
-std::string JDBCScanLocalState::name_suffix() const {
-    return fmt::format("(nereids_id={} . table name = {})" + operator_name_suffix,
+std::string JDBCScanLocalState::name_suffix() const override {
+    return fmt::format("(nereids_id={}. table_name={})" + operator_name_suffix,
                        std::to_string(_parent->nereids_id()),
                        _parent->cast<JDBCScanOperatorX>()._table_name,
                        std::to_string(_parent->node_id()));

--- a/be/src/pipeline/exec/jdbc_scan_operator.cpp
+++ b/be/src/pipeline/exec/jdbc_scan_operator.cpp
@@ -22,7 +22,7 @@
 
 namespace doris::pipeline {
 #include "common/compile_check_begin.h"
-std::string JDBCScanLocalState::name_suffix() const override {
+std::string JDBCScanLocalState::name_suffix() const {
     return fmt::format("(nereids_id={}. table_name={})" + operator_name_suffix,
                        std::to_string(_parent->nereids_id()),
                        _parent->cast<JDBCScanOperatorX>()._table_name,


### PR DESCRIPTION
### What problem does this PR solve?

Before:
`FILE_SCAN_OPERATOR (id=4. nereids_id=1053. table name = warehouse):`

After:
`FILE_SCAN_OPERATOR (nereids_id=1052. table_name=inventory)(id=6):`

Same format as OLAP_SCAN_OPERATOR

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

