### PR TITLE
[refine](dep)Ensure that calls to the watcher's start/stop are protected by a lock.

### DIFF
--- a/be/src/pipeline/dependency.cpp
+++ b/be/src/pipeline/dependency.cpp
@@ -78,7 +78,7 @@ void Dependency::set_ready() {
         if (_ready) {
             return;
         }
-        _watcher.stop();
+        stop_watcher(lc);
         _ready = true;
         local_block_task.swap(_blocked_task);
     }
@@ -95,7 +95,7 @@ Dependency* Dependency::is_blocked_by(std::shared_ptr<PipelineTask> task) {
     auto ready = _ready.load();
     if (!ready && task) {
         _add_block_task(task);
-        start_watcher();
+        start_watcher(lc);
         THROW_IF_ERROR(task->blocked(this, lc));
     }
     return ready ? nullptr : this;

--- a/be/src/pipeline/dependency.h
+++ b/be/src/pipeline/dependency.h
@@ -115,7 +115,10 @@ public:
     bool ready() const { return _ready; }
 
     // Start the watcher. We use it to count how long this dependency block the current pipeline task.
-    void start_watcher() { _watcher.start(); }
+    void start_watcher(const std::unique_lock<std::mutex>&) { _watcher.start(); }
+
+    // Stop the watcher. make sure to call it in lock of _task_lock.
+    void stop_watcher(const std::unique_lock<std::mutex>&) { _watcher.stop(); }
     [[nodiscard]] int64_t watcher_elapse_time() { return _watcher.elapsed_time(); }
 
     // Which dependency current pipeline task is blocked by. `nullptr` if this dependency is ready.


### PR DESCRIPTION
### What problem does this PR solve?


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

