### PR TITLE
[fix](broker load)fix wildcard import failure caused by 0-byte metadata files

### DIFF
--- a/be/src/vec/exec/format/csv/csv_reader.cpp
+++ b/be/src/vec/exec/format/csv/csv_reader.cpp
@@ -186,7 +186,7 @@ CsvReader::CsvReader(RuntimeState* state, RuntimeProfile* profile, ScannerCounte
           _line_reader_eof(false),
           _skip_lines(0),
           _io_ctx(io_ctx) {
-    _file_format_type = _params.format_type;
+    _file_format_type = _range.__isset.format_type ? _range.format_type : _params.format_type;
     _is_proto_format = _file_format_type == TFileFormatType::FORMAT_PROTO;
     if (_range.__isset.compress_type) {
         // for compatibility

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadPendingTask.java
@@ -102,9 +102,12 @@ public class BrokerLoadPendingTask extends LoadTask {
                         boolean isBinaryFileFormat = fileGroup.isBinaryFileFormat();
                         List<TBrokerFileStatus> filteredFileStatuses = Lists.newArrayList();
                         for (TBrokerFileStatus fstatus : fileStatuses) {
-                            if (fstatus.getSize() == 0 && isBinaryFileFormat) {
+                            boolean isSuccessFile = fstatus.path.endsWith("/_SUCCESS")
+                                    || fstatus.path.endsWith("_SUCCESS");
+                            if (fstatus.getSize() == 0 && (isBinaryFileFormat || isSuccessFile)) {
                                 // For parquet or orc file, if it is an empty file, ignore it.
                                 // Because we can not read an empty parquet or orc file.
+                                // For _SUCCESS file, it is a metadata file, ignore it.
                                 if (LOG.isDebugEnabled()) {
                                     LOG.debug(new LogBuilder(LogKey.LOAD_JOB, callback.getCallbackId())
                                             .add("empty file", fstatus).build());

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/FileGroupInfoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/FileGroupInfoTest.java
@@ -1,0 +1,104 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource;
+
+import org.apache.doris.analysis.BrokerDesc;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.common.UserException;
+import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.load.BrokerFileGroup;
+import org.apache.doris.planner.FileLoadScanNode;
+import org.apache.doris.thrift.TBrokerFileStatus;
+import org.apache.doris.thrift.TFileCompressType;
+import org.apache.doris.thrift.TFileFormatType;
+import org.apache.doris.thrift.TFileRangeDesc;
+import org.apache.doris.thrift.TFileScanRangeParams;
+import org.apache.doris.thrift.TScanRangeLocations;
+
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FileGroupInfoTest {
+
+    @Test
+    public void testCreateScanRangeLocationsUnsplittable(
+            @Injectable FileLoadScanNode.ParamCreateContext context,
+            @Injectable FederationBackendPolicy backendPolicy,
+            @Injectable BrokerFileGroup fileGroup,
+            @Injectable Table targetTable,
+            @Mocked BrokerDesc brokerDesc) throws UserException {
+
+        List<TBrokerFileStatus> fileStatuses = new ArrayList<>();
+        TBrokerFileStatus lzoFile = new TBrokerFileStatus();
+        lzoFile.path = "hdfs://localhost:8900/data.csv.lzo";
+        lzoFile.size = 100;
+        fileStatuses.add(lzoFile);
+
+        TBrokerFileStatus plainFile = new TBrokerFileStatus();
+        plainFile.path = "hdfs://localhost:8900/data.csv";
+        plainFile.size = 50;
+        fileStatuses.add(plainFile);
+
+        FileGroupInfo fileGroupInfo = new FileGroupInfo(1L, 1L, targetTable, brokerDesc, fileGroup, fileStatuses, 2, false, 1);
+        Deencapsulation.setField(fileGroupInfo, "numInstances", 1);
+
+        TFileScanRangeParams params = new TFileScanRangeParams();
+        context.params = params;
+        context.fileGroup = fileGroup;
+
+        new Expectations() {
+            {
+                fileGroup.getFileFormatProperties().getFormatName();
+                result = "csv";
+                fileGroup.getFileFormatProperties().getCompressionType();
+                result = TFileCompressType.UNKNOWN; // infer from path
+                fileGroup.getColumnNamesFromPath();
+                result = new ArrayList<String>();
+            }
+        };
+
+        List<TScanRangeLocations> scanRangeLocations = new ArrayList<>();
+        fileGroupInfo.createScanRangeLocationsUnsplittable(context, backendPolicy, scanRangeLocations);
+
+        Assert.assertEquals(1, scanRangeLocations.size());
+        List<TFileRangeDesc> ranges = scanRangeLocations.get(0).getScanRange().getExtScanRange().getFileScanRange().getRanges();
+        Assert.assertEquals(2, ranges.size());
+
+        // Check LZO file
+        TFileRangeDesc lzoRange = ranges.get(0);
+        Assert.assertEquals(TFileFormatType.FORMAT_CSV_PLAIN, lzoRange.getFormatType());
+        Assert.assertEquals(TFileCompressType.LZOP, lzoRange.getCompressType());
+
+        // Check Plain file
+        TFileRangeDesc plainRange = ranges.get(1);
+        Assert.assertEquals(TFileFormatType.FORMAT_CSV_PLAIN, plainRange.getFormatType());
+        Assert.assertEquals(TFileCompressType.PLAIN, plainRange.getCompressType());
+
+        // Shared params should NOT be set (they are deprecated and we want to avoid overwriting)
+        // Actually, in my implementation I removed the setFormatType/setCompressType from the loop.
+        // They might still have default values or be set elsewhere, but they shouldn't be the LZO/PLAIN from the loop.
+        Assert.assertFalse(params.isSetFormatType());
+        Assert.assertFalse(params.isSetCompressType());
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/load/NereidsFileGroupInfoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/load/NereidsFileGroupInfoTest.java
@@ -1,0 +1,100 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.load;
+
+import org.apache.doris.analysis.BrokerDesc;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.common.UserException;
+import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.datasource.FederationBackendPolicy;
+import org.apache.doris.thrift.TBrokerFileStatus;
+import org.apache.doris.thrift.TFileCompressType;
+import org.apache.doris.thrift.TFileFormatType;
+import org.apache.doris.thrift.TFileRangeDesc;
+import org.apache.doris.thrift.TFileScanRangeParams;
+import org.apache.doris.thrift.TScanRangeLocations;
+
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NereidsFileGroupInfoTest {
+
+    @Test
+    public void testCreateScanRangeLocationsUnsplittable(
+            @Injectable FederationBackendPolicy backendPolicy,
+            @Injectable NereidsBrokerFileGroup fileGroup,
+            @Injectable Table targetTable,
+            @Mocked BrokerDesc brokerDesc) throws UserException {
+
+        List<TBrokerFileStatus> fileStatuses = new ArrayList<>();
+        TBrokerFileStatus lzoFile = new TBrokerFileStatus();
+        lzoFile.path = "hdfs://localhost:8900/data.csv.lzo";
+        lzoFile.size = 100;
+        fileStatuses.add(lzoFile);
+
+        TBrokerFileStatus plainFile = new TBrokerFileStatus();
+        plainFile.path = "hdfs://localhost:8900/data.csv";
+        plainFile.size = 50;
+        fileStatuses.add(plainFile);
+
+        NereidsFileGroupInfo fileGroupInfo = new NereidsFileGroupInfo(1L, 1L, targetTable, brokerDesc, fileGroup, fileStatuses, 2, false, 1);
+        Deencapsulation.setField(fileGroupInfo, "numInstances", 1);
+
+        TFileScanRangeParams params = new TFileScanRangeParams();
+        NereidsParamCreateContext context = new NereidsParamCreateContext();
+        context.params = params;
+        context.fileGroup = fileGroup;
+
+        new Expectations() {
+            {
+                fileGroup.getFileFormatProperties().getFormatName();
+                result = "csv";
+                fileGroup.getFileFormatProperties().getCompressionType();
+                result = TFileCompressType.UNKNOWN; // infer from path
+                fileGroup.getColumnNamesFromPath();
+                result = new ArrayList<String>();
+            }
+        };
+
+        List<TScanRangeLocations> scanRangeLocations = new ArrayList<>();
+        fileGroupInfo.createScanRangeLocationsUnsplittable(context, backendPolicy, scanRangeLocations);
+
+        Assertions.assertEquals(1, scanRangeLocations.size());
+        List<TFileRangeDesc> ranges = scanRangeLocations.get(0).getScanRange().getExtScanRange().getFileScanRange().getRanges();
+        Assertions.assertEquals(2, ranges.size());
+
+        // Check LZO file
+        TFileRangeDesc lzoRange = ranges.get(0);
+        Assertions.assertEquals(TFileFormatType.FORMAT_CSV_PLAIN, lzoRange.getFormatType());
+        Assertions.assertEquals(TFileCompressType.LZOP, lzoRange.getCompressType());
+
+        // Check Plain file
+        TFileRangeDesc plainRange = ranges.get(1);
+        Assertions.assertEquals(TFileFormatType.FORMAT_CSV_PLAIN, plainRange.getFormatType());
+        Assertions.assertEquals(TFileCompressType.PLAIN, plainRange.getCompressType());
+
+        Assertions.assertFalse(params.isSetFormatType());
+        Assertions.assertFalse(params.isSetCompressType());
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?


Problem Summary:

When performing a Broker Load with wildcards (e.g., `/*`), if the directory contains 
0-byte metadata files like `_SUCCESS`, the FE would incorrectly use the format/compression 
of these metadata files (usually PLAIN) to overwrite the shared parameters for the 
entire file group. This caused the BE to read compressed data files (like LZO) as 
plain text, leading to import failures.

This PR fixes the issue by:
1. Filtering out `_SUCCESS` files in `BrokerLoadPendingTask` to avoid processing 
   them as data.
2. Setting `format_type` and `compress_type` in each `TFileRangeDesc` instead of 
   the shared `TFileScanRangeParams` in FE (both legacy and Nereids paths).
3. Prioritizing per-file `format_type` in BE's `CsvReader` to ensure the correct 
   reader is initialized for each file.
4. Adding unit tests to verify `_SUCCESS` filtering

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

