### PR TITLE
[Exec](profile) add max row count one backend in materialization profile

### DIFF
--- a/be/src/pipeline/exec/materialization_opertor.cpp
+++ b/be/src/pipeline/exec/materialization_opertor.cpp
@@ -56,6 +56,7 @@ void MaterializationSharedState::get_block(vectorized::Block* block) {
 
 Status MaterializationSharedState::merge_multi_response() {
     std::unordered_map<int64_t, std::pair<vectorized::Block, int>> block_maps;
+
     for (int i = 0; i < block_order_results.size(); ++i) {
         for (auto& [backend_id, rpc_struct] : rpc_struct_map) {
             vectorized::Block partial_block;
@@ -175,9 +176,19 @@ Status MaterializationSharedState::create_muiltget_result(const vectorized::Colu
                 rpc_struct->second.request.mutable_request_block_descs(i)->add_file_id(
                         row_location.file_id);
                 block_order[j] = row_location.backend_id;
+
+                // Count rows per backend
+                _backend_rows_count[row_location.backend_id]++;
             } else {
                 block_order[j] = 0;
             }
+        }
+    }
+
+    // Update max rows per backend
+    for (const auto& [_, row_count] : _backend_rows_count) {
+        if (row_count > _max_rows_per_backend) {
+            _max_rows_per_backend = row_count;
         }
     }
 
@@ -361,6 +372,8 @@ Status MaterializationOperator::push(RuntimeState* state, vectorized::Block* in_
         if (local_state._materialization_state.need_merge_block) {
             SCOPED_TIMER(local_state._merge_response_timer);
             RETURN_IF_ERROR(local_state._materialization_state.merge_multi_response());
+            local_state._max_rows_per_backend_counter->set(
+                    (int64_t)local_state._materialization_state._max_rows_per_backend);
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

feat(materialization): track and expose max rows per backend metric

- Add `_backend_rows_count` to `MaterializationSharedState` to count the number of rows assigned to each backend during block distribution.
- Introduce `_max_rows_per_backend` to record the maximum row count handled by any single backend in the current batch.
- Update `merge_multi_response()` to compute `_max_rows_per_backend` after row assignment.
- Expose this metric via a new runtime profile counter `MaxRowsPerBackend` in `MaterializationLocalState`.
- This helps monitor data skew across backends and aids in performance debugging for materialization-heavy queries.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

