### PR TITLE
Update ColocationGroupProcDir.java

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ColocationGroupProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ColocationGroupProcDir.java
@@ -60,9 +60,46 @@ public class ColocationGroupProcDir implements ProcDirInterface {
 
         GroupId groupId = new GroupId(dbId, grpId);
         ColocateTableIndex index = Env.getCurrentColocateIndex();
-        Map<Tag, List<List<Long>>> beSeqs = index.getBackendsPerBucketSeq(groupId);
+        Map<Tag, List<List<Long>>> beSeqs;
+        
+         // ==========Core modification: Distinguish between cloud/non-cloud environments to obtain the BE sequence==========
+        if (CloudReplica.isCloudEnv()) {
+            // Cloud environment: Call CloudReplica to obtain the Colocated BE ID and construct the compatible beSeqs structure
+            beSeqs = buildCloudBeSeqs(dbId, grpId);
+        } else {
+            // Non-cloud environment: Maintain the original logic
+            beSeqs = index.getBackendsPerBucketSeq(groupId);
+        }
+
         return new ColocationGroupBackendSeqsProcNode(beSeqs);
     }
+
+    /**
+     * Construct the beSeqs data structure in the cloud environment and match it with the format of the non-cloud environment.
+     * @param dbId dbId of the Colocation Group
+     * @param grpId grpId of Colocation Group
+     * @return Compatible Map structure of type <Tag, List<List<Long>>>
+     */
+    private Map<Tag, List<List<Long>>> buildCloudBeSeqs(long dbId, long grpId) {
+        Map<Tag, List<List<Long>>> beSeqs = Maps.newHashMap();
+        
+        // 1.Call the core function of the cloud environment to obtain the list of associated BE IDs
+        List<Long> colocatedBeIds = CloudReplica.getColocatedBeId(dbId, grpId);
+        
+        // 2. Construct a structure that is compatible with the original format (the Tag is set to DEFAULT, and the Bucket sequence is organized according to the BE ID)
+        // Original format description:
+        // - Key: Tag(Resource Label)
+        // - Value: List<List<Long>> → The outer List corresponds to the Bucket sequence, and the inner List corresponds to the BE ID list of each Bucket.
+        Tag defaultTag = Tag.DEFAULT_TAG;
+        List<List<Long>> bucketSeqs = Lists.newArrayList();
+        
+        // Simplified processing in the cloud environment: A single Bucket sequence contains all the associated BE IDs
+        bucketSeqs.add(colocatedBeIds);
+        
+        beSeqs.put(defaultTag, bucketSeqs);
+        return beSeqs;
+    }
+
 
     @Override
     public ProcResult fetchResult() throws AnalysisException {


### PR DESCRIPTION
In the lookup function, add a judgment for the cloud environment, call CloudReplica.getColocatedBeId to obtain the BE ID, and construct beSeqs that are compatible with the original format.

### What problem does this PR solve?
In the lookup function, add a judgment for the cloud environment, call CloudReplica.getColocatedBeId to obtain the BE ID, and construct beSeqs that are compatible with the original format.

Issue Number: close #xxx

solve issue #55756
