### PR TITLE
[Fix](function) fix wrong nested value of null returned by element_at

### DIFF
--- a/be/src/vec/columns/column_decimal.h
+++ b/be/src/vec/columns/column_decimal.h
@@ -141,6 +141,7 @@ public:
 
     void insert_data(const char* pos, size_t /*length*/) override;
     void insert_default() override { data.push_back(value_type()); }
+    value_type scalar_default_value() const { return value_type(); }
     void insert(const Field& x) override {
         data.push_back(
                 doris::vectorized::get<typename PrimitiveTypeTraits<T>::NearestFieldType>(x));

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -178,6 +178,7 @@ public:
     }
 
     void insert_default() override { data.push_back(default_value()); }
+    value_type scalar_default_value() const { return default_value(); }
 
     void insert_many_defaults(size_t length) override {
         size_t old_size = data.size();

--- a/be/src/vec/functions/array/function_array_element.h
+++ b/be/src/vec/functions/array/function_array_element.h
@@ -175,10 +175,10 @@ private:
     ColumnPtr _execute_number(const ColumnArray::Offsets64& offsets, const IColumn& nested_column,
                               const UInt8* arr_null_map, const IColumn& indices,
                               const UInt8* nested_null_map, UInt8* dst_null_map) const {
-        const auto& nested_data = reinterpret_cast<const ColumnType&>(nested_column).get_data();
+        const auto& nested_data = assert_cast<const ColumnType&>(nested_column).get_data();
 
         auto dst_column = nested_column.clone_empty();
-        auto& dst_data = reinterpret_cast<ColumnType&>(*dst_column).get_data();
+        auto& dst_data = assert_cast<ColumnType&>(*dst_column).get_data();
         dst_data.resize(offsets.size());
 
         // process
@@ -203,7 +203,8 @@ private:
             // actual data copy
             if (null_flag) {
                 dst_null_map[row] = true;
-                dst_data[row] = typename ColumnType::value_type();
+                // scalar type -> ColumnVector/ColumnDecimal -> scalar_default_value
+                dst_data[row] = assert_cast<ColumnType&>(*dst_column).scalar_default_value();
             } else {
                 DCHECK(index >= 0 && index < nested_data.size());
                 dst_null_map[row] = false;

--- a/regression-test/data/nereids_function_p0/scalar_function/nereids_scalar_fn_map.out
+++ b/regression-test/data/nereids_function_p0/scalar_function/nereids_scalar_fn_map.out
@@ -3722,3 +3722,11 @@ false
 -- !sql --
 {"{"zip":10001}":"{"city":"NY"}", "{"code":10002}":"{"state":"NY"}"}
 
+-- !element_at_tint_date_dayname --
+\N
+Sunday
+
+-- !element_at_tint_date_dayname_notnull --
+\N
+Saturday
+

--- a/regression-test/suites/nereids_function_p0/scalar_function/nereids_scalar_fn_map.groovy
+++ b/regression-test/suites/nereids_function_p0/scalar_function/nereids_scalar_fn_map.groovy
@@ -35,6 +35,7 @@ suite("nereids_scalar_fn_map") {
     order_qt_element_at_str_tint    """ select km_str_tint[kstr] from fn_test """
     order_qt_element_at_date_tint   """ select km_date_tint[kdt] from fn_test """
     order_qt_element_at_dtm_tint    """ select km_dtm_tint[kdtm] from fn_test """
+
     order_qt_element_at_bool_tint_notnull   """ select km_bool_tint[kbool] from fn_test_not_nullable """
     order_qt_element_at_tint_tint_notnull   """ select km_tint_tint[ktint] from fn_test_not_nullable """
     order_qt_element_at_sint_tint_notnull   """ select km_sint_tint[ksint] from fn_test_not_nullable """
@@ -314,4 +315,24 @@ suite("nereids_scalar_fn_map") {
     qt_sql "select map('postal_code', 10001, 'area_code', 10002, 'zip_plus_4', 10003)"
     qt_sql "select map('{\"zip\":10001}', '{\"city\":\"NY\"}', '{\"code\":10002}', '{\"state\":\"NY\"}')"
 
+    sql """ drop table if exists fn_test_element_at_map_date """
+    sql """
+        create table fn_test_element_at_map_date (
+            id int null,
+            m map<tinyint, date> null
+        ) engine=olap
+        distributed by hash(id) buckets 1
+        properties('replication_num' = '1')
+    """
+    sql """
+        insert into fn_test_element_at_map_date values
+        (1, map(1,null, 2,'2023-12-16')),
+        (2, map(1,'2023-01-01', 2,null));
+    """
+    order_qt_element_at_tint_date_dayname         """
+    select dayname(element_at(m, 1)) from fn_test_element_at_map_date
+    """
+    order_qt_element_at_tint_date_dayname_notnull """
+    select dayname(element_at(m, 2)) from fn_test_element_at_map_date
+    """
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

before the function `element_at` return the column's value type inside null. but it's not the correct default value( for datelike types). so in default framework, some subsequent function call will raise false alarm.

before:
```sql
mysql> select 
    -> dayname (
    ->                 element_at (
    ->                     col_map_date__date__undef_signed_not_null,
    ->                     '2023-12-16'
    ->                 )
    ->             ) from table_1_20_undef_partitions2_keys3_properties4_distributed_by5;
```
coredump.
now:
```sql
mysql> select 
    -> dayname (
    ->                 element_at (
    ->                     col_map_date__date__undef_signed_not_null,
    ->                     '2023-12-16'
    ->                 )
    ->             ) from table_1_20_undef_partitions2_keys3_properties4_distributed_by5;
+--------------------------------------------------------------------------------------------------------------------------------+
| element_at (
                    col_map_date__date__undef_signed_not_null,
                    '2023-12-16'
                ) |
+--------------------------------------------------------------------------------------------------------------------------------+
| NULL                                                                                                                           |
| 2023-12-09                                                                                                                     |
......
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

