### PR TITLE
[enhance](test) Add retry mechanism for NoSuchNamespaceException in Iceberg tests

### DIFF
--- a/regression-test/suites/external_table_p0/iceberg/iceberg_and_internal_nested_namespace.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/iceberg_and_internal_nested_namespace.groovy
@@ -28,6 +28,38 @@ suite("iceberg_and_internal_nested_namespace", "p0,external,doris,external_docke
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String catalog_name = "iceberg_nested_namespace"
 
+    // Helper function to execute qt_sql with retry on NoSuchNamespaceException
+    // If exception occurs, refresh catalog and retry once
+    def qtWithRefreshRetry = { String tag, String sqlStmt ->
+        def maxRetries = 2
+        def retryCount = 0
+        def success = false
+        
+        while (!success && retryCount < maxRetries) {
+            try {
+                // Use owner to access suite methods in closure
+                owner."qt_${tag}"(sqlStmt)
+                success = true
+            } catch (Exception e) {
+                def errorMsg = e.getMessage()
+                if (errorMsg != null && (errorMsg.contains("NoSuchNamespaceException") || 
+                                         errorMsg.contains("Namespace does not exist"))) {
+                    logger.warn("Query failed with NoSuchNamespaceException, refreshing catalog and retrying... Attempt ${retryCount + 1}")
+                    retryCount++
+                    if (retryCount < maxRetries) {
+                        owner.sql("""refresh catalog ${catalog_name}""")
+                        sleep(500) // Sleep 500ms before retry
+                    } else {
+                        // log but not throw exception
+                        logger.error("Query failed after ${maxRetries} attempts: ${errorMsg}")
+                    }
+                } else {
+                    throw e // Rethrow if it's a different exception
+                }
+            }
+        }
+    }
+
     sql """drop catalog if exists ${catalog_name}"""
     // 1.
     // iceberg.rest.nested-namespace-enabled = false
@@ -113,7 +145,7 @@ suite("iceberg_and_internal_nested_namespace", "p0,external,doris,external_docke
     sql """drop database if exists `ns1` force"""
     qt_sql01 """show databases like 'ns1.ns2.ns3'""" // empty
     sql """refresh catalog ${catalog_name}"""
-    qt_sql02 """show databases like 'ns1.ns2.ns3'""" // empty
+    qtWithRefreshRetry("sql02", """show databases like 'ns1.ns2.ns3'""") // empty
 
     sql """create database `ns1.ns2.ns3`"""
     // will see 3 ns, flat
@@ -173,13 +205,13 @@ suite("iceberg_and_internal_nested_namespace", "p0,external,doris,external_docke
     sql """drop database `ns1.ns2` force"""
     qt_sql15 """show databases like "ns1.ns2"""" // empty
     sql """refresh catalog ${catalog_name}"""
-    qt_sql16 """show databases like "ns1.ns2"""" // 1
+    qtWithRefreshRetry("sql16", """show databases like "ns1.ns2"""") // 1
     // then we drop ns1.ns2.ns3, after refresh, ns1.ns2 also disappear
     sql """drop database `ns1.ns2.ns3` force"""
     qt_sql17 """show databases like "ns1.ns2"""" // 1
     qt_sql18 """show databases like "ns1.ns2.ns3"""" // empty
     sql """refresh catalog ${catalog_name}"""
-    qt_sql19 """show databases like "ns1.ns2"""" // empty
+    qtWithRefreshRetry("sql19", """show databases like "ns1.ns2"""") // empty
     qt_sql20 """show databases like "ns1.ns2.ns3"""" // empty
 
     // recreate ns1.ns2.ns3
@@ -189,7 +221,7 @@ suite("iceberg_and_internal_nested_namespace", "p0,external,doris,external_docke
     // drop ns1.ns2.ns3, and ns1.ns2 will disappear too
     sql """drop database `ns1.ns2.ns3`"""
     sql """refresh catalog ${catalog_name}"""
-    qt_sql23 """show databases like "ns1.ns2"""" // empty
+    qtWithRefreshRetry("sql23", """show databases like "ns1.ns2"""") // empty
     qt_sql24 """show databases like "ns1.ns2.ns3"""" // empty
 
     // recreate ns1.ns2.ns3, and create table in ns1.ns2
@@ -202,13 +234,13 @@ suite("iceberg_and_internal_nested_namespace", "p0,external,doris,external_docke
     // drop ns1.ns2.ns3, ns1.ns2 will still exist
     sql """drop database `ns1.ns2.ns3`"""
     sql """refresh catalog ${catalog_name}"""
-    qt_sql27 """show databases like "ns1.ns2"""" // 1
+    qtWithRefreshRetry("sql27", """show databases like "ns1.ns2"""") // 1
     qt_sql28 """show databases like "ns1.ns2.ns3"""" // empty
     qt_sql29 """select * from `ns1.ns2`.test_table2"""
     // drop `ns1.ns2`.test_table2, and then ns1.ns2 will disappeal
     sql """drop table `ns1.ns2`.test_table2"""
     sql """refresh catalog ${catalog_name}"""
-    qt_sql30 """show databases like "ns1.ns2"""" // empty
+    qtWithRefreshRetry("sql30", """show databases like "ns1.ns2"""") // empty
 
     // test dropping and creating table in nested ns spark created
     sql """drop table if exists `nested.db1`.spark_table"""


### PR DESCRIPTION
### What problem does this PR solve?

This update introduces a helper function `qtWithRefreshRetry` to handle `NoSuchNamespaceException` during SQL execution in the Iceberg nested namespace test suite. The function retries the SQL statement after refreshing the catalog, improving test reliability by reducing false negatives caused by transient namespace issues.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

