### PR TITLE
[condition_cache](exec) Fix cast target not count in expr digest

### DIFF
--- a/be/src/vec/exprs/vcast_expr.h
+++ b/be/src/vec/exprs/vcast_expr.h
@@ -60,6 +60,15 @@ public:
 
     virtual std::string cast_name() const { return "CAST"; }
 
+    uint64_t get_digest(uint64_t seed) const override {
+        auto res = VExpr::get_digest(seed);
+        if (res) {
+            return HashUtil::hash64(_target_data_type_name.data(), _target_data_type_name.size(),
+                                    res);
+        }
+        return 0;
+    }
+
 protected:
     FunctionBasePtr _function;
     std::string _expr_name;

--- a/regression-test/data/query_p0/cache/condition_cache.out
+++ b/regression-test/data/query_p0/cache/condition_cache.out
@@ -66,70 +66,7 @@
 5	Eve	26	Finance	Analyst
 6	Frank	32	Engineering	Team Lead
 
--- !condition_cache1 --
-2	Bob	30	90
-4	David	28	92
-5	Eve	26	88
+-- !cast_diff1 --
 
--- !condition_cache2 --
-1	Alice	25	85.5
-3	Charlie	22	75.5
-
--- !condition_cache3 --
-2	Bob	30	90
-4	David	28	92
-5	Eve	26	88
-
--- !condition_cache4 --
-1	Alice	25	85.5
-3	Charlie	22	75.5
-
--- !condition_cache5 --
-2	Bob	30	90
-4	David	28	92
-5	Eve	26	88
-
--- !condition_cache6 --
-1	Alice	25	85.5
-3	Charlie	22	75.5
-
--- !condition_delete1 --
-4	David	28	92
-5	Eve	26	88
-
--- !condition_delete2 --
-1	Alice	25	85.5
-3	Charlie	22	75.5
-
--- !join_no_cache --
-4	David	28	Engineering	Senior Developer
-5	Eve	26	Finance	Analyst
-
--- !join_cache1 --
-4	David	28	Engineering	Senior Developer
-5	Eve	26	Finance	Analyst
-
--- !join_cache2 --
-4	David	28	Engineering	Senior Developer
-5	Eve	26	Finance	Analyst
-
--- !join_bf_cache1 --
-
--- !join_bf_cache2 --
-1	Alice	25	Marketing	Manager
-3	Charlie	22	Engineering	Senior Developer
-4	David	28	Finance	Analyst
-
--- !join_cache3 --
-4	David	28	Engineering	Senior Developer
-5	Eve	26	Finance	Analyst
-
--- !join_diff_cond --
-1	Alice	Engineering	100000
-4	David	Engineering	140000
-
--- !join_after_mod --
-4	David	28	Engineering	Senior Developer
-5	Eve	26	Finance	Analyst
-6	Frank	32	Engineering	Team Lead
+-- !cast_diff2 --
 


### PR DESCRIPTION
### What problem does this PR solve?


type datetime(3) is different from type datatime(8) which may change the condition cache result

in regression test

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

