### PR TITLE
[fix](compaction) Fix wrong JSON value used for tablet IDs in compaction status

### DIFF
--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -164,8 +164,9 @@ void CompactionSubmitRegistry::jsonfy_compaction_status(std::string* result) {
     root.SetObject();
 
     auto add_node = [&root](const std::string& name, const Registry& registry) {
-        rapidjson::Value key;
-        key.SetString(name.c_str(), cast_set<uint32_t>(name.length()), root.GetAllocator());
+        rapidjson::Value compaction_name;
+        compaction_name.SetString(name.c_str(), cast_set<uint32_t>(name.length()),
+                                  root.GetAllocator());
         rapidjson::Document path_obj;
         path_obj.SetObject();
         for (const auto& it : registry) {
@@ -177,15 +178,16 @@ void CompactionSubmitRegistry::jsonfy_compaction_status(std::string* result) {
             arr.SetArray();
 
             for (const auto& tablet : it.second) {
-                rapidjson::Value temp_key;
-                auto key_str = std::to_string(tablet->tablet_id());
-                temp_key.SetString(key_str.c_str(), cast_set<uint32_t>(key_str.length()),
-                                   root.GetAllocator());
-                arr.PushBack(key, root.GetAllocator());
+                rapidjson::Value tablet_id;
+                auto tablet_id_str = std::to_string(tablet->tablet_id());
+                tablet_id.SetString(tablet_id_str.c_str(),
+                                    cast_set<uint32_t>(tablet_id_str.length()),
+                                    root.GetAllocator());
+                arr.PushBack(tablet_id, root.GetAllocator());
             }
             path_obj.AddMember(path_key, arr, root.GetAllocator());
         }
-        root.AddMember(key, path_obj, root.GetAllocator());
+        root.AddMember(compaction_name, path_obj, root.GetAllocator());
     };
 
     std::unique_lock<std::mutex> l(_tablet_submitted_compaction_mutex);


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #53557

Problem Summary:

```
 thrift error, reason=THRIFT_EAGAIN (timed out)doris_be: /var/local/thirdparty/installed/include/rapidjson/document.h:1368: GenericValue<Encoding, Allocator> &rapidjson::GenericValue<rapidjson::UTF8<>>::AddMember(GenericValue<Encoding, Allocator> &, GenericValue<Encoding, Allocator> &, Allocator &) [Encoding = rapidjson::UTF8<>, Allocator = rapidjson::MemoryPoolAllocator<>]: Assertion `name.IsString()' failed.
13:43:12   *** Query id: 0-0 ***
13:43:12   *** is nereids: 0 ***
13:43:12   *** tablet id: 0 ***
13:43:12   *** Aborted at 1766294113 (unix time) try "date -d @1766294113" if you are using GNU date ***
13:43:12   *** Current BE git commitID: fa1f86a774 ***
13:43:12   *** SIGABRT unknown detail explain (@0x9b02) received by PID 39682 (TID 42141 OR 0x7b271cc0d700) from PID 39682; stack trace: ***
13:43:12    0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:420
13:43:12    1# 0x00007F305D563420 in /lib/x86_64-linux-gnu/libpthread.so.0
13:43:12    2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
13:43:12    3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
13:43:12    4# _nl_load_domain at /build/glibc-SzIz7B/glibc-2.31/intl/loadmsgcat.c:970
13:43:12    5# 0x00007F305D37EFD6 in /lib/x86_64-linux-gnu/libc.so.6
13:43:12    6# 0x000055C98F386B8A in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
13:43:12    7# doris::CompactionSubmitRegistry::jsonfy_compaction_status(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*)::$_0::operator()(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::map<doris::DataDir*, std::unordered_set<std::shared_ptr<doris::Tablet>, std::hash<std::shared_ptr<doris::Tablet> >, std::equal_to<std::shared_ptr<doris::Tablet> >, std::allocator<std::shared_ptr<doris::Tablet> > >, std::less<doris::DataDir*>, std::allocator<std::pair<doris::DataDir* const, std::unordered_set<std::shared_ptr<doris::Tablet>, std::hash<std::shared_ptr<doris::Tablet> >, std::equal_to<std::shared_ptr<doris::Tablet> >, std::allocator<std::shared_ptr<doris::Tablet> > > > > > const&) const at /root/doris/be/src/olap/storage_engine.cpp:189
13:43:12    8# doris::CompactionSubmitRegistry::jsonfy_compaction_status(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) at /root/doris/be/src/olap/storage_engine.cpp:192
13:43:12    9# doris::CompactionAction::_handle_run_status_compaction(doris::HttpRequest*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) at /root/doris/be/src/http/action/compaction_action.cpp:225
13:43:12   10# doris::CompactionAction::handle(doris::HttpRequest*) at /root/doris/be/src/http/action/compaction_action.cpp:385
13:43:12   11# 0x000055C9AC3CFEC7 in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
13:43:12   12# bufferevent_run_readcb_ at /home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/doris-thirdparty-libevent-2.1.12.1/bufferevent.c:252
13:43:12   13# bufferevent_readcb at /home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/doris-thirdparty-libevent-2.1.12.1/bufferevent_sock.c:227
13:43:12   14# event_process_active_single_queue at /home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/doris-thirdparty-libevent-2.1.12.1/event.c:1682
13:43:12   15# event_process_active at /home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/doris-thirdparty-libevent-2.1.12.1/event.c:1788
13:43:12   16# event_base_loop.constprop.0 at /home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/doris-thirdparty-libevent-2.1.12.1/event.c:2006
13:43:12   17# std::_Function_handler<void (), doris::EvHttpServer::start()::$_0>::_M_invoke(std::_Any_data const&) at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:292
13:43:12   18# doris::ThreadPool::dispatch_thread() at /root/doris/be/src/util/threadpool.cpp:623
13:43:12   19# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:461
13:43:12   20# asan_thread_start(void*) in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
13:43:12   21# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
```

Fix incorrect JSON value used for tablet IDs in compaction status

The compaction status JSON builder mistakenly pushed the compaction name
Value into the tablet ID array instead of using the tablet ID itself.
This resulted in incorrect JSON output and could trigger RapidJSON
assertions when the moved Value was later reused as an object key.

Fix the logic by:
- Using tablet ID as the array element instead of the compaction name
- Ensuring each rapidjson::Value is used only for its intended purpose
- Cleaning up JSON construction to avoid reusing moved values

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

