### PR TITLE
[fix](simplify range) no merge compound value with different references

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyRangeTest.java
@@ -307,7 +307,7 @@ public class SimplifyRangeTest extends ExpressionRewrite {
         assertRewrite("TA > 5 + 1 and TA > 10", "cast(TA as smallint) > 6 and TA > 10");
         assertRewrite("(TA > 1 and TA > 10) or TA > 20", "TA > 10");
         assertRewrite("(TA > 1 or TA > 10) and TA > 20", "TA > 20");
-        assertRewrite("(TA < 1 and TA > 10) or TA = 20 and TB > 10", "TA = 20 and TB > 10 or (TA is null and null) ");
+        assertRewrite("(TA < 1 and TA > 10) or TA = 20 and TB > 10", "(TA is null and null) or TA = 20 and TB > 10");
         assertRewrite("(TA + TB > 1 or TA + TB > 10) and TA + TB > 20", "TA + TB > 20");
         assertRewrite("TA > 10 or TA > 10", "TA > 10");
         assertRewrite("(TA > 10 or TA > 20) and (TB > 10 and TB < 20)", "TA > 10 and (TB > 10 and TB < 20) ");


### PR DESCRIPTION
simplify range have exception:

```
mysql >  explain select pk from table_0_500_undef_partitions2_keys3_properties4_distributed_by5 where  not ( date_sub(col_date_undef_signed, interval 1 day) > '2010-03-21' or null ) or lower(col_varchar_20__undef_signed) between null and 'e';
(1105, "errCode = 2, detailMessage = Cannot compare two values with different data types: 2010-03-22 (DATEV2) vs 'e' (VARCHAR(1))")
```

PR #57537  introduce  merging compound value with other value desc.

when merge value desc, it will merge values with the same reference.

but for compound value,  its reference have other meaning:
1) a < 1 or a > 10,  this is a compound value,  its reference is a;
2) a < 1 or b > 10,  this is a compound value,  its reference is 'a < 1 or b > 10'.

then for expression  `TA > 1 and FALSE  or FALSE and SB > 'abc''`,  for the operator OR,  it will have two compound values:
a.  C1 = CompoundValue(referece = getCompoundExpression(TA > 1 and FALSE) = FALSE,   source values={TA > 1,  FALSE})
b.  C2 = CompoundValue(reference = getCompoundExpression(FALSE and SB > 'abc') = FALSE, source values={FALSE, SB > 'abc'})

because the function getCompoundExpression will fold constant,  then C1 andC2's referece will be 'FALSE', and since C1 and C2's reference equals, then will try merge C1 and C2,  then will check merge ' >  1'  and ' > abc'  will cause the above exception.

to fix this,  for a compound value if its source values different reference (like a < 1 or b > 10)， then don't merge it with other values descs.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

