### PR TITLE
[fix](temp-table) not clean temp table temporary until fix mem leak

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -861,7 +861,8 @@ public class Env {
     }
 
     private void refreshSession(String sessionId) {
-        sessionReportTimeMap.put(sessionId, System.currentTimeMillis());
+        // TODO: do nothing now until we fix memory link on Env#sessionReportTimeMap and Env#aliveSessionSet
+        // sessionReportTimeMap.put(sessionId, System.currentTimeMillis());
     }
 
     public void checkAndRefreshSession(String sessionId) {
@@ -7365,7 +7366,8 @@ public class Env {
     }
 
     public void registerSessionInfo(String sessionId) {
-        this.aliveSessionSet.add(sessionId);
+        // TODO: do nothing now until we fix memory link on Env#sessionReportTimeMap and Env#aliveSessionSet
+        // this.aliveSessionSet.add(sessionId);
     }
 
     public void unregisterSessionInfo(String sessionId) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TemporaryTableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TemporaryTableMgr.java
@@ -17,16 +17,10 @@
 
 package org.apache.doris.catalog;
 
-import org.apache.doris.common.Config;
 import org.apache.doris.common.util.MasterDaemon;
-import org.apache.doris.common.util.Util;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import java.util.Collection;
-import java.util.Date;
-import java.util.Map;
 
 /*
  * Delete temporary table when its creating session is gone
@@ -41,38 +35,39 @@ public class TemporaryTableMgr extends MasterDaemon {
 
     @Override
     protected void runAfterCatalogReady() {
-        Map<String, Long> sessionReportTimeMap = Env.getCurrentEnv().getSessionReportTimeMap();
-        long currentTs = System.currentTimeMillis();
-        Collection<DatabaseIf<? extends TableIf>> internalDBs = Env.getCurrentEnv().getInternalCatalog().getAllDbs();
-        for (DatabaseIf<? extends TableIf> db : internalDBs) {
-            for (TableIf table : db.getTables()) {
-                if (!table.isTemporary()) {
-                    continue;
-                }
-
-                String sessionId = Util.getTempTableSessionId(table.getName());
-                boolean needDelete = false;
-                if (!sessionReportTimeMap.containsKey(sessionId)) {
-                    LOG.info("Cannot find session id for table " + table.getName());
-                    needDelete = true;
-                } else if (currentTs > sessionReportTimeMap.get(sessionId)
-                        + Config.loss_conn_fe_temp_table_keep_second * 1000) {
-                    LOG.info("Temporary table " + table.getName() + " is out of time: "
-                            + new Date(sessionReportTimeMap.get(sessionId)) + ", current: " + new Date(currentTs));
-                    needDelete = true;
-                }
-
-                if (needDelete) {
-                    LOG.info("Drop temporary table " + table);
-                    try {
-                        Env.getCurrentEnv().getInternalCatalog()
-                            .dropTableWithoutCheck((Database) db, (Table) table, false, true);
-                    } catch (Exception e) {
-                        LOG.error("Drop temporary table error: db: {}, table: {}",
-                                db.getFullName(), table.getName(), e);
-                    }
-                }
-            }
-        }
+        // TODO: do nothing now until we fix memory link on Env#sessionReportTimeMap and Env#aliveSessionSet
+        // Map<String, Long> sessionReportTimeMap = Env.getCurrentEnv().getSessionReportTimeMap();
+        // long currentTs = System.currentTimeMillis();
+        // Collection<DatabaseIf<? extends TableIf>> internalDBs = Env.getCurrentEnv().getInternalCatalog().getAllDbs();
+        // for (DatabaseIf<? extends TableIf> db : internalDBs) {
+        //     for (TableIf table : db.getTables()) {
+        //         if (!table.isTemporary()) {
+        //             continue;
+        //         }
+        //
+        //         String sessionId = Util.getTempTableSessionId(table.getName());
+        //         boolean needDelete = false;
+        //         if (!sessionReportTimeMap.containsKey(sessionId)) {
+        //             LOG.info("Cannot find session id for table " + table.getName());
+        //             needDelete = true;
+        //         } else if (currentTs > sessionReportTimeMap.get(sessionId)
+        //                 + Config.loss_conn_fe_temp_table_keep_second * 1000) {
+        //             LOG.info("Temporary table " + table.getName() + " is out of time: "
+        //                     + new Date(sessionReportTimeMap.get(sessionId)) + ", current: " + new Date(currentTs));
+        //             needDelete = true;
+        //         }
+        //
+        //         if (needDelete) {
+        //             LOG.info("Drop temporary table " + table);
+        //             try {
+        //                 Env.getCurrentEnv().getInternalCatalog()
+        //                     .dropTableWithoutCheck((Database) db, (Table) table, false, true);
+        //             } catch (Exception e) {
+        //                 LOG.error("Drop temporary table error: db: {}, table: {}",
+        //                         db.getFullName(), table.getName(), e);
+        //             }
+        //         }
+        //     }
+        // }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #40680

Problem Summary:

This pull request temporarily disables session tracking and automatic cleanup for temporary tables due to a memory leak issue involving `Env#sessionReportTimeMap` and `Env#aliveSessionSet`. The affected logic is commented out with TODO notes, and related imports are cleaned up.

Session management changes:

* Disabled the code that adds sessions to `aliveSessionSet` in `Env.registerSessionInfo`, preventing new session tracking until the memory leak is fixed.
* Disabled the code that updates session report times in `Env.refreshSession`, pausing session activity tracking.

Temporary table cleanup changes:

* Commented out the logic in `TemporaryTableMgr.runAfterCatalogReady` that deletes temporary tables when their creating session is gone, halting automatic cleanup.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

