### PR TITLE
[refact](inverted index) refact compound idx writer

### DIFF
--- a/be/src/olap/rowset/segment_v2/index_storage_format_v2.h
+++ b/be/src/olap/rowset/segment_v2/index_storage_format_v2.h
@@ -43,9 +43,10 @@ public:
 private:
     int64_t header_length();
     std::vector<FileMetadata> prepare_file_metadata(int64_t& current_offset);
-    virtual std::pair<std::unique_ptr<lucene::store::Directory, DirectoryDeleter>,
-                      std::unique_ptr<lucene::store::IndexOutput>>
-    create_output_stream();
+    // Creates the output stream for writing the compound file.
+    // For V2 format, we directly create FSIndexOutputV2 using the file writer,
+    // avoiding unnecessary directory operations (important for cloud storage like S3).
+    virtual std::unique_ptr<lucene::store::IndexOutput> create_output_stream();
     void write_version_and_indices_count(lucene::store::IndexOutput* output);
     virtual void write_index_headers_and_metadata(lucene::store::IndexOutput* output,
                                                   const std::vector<FileMetadata>& file_metadata);

--- a/be/src/olap/rowset/segment_v2/inverted_index_fs_directory.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_fs_directory.cpp
@@ -925,28 +925,25 @@ DorisFSDirectory* DorisFSDirectoryFactory::getDirectory(const io::FileSystemSPtr
     if (config::inverted_index_ram_dir_enable && can_use_ram_dir) {
         dir = _CLNEW DorisRAMFSDirectory();
     } else {
-        // cloud mode does not need to create directory
-        if (!config::is_cloud_mode()) {
-            bool exists = false;
-            auto st = _fs->exists(file, &exists);
-            DBUG_EXECUTE_IF("DorisFSDirectoryFactory::getDirectory_exists_status_is_not_ok", {
-                st = Status::Error<ErrorCode::INTERNAL_ERROR>(
-                        "debug point: "
-                        "DorisFSDirectoryFactory::getDirectory_exists_status_is_not_ok");
-            })
-            LOG_AND_THROW_IF_ERROR(st, "Get directory exists IO error");
-            if (!exists) {
-                st = _fs->create_directory(file);
-                DBUG_EXECUTE_IF(
-                        "DorisFSDirectoryFactory::getDirectory_create_directory_status_is_not_ok", {
-                            st = Status::Error<ErrorCode::INTERNAL_ERROR>(
-                                    "debug point: "
-                                    "DorisFSDirectoryFactory::getDirectory_create_directory_status_"
-                                    "is_"
-                                    "not_ok");
-                        })
-                LOG_AND_THROW_IF_ERROR(st, "Get directory create directory IO error");
-            }
+        bool exists = false;
+        auto st = _fs->exists(file, &exists);
+        DBUG_EXECUTE_IF("DorisFSDirectoryFactory::getDirectory_exists_status_is_not_ok", {
+            st = Status::Error<ErrorCode::INTERNAL_ERROR>(
+                    "debug point: "
+                    "DorisFSDirectoryFactory::getDirectory_exists_status_is_not_ok");
+        })
+        LOG_AND_THROW_IF_ERROR(st, "Get directory exists IO error");
+        if (!exists) {
+            st = _fs->create_directory(file);
+            DBUG_EXECUTE_IF(
+                    "DorisFSDirectoryFactory::getDirectory_create_directory_status_is_not_ok", {
+                        st = Status::Error<ErrorCode::INTERNAL_ERROR>(
+                                "debug point: "
+                                "DorisFSDirectoryFactory::getDirectory_create_directory_status_"
+                                "is_"
+                                "not_ok");
+                    })
+            LOG_AND_THROW_IF_ERROR(st, "Get directory create directory IO error");
         }
         dir = _CLNEW DorisFSDirectory();
     }

--- a/be/src/olap/rowset/segment_v2/inverted_index_fs_directory.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_fs_directory.h
@@ -246,6 +246,11 @@ public:
     ~FSIndexOutputV2() override;
     void close() override;
     int64_t length() const override;
+
+    // Static factory method to create FSIndexOutputV2 directly without Directory object.
+    // This is useful for compound file creation where we already have a FileWriter
+    // and don't need directory operations (especially for cloud storage like S3).
+    static std::unique_ptr<lucene::store::IndexOutput> create(io::FileWriter* file_writer);
 };
 
 /**

--- a/be/test/olap/rowset/segment_v2/inverted_index_file_writer_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_file_writer_test.cpp
@@ -807,12 +807,9 @@ TEST_F(IndexFileWriterTest, WriteV2OutputTest) {
     EXPECT_CALL(
             *(IndexStorageFormatV2MockCreateOutputStream*)writer_mock._index_storage_format.get(),
             create_output_stream())
-            .WillOnce(::testing::Invoke(
-                    [&]() -> std::pair<std::unique_ptr<lucene::store::Directory, DirectoryDeleter>,
-                                       std::unique_ptr<lucene::store::IndexOutput>> {
-                        return std::make_pair(std::move(out_dir_ptr),
-                                              std::move(compound_file_output));
-                    }));
+            .WillOnce(::testing::Invoke([&]() -> std::unique_ptr<lucene::store::IndexOutput> {
+                return std::move(compound_file_output);
+            }));
 
     int64_t index_id = 1;
     std::string index_suffix = "suffix1";
@@ -870,12 +867,9 @@ TEST_F(IndexFileWriterTest, WriteV2OutputCloseErrorTest) {
     EXPECT_CALL(
             *(IndexStorageFormatV2MockCreateOutputStream*)writer_mock._index_storage_format.get(),
             create_output_stream())
-            .WillOnce(::testing::Invoke(
-                    [&]() -> std::pair<std::unique_ptr<lucene::store::Directory, DirectoryDeleter>,
-                                       std::unique_ptr<lucene::store::IndexOutput>> {
-                        return std::make_pair(std::move(out_dir_ptr),
-                                              std::move(compound_file_output));
-                    }));
+            .WillOnce(::testing::Invoke([&]() -> std::unique_ptr<lucene::store::IndexOutput> {
+                return std::move(compound_file_output);
+            }));
 
     int64_t index_id = 1;
     std::string index_suffix = "suffix1";

--- a/be/test/olap/rowset/segment_v2/inverted_index_file_writer_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_file_writer_test.cpp
@@ -692,9 +692,8 @@ public:
     IndexStorageFormatV2MockCreateOutputStream(IndexFileWriter* index_file_writer)
             : IndexStorageFormatV2(index_file_writer) {}
 
-    MOCK_METHOD((std::pair<std::unique_ptr<lucene::store::Directory, DirectoryDeleter>,
-                           std::unique_ptr<lucene::store::IndexOutput>>),
-                create_output_stream, (), (override));
+    MOCK_METHOD((std::unique_ptr<lucene::store::IndexOutput>), create_output_stream, (),
+                (override));
 };
 
 class IndexFileWriterMockCreateOutputStreamV1 : public IndexFileWriter {


### PR DESCRIPTION
### What problem does this PR solve?
This PR refactors the compound index writer for the inverted index V2 format to optimize performance, particularly for cloud storage systems like S3. The main improvement is bypassing unnecessary directory operations by directly creating the output stream using an existing file writer.

Key changes:

Added a static factory method FSIndexOutputV2::create() for direct instantiation without requiring a Directory object
Refactored IndexStorageFormatV2::create_output_stream() to return only an IndexOutput instead of a Directory-IndexOutput pair
Removed the cloud mode check in DorisFSDirectoryFactory::getDirectory() to simplify code (directory creation is safe for all file systems)

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

