### PR TITLE
[improvement](nereids): Set DEFAULT as a non-reversed keyword

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -286,7 +286,7 @@ supportedAlterStatement
     | ALTER COMPUTE GROUP name=identifierOrText
         properties=propertyClause?                                                          #alterComputeGroup
     | ALTER CATALOG name=identifier SET PROPERTIES
-        LEFT_PAREN propertyItemList RIGHT_PAREN                                             #alterCatalogProperties        
+        LEFT_PAREN propertyItemList RIGHT_PAREN                                             #alterCatalogProperties
     | ALTER WORKLOAD POLICY name=identifierOrText
         properties=propertyClause?                                                          #alterWorkloadPolicy
     | ALTER SQL_BLOCK_RULE name=identifier properties=propertyClause?                       #alterSqlBlockRule
@@ -311,7 +311,7 @@ supportedAlterStatement
     | ALTER SYSTEM RENAME COMPUTE GROUP name=identifier newName=identifier                  #alterSystemRenameComputeGroup
     | ALTER RESOURCE name=identifierOrText properties=propertyClause?                       #alterResource
     | ALTER REPOSITORY name=identifier properties=propertyClause?                           #alterRepository
-    | ALTER ROUTINE LOAD FOR name=multipartIdentifier 
+    | ALTER ROUTINE LOAD FOR name=multipartIdentifier
             (loadProperty (COMMA loadProperty)*)?
             properties=propertyClause?
             (FROM type=identifier LEFT_PAREN propertyItemList RIGHT_PAREN)?                 #alterRoutineLoad
@@ -387,7 +387,7 @@ supportedShowStatement
         (FROM |IN) tableName=multipartIdentifier
         ((FROM | IN) database=identifier)?                                          #showView
     | SHOW PLUGINS                                                                  #showPlugins
-    | SHOW STORAGE (VAULT | VAULTS)                                                 #showStorageVault    
+    | SHOW STORAGE (VAULT | VAULTS)                                                 #showStorageVault
     | SHOW REPOSITORIES                                                             #showRepositories
     | SHOW ENCRYPTKEYS ((FROM | IN) database=multipartIdentifier)?
         (LIKE STRING_LITERAL)?                                                      #showEncryptKeys
@@ -409,7 +409,7 @@ supportedShowStatement
     | SHOW ALL PROPERTIES (LIKE STRING_LITERAL)?                                    #showAllProperties
     | SHOW COLLATION wildWhere?                                                     #showCollation
     | SHOW ROW POLICY (FOR (userIdentify | (ROLE role=identifier)))?                #showRowPolicy
-    | SHOW STORAGE POLICY (USING (FOR policy=identifierOrText)?)?                   #showStoragePolicy   
+    | SHOW STORAGE POLICY (USING (FOR policy=identifierOrText)?)?                   #showStoragePolicy
     | SHOW SQL_BLOCK_RULE (FOR ruleName=identifier)?                                #showSqlBlockRule
     | SHOW CREATE VIEW name=multipartIdentifier                                     #showCreateView
     | SHOW CREATE STORAGE VAULT identifier                                          #showCreateStorageVault
@@ -434,11 +434,11 @@ supportedShowStatement
     | SHOW FRONTENDS name=identifier?                                               #showFrontends
     | SHOW DATABASE databaseId=INTEGER_VALUE                                        #showDatabaseId
     | SHOW FULL? (COLUMNS | FIELDS) (FROM | IN) tableName=multipartIdentifier
-        ((FROM | IN) database=multipartIdentifier)? wildWhere?          #showColumns    
+        ((FROM | IN) database=multipartIdentifier)? wildWhere?          #showColumns
     | SHOW TABLE tableId=INTEGER_VALUE                                              #showTableId
     | SHOW TRASH (ON backend=STRING_LITERAL)?                                       #showTrash
     | SHOW TYPECAST ((FROM | IN) database=identifier)?                              #showTypeCast
-    | SHOW (CLUSTERS | (COMPUTE GROUPS))                                            #showClusters    
+    | SHOW (CLUSTERS | (COMPUTE GROUPS))                                            #showClusters
     | SHOW statementScope? STATUS                                                   #showStatus
     | SHOW WHITELIST                                                                #showWhitelist
     | SHOW TABLETS BELONG
@@ -473,7 +473,7 @@ supportedShowStatement
 
 supportedLoadStatement
     : SYNC                                                                          #sync
-    | SHOW CREATE LOAD FOR label=multipartIdentifier                                #showCreateLoad    
+    | SHOW CREATE LOAD FOR label=multipartIdentifier                                #showCreateLoad
     | createRoutineLoad                                                             #createRoutineLoadAlias
     | LOAD mysqlDataDesc
         (PROPERTIES LEFT_PAREN properties=propertyItemList RIGHT_PAREN)?
@@ -1048,7 +1048,7 @@ dataDesc
 statementScope
     : (GLOBAL | SESSION | LOCAL)
     ;
-    
+
 buildMode
     : BUILD (IMMEDIATE | DEFERRED)
     ;
@@ -1988,6 +1988,7 @@ nonReserved
     | DECIMAL
     | DECIMALV2
     | DECIMALV3
+    | DEFAULT
     | DEFERRED
     | DEMAND
     | DIAGNOSE

--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -931,7 +931,7 @@ supportedSetStatement
     ;
 
 optionWithType
-    : statementScope identifier EQ (expression | DEFAULT | ON | ALL)    #setVariableWithType
+    : statementScope identifier EQ (expression | ON | ALL)              #setVariableWithType
     ;
 
 optionWithoutType
@@ -948,7 +948,7 @@ optionWithoutType
 
 variable
     : (DOUBLEATSIGN (statementScope DOT)?)? identifier EQ
-        (expression | DEFAULT | ON | ALL)                               #setSystemVariable
+        (expression | ON | ALL)                                         #setSystemVariable
     | ATSIGN identifier EQ expression                                   #setUserVariable
     ;
 
@@ -1344,7 +1344,7 @@ hintAssignment
     ;
 
 updateAssignment
-    : col=multipartIdentifier EQ (expression | DEFAULT)
+    : col=multipartIdentifier EQ expression
     ;
 
 updateAssignmentSeq
@@ -1578,7 +1578,6 @@ rowConstructor
 
 rowConstructorItem
     : constant // duplicate constant rule for improve the parse of `insert into tbl values`
-    | DEFAULT
     | namedExpression
     ;
 
@@ -1738,6 +1737,7 @@ specifiedPartition
 
 constant
     : NULL                                                                                     #nullLiteral
+    | DEFAULT                                                                                  #defaultLiteral
     | type=(DATE | DATEV1 | DATEV2 | TIMESTAMP) STRING_LITERAL                                 #typeConstructor
     | number                                                                                   #numericLiteral
     | booleanValue                                                                             #booleanLiteral

--- a/regression-test/suites/nereids_syntax_p0/test_keywords.groovy
+++ b/regression-test/suites/nereids_syntax_p0/test_keywords.groovy
@@ -18,25 +18,26 @@
 suite("test_keywords") {
     // DEFAULT is a non-reserved keyword
     sql """
-    drop table if exists default;
+    drop table if exists DEFAULT;
     """
 
     sql """
-            CREATE TABLE IF NOT EXISTS default(
+            CREATE TABLE IF NOT EXISTS DEFAULT(
                 id int
             )
             DISTRIBUTED BY HASH(id) properties("replication_num" = "1");
         """
 
-    sql """ DESCRIBE default; """
+    sql """ DESCRIBE DEFAULT; """
 
-    sql """ insert into default values(1) """
+    sql """ insert into DEFAULT values(1) """
 
     test {
-        sql "select * from default"
+        sql "select * from DEFAULT"
         result([[1]])
     }
 
-    sql """ truncate table default; """
+    sql """ truncate table DEFAULT; """
 
+    sql """ set query_timeout = DEFAULT; """
 }

--- a/regression-test/suites/nereids_syntax_p0/test_keywords.groovy
+++ b/regression-test/suites/nereids_syntax_p0/test_keywords.groovy
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_keywords") {
+    // DEFAULT is a non-reserved keyword
+    sql """
+    drop table if exists default;
+    """
+
+    sql """
+            CREATE TABLE IF NOT EXISTS default(
+                id int
+            )
+            DISTRIBUTED BY HASH(id) properties("replication_num" = "1");
+        """
+
+    sql """ DESCRIBE default; """
+
+    sql """ insert into default values(1) """
+
+    test {
+        sql "select * from default"
+        result([[1]])
+    }
+
+    sql """ truncate table default; """
+
+}


### PR DESCRIPTION
### What problem does this PR solve?

This PR sets DEFAULT as a non-reserved keyword since database name or table/column name may use DEFAULT/default as the name.

before:

```sql
MySQL [langchain]> show tables;
+---------------------+
| Tables_in_langchain |
+---------------------+
| default             |
| langchain           |
+---------------------+
2 rows in set (0.003 sec)

MySQL [langchain]> DESCRIBE langchain;
+----------+--------------+------+-------+---------+-------+
| Field    | Type         | Null | Key   | Default | Extra |
+----------+--------------+------+-------+---------+-------+
| id       | varchar(64)  | Yes  | true  | NULL    |       |
| text     | text         | Yes  | false | NULL    | NONE  |
| vector   | array<float> | No   | false | NULL    | NONE  |
| metadata | text         | Yes  | false | NULL    | NONE  |
+----------+--------------+------+-------+---------+-------+
4 rows in set (0.003 sec)

MySQL [langchain]> DESCRIBE default;
ERROR 1105 (HY000): errCode = 2, detailMessage =
no viable alternative at input 'DESCRIBE default'(line 1, pos 9)

MySQL [langchain]> select * from default;
ERROR 1105 (HY000): errCode = 2, detailMessage =
mismatched input 'default' expecting {'(', '{', '}', 'ACTIONS', 'AFTER', 'AGG_STATE', 'AGGREGATE', 'ALIAS', 'ANALYZED', 'ARRAY', 'AT', 'AUTHORS', 'AUTO_INCREMENT', 'ALWAYS', 'BACKENDS', 'BACKUP', 'BEGIN', 'BELONG', 'BIN', 'BITAND', 'BITMAP', 'BITMAP_EMPTY', 'BITMAP_UNION', 'BITOR', 'BITXOR', 'BLOB', 'BOOLEAN', 'BRANCH', 'BRIEF', 'BROKER', 'BUCKETS', 'BUILD', 'BUILTIN', 'BULK', 'CACHE', 'CACHED', 'CALL', 'CATALOG', 'CATALOGS', 'CHAIN', CHAR, 'CHARSET', 'CHECK', 'CLUSTER', 'CLUS
```

after:

```sql
MySQL [langchain]> DESCRIBE default;
+----------+--------------+------+-------+---------+-------+
| Field    | Type         | Null | Key   | Default | Extra |
+----------+--------------+------+-------+---------+-------+
| id       | varchar(64)  | Yes  | true  | NULL    |       |
| text     | text         | Yes  | false | NULL    | NONE  |
| vector   | array<float> | No   | false | NULL    | NONE  |
| metadata | text         | Yes  | false | NULL    | NONE  |
+----------+--------------+------+-------+---------+-------+
4 rows in set (0.004 sec)

MySQL [langchain]> select id from default limit 1;
+--------------------------------------+
| id                                   |
+--------------------------------------+
| 011645f8-e045-45d5-88f8-e12a5a62ab89 |
+--------------------------------------+
1 row in set (0.078 sec)
```

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

