### PR TITLE
[enhance](job) optimize auto resume rule to adapt VCG failover

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1360,12 +1360,6 @@ public class Config extends ConfigBase {
     public static boolean check_java_version = true;
 
     /**
-     * it can't auto-resume routine load job as long as one of the backends is down
-     */
-    @ConfField(mutable = true, masterOnly = true)
-    public static int max_tolerable_backend_down_num = 0;
-
-    /**
      * a period for auto resume routine load
      */
     @ConfField(mutable = true, masterOnly = true)

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/ScheduleRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/ScheduleRule.java
@@ -59,16 +59,6 @@ public class ScheduleRule {
                 && jobRoutine.pauseReason.getCode() != InternalErrorCode.MANUAL_PAUSE_ERR
                 && jobRoutine.pauseReason.getCode() != InternalErrorCode.TOO_MANY_FAILURE_ROWS_ERR
                 && jobRoutine.pauseReason.getCode() != InternalErrorCode.CANNOT_RESUME_ERR) {
-            int dead = deadBeCount();
-            if (dead > Config.max_tolerable_backend_down_num) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("dead backend num {} is larger than config {}, "
-                                    + "routine load job {} can not be auto rescheduled",
-                            dead, Config.max_tolerable_backend_down_num, jobRoutine.id);
-                }
-                return false;
-            }
-
             if (jobRoutine.latestResumeTimestamp == 0) { //the first resume
                 jobRoutine.latestResumeTimestamp = System.currentTimeMillis();
                 jobRoutine.autoResumeCount = 1;


### PR DESCRIPTION
### What problem does this PR solve?

In https://github.com/apache/doris/pull/52515 introduces VCG(Virtual Compute Group) to be used for multi availability zone disaster recovery.

But routine load job do not adapt it perfectly: If a cluster in an availability zone crashes, VCG provides disaster recovery capabilities, but the job will not be automatically resume. So this PR removed the `dead BE count` calculation when judge `isNeedAutoSchedule`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

