### PR TITLE
[fix](compaction) Check schema version before ordered data compaction

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -48,6 +48,7 @@
 #include "io/fs/file_writer.h"
 #include "io/fs/remote_file_system.h"
 #include "io/io_common.h"
+#include "olap/collection_statistics.h"
 #include "olap/cumulative_compaction.h"
 #include "olap/cumulative_compaction_policy.h"
 #include "olap/cumulative_compaction_time_series_policy.h"
@@ -424,6 +425,28 @@ bool CompactionMixin::handle_ordered_data_compaction() {
     if (!config::enable_ordered_data_compaction) {
         return false;
     }
+
+    // If some rowsets has idx files and some rowsets has not, we can not do link file compaction.
+    // Since the output rowset will be broken.
+
+    // Use schema version instead of schema hash to check if they are the same,
+    // because light schema change will not change the schema hash on BE, but will increase the schema version
+    // See fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java::2979
+    std::vector<int32_t> schema_versions_of_rowsets;
+
+    for (auto input_rowset : _input_rowsets) {
+        schema_versions_of_rowsets.push_back(input_rowset->rowset_meta()->schema_version());
+    }
+
+    // If all rowsets has same schema version, then we can do link file compaction directly.
+    bool all_same_schema_version =
+            std::all_of(schema_versions_of_rowsets.begin(), schema_versions_of_rowsets.end(),
+                        [&](int32_t v) { return v == schema_versions_of_rowsets.front(); });
+
+    if (!all_same_schema_version) {
+        return false;
+    }
+
     if (compaction_type() == ReaderType::READER_COLD_DATA_COMPACTION ||
         compaction_type() == ReaderType::READER_FULL_COMPACTION) {
         // The remote file system and full compaction does not support to link files.

--- a/be/src/olap/rowset/rowset_meta.h
+++ b/be/src/olap/rowset/rowset_meta.h
@@ -434,6 +434,8 @@ public:
         index_pb.set_size(size);
     }
 
+    int32_t schema_version() const { return _rowset_meta_pb.schema_version(); }
+
 private:
     bool _deserialize_from_pb(std::string_view value);
 


### PR DESCRIPTION
### What problem does this PR solve?

Ordered data compaction should not be used to accelerate the merging of rowsets that have undergone a light schema change; otherwise, it may result in schema-inconsistent segments within the newly generated rowset.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

