### PR TITLE
[chore](FE) Fix incorrect character encoding in FE responses by updating encoding properties

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/HttpServer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/HttpServer.java
@@ -153,9 +153,9 @@ public class HttpServer extends SpringBootServletInitializer {
         }
         properties.put("spring.resources.static-locations", "classpath:/static/");
         properties.put("server.servlet.context-path", "/");
-        properties.put("spring.http.encoding.charset", "UTF-8");
-        properties.put("spring.http.encoding.enabled", true);
-        properties.put("spring.http.encoding.force", true);
+        properties.put("server.servlet.encoding.charset", "UTF-8");
+        properties.put("server.servlet.encoding.enabled", true);
+        properties.put("server.servlet.encoding.force", true);
         // enable jetty config
         properties.put("server.jetty.acceptors", this.acceptors);
         properties.put("server.jetty.max-http-post-size", this.maxHttpPostSize);


### PR DESCRIPTION
Spring Boot 2.x or 3.x change properties of "spring.http.encoding" to "server.servlet.encoding".

Problem:​ Using the deprecated `spring.http.encoding` properties resulted in the frontend webserver returning non-UTF-8 encoded responses. This caused specific issues such as misencoded characters in table name related metrics when `enable_unicode_name_support=true` was set.
Solution:​ Migrate to the current `server.servlet.encoding` properties to ensure consistent and correct UTF-8 encoding.