### PR TITLE
[Bug](cte) do not release stream_recvr in close

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -92,7 +92,7 @@ namespace pipeline {
 ExchangeSinkBuffer::ExchangeSinkBuffer(PUniqueId query_id, PlanNodeId dest_node_id,
                                        PlanNodeId node_id, RuntimeState* state,
                                        const std::vector<InstanceLoId>& sender_ins_ids)
-        : HasTaskExecutionCtx(state, false),
+        : HasTaskExecutionCtx(state),
           _queue_capacity(0),
           _is_failed(false),
           _query_id(std::move(query_id)),

--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -269,7 +269,7 @@ public:
                        RuntimeState* state, const std::vector<InstanceLoId>& sender_ins_ids);
 #ifdef BE_TEST
     ExchangeSinkBuffer(RuntimeState* state, int64_t sinknum)
-            : HasTaskExecutionCtx(state, false), _state(state), _exchange_sink_num(sinknum) {};
+            : HasTaskExecutionCtx(state), _state(state), _exchange_sink_num(sinknum) {};
 #endif
 
     ~ExchangeSinkBuffer() override = default;

--- a/be/src/pipeline/exec/exchange_source_operator.cpp
+++ b/be/src/pipeline/exec/exchange_source_operator.cpp
@@ -50,7 +50,7 @@ ExchangeLocalState::~ExchangeLocalState() {
 std::string ExchangeLocalState::debug_string(int indentation_level) const {
     fmt::memory_buffer debug_string_buffer;
     fmt::format_to(debug_string_buffer, "{}, recvr: ({})", Base::debug_string(indentation_level),
-                   stream_recvr ? stream_recvr->debug_string() : "null");
+                   stream_recvr->debug_string());
     return fmt::to_string(debug_string_buffer);
 }
 
@@ -210,7 +210,6 @@ Status ExchangeLocalState::close(RuntimeState* state) {
     }
     if (stream_recvr != nullptr) {
         stream_recvr->close();
-        stream_recvr.reset();
     }
     if (_parent->cast<ExchangeSourceOperatorX>()._is_merging) {
         vsort_exec_exprs.close(state);

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -1239,7 +1239,7 @@ Status ScanLocalState<Derived>::close(RuntimeState* state) {
         ctx->stop_scanners(state);
         // _scanner_ctx may be accessed in debug_string concurrently
         // so use atomic shared ptr to avoid use after free
-        _scanner_ctx.reset();
+        _scanner_ctx.store(nullptr);
     }
     std::list<std::shared_ptr<vectorized::ScannerDelegate>> {}.swap(_scanners);
     COUNTER_SET(_wait_for_dependency_timer, _scan_dependency->watcher_elapse_time());

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -1237,6 +1237,9 @@ Status ScanLocalState<Derived>::close(RuntimeState* state) {
     SCOPED_TIMER(exec_time_counter());
     if (auto ctx = _scanner_ctx.load()) {
         ctx->stop_scanners(state);
+        // _scanner_ctx may be accessed in debug_string concurrently
+        // so use atomic shared ptr to avoid use after free
+        _scanner_ctx.reset();
     }
     std::list<std::shared_ptr<vectorized::ScannerDelegate>> {}.swap(_scanners);
     COUNTER_SET(_wait_for_dependency_timer, _scan_dependency->watcher_elapse_time());

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -1237,7 +1237,6 @@ Status ScanLocalState<Derived>::close(RuntimeState* state) {
     SCOPED_TIMER(exec_time_counter());
     if (_scanner_ctx) {
         _scanner_ctx->stop_scanners(state);
-        _scanner_ctx.reset();
     }
     std::list<std::shared_ptr<vectorized::ScannerDelegate>> {}.swap(_scanners);
     COUNTER_SET(_wait_for_dependency_timer, _scan_dependency->watcher_elapse_time());

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -173,9 +173,9 @@ Status ScanLocalState<Derived>::open(RuntimeState* state) {
 
     auto status = _eos ? Status::OK() : _prepare_scanners();
     RETURN_IF_ERROR(status);
-    if (_scanner_ctx) {
+    if (auto ctx = _scanner_ctx.load()) {
         DCHECK(!_eos && _num_scanners->value() > 0);
-        RETURN_IF_ERROR(_scanner_ctx->init());
+        RETURN_IF_ERROR(ctx->init());
     }
     _opened = true;
     return status;
@@ -565,9 +565,9 @@ std::string ScanLocalState<Derived>::debug_string(int indentation_level) const {
     fmt::format_to(debug_string_buffer, "{}, _eos = {} , _opened = {}",
                    PipelineXLocalState<>::debug_string(indentation_level), _eos.load(),
                    _opened.load());
-    if (_scanner_ctx) {
+    if (auto ctx = _scanner_ctx.load()) {
         fmt::format_to(debug_string_buffer, "");
-        fmt::format_to(debug_string_buffer, ", Scanner Context: {}", _scanner_ctx->debug_string());
+        fmt::format_to(debug_string_buffer, ", Scanner Context: {}", ctx->debug_string());
     } else {
         fmt::format_to(debug_string_buffer, "");
         fmt::format_to(debug_string_buffer, ", Scanner Context: NULL");
@@ -1235,8 +1235,8 @@ Status ScanLocalState<Derived>::close(RuntimeState* state) {
     SCOPED_TIMER(_close_timer);
 
     SCOPED_TIMER(exec_time_counter());
-    if (_scanner_ctx) {
-        _scanner_ctx->stop_scanners(state);
+    if (auto ctx = _scanner_ctx.load()) {
+        ctx->stop_scanners(state);
     }
     std::list<std::shared_ptr<vectorized::ScannerDelegate>> {}.swap(_scanners);
     COUNTER_SET(_wait_for_dependency_timer, _scan_dependency->watcher_elapse_time());
@@ -1252,8 +1252,8 @@ Status ScanOperatorX<LocalStateType>::get_block(RuntimeState* state, vectorized:
     SCOPED_TIMER(local_state.exec_time_counter());
 
     if (state->is_cancelled()) {
-        if (local_state._scanner_ctx) {
-            local_state._scanner_ctx->stop_scanners(state);
+        if (auto ctx = local_state._scanner_ctx.load()) {
+            ctx->stop_scanners(state);
         }
         return state->cancel_reason();
     }
@@ -1263,13 +1263,15 @@ Status ScanOperatorX<LocalStateType>::get_block(RuntimeState* state, vectorized:
         return Status::OK();
     }
 
-    DCHECK(local_state._scanner_ctx != nullptr);
-    RETURN_IF_ERROR(local_state._scanner_ctx->get_block_from_queue(state, block, eos, 0));
+    auto ctx = local_state._scanner_ctx.load();
+
+    DCHECK(ctx != nullptr);
+    RETURN_IF_ERROR(ctx->get_block_from_queue(state, block, eos, 0));
 
     local_state.reached_limit(block, eos);
     if (*eos) {
         // reach limit, stop the scanners.
-        local_state._scanner_ctx->stop_scanners(state);
+        ctx->stop_scanners(state);
         local_state._scanner_profile->add_info_string("EOS", "True");
     }
 
@@ -1279,16 +1281,16 @@ Status ScanOperatorX<LocalStateType>::get_block(RuntimeState* state, vectorized:
 template <typename LocalStateType>
 size_t ScanOperatorX<LocalStateType>::get_reserve_mem_size(RuntimeState* state) {
     auto& local_state = get_local_state(state);
-    if (!local_state._opened || local_state._closed || !local_state._scanner_ctx) {
+    auto ctx = local_state._scanner_ctx.load();
+    if (!local_state._opened || local_state._closed || !ctx) {
         return config::doris_scanner_row_bytes;
     }
 
     if (local_state.low_memory_mode()) {
-        return local_state._scanner_ctx->low_memory_mode_scan_bytes_per_scanner() *
-               local_state._scanner_ctx->low_memory_mode_scanners();
+        return ctx->low_memory_mode_scan_bytes_per_scanner() * ctx->low_memory_mode_scanners();
     } else {
         const auto peak_usage = local_state._memory_used_counter->value();
-        const auto block_usage = local_state._scanner_ctx->block_memory_usage();
+        const auto block_usage = ctx->block_memory_usage();
         if (peak_usage > 0) {
             // It is only a safty check, to avoid some counter not right.
             if (peak_usage > block_usage) {

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -310,7 +310,7 @@ protected:
     vectorized::VExprContextSPtrs _stale_expr_ctxs;
     vectorized::VExprContextSPtrs _common_expr_ctxs_push_down;
 
-    std::shared_ptr<vectorized::ScannerContext> _scanner_ctx = nullptr;
+    atomic_shared_ptr<vectorized::ScannerContext> _scanner_ctx = nullptr;
 
     // Save all function predicates which may be pushed down to data source.
     std::vector<FunctionFilter> _push_down_functions;
@@ -374,8 +374,8 @@ public:
     void set_low_memory_mode(RuntimeState* state) override {
         auto& local_state = get_local_state(state);
 
-        if (local_state._scanner_ctx) {
-            local_state._scanner_ctx->clear_free_blocks();
+        if (auto ctx = local_state._scanner_ctx.load()) {
+            ctx->clear_free_blocks();
         }
     }
 

--- a/be/src/runtime/task_execution_context.cpp
+++ b/be/src/runtime/task_execution_context.cpp
@@ -19,10 +19,7 @@
 
 #include <glog/logging.h>
 
-#include <atomic>
 #include <condition_variable>
-
-#include "util/stack_util.h"
 
 namespace doris {
 void TaskExecutionContext::ref_task_execution_ctx() {
@@ -36,25 +33,8 @@ void TaskExecutionContext::unref_task_execution_ctx() {
     }
 }
 
-HasTaskExecutionCtx::HasTaskExecutionCtx(RuntimeState* state, bool maintain_ref_count)
-        : task_exec_ctx_(state->get_task_execution_context()),
-          _maintain_ref_count(maintain_ref_count) {
-    if (!_maintain_ref_count) {
-        return;
-    }
-    TaskExecutionContextSPtr task_exec_ctx = task_exec_ctx_.lock();
-    if (task_exec_ctx) {
-        task_exec_ctx->ref_task_execution_ctx();
-    }
-}
+HasTaskExecutionCtx::HasTaskExecutionCtx(RuntimeState* state)
+        : task_exec_ctx_(state->get_task_execution_context()) {}
 
-HasTaskExecutionCtx::~HasTaskExecutionCtx() {
-    if (!_maintain_ref_count) {
-        return;
-    }
-    TaskExecutionContextSPtr task_exec_ctx = task_exec_ctx_.lock();
-    if (task_exec_ctx) {
-        task_exec_ctx->unref_task_execution_ctx();
-    }
-}
+HasTaskExecutionCtx::~HasTaskExecutionCtx() = default;
 } // namespace doris

--- a/be/src/runtime/task_execution_context.h
+++ b/be/src/runtime/task_execution_context.h
@@ -54,7 +54,7 @@ using TaskExecutionContextSPtr = std::shared_ptr<TaskExecutionContext>;
 struct HasTaskExecutionCtx {
     using Weak = typename TaskExecutionContextSPtr::weak_type;
 
-    HasTaskExecutionCtx(RuntimeState* state, bool maintain_ref_count);
+    HasTaskExecutionCtx(RuntimeState* state);
 
     virtual ~HasTaskExecutionCtx();
 
@@ -64,7 +64,6 @@ public:
 
 private:
     Weak task_exec_ctx_;
-    bool _maintain_ref_count;
 };
 
 } // namespace doris

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -62,7 +62,7 @@ ScannerContext::ScannerContext(
         int num_parallel_instances
 #endif
         )
-        : HasTaskExecutionCtx(state, true),
+        : HasTaskExecutionCtx(state),
           _state(state),
           _local_state(local_state),
           _output_tuple_desc(output_row_descriptor

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -98,6 +98,9 @@ ScannerContext::ScannerContext(
     }
     _dependency = dependency;
     DorisMetrics::instance()->scanner_ctx_cnt->increment(1);
+    if (task_exec_ctx()) {
+        task_exec_ctx()->ref_task_execution_ctx();
+    }
 }
 
 // After init function call, should not access _parent
@@ -191,6 +194,9 @@ ScannerContext::~ScannerContext() {
             static_cast<void>(task_executor_scheduler->task_executor()->remove_task(_task_handle));
         }
         _task_handle = nullptr;
+    }
+    if (task_exec_ctx()) {
+        task_exec_ctx()->unref_task_execution_ctx();
     }
 }
 

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -67,10 +67,6 @@ public:
         DorisMetrics::instance()->scanner_task_cnt->increment(1);
     }
 
-    ScanTask(std::shared_ptr<ResourceContext> resource_ctx,
-             std::weak_ptr<ScannerDelegate> delegate_scanner)
-            : _resource_ctx(std::move(resource_ctx)), scanner(delegate_scanner) {}
-
     ~ScanTask() {
         SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_resource_ctx->memory_context()->mem_tracker());
         cached_blocks.clear();

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -43,7 +43,6 @@
 #include "util/defer_op.h"
 #include "util/thread.h"
 #include "util/threadpool.h"
-#include "vec/columns/column_nothing.h"
 #include "vec/core/block.h"
 #include "vec/exec/scan/olap_scanner.h" // IWYU pragma: keep
 #include "vec/exec/scan/scan_node.h"

--- a/be/src/vec/exec/scan/scanner_scheduler.h
+++ b/be/src/vec/exec/scan/scanner_scheduler.h
@@ -54,15 +54,6 @@ struct SimplifiedScanTask {
         this->scan_func = scan_func;
         this->scanner_context = scanner_context;
         this->scan_task = scan_task;
-        if (scanner_context->task_exec_ctx()) {
-            scanner_context->task_exec_ctx()->ref_task_execution_ctx();
-        }
-    }
-
-    ~SimplifiedScanTask() {
-        if (scanner_context->task_exec_ctx()) {
-            scanner_context->task_exec_ctx()->unref_task_execution_ctx();
-        }
     }
 
     std::function<bool()> scan_func;

--- a/be/src/vec/exec/scan/scanner_scheduler.h
+++ b/be/src/vec/exec/scan/scanner_scheduler.h
@@ -54,6 +54,15 @@ struct SimplifiedScanTask {
         this->scan_func = scan_func;
         this->scanner_context = scanner_context;
         this->scan_task = scan_task;
+        if (scanner_context->task_exec_ctx()) {
+            scanner_context->task_exec_ctx()->ref_task_execution_ctx();
+        }
+    }
+
+    ~SimplifiedScanTask() {
+        if (scanner_context->task_exec_ctx()) {
+            scanner_context->task_exec_ctx()->unref_task_execution_ctx();
+        }
     }
 
     std::function<bool()> scan_func;

--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -372,7 +372,7 @@ VDataStreamRecvr::VDataStreamRecvr(VDataStreamMgr* stream_mgr,
                                    RuntimeState* state, const TUniqueId& fragment_instance_id,
                                    PlanNodeId dest_node_id, int num_senders, bool is_merging,
                                    RuntimeProfile* profile, size_t data_queue_capacity)
-        : HasTaskExecutionCtx(state, false),
+        : HasTaskExecutionCtx(state),
           _mgr(stream_mgr),
           _memory_used_counter(memory_used_counter),
           _resource_ctx(state->get_query_ctx()->resource_ctx()),

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1370,6 +1370,8 @@ build_cctz() {
     # -Wno-elaborated-enum-base to make C++20 on MacOS happy
     "${CMAKE_CMD}" -G "${GENERATOR}" \
     -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS -Wno-elaborated-enum-base" \
+    -DBUILD_EXAMPLES=OFF \
+    -DBUILD_TOOLS=OFF \
     -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" -DBUILD_TESTING=OFF ..
     "${BUILD_SYSTEM}" -j "${PARALLEL}" install
 }


### PR DESCRIPTION
### What problem does this PR solve?
relase stream_recvr may lead coredump in debug_string()
This pull request primarily refactors how task execution context reference counting is managed, moving the responsibility from the `HasTaskExecutionCtx` base class to the `ScannerContext` class. Additionally, it improves thread safety and atomic access for the scanner context in scan operators, and makes some minor optimizations and cleanup in related pipeline and exchange components.

The most important changes are:

### Task Execution Context Reference Counting

* Removed the `maintain_ref_count` logic from the `HasTaskExecutionCtx` class and its consumers, so that reference counting is now explicitly handled only within `ScannerContext`, simplifying object lifecycle management. (`be/src/runtime/task_execution_context.h`, `be/src/runtime/task_execution_context.cpp`, `be/src/pipeline/exec/exchange_sink_buffer.cpp`, `be/src/pipeline/exec/exchange_sink_buffer.h`, `be/src/vec/exec/scan/scanner_context.cpp`, `be/src/vec/runtime/vdata_stream_recvr.cpp`) [[1]](diffhunk://#diff-2b2849562b95eca79350a61b3ab4132724eaed501f27f760d7949f158531b992L57-R57) [[2]](diffhunk://#diff-e676627bdc430eb510faa67a5919dd16b5f47566c4e22c59384c821c7da042a3L39-R39) [[3]](diffhunk://#diff-1d297fbd1be58030c0f1c0193211c3a295bfa553ad412dea00beb4757c34ecc4L95-R95) [[4]](diffhunk://#diff-a4592d017ead7e98a51753f78f9e80336f4ce6f24262e9c488182090bcff0877L272-R272) [[5]](diffhunk://#diff-c2c3c9714f0d7100f18ba7f81f4067ddf9dd83d608eaddc6a3b621d2fef4f08cL65-R65) [[6]](diffhunk://#diff-72c868e2e5815f903b1617c9f5ef44d9cf903aa664ddb911ef1a9e28bd1d1efdL375-R375)

* `ScannerContext` now explicitly increments and decrements the task execution context reference count in its constructor and destructor, ensuring correct resource management. (`be/src/vec/exec/scan/scanner_context.cpp`) [[1]](diffhunk://#diff-c2c3c9714f0d7100f18ba7f81f4067ddf9dd83d608eaddc6a3b621d2fef4f08cR101-R103) [[2]](diffhunk://#diff-c2c3c9714f0d7100f18ba7f81f4067ddf9dd83d608eaddc6a3b621d2fef4f08cR198-R200)

### Thread Safety and Atomic Access

* Changed `_scanner_ctx` in `ScanLocalState` to use `atomic_shared_ptr`, and updated all accesses to use atomic load for thread safety. (`be/src/pipeline/exec/scan_operator.h`, `be/src/pipeline/exec/scan_operator.cpp`) [[1]](diffhunk://#diff-f5a0db9faf0b649227b0126cca493d8dce22c9d497116fd480d7d018ce1696d2L313-R313) [[2]](diffhunk://#diff-ac38473f151ccd99db4ed80dfbfa176f4f957ae2f5335ce8fbb4f5dbb0e932e9L176-R178) [[3]](diffhunk://#diff-ac38473f151ccd99db4ed80dfbfa176f4f957ae2f5335ce8fbb4f5dbb0e932e9L568-R570) [[4]](diffhunk://#diff-ac38473f151ccd99db4ed80dfbfa176f4f957ae2f5335ce8fbb4f5dbb0e932e9L1238-R1239) [[5]](diffhunk://#diff-ac38473f151ccd99db4ed80dfbfa176f4f957ae2f5335ce8fbb4f5dbb0e932e9L1256-R1256) [[6]](diffhunk://#diff-ac38473f151ccd99db4ed80dfbfa176f4f957ae2f5335ce8fbb4f5dbb0e932e9L1267-R1274) [[7]](diffhunk://#diff-ac38473f151ccd99db4ed80dfbfa176f4f957ae2f5335ce8fbb4f5dbb0e932e9L1283-R1293) [[8]](diffhunk://#diff-f5a0db9faf0b649227b0126cca493d8dce22c9d497116fd480d7d018ce1696d2L377-R378)

### Pipeline and Exchange Improvements

* Improved cancellation handling in `PipelineFragmentContext::wait_close` by adding periodic checks for query cancellation and using `wait_for` instead of `wait` to avoid indefinite blocking. (`be/src/pipeline/pipeline_fragment_context.cpp`)
* Minor cleanup in exchange and scan operator components, such as removing unnecessary `reset()` calls and simplifying debug string generation. (`be/src/pipeline/exec/exchange_source_operator.cpp`, `be/src/vec/exec/scan/scanner_context.h`, `be/src/vec/exec/scan/scanner_scheduler.cpp`) [[1]](diffhunk://#diff-1e274a427d9138d0c5d6d9916fa9c4918d8be155e8bf070686a9def45c23a0d8L53-R53) [[2]](diffhunk://#diff-1e274a427d9138d0c5d6d9916fa9c4918d8be155e8bf070686a9def45c23a0d8L213) [[3]](diffhunk://#diff-1db0a440b7d7a41f9ca3c1eb77d3902395085d85b15f90b23ee50d2aeca8986aL70-L73) [[4]](diffhunk://#diff-fed6de54b050e0237779e951348e264cdc5255688fdc6f7c46502d31e4096c91L46)

### Build Script Optimization

* Disabled building of examples and tools in the third-party `cctz` build script for faster and leaner builds. (`thirdparty/build-thirdparty.sh`)
### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

