### PR TITLE
[refine](type) Ensure that the internal encoding types in Doris are trivially copyable.

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_sequence_match.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sequence_match.h
@@ -123,7 +123,8 @@ public:
     void merge(const AggregateFunctionSequenceMatchData& other) {
         if (other.events_list.empty()) return;
 
-        events_list.insert(std::begin(other.events_list), std::end(other.events_list));
+        events_list.insert(std::end(events_list), std::begin(other.events_list),
+                           std::end(other.events_list));
         sorted = false;
         conditions_met |= other.conditions_met;
     }
@@ -570,7 +571,7 @@ private:
 
 public:
     bool sorted = true;
-    PODArrayWithStackMemory<TimestampEvents, 64> events_list;
+    std::vector<TimestampEvents> events_list;
     // sequenceMatch conditions met at least once in events_list
     std::bitset<MAX_EVENTS> conditions_met;
     // sequenceMatch conditions met at least once in the pattern

--- a/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
@@ -160,7 +160,6 @@ struct WindowFunnelState {
     template <WindowFunnelMode WINDOW_FUNNEL_MODE>
     int _match_event_list(size_t& start_row, size_t row_count) const {
         int matched_count = 0;
-        DateValueType start_timestamp;
         DateValueType end_timestamp;
 
         if (window < 0) {

--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -408,6 +408,11 @@ class PODArray : public PODArrayBase<sizeof(T), initial_bytes, TAllocator, pad_r
 protected:
     using Base = PODArrayBase<sizeof(T), initial_bytes, TAllocator, pad_right_, pad_left_>;
 
+    static_assert(std::is_trivially_destructible_v<T>,
+                  "PODArray can only be used with POD types or types with trivial destructor");
+    static_assert(std::is_trivially_copyable_v<T>,
+                  "PODArray can only be used with POD types or types with trivial copy");
+
     T* t_start() { return reinterpret_cast<T*>(this->c_start); }
     T* t_end() { return reinterpret_cast<T*>(this->c_end); }
 

--- a/be/src/vec/core/types.h
+++ b/be/src/vec/core/types.h
@@ -481,6 +481,12 @@ using Decimal64 = Decimal<Int64>;
 using Decimal128V2 = Decimal<Int128>;
 using Decimal256 = Decimal<wide::Int256>;
 
+static_assert(std::is_trivial_v<Decimal32>, "Decimal32 must be trivial");
+static_assert(std::is_trivial_v<Decimal64>, "Decimal64 must be trivial");
+static_assert(std::is_trivial_v<Decimal128V2>, "Decimal128V2 must be trivial");
+static_assert(std::is_trivial_v<Decimal128V3>, "Decimal128V3 must be trivial");
+static_assert(std::is_trivial_v<Decimal256>, "Decimal256 must be trivial");
+
 inline bool operator<(const Decimal256& x, const Decimal256& y) {
     return x.value < y.value;
 }

--- a/be/src/vec/runtime/timestamptz_value.cpp
+++ b/be/src/vec/runtime/timestamptz_value.cpp
@@ -101,8 +101,6 @@ bool TimestampTzValue::from_datetime(const DateV2Value<DateTimeV2ValueType>& ori
 
     auto utc_cs = cctz::convert(local_tp, cctz::utc_time_zone());
 
-    DateV2Value<DateTimeV2ValueType> utc_dt;
-
     return _utc_dt.check_range_and_set_time((uint16_t)utc_cs.year(), (uint8_t)utc_cs.month(),
                                             (uint8_t)utc_cs.day(), (uint8_t)utc_cs.hour(),
                                             (uint8_t)utc_cs.minute(), (uint8_t)utc_cs.second(),

--- a/be/src/vec/runtime/vdatetime_value.h
+++ b/be/src/vec/runtime/vdatetime_value.h
@@ -811,6 +811,10 @@ private:
               _year(year) {}
 };
 
+static_assert(std::is_trivially_destructible_v<VecDateTimeValue>,
+              "VecDateTimeValue must be trivial destructible");
+static_assert(std::is_trivially_copyable_v<VecDateTimeValue>,
+              "VecDateTimeValue must be trivial copyable");
 inline const VecDateTimeValue VecDateTimeValue::FIRST_DAY(false, TYPE_DATETIME, 0, 0, 0, 1, 1, 1);
 inline const VecDateTimeValue VecDateTimeValue::DEFAULT_VALUE(false, TYPE_DATETIME, 0, 0, 0, 1970,
                                                               1, 1);
@@ -1471,6 +1475,15 @@ private:
                 uint8_t second, uint32_t microsecond)
             : date_v2_value_(year, month, day, hour, minute, second, microsecond) {}
 };
+
+static_assert(std::is_trivially_destructible_v<DateV2Value<DateV2ValueType>>,
+              "DateV2Value<DateV2ValueType> must be trivial destructible");
+static_assert(std::is_trivially_destructible_v<DateV2Value<DateTimeV2ValueType>>,
+              "DateV2Value<DateTimeV2ValueType> must be trivial destructible");
+static_assert(std::is_trivially_copyable_v<DateV2Value<DateV2ValueType>>,
+              "DateV2Value<DateV2ValueType> must be trivial copyable");
+static_assert(std::is_trivially_copyable_v<DateV2Value<DateTimeV2ValueType>>,
+              "DateV2Value<DateTimeV2ValueType> must be trivial copyable");
 
 template <typename T>
 inline const DateV2Value<T> DateV2Value<T>::FIRST_DAY = DateV2Value<T>(0001, 1, 1, 0, 0, 0, 0);

--- a/be/test/vec/columns/pod_array_type_test.cpp
+++ b/be/test/vec/columns/pod_array_type_test.cpp
@@ -1,0 +1,66 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "runtime/decimalv2_value.h"
+#include "runtime/primitive_type.h"
+#include "testutil/column_helper.h"
+#include "vec/columns/column.h"
+#include "vec/columns/column_array.h"
+#include "vec/columns/column_const.h"
+#include "vec/data_types/data_type_number.h"
+#include "vec/functions/function.h"
+#include "vec/runtime/vdatetime_value.h"
+
+namespace doris::vectorized {
+
+template <typename T>
+void test_for_type() {
+    PaddedPODArray<T> arr;
+    for (int i = 0; i < 100; ++i) {
+        arr.push_back(T {});
+    }
+    arr.resize(1000);
+    for (int i = 0; i < 100; ++i) {
+        EXPECT_EQ(T {}, arr[i]);
+    }
+}
+
+TEST(PodArrayTypeTest, test) {
+    test_for_type<int8_t>();
+    test_for_type<int16_t>();
+    test_for_type<int32_t>();
+    test_for_type<int64_t>();
+    test_for_type<uint8_t>();
+    test_for_type<uint16_t>();
+    test_for_type<uint32_t>();
+    test_for_type<uint64_t>();
+    test_for_type<float>();
+    test_for_type<double>();
+    test_for_type<VecDateTimeValue>();
+    test_for_type<DateV2Value<DateV2ValueType>>();
+    test_for_type<DateV2Value<DateTimeV2ValueType>>();
+    test_for_type<DecimalV2Value>();
+    test_for_type<Decimal32>();
+    test_for_type<Decimal64>();
+    test_for_type<Decimal128V2>();
+    test_for_type<Decimal128V3>();
+    test_for_type<Decimal256>();
+}
+
+} // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?

For example, types like Decimal and DateTime-related types must be guaranteed to be trivial — e.g. using is_trivial_v or is_trivially_destructible_v / is_trivially_copyable_v. That way they can be stored in PODArray, since PODArray copies elements with memcpy.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

