### PR TITLE
[fix](be) Enable DYNAMIC_ARCH in OpenBLAS for cross-architecture compatibility

### DIFF
--- a/be/src/olap/rowset/segment_v2/ann_index/cmake-protect/CMakeLists.txt
+++ b/be/src/olap/rowset/segment_v2/ann_index/cmake-protect/CMakeLists.txt
@@ -31,6 +31,7 @@ set(BUILD_BENCHMARKS OFF CACHE BOOL "Build benchmarks in OpenBLAS")
 set(NO_LAPACK OFF CACHE BOOL "Disable LAPACK in OpenBLAS")
 set(NO_CBLAS ON CACHE BOOL "Disable CBLAS in OpenBLAS")
 set(NO_AVX512 ON CACHE BOOL "Disable AVX512 in OpenBLAS")
+set(DYNAMIC_ARCH ON CACHE BOOL "Enable runtime CPU detection in OpenBLAS")
 
 # EXCLUDE_FROM_ALL so that binary in openblas is not installed.
 add_subdirectory(${PROJECT_SOURCE_DIR}/../contrib/openblas ${PROJECT_BINARY_DIR}/openblas EXCLUDE_FROM_ALL)


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
Enable runtime CPU detection in OpenBLAS by setting `DYNAMIC_ARCH=ON`. This allows the compiled binary to run on different CPU architectures by detecting CPU features at runtime instead of compile time.

Without this option, OpenBLAS is compiled for the specific CPU architecture of the build machine, which may cause issues when running on machines with different CPU capabilities (e.g., missing AVX2 instructions).

### Release note

Enable DYNAMIC_ARCH in OpenBLAS for better cross-architecture binary compatibility.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason: Build configuration change, verified by successful compilation.

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label