### PR TITLE
[fix](core)be core when BeConfDataDirReader::get_data_dir_by_file_path

### DIFF
--- a/be/src/io/fs/local_file_reader.cpp
+++ b/be/src/io/fs/local_file_reader.cpp
@@ -46,7 +46,7 @@
 namespace doris {
 namespace io {
 
-std::atomic_bool be_config_data_dir_list_inited = false;
+std::atomic_bool BeConfDataDirReader::be_config_data_dir_list_inited = false;
 
 std::vector<doris::DataDirInfo> BeConfDataDirReader::be_config_data_dir_list;
 

--- a/be/src/io/fs/local_file_reader.cpp
+++ b/be/src/io/fs/local_file_reader.cpp
@@ -46,16 +46,20 @@
 
 namespace doris {
 namespace io {
-
-std::atomic_bool BeConfDataDirReader::be_config_data_dir_list_initing = false;
+// 1: initing 2: inited 0: before init
+std::atomic_int BeConfDataDirReader::be_config_data_dir_list_state = 0;
 
 std::vector<doris::DataDirInfo> BeConfDataDirReader::be_config_data_dir_list;
 
 void BeConfDataDirReader::get_data_dir_by_file_path(io::Path* file_path,
                                                     std::string* data_dir_arg) {
-#ifndef BE_TEST
-    be_config_data_dir_list_initing.wait(true);
-#endif
+    int state = be_config_data_dir_list_state.load(std::memory_order_acquire);
+    if (state == 0) [[unlikely]] {
+        return;
+    } else if (state == 1) [[unlikely]] {
+        be_config_data_dir_list_state.wait(1);
+    }
+
     for (const auto& data_dir_info : be_config_data_dir_list) {
         if (data_dir_info.path.size() >= file_path->string().size()) {
             continue;
@@ -71,10 +75,10 @@ void BeConfDataDirReader::init_be_conf_data_dir(
         const std::vector<doris::StorePath>& store_paths,
         const std::vector<doris::StorePath>& spill_store_paths,
         const std::vector<doris::CachePath>& cache_paths) {
-    be_config_data_dir_list_initing.store(true);
+    be_config_data_dir_list_state.store(1, std::memory_order_release);
     Defer defer {[]() {
-        be_config_data_dir_list_initing.store(false, std::memory_order_release);
-        be_config_data_dir_list_initing.notify_all();
+        be_config_data_dir_list_state.store(2, std::memory_order_release);
+        be_config_data_dir_list_state.notify_all();
     }};
     for (int i = 0; i < store_paths.size(); i++) {
         DataDirInfo data_dir_info;

--- a/be/src/io/fs/local_file_reader.cpp
+++ b/be/src/io/fs/local_file_reader.cpp
@@ -52,7 +52,9 @@ std::vector<doris::DataDirInfo> BeConfDataDirReader::be_config_data_dir_list;
 
 void BeConfDataDirReader::get_data_dir_by_file_path(io::Path* file_path,
                                                     std::string* data_dir_arg) {
+#ifndef BE_TEST
     be_config_data_dir_list_inited.wait(false);
+#endif
     for (const auto& data_dir_info : be_config_data_dir_list) {
         if (data_dir_info.path.size() >= file_path->string().size()) {
             continue;

--- a/be/src/io/fs/local_file_reader.h
+++ b/be/src/io/fs/local_file_reader.h
@@ -35,6 +35,7 @@ struct CachePath;
 namespace doris::io {
 
 struct BeConfDataDirReader {
+    static std::atomic_bool be_config_data_dir_list_inited;
     static std::vector<doris::DataDirInfo> be_config_data_dir_list;
 
     static void get_data_dir_by_file_path(Path* file_path, std::string* data_dir_arg);

--- a/be/src/io/fs/local_file_reader.h
+++ b/be/src/io/fs/local_file_reader.h
@@ -35,7 +35,7 @@ struct CachePath;
 namespace doris::io {
 
 struct BeConfDataDirReader {
-    static std::atomic_bool be_config_data_dir_list_inited;
+    static std::atomic_bool be_config_data_dir_list_initing;
     static std::vector<doris::DataDirInfo> be_config_data_dir_list;
 
     static void get_data_dir_by_file_path(Path* file_path, std::string* data_dir_arg);

--- a/be/src/io/fs/local_file_reader.h
+++ b/be/src/io/fs/local_file_reader.h
@@ -35,7 +35,7 @@ struct CachePath;
 namespace doris::io {
 
 struct BeConfDataDirReader {
-    static std::atomic_bool be_config_data_dir_list_initing;
+    static std::atomic_int be_config_data_dir_list_state;
     static std::vector<doris::DataDirInfo> be_config_data_dir_list;
 
     static void get_data_dir_by_file_path(Path* file_path, std::string* data_dir_arg);

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -295,9 +295,9 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
     _file_cache_open_fd_cache = std::make_unique<io::FDCache>();
     _file_cache_factory = new io::FileCacheFactory();
     std::vector<doris::CachePath> cache_paths;
+    init_file_cache_factory(cache_paths);
     doris::io::BeConfDataDirReader::init_be_conf_data_dir(store_paths, spill_store_paths,
                                                           cache_paths);
-    init_file_cache_factory(cache_paths);
     _pipeline_tracer_ctx = std::make_unique<pipeline::PipelineTracerContext>(); // before query
     _init_runtime_filter_timer_queue();
 

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -295,9 +295,9 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
     _file_cache_open_fd_cache = std::make_unique<io::FDCache>();
     _file_cache_factory = new io::FileCacheFactory();
     std::vector<doris::CachePath> cache_paths;
-    init_file_cache_factory(cache_paths);
     doris::io::BeConfDataDirReader::init_be_conf_data_dir(store_paths, spill_store_paths,
                                                           cache_paths);
+    init_file_cache_factory(cache_paths);
     _pipeline_tracer_ctx = std::make_unique<pipeline::PipelineTracerContext>(); // before query
     _init_runtime_filter_timer_queue();
 


### PR DESCRIPTION
During the execution of `init_file_cache_factory`, the following call path is triggered:

```txt
init_file_cache_factory -> FileCacheFactory::create_file_cache -> cache->initialize() -> initialize_unlocked -> _storage->init(this) -> FSFileCacheStorage::init()

```

(At this point, a thread named `_cache_background_load_thread` is created, and the remaining operations run within this thread)
`-> upgrade_cache_dir_if_necessary -> read_file_cache_version -> FileSystem::open_file -> open_file_impl -> LocalFileReader::LocalFileReader -> BeConfDataDirReader::get_data_dir_by_file_path`

After `FSFileCacheStorage::init` completes (spawning the `_cache_background_load_thread`), `ExecEnv::_init` continues to execute `doris::io::BeConfDataDirReader::init_be_conf_data_dir`. This function performs push operations on `be_config_data_dir_list`.

Simultaneously, `BeConfDataDirReader::get_data_dir_by_file_path` (running in the background thread) iterates over this same `be_config_data_dir_list`. This leads to a race condition: if `doris::io::BeConfDataDirReader::init_be_conf_data_dir` is inserting data while the vector is being read, two issues arise:

1. Modifying `be_config_data_dir_list` while iterating over it via a range-based for loop results in **Undefined Behavior (UB)**.
2. If `be_config_data_dir_list` triggers a reallocation (expansion) during the insertion, concurrent read operations on its elements will access dangling references, triggering a **heap-use-after-free** error.

Since `init_be_conf_data_dir` depends on `cache_paths` derived from `init_file_cache_factory`, we must carefully manage the synchronization sequence to prevent these errors.