### PR TITLE
[opt](coordinator) build TPlan within the table lock

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -164,7 +164,7 @@ public class NereidsPlanner extends Planner {
                 if (plan instanceof PhysicalPlan) {
                     physicalPlan = (PhysicalPlan) plan;
                     distribute(physicalPlan, explainLevel);
-                    cachePlanFragments(explainLevel);
+                    cacheThriftPlans(explainLevel);
                 }
             });
         } finally {
@@ -721,14 +721,14 @@ public class NereidsPlanner extends Planner {
         }
     }
 
-    private void cachePlanFragments(ExplainLevel explainLevel) {
+    private void cacheThriftPlans(ExplainLevel explainLevel) {
         if (explainLevel != ExplainLevel.NONE && explainLevel.isPlanLevel
                 && (explainLevel != ExplainLevel.ALL_PLAN && explainLevel != ExplainLevel.DISTRIBUTED_PLAN)) {
             return;
         }
         for (PlanFragment fragment : fragments) {
             // cache TPlanFragment in the table lock, to prevent concurrent schema change when ThriftPlansBuilder
-            fragment.toThrift();
+            fragment.cacheThriftPlan();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -164,6 +164,7 @@ public class NereidsPlanner extends Planner {
                 if (plan instanceof PhysicalPlan) {
                     physicalPlan = (PhysicalPlan) plan;
                     distribute(physicalPlan, explainLevel);
+                    cachePlanFragments(explainLevel);
                 }
             });
         } finally {
@@ -717,6 +718,17 @@ public class NereidsPlanner extends Planner {
         if (statementContext.getConnectContext().getExecutor() != null) {
             statementContext.getConnectContext().getExecutor().getSummaryProfile()
                     .setNereidsDistributeTime(TimeUtils.getStartTimeMs());
+        }
+    }
+
+    private void cachePlanFragments(ExplainLevel explainLevel) {
+        if (explainLevel != ExplainLevel.NONE && explainLevel.isPlanLevel
+                && (explainLevel != ExplainLevel.ALL_PLAN && explainLevel != ExplainLevel.DISTRIBUTED_PLAN)) {
+            return;
+        }
+        for (PlanFragment fragment : fragments) {
+            // cache TPlanFragment in the table lock, to prevent concurrent schema change when ThriftPlansBuilder
+            fragment.toThrift();
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

build thrift for TPLan within the table lock, to prevent concurrent schema change when fragment to thrift and throw exception:
```
java.lang.NullPointerException: Cannot invoke "org.apache.doris.catalog.MaterializedIndexMeta.getSchema()" because the return value of "java.util.Map.get(Object)" is null
    at org.apache.doris.catalog.OlapTable.getSchemaByIndexId(OlapTable.java:1101)         
    at org.apache.doris.catalog.OlapTable.getColumnDesc(OlapTable.java:3135)                           
    at org.apache.doris.planner.OlapScanNode.toThrift(OlapScanNode.java:1095)
    at org.apache.doris.planner.PlanNode.treeToThriftHelper(PlanNode.java:508)
    at org.apache.doris.planner.PlanNode.treeToThriftHelper(PlanNode.java:538)
    at org.apache.doris.planner.PlanNode.treeToThrift(PlanNode.java:468)
    at org.apache.doris.planner.PlanFragment.toThrift(PlanFragment.java:325)
    at org.apache.doris.qe.runtime.ThriftPlansBuilder.lambda$fragmentToThriftIfAbsent$2(ThriftPlansBuilder.java:379)
    at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1220)
    at org.apache.doris.qe.runtime.ThriftPlansBuilder.fragmentToThriftIfAbsent(ThriftPlansBuilder.java:330)
    at org.apache.doris.qe.runtime.ThriftPlansBuilder.plansToThrift(ThriftPlansBuilder.java:114)
    at org.apache.doris.qe.NereidsCoordinator.exec(NereidsCoordinator.java:149)
    at org.apache.doris.qe.StmtExecutor.executeAndSendResult(StmtExecutor.java:1301)
    at org.apache.doris.qe.StmtExecutor.handleCacheStmt(StmtExecutor.java:1183)
    at org.apache.doris.qe.StmtExecutor.handleQueryStmt(StmtExecutor.java:1254)
    at org.apache.doris.qe.StmtExecutor.handleQueryWithRetry(StmtExecutor.java:914)
    at org.apache.doris.qe.StmtExecutor.executeByNereids(StmtExecutor.java:818)
    at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:541)
    at org.apache.doris.qe.StmtExecutor.queryRetry(StmtExecutor.java:500)
    at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:485)
    at org.apache.doris.qe.ConnectProcessor.executeQuery(ConnectProcessor.java:307)
    at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:194)
    at org.apache.doris.qe.MysqlConnectProcessor.handleQuery(MysqlConnectProcessor.java:231)
    at org.apache.doris.qe.MysqlConnectProcessor.dispatch(MysqlConnectProcessor.java:259)        
    at org.apache.doris.qe.MysqlConnectProcessor.processOnce(MysqlConnectProcessor.java:403)
    at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52)
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

