### PR TITLE
[performance][Exec] scanner merge block before projection

### DIFF
--- a/be/src/vec/exec/scan/scanner.h
+++ b/be/src/vec/exec/scan/scanner.h
@@ -103,13 +103,14 @@ protected:
     // Subclass should implement this to return data.
     virtual Status _get_block_impl(RuntimeState* state, Block* block, bool* eof) = 0;
 
-    void _merge_padding_block() {
+    Status _merge_padding_block() {
         if (_padding_block.empty()) {
             _padding_block.swap(_origin_block);
+        } else if (_origin_block.rows()) {
+            RETURN_IF_ERROR(
+                    MutableBlock::build_mutable_block(&_padding_block).merge(_origin_block));
         }
-        if (_origin_block.rows()) {
-            (void)MutableBlock::build_mutable_block(&_padding_block).merge(_origin_block);
-        }
+        return Status::OK();
     }
 
     // Update the counters before closing this scanner

--- a/be/src/vec/exec/scan/scanner.h
+++ b/be/src/vec/exec/scan/scanner.h
@@ -103,6 +103,15 @@ protected:
     // Subclass should implement this to return data.
     virtual Status _get_block_impl(RuntimeState* state, Block* block, bool* eof) = 0;
 
+    void _merge_padding_block() {
+        if (_padding_block.empty()) {
+            _padding_block.swap(_origin_block);
+        }
+        if (_origin_block.rows()) {
+            (void)MutableBlock::build_mutable_block(&_padding_block).merge(_origin_block);
+        }
+    }
+
     // Update the counters before closing this scanner
     virtual void _collect_profile_before_close();
 
@@ -217,6 +226,8 @@ protected:
     // Used in common subexpression elimination to compute intermediate results.
     std::vector<vectorized::VExprContextSPtrs> _intermediate_projections;
     vectorized::Block _origin_block;
+    vectorized::Block _padding_block;
+    bool _alreay_eos = false;
 
     VExprContextSPtrs _common_expr_ctxs_push_down;
     // Late arriving runtime filters will update _conjuncts.


### PR DESCRIPTION
### What problem does this PR solve?

Description
Add batch size based block fetching strategy with min_batch_size (max of 1/4 of state batch size and 1) to reduce frequent small block processing
Implement block merging logic between _origin_block and _padding_block when total rows do not exceed state batch size
Optimize EOS handling logic to ensure proper output sequence of origin block first then padding block
Add block swap mechanism between origin and padding block for efficient data transfer
Ensure correct column data clearing based on row descriptor's materialized slots count

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

