### PR TITLE
[fix] Fix build failures under -Werror and strict toolchains

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -254,10 +254,8 @@ add_compile_options(-g
                     $<$<COMPILE_LANGUAGE:CXX>:-Wnon-virtual-dtor>)
 
 add_compile_options(-Wno-unused-parameter
-                    $<$<COMPILE_LANGUAGE:CXX>:-Wno-incompatible-pointer-types>
-                    -Wno-unknown-warning-option
+                    $<$<COMPILE_LANGUAGE:C>:-Wno-incompatible-pointer-types>
                     -Wno-deprecated-declarations
-                    -Wno-missing-designated-field-initializers
                     -Wno-sign-compare)
 
 if (COMPILER_GCC)

--- a/be/src/util/bit_util.h
+++ b/be/src/util/bit_util.h
@@ -107,7 +107,7 @@ public:
         T value = input;
         for (int i = 0; i < sizeof(value); ++i) {
             // Applies a mask for a byte range on the input.
-            char value_to_save = value & 0XFF;
+            signed char value_to_save = value & 0XFF;
             buffer.push_back(value_to_save);
             // Remove the just processed part from the input so that we can exit early if there
             // is nothing left to process.

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -1120,7 +1120,7 @@ public:
             if (max_len <= MAX_COMPRESSION_BUFFER_SIZE_FOR_REUSE) {
                 output->assign_copy(reinterpret_cast<uint8_t*>(compressed_buf.data), out_buf.pos);
             }
-        } catch (std::exception e) {
+        } catch (const std::exception& e) {
             return Status::InternalError("Fail to do ZSTD compress due to exception {}", e.what());
         } catch (...) {
             // Do not set compress_failed to release context

--- a/be/src/util/deletion_vector.h
+++ b/be/src/util/deletion_vector.h
@@ -68,7 +68,7 @@ public:
         roaring::Roaring roaring_bitmap;
         try {
             roaring_bitmap = roaring::Roaring::readSafe(buf, length);
-        } catch (std::runtime_error) {
+        } catch (const std::runtime_error&) {
             return ResultError(Status::RuntimeError(
                     "DeletionVector deserialize error: failed to deserialize roaring bitmap"));
         }

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1408,7 +1408,11 @@ build_xml2() {
 
     export ACLOCAL_PATH='/usr/share/aclocal'
 
-    sed '/(libtoolize/,/}/d' autogen.sh | bash
+    sed '/(libtoolize/,/}/d' autogen.sh > autogen_fixed.sh
+    chmod +x autogen_fixed.sh
+    ./autogen_fixed.sh
+    rm -f autogen_fixed.sh
+    
     make distclean
 
     mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
#### 1. Compiler warning handling in `be/CMakeLists.txt`

* **Issue**: `-Wno-incompatible-pointer-types` was incorrectly applied to both C and C++ builds, together with overly broad warning suppressions.
* **Impact**: Under strict toolchains and `-Werror`, this leads to **build failures** by misrouting or masking diagnostics between C and C++ compilation.
* **Fix**: Restrict `-Wno-incompatible-pointer-types` to C-only compilation and remove redundant suppressions (e.g. `-Wno-unknown-warning-option`) to restore correct, build-safe warning behavior.

#### 2. Signedness correctness in `be/src/util/bit_util.h`

* **Issue**: Byte extraction used plain `char`, whose signedness is platform- and compiler-dependent.
* **Impact**: Triggers signedness-related warnings that are promoted to **hard errors** under `-Werror`, breaking the build on some platforms.
* **Fix**: Explicitly use `signed char` to enforce consistent signed-byte semantics and ensure successful compilation.

#### 3. Exception catching causing build failures in `block_compression.cpp` and `deletion_vector.h`

* **Issue**: Polymorphic exceptions (`std::exception`, `std::runtime_error`) were caught by value.
* **Impact**: GCC emits `-Wcatch-value` (“catching polymorphic type by value”), which is treated as a **compilation error** under `-Werror`, causing the build to fail.
* **Fix**: Catch exceptions by `const` reference (`const std::exception&`, `const std::runtime_error&`) to preserve polymorphism and eliminate the build-blocking warning.


#### 4. libxml2 `autogen.sh` execution fix in `thirdparty/build-thirdparty.sh`

* **Issue**: `autogen.sh` failed with
  `"You must run this script in the top-level libxml directory"`
  when executed via a pipe (`sed ... | bash`), aborting the third-party build.

* **Root Cause** (verified with `bash -x` trace, see below):
  * libxml2 v2.9.10 `autogen.sh` derives its source directory from `$0`:
    `srcdir=` `` `dirname $0` `` , then `cd $srcdir`, then `test -f entities.c`.
  * On the affected environment (CentOS 8 aarch64, system bash
    `5.1.8(1)-release (aarch64-redhat-linux-gnu)`), when bash is invoked as the
    right side of a pipeline (`... | bash`), the child bash sets `$0` to the
    **absolute path** of the bash binary (`/usr/bin/bash`), not the bare name
    `bash`.
  * Consequently `dirname $0` resolves to `/usr/bin`, `cd $srcdir` lands in
    `/usr/bin`, and `test -f entities.c` deterministically fails.
  * Reproducing trace:
    ```
    $ sed '/(libtoolize/,/}/d' autogen.sh | bash -x
    ++ dirname /usr/bin/bash
    + srcdir=/usr/bin
    + cd /usr/bin
    + test -f entities.c
    + echo 'You must run this script in the top-level libxml directory'
    ```
  * This `$0` rewriting is specific to certain bash builds (notably the
    Red Hat-flavored bash on CentOS/RHEL aarch64); upstream / Debian-family
    bash typically leaves `$0` as the literal `bash`, which is why the original
    code works on x86 CI and on other ARM environments.

* **Fix**:
  * Write the modified script to a temporary file (`autogen_fixed.sh`).
  * Run it directly so `$0` is `./autogen_fixed.sh`, making `dirname $0`
    correctly resolve to `.` (the libxml2 source directory).
  * Clean up the temporary file.

* **Alternative fix considered** (not adopted, kept as a note for future
  hardening): pin `$0` explicitly via
  ``bash -c "$(sed '/(libtoolize/,/}/d' autogen.sh)" "$(pwd)/autogen.sh"`` ,
  which makes `$0` independent of how the bash binary was invoked.