### PR TITLE
[check](column) Add nullable checks for array/map.

### DIFF
--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -666,6 +666,8 @@ public:
 
     bool null_map_check() const;
 
+    bool complex_type_data_nullable_check() const;
+
     // const column nested check, eg. const(nullable(...)) is allowed
     //  const(array(const(...))) is not allowed
     bool const_nested_check() const;

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -279,6 +279,9 @@ Status Block::check_type_and_column() const {
         if (!elem.type) {
             continue;
         }
+        if (elem.name.find(BeConsts::SPARSE_COLUMN_PATH) != std::string::npos) {
+            continue;
+        }
 
         // ColumnNothing is a special column type, it is used to represent a column that
         // is not materialized, so we don't need to check it.

--- a/be/test/vec/columns/column_self_check.cpp
+++ b/be/test/vec/columns/column_self_check.cpp
@@ -22,6 +22,7 @@
 #include "vec/columns/column.h"
 #include "vec/columns/column_array.h"
 #include "vec/columns/column_const.h"
+#include "vec/columns/column_map.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/functions/function.h"
 #include "vec/functions/simple_function_factory.h"
@@ -117,6 +118,36 @@ TEST(ColumnSelfCheckTest, nullmap_check_test) {
         auto col_const = ColumnConst::create(col, 2);
 
         EXPECT_EQ(col_const->column_self_check(), false);
+    }
+}
+TEST(ColumnSelfCheckTest, complex_type_data_nullable_check) {
+    // array/map data column is nullable check
+    {
+        auto data_col = ColumnHelper::create_nullable_column<DataTypeInt32>({1, 2, 3}, {0, 0, 0});
+        auto offsets_col = ColumnArray::ColumnOffsets::create(0, 3);
+        auto array_col = ColumnArray::create(data_col, std::move(offsets_col));
+
+        EXPECT_EQ(array_col->complex_type_data_nullable_check(), true);
+    }
+    {
+        auto data_col = ColumnHelper::create_column<DataTypeInt32>({1, 2, 3});
+        auto offsets_col = ColumnArray::ColumnOffsets::create(0, 3);
+        auto array_col = ColumnArray::create(data_col, std::move(offsets_col));
+        EXPECT_EQ(array_col->complex_type_data_nullable_check(), false);
+    }
+    {
+        auto keys_col = ColumnHelper::create_nullable_column<DataTypeInt32>({1, 2, 3}, {0, 0, 0});
+        auto values_col = ColumnHelper::create_nullable_column<DataTypeInt32>({4, 5, 6}, {0, 0, 0});
+        auto offsets_col = ColumnArray::ColumnOffsets::create(0, 3);
+        auto map_col = ColumnMap::create(keys_col, values_col, std::move(offsets_col));
+        EXPECT_EQ(map_col->complex_type_data_nullable_check(), true);
+    }
+    {
+        auto keys_col = ColumnHelper::create_column<DataTypeInt32>({1, 2, 3});
+        auto values_col = ColumnHelper::create_nullable_column<DataTypeInt32>({4, 5, 6}, {0, 0, 0});
+        auto offsets_col = ColumnArray::ColumnOffsets::create(0, 3);
+        auto map_col = ColumnMap::create(keys_col, values_col, std::move(offsets_col));
+        EXPECT_EQ(map_col->complex_type_data_nullable_check(), false);
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

For array/map types, their data column must be nullable. Specifically, because variant constructs a special map column internally, that case will skip the check.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

