### PR TITLE
[fix](jdbc catalog): Fix query for different catalog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/JdbcQueryTableValueFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/JdbcQueryTableValueFunction.java
@@ -50,7 +50,7 @@ public class JdbcQueryTableValueFunction extends QueryTableValueFunction {
     @Override
     public ScanNode getScanNode(PlanNodeId id, TupleDescriptor desc, SessionVariable sv) {
         JdbcExternalCatalog catalog = (JdbcExternalCatalog) catalogIf;
-        JdbcTable jdbcTable = new JdbcTable(1, desc.getTable().getName(), desc.getTable().getFullSchema(),
+        JdbcTable jdbcTable = new JdbcTable(desc.getId().asInt(), desc.getTable().getName(), desc.getTable().getFullSchema(),
                 TableType.JDBC);
         catalog.configureJdbcTable(jdbcTable, desc.getTable().getName());
         desc.setTable(jdbcTable);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
Fixes an issue where the incorrect Catalog ID or Schema name might be used when fetching table structures in the JDBC Catalog query. The original code potentially misused 1 as the Catalog ID. The modified code explicitly uses the correct desc.getId().asInt(). This ensures that the JdbcTable object is built correctly for different JDBC catalogs.
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [✔] Yes. Fixed behavior: Ensures the JDBC table function uses the correct Catalog ID to configure the JdbcTable instance, allowing proper differentiation between various data sources.

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

