### PR TITLE
[fix](cloud) Not print too much peer read err log

### DIFF
--- a/be/src/io/cache/cached_remote_file_reader.cpp
+++ b/be/src/io/cache/cached_remote_file_reader.cpp
@@ -170,12 +170,13 @@ std::pair<std::string, int> get_peer_connection_info(const std::string& file_pat
             host = tablet_info->first;
             port = tablet_info->second;
         } else {
-            LOG_EVERY_N(WARNING, 100) << "get peer connection info not found"
+            LOG_EVERY_N(WARNING, 100)
+                    << "get peer connection info not found"
                     << ", tablet_id=" << *tablet_id << ", file_path=" << file_path;
         }
     } else {
         LOG_EVERY_N(WARNING, 100) << "parse tablet id from path failed"
-                << "tablet_id=null, file_path=" << file_path;
+                                  << "tablet_id=null, file_path=" << file_path;
     }
 
     DBUG_EXECUTE_IF("PeerFileCacheReader::_fetch_from_peer_cache_blocks", {
@@ -213,8 +214,9 @@ Status execute_peer_read(const std::vector<FileBlockSPtr>& empty_blocks, size_t 
     auto st = peer_reader.fetch_blocks(empty_blocks, empty_start, Slice(buffer.get(), size), &size,
                                        file_size, io_ctx);
     if (!st.ok()) {
-        LOG_EVERY_N(WARNING, 100) << "PeerFileCacheReader read from peer failed")
-                << ", host=" << host << ", port=" << port << ", error=" << st.msg();
+        LOG_EVERY_N(WARNING, 100) << "PeerFileCacheReader read from peer failed"
+                                  << ", host=" << host << ", port=" << port
+                                  << ", error=" << st.msg();
     }
     stats.from_peer_cache = true;
     return st;

--- a/be/src/io/cache/cached_remote_file_reader.cpp
+++ b/be/src/io/cache/cached_remote_file_reader.cpp
@@ -170,14 +170,12 @@ std::pair<std::string, int> get_peer_connection_info(const std::string& file_pat
             host = tablet_info->first;
             port = tablet_info->second;
         } else {
-            LOG_WARNING("get peer connection info not found")
-                    .tag("tablet_id", *tablet_id)
-                    .tag("file_path", file_path);
+            LOG_EVERY_N(WARNING, 100) << "get peer connection info not found"
+                    << ", tablet_id=" << *tablet_id << ", file_path=" << file_path;
         }
     } else {
-        LOG_WARNING("parse tablet id from path failed")
-                .tag("tablet_id", "null")
-                .tag("file_path", file_path);
+        LOG_EVERY_N(WARNING, 100) << "parse tablet id from path failed"
+                << "tablet_id=null, file_path=" << file_path;
     }
 
     DBUG_EXECUTE_IF("PeerFileCacheReader::_fetch_from_peer_cache_blocks", {
@@ -215,10 +213,8 @@ Status execute_peer_read(const std::vector<FileBlockSPtr>& empty_blocks, size_t 
     auto st = peer_reader.fetch_blocks(empty_blocks, empty_start, Slice(buffer.get(), size), &size,
                                        file_size, io_ctx);
     if (!st.ok()) {
-        LOG_WARNING("PeerFileCacheReader read from peer failed")
-                .tag("host", host)
-                .tag("port", port)
-                .tag("error", st.msg());
+        LOG_EVERY_N(WARNING, 100) << "PeerFileCacheReader read from peer failed")
+                << ", host=" << host << ", port=" << port << ", error=" << st.msg();
     }
     stats.from_peer_cache = true;
     return st;

--- a/be/src/io/cache/peer_file_cache_reader.cpp
+++ b/be/src/io/cache/peer_file_cache_reader.cpp
@@ -133,7 +133,8 @@ Status PeerFileCacheReader::fetch_blocks(const std::vector<FileBlockSPtr>& block
         return Status::RpcError<false>(cntl.ErrorText());
     }
     if (resp.has_status()) {
-        Status st2 = Status::create(resp.status());
+        Status st2 = Status::create<false>(resp.status());
+        LOG_EVERY_N(WARNING, 1000) << "peer cache read failed, status=" << resp.status();
         if (!st2.ok()) return st2;
     }
 

--- a/be/src/io/cache/peer_file_cache_reader.cpp
+++ b/be/src/io/cache/peer_file_cache_reader.cpp
@@ -134,7 +134,7 @@ Status PeerFileCacheReader::fetch_blocks(const std::vector<FileBlockSPtr>& block
     }
     if (resp.has_status()) {
         Status st2 = Status::create<false>(resp.status());
-        LOG_EVERY_N(WARNING, 1000) << "peer cache read failed, status=" << resp.status();
+        LOG_EVERY_N(WARNING, 1000) << "peer cache read failed, status=" << st2.msg();
         if (!st2.ok()) return st2;
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Not print stack when peer read meet err

```
W20251225 11:05:21.592509 399889 status.h:445] meet error status: [INTERNAL_ERROR]PStatus: read cache file error

        0#  doris::Status doris::Status::create<true>(doris::PStatus const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:187
        1#  doris::io::PeerFileCacheReader::fetch_blocks(std::vector<std::shared_ptr<doris::io::FileBlock>, std::allocator<std::shared_ptr<doris::io::FileBlock> > > const&, unsigned long, doris::Slice, unsigned long*, unsigned long, doris::io::IOContext const*) at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/io/cache/peer_file_cache
_reader.cpp:0
        2#  doris::io::(anonymous namespace)::execute_peer_read(std::vector<std::shared_ptr<doris::io::FileBlock>, std::allocator<std::shared_ptr<doris::io::FileBlock> > > const&, unsigned long, unsigned long&, std::unique_ptr<char [], std::default_delete<char []> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned long, bool, doris::io::ReadStatistics&, doris::io::IOContext const*) at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/common/status.h:506
        3#  doris::io::CachedRemoteFileReader::_execute_remote_read(std::vector<std::shared_ptr<doris::io::FileBlock>, std::allocator<std::shared_ptr<doris::io::FileBlock> > > const&, unsigned long, unsigned long&, std::unique_ptr<char [], std::default_delete<char []> >&, doris::io::ReadStatistics&, doris::io::IOContext const*) at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/io/cache/cached_remote_file_reader.cpp:270
        4#  doris::io::CachedRemoteFileReader::read_at_impl(unsigned long, doris::Slice, unsigned long*, doris::io::IOContext const*) at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/common/status.h:506
        5#  doris::io::FileReader::read_at(unsigned long, doris::Slice, unsigned long*, doris::io::IOContext const*) at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/common/status.h:506
        6#  doris::segment_v2::PageIO::read_and_decompress_page_(doris::segment_v2::PageReadOptions const&, doris::segment_v2::PageHandle*, doris::Slice*, doris::segment_v2::PageFooterPB*) at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/common/status.h:506
        7#  doris::segment_v2::PageIO::do_read_and_decompress_page(doris::segment_v2::PageReadOptions const&, doris::segment_v2::PageHandle*, doris::Slice*, doris::segment_v2::PageFooterPB*) at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/olap/rowset/segment_v2/page_io.h:157
        8#  doris::segment_v2::PageIO::read_and_decompress_page(doris::segment_v2::PageReadOptions const&, doris::segment_v2::PageHandle*, doris::Slice*, doris::segment_v2::PageFooterPB*) at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/common/status.h:501
        9#  doris::segment_v2::FileColumnIterator::_read_data_page(doris::segment_v2::OrdinalPageIndexIterator const&) at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/olap/rowset/segment_v2/column_reader.cpp:0
        10# doris::segment_v2::FileColumnIterator::_load_next_page(bool*) at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/common/status.h:506
        11# doris::segment_v2::FileColumnIterator::next_batch(unsigned long*, COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn>&, bool*) at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/common/status.h:506
        12# doris::segment_v2::SegmentIterator::_read_columns_by_index(unsigned int, unsigned int&, bool) at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/common/status.h:506
        13# doris::segment_v2::SegmentIterator::_next_batch_internal(doris::vectorized::Block*) at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/common/status.h:506
        14# doris::segment_v2::SegmentIterator::next_batch(doris::vectorized::Block*) at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/common/status.h:506
        15# doris::vectorized::VerticalMergeIteratorContext::_load_next_block() at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/common/status.h:506
        16# doris::vectorized::VerticalHeapMergeIterator::next_batch(doris::vectorized::Block*) at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/common/status.h:506
        17# doris::vectorized::VerticalBlockReader::_direct_next_block(doris::vectorized::Block*, bool*) at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/common/status.h:506
        18# doris::vectorized::VerticalBlockReader::next_block_with_aggregation(doris::vectorized::Block*, bool*) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:907
        19# doris::Merger::vertical_compact_one_group(std::shared_ptr<doris::BaseTablet>, doris::ReaderType, doris::TabletSchema const&, bool, std::vector<unsigned int, std::allocator<unsigned int> > const&, doris::vectorized::RowSourcesBuffer*, std::vector<std::shared_ptr<doris::RowsetReader>, std::allocator<std::shared_ptr<doris::RowsetReader> > > const&, doris::RowsetWriter*, long, doris::Merger::Statistics*, std::vector<unsigned int, std::allocator<unsigned int> >, long, doris::CompactionSampleInfo*) at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/olap/merger.cpp:0
        20# doris::Merger::vertical_merge_rowsets(std::shared_ptr<doris::BaseTablet>, doris::ReaderType, doris::TabletSchema const&, std::vector<std::shared_ptr<doris::RowsetReader>, std::allocator<std::shared_ptr<doris::RowsetReader> > > const&, doris::RowsetWriter*, long, long, doris::Merger::Statistics*) at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/olap/merger.cpp:481
        21# doris::Compaction::merge_input_rowsets() at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/olap/compaction.cpp:204
        22# doris::CloudCompactionMixin::execute_compact_impl(long) at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/common/status.h:506
        23# doris::CloudCompactionMixin::execute_compact() at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/common/status.h:506
        24# doris::CloudBaseCompaction::execute_compact() at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/common/status.h:392
        25# std::_Function_handler<void (), doris::CloudStorageEngine::_submit_base_compaction_task(std::shared_ptr<doris::CloudTablet> const&)::$_0>::_M_invoke(std::_Any_data const&) at /mnt/disk3/pipeline/repo/selectdb-core_branch-hotfix-selectdb-doris-3.1-c/selectdb-core/be/src/common/status.h:392
        26# doris::ThreadPool::dispatch_thread() at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:730
        27# doris::Thread::supervise_thread(void*) at /var/local/ldb-toolchain/bin/../usr/include/pthread.h:562
        28# ?
        29# ?
```

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

