### PR TITLE
[Bug](function) clear bits when bitmap_from_string parse failed

### DIFF
--- a/be/src/vec/functions/function_bitmap.cpp
+++ b/be/src/vec/functions/function_bitmap.cpp
@@ -232,6 +232,7 @@ struct BitmapFromString {
         }
 
         auto split_and_parse = [&bits](const char* raw_str, size_t str_size) {
+            bits.clear();
             auto res = absl::StrSplit(std::string_view {raw_str, str_size}, ",", absl::SkipEmpty());
             uint64_t value = 0;
             for (auto s : res) {
@@ -255,7 +256,6 @@ struct BitmapFromString {
                 continue;
             }
             res.emplace_back(bits);
-            bits.clear();
         }
         return Status::OK();
     }

--- a/be/test/vec/function/function_bitmap_test.cpp
+++ b/be/test/vec/function/function_bitmap_test.cpp
@@ -498,12 +498,13 @@ TEST(function_bitmap_test, function_bitmap_from_string_multiple_rows) {
     BitmapValue bitmap3({7, 8, 9});
     BitmapValue bitmap4({10, 11, 12});
     BitmapValue bitmap5({13, 14, 15});
+    BitmapValue bitmap6({18, 19, 20});
 
     DataSet data_set = {
             {{std::string("1,2,3")}, &bitmap1},    {{std::string("4,5,6")}, &bitmap2},
             {{std::string("7,8,9")}, &bitmap3},    {{std::string("10,11,12")}, &bitmap4},
             {{std::string("13,14,15")}, &bitmap5}, {{std::string("16,invalid,17")}, Null()},
-            {{std::string("18,19,20")}, &bitmap5}};
+            {{std::string("18,19,20")}, &bitmap6}};
 
     static_cast<void>(check_function<DataTypeBitMap, true>(func_name, input_types, data_set));
 }

--- a/be/test/vec/function/function_bitmap_test.cpp
+++ b/be/test/vec/function/function_bitmap_test.cpp
@@ -465,4 +465,47 @@ TEST(function_bitmap_test, function_bitmap_has_all) {
     static_cast<void>(check_function<DataTypeUInt8, true>(func_name, input_types, data_set));
 }
 
+TEST(function_bitmap_test, function_bitmap_from_string) {
+    std::string func_name = "bitmap_from_string";
+    InputTypeSet input_types = {PrimitiveType::TYPE_VARCHAR};
+
+    BitmapValue bitmap1(1);
+    BitmapValue bitmap2({1, 2, 3});
+    BitmapValue bitmap3({1, 9999999});
+    BitmapValue empty_bitmap;
+    BitmapValue bitmap4({0, 1, 2, 3, 4, 5});
+    BitmapValue bitmap5({10, 20, 30});
+
+    DataSet data_set = {{{std::string("1")}, &bitmap1},
+                        {{std::string("1,2,3")}, &bitmap2},
+                        {{std::string("1,9999999")}, &bitmap3},
+                        {{std::string("")}, &empty_bitmap},
+                        {{std::string("0,1,2,3,4,5")}, &bitmap4},
+                        {{std::string("10,20,30")}, &bitmap5},
+                        {{std::string("1,abc,3")}, Null()},
+                        {{std::string("invalid")}, Null()},
+                        {{Null()}, Null()}};
+
+    static_cast<void>(check_function<DataTypeBitMap, true>(func_name, input_types, data_set));
+}
+
+TEST(function_bitmap_test, function_bitmap_from_string_multiple_rows) {
+    std::string func_name = "bitmap_from_string";
+    InputTypeSet input_types = {PrimitiveType::TYPE_VARCHAR};
+
+    BitmapValue bitmap1({1, 2, 3});
+    BitmapValue bitmap2({4, 5, 6});
+    BitmapValue bitmap3({7, 8, 9});
+    BitmapValue bitmap4({10, 11, 12});
+    BitmapValue bitmap5({13, 14, 15});
+
+    DataSet data_set = {
+            {{std::string("1,2,3")}, &bitmap1},    {{std::string("4,5,6")}, &bitmap2},
+            {{std::string("7,8,9")}, &bitmap3},    {{std::string("10,11,12")}, &bitmap4},
+            {{std::string("13,14,15")}, &bitmap5}, {{std::string("16,invalid,17")}, Null()},
+            {{std::string("18,19,20")}, &bitmap5}};
+
+    static_cast<void>(check_function<DataTypeBitMap, true>(func_name, input_types, data_set));
+}
+
 } // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?
This pull request makes a minor adjustment to the `BitmapFromString` struct in `function_bitmap.cpp` to improve how the `bits` container is managed during string parsing. The main change is relocating the `bits.clear()` call to ensure it is always cleared before parsing each new string, rather than after adding to the result.

- Refactored the `split_and_parse` lambda to clear the `bits` container at the start of each parse, ensuring no leftover data from previous iterations (`function_bitmap.cpp`).
- Removed the redundant `bits.clear()` call after adding `bits` to the result, as it is now handled at the beginning of parsing.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

