### PR TITLE
[Fix](Exception) Fix potential use-after-free because `Exception::to_string` is not thread safe

### DIFF
--- a/be/src/common/exception.cpp
+++ b/be/src/common/exception.cpp
@@ -48,6 +48,14 @@ Exception::Exception(int code, const std::string_view& msg, bool from_status) {
     // std::cout << "Exception: " << code << ", " << msg << ", " << get_stack_trace(0, "DISABLED")
     //           << std::endl;
 #endif
+
+    fmt::memory_buffer buf;
+    fmt::format_to(buf, "[E{}] {}", _code, _err_msg->_msg);
+    if (!_err_msg->_stack.empty()) {
+        fmt::format_to(buf, "\n{}", _err_msg->_stack);
+    }
+    _cache_string = fmt::to_string(buf);
+
     if (config::exit_on_exception) {
         LOG(FATAL) << "[ExitOnException] error code: " << code << ", message: " << msg;
     }

--- a/be/src/common/exception.h
+++ b/be/src/common/exception.h
@@ -46,9 +46,9 @@ public:
     int code() const { return _code; }
     std::string message() const { return _err_msg ? _err_msg->_msg : ""; }
 
-    const std::string& to_string() const;
+    const std::string& to_string() const { return _cache_string; }
 
-    const char* what() const noexcept override { return to_string().c_str(); }
+    const char* what() const noexcept override { return _cache_string.c_str(); }
 
     Status to_status() const { return {code(), _err_msg->_msg, _err_msg->_stack}; }
 
@@ -61,22 +61,8 @@ private:
         std::string _stack;
     };
     std::unique_ptr<ErrMsg> _err_msg;
-    mutable std::string _cache_string;
+    std::string _cache_string {};
 };
-
-inline const std::string& Exception::to_string() const {
-    if (!_cache_string.empty()) {
-        return _cache_string;
-    }
-    fmt::memory_buffer buf;
-    fmt::format_to(buf, "[E{}] {}", _code, _err_msg ? _err_msg->_msg : "");
-    if (_err_msg && !_err_msg->_stack.empty()) {
-        fmt::format_to(buf, "\n{}", _err_msg->_stack);
-    }
-    _cache_string = fmt::to_string(buf);
-    return _cache_string;
-}
-
 } // namespace doris
 
 #define RETURN_IF_CATCH_EXCEPTION(stmt)                                                          \


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

`Exception::to_string()` may by accessed concurrently in the following situation:
- thread A and thread B access the same `DorisCallOnce` object
- An Exception `e` is throw when thread A is calling `DorisCallOnce::call` and `e` is thrown to thread A
- `e` will be also thrown to thread B later by DorisCallOnce
- thread A and thread B access `Exception::to_string()` concurrently

This may cause use-after-free due to the assignment of `_cache_string` in `Exception::to_string`

Considering that `Exception` should not be frequently used, this PR construct `_cache_string` in constructor `Exception::Exception` rather than lazily creating it. This can avoid additional unnessary synchronazation.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

