### PR TITLE
branch-4.0: Fix: Ensure HUDI tables are processed correctly by throwing an error for incorrect PhysicalFileScan usage

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -656,6 +656,13 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
                                 fileScan.getTableSample().get().sampleValue, fileScan.getTableSample().get().seek));
                     }
                     break;
+                case HUDI:
+                    // HUDI table should be handled by visitPhysicalHudiScan, not here.
+                    // If we reach here, it means LogicalHudiScan was incorrectly converted to
+                    // PhysicalFileScan.
+                    throw new RuntimeException("HUDI table should use PhysicalHudiScan instead of PhysicalFileScan. "
+                            + "This indicates a bug in the optimizer rules. "
+                            + "FileScan class: " + fileScan.getClass().getSimpleName());
                 default:
                     throw new RuntimeException("do not support DLA type " + ((HMSExternalTable) table).getDlaType());
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHudiScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHudiScan.java
@@ -182,7 +182,8 @@ public class LogicalHudiScan extends LogicalFileScan {
     public LogicalFileScan withCachedOutput(List<Slot> cachedOutputs) {
         return new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
             selectedPartitions, tableSample, tableSnapshot, scanParams, incrementalRelation,
-            operativeSlots, virtualColumns, groupExpression, Optional.of(getLogicalProperties()), cachedOutputs);
+            operativeSlots, virtualColumns, groupExpression, Optional.of(getLogicalProperties()),
+            Optional.of(cachedOutputs));
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHudiScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHudiScan.java
@@ -178,6 +178,13 @@ public class LogicalHudiScan extends LogicalFileScan {
             operativeSlots, virtualColumns, groupExpression, Optional.of(getLogicalProperties()), cachedOutputs);
     }
 
+    @Override
+    public LogicalFileScan withCachedOutput(List<Slot> cachedOutputs) {
+        return new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
+            selectedPartitions, tableSample, tableSnapshot, scanParams, incrementalRelation,
+            operativeSlots, virtualColumns, groupExpression, Optional.of(getLogicalProperties()), cachedOutputs);
+    }
+
     /**
      * Set scan params for incremental read
      *


### PR DESCRIPTION
bp: #58413
LogicalHudiScan did not override withCachedOutput() method, causing HUDI table type information to be lost during optimization, and the table was incorrectly processed as PhysicalFileScan.