### PR TITLE
[enhancement](spilldisk)Cancel query fast when reserver memory failed and could not find revocable tasks

### DIFF
--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -126,7 +126,6 @@ public:
     int64_t group_num() const { return _group_num; }
     int64_t limit() const { return _limit; }
     void set_limit(int64_t new_mem_limit) { _limit = new_mem_limit; }
-    bool enable_check_limit() const { return _enable_check_limit; }
     void set_enable_check_limit(bool enable_check_limit) {
         _enable_check_limit = enable_check_limit;
     }
@@ -298,7 +297,7 @@ inline void MemTrackerLimiter::cache_consume(int64_t bytes) {
 }
 
 inline Status MemTrackerLimiter::check_limit(int64_t bytes) {
-    if (bytes <= 0 || !enable_check_limit() || _limit <= 0) {
+    if (bytes <= 0 || !_enable_check_limit || _limit <= 0) {
         return Status::OK();
     }
 

--- a/be/src/runtime/workload_management/query_task_controller.cpp
+++ b/be/src/runtime/workload_management/query_task_controller.cpp
@@ -120,6 +120,15 @@ size_t QueryTaskController::get_revocable_size() {
     return revocable_size;
 }
 
+void QueryTaskController::disable_reserve_memory() {
+    TaskController::disable_reserve_memory();
+    auto query_ctx = query_ctx_.lock();
+    if (query_ctx == nullptr) {
+        return;
+    }
+    query_ctx->query_mem_tracker()->set_enable_check_limit(true);
+}
+
 Status QueryTaskController::revoke_memory() {
     auto query_ctx = query_ctx_.lock();
     if (query_ctx == nullptr) {

--- a/be/src/runtime/workload_management/query_task_controller.h
+++ b/be/src/runtime/workload_management/query_task_controller.h
@@ -37,6 +37,7 @@ public:
     bool cancel_impl(const Status& reason) override { return cancel_impl(reason, -1); }
     bool is_pure_load_task() const override;
     int32_t get_slot_count() const override;
+    void disable_reserve_memory() override;
     bool is_enable_reserve_memory() const override;
     void set_memory_sufficient(bool sufficient) override;
     int64_t memory_sufficient_time() override;

--- a/be/src/runtime/workload_management/task_controller.h
+++ b/be/src/runtime/workload_management/task_controller.h
@@ -96,7 +96,7 @@ public:
     virtual bool is_pure_load_task() const { return false; }
     void set_low_memory_mode(bool low_memory_mode) { low_memory_mode_ = low_memory_mode; }
     bool low_memory_mode() { return low_memory_mode_; }
-    void disable_reserve_memory() { enable_reserve_memory_ = false; }
+    virtual void disable_reserve_memory() { enable_reserve_memory_ = false; }
     virtual bool is_enable_reserve_memory() const { return enable_reserve_memory_; }
     virtual void set_memory_sufficient(bool sufficient) {};
     virtual int64_t memory_sufficient_time() { return 0; };

--- a/be/test/pipeline/thrift_builder.h
+++ b/be/test/pipeline/thrift_builder.h
@@ -96,6 +96,11 @@ public:
         return *this;
     }
 
+    TQueryOptionsBuilder& set_enable_spill(int64_t enable_spill) {
+        _query_options.__set_enable_spill(enable_spill);
+        return *this;
+    }
+
     TQueryOptions& build() { return _query_options; }
 
     TQueryOptionsBuilder(const TQueryOptionsBuilder&) = delete;

--- a/be/test/runtime/workload_group/workload_group_manager_test.cpp
+++ b/be/test/runtime/workload_group/workload_group_manager_test.cpp
@@ -231,8 +231,8 @@ TEST_F(WorkloadGroupManagerTest, wg_exceed3) {
 
     query_context->query_mem_tracker()->consume(-1024L * 1024 * 4);
 
-    // Query was not cancelled, because the query's limit is bigger than the wg's limit and the wg's policy is NONE.
-    ASSERT_FALSE(query_context->is_cancelled());
+    // In the wg's policy is NONE. If the query reserve memory failed and revocable memory == 0, just cancel it.
+    ASSERT_TRUE(query_context->is_cancelled());
     // Its limit == workload group's limit
     ASSERT_EQ(query_context->resource_ctx()->memory_context()->mem_limit(), wg->memory_limit());
 

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -146,7 +146,7 @@ struct TQueryOptions {
   // if set, this will overwrite the BE config.
   30: optional i32 max_pushdown_conditions_per_column
   // whether enable spilling to disk
-  31: optional bool enable_spilling = false;
+  // 31: optional bool enable_spilling = false;
   // whether enable parallel merge in exchange node
   32: optional bool enable_enable_exchange_node_parallel_merge = false; // deprecated
 


### PR DESCRIPTION
### What problem does this PR solve?

There  are some problems in the previous code:
1. revocable memory size is ineffective for non-spill operators and remains 0 in all cases. In this scenario, if we disable spill and enable reserve, it appears that memlimit will stop working entirely.
2. too complicated in process reserve failed.

In this PR, I simplified the logic:
1. If the query is not enable spill, and if reserve memory failed, just disable reserve memory and it will enable memory check immediately and let the query run.
2. If reserve memory failed and not find any revocable tasks, then just cancel the query.
3. If reserve memory failed, should add to paused query immediately because it maybe the last block for join build. If not paused, it may try to allocate a lot of memory.
4. If there are some query in cancel stage, then not check paused query for a bit while because the cancelling query may release some memory.

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

