### PR TITLE
[fix](catalog) fix wrong issue of getBackendMeta

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -4179,12 +4179,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
 
         TGetBackendMetaResult result = new TGetBackendMetaResult();
-        TStatus status = checkMaster();
+        TStatus status = new TStatus(TStatusCode.OK);
         result.setStatus(status);
-
-        if (status.getStatusCode() != TStatusCode.OK) {
-            return result;
-        }
 
         try {
             result = getBackendMetaImpl(request, clientAddr);


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #57898

Problem Summary:
The `getBackendMeta` does not need to call to Master FE.
If use specified non-master FE address in Doris Catalog, it will result in dead loop

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

