### PR TITLE
[opt](memo) reduce enforcer number in memo

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
@@ -155,7 +155,7 @@ public class CascadesContext implements ScheduleContext {
         this.ruleSet = new RuleSet();
         this.jobPool = new JobStack();
         this.jobScheduler = new SimpleJobScheduler();
-        this.currentJobContext = new JobContext(this, requireProperties, Double.MAX_VALUE);
+        this.currentJobContext = new JobContext(this, requireProperties);
         this.subqueryExprIsAnalyzed = new HashMap<>();
         IdGenerator<RuntimeFilterId> runtimeFilterIdGen = RuntimeFilterId.createGenerator();
         this.runtimeFilterContext = new RuntimeFilterContext(getConnectContext().getSessionVariable(),
@@ -362,7 +362,7 @@ public class CascadesContext implements ScheduleContext {
     }
 
     public CascadesContext setJobContext(PhysicalProperties physicalProperties) {
-        this.currentJobContext = new JobContext(this, physicalProperties, Double.MAX_VALUE);
+        this.currentJobContext = new JobContext(this, physicalProperties);
         return this;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/PlanContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/PlanContext.java
@@ -18,12 +18,13 @@
 package org.apache.doris.nereids;
 
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DistributionSpecReplicated;
+import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.statistics.Statistics;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -34,23 +35,21 @@ import java.util.List;
  */
 public class PlanContext {
     private final ConnectContext connectContext;
-    private final List<Statistics> childrenStats;
-    private final Statistics planStats;
-    private final int arity;
-    private boolean isBroadcastJoin = false;
-    private final boolean isStatsReliable;
+    private final GroupExpression groupExpression;
+    private final boolean isBroadcastJoin;
 
     /**
      * Constructor for PlanContext.
      */
-    public PlanContext(ConnectContext connectContext, GroupExpression groupExpression) {
+    public PlanContext(ConnectContext connectContext, GroupExpression groupExpression,
+            List<PhysicalProperties> childrenProperties) {
         this.connectContext = connectContext;
-        this.arity = groupExpression.arity();
-        this.planStats = groupExpression.getOwnerGroup().getStatistics();
-        this.isStatsReliable = groupExpression.getOwnerGroup().isStatsReliable();
-        this.childrenStats = new ArrayList<>(groupExpression.arity());
-        for (int i = 0; i < groupExpression.arity(); i++) {
-            childrenStats.add(groupExpression.childStatistics(i));
+        this.groupExpression = groupExpression;
+        if (childrenProperties.size() >= 2
+                && childrenProperties.get(1).getDistributionSpec() instanceof DistributionSpecReplicated) {
+            isBroadcastJoin = true;
+        } else {
+            isBroadcastJoin = false;
         }
     }
 
@@ -58,35 +57,27 @@ public class PlanContext {
         return connectContext.getSessionVariable();
     }
 
-    public void setBroadcastJoin() {
-        isBroadcastJoin = true;
-    }
-
     public boolean isBroadcastJoin() {
         return isBroadcastJoin;
     }
 
     public int arity() {
-        return arity;
+        return groupExpression.arity();
     }
 
     public Statistics getStatisticsWithCheck() {
-        return planStats;
+        return groupExpression.getOwnerGroup().getStatistics();
     }
 
     public boolean isStatsReliable() {
-        return isStatsReliable;
+        return groupExpression.getOwnerGroup().isStatsReliable();
     }
 
     /**
      * Get child statistics.
      */
     public Statistics getChildStatistics(int index) {
-        return childrenStats.get(index);
-    }
-
-    public List<Statistics> getChildrenStatistics() {
-        return childrenStats;
+        return groupExpression.childStatistics(index);
     }
 
     public StatementContext getStatementContext() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostCalculator.java
@@ -19,7 +19,6 @@ package org.apache.doris.nereids.cost;
 
 import org.apache.doris.nereids.PlanContext;
 import org.apache.doris.nereids.memo.GroupExpression;
-import org.apache.doris.nereids.properties.DistributionSpecReplicated;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.qe.ConnectContext;
@@ -38,12 +37,7 @@ public class CostCalculator {
      */
     public static Cost calculateCost(ConnectContext connectContext, GroupExpression groupExpression,
             List<PhysicalProperties> childrenProperties) {
-        PlanContext planContext = new PlanContext(connectContext, groupExpression);
-        if (childrenProperties.size() >= 2
-                && childrenProperties.get(1).getDistributionSpec() instanceof DistributionSpecReplicated) {
-            planContext.setBroadcastJoin();
-        }
-
+        PlanContext planContext = new PlanContext(connectContext, groupExpression, childrenProperties);
         CostModel costModelV1 = new CostModel(connectContext);
         return groupExpression.getPlan().accept(costModelV1, planContext);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/JobContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/JobContext.java
@@ -37,7 +37,6 @@ public class JobContext {
     // use for optimizer
     protected final ScheduleContext scheduleContext;
     protected final PhysicalProperties requiredProperties;
-    protected double costUpperBound;
 
     // use for rewriter
     protected boolean rewritten = false;
@@ -46,10 +45,9 @@ public class JobContext {
     // user for trace
     protected Map<RuleType, Integer> ruleInvokeTimes = Maps.newLinkedHashMap();
 
-    public JobContext(ScheduleContext scheduleContext, PhysicalProperties requiredProperties, double costUpperBound) {
+    public JobContext(ScheduleContext scheduleContext, PhysicalProperties requiredProperties) {
         this.scheduleContext = scheduleContext;
         this.requiredProperties = requiredProperties;
-        this.costUpperBound = costUpperBound;
     }
 
     public ScheduleContext getScheduleContext() {
@@ -62,14 +60,6 @@ public class JobContext {
 
     public PhysicalProperties getRequiredProperties() {
         return requiredProperties;
-    }
-
-    public double getCostUpperBound() {
-        return costUpperBound;
-    }
-
-    public void setCostUpperBound(double costUpperBound) {
-        this.costUpperBound = costUpperBound;
     }
 
     public boolean isRewritten() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/CostAndEnforcerJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/CostAndEnforcerJob.java
@@ -174,9 +174,7 @@ public class CostAndEnforcerJob extends Job implements Cloneable {
                     // Meaning that optimize recursively by derive job.
                     prevChildIndex = curChildIndex;
                     pushJob(clone());
-                    double newCostUpperBound = context.getCostUpperBound() - curTotalCost.getValue();
-                    JobContext jobContext = new JobContext(context.getCascadesContext(),
-                            requestChildProperty, newCostUpperBound);
+                    JobContext jobContext = new JobContext(context.getCascadesContext(), requestChildProperty);
                     pushJob(new OptimizeGroupJob(childGroup, jobContext));
                     return;
                 }
@@ -215,13 +213,7 @@ public class CostAndEnforcerJob extends Job implements Cloneable {
             // This mean that we successfully optimize all child groups.
             // if break when running the loop above, the condition must be false.
             if (curChildIndex == groupExpression.arity()) {
-                if (!calculateEnforce(requestChildrenProperties, outputChildrenProperties)) {
-                    clear();
-                    continue; // if error exists, return
-                }
-                if (curTotalCost.getValue() < context.getCostUpperBound()) {
-                    context.setCostUpperBound(curTotalCost.getValue());
-                }
+                calculateEnforce(requestChildrenProperties, outputChildrenProperties);
             }
             clear();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/PlanReceiver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/PlanReceiver.java
@@ -188,7 +188,7 @@ public class PlanReceiver implements AbstractReceiver {
 
     private void proposeAllDistributedPlans(GroupExpression groupExpression) {
         jobContext.getCascadesContext().pushJob(new OptimizeGroupExpressionJob(groupExpression,
-                new JobContext(jobContext.getCascadesContext(), PhysicalProperties.ANY, Double.MAX_VALUE)));
+                new JobContext(jobContext.getCascadesContext(), PhysicalProperties.ANY)));
         if (!groupExpression.isStatDerived()) {
             jobContext.getCascadesContext().pushJob(new DeriveStatsJob(groupExpression,
                     jobContext.getCascadesContext().getCurrentJobContext()));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.memo;
 
 import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.cost.Cost;
+import org.apache.doris.nereids.properties.DistributionSpec;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
@@ -27,6 +28,7 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalDistribute;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.util.TreeStringUtils;
 import org.apache.doris.nereids.util.Utils;
@@ -60,6 +62,7 @@ public class Group {
     private final List<GroupExpression> logicalExpressions = Lists.newArrayList();
     private final List<GroupExpression> physicalExpressions = Lists.newArrayList();
     private final Map<GroupExpression, GroupExpression> enforcers = Maps.newHashMap();
+    private final Map<DistributionSpec, GroupExpression> enforcerSpecs = Maps.newHashMap();
     private boolean isStatsReliable = true;
     private LogicalProperties logicalProperties;
 
@@ -243,13 +246,26 @@ public class Group {
         return null;
     }
 
+    /**
+     * add a new enforcer to this group.
+     */
     public void addEnforcer(GroupExpression enforcer) {
         enforcer.setOwnerGroup(this);
+        if (enforcer.getPlan() instanceof PhysicalDistribute) {
+            DistributionSpec distributionSpec = ((PhysicalDistribute) enforcer.getPlan()).getDistributionSpec();
+            if (null != enforcerSpecs.put(distributionSpec, enforcer)) {
+                return;
+            }
+        }
         enforcers.put(enforcer, enforcer);
     }
 
     public Map<GroupExpression, GroupExpression> getEnforcers() {
         return enforcers;
+    }
+
+    public Map<DistributionSpec, GroupExpression> getEnforcerSpecs() {
+        return enforcerSpecs;
     }
 
     /**
@@ -356,6 +372,7 @@ public class Group {
         // TODO: dedup?
         enforcers.forEach((k, v) -> target.addEnforcer(k));
         enforcers.clear();
+        enforcerSpecs.clear();
 
         // move LogicalExpression PhysicalExpression Ownership
         Map<GroupExpression, GroupExpression> logicalSet = target.getLogicalExpressions().stream()
@@ -390,10 +407,16 @@ public class Group {
         lowestCostPlans.forEach((physicalProperties, costAndGroupExpr) -> {
             // move lowestCostPlans Ownership
             if (!target.lowestCostPlans.containsKey(physicalProperties)) {
+                // we must set owner group here, because the instance in logical expression, physical expression
+                // and enforcer maybe not same with the instance in the lowestCostPlans map
+                costAndGroupExpr.second.setOwnerGroup(target);
                 target.lowestCostPlans.put(physicalProperties, costAndGroupExpr);
             } else {
                 if (costAndGroupExpr.first.getValue()
                         < target.lowestCostPlans.get(physicalProperties).first.getValue()) {
+                    // we must set owner group here, because the instance in logical expression, physical expression
+                    // and enforcer maybe not same with the instance in the lowestCostPlans map
+                    costAndGroupExpr.second.setOwnerGroup(target);
                     target.lowestCostPlans.put(physicalProperties, costAndGroupExpr);
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
@@ -54,7 +54,7 @@ public class GroupExpression {
     private static final EventProducer COST_STATE_TRACER = new EventProducer(CostStateUpdateEvent.class,
             EventChannel.getDefaultChannel().addConsumers(new LogConsumer(CostStateUpdateEvent.class,
                     EventChannel.LOG)));
-    private Cost cost;
+    private Cost cost = null;
     private Group ownerGroup;
     private final List<Group> children;
     private final Plan plan;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriver.java
@@ -76,6 +76,7 @@ import com.google.common.collect.Sets;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -101,7 +102,8 @@ public class ChildOutputPropertyDeriver extends PlanVisitor<PhysicalProperties, 
     }
 
     public PhysicalProperties getOutputProperties(ConnectContext connectContext, GroupExpression groupExpression) {
-        return groupExpression.getPlan().accept(this, new PlanContext(connectContext, groupExpression));
+        return groupExpression.getPlan().accept(this,
+                new PlanContext(connectContext, groupExpression, Collections.emptyList()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulator.java
@@ -867,6 +867,9 @@ public class ChildrenPropertiesRegulator extends PlanVisitor<List<List<PhysicalP
             currentCost = newChildAndCost.first;
         }
 
+        if (child.getOwnerGroup().getEnforcerSpecs().containsKey(target)) {
+            return;
+        }
         PhysicalProperties newOutputProperty = new PhysicalProperties(target);
         GroupExpression enforcer = target.addEnforcer(child.getOwnerGroup());
         child.getOwnerGroup().addEnforcer(enforcer);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/DistributionSpecHiveTableSinkHashPartitioned.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/DistributionSpecHiveTableSinkHashPartitioned.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.properties;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * use for shuffle data by partition keys before sink.
@@ -43,5 +44,22 @@ public class DistributionSpecHiveTableSinkHashPartitioned extends DistributionSp
     @Override
     public boolean satisfy(DistributionSpec other) {
         return other instanceof DistributionSpecHiveTableSinkHashPartitioned;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        DistributionSpecHiveTableSinkHashPartitioned that = (DistributionSpecHiveTableSinkHashPartitioned) o;
+        return Objects.equals(outputColExprIds, that.outputColExprIds);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), outputColExprIds);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
@@ -74,6 +74,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -114,7 +115,8 @@ public class RequestPropertyDeriver extends PlanVisitor<Void, PlanContext> {
      */
     public List<List<PhysicalProperties>> getRequestChildrenPropertyList(GroupExpression groupExpression) {
         requestPropertyToChildren = Lists.newArrayList();
-        groupExpression.getPlan().accept(this, new PlanContext(connectContext, groupExpression));
+        groupExpression.getPlan().accept(this,
+                new PlanContext(connectContext, groupExpression, Collections.emptyList()));
         return requestPropertyToChildren;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinLAsscomProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinLAsscomProject.java
@@ -23,7 +23,6 @@ import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.rules.exploration.CBOUtils;
 import org.apache.doris.nereids.rules.exploration.OneExplorationRuleFactory;
 import org.apache.doris.nereids.trees.expressions.ExprId;
-import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
@@ -36,7 +35,6 @@ import com.google.common.collect.ImmutableSet;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -116,11 +114,7 @@ public class OuterJoinLAsscomProject extends OneExplorationRuleFactory {
                         topJoin.getHashJoinConjuncts().stream(),
                         topJoin.getOtherJoinConjuncts().stream())
                 .allMatch(expr -> {
-                    Set<ExprId> usedExprIdSet = expr.<SlotReference>collect(SlotReference.class::isInstance)
-                            .stream()
-                            .map(SlotReference::getExprId)
-                            .collect(Collectors.toSet());
-                    return !Utils.isIntersecting(usedExprIdSet, bOutputExprIdSet);
+                    return !Utils.isIntersecting(expr.getInputSlotExprIds(), bOutputExprIdSet);
                 });
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -71,6 +71,16 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
     private final boolean hasUnbound;
     private final Supplier<Set<Slot>> inputSlots = LazyCompute.of(
             () -> collect(e -> e instanceof Slot && !(e instanceof ArrayItemSlot)));
+    private final Supplier<Set<ExprId>> inputExprIds = LazyCompute.of(
+            () -> {
+                Set<Slot> inputSlots = getInputSlots();
+                Builder<ExprId> exprIds = ImmutableSet.builderWithExpectedSize(inputSlots.size());
+                for (Slot inputSlot : inputSlots) {
+                    exprIds.add(inputSlot.getExprId());
+                }
+                return exprIds.build();
+            }
+    );
     private final int fastChildrenHashCode;
     private final Supplier<String> toSqlCache = LazyCompute.of(this::computeToSql);
     private final Supplier<Integer> hashCodeCache = LazyCompute.of(this::computeHashCode);
@@ -394,12 +404,7 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
      * Note that the input slots of subquery's inner plan is not included.
      */
     public final Set<ExprId> getInputSlotExprIds() {
-        Set<Slot> inputSlots = getInputSlots();
-        Builder<ExprId> exprIds = ImmutableSet.builderWithExpectedSize(inputSlots.size());
-        for (Slot inputSlot : inputSlots) {
-            exprIds.add(inputSlot.getExprId());
-        }
-        return exprIds.build();
+        return inputExprIds.get();
     }
 
     public boolean isLiteral() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
@@ -131,13 +131,11 @@ public class PhysicalHashJoin<
         //  mark join with non-empty hash join conjuncts allow shuffle join by hash join conjuncts
         Preconditions.checkState(!(isMarkJoin() && hashJoinConjuncts.isEmpty()),
                 "shouldn't call mark join's getHashConjunctsExprIds method for standalone mark join");
-        int size = hashJoinConjuncts.size();
-
-        List<ExprId> exprIds1 = new ArrayList<>(size);
-        List<ExprId> exprIds2 = new ArrayList<>(size);
 
         Set<ExprId> leftExprIds = left().getOutputExprIdSet();
         Set<ExprId> rightExprIds = right().getOutputExprIdSet();
+        List<ExprId> exprIds1 = new ArrayList<>(leftExprIds.size());
+        List<ExprId> exprIds2 = new ArrayList<>(rightExprIds.size());
 
         for (Expression expr : hashJoinConjuncts) {
             for (ExprId exprId : expr.getInputSlotExprIds()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/cascades/DeriveStatsJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/cascades/DeriveStatsJobTest.java
@@ -68,7 +68,7 @@ public class DeriveStatsJobTest {
         LogicalAggregate agg = constructAgg(olapScan);
         CascadesContext cascadesContext = MemoTestUtils.createCascadesContext(agg);
         new DeriveStatsJob(cascadesContext.getMemo().getRoot().getLogicalExpression(),
-                new JobContext(cascadesContext, null, Double.MAX_VALUE)).execute();
+                new JobContext(cascadesContext, null)).execute();
         while (!cascadesContext.getJobPool().isEmpty()) {
             cascadesContext.getJobPool().pop().execute();
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/ConstantPropagationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/ConstantPropagationTest.java
@@ -88,7 +88,7 @@ class ConstantPropagationTest {
     ConstantPropagationTest() {
         cascadesContext = MemoTestUtils.createCascadesContext(
                 new UnboundRelation(new RelationId(1), ImmutableList.of("tbl")));
-        jobContext = new JobContext(cascadesContext, null, Double.MAX_VALUE);
+        jobContext = new JobContext(cascadesContext, null);
 
         student = new LogicalOlapScan(PlanConstructor.getNextRelationId(), PlanConstructor.student, ImmutableList.of(""));
         studentId = (SlotReference) student.getOutput().get(0);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
@@ -700,8 +700,7 @@ public class PlanChecker {
     public PlanChecker setMaxInvokeTimesPerRule(int maxInvokeTime) {
         JobContext originJobContext = cascadesContext.getCurrentJobContext();
         cascadesContext.setCurrentJobContext(
-                new JobContext(cascadesContext,
-                        originJobContext.getRequiredProperties(), originJobContext.getCostUpperBound()) {
+                new JobContext(cascadesContext, originJobContext.getRequiredProperties()) {
                     @Override
                     public void onInvokeRule(RuleType ruleType) {
                         // add invoke times


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

This pull request refactors and simplifies the handling of job context and enforcer management in the Cascades optimizer framework. The main changes remove the cost upper bound from `JobContext`, improve enforcer deduplication for distribution specs, and streamline how broadcast joins are detected and handled. Additionally, the `PlanContext` class is refactored for clarity and efficiency, and equality checks are improved for distribution specs.

**Refactoring and Simplification of Job Context:**

- Removed the `costUpperBound` parameter and related logic from `JobContext` and its usage throughout the optimizer, simplifying job scheduling and context management. [[1]](diffhunk://#diff-60925a3365a562ae91e07cc8a266f3026a85242a7e2f8e9b73c8ddfb2a9345a0L40) [[2]](diffhunk://#diff-60925a3365a562ae91e07cc8a266f3026a85242a7e2f8e9b73c8ddfb2a9345a0L49-L52) [[3]](diffhunk://#diff-60925a3365a562ae91e07cc8a266f3026a85242a7e2f8e9b73c8ddfb2a9345a0L67-L74) [[4]](diffhunk://#diff-ae1da42cd565f95be0c025e7a60575aac58eeb090548fb3e1a2e4f5cdaf16a7aL158-R158) [[5]](diffhunk://#diff-ae1da42cd565f95be0c025e7a60575aac58eeb090548fb3e1a2e4f5cdaf16a7aL365-R365) [[6]](diffhunk://#diff-daca25589f7ee5d5c0c9b57d9a5004698d4ab56bdfe8491d38df4df7bf2ea174L177-R177) [[7]](diffhunk://#diff-daca25589f7ee5d5c0c9b57d9a5004698d4ab56bdfe8491d38df4df7bf2ea174L218-R216) [[8]](diffhunk://#diff-4155b70e30cabf577ca7a18b53f766032da352e3b9acd98c16f286914e60f637L191-R191)

**Enforcer Deduplication and Management:**

- Added a new `enforcerSpecs` map in `Group` to deduplicate enforcers based on `DistributionSpec`, ensuring only one enforcer per spec and improving efficiency during group merges and enforcer addition. [[1]](diffhunk://#diff-dc5e6a82ea2e54bd9bcf8da1b1b65d59758b5104ecf25221b6f839c8e427df99R65) [[2]](diffhunk://#diff-dc5e6a82ea2e54bd9bcf8da1b1b65d59758b5104ecf25221b6f839c8e427df99R249-R270) [[3]](diffhunk://#diff-dc5e6a82ea2e54bd9bcf8da1b1b65d59758b5104ecf25221b6f839c8e427df99R375)
- Updated enforcer lookup and creation logic in both property enforcement and regulation helpers to use the new deduplication mechanism. [[1]](diffhunk://#diff-a940a6f532b4326093c12f3b507403c0453a1deb17ca0ce6a1717f97f4af2c45L126-R130) [[2]](diffhunk://#diff-79d8abdb9d7855b95a985ffa9b4ddbe1c646b58245fc2d0c02bef33374743777R870-R872)

**PlanContext Refactoring:**

- Refactored `PlanContext` to remove redundant fields, directly use `GroupExpression`, and determine broadcast join status based on child properties, making the class more focused and reducing unnecessary state. [[1]](diffhunk://#diff-f2c9bd79c6c7c9fa7e4b0792f27a6bd63577b02f9ff49c43b50c5dbf1ace55d5L37-R80) [[2]](diffhunk://#diff-c734d959249b73c3db507a3071902d220645ed1bffa153502813d70feea12fd4L41-R40) [[3]](diffhunk://#diff-cab02f11d1f8442aa712018479c1a80992ae8a928ff5416a47541b71a5a212f2L104-R106)

**DistributionSpec Equality Improvements:**

- Implemented `equals` and `hashCode` methods for `DistributionSpecHiveTableSinkHashPartitioned` to ensure correct behavior in collections and when used as map keys, supporting the new enforcer deduplication logic.

**Miscellaneous Improvements:**

- Ensured that ownership is properly set when merging groups and updating cost plans, preventing inconsistencies in group expression ownership.
- Minor code cleanups and import adjustments to support the above changes. [[1]](diffhunk://#diff-f2c9bd79c6c7c9fa7e4b0792f27a6bd63577b02f9ff49c43b50c5dbf1ace55d5R21-L26) [[2]](diffhunk://#diff-c734d959249b73c3db507a3071902d220645ed1bffa153502813d70feea12fd4L22) [[3]](diffhunk://#diff-dc5e6a82ea2e54bd9bcf8da1b1b65d59758b5104ecf25221b6f839c8e427df99R22) [[4]](diffhunk://#diff-dc5e6a82ea2e54bd9bcf8da1b1b65d59758b5104ecf25221b6f839c8e427df99R31) [[5]](diffhunk://#diff-cab02f11d1f8442aa712018479c1a80992ae8a928ff5416a47541b71a5a212f2R79) [[6]](diffhunk://#diff-005f37cce3e0bdb9ebc11c41e229d29bf6b6ad5e5aa050f51762adffe5f13470L57-R57) [[7]](diffhunk://#diff-624f1cd8f9c142c50fa19fd3c98f8e6882215729b32f60049580dc93188109c5R23)

**Test Result:**

- In TPC-DS Q72, this PR could reduce enforcer number from 89837 to 16344, reduce Memory usage more than 200MB.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

