### PR TITLE
[Fix](restapi) Fix Content-Length mismatch issue in RestBaseController forwardToMaster logic

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
@@ -266,6 +266,10 @@ public class RestBaseController extends BaseController {
 
             HttpHeaders headers = new HttpHeaders();
             for (String headerName : Collections.list(request.getHeaderNames())) {
+                // remove Content-Length because RestTemplate will recalculate Content-Length for request body
+                if ("Content-Length".equalsIgnoreCase(headerName)) {
+                    continue;
+                }
                 headers.add(headerName, request.getHeader(headerName));
             }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Fix Content-Length mismatch issue in RestBaseController forwardToMaster logic because of using RestTemplate.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Manual test (add detailed scripts or steps below)
[测试报告.docx](https://github.com/user-attachments/files/24525583/default.docx)

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

