### PR TITLE
[Fix](restapi) fix node action restapi throw '-parameters' error because of PathVariable annotation without value declaration

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
@@ -611,8 +611,8 @@ public class NodeAction extends RestBaseController {
     }
 
     @PostMapping("/{action}/be")
-    public Object operateBackend(HttpServletRequest request, HttpServletResponse response, @PathVariable String action,
-            @RequestBody BackendReqInfo reqInfo) {
+    public Object operateBackend(HttpServletRequest request, HttpServletResponse response,
+            @PathVariable("action") String action, @RequestBody BackendReqInfo reqInfo) {
         try {
             if (needRedirect(request.getScheme())) {
                 return redirectToHttps(request);
@@ -659,7 +659,7 @@ public class NodeAction extends RestBaseController {
 
     @PostMapping("/{action}/fe")
     public Object operateFrontends(HttpServletRequest request, HttpServletResponse response,
-            @PathVariable String action, @RequestBody FrontendReqInfo reqInfo) {
+            @PathVariable("action") String action, @RequestBody FrontendReqInfo reqInfo) {
         try {
             if (needRedirect(request.getScheme())) {
                 return redirectToHttps(request);
@@ -691,7 +691,7 @@ public class NodeAction extends RestBaseController {
 
     @PostMapping("/{action}/broker")
     public Object operateBroker(HttpServletRequest request, HttpServletResponse response,
-                                @PathVariable String action, @RequestBody BrokerReqInfo reqInfo) {
+                                @PathVariable("action") String action, @RequestBody BrokerReqInfo reqInfo) {
         try {
             if (!Env.getCurrentEnv().isMaster()) {
                 return redirectToMasterOrException(request, response);


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
fix node action restapi throw '-parameters' error because of PathVariable annotation without value declaration

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Manual test (add detailed scripts or steps below)
[测试报告.docx](https://github.com/user-attachments/files/24549981/default.docx)

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

