### PR TITLE
[Bug](runtime-filter) use rf_lock to lock local_state.conjuncts read operator

### DIFF
--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -1089,18 +1089,6 @@ int64_t ScanLocalState<Derived>::limit_per_scanner() {
 }
 
 template <typename Derived>
-Status ScanLocalState<Derived>::clone_conjunct_ctxs(vectorized::VExprContextSPtrs& conjuncts) {
-    if (!_conjuncts.empty()) {
-        std::unique_lock l(_conjunct_lock);
-        conjuncts.resize(_conjuncts.size());
-        for (size_t i = 0; i != _conjuncts.size(); ++i) {
-            RETURN_IF_ERROR(_conjuncts[i]->clone(state(), conjuncts[i]));
-        }
-    }
-    return Status::OK();
-}
-
-template <typename Derived>
 Status ScanLocalState<Derived>::_init_profile() {
     // 1. counters for scan node
     _rows_read_counter = ADD_COUNTER(custom_profile(), "RowsRead", TUnit::UNIT);

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -68,7 +68,6 @@ public:
 
     virtual int64_t limit_per_scanner() = 0;
 
-    virtual Status clone_conjunct_ctxs(vectorized::VExprContextSPtrs& conjuncts) = 0;
     virtual void set_scan_ranges(RuntimeState* state,
                                  const std::vector<TScanRangeParams>& scan_ranges) = 0;
     virtual TPushAggOp::type get_push_down_agg_type() = 0;
@@ -122,7 +121,6 @@ protected:
     RuntimeProfile::Counter* _scan_bytes = nullptr;
 
     RuntimeFilterConsumerHelper _helper;
-    std::mutex _conjunct_lock;
     // magic number as seed to generate hash value for condition cache
     uint64_t _condition_cache_digest = 0;
 };
@@ -152,7 +150,6 @@ class ScanLocalState : public ScanLocalStateBase {
 
     int64_t limit_per_scanner() override;
 
-    Status clone_conjunct_ctxs(vectorized::VExprContextSPtrs& conjuncts) override;
     void set_scan_ranges(RuntimeState* state,
                          const std::vector<TScanRangeParams>& scan_ranges) override {}
 

--- a/be/src/runtime_filter/runtime_filter_consumer_helper.cpp
+++ b/be/src/runtime_filter/runtime_filter_consumer_helper.cpp
@@ -135,8 +135,8 @@ Status RuntimeFilterConsumerHelper::clone_conjunct_ctxs(
         vectorized::VExprContextSPtrs& local_state_conjuncts) {
     std::unique_lock l(_rf_locks);
     scanner_conjuncts.resize(local_state_conjuncts.size());
-    for (size_t i = 0; i != _conjuncts.size(); ++i) {
-        RETURN_IF_ERROR(_conjuncts[i]->clone(state(), conjuncts[i]));
+    for (size_t i = 0; i != local_state_conjuncts.size(); ++i) {
+        RETURN_IF_ERROR(local_state_conjuncts[i]->clone(state, scanner_conjuncts[i]));
     }
     return Status::OK();
 }

--- a/be/src/runtime_filter/runtime_filter_consumer_helper.cpp
+++ b/be/src/runtime_filter/runtime_filter_consumer_helper.cpp
@@ -130,6 +130,17 @@ Status RuntimeFilterConsumerHelper::try_append_late_arrival_runtime_filter(
     return Status::OK();
 }
 
+Status RuntimeFilterConsumerHelper::clone_conjunct_ctxs(
+        RuntimeState* state, vectorized::VExprContextSPtrs& scanner_conjuncts,
+        vectorized::VExprContextSPtrs& local_state_conjuncts) {
+    std::unique_lock l(_rf_locks);
+    scanner_conjuncts.resize(local_state_conjuncts.size());
+    for (size_t i = 0; i != _conjuncts.size(); ++i) {
+        RETURN_IF_ERROR(_conjuncts[i]->clone(state(), conjuncts[i]));
+    }
+    return Status::OK();
+}
+
 void RuntimeFilterConsumerHelper::collect_realtime_profile(
         RuntimeProfile* parent_operator_profile) {
     std::ignore = parent_operator_profile->add_counter("RuntimeFilterInfo", TUnit::NONE,

--- a/be/src/runtime_filter/runtime_filter_consumer_helper.h
+++ b/be/src/runtime_filter/runtime_filter_consumer_helper.h
@@ -48,6 +48,10 @@ public:
                                                   vectorized::VExprContextSPtrs& conjuncts,
                                                   const RowDescriptor& row_descriptor);
 
+    Status clone_conjunct_ctxs(RuntimeState* state,
+                               vectorized::VExprContextSPtrs& scanner_conjuncts,
+                               vectorized::VExprContextSPtrs& local_state_conjuncts);
+
     // Called by XXXLocalState::close()
     // parent_operator_profile is owned by LocalState so update it is safe at here.
     void collect_realtime_profile(RuntimeProfile* parent_operator_profile);

--- a/be/src/vec/exec/scan/scanner.cpp
+++ b/be/src/vec/exec/scan/scanner.cpp
@@ -247,7 +247,8 @@ Status Scanner::try_append_late_arrival_runtime_filter() {
     }
     // Notice that the number of runtime filters may be larger than _applied_rf_num.
     // But it is ok because it will be updated at next time.
-    RETURN_IF_ERROR(_local_state->clone_conjunct_ctxs(_conjuncts));
+    RETURN_IF_ERROR(_local_state->_helper.clone_conjunct_ctxs(_state, _conjuncts,
+                                                              _local_state->_conjuncts));
     _applied_rf_num = arrived_rf_num;
     return Status::OK();
 }


### PR DESCRIPTION
### What problem does this PR solve?
Currently, the reading and writing of conjuncts are not using the same lock, which may cause errors when reading conjuncts during vector expansion.

This pull request refactors how conjunct contexts are cloned in the scan operator pipeline. The main change is moving the responsibility for cloning conjunct contexts from the `ScanLocalState` class to the `RuntimeFilterConsumerHelper` class, simplifying the interface and improving encapsulation.

**Refactoring and responsibility shift:**

* Removed the `clone_conjunct_ctxs` method from `ScanLocalState` and its base class, along with related members such as `_conjunct_lock`. This simplifies the scan local state classes and reduces their responsibilities. [[1]](diffhunk://#diff-ac38473f151ccd99db4ed80dfbfa176f4f957ae2f5335ce8fbb4f5dbb0e932e9L1091-L1102) [[2]](diffhunk://#diff-f5a0db9faf0b649227b0126cca493d8dce22c9d497116fd480d7d018ce1696d2L71) [[3]](diffhunk://#diff-f5a0db9faf0b649227b0126cca493d8dce22c9d497116fd480d7d018ce1696d2L125) [[4]](diffhunk://#diff-f5a0db9faf0b649227b0126cca493d8dce22c9d497116fd480d7d018ce1696d2L155)
* Added a new `clone_conjunct_ctxs` method to `RuntimeFilterConsumerHelper`, which now handles cloning of conjunct contexts, including locking and context management. [[1]](diffhunk://#diff-ed4cbc22dcb1b5d27652827cea0f12373591a9b06e3c857f0dd0e32f58422026R133-R143) [[2]](diffhunk://#diff-61d96ad649abf519ee21143b6a4d9ed0c1b820ba273281ca8650a1e047d10f15R51-R54)

**Integration and usage updates:**

* Updated the `Scanner::try_append_late_arrival_runtime_filter` method to use the new `clone_conjunct_ctxs` method from `RuntimeFilterConsumerHelper` instead of the previous approach.
### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

