### PR TITLE
[Bug](cte) set rec cte source dep ready after exchange reset

### DIFF
--- a/be/src/pipeline/exec/exchange_source_operator.h
+++ b/be/src/pipeline/exec/exchange_source_operator.h
@@ -100,7 +100,7 @@ public:
     Status init(const TPlanNode& tnode, RuntimeState* state) override;
     Status prepare(RuntimeState* state) override;
 
-    Status reset(RuntimeState* state);
+    Status reset(RuntimeState* state) override;
 
     Status get_block(RuntimeState* state, vectorized::Block* block, bool* eos) override;
 

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "common/be_mock_util.h"
+#include "common/exception.h"
 #include "common/logging.h"
 #include "common/status.h"
 #include "pipeline/dependency.h"
@@ -157,6 +158,10 @@ public:
     [[nodiscard]] virtual DataDistribution required_data_distribution(
             RuntimeState* /*state*/) const;
     [[nodiscard]] virtual bool require_shuffled_data_distribution(RuntimeState* /*state*/) const;
+
+    virtual Status reset(RuntimeState* state) {
+        return Status::InternalError("Reset is not implemented in operator: {}", get_name());
+    }
 
 protected:
     OperatorPtr _child = nullptr;
@@ -613,7 +618,10 @@ public:
     // For agg/sort/join sink.
     virtual Status init(const TPlanNode& tnode, RuntimeState* state);
 
-    virtual bool need_rerun(RuntimeState* state) const { return false; }
+    virtual bool reset_to_rerun(RuntimeState* state, OperatorXBase* root) const {
+        throw Exception(ErrorCode::INTERNAL_ERROR,
+                        "reset_to_rerun() is only implemented in rec CTE sink!");
+    }
 
     Status init(const TDataSink& tsink) override;
     [[nodiscard]] virtual Status init(RuntimeState* state, ExchangeType type, const int num_buckets,

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -618,10 +618,7 @@ public:
     // For agg/sort/join sink.
     virtual Status init(const TPlanNode& tnode, RuntimeState* state);
 
-    virtual bool reset_to_rerun(RuntimeState* state, OperatorXBase* root) const {
-        throw Exception(ErrorCode::INTERNAL_ERROR,
-                        "reset_to_rerun() is only implemented in rec CTE sink!");
-    }
+    virtual bool reset_to_rerun(RuntimeState* state, OperatorXBase* root) const { return false; }
 
     Status init(const TDataSink& tsink) override;
     [[nodiscard]] virtual Status init(RuntimeState* state, ExchangeType type, const int num_buckets,

--- a/be/src/pipeline/exec/rec_cte_sink_operator.h
+++ b/be/src/pipeline/exec/rec_cte_sink_operator.h
@@ -83,10 +83,6 @@ public:
             RETURN_IF_ERROR(materialize_block(local_state._child_expr, input_block, &block, true));
             RETURN_IF_ERROR(local_state._shared_state->emplace_block(state, std::move(block)));
         }
-
-        if (eos) {
-            local_state._shared_state->source_dep->set_ready();
-        }
         return Status::OK();
     }
 

--- a/be/src/pipeline/exec/rec_cte_sink_operator.h
+++ b/be/src/pipeline/exec/rec_cte_sink_operator.h
@@ -62,8 +62,16 @@ public:
     Status init(const TPlanNode& tnode, RuntimeState* state) override;
     Status prepare(RuntimeState* state) override;
 
-    bool need_rerun(RuntimeState* state) const override {
-        return get_local_state(state)._shared_state->ready_to_return == false;
+    bool reset_to_rerun(RuntimeState* state, OperatorXBase* root) const override {
+        auto* shared_state = get_local_state(state)._shared_state;
+        if (shared_state->ready_to_return == false) {
+            THROW_IF_ERROR(root->reset(state));
+            // must set_ready after root(exchange) reset
+            // if next round executed before exchange source reset, it maybe cant find receiver and cause blocked forever
+            shared_state->source_dep->set_ready();
+            return true;
+        }
+        return false;
     }
 
     std::shared_ptr<BasicSharedState> create_shared_state() const override { return nullptr; }

--- a/be/src/pipeline/exec/sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/sort_sink_operator.cpp
@@ -189,9 +189,10 @@ Status SortSinkOperatorX::merge_sort_read_for_spill(RuntimeState* state,
     return local_state._shared_state->sorter->merge_sort_read_for_spill(state, block, batch_size,
                                                                         eos);
 }
-void SortSinkOperatorX::reset(RuntimeState* state) {
+Status SortSinkOperatorX::reset(RuntimeState* state) {
     auto& local_state = get_local_state(state);
     local_state._shared_state->sorter->reset();
+    return Status::OK();
 }
 #include "common/compile_check_end.h"
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/sort_sink_operator.h
+++ b/be/src/pipeline/exec/sort_sink_operator.h
@@ -99,7 +99,7 @@ public:
 
     Status merge_sort_read_for_spill(RuntimeState* state, doris::vectorized::Block* block,
                                      int batch_size, bool* eos);
-    void reset(RuntimeState* state);
+    Status reset(RuntimeState* state) override;
 
     int64_t limit() const { return _limit; }
     int64_t offset() const { return _offset; }

--- a/be/src/pipeline/exec/spill_sort_sink_operator.cpp
+++ b/be/src/pipeline/exec/spill_sort_sink_operator.cpp
@@ -230,7 +230,7 @@ Status SpillSortSinkLocalState::_execute_spill_sort(RuntimeState* state, TUnique
         RETURN_IF_ERROR(status);
         block.clear_column_data();
     }
-    parent._sort_sink_operator->reset(_runtime_state.get());
+    RETURN_IF_ERROR(parent._sort_sink_operator->reset(_runtime_state.get()));
 
     return Status::OK();
 }

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -607,6 +607,17 @@ Status PipelineTask::execute(bool* done) {
                                 "Only ExchangeSourceOperatorX can be rerun, real is {}",
                                 _root->get_name());
                     }
+
+                    // must set_ready after exchange reset
+                    // if next round executed before exchange source reset, it maybe cant find receiver and cause blocked forever
+                    if (auto* shared_state =
+                                dynamic_cast<RecCTESharedState*>(_sink_shared_state.get())) {
+                        shared_state->source_dep->set_ready();
+                    } else {
+                        return Status::InternalError(
+                                "Only RecCTESinkOperatorX can have RecCTESharedState, real is {}",
+                                _sink->get_name());
+                    }
                 }
             }
 


### PR DESCRIPTION
### What problem does this PR solve?
This pull request addresses the handling of the `set_ready()` call for the `RecCTESharedState` in the pipeline execution logic. The main change is to ensure that the readiness signal is set at the correct point in the pipeline, specifically after the exchange source has been reset, to prevent potential deadlocks.

Key changes:

**Pipeline execution logic:**

* Moved the call to `set_ready()` for `RecCTESharedState` from the `RecCTESinkOperatorX` to the pipeline task execution, ensuring it is invoked after the exchange source reset to avoid blocking issues. [[1]](diffhunk://#diff-00c79e5e3bf6d92b947372a45d5ad4df30ac275c831ffb7b634f233a9fb2229eL86-L89) [[2]](diffhunk://#diff-dd9f3f47f0ec9d346d560dc86f3c0c518f21d5e512e62b623b5db48bddf04ebbR610-R620)
### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

