### PR TITLE
[Chore](bitmap) change BitmapValue CHECK to throw exception

### DIFF
--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -1977,12 +1977,19 @@ public:
             ++src;
             uint8_t count = *src;
             ++src;
-            CHECK(count <= SET_TYPE_THRESHOLD) << "bitmap value with incorrect set count";
+            if (count > SET_TYPE_THRESHOLD) {
+                throw Exception(ErrorCode::INTERNAL_ERROR,
+                                "bitmap value with incorrect set count, count: {}", count);
+            }
             _set.reserve(count);
             for (uint8_t i = 0; i != count; ++i, src += sizeof(uint64_t)) {
                 _set.insert(decode_fixed64_le(reinterpret_cast<const uint8_t*>(src)));
             }
-            CHECK_EQ(count, _set.size()) << "bitmap value with incorrect set count";
+            if (_set.size() != count) {
+                throw Exception(ErrorCode::INTERNAL_ERROR,
+                                "bitmap value with incorrect set count, count: {}, set size: {}",
+                                count, _set.size());
+            }
 
             if (!config::enable_set_in_bitmap_value) {
                 _prepare_bitmap_for_write();


### PR DESCRIPTION
### What problem does this PR solve?
This pull request refactors error handling in the `BitmapValue` class to improve robustness and provide clearer error messages. Instead of using `CHECK` macros, it now throws exceptions with detailed information when inconsistencies are detected in the bitmap value's set count.

**Error handling improvements:**

* Replaced `CHECK` and `CHECK_EQ` macros with explicit exception throwing (`Exception(ErrorCode::INTERNAL_ERROR, ...)`) when the set count exceeds the threshold or does not match the expected size, including detailed error messages with the problematic values.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

