### PR TITLE
[fix](fe) add compatible code for CloudTablet

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTablet.java
@@ -22,13 +22,23 @@ import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.common.InternalErrorCode;
 import org.apache.doris.common.UserException;
+import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.system.SystemInfoService;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
+import com.google.gson.annotations.SerializedName;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
+import java.io.IOException;
 import java.util.Iterator;
 
-public class CloudTablet extends Tablet {
+public class CloudTablet extends Tablet implements GsonPostProcessable {
+    private static final Logger LOG = LogManager.getLogger(CloudTablet.class);
+
+    @SerializedName(value = "r")
+    private Replica replica;
 
     public CloudTablet() {
         super();
@@ -96,4 +106,18 @@ public class CloudTablet extends Tablet {
         }
     }
 
+    @Override
+    public void gsonPostProcess() throws IOException {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("convert replica to replicas for CloudTablet: {}, replica: {}, replicas: {}", this.id,
+                    this.replica, this.replicas);
+        }
+        if (replica != null) {
+            if (this.replicas == null) {
+                this.replicas = Lists.newArrayList();
+            }
+            this.replicas.add(replica);
+            this.replica = null;
+        }
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

https://github.com/apache/doris/pull/59814 modify `replicas` to `replica` in `CloudTablet`, and will merge into 4.1.
This pr add compatible code for CloudTablet to make 4.1 can downgrade to 4.0.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

