### PR TITLE
[fix](memtable) fix memtable memory limit waiting threads count error

### DIFF
--- a/be/src/olap/memtable_memory_limiter.cpp
+++ b/be/src/olap/memtable_memory_limiter.cpp
@@ -147,6 +147,7 @@ void MemTableMemoryLimiter::handle_memtable_flush(std::function<bool()> cancel_c
         }
         if (cancel_check && cancel_check()) {
             LOG(INFO) << "cancelled when waiting for memtable flush";
+            g_memtable_memory_limit_waiting_threads << -1;
             return;
         }
         first = false;


### PR DESCRIPTION
### What problem does this PR solve?

Introduced by https://github.com/apache/doris/pull/53070

If `cancel_check && cancel_check()` returns true, simply return without decrementing `memtable_memory_limit_waiting _threads` counter.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

