### PR TITLE
[opt](hdfs): Using convar for avoiding the unneccessary _create_hdfs_fs function call

### DIFF
--- a/be/src/io/fs/hdfs/hdfs_mgr.h
+++ b/be/src/io/fs/hdfs/hdfs_mgr.h
@@ -20,11 +20,13 @@
 #include <gen_cpp/PlanNodes_types.h>
 
 #include <atomic>
+#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "common/status.h"
 #include "io/fs/hdfs.h"
@@ -79,6 +81,8 @@ private:
 
 private:
     std::mutex _mutex;
+    std::condition_variable _creation_cv;
+    std::unordered_set<uint64_t> _creating_fs;
     std::unordered_map<uint64_t, std::shared_ptr<HdfsHandler>> _fs_handlers;
 
     std::atomic<bool> _should_stop_cleanup_thread;


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
The current HdfsMgr::get_or_create_fs() uses a double-checked locking pattern that still allows a race condition. This commit introduce a conditional variable mechanism to coordinate threads:
  - Track which filesystem keys are currently being created via std::unordered_set<uint64_t> _creating_fs
  - Waiting threads block on std::condition_variable _creation_cv instead of creating duplicates
  - The creating thread notifies all waiters upon completion (success or failure)
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

