### PR TITLE
[opt](arm) Improve performance of bytes32_mask_to_bits32_mask functions with SVE intrinsics

### DIFF
--- a/be/benchmark/benchmark_bit_simd.hpp
+++ b/be/benchmark/benchmark_bit_simd.hpp
@@ -1,0 +1,114 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <benchmark/benchmark.h>
+#include <vector>
+#include <random>
+
+#include "util/simd/bits.h"
+
+namespace doris {
+
+static void create_test_data(std::vector<uint8_t> &data, size_t size) {
+    std::mt19937 rng(123);
+    for (int i = 0; i < size; ++i) {
+        data[i] = rng() & 1;
+    }
+}
+
+inline uint32_t bitmask_8(const uint8_t* data) {
+    static constexpr uint8_t mask_arr[16] = {1, 2, 4, 8, 16, 32, 64, 128, 1, 2, 4, 8, 16, 32, 64, 128};
+    svbool_t pg = svwhilelt_b8(0, 16);
+    svuint8_t mask_vec = svld1_u8(pg, mask_arr);
+
+    svbool_t nonzero = svcmpne_n_u8(pg, svld1_u8(pg, data), 0);
+    svuint8_t masked = svsel_u8(nonzero, mask_vec, svdup_u8(0));
+
+    svuint8_t idx = svindex_u8(0, 1);
+    svuint8_t rev_idx = svsub_u8_x(pg, svdup_u8(15), idx);
+    svuint8_t res_hi = svtbl_u8(masked, rev_idx);
+
+    uint32_t mask = static_cast<uint32_t>(svaddv_u16(pg, svreinterpret_u16_u8(svzip1_u8(masked, res_hi))));
+    return mask;
+}
+
+uint32_t bytes32_mask_to_bits32_mask(const uint8_t* data) {
+    return bitmask_8(data) | (bitmask_8(data + 16) << 16);
+}  
+
+static void BM_bytes32_mask_to_bits32_mask(benchmark::State& state) {
+    const size_t size = state.range(0);
+
+    std::vector<uint8_t> data(size);
+    create_test_data(data, size);
+
+    for (auto _ : state) {
+        uint32_t acc = 0;
+
+        for (size_t i = 0; i + 32 <= size; i += 32) {
+            acc ^= simd::bytes32_mask_to_bits32_mask(data.data() + i);
+        }
+
+        benchmark::DoNotOptimize(acc);
+    }
+
+    state.SetBytesProcessed(
+        static_cast<int64_t>(state.iterations()) * size
+    );
+}
+
+static void BM_bytes32_mask_to_bits32_mask_2(benchmark::State& state) {
+    const size_t size = state.range(0);
+
+    std::vector<uint8_t> data(size);
+    create_test_data(data, size);
+
+    for (auto _ : state) {
+        uint32_t acc = 0;
+
+        for (size_t i = 0; i + 32 <= size; i += 32) {
+            acc ^= bytes32_mask_to_bits32_mask(data.data() + i);
+        }
+
+        benchmark::DoNotOptimize(acc);
+    }
+
+    state.SetBytesProcessed(
+        static_cast<int64_t>(state.iterations()) * size
+    );
+}
+
+BENCHMARK(BM_bytes32_mask_to_bits32_mask)
+        ->Unit(benchmark::kNanosecond)
+        ->Arg(32)   // 32 bytes
+        ->Arg(64)   // 64 bytes
+        ->Arg(256)  // 256 bytes
+        ->Arg(1024) // 1KB
+        ->Repetitions(5)
+        ->DisplayAggregatesOnly();
+
+BENCHMARK(BM_bytes32_mask_to_bits32_mask_2)
+        ->Unit(benchmark::kNanosecond)
+        ->Arg(32)   // 32 bytes
+        ->Arg(64)   // 64 bytes
+        ->Arg(256)  // 256 bytes
+        ->Arg(1024) // 1KB
+        ->Repetitions(5)
+        ->DisplayAggregatesOnly();
+
+} // namespace doris
+

--- a/be/test/util/simd/bits_test.cpp
+++ b/be/test/util/simd/bits_test.cpp
@@ -76,7 +76,6 @@ TEST(BitsTest, Bytes32MaskToBits32Mask) {
             res += static_cast<uint32_t>(data[j]) << j;
         }
         EXPECT_EQ(bytes32_mask_to_bits32_mask(data.data()), res);
-        EXPECT_EQ(res, res);
     }
 }
 

--- a/be/test/util/simd/bits_test.cpp
+++ b/be/test/util/simd/bits_test.cpp
@@ -22,6 +22,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <random>
 
 #include "gtest/gtest_pred_impl.h"
 
@@ -61,6 +62,22 @@ TEST(BitsTest, BytesMaskToBitsMask) {
     std::vector<uint8_t> ones(len, 1);
     auto full_mask = bytes_mask_to_bits_mask(ones.data());
     EXPECT_EQ(full_mask, bits_mask_all());
+}
+
+TEST(BitsTest, Bytes32MaskToBits32Mask) {
+    std::mt19937 rng(123);
+
+    for (int i = 0; i < 50; i++) {
+        std::vector<uint8_t> data;
+        data.resize(32);
+        uint32_t res = 0;
+        for (int j = 0; j < 32; ++j) {
+            data[j] = rng() & 1;
+            res += static_cast<uint32_t>(data[j]) << j;
+        }
+        EXPECT_EQ(bytes32_mask_to_bits32_mask(data.data()), res);
+        EXPECT_EQ(res, res);
+    }
 }
 
 TEST(BitsTest, CountZeroNum) {


### PR DESCRIPTION
### What problem does this PR solve?

Improve performance of bytes32_mask_to_bits32_mask functions with SVE intrinsics

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

