### PR TITLE
(fix)[deleteJob] It will not dispatch task when backend has been drop…

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -790,7 +790,7 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, masterOnly = true, description = {
             "是否禁用存储介质检查。如果禁用，ReportHandler 将不会检查 tablet 的存储介质，"
                     + "并且禁用存储介质冷却功能。默认值为 false。",
-            "When disable_storage_medium_check is true, ReportHandler would not check tablet's storage medium "
+            "When disable_storage_medium_check is true, ReportHandler would not check tablet's stor5rage medium "
                     + "and disable storage cool down function."})
     public static boolean disable_storage_medium_check = false;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -212,7 +212,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                 totalReplicaNum += tablet.getReplicas().size();
             }
         }
-        MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<Long, Long>(totalReplicaNum);
+        MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<Long, Long>();
         OlapTable tbl;
         try {
             tbl = (OlapTable) db.getTableOrMetaException(tableId, Table.TableType.OLAP);

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -2773,7 +2773,7 @@ public class SchemaChangeHandler extends AlterHandler {
         }
 
         int totalTaskNum = beIdToTabletIdWithHash.keySet().size();
-        MarkedCountDownLatch<Long, Set<Pair<Long, Integer>>> countDownLatch = new MarkedCountDownLatch<>(totalTaskNum);
+        MarkedCountDownLatch<Long, Set<Pair<Long, Integer>>> countDownLatch = new MarkedCountDownLatch<>();
         AgentBatchTask batchTask = new AgentBatchTask();
         for (Map.Entry<Long, Set<Pair<Long, Integer>>> kv : beIdToTabletIdWithHash.entrySet()) {
             countDownLatch.addMark(kv.getKey(), kv.getValue());

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -2487,8 +2487,8 @@ public class SchemaChangeHandler extends AlterHandler {
                     for (Tablet tablet : index.getTablets()) {
                         for (Replica replica : tablet.getReplicas()) {
                             ClearAlterTask alterTask = new ClearAlterTask(replica.getBackendIdWithoutException(),
-                                    db.getId(), olapTable.getId(), partition.getId(),
-                                    index.getId(), tablet.getId(), schemaHash);
+                                    db.getId(), olapTable.getId(), partition.getId(), index.getId(),
+                                    tablet.getId(), replica.getId(), schemaHash);
                             batchTask.addTask(alterTask);
                         }
                     }
@@ -2809,7 +2809,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 } else {
                     // only show at most 3 results
                     List<String> subList = countDownLatch.getLeftMarks().stream().limit(3)
-                            .map(item -> "(backendId = " + item.getKey() + ", tabletsWithHash = "
+                            .map(item -> "(markKey = " + item.getKey() + ", tabletsWithHash = "
                                     + item.getValue() + ")")
                             .collect(Collectors.toList());
                     if (!subList.isEmpty()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -261,7 +261,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 implements GsonPostProcessable
                 totalReplicaNum += tablet.getReplicas().size();
             }
         }
-        MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<>(totalReplicaNum);
+        MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<>();
 
         OlapTable tbl;
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -1041,7 +1041,7 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
                 .stream()
                 .mapToInt(AgentBatchTask::getTaskNum)
                 .sum();
-        createReplicaTasksLatch = new MarkedCountDownLatch<>(numBatchTasks);
+        createReplicaTasksLatch = new MarkedCountDownLatch<>();
         if (numBatchTasks > 0) {
             LOG.info("begin to send create replica tasks to BE for restore. total {} tasks. {}",
                     numBatchTasks, this);

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -225,7 +225,7 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
 
     private Map<Long, AgentBoundedBatchTask> batchTaskPerTable = new HashMap<>();
 
-    private MarkedCountDownLatch<Long, Long> createReplicaTasksLatch = null;
+    private MarkedCountDownLatch<String, Long> createReplicaTasksLatch = null;
 
     public RestoreJob() {
         super(JobType.RESTORE);
@@ -1047,7 +1047,9 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
                     numBatchTasks, this);
             for (AgentBatchTask batchTask : batchTaskPerTable.values()) {
                 for (AgentTask task : batchTask.getAllTasks()) {
-                    createReplicaTasksLatch.addMark(task.getBackendId(), task.getTabletId());
+                    CreateReplicaTask crt =  (CreateReplicaTask) task;
+                    String markKey = String.format("%s-%s", crt.getBackendId(), crt.getReplicaId());
+                    createReplicaTasksLatch.addMark(markKey, task.getTabletId());
                     ((CreateReplicaTask) task).setLatch(createReplicaTasksLatch);
                 }
                 AgentTaskExecutor.submit(batchTask);
@@ -1069,7 +1071,7 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
         try {
             if (!createReplicaTasksLatch.await(0, TimeUnit.SECONDS)) {
                 LOG.info("waiting {} create replica tasks for restore to finish. {}",
-                        createReplicaTasksLatch.getCount(), this);
+                        createReplicaTasksLatch.getMarkCount(), this);
                 long createReplicasTimeOut = DbUtil.getCreateReplicasTimeoutMs(createReplicaTasksLatch.getMarkCount());
                 long tryCreateTime = System.currentTimeMillis() - createReplicasTimeStamp;
                 if (tryCreateTime > createReplicasTimeOut) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
@@ -75,7 +75,7 @@ public class TabletStatMgr extends MasterDaemon {
         // no need to get tablet stat if backend is not alive
         List<Backend> aliveBackends = backends.values().stream().filter(Backend::isAlive)
                 .collect(Collectors.toList());
-        updateTabletStatsLatch = new MarkedCountDownLatch<>(aliveBackends.size());
+        updateTabletStatsLatch = new MarkedCountDownLatch<>();
         aliveBackends.forEach(backend -> {
             updateTabletStatsLatch.addMark(backend.getId(), backend);
             executor.submit(() -> {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
@@ -322,7 +322,7 @@ public class TabletStatMgr extends MasterDaemon {
         try {
             if (!updateTabletStatsLatch.await(600, TimeUnit.SECONDS)) {
                 LOG.info("timeout waiting {} update tablet stats tasks finish after {} seconds.",
-                        updateTabletStatsLatch.getCount(), 600);
+                        updateTabletStatsLatch.getMarkCount(), 600);
                 ok = false;
             }
         } catch (InterruptedException e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -1302,9 +1302,7 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
         stopWatch.start();
         boolean res = false;
         try {
-            int totalTaskNum = backendToPartitionInfos.size();
-            MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<Long, Long>(
-                    totalTaskNum);
+            MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<Long, Long>();
             AgentBatchTask batchTask = new AgentBatchTask();
 
             long signature = getTxnLastSignature(dbId, transactionId);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/MarkedCountDownLatch.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MarkedCountDownLatch.java
@@ -33,15 +33,9 @@ public class MarkedCountDownLatch<K, V>  {
     private Multimap<K, V> marks;
     private Multimap<K, V> failedMarks;
     private Status st = Status.OK;
-    private int markCount = 0;
+    private int markCount;
     private CountDownLatch downLatch;
 
-    public MarkedCountDownLatch(int count) {
-        this.markCount = count;
-        this.downLatch = new CountDownLatch(count);
-        marks = HashMultimap.create();
-        failedMarks = HashMultimap.create();
-    }
 
     public MarkedCountDownLatch() {
         marks = HashMultimap.create();

--- a/fe/fe-core/src/main/java/org/apache/doris/common/MarkedCountDownLatch.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/MarkedCountDownLatch.java
@@ -28,13 +28,17 @@ import java.util.concurrent.TimeUnit;
 
 public class MarkedCountDownLatch<K, V>  {
 
+    private static final long DEFAULT_INIT_TIMEOUT = 2 * 60 * 1000L;
+
     private final Object lock = new Object();
+    private final Object signal = new Object();
 
     private Multimap<K, V> marks;
     private Multimap<K, V> failedMarks;
     private Status st = Status.OK;
     private int markCount;
-    private CountDownLatch downLatch;
+    private long initTimeout;
+    private volatile CountDownLatch downLatch;
 
 
     public MarkedCountDownLatch() {
@@ -42,43 +46,64 @@ public class MarkedCountDownLatch<K, V>  {
         failedMarks = HashMultimap.create();
         markCount = 0;
         downLatch = null;
+        initTimeout = DEFAULT_INIT_TIMEOUT;
     }
 
-    public int getMarkCount() {
-        return markCount;
-    }
-
-    public long getCount() {
-        synchronized (lock) {
-            if (downLatch == null) {
-                throw new IllegalStateException("downLatch is not initialize checkout usage is valid.");
-            }
-        }
-        return downLatch.getCount();
-    }
-
-    public void countDown() {
-        synchronized (lock) {
-            if (downLatch == null) {
-                throw new IllegalStateException("downLatch is not initialize checkout usage is valid.");
-            }
-        }
-        downLatch.countDown();
+    public void setInitTimeout(long initTimeout) {
+        this.initTimeout = initTimeout;
     }
 
     public void addMark(K key, V value) {
+        if (downLatch != null) {
+            throw new IllegalStateException("downLatch must initialize after mark.");
+        }
         synchronized (lock) {
             marks.put(key, value);
             markCount++;
         }
     }
 
-    public boolean markedCountDown(K key, V value) {
-        synchronized (lock) {
+    public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
+        synchronized (signal) {
             if (downLatch == null) {
-                throw new IllegalStateException("downLatch is not initialize checkout usage is valid.");
+                this.downLatch = new CountDownLatch(markCount);
+                signal.notifyAll();
             }
+        }
+        return downLatch.await(timeout, unit);
+    }
+
+    public void await() throws InterruptedException {
+        synchronized (signal) {
+            if (downLatch == null) {
+                this.downLatch = new CountDownLatch(markCount);
+                signal.notifyAll();
+            }
+        }
+        downLatch.await();
+    }
+
+    public boolean markedCountDown(K key, V value) {
+        // check and wait util downLatch is initialized
+        if (downLatch == null) {
+            synchronized (signal) {
+                long startTime = System.currentTimeMillis();
+                while (downLatch == null) {
+                    if (System.currentTimeMillis() - startTime > initTimeout) {
+                        throw new RuntimeException("MarkedCountDownLatch init timeout.");
+                    }
+                    try {
+                        signal.wait(initTimeout);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        }
+        //remove mark and countDown
+        synchronized (lock) {
             if (marks.remove(key, value)) {
+                markCount--;
                 downLatch.countDown();
                 return true;
             }
@@ -86,31 +111,26 @@ public class MarkedCountDownLatch<K, V>  {
         }
     }
 
-    public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
-        synchronized (lock) {
-            if (downLatch == null) {
-                this.downLatch = new CountDownLatch(markCount);
+    public boolean markedCountDownWithStatus(K key, V value, Status status)  {
+        // check and wait util downLatch is initialized
+        if (downLatch == null) {
+            synchronized (signal) {
+                long startTime = System.currentTimeMillis();
+                while (downLatch == null) {
+                    if (System.currentTimeMillis() - startTime > initTimeout) {
+                        throw new RuntimeException("MarkedCountDownLatch init timeout.");
+                    }
+                    try {
+                        signal.wait(initTimeout);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
             }
         }
-        return downLatch.await(timeout, unit);
-    }
-
-    public void await() throws InterruptedException {
-        synchronized (lock) {
-            if (downLatch == null) {
-                this.downLatch = new CountDownLatch(markCount);
-            }
-        }
-        downLatch.await();
-    }
-
-    public boolean markedCountDownWithStatus(K key, V value, Status status) {
         // update status first before countDown.
         // so that the waiting thread will get the correct status.
         synchronized (lock) {
-            if (downLatch == null) {
-                throw new IllegalStateException("downLatch is not initialize checkout usage is valid.");
-            }
 
             if (st.ok()) {
                 st = status;
@@ -123,10 +143,52 @@ public class MarkedCountDownLatch<K, V>  {
             // Search `getLeftMarks` for details.
             if (!failedMarks.containsEntry(key, value)) {
                 failedMarks.put(key, value);
+                marks.remove(key, value);
+                markCount--;
                 downLatch.countDown();
                 return true;
             }
             return false;
+        }
+    }
+
+    public void countDownToZero(Status status)  {
+        // check and wait util downLatch is initialized
+        if (downLatch == null) {
+            synchronized (signal) {
+                long startTime = System.currentTimeMillis();
+                while (downLatch == null) {
+                    if (System.currentTimeMillis() - startTime > initTimeout) {
+                        throw new RuntimeException("MarkedCountDownLatch init timeout.");
+                    }
+                    try {
+                        signal.wait(initTimeout);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        }
+
+        // update status first before countDown.
+        // so that the waiting thread will get the correct status.
+        synchronized (lock) {
+            if (st.ok()) {
+                st = status;
+            }
+            while (downLatch.getCount() > 0) {
+                markCount--;
+                downLatch.countDown();
+            }
+
+            //clear up the marks list
+            marks.clear();
+        }
+    }
+
+    public int getMarkCount() {
+        synchronized (lock) {
+            return markCount;
         }
     }
 
@@ -142,19 +204,5 @@ public class MarkedCountDownLatch<K, V>  {
         }
     }
 
-    public void countDownToZero(Status status) {
-        synchronized (lock) {
-            if (downLatch == null) {
-                throw new IllegalStateException("downLatch is not initialize checkout usage is valid.");
-            }
-            // update status first before countDown.
-            // so that the waiting thread will get the correct status.
-            if (st.ok()) {
-                st = status;
-            }
-            while (downLatch.getCount() > 0) {
-                downLatch.countDown();
-            }
-        }
-    }
+
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/consistency/CheckConsistencyJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/consistency/CheckConsistencyJob.java
@@ -190,7 +190,9 @@ public class CheckConsistencyJob {
                                                                      tabletMeta.getTableId(),
                                                                      tabletMeta.getPartitionId(),
                                                                      tabletMeta.getIndexId(),
-                                                                     tabletId, checkedSchemaHash,
+                                                                     tabletId,
+                                                                     replica.getId(),
+                                                                     checkedSchemaHash,
                                                                      checkedVersion);
 
                 // add task to send

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -2093,7 +2093,7 @@ public class InternalCatalog implements CatalogIf<Database> {
             KeysType keysType = indexMeta.getKeysType();
             List<Index> indexes = indexId == tbl.getBaseIndexId() ? tbl.getCopiedIndexes() : null;
             int totalTaskNum = index.getTablets().size() * totalReplicaNum;
-            MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<Long, Long>(totalTaskNum);
+            MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<Long, Long>();
             AgentBatchTask batchTask = new AgentBatchTask();
             List<String> rowStoreColumns = tbl.getTableProperty().getCopiedRowStoreColumns();
             for (Tablet tablet : index.getTablets()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -2093,7 +2093,7 @@ public class InternalCatalog implements CatalogIf<Database> {
             KeysType keysType = indexMeta.getKeysType();
             List<Index> indexes = indexId == tbl.getBaseIndexId() ? tbl.getCopiedIndexes() : null;
             int totalTaskNum = index.getTablets().size() * totalReplicaNum;
-            MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<Long, Long>();
+            MarkedCountDownLatch<String, Long> countDownLatch = new MarkedCountDownLatch<String, Long>();
             AgentBatchTask batchTask = new AgentBatchTask();
             List<String> rowStoreColumns = tbl.getTableProperty().getCopiedRowStoreColumns();
             for (Tablet tablet : index.getTablets()) {
@@ -2101,7 +2101,8 @@ public class InternalCatalog implements CatalogIf<Database> {
                 for (Replica replica : tablet.getReplicas()) {
                     long backendId = replica.getBackendIdWithoutException();
                     long replicaId = replica.getId();
-                    countDownLatch.addMark(backendId, tabletId);
+                    String markKey = String.format("%s-%s", backendId, replicaId);
+                    countDownLatch.addMark(markKey, tabletId);
                     CreateReplicaTask task = new CreateReplicaTask(backendId, dbId, tbl.getId(), partitionId, indexId,
                             tabletId, replicaId, shortKeyColumnCount, schemaHash, version, keysType, storageType,
                             realStorageMedium, schema, bfColumns, tbl.getBfFpp(), countDownLatch,
@@ -2165,8 +2166,11 @@ public class InternalCatalog implements CatalogIf<Database> {
                     if (countDownLatch.getStatus().getErrorCode() == TStatusCode.TIMEOUT) {
                         SystemInfoService infoService = Env.getCurrentSystemInfo();
                         Set<String> downBeSet = countDownLatch.getLeftMarks().stream()
-                                .map(item -> infoService.getBackend(item.getKey()))
-                                .filter(backend -> !backend.isAlive())
+                                .map(item -> {
+                                    long backendId = Long.parseLong(item.getKey().split("-")[0]);
+                                    return infoService.getBackend(backendId);
+                                }
+                                ).filter(backend -> !backend.isAlive())
                                 .map(Backend::getHost)
                                 .collect(Collectors.toSet());
                         if (null != downBeSet || downBeSet.size() != 0) {
@@ -2178,7 +2182,7 @@ public class InternalCatalog implements CatalogIf<Database> {
                     errMsg += "Timeout:" + (timeout / 1000) + " seconds.";
                     // only show at most 3 results
                     List<String> subList = countDownLatch.getLeftMarks().stream().limit(3)
-                            .map(item -> "(backendId = " + item.getKey() + ", tabletId = "  + item.getValue() + ")")
+                            .map(item -> "(markKey = " + item.getKey() + ", tabletId = "  + item.getValue() + ")")
                             .collect(Collectors.toList());
                     if (!subList.isEmpty()) {
                         errMsg += " Unfinished: " + Joiner.on(", ").join(subList);

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
@@ -365,7 +365,7 @@ public class NodeAction extends RestBaseController {
         // The configuration information returned by each node is a List<List<String>> type,
         // configInfoTotal is used to store the configuration information of all nodes.
         List<List<List<String>>> configInfoTotal = Lists.newArrayList();
-        MarkedCountDownLatch<String, Integer> configRequestDoneSignal = new MarkedCountDownLatch<>(hostPorts.size());
+        MarkedCountDownLatch<String, Integer> configRequestDoneSignal = new MarkedCountDownLatch<>();
         for (int i = 0; i < hostPorts.size(); ++i) {
             configInfoTotal.add(Lists.newArrayList());
 
@@ -815,9 +815,7 @@ public class NodeAction extends RestBaseController {
             List<Map<String, String>> failedTotal) {
         initHttpExecutor();
 
-        int configNum = nodeConfigList.stream().mapToInt(e -> e.getConfigs(true).size() + e.getConfigs(false).size())
-                .sum();
-        MarkedCountDownLatch<String, Integer> beSetConfigCountDownSignal = new MarkedCountDownLatch<>(configNum);
+        MarkedCountDownLatch<String, Integer> beSetConfigCountDownSignal = new MarkedCountDownLatch<>();
         for (NodeConfigs nodeConfigs : nodeConfigList) {
             submitBeSetConfigTask(nodeConfigs, true, authorization, beSetConfigCountDownSignal, failedTotal);
             submitBeSetConfigTask(nodeConfigs, false, authorization, beSetConfigCountDownSignal, failedTotal);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/DeleteJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/DeleteJob.java
@@ -559,12 +559,11 @@ public class DeleteJob extends AbstractTxnStateChangeCallback implements DeleteJ
             DeleteJob deleteJob = ConnectContext.get() != null && ConnectContext.get().isTxnModel()
                     ? new TxnDeleteJob(jobId, -1, label, partitionReplicaNum, deleteInfo)
                     : new DeleteJob(jobId, -1, label, partitionReplicaNum, deleteInfo);
-            long replicaNum = partitions.stream().mapToLong(Partition::getAllReplicaCount).sum();
             deleteJob.setPartitions(partitions);
             deleteJob.setDeleteConditions(params.getDeleteConditions());
             deleteJob.setTargetDb(params.getDb());
             deleteJob.setTargetTbl(params.getTable());
-            deleteJob.setCountDownLatch(new MarkedCountDownLatch<>((int) replicaNum));
+            deleteJob.setCountDownLatch(new MarkedCountDownLatch<>());
             ConnectContext connectContext = ConnectContext.get();
             if (connectContext != null) {
                 deleteJob.setTimeoutS(connectContext.getExecTimeoutS());
@@ -596,7 +595,6 @@ public class DeleteJob extends AbstractTxnStateChangeCallback implements DeleteJ
             DeleteJob deleteJob = ConnectContext.get() != null && ConnectContext.get().isTxnModel()
                     ? new TxnDeleteJob(jobId, -1, label, partitionReplicaNum, deleteInfo)
                     : new DeleteJob(jobId, -1, label, partitionReplicaNum, deleteInfo);
-            long replicaNum = partitions.stream().mapToLong(Partition::getAllReplicaCount).sum();
             deleteJob.setPartitions(partitions);
             deleteJob.setDeleteConditions(params.getDeleteConditions());
             deleteJob.setTargetDb(params.getDb());

--- a/fe/fe-core/src/main/java/org/apache/doris/load/DeleteJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/DeleteJob.java
@@ -352,6 +352,11 @@ public class DeleteJob extends AbstractTxnStateChangeCallback implements DeleteJ
                     for (Replica replica : tablet.getReplicas()) {
                         long replicaId = replica.getId();
                         long backendId = replica.getBackendId();
+                        //if backend has been dropped or not alive it will skip dispatch agent task
+                        if (!Env.getCurrentSystemInfo().checkBackendAlive(backendId)) {
+                            continue;
+                        }
+
                         countDownLatch.addMark(backendId, tabletId);
 
                         // create push task for each replica
@@ -412,31 +417,6 @@ public class DeleteJob extends AbstractTxnStateChangeCallback implements DeleteJ
             errMsg = "unfinished replicas [BackendId=TabletId]: " + Joiner.on(", ").join(subList);
         }
         LOG.warn(errMsg);
-        checkAndUpdateQuorum();
-        switch (state) {
-            case UN_QUORUM:
-                LOG.warn("delete job timeout: transactionId {}, timeout {}, {}",
-                        transactionId, timeoutMs, errMsg);
-                throw new UserException(String.format("delete job timeout, timeout(ms):%s, msg:%s", timeoutMs, errMsg));
-            case QUORUM_FINISHED:
-            case FINISHED:
-                long nowQuorumTimeMs = System.currentTimeMillis();
-                long endQuorumTimeoutMs = nowQuorumTimeMs + timeoutMs / 2;
-                // if job's state is quorum_finished then wait for a period of time and commit it.
-                while (state == DeleteState.QUORUM_FINISHED
-                        && endQuorumTimeoutMs > nowQuorumTimeMs) {
-                    checkAndUpdateQuorum();
-                    Thread.sleep(1000);
-                    nowQuorumTimeMs = System.currentTimeMillis();
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("wait for quorum finished delete job: {}, txn id: {}",
-                                id, transactionId);
-                    }
-                }
-                break;
-            default:
-                throw new IllegalStateException("wrong delete job state: " + state.name());
-        }
     }
 
     protected List<TabletCommitInfo> generateTabletCommitInfos() {
@@ -621,7 +601,7 @@ public class DeleteJob extends AbstractTxnStateChangeCallback implements DeleteJ
             deleteJob.setDeleteConditions(params.getDeleteConditions());
             deleteJob.setTargetDb(params.getDb());
             deleteJob.setTargetTbl(params.getTable());
-            deleteJob.setCountDownLatch(new MarkedCountDownLatch<>((int) replicaNum));
+            deleteJob.setCountDownLatch(new MarkedCountDownLatch<>());
             ConnectContext connectContext = ConnectContext.get();
             if (connectContext != null) {
                 deleteJob.setTimeoutS(connectContext.getExecTimeoutS());

--- a/fe/fe-core/src/main/java/org/apache/doris/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/MasterImpl.java
@@ -303,7 +303,7 @@ public class MasterImpl {
                 Env.getCurrentSystemInfo().updateBackendReportVersion(task.getBackendId(),
                         request.getReportVersion(), task.getDbId(), task.getTableId(), true);
 
-                createReplicaTask.countDownLatch(task.getBackendId(), task.getSignature());
+                createReplicaTask.countDownLatch(task.getBackendId(), task.getSignature(), task.getTabletId());
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("finish create replica. tablet id: {}, be: {}, report version: {}",
                             tabletId, task.getBackendId(), request.getReportVersion());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminCopyTabletCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminCopyTabletCommand.java
@@ -193,7 +193,7 @@ public class AdminCopyTabletCommand extends ShowCommand {
                 tabletMeta.getTableId(), tabletMeta.getPartitionId(), tabletMeta.getIndexId(), tabletId, version, 0,
                 getExpirationMinutes() * 60 * 1000, false);
         task.setIsCopyTabletTask(true);
-        MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<Long, Long>(1);
+        MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<Long, Long>();
         countDownLatch.addMark(backendId, tabletId);
         task.setCountDownLatch(countDownLatch);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -891,7 +891,7 @@ public class Coordinator implements CoordInterface {
             } // end for fragments
 
             // Init the mark done in order to track the finished state of the query
-            fragmentsDoneLatch = new MarkedCountDownLatch<>(backendFragments.size());
+            fragmentsDoneLatch = new MarkedCountDownLatch<>();
             for (Pair<PlanFragmentId, Long> pair : backendFragments) {
                 fragmentsDoneLatch.addMark(pair.first.asInt(), pair.second);
             }
@@ -1365,7 +1365,7 @@ public class Coordinator implements CoordInterface {
         }
 
         // Init instancesDoneLatch, it will be used to track if the instances has finished for insert stmt
-        instancesDoneLatch = new MarkedCountDownLatch<>(instanceIds.size());
+        instancesDoneLatch = new MarkedCountDownLatch<>();
         for (TUniqueId instanceId : instanceIds) {
             instancesDoneLatch.addMark(instanceId, -1L /* value is meaningless */);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -2556,9 +2556,9 @@ public class Coordinator implements CoordInterface {
 
     public boolean isDone() {
         if (fragmentsDoneLatch != null) {
-            return fragmentsDoneLatch.getCount() == 0;
+            return fragmentsDoneLatch.getMarkCount() == 0;
         } else {
-            return instancesDoneLatch.getCount() == 0;
+            return instancesDoneLatch.getMarkCount() == 0;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/LoadProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/LoadProcessor.java
@@ -125,7 +125,7 @@ public class LoadProcessor extends AbstractJobProcessor {
     }
 
     public boolean isDone() {
-        return latch.map(l -> l.getCount() == 0).orElse(false);
+        return latch.map(l -> l.getMarkCount() == 0).orElse(false);
     }
 
     public boolean join(int timeoutS) {
@@ -243,7 +243,7 @@ public class LoadProcessor extends AbstractJobProcessor {
             if (topFragmentId == params.getFragmentId()) {
                 MarkedCountDownLatch<Integer, Long> topFragmentLatch = this.topFragmentLatch.get();
                 topFragmentLatch.markedCountDown(params.getFragmentId(), params.getBackendId());
-                if (topFragmentLatch.getCount() == 0) {
+                if (topFragmentLatch.getMarkCount() == 0) {
                     tryFinishSchedule();
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/LoadProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/LoadProcessor.java
@@ -85,7 +85,7 @@ public class LoadProcessor extends AbstractJobProcessor {
     @Override
     protected void afterSetPipelineExecutionTask(PipelineExecutionTask pipelineExecutionTask) {
         Map<BackendFragmentId, SingleFragmentPipelineTask> backendFragmentTasks = this.backendFragmentTasks.get();
-        MarkedCountDownLatch<Integer, Long> latch = new MarkedCountDownLatch<>(backendFragmentTasks.size());
+        MarkedCountDownLatch<Integer, Long> latch = new MarkedCountDownLatch<>();
         for (BackendFragmentId backendFragmentId : backendFragmentTasks.keySet()) {
             latch.addMark(backendFragmentId.fragmentId, backendFragmentId.backendId);
         }
@@ -107,7 +107,7 @@ public class LoadProcessor extends AbstractJobProcessor {
         this.topFragmentTasks = topFragmentTasks;
 
         // only wait top fragments
-        MarkedCountDownLatch<Integer, Long> topFragmentLatch = new MarkedCountDownLatch<>(topFragmentTasks.size());
+        MarkedCountDownLatch<Integer, Long> topFragmentLatch = new MarkedCountDownLatch<>();
         for (SingleFragmentPipelineTask topFragmentTask : topFragmentTasks) {
             topFragmentLatch.addMark(topFragmentTask.getFragmentId(), topFragmentTask.getBackend().getId());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/task/AlterReplicaTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/AlterReplicaTask.java
@@ -75,7 +75,8 @@ public class AlterReplicaTask extends AgentTask {
             int baseSchemaHash, long version, long jobId, AlterJobV2.JobType jobType, Map<String, Expr> defineExprs,
             DescriptorTable descTable, List<Column> baseSchemaColumns, Map<Object, Object> objectPool,
             Expr whereClause, long expiration, String vaultId, TQueryOptions queryOptions, TQueryGlobals queryGlobals) {
-        super(null, backendId, TTaskType.ALTER, dbId, tableId, partitionId, rollupIndexId, rollupTabletId);
+        super(null, backendId, TTaskType.ALTER, dbId, tableId, partitionId, rollupIndexId,
+                rollupTabletId, newReplicaId);
 
         this.baseTabletId = baseTabletId;
         this.newReplicaId = newReplicaId;

--- a/fe/fe-core/src/main/java/org/apache/doris/task/CalcDeleteBitmapTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/CalcDeleteBitmapTask.java
@@ -54,7 +54,7 @@ public class CalcDeleteBitmapTask extends AgentTask  {
             if (latch.markedCountDown(backendId, transactionId)) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("CalcDeleteBitmapTask current latch count: {}, backend: {}, transactionId:{}",
-                            latch.getCount(), backendId, transactionId);
+                            latch.getMarkCount(), backendId, transactionId);
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/task/CheckConsistencyTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/CheckConsistencyTask.java
@@ -28,8 +28,9 @@ public class CheckConsistencyTask extends AgentTask {
 
     public CheckConsistencyTask(TResourceInfo resourceInfo, long backendId, long dbId,
                                 long tableId, long partitionId, long indexId, long tabletId,
-                                int schemaHash, long version) {
-        super(resourceInfo, backendId, TTaskType.CHECK_CONSISTENCY, dbId, tableId, partitionId, indexId, tabletId);
+                                long replicaId, int schemaHash, long version) {
+        super(resourceInfo, backendId, TTaskType.CHECK_CONSISTENCY, dbId, tableId, partitionId,
+                indexId, tabletId, replicaId);
 
         this.schemaHash = schemaHash;
         this.version = version;

--- a/fe/fe-core/src/main/java/org/apache/doris/task/ClearAlterTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/ClearAlterTask.java
@@ -24,8 +24,9 @@ public class ClearAlterTask extends AgentTask {
     private int schemaHash;
 
     public ClearAlterTask(long backendId, long dbId, long tableId, long partitionId, long indexId,
-                            long tabletId, int schemaHash) {
-        super(null, backendId, TTaskType.CLEAR_ALTER_TASK, dbId, tableId, partitionId, indexId, tabletId);
+                            long tabletId, long signature, int schemaHash) {
+        super(null, backendId, TTaskType.CLEAR_ALTER_TASK, dbId, tableId, partitionId,
+                indexId, tabletId, signature);
 
         this.schemaHash = schemaHash;
         this.isFinished = false;

--- a/fe/fe-core/src/main/java/org/apache/doris/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/CreateReplicaTask.java
@@ -86,7 +86,7 @@ public class CreateReplicaTask extends AgentTask {
     private TTabletType tabletType;
 
     // used for synchronous process
-    private MarkedCountDownLatch<Long, Long> latch;
+    private MarkedCountDownLatch<String, Long> latch;
 
     private boolean inRestoreMode = false;
 
@@ -143,7 +143,7 @@ public class CreateReplicaTask extends AgentTask {
                              long replicaId, short shortKeyColumnCount, int schemaHash, long version,
                              KeysType keysType, TStorageType storageType,
                              TStorageMedium storageMedium, List<Column> columns,
-                             Set<String> bfColumns, double bfFpp, MarkedCountDownLatch<Long, Long> latch,
+                             Set<String> bfColumns, double bfFpp, MarkedCountDownLatch<String, Long> latch,
                              List<Index> indexes,
                              boolean isInMemory,
                              TTabletType tabletType,
@@ -167,7 +167,7 @@ public class CreateReplicaTask extends AgentTask {
                              boolean variantEnableFlattenNested,
                              long storagePageSize, TEncryptionAlgorithm tdeAlgorithm,
                              long storageDictPageSize, Map<String, List<String>> columnSeqMapping) {
-        super(null, backendId, TTaskType.CREATE, dbId, tableId, partitionId, indexId, tabletId);
+        super(null, backendId, TTaskType.CREATE, dbId, tableId, partitionId, indexId, tabletId, replicaId);
 
         this.replicaId = replicaId;
         this.shortKeyColumnCount = shortKeyColumnCount;
@@ -228,12 +228,13 @@ public class CreateReplicaTask extends AgentTask {
         return isRecoverTask;
     }
 
-    public void countDownLatch(long backendId, long tabletId) {
+    public void countDownLatch(long backendId, long replicaId, long tabletId) {
         if (this.latch != null) {
-            if (latch.markedCountDown(backendId, tabletId)) {
+            String markKey = String.format("%s-%s", backendId, replicaId);
+            if (latch.markedCountDown(markKey, tabletId)) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("CreateReplicaTask current latch count: {}, backend: {}, tablet:{}",
-                              latch.getCount(), backendId, tabletId);
+                              latch.getMarkCount(), backendId, tabletId);
                 }
             }
         }
@@ -258,7 +259,8 @@ public class CreateReplicaTask extends AgentTask {
         // CreateReplicaTask need to be awakened.
         if (this.latch != null) {
             Status s = new Status(TStatusCode.CANCELLED, errMsg);
-            latch.markedCountDownWithStatus(getBackendId(), getTabletId(), s);
+            String markKey = String.format("%s-%s", getBackendId(), getReplicaId());
+            latch.markedCountDownWithStatus(markKey, getTabletId(), s);
             if (LOG.isDebugEnabled()) {
                 LOG.debug("CreateReplicaTask failed with msg: {}, tablet: {}, backend: {}",
                         errMsg, getTabletId(), getBackendId());
@@ -266,7 +268,7 @@ public class CreateReplicaTask extends AgentTask {
         }
     }
 
-    public void setLatch(MarkedCountDownLatch<Long, Long> latch) {
+    public void setLatch(MarkedCountDownLatch<String, Long> latch) {
         this.latch = latch;
     }
 
@@ -289,6 +291,10 @@ public class CreateReplicaTask extends AgentTask {
 
     public void setClusterKeyUids(List<Integer> clusterKeyUids) {
         this.clusterKeyUids = clusterKeyUids;
+    }
+
+    public long getReplicaId() {
+        return replicaId;
     }
 
     public TCreateTabletReq toThrift() {

--- a/fe/fe-core/src/main/java/org/apache/doris/task/PushTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/PushTask.java
@@ -205,8 +205,8 @@ public class PushTask extends AgentTask {
         if (this.latch != null) {
             if (latch.markedCountDown(backendId, tabletId)) {
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("pushTask current latch count: {}. backend: {}, tablet:{}", latch.getCount(), backendId,
-                            tabletId);
+                    LOG.debug("pushTask current latch count: {}. backend: {}, tablet:{}", latch.getMarkCount(),
+                            backendId, tabletId);
                 }
             }
         }
@@ -219,7 +219,7 @@ public class PushTask extends AgentTask {
         if (latch.markedCountDownWithStatus(backendId, tabletId, st)) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("pushTask current latch count with status: {}. backend: {}, tablet:{}, st::{}",
-                        latch.getCount(), backendId, tabletId, st);
+                        latch.getMarkCount(), backendId, tabletId, st);
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/task/UpdateTabletMetaInfoTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/UpdateTabletMetaInfoTask.java
@@ -103,7 +103,7 @@ public class UpdateTabletMetaInfoTask extends AgentTask {
             if (latch.markedCountDown(backendId, tablets)) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("UpdateTabletMetaInfoTask current latch count: {}, backend: {}, tablets:{}",
-                            latch.getCount(), backendId, tablets);
+                            latch.getMarkCount(), backendId, tablets);
                 }
             }
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/MarkedCountDownLatchTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/MarkedCountDownLatchTest.java
@@ -1,0 +1,195 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+
+public class MarkedCountDownLatchTest {
+
+
+    @Test
+    public void testNormal() throws Exception {
+
+        final MarkedCountDownLatch<String, String> markedCountDownLatch = new MarkedCountDownLatch<>();
+        markedCountDownLatch.addMark("k1", "v1");
+        markedCountDownLatch.addMark("k2", "v2");
+        markedCountDownLatch.addMark("k3", "v3");
+        Assert.assertEquals(3, markedCountDownLatch.getMarkCount());
+
+
+        Thread t = new Thread(() -> {
+            int i = 1;
+            while (i < 4) {
+                try {
+                    markedCountDownLatch.markedCountDown("k" + i, "v" + i);
+                } catch (Exception e) {
+                    if (e instanceof IllegalStateException) {
+                        continue;
+                    }
+                    throw e;
+                }
+                Assert.assertEquals(3 - i, markedCountDownLatch.getMarkCount());
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                i++;
+            }
+        });
+        t.start();
+
+        long startTime = System.currentTimeMillis();
+        markedCountDownLatch.await(10, TimeUnit.SECONDS);
+        long endTime = System.currentTimeMillis();
+        Assert.assertEquals(0, markedCountDownLatch.getMarkCount());
+        Assert.assertTrue(endTime - startTime < 10 * 1000L);
+    }
+
+    @Test
+    public void testCountWithStatus() throws Exception {
+        final MarkedCountDownLatch<String, String> markedCountDownLatch = new MarkedCountDownLatch<>();
+        markedCountDownLatch.addMark("k1", "v1");
+        markedCountDownLatch.addMark("k2", "v2");
+        markedCountDownLatch.addMark("k3", "v3");
+        Assert.assertEquals(3, markedCountDownLatch.getMarkCount());
+
+        Thread t = new Thread(() -> {
+            int i = 1;
+            while (i < 4) {
+                try {
+                    markedCountDownLatch.markedCountDownWithStatus("k" + i, "v" + i, Status.FINISHED);
+                } catch (Exception e) {
+                    if (e instanceof IllegalStateException) {
+                        continue;
+                    }
+                    throw e;
+                }
+                Assert.assertEquals(3 - i, markedCountDownLatch.getMarkCount());
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                i++;
+            }
+        });
+        t.start();
+
+        long startTime = System.currentTimeMillis();
+        markedCountDownLatch.await(10, TimeUnit.SECONDS);
+        long endTime = System.currentTimeMillis();
+        Assert.assertEquals(0, markedCountDownLatch.getMarkCount());
+        Assert.assertTrue(endTime - startTime < 10 * 1000L);
+        Assert.assertEquals(Status.FINISHED, markedCountDownLatch.getStatus());
+    }
+
+    @Test
+    public void testTimeout() throws Exception {
+
+        final MarkedCountDownLatch<String, String> markedCountDownLatch = new MarkedCountDownLatch<>();
+        markedCountDownLatch.addMark("k1", "v1");
+        markedCountDownLatch.addMark("k2", "v2");
+        markedCountDownLatch.addMark("k3", "v3");
+        Assert.assertEquals(3, markedCountDownLatch.getMarkCount());
+
+        Thread t = new Thread(() -> {
+            int i = 1;
+            while (i < 3) {
+                try {
+                    markedCountDownLatch.markedCountDown("k" + i, "v" + i);
+                } catch (Exception e) {
+                    if (e instanceof IllegalStateException) {
+                        continue;
+                    }
+                    throw e;
+                }
+                Assert.assertEquals(3 - i, markedCountDownLatch.getMarkCount());
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                i++;
+            }
+        });
+        t.start();
+
+        long startTime = System.currentTimeMillis();
+        markedCountDownLatch.await(10, TimeUnit.SECONDS);
+        long endTime = System.currentTimeMillis();
+        Assert.assertEquals(1, markedCountDownLatch.getMarkCount());
+        Assert.assertTrue(endTime - startTime >= 10 * 1000L);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testNotWaitException()  {
+
+        final MarkedCountDownLatch<String, String> markedCountDownLatch = new MarkedCountDownLatch<>();
+        markedCountDownLatch.addMark("k1", "v1");
+        markedCountDownLatch.addMark("k2", "v2");
+        markedCountDownLatch.addMark("k3", "v3");
+        Assert.assertEquals(3, markedCountDownLatch.getMarkCount());
+
+        //20s init timeout
+        markedCountDownLatch.setInitTimeout(20 * 1000);
+
+        //call markedCountDown before wait method will throw  IllegalStateException
+        markedCountDownLatch.markedCountDown("k1", "v1");
+    }
+
+
+    @Test
+    public void testCountDownToZero() throws Exception {
+        final MarkedCountDownLatch<String, String> markedCountDownLatch = new MarkedCountDownLatch<>();
+        markedCountDownLatch.addMark("k1", "v1");
+        markedCountDownLatch.addMark("k2", "v2");
+        markedCountDownLatch.addMark("k3", "v3");
+        Assert.assertEquals(3, markedCountDownLatch.getMarkCount());
+
+        Thread t = new Thread(() -> {
+            while (true) {
+                try {
+                    markedCountDownLatch.countDownToZero(Status.CANCELLED);
+                } catch (Exception e) {
+                    if (e instanceof IllegalStateException) {
+                        continue;
+                    }
+                    throw e;
+                }
+                Assert.assertEquals(0, markedCountDownLatch.getMarkCount());
+                break;
+            }
+
+        });
+        t.start();
+
+        long startTime = System.currentTimeMillis();
+        markedCountDownLatch.await(10, TimeUnit.SECONDS);
+        long endTime = System.currentTimeMillis();
+        Assert.assertEquals(0, markedCountDownLatch.getMarkCount());
+        Assert.assertTrue(endTime - startTime < 10 * 1000L);
+        Assert.assertEquals(Status.CANCELLED, markedCountDownLatch.getStatus());
+    }
+
+
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/task/AgentTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/task/AgentTaskTest.java
@@ -81,7 +81,7 @@ public class AgentTaskTest {
     private long storageDictPageSize = 262144L;
 
     private List<Column> columns;
-    private MarkedCountDownLatch<Long, Long> latch = new MarkedCountDownLatch<Long, Long>();
+    private MarkedCountDownLatch<String, Long> latch = new MarkedCountDownLatch<>();
 
     private Range<PartitionKey> range1;
     private Range<PartitionKey> range2;

--- a/fe/fe-core/src/test/java/org/apache/doris/task/AgentTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/task/AgentTaskTest.java
@@ -81,7 +81,7 @@ public class AgentTaskTest {
     private long storageDictPageSize = 262144L;
 
     private List<Column> columns;
-    private MarkedCountDownLatch<Long, Long> latch = new MarkedCountDownLatch<Long, Long>(3);
+    private MarkedCountDownLatch<Long, Long> latch = new MarkedCountDownLatch<Long, Long>();
 
     private Range<PartitionKey> range1;
     private Range<PartitionKey> range2;
@@ -93,8 +93,9 @@ public class AgentTaskTest {
     private AgentTask storageMediaMigrationTask;
 
     @Before
-    public void setUp() throws AnalysisException {
+    public void setUp() throws AnalysisException, InterruptedException {
         MetricRepo.init();
+
         agentBatchTask = new AgentBatchTask();
 
         columns = new LinkedList<Column>();
@@ -112,6 +113,7 @@ public class AgentTaskTest {
         // create tasks
         Map<Object, Object> objectPool = new HashMap<Object, Object>();
         // create
+
         createReplicaTask = new CreateReplicaTask(backendId1, dbId, tableId, partitionId,
                 indexId1, tabletId1, replicaId1, shortKeyNum, schemaHash1, version, KeysType.AGG_KEYS, storageType,
                 TStorageMedium.SSD, columns, null, 0, latch, null, false, TTabletType.TABLET_TYPE_DISK, null,


### PR DESCRIPTION
…ped or not alive on delete from command.

When a node is abnormal or dropped, the delete job function does not filter the replicas for these nodes, resulting in failure during task dispatch and causing the task to not execute properly during the Delete operation. On the other hand, after a task execution fails, it keeps retrying; however, it does not adequately consider that in certain scenarios a retry cannot resolve the issue and can only rely on the overall timeout of the outer task to terminate, which can lead to the task being stuck for a long time.

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
