### PR TITLE
[fix](column) Add back hash functions of ColumnComplex

### DIFF
--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -192,6 +192,18 @@ public:
         __builtin_unreachable();
     }
 
+    /// Do NOT remove these following two functions,
+    /// There are used by some `EngineChecksumTask::_compute_checksum()`.
+    // maybe we do not need to impl the function
+    void update_hash_with_value(size_t n, SipHash& hash) const override {
+        // TODO add hash function
+    }
+
+    void update_hashes_with_value(uint64_t* __restrict hashes,
+                                  const uint8_t* __restrict null_data = nullptr) const override {
+        // TODO add hash function
+    }
+
     StringRef get_raw_data() const override {
         return StringRef(reinterpret_cast<const char*>(data.data()), data.size());
     }

--- a/be/test/vec/core/column_complex_test.cpp
+++ b/be/test/vec/core/column_complex_test.cpp
@@ -705,4 +705,24 @@ TEST(ColumnComplexTest, TestErase) {
     EXPECT_EQ(column_test->size(), 4);
 }
 
+TEST(ColumnComplexTest, TestUpdateHashWithValue) {
+    using ColumnTest = ColumnComplexType<TYPE_BITMAP>;
+
+    auto column_test = ColumnTest::create();
+
+    column_test->data.push_back(BitmapValue {});
+    column_test->data.push_back(BitmapValue {});
+    column_test->data.push_back(BitmapValue {});
+    column_test->data.push_back(BitmapValue {});
+    column_test->data.push_back(BitmapValue {});
+
+    SipHash hash;
+    for (size_t i = 0; i < column_test->size(); ++i) {
+        column_test->update_hash_with_value(i, hash);
+    }
+
+    std::vector<uint64_t> hash_values(column_test->size());
+    column_test->update_hashes_with_value(hash_values.data());
+}
+
 } // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?

The function `update_hash_with_value` and `update_hashes_with_value` are used by some `EngineChecksumTask::_compute_checksum()`.

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

