### PR TITLE
[fix](storage-engine) _clean_unused_rowset_metas should skip rowsets in _unused_rowsets map

### DIFF
--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -957,7 +957,8 @@ void StorageEngine::_clean_unused_rowset_metas() {
             return true;
         }
         if (rowset_meta->rowset_state() == RowsetStatePB::VISIBLE &&
-            (!tablet->rowset_meta_is_useful(rowset_meta))) {
+            (!tablet->rowset_meta_is_useful(rowset_meta)) &&
+            !check_rowset_id_in_unused_rowsets(rowset_id)) {
             LOG(INFO) << "rowset meta is not used any more, remove it. rowset_id="
                       << rowset_meta->rowset_id();
             invalid_rowset_metas.push_back(rowset_meta);

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -920,8 +920,10 @@ void Tablet::delete_expired_stale_rowset() {
     if (config::enable_mow_verbose_log) {
         LOG_INFO("finish delete_expired_stale_rowset for tablet={}", tablet_id());
     }
-    DBUG_EXECUTE_IF("Tablet.delete_expired_stale_rowset.start_delete_unused_rowset",
-                    { _engine.start_delete_unused_rowset(); });
+    DBUG_EXECUTE_IF("Tablet.delete_expired_stale_rowset.start_delete_unused_rowset", {
+        _engine.start_delete_unused_rowset();
+        [[maybe_unused]] auto st = _engine.start_trash_sweep(nullptr);
+    });
 }
 
 Status Tablet::check_version_integrity(const Version& version, bool quiet) {


### PR DESCRIPTION
### What problem does this PR solve?

`_clean_unused_rowset_metas` could incorrectly remove rowset metas (and its delete_bitmap) that are still tracked in the `_unused_rowsets` map, which holds rowsets pending deletion. 
The fix adds a check to skip these rowsets during cleanup, preventing premature removal of `_unused_rowsets`. Otherwise, if query a mow table with rowsets in `_unused_rowsets` map, and `_clean_unused_rowset_metas` delete delete_bitmap of these rowset, will get duplicated keys.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

