### PR TITLE
[Bug](cte) fix core dump due to ref_task_execution_ctx

### DIFF
--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -98,8 +98,8 @@ ScannerContext::ScannerContext(
     }
     _dependency = dependency;
     DorisMetrics::instance()->scanner_ctx_cnt->increment(1);
-    if (task_exec_ctx()) {
-        task_exec_ctx()->ref_task_execution_ctx();
+    if (auto ctx = task_exec_ctx(); ctx) {
+        ctx->ref_task_execution_ctx();
     }
 }
 
@@ -195,8 +195,8 @@ ScannerContext::~ScannerContext() {
         }
         _task_handle = nullptr;
     }
-    if (task_exec_ctx()) {
-        task_exec_ctx()->unref_task_execution_ctx();
+    if (auto ctx = task_exec_ctx(); ctx) {
+        ctx->unref_task_execution_ctx();
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?
```cpp
*** Current BE git commitID: 5718f3451e ***

[20:13:07 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/872245?buildTab=log&linesState=493112&logView=flowAware&focusLine=493112)
  *** SIGSEGV address not mapped to object (@0x0) received by PID 39681 (TID 40553 OR 0x7b8af3931700) from PID 0; stack trace: ***

[20:13:07 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/872245?buildTab=log&linesState=493113&logView=flowAware&focusLine=493113)
   0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:420

[20:13:07 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/872245?buildTab=log&linesState=493114&logView=flowAware&focusLine=493114)
   1# PosixSignals::chained_handler(int, siginfo_t*, void*) [clone .part.0] in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so

[20:13:07 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/872245?buildTab=log&linesState=493115&logView=flowAware&focusLine=493115)
   2# JVM_handle_linux_signal in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so

[20:13:07 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/872245?buildTab=log&linesState=493116&logView=flowAware&focusLine=493116)
   3# 0x00007F8ED4A4B420 in /lib/x86_64-linux-gnu/libpthread.so.0

[20:13:07 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/872245?buildTab=log&linesState=493117&logView=flowAware&focusLine=493117)
   4# doris::TaskExecutionContext::unref_task_execution_ctx() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be

[20:13:07 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/872245?buildTab=log&linesState=493118&logView=flowAware&focusLine=493118)
   5# doris::vectorized::ScannerContext::~ScannerContext() at /root/doris/be/src/vec/exec/scan/scanner_context.cpp:199
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

