### PR TITLE
[Chore](shuffle) adjust some local shuffle rules

### DIFF
--- a/be/src/pipeline/exec/distinct_streaming_aggregation_operator.h
+++ b/be/src/pipeline/exec/distinct_streaming_aggregation_operator.h
@@ -120,7 +120,7 @@ public:
                            ? DataDistribution(ExchangeType::BUCKET_HASH_SHUFFLE, _partition_exprs)
                            : DataDistribution(ExchangeType::HASH_SHUFFLE, _partition_exprs);
         }
-        return StatefulOperatorX<DistinctStreamingAggLocalState>::required_data_distribution(state);
+        return {ExchangeType::PASSTHROUGH};
     }
 
     bool require_data_distribution() const override { return _is_colocate; }


### PR DESCRIPTION
### What problem does this PR solve?
1. make distinct streaming agg always shuffle(Improve parallelism)
2. make broadcast join probe do not shuffle

This pull request updates the logic for determining required data distributions in the aggregation and join pipeline operators. The main focus is on improving the handling of exchange types, especially for passthrough and broadcast scenarios.

Key changes include:

**Data distribution logic updates:**

* In `DistinctStreamingAggOperatorX`, the method now always returns `ExchangeType::PASSTHROUGH` instead of delegating to the base class, simplifying the distribution requirement when colocation is not needed.
* In `HashJoinProbeOperatorX`, the logic for broadcast joins is refined: if the child is a serial operator, it returns `ExchangeType::PASSTHROUGH`; otherwise, it returns `ExchangeType::NOOP`. The handling of bucket shuffle and colocate join distributions is also clarified.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

