### PR TITLE
[fix](fe) move some variables from Tablet to LocalTablet which are not used in CloudTablet

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/EnvFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/EnvFactory.java
@@ -99,11 +99,11 @@ public class EnvFactory {
     }
 
     public Tablet createTablet() {
-        return new Tablet();
+        return new LocalTablet();
     }
 
     public Tablet createTablet(long tabletId) {
-        return new Tablet(tabletId);
+        return new LocalTablet(tabletId);
     }
 
     public Replica createReplica() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/LocalTablet.java
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.common.Pair;
+
+import com.google.gson.annotations.SerializedName;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Comparator;
+
+public class LocalTablet extends Tablet {
+    private static final Logger LOG = LogManager.getLogger(LocalTablet.class);
+
+    // cooldown conf
+    @SerializedName(value = "cri", alternate = {"cooldownReplicaId"})
+    private long cooldownReplicaId = -1;
+    @SerializedName(value = "ctm", alternate = {"cooldownTerm"})
+    private long cooldownTerm = -1;
+    private final Object cooldownConfLock = new Object();
+
+    public LocalTablet() {
+    }
+
+    public LocalTablet(long tabletId) {
+        super(tabletId);
+    }
+
+    @Override
+    public void setCooldownConf(long cooldownReplicaId, long cooldownTerm) {
+        synchronized (cooldownConfLock) {
+            this.cooldownReplicaId = cooldownReplicaId;
+            this.cooldownTerm = cooldownTerm;
+        }
+    }
+
+    @Override
+    public long getCooldownReplicaId() {
+        return cooldownReplicaId;
+    }
+
+    @Override
+    public Pair<Long, Long> getCooldownConf() {
+        synchronized (cooldownConfLock) {
+            return Pair.of(cooldownReplicaId, cooldownTerm);
+        }
+    }
+
+    @Override
+    public long getRemoteDataSize() {
+        // if CooldownReplicaId is not init
+        // [fix](fe) move some variables from Tablet to LocalTablet which are not used in CloudTablet
+        if (cooldownReplicaId <= 0) {
+            return 0;
+        }
+        for (Replica r : replicas) {
+            if (r.getId() == cooldownReplicaId) {
+                return r.getRemoteDataSize();
+            }
+        }
+        // return replica with max remoteDataSize
+        return replicas.stream().max(Comparator.comparing(Replica::getRemoteDataSize)).get().getRemoteDataSize();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -41,7 +41,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -114,13 +113,6 @@ public class Tablet extends MetaObject {
     @SerializedName(value = "ic", alternate = {"isConsistent"})
     private boolean isConsistent;
 
-    // cooldown conf
-    @SerializedName(value = "cri", alternate = {"cooldownReplicaId"})
-    private long cooldownReplicaId = -1;
-    @SerializedName(value = "ctm", alternate = {"cooldownTerm"})
-    private long cooldownTerm = -1;
-    private final Object cooldownConfLock = new Object();
-
     // last time that the tablet checker checks this tablet.
     // no need to persist
     private long lastStatusCheckTime = -1;
@@ -176,20 +168,15 @@ public class Tablet extends MetaObject {
     }
 
     public void setCooldownConf(long cooldownReplicaId, long cooldownTerm) {
-        synchronized (cooldownConfLock) {
-            this.cooldownReplicaId = cooldownReplicaId;
-            this.cooldownTerm = cooldownTerm;
-        }
+        throw new UnsupportedOperationException("not support setCooldownConf in Tablet");
     }
 
     public long getCooldownReplicaId() {
-        return cooldownReplicaId;
+        return -1;
     }
 
     public Pair<Long, Long> getCooldownConf() {
-        synchronized (cooldownConfLock) {
-            return Pair.of(cooldownReplicaId, cooldownTerm);
-        }
+        return Pair.of(-1L, -1L);
     }
 
     protected boolean isLatestReplicaAndDeleteOld(Replica newReplica) {
@@ -482,17 +469,7 @@ public class Tablet extends MetaObject {
     }
 
     public long getRemoteDataSize() {
-        // if CooldownReplicaId is not init
-        if (cooldownReplicaId <= 0) {
-            return 0;
-        }
-        for (Replica r : replicas) {
-            if (r.getId() == cooldownReplicaId) {
-                return r.getRemoteDataSize();
-            }
-        }
-        // return replica with max remoteDataSize
-        return replicas.stream().max(Comparator.comparing(Replica::getRemoteDataSize)).get().getRemoteDataSize();
+        return 0;
     }
 
     public long getRowCount(boolean singleReplica) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ReplicasProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ReplicasProcNode.java
@@ -136,7 +136,7 @@ public class ReplicasProcNode implements ProcNodeInterface {
                     path,
                     metaUrl,
                     compactionUrl,
-                    String.valueOf(tablet.getCooldownConf().first),
+                    String.valueOf(tablet.getCooldownReplicaId()),
                     cooldownMetaId,
                     String.valueOf(queryHits));
             if (Config.isCloudMode()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/TabletsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/TabletsProcDir.java
@@ -178,7 +178,7 @@ public class TabletsProcDir implements ProcDirInterface {
                         String compactionUrl = String.format(
                                 "http://" + hostPort + "/api/compaction/show?tablet_id=%d", tabletId);
                         tabletInfo.add(compactionUrl);
-                        tabletInfo.add(tablet.getCooldownConf().first);
+                        tabletInfo.add(tablet.getCooldownReplicaId());
                         if (replica.getCooldownMetaId() == null) {
                             tabletInfo.add("");
                         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
@@ -85,6 +85,7 @@ import org.apache.doris.catalog.JdbcResource;
 import org.apache.doris.catalog.JdbcTable;
 import org.apache.doris.catalog.ListPartitionInfo;
 import org.apache.doris.catalog.ListPartitionItem;
+import org.apache.doris.catalog.LocalTablet;
 import org.apache.doris.catalog.MTMV;
 import org.apache.doris.catalog.MapType;
 import org.apache.doris.catalog.MysqlDBTable;
@@ -528,10 +529,11 @@ public class GsonUtils {
     static {
         tabletTypeAdapterFactory = RuntimeTypeAdapterFactory
                 .of(Tablet.class, "clazz")
-                .registerSubtype(Tablet.class, Tablet.class.getSimpleName())
+                .registerSubtype(LocalTablet.class, LocalTablet.class.getSimpleName())
                 .registerSubtype(CloudTablet.class, CloudTablet.class.getSimpleName());
         if (Config.isNotCloudMode()) {
-            tabletTypeAdapterFactory.registerDefaultSubtype(Tablet.class);
+            tabletTypeAdapterFactory.registerDefaultSubtype(LocalTablet.class);
+            tabletTypeAdapterFactory.registerCompatibleSubtype(LocalTablet.class, Tablet.class.getSimpleName());
         } else {
             // compatible with old cloud code.
             tabletTypeAdapterFactory.registerDefaultSubtype(CloudTablet.class);

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/CatalogMocker.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/CatalogMocker.java
@@ -27,6 +27,7 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.FakeEditLog;
 import org.apache.doris.catalog.HashDistributionInfo;
 import org.apache.doris.catalog.KeysType;
+import org.apache.doris.catalog.LocalTablet;
 import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.MaterializedIndex.IndexState;
 import org.apache.doris.catalog.MysqlTable;
@@ -247,7 +248,7 @@ public class CatalogMocker {
                                             KeysType.AGG_KEYS, partitionInfo, distributionInfo);
         Deencapsulation.setField(olapTable, "baseIndexId", TEST_TBL_ID);
 
-        Tablet tablet0 = new Tablet(TEST_TABLET0_ID);
+        Tablet tablet0 = new LocalTablet(TEST_TABLET0_ID);
         TabletMeta tabletMeta = new TabletMeta(TEST_DB_ID, TEST_TBL_ID, TEST_SINGLE_PARTITION_ID,
                                                TEST_TBL_ID, SCHEMA_HASH, TStorageMedium.HDD);
         baseIndex.addTablet(tablet0, tabletMeta);
@@ -321,7 +322,7 @@ public class CatalogMocker {
                 KeysType.AGG_KEYS, rangePartitionInfo, distributionInfo2);
         Deencapsulation.setField(olapTable2, "baseIndexId", TEST_TBL2_ID);
 
-        Tablet baseTabletP1 = new Tablet(TEST_BASE_TABLET_P1_ID);
+        Tablet baseTabletP1 = new LocalTablet(TEST_BASE_TABLET_P1_ID);
         TabletMeta tabletMetaBaseTabletP1 = new TabletMeta(TEST_DB_ID, TEST_TBL2_ID, TEST_PARTITION1_ID,
                                                            TEST_TBL2_ID, SCHEMA_HASH, TStorageMedium.HDD);
         baseIndexP1.addTablet(baseTabletP1, tabletMetaBaseTabletP1);
@@ -333,7 +334,7 @@ public class CatalogMocker {
         baseTabletP1.addReplica(replica4);
         baseTabletP1.addReplica(replica5);
 
-        Tablet baseTabletP2 = new Tablet(TEST_BASE_TABLET_P2_ID);
+        Tablet baseTabletP2 = new LocalTablet(TEST_BASE_TABLET_P2_ID);
         TabletMeta tabletMetaBaseTabletP2 = new TabletMeta(TEST_DB_ID, TEST_TBL2_ID, TEST_PARTITION2_ID,
                                                            TEST_TBL2_ID, SCHEMA_HASH, TStorageMedium.HDD);
         baseIndexP2.addTablet(baseTabletP2, tabletMetaBaseTabletP2);
@@ -353,7 +354,7 @@ public class CatalogMocker {
 
         // rollup index p1
         MaterializedIndex rollupIndexP1 = new MaterializedIndex(TEST_ROLLUP_ID, IndexState.NORMAL);
-        Tablet rollupTabletP1 = new Tablet(TEST_ROLLUP_TABLET_P1_ID);
+        Tablet rollupTabletP1 = new LocalTablet(TEST_ROLLUP_TABLET_P1_ID);
         TabletMeta tabletMetaRollupTabletP1 = new TabletMeta(TEST_DB_ID, TEST_TBL2_ID, TEST_PARTITION1_ID,
                                                              TEST_ROLLUP_TABLET_P1_ID, ROLLUP_SCHEMA_HASH,
                                                              TStorageMedium.HDD);
@@ -370,7 +371,7 @@ public class CatalogMocker {
 
         // rollup index p2
         MaterializedIndex rollupIndexP2 = new MaterializedIndex(TEST_ROLLUP_ID, IndexState.NORMAL);
-        Tablet rollupTabletP2 = new Tablet(TEST_ROLLUP_TABLET_P2_ID);
+        Tablet rollupTabletP2 = new LocalTablet(TEST_ROLLUP_TABLET_P2_ID);
         TabletMeta tabletMetaRollupTabletP2 = new TabletMeta(TEST_DB_ID, TEST_TBL2_ID, TEST_PARTITION1_ID,
                                                              TEST_ROLLUP_TABLET_P2_ID, ROLLUP_SCHEMA_HASH,
                                                              TStorageMedium.HDD);

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CatalogTestUtil.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CatalogTestUtil.java
@@ -198,7 +198,7 @@ public class CatalogTestUtil {
 
 
         // tablet
-        Tablet tablet = new Tablet(tabletId);
+        Tablet tablet = new LocalTablet(tabletId);
 
         // index
         MaterializedIndex index = new MaterializedIndex(indexId, IndexState.NORMAL);
@@ -268,7 +268,7 @@ public class CatalogTestUtil {
         }
 
         // tablet
-        Tablet tablet = new Tablet(testTabletId2);
+        Tablet tablet = new LocalTablet(testTabletId2);
 
         // index
         MaterializedIndex index = new MaterializedIndex(testIndexId2, IndexState.NORMAL);

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/TabletTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/TabletTest.java
@@ -80,7 +80,7 @@ public class TabletTest {
             }
         };
 
-        tablet = new Tablet(1);
+        tablet = new LocalTablet(1);
         TabletMeta tabletMeta = new TabletMeta(10, 20, 30, 40, 1, TStorageMedium.HDD);
         invertedIndex.addTablet(1, tabletMeta);
         replica1 = new Replica(1L, 1L, 100L, 0, 200000L, 0, 3000L, ReplicaState.NORMAL, 0, 0);
@@ -146,7 +146,7 @@ public class TabletTest {
         Assert.assertEquals(rTablet1, tablet);
         Assert.assertEquals(rTablet1, rTablet1);
 
-        Tablet tablet2 = new Tablet(1);
+        Tablet tablet2 = new LocalTablet(1);
         Replica replica1 = new Replica(1L, 1L, 100L, 0, 200000L, 0, 3000L, ReplicaState.NORMAL, 0, 0);
         Replica replica2 = new Replica(2L, 2L, 100L, 0, 200000L, 0, 3000L, ReplicaState.NORMAL, 0, 0);
         Replica replica3 = new Replica(3L, 3L, 100L, 0, 200000L, 0, 3000L, ReplicaState.NORMAL, 0, 0);
@@ -156,7 +156,7 @@ public class TabletTest {
         tablet2.addReplica(replica3);
         Assert.assertEquals(tablet2, tablet);
 
-        Tablet tablet3 = new Tablet(1);
+        Tablet tablet3 = new LocalTablet(1);
         tablet3.addReplica(replica1);
         tablet3.addReplica(replica2);
         tablet3.addReplica(new Replica(4L, 4L, 100L, 0, 200000L, 0, 3000L, ReplicaState.NORMAL, 0, 0));
@@ -173,7 +173,7 @@ public class TabletTest {
     @SafeVarargs
     private final void testTabletColocateHealthStatus0(Tablet.TabletStatus exceptedTabletStatus,
             Pair<Long, Boolean>... backendId2ReplicaIsBad) {
-        Tablet tablet = new Tablet(1);
+        Tablet tablet = new LocalTablet(1);
         int replicaId = 1;
         for (Pair<Long, Boolean> pair : backendId2ReplicaIsBad) {
             long versionAndSuccessVersion = 100L;
@@ -218,7 +218,7 @@ public class TabletTest {
 
     @Test
     public void testGetMinReplicaRowCount() {
-        Tablet t = new Tablet(1);
+        Tablet t = new LocalTablet(1);
         long row = t.getMinReplicaRowCount(1);
         Assert.assertEquals(0, row);
 

--- a/fe/fe-core/src/test/java/org/apache/doris/clone/RebalancerTestUtil.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/RebalancerTestUtil.java
@@ -20,6 +20,7 @@ package org.apache.doris.clone;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.DiskInfo;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.LocalTablet;
 import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.MysqlCompatibleDatabase;
 import org.apache.doris.catalog.OlapTable;
@@ -85,7 +86,7 @@ public class RebalancerTestUtil {
 
         TabletMeta tabletMeta = new TabletMeta(db.getId(), olapTable.getId(),
                 partition.getId(), baseIndex.getId(), schemaHash, medium);
-        Tablet tablet = new Tablet(tabletId);
+        Tablet tablet = new LocalTablet(tabletId);
 
         // add tablet to olapTable
         olapTable.getPartition("p0").getBaseIndex().addTablet(tablet, tabletMeta);

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/cache/CacheHotspotManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/cache/CacheHotspotManagerTest.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.cloud.CacheHotspotManager;
+import org.apache.doris.cloud.catalog.CloudTablet;
 import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.common.Triple;
 import org.apache.doris.system.Backend;
@@ -89,7 +90,7 @@ public class CacheHotspotManagerTest {
             @Mock
             public List<Tablet> getTabletsFromIndexs(List<MaterializedIndex> indexes) {
                 List<Tablet> list = new ArrayList<>();
-                Tablet tablet = new Tablet(1001L);
+                Tablet tablet = new CloudTablet(1001L);
                 list.add(tablet);
                 return list;
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/UnitTestUtil.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/UnitTestUtil.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DataProperty;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.KeysType;
+import org.apache.doris.catalog.LocalTablet;
 import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.MaterializedIndex.IndexState;
 import org.apache.doris.catalog.OlapTable;
@@ -76,7 +77,7 @@ public class UnitTestUtil {
         Replica replica3 = new Replica(replicaId + 2, backendId + 2, ReplicaState.NORMAL, version, 0);
 
         // tablet
-        Tablet tablet = new Tablet(tabletId);
+        Tablet tablet = new LocalTablet(tabletId);
 
         // index
         MaterializedIndex index = new MaterializedIndex(indexId, IndexState.NORMAL);

--- a/fe/fe-core/src/test/java/org/apache/doris/cooldown/CooldownConfHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cooldown/CooldownConfHandlerTest.java
@@ -24,6 +24,7 @@ import org.apache.doris.catalog.AccessPrivilege;
 import org.apache.doris.catalog.AccessPrivilegeWithCols;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.LocalTablet;
 import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.Replica;
@@ -55,7 +56,7 @@ public class CooldownConfHandlerTest extends TestWithFeService {
     private long indexId = 103L;
     private long tabletId = 104;
 
-    private Tablet tablet = null;
+    private LocalTablet tablet = null;
 
     @Override
     protected void runBeforeAll() throws Exception {
@@ -95,7 +96,7 @@ public class CooldownConfHandlerTest extends TestWithFeService {
         indexId = index.getId();
         List<Tablet> tablets = index.getTablets();
         assert tablets.size() > 0;
-        tablet = tablets.get(0);
+        tablet = (LocalTablet) tablets.get(0);
         tablet.setCooldownConf(-1, 100);
         tabletId = tablet.getId();
         LOG.info("create table: db: {}, tbl: {}, partition: {}, index: {}, tablet: {}", dbId, tableId, partitionId,

--- a/fe/fe-core/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
@@ -26,6 +26,7 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.EsResource;
 import org.apache.doris.catalog.EsTable;
 import org.apache.doris.catalog.KeysType;
+import org.apache.doris.catalog.LocalTablet;
 import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
@@ -152,7 +153,7 @@ public abstract class DorisHttpTestCase {
                 Replica.ReplicaState.NORMAL, -1, 0);
 
         // tablet
-        Tablet tablet = new Tablet(tabletId);
+        Tablet tablet = new LocalTablet(tabletId);
 
         // index
         MaterializedIndex baseIndex = new MaterializedIndex(testIndexId, MaterializedIndex.IndexState.NORMAL);


### PR DESCRIPTION
### What problem does this PR solve?

### Purpose
1. some fields are not used in cloud mode, but `CloudTablet` extends `Tablet` and inherits these fields, which consumes too much memory
2. this pr add `LocalTablet` subclass to keep these fields which are only used in local mode
3. this pr only move cooldown related fileds, more fileds will be moved later

### TestResult
in a cloud cluster with one million tablets, the test results are as follows:
||before|after||
|--------|--------|--------|--------|
|total memory of `CloudTablet`|<img width="1280" height="351" alt="1-1" src="https://github.com/user-attachments/assets/b20cb1dd-da76-420d-8093-53891bbd5063" />|<img width="1280" height="358" alt="2-1" src="https://github.com/user-attachments/assets/00791566-83b7-4605-b7ac-1e25d7274223" />| reduce 272.93 MB |
|memory of one `CloudTablet`|<img width="1386" height="762" alt="1-2" src="https://github.com/user-attachments/assets/424a01eb-d276-463d-9a8d-ff3a9ed185b2" />|<img width="1396" height="692" alt="2-2" src="https://github.com/user-attachments/assets/2bedff14-7bcc-42ab-bf7b-d5a8f993b8dd" />|reduce 272 B|
|fields of `CloudTablet`|<img width="1388" height="620" alt="1-3" src="https://github.com/user-attachments/assets/cbc7fca3-5e39-4a44-b1c2-1e21d8328769" />|<img width="1388" height="512" alt="2-3" src="https://github.com/user-attachments/assets/cfc094f9-46e1-4fc3-8f1d-37dad0d04a8a" />||

### Compatibility
||old FE upgrade to new FE| new FE downgrade to old FE|
|--------|--------|--------|
|cloud mode| supported | supported|
|local mode| supported | unsupported (need modify code in old FE to support it) |


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

