### PR TITLE
[fix](cloud) Fix memory leak in CloudTxnDeleteBitmapCache for empty rowsets

### DIFF
--- a/be/src/cloud/cloud_engine_calc_delete_bitmap_task.cpp
+++ b/be/src/cloud/cloud_engine_calc_delete_bitmap_task.cpp
@@ -222,7 +222,6 @@ Status CloudTabletCalcDeleteBitmapTask::handle() const {
             std::this_thread::sleep_for(std::chrono::seconds(sleep_time));
         }
     });
-
     Status status;
     if (_sub_txn_ids.empty()) {
         // Check empty rowset for non-sub_txn case

--- a/be/src/cloud/cloud_engine_calc_delete_bitmap_task.cpp
+++ b/be/src/cloud/cloud_engine_calc_delete_bitmap_task.cpp
@@ -223,13 +223,6 @@ Status CloudTabletCalcDeleteBitmapTask::handle() const {
         }
     });
 
-    // Check if this is a known empty/skipped rowset
-    if (_engine.txn_delete_bitmap_cache().is_empty_rowset(_transaction_id, _tablet_id)) {
-        LOG(INFO) << "tablet=" << _tablet_id << ", txn=" << _transaction_id
-                  << " is empty rowset, skip delete bitmap calculation";
-        return Status::OK();
-    }
-
     Status status;
     if (_sub_txn_ids.empty()) {
         status = _handle_rowset(tablet, _version);
@@ -293,6 +286,12 @@ Status CloudTabletCalcDeleteBitmapTask::_handle_rowset(
     int64_t transaction_id = sub_txn_id == -1 ? _transaction_id : sub_txn_id;
     std::string txn_str = "txn_id=" + std::to_string(_transaction_id) +
                           (sub_txn_id == -1 ? "" : ", sub_txn_id=" + std::to_string(sub_txn_id));
+    // Check if this is a known empty/skipped rowset
+    if (_engine.txn_delete_bitmap_cache().is_empty_rowset(_transaction_id, _tablet_id)) {
+        LOG(INFO) << "tablet=" << _tablet_id << ", txn=" << _transaction_id
+                  << " is empty rowset, skip delete bitmap calculation";
+        return Status::OK();
+    }
     RowsetSharedPtr rowset;
     DeleteBitmapPtr delete_bitmap;
     RowsetIdUnorderedSet rowset_ids;

--- a/be/src/cloud/cloud_engine_calc_delete_bitmap_task.cpp
+++ b/be/src/cloud/cloud_engine_calc_delete_bitmap_task.cpp
@@ -222,6 +222,14 @@ Status CloudTabletCalcDeleteBitmapTask::handle() const {
             std::this_thread::sleep_for(std::chrono::seconds(sleep_time));
         }
     });
+
+    // Check if this is a known empty/skipped rowset
+    if (_engine.txn_delete_bitmap_cache().is_empty_rowset(_transaction_id, _tablet_id)) {
+        LOG(INFO) << "tablet=" << _tablet_id << ", txn=" << _transaction_id
+                  << " is empty rowset, skip delete bitmap calculation";
+        return Status::OK();
+    }
+
     Status status;
     if (_sub_txn_ids.empty()) {
         status = _handle_rowset(tablet, _version);

--- a/be/src/cloud/cloud_rowset_builder.cpp
+++ b/be/src/cloud/cloud_rowset_builder.cpp
@@ -127,6 +127,15 @@ const RowsetMetaSharedPtr& CloudRowsetBuilder::rowset_meta() {
 
 Status CloudRowsetBuilder::set_txn_related_delete_bitmap() {
     if (_tablet->enable_unique_key_merge_on_write()) {
+        // For empty rowsets when skip_writing_empty_rowset_metadata=true,
+        // store only a lightweight marker instead of full rowset info.
+        // This allows CalcDeleteBitmapTask to detect and skip gracefully,
+        // while using minimal memory (~16 bytes per entry).
+        if (_skip_writing_rowset_metadata) {
+            _engine.txn_delete_bitmap_cache().mark_empty_rowset(_req.txn_id, _tablet->tablet_id(),
+                                                                _req.txn_expiration);
+            return Status::OK();
+        }
         if (config::enable_merge_on_write_correctness_check && _rowset->num_rows() != 0) {
             auto st = _tablet->check_delete_bitmap_correctness(
                     _delete_bitmap, _rowset->end_version() - 1, _req.txn_id, *_rowset_ids);

--- a/be/src/cloud/cloud_txn_delete_bitmap_cache.cpp
+++ b/be/src/cloud/cloud_txn_delete_bitmap_cache.cpp
@@ -229,7 +229,9 @@ void CloudTxnDeleteBitmapCache::remove_expired_tablet_txn_info() {
     std::unique_lock<std::shared_mutex> wlock(_rwlock);
     while (!_expiration_txn.empty()) {
         auto iter = _expiration_txn.begin();
-        if (_txn_map.find(iter->second) == _txn_map.end()) {
+        bool in_txn_map = _txn_map.find(iter->second) != _txn_map.end();
+        bool in_markers = _empty_rowset_markers.find(iter->second) != _empty_rowset_markers.end();
+        if (!in_txn_map && !in_markers) {
             _expiration_txn.erase(iter);
             continue;
         }
@@ -239,6 +241,7 @@ void CloudTxnDeleteBitmapCache::remove_expired_tablet_txn_info() {
         if (iter->first > current_time) {
             break;
         }
+        // Clean from _txn_map if exists
         auto txn_iter = _txn_map.find(iter->second);
         if ((txn_iter != _txn_map.end()) && (iter->first == txn_iter->second.txn_expiration)) {
             LOG_INFO("clean expired delete bitmap")
@@ -250,6 +253,14 @@ void CloudTxnDeleteBitmapCache::remove_expired_tablet_txn_info() {
             CacheKey cache_key(key_str);
             erase(cache_key);
             _txn_map.erase(iter->second);
+        }
+        // Clean from _empty_rowset_markers if exists
+        auto marker_iter = _empty_rowset_markers.find(iter->second);
+        if (marker_iter != _empty_rowset_markers.end()) {
+            LOG_INFO("clean expired empty rowset marker")
+                    .tag("txn_id", iter->second.txn_id)
+                    .tag("tablet_id", iter->second.tablet_id);
+            _empty_rowset_markers.erase(marker_iter);
         }
         _expiration_txn.erase(iter);
     }
@@ -270,6 +281,32 @@ void CloudTxnDeleteBitmapCache::remove_unused_tablet_txn_info(TTransactionId tra
         erase(cache_key);
         _txn_map.erase(txn_key);
     }
+}
+
+void CloudTxnDeleteBitmapCache::mark_empty_rowset(TTransactionId txn_id, int64_t tablet_id,
+                                                  int64_t txn_expiration) {
+    int64_t txn_expiration_min =
+            duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch())
+                    .count() +
+            config::tablet_txn_info_min_expired_seconds;
+    txn_expiration = std::max(txn_expiration_min, txn_expiration);
+
+    if (config::enable_mow_verbose_log) {
+        LOG_INFO("mark empty rowset")
+                .tag("txn_id", txn_id)
+                .tag("tablet_id", tablet_id)
+                .tag("expiration", txn_expiration);
+    }
+    std::unique_lock<std::shared_mutex> wlock(_rwlock);
+    TxnKey txn_key(txn_id, tablet_id);
+    _empty_rowset_markers.emplace(txn_key);
+    _expiration_txn.emplace(txn_expiration, txn_key);
+}
+
+bool CloudTxnDeleteBitmapCache::is_empty_rowset(TTransactionId txn_id, int64_t tablet_id) {
+    std::shared_lock<std::shared_mutex> rlock(_rwlock);
+    TxnKey txn_key(txn_id, tablet_id);
+    return _empty_rowset_markers.contains(txn_key);
 }
 
 void CloudTxnDeleteBitmapCache::_clean_thread_callback() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #54395

Problem Summary:
When skip_writing_empty_rowset_metadata is enabled, empty rowsets are not committed to meta-service. Previously, set_txn_related_delete_bitmap() would either:
1. Store full rowset info in cache (causing memory leak since sync_tablet_delete_bitmap_by_cache() never cleans it up), or
2. Skip storing entirely (causing CalcDeleteBitmapTask to fail with NOT_FOUND error)

This fix introduces a lightweight marker mechanism:
- For empty rowsets, store only a TxnKey marker (~16 bytes) instead of full rowset info
- CalcDeleteBitmapTask checks for marker via is_empty_rowset() and returns success if found (marker is NOT removed to support task retry)
- Cleanup is handled by expiration-based removal in remove_expired_tablet_txn_info()
- Expiration time is consistent with set_tablet_txn_info()

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

