### PR TITLE
[Feature](sql) Support filtering backends by ID in SHOW BACKENDS command

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -421,6 +421,7 @@ supportedShowStatement
     | SHOW (WARNINGS | ERRORS) limitClause?                                         #showWarningErrors
     | SHOW COUNT LEFT_PAREN ASTERISK RIGHT_PAREN (WARNINGS | ERRORS)                #showWarningErrorCount
     | SHOW BACKENDS                                                                 #showBackends
+    | SHOW BACKENDS backendIds+=INTEGER_VALUE (COMMA backendIds+=INTEGER_VALUE)*    #showBackendsWithIds
     | SHOW STAGES                                                                   #showStages
     | SHOW REPLICA DISTRIBUTION FROM baseTableRef                                   #showReplicaDistribution
     | SHOW RESOURCES wildWhere? sortClause? limitClause?                            #showResources

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -355,6 +355,7 @@ import org.apache.doris.nereids.DorisParser.ShowAnalyzeContext;
 import org.apache.doris.nereids.DorisParser.ShowAnalyzeTaskContext;
 import org.apache.doris.nereids.DorisParser.ShowAuthorsContext;
 import org.apache.doris.nereids.DorisParser.ShowBackendsContext;
+import org.apache.doris.nereids.DorisParser.ShowBackendsWithIdsContext;
 import org.apache.doris.nereids.DorisParser.ShowBackupContext;
 import org.apache.doris.nereids.DorisParser.ShowBrokerContext;
 import org.apache.doris.nereids.DorisParser.ShowBuildIndexContext;
@@ -6178,6 +6179,14 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
     @Override
     public LogicalPlan visitShowBackends(ShowBackendsContext ctx) {
         return new ShowBackendsCommand();
+    }
+
+    @Override
+    public LogicalPlan visitShowBackendsWithIds(ShowBackendsWithIdsContext ctx) {
+        List<Long> backendIds = ctx.backendIds.stream()
+                .map(token -> Long.parseLong(token.getText()))
+                .collect(Collectors.toList());
+        return new ShowBackendsCommand(backendIds);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommand.java
@@ -35,18 +35,28 @@ import org.apache.doris.qe.ShowResultSetMetaData;
 import org.apache.doris.qe.StmtExecutor;
 
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * show backends command
  */
 public class ShowBackendsCommand extends ShowCommand {
 
+    private final List<Long> backendIds;
+
     /**
      * constructor
      */
     public ShowBackendsCommand() {
+        this(null);
+    }
+
+    public ShowBackendsCommand(List<Long> backendIds) {
         super(PlanType.SHOW_BACKENDS_COMMAND);
+        this.backendIds = backendIds;
     }
 
     public ShowResultSetMetaData getMetaData() {
@@ -66,6 +76,12 @@ public class ShowBackendsCommand extends ShowCommand {
         }
 
         List<List<String>> backendInfos = BackendsProcDir.getBackendInfos();
+        if (backendIds != null && !backendIds.isEmpty()) {
+            Set<Long> idSet = new HashSet<>(backendIds);
+            backendInfos = backendInfos.stream()
+                .filter(info -> idSet.contains(Long.parseLong(info.get(0))))
+                .collect(Collectors.toList());
+        }
         backendInfos.sort(new Comparator<List<String>>() {
             @Override
             public int compare(List<String> o1, List<String> o2) {


### PR DESCRIPTION
### What problem does this PR solve?

Currently, the SHOW BACKENDS command can only display information about all backend nodes and cannot filter based on specific backend IDs. When a cluster has a large number of backend nodes, it's difficult for users to quickly locate the status information of specific backends.
This feature solves the following problems:

Operational Efficiency: Administrators can quickly view the status of specific backend nodes without manually searching through all backends
Monitoring Integration: Facilitates monitoring systems to query the status of specific backends
Troubleshooting: When a backend has issues, you can quickly get detailed information about that backend

Problem Summary:

Feature Description
Enhances the SHOW BACKENDS command to support filtering backend nodes by ID, including both single ID and multiple IDs (comma-separated) filtering methods.

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->
[测试报告.docx](https://github.com/user-attachments/files/24525355/default.docx)

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

