### PR TITLE
[fix](filecache) fix observation bug in multi-BE cluster

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/BackendPartitionedSchemaScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/BackendPartitionedSchemaScanNode.java
@@ -70,7 +70,7 @@ public class BackendPartitionedSchemaScanNode extends SchemaScanNode {
         BEACKEND_ID_COLUMN_SET.add("be_id");
 
         BACKEND_TABLE.add("file_cache_statistics");
-	BACKEND_TABLE.add("file_cache_info");
+        BACKEND_TABLE.add("file_cache_info");
         BACKEND_TABLE.add("backend_kerberos_ticket_cache");
 
         BACKEND_TABLE.add("backend_tablets");

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/BackendPartitionedSchemaScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/BackendPartitionedSchemaScanNode.java
@@ -70,6 +70,7 @@ public class BackendPartitionedSchemaScanNode extends SchemaScanNode {
         BEACKEND_ID_COLUMN_SET.add("be_id");
 
         BACKEND_TABLE.add("file_cache_statistics");
+	BACKEND_TABLE.add("file_cache_info");
         BACKEND_TABLE.add("backend_kerberos_ticket_cache");
 
         BACKEND_TABLE.add("backend_tablets");


### PR DESCRIPTION
BE_ID column should be in partition column list otherwise results from all BE won't be merged and thus provides flickering results.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

