### PR TITLE
[Chore](runtime-filter) refactor of try_append_late_arrival_runtime_filter

### DIFF
--- a/be/src/pipeline/exec/multi_cast_data_stream_source.cpp
+++ b/be/src/pipeline/exec/multi_cast_data_stream_source.cpp
@@ -98,7 +98,7 @@ Status MultiCastDataStreamerSourceOperatorX::get_block(RuntimeState* state,
 
     int arrived_rf_num = 0;
     RETURN_IF_ERROR(local_state._helper.try_append_late_arrival_runtime_filter(
-            state, &arrived_rf_num, local_state._conjuncts, _multi_cast_output_row_descriptor));
+            state, _multi_cast_output_row_descriptor, arrived_rf_num, local_state._conjuncts));
 
     if (!local_state._conjuncts.empty() && !output_block->empty()) {
         SCOPED_TIMER(local_state._filter_timer);

--- a/be/src/pipeline/exec/multi_cast_data_stream_source.cpp
+++ b/be/src/pipeline/exec/multi_cast_data_stream_source.cpp
@@ -97,6 +97,8 @@ Status MultiCastDataStreamerSourceOperatorX::get_block(RuntimeState* state,
     }
 
     int arrived_rf_num = 0;
+    // No lock needed here because this is single-threaded execution without scanners
+    // and no concurrent access to _conjuncts
     RETURN_IF_ERROR(local_state._helper.try_append_late_arrival_runtime_filter(
             state, _multi_cast_output_row_descriptor, arrived_rf_num, local_state._conjuncts));
 

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -73,6 +73,22 @@ bool ScanLocalState<Derived>::should_run_serial() const {
     return _parent->cast<typename Derived::Parent>()._should_run_serial;
 }
 
+Status ScanLocalStateBase::update_late_arrival_runtime_filter(RuntimeState* state,
+                                                              int& arrived_rf_num) {
+    std::unique_lock lock(_conjuncts_lock);
+    return _helper.try_append_late_arrival_runtime_filter(state, _parent->row_descriptor(),
+                                                          arrived_rf_num, _conjuncts);
+}
+
+Status ScanLocalStateBase::clone_conjunct_ctxs(vectorized::VExprContextSPtrs& scanner_conjuncts) {
+    std::unique_lock lock(_conjuncts_lock);
+    scanner_conjuncts.resize(_conjuncts.size());
+    for (size_t i = 0; i != _conjuncts.size(); ++i) {
+        RETURN_IF_ERROR(_conjuncts[i]->clone(_state, scanner_conjuncts[i]));
+    }
+    return Status::OK();
+}
+
 int ScanLocalStateBase::max_scanners_concurrency(RuntimeState* state) const {
     // For select * from table limit 10; should just use one thread.
     if (should_run_serial()) {

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -75,12 +75,14 @@ bool ScanLocalState<Derived>::should_run_serial() const {
 
 Status ScanLocalStateBase::update_late_arrival_runtime_filter(RuntimeState* state,
                                                               int& arrived_rf_num) {
+    // Lock needed because _conjuncts can be accessed concurrently by multiple scanner threads
     std::unique_lock lock(_conjuncts_lock);
     return _helper.try_append_late_arrival_runtime_filter(state, _parent->row_descriptor(),
                                                           arrived_rf_num, _conjuncts);
 }
 
 Status ScanLocalStateBase::clone_conjunct_ctxs(vectorized::VExprContextSPtrs& scanner_conjuncts) {
+    // Lock needed because _conjuncts can be accessed concurrently by multiple scanner threads
     std::unique_lock lock(_conjuncts_lock);
     scanner_conjuncts.resize(_conjuncts.size());
     for (size_t i = 0; i != _conjuncts.size(); ++i) {

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cstdint>
+#include <mutex>
 #include <string>
 
 #include "common/status.h"
@@ -87,6 +88,10 @@ public:
 
     uint64_t get_condition_cache_digest() const { return _condition_cache_digest; }
 
+    Status update_late_arrival_runtime_filter(RuntimeState* state, int& arrived_rf_num);
+
+    Status clone_conjunct_ctxs(vectorized::VExprContextSPtrs& scanner_conjuncts);
+
 protected:
     friend class vectorized::ScannerContext;
     friend class vectorized::Scanner;
@@ -120,6 +125,7 @@ protected:
     RuntimeProfile::Counter* _scan_rows = nullptr;
     RuntimeProfile::Counter* _scan_bytes = nullptr;
 
+    std::mutex _conjuncts_lock;
     RuntimeFilterConsumerHelper _helper;
     // magic number as seed to generate hash value for condition cache
     uint64_t _condition_cache_digest = 0;

--- a/be/src/runtime_filter/runtime_filter_consumer_helper.h
+++ b/be/src/runtime_filter/runtime_filter_consumer_helper.h
@@ -44,13 +44,10 @@ public:
     // The un-arrival filters will be checked every time the scanner is scheduled.
     // And once new runtime filters arrived, we will use it to do operator's filtering.
     // Called by Scanner.
-    Status try_append_late_arrival_runtime_filter(RuntimeState* state, int* arrived_rf_num,
-                                                  vectorized::VExprContextSPtrs& conjuncts,
-                                                  const RowDescriptor& row_descriptor);
-
-    Status clone_conjunct_ctxs(RuntimeState* state,
-                               vectorized::VExprContextSPtrs& scanner_conjuncts,
-                               vectorized::VExprContextSPtrs& local_state_conjuncts);
+    Status try_append_late_arrival_runtime_filter(RuntimeState* state,
+                                                  const RowDescriptor& row_descriptor,
+                                                  int& arrived_rf_num,
+                                                  vectorized::VExprContextSPtrs& arrived_conjuncts);
 
     // Called by XXXLocalState::close()
     // parent_operator_profile is owned by LocalState so update it is safe at here.

--- a/be/src/vec/exec/scan/file_scanner.cpp
+++ b/be/src/vec/exec/scan/file_scanner.cpp
@@ -357,13 +357,9 @@ Status FileScanner::_process_late_arrival_conjuncts(bool* changed,
     *changed = false;
     if (_push_down_conjuncts.size() < _conjuncts.size()) {
         *changed = true;
-        _push_down_conjuncts.clear();
-        _push_down_conjuncts.resize(_conjuncts.size());
-        for (size_t i = 0; i != _conjuncts.size(); ++i) {
-            RETURN_IF_ERROR(_conjuncts[i]->clone(_state, _push_down_conjuncts[i]));
-        }
+        _push_down_conjuncts = _conjuncts;
+        _conjuncts.clear();
         RETURN_IF_ERROR(_process_conjuncts());
-        _discard_conjuncts();
         new_push_down_conjuncts = _push_down_conjuncts;
     }
     if (_applied_rf_num == _total_rf_num) {

--- a/be/src/vec/exec/scan/scanner.cpp
+++ b/be/src/vec/exec/scan/scanner.cpp
@@ -229,27 +229,20 @@ Status Scanner::try_append_late_arrival_runtime_filter() {
         return Status::OK();
     }
     DCHECK(_applied_rf_num < _total_rf_num);
-
     int arrived_rf_num = 0;
-    RETURN_IF_ERROR(_local_state->_helper.try_append_late_arrival_runtime_filter(
-            _state, &arrived_rf_num, _local_state->_conjuncts,
-            _local_state->_parent->row_descriptor()));
+    RETURN_IF_ERROR(_local_state->update_late_arrival_runtime_filter(_state, arrived_rf_num));
 
     if (arrived_rf_num == _applied_rf_num) {
         // No newly arrived runtime filters, just return;
         return Status::OK();
     }
 
-    // There are newly arrived runtime filters,
-    // renew the _conjuncts
-    if (!_conjuncts.empty()) {
-        _discard_conjuncts();
+    // avoid conjunct destroy in used by storage layer
+    for (auto& conjunct : _conjuncts) {
+        _stale_expr_ctxs.emplace_back(conjunct);
     }
-    // Notice that the number of runtime filters may be larger than _applied_rf_num.
-    // But it is ok because it will be updated at next time.
-    RETURN_IF_ERROR(_local_state->_helper.clone_conjunct_ctxs(_state, _conjuncts,
-                                                              _local_state->_conjuncts));
-    _applied_rf_num = arrived_rf_num;
+    _conjuncts.clear();
+    RETURN_IF_ERROR(_local_state->clone_conjunct_ctxs(_conjuncts));
     return Status::OK();
 }
 

--- a/be/src/vec/exec/scan/scanner.h
+++ b/be/src/vec/exec/scan/scanner.h
@@ -160,7 +160,7 @@ public:
 
     RuntimeState* runtime_state() { return _state; }
 
-    bool is_open() { return _is_open; }
+    bool is_open() const { return _is_open; }
     void set_opened() { _is_open = true; }
 
     virtual doris::TabletStorageType get_storage_type() {
@@ -189,13 +189,6 @@ public:
     void update_block_avg_bytes(size_t block_avg_bytes) { _block_avg_bytes = block_avg_bytes; }
 
 protected:
-    void _discard_conjuncts() {
-        for (auto& conjunct : _conjuncts) {
-            _stale_expr_ctxs.emplace_back(conjunct);
-        }
-        _conjuncts.clear();
-    }
-
     RuntimeState* _state = nullptr;
     pipeline::ScanLocalStateBase* _local_state = nullptr;
 

--- a/be/test/runtime_filter/runtime_filter_consumer_helper_test.cpp
+++ b/be/test/runtime_filter/runtime_filter_consumer_helper_test.cpp
@@ -102,7 +102,7 @@ TEST_F(RuntimeFilterConsumerHelperTest, basic) {
     int arrived_rf_num = -1;
     helper._consumers[1]->signal(producer.get());
     FAIL_IF_ERROR_OR_CATCH_EXCEPTION(helper.try_append_late_arrival_runtime_filter(
-            _runtime_states[0].get(), &arrived_rf_num, conjuncts, row_desc));
+            _runtime_states[0].get(), row_desc, arrived_rf_num, conjuncts));
     ASSERT_EQ(conjuncts.size(), 1);
     ASSERT_EQ(arrived_rf_num, 2);
 }


### PR DESCRIPTION
### What problem does this PR solve?
This pull request refactors and simplifies the handling of late-arriving runtime filters and conjunct context cloning in the scan pipeline. The main changes include streamlining the interfaces for applying runtime filters, improving thread safety with new locking mechanisms, and removing redundant or duplicated code. The changes also clarify ownership and lifecycle of conjunct expressions to prevent concurrent access issues.

**Runtime filter and conjunct management improvements:**

* Refactored `try_append_late_arrival_runtime_filter` in `RuntimeFilterConsumerHelper` to use references instead of pointers for `arrived_rf_num` and conjuncts, and updated all call sites accordingly for clearer and safer usage. [[1]](diffhunk://#diff-ed4cbc22dcb1b5d27652827cea0f12373591a9b06e3c857f0dd0e32f58422026L99-R110) [[2]](diffhunk://#diff-61d96ad649abf519ee21143b6a4d9ed0c1b820ba273281ca8650a1e047d10f15L47-R50) [[3]](diffhunk://#diff-04a5f666c19cc90dfb8f222f1fadc43f08fa2d59f5ae61e2889e615e3cffc35dL101-R101) [[4]](diffhunk://#diff-2c575051a29b06200611882d17cb4c0fea6df46659e8ea953c705aaca2c2b5a4L232-R245)
* Removed the redundant `clone_conjunct_ctxs` method from `RuntimeFilterConsumerHelper` and moved conjunct cloning logic into `ScanLocalStateBase`, introducing new methods `update_late_arrival_runtime_filter` and `clone_conjunct_ctxs` for better encapsulation. [[1]](diffhunk://#diff-ac38473f151ccd99db4ed80dfbfa176f4f957ae2f5335ce8fbb4f5dbb0e932e9R76-R91) [[2]](diffhunk://#diff-f5a0db9faf0b649227b0126cca493d8dce22c9d497116fd480d7d018ce1696d2R91-R94) [[3]](diffhunk://#diff-ed4cbc22dcb1b5d27652827cea0f12373591a9b06e3c857f0dd0e32f58422026L123-R128) [[4]](diffhunk://#diff-61d96ad649abf519ee21143b6a4d9ed0c1b820ba273281ca8650a1e047d10f15L47-R50) [[5]](diffhunk://#diff-2c575051a29b06200611882d17cb4c0fea6df46659e8ea953c705aaca2c2b5a4L232-R245)

**Thread safety enhancements:**

* Added a `std::mutex _conjuncts_lock` to `ScanLocalStateBase` and used it to guard access to `_conjuncts` for thread-safe updates and cloning. [[1]](diffhunk://#diff-f5a0db9faf0b649227b0126cca493d8dce22c9d497116fd480d7d018ce1696d2R21) [[2]](diffhunk://#diff-f5a0db9faf0b649227b0126cca493d8dce22c9d497116fd480d7d018ce1696d2R128) [[3]](diffhunk://#diff-ac38473f151ccd99db4ed80dfbfa176f4f957ae2f5335ce8fbb4f5dbb0e932e9R76-R91) [[4]](diffhunk://#diff-f5a0db9faf0b649227b0126cca493d8dce22c9d497116fd480d7d018ce1696d2R91-R94)

**Scanner and file scanner lifecycle fixes:**

* Changed handling of conjuncts in `FileScanner` and `Scanner` to avoid destroying conjuncts that may still be in use, by explicitly moving them to a `_stale_expr_ctxs` vector before clearing. Removed the `_discard_conjuncts` method and replaced it with direct management. [[1]](diffhunk://#diff-6afbc092caa913a8775be9772777060161de5608b9aae939202e963e8aaf4e8bL360-L366) [[2]](diffhunk://#diff-2c575051a29b06200611882d17cb4c0fea6df46659e8ea953c705aaca2c2b5a4L232-R245) [[3]](diffhunk://#diff-17432beb88ab0d918d9bbe41b3ba500e3f5102645896e89587a4dc43bcab2125L192-L198)

**Minor interface improvements:**

* Made `Scanner::is_open()` a `const` method for correctness.
### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

