### PR TITLE
[Bug] Fix ConcurrentModificationException in TabletStatMgr #59138

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
@@ -128,13 +128,17 @@ public class TabletStatMgr extends MasterDaemon {
         Long tabletCount = 0L;
         Long partitionCount = 0L;
         Long tableCount = 0L;
-        List<Long> dbIds = Env.getCurrentInternalCatalog().getDbIds();
+        // Create a snapshot of dbIds to avoid ConcurrentModificationException
+        List<Long> dbIds = Env.getCurrentInternalCatalog().getDbIds().stream()
+                .collect(Collectors.toList());
         for (Long dbId : dbIds) {
             Database db = Env.getCurrentInternalCatalog().getDbNullable(dbId);
             if (db == null) {
                 continue;
             }
-            List<Table> tableList = db.getTables();
+            // Create a snapshot of tables to avoid ConcurrentModificationException
+            List<Table> tableList = db.getTables().stream()
+                    .collect(Collectors.toList());
             for (Table table : tableList) {
                 // Will process OlapTable and MTMV
                 if (!table.isManagedTable()) {
@@ -161,7 +165,9 @@ public class TabletStatMgr extends MasterDaemon {
                     continue;
                 }
                 try {
-                    List<Partition> allPartitions = olapTable.getAllPartitions();
+                    // Create a snapshot of partitions to avoid ConcurrentModificationException
+                    List<Partition> allPartitions = olapTable.getAllPartitions().stream()
+                            .collect(Collectors.toList());
                     partitionCount += allPartitions.size();
                     for (Partition partition : allPartitions) {
                         Long partitionDataSize = 0L;


### PR DESCRIPTION
Problem:
TabletStatMgr.runAfterCatalogReady() throws ConcurrentModificationException when iterating over dbIds and table lists while they are being modified by other threads concurrently.

Root Cause:
1. Line 132: Direct iteration over dbIds returned from getDbIds()
2. Line 137: Direct iteration over tables returned from getTables()
3. Line 164: Direct iteration over partitions from getAllPartitions()

These collections can be modified by other threads during iteration, causing ConcurrentModificationException.

Solution:
Create immutable snapshots of the collections using stream().collect() before iteration to avoid concurrent modification issues.

Changes:
- Create snapshot of dbIds before iteration
- Create snapshot of tableList for each database
- Create snapshot of allPartitions for each table
- Add comments explaining the fix

This ensures thread-safe iteration without requiring additional locks.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

