### PR TITLE
[feature](ann-index) Support skip_write_index_on_load for ANN index

### DIFF
--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -56,6 +56,7 @@
 #include "olap/rowset/rowset_factory.h"
 #include "olap/rowset/rowset_fwd.h"
 #include "olap/rowset/rowset_writer.h"
+#include "olap/rowset/segment_v2/index_file_reader.h"
 #include "olap/rowset/segment_v2/inverted_index_desc.h"
 #include "olap/storage_policy.h"
 #include "olap/tablet_schema.h"
@@ -1180,10 +1181,110 @@ Status CloudTablet::check_rowset_schema_for_build_index(std::vector<TColumn>& co
     return Status::OK();
 }
 
-Result<RowsetSharedPtr> CloudTablet::pick_a_rowset_for_index_change(int schema_version,
-                                                                    bool& is_base_rowset) {
+Result<RowsetSharedPtr> CloudTablet::pick_a_rowset_for_index_change(
+        int schema_version, bool& is_base_rowset, const std::set<int64_t>& index_ids) {
     TEST_SYNC_POINT_RETURN_WITH_VALUE("CloudTablet::pick_a_rowset_for_index_change",
                                       Result<RowsetSharedPtr>(nullptr));
+
+    // Check if the specified indexes are actually built (exist in files)
+    // Returns true only if ALL required indexes exist in files for ALL segments
+    auto are_indexes_built_in_files = [&](const RowsetSharedPtr& rowset) -> bool {
+        if (index_ids.empty()) {
+            return false; // No index IDs specified, need to process
+        }
+
+        const auto& tablet_schema = rowset->tablet_schema();
+        auto storage_format = tablet_schema->get_inverted_index_storage_format();
+
+        // Collect index metadata that needs to be checked
+        std::vector<const TabletIndex*> indexes_to_check;
+        for (const auto& index : tablet_schema->indexes()) {
+            if ((index->index_type() == IndexType::INVERTED ||
+                 index->index_type() == IndexType::ANN) &&
+                index_ids.count(index->index_id()) > 0) {
+                indexes_to_check.push_back(index.get());
+            }
+        }
+
+        if (indexes_to_check.empty()) {
+            return false; // No matching indexes in schema, need to process
+        }
+
+        // Check each segment
+        for (int seg_id = 0; seg_id < rowset->num_segments(); seg_id++) {
+            auto idx_file_info = rowset->rowset_meta()->inverted_index_file_info(seg_id);
+
+            // === Fast path: V2 format check index_size ===
+            if (storage_format >= InvertedIndexStorageFormatPB::V2) {
+                if (!idx_file_info.has_index_size() || idx_file_info.index_size() == 0) {
+                    // Compound file is empty, indexes not built
+                    LOG(INFO) << "[index_change] Index file is empty for tablet "
+                              << _tablet_meta->tablet_id() << ", segment " << seg_id
+                              << ", need to build index";
+                    return false;
+                }
+            }
+
+            // === Fast path: V1 format check specific index files ===
+            if (storage_format == InvertedIndexStorageFormatPB::V1) {
+                auto seg_path_result = rowset->segment_path(seg_id);
+                if (!seg_path_result.has_value()) {
+                    return false;
+                }
+                auto fs = rowset->rowset_meta()->fs();
+                std::string prefix {segment_v2::InvertedIndexDescriptor::get_index_file_path_prefix(
+                        seg_path_result.value())};
+
+                for (const auto* index_meta : indexes_to_check) {
+                    auto index_path = segment_v2::InvertedIndexDescriptor::get_index_file_path_v1(
+                            prefix, index_meta->index_id(), index_meta->get_index_suffix());
+                    bool exists = false;
+                    auto st = fs->exists(index_path, &exists);
+                    if (!st.ok() || !exists) {
+                        LOG(INFO) << "[index_change] Index file not found: " << index_path
+                                  << ", need to build index";
+                        return false;
+                    }
+                }
+                continue; // V1 check done, continue to next segment
+            }
+
+            // === V2 format: need to open file to check specific indexes ===
+            auto seg_path_result = rowset->segment_path(seg_id);
+            if (!seg_path_result.has_value()) {
+                return false;
+            }
+
+            auto idx_file_reader = std::make_unique<segment_v2::IndexFileReader>(
+                    rowset->rowset_meta()->fs(),
+                    std::string {segment_v2::InvertedIndexDescriptor::get_index_file_path_prefix(
+                            seg_path_result.value())},
+                    storage_format, idx_file_info);
+
+            auto init_st = idx_file_reader->init();
+            if (!init_st.ok()) {
+                LOG(INFO) << "[index_change] Failed to init index file reader for tablet "
+                          << _tablet_meta->tablet_id() << ", segment " << seg_id
+                          << ", error: " << init_st << ", need to build index";
+                return false;
+            }
+
+            // Check if each required index exists
+            for (const auto* index_meta : indexes_to_check) {
+                bool exists = false;
+                auto st = idx_file_reader->index_file_exist(index_meta, &exists);
+                if (!st.ok() || !exists) {
+                    LOG(INFO) << "[index_change] Index " << index_meta->index_id()
+                              << " not found in compound file for tablet "
+                              << _tablet_meta->tablet_id() << ", segment " << seg_id
+                              << ", need to build index";
+                    return false;
+                }
+            }
+        }
+        return true;
+    };
+
     RowsetSharedPtr ret_rowset = nullptr;
     std::shared_lock rlock(_meta_lock);
     for (const auto& [version, rs] : _rs_version_map) {
@@ -1199,6 +1300,13 @@ Result<RowsetSharedPtr> CloudTablet::pick_a_rowset_for_index_change(int schema_v
         if (rs->tablet_schema()->schema_version() >= schema_version) {
             VLOG_DEBUG << "[index_change] skip rowset " << rs->tablet_schema()->schema_version()
                        << "," << schema_version;
+            continue;
+        }
+
+        // Skip rowsets where all required indexes are already built
+        if (are_indexes_built_in_files(rs)) {
+            VLOG_DEBUG << "[index_change] skip rowset " << rs->rowset_id().to_string()
+                       << " because indexes are already built";
             continue;
         }
 

--- a/be/src/cloud/cloud_tablet.h
+++ b/be/src/cloud/cloud_tablet.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <memory>
+#include <set>
 
 #include "olap/base_tablet.h"
 #include "olap/partial_update_info.h"
@@ -256,8 +257,9 @@ public:
     int64_t base_size() const { return _base_size; }
 
     std::vector<RowsetSharedPtr> pick_candidate_rowsets_to_full_compaction();
-    Result<RowsetSharedPtr> pick_a_rowset_for_index_change(int schema_version,
-                                                           bool& is_base_rowset);
+    Result<RowsetSharedPtr> pick_a_rowset_for_index_change(
+            int schema_version, bool& is_base_rowset,
+            const std::set<int64_t>& index_ids = std::set<int64_t>());
     Status check_rowset_schema_for_build_index(std::vector<TColumn>& columns, int schema_version);
 
     std::mutex& get_base_compaction_lock() { return _base_compaction_lock; }

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -777,9 +777,24 @@ Status Segment::new_index_iterator(const TabletColumn& tablet_column, const Tabl
     if (index_meta) {
         // call DorisCallOnce.call without check if _index_file_reader is nullptr
         // to avoid data race during parallel method calls
-        RETURN_IF_ERROR(_index_file_reader_open.call([&] { return _open_index_file_reader(); }));
+        st = _index_file_reader_open.call([&] { return _open_index_file_reader(); });
+        // If index file is empty or not found for ANN index, return OK to fallback to brute force
+        // This can happen when skip_write_index_on_load=true skips index during data loading
+        // but compaction hasn't built the index yet
+        bool is_ann_index = index_meta->index_type() == IndexType::ANN;
+        if (is_ann_index && (st.is<ErrorCode::INVERTED_INDEX_BYPASS>() ||
+                             st.is<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>())) {
+            return Status::OK();
+        }
+        RETURN_IF_ERROR(st);
         // after DorisCallOnce.call, _index_file_reader is guaranteed to be not nullptr
-        RETURN_IF_ERROR(reader->new_index_iterator(_index_file_reader, index_meta, iter));
+        st = reader->new_index_iterator(_index_file_reader, index_meta, iter);
+        // If loading index fails due to empty/missing data for ANN index
+        if (is_ann_index && (st.is<ErrorCode::INVERTED_INDEX_BYPASS>() ||
+                             st.is<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>())) {
+            return Status::OK();
+        }
+        RETURN_IF_ERROR(st);
         return Status::OK();
     }
     return Status::OK();

--- a/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
@@ -220,11 +220,6 @@ Status VerticalSegmentWriter::_create_column_writer(uint32_t cid, const TabletCo
         skip_inverted_index =
                 _opts.rowset_ctx->columns_to_do_index_compaction.contains(column.unique_id());
     }
-    // skip write inverted index on load if skip_write_index_on_load is true
-    if (_opts.write_type == DataWriteType::TYPE_DIRECT &&
-        tablet_schema->skip_write_index_on_load()) {
-        skip_inverted_index = true;
-    }
     if (!skip_inverted_index) {
         auto inverted_indexs = tablet_schema->inverted_indexs(column);
         if (!inverted_indexs.empty()) {
@@ -235,11 +230,16 @@ Status VerticalSegmentWriter::_create_column_writer(uint32_t cid, const TabletCo
     }
     opts.index_file_writer = _index_file_writer;
 
-    if (const auto& index = tablet_schema->ann_index(column); index != nullptr) {
-        opts.ann_index = index;
-        opts.need_ann_index = true;
-        DCHECK(_index_file_writer != nullptr);
-        opts.index_file_writer = _index_file_writer;
+    // skip write ann index on load if skip_write_index_on_load is true
+    bool skip_ann_index = _opts.write_type == DataWriteType::TYPE_DIRECT &&
+                          tablet_schema->skip_write_index_on_load();
+    if (!skip_ann_index) {
+        if (const auto& index = tablet_schema->ann_index(column); index != nullptr) {
+            opts.ann_index = index;
+            opts.need_ann_index = true;
+            DCHECK(_index_file_writer != nullptr);
+            opts.index_file_writer = _index_file_writer;
+        }
     }
 
 #define DISABLE_INDEX_IF_FIELD_TYPE(TYPE, type_name)          \

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -494,6 +494,10 @@ public:
         }
         return inverted_indexes;
     }
+
+    // Returns all indexes (INVERTED, ANN, etc.)
+    const std::vector<TabletIndexPtr>& indexes() const { return _indexes; }
+
     bool has_inverted_index() const {
         for (const auto& index : _indexes) {
             DBUG_EXECUTE_IF("tablet_schema::has_inverted_index", {

--- a/be/src/olap/task/index_builder.cpp
+++ b/be/src/olap/task/index_builder.cpp
@@ -285,7 +285,9 @@ Status IndexBuilder::update_inverted_index_info() {
                             st = Status::Error<ErrorCode::INIT_FAILED>(
                                     "debug point: reader init error");
                         })
-                if (!st.ok() && !st.is<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>()) {
+                // Allow empty index file (INVERTED_INDEX_BYPASS) for skip_write_index_on_load case
+                if (!st.ok() && !st.is<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>() &&
+                    !st.is<ErrorCode::INVERTED_INDEX_BYPASS>()) {
                     return st;
                 }
                 _index_file_readers.emplace(

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/CloudRollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/CloudRollupJobV2.java
@@ -228,7 +228,7 @@ public class CloudRollupJobV2 extends RollupJobV2 {
                                     tbl.getTimeSeriesCompactionTimeThresholdSeconds(),
                                     tbl.getTimeSeriesCompactionEmptyRowsetsThreshold(),
                                     tbl.getTimeSeriesCompactionLevelThreshold(),
-                                    tbl.disableAutoCompaction(),
+                                    tbl.disableAutoCompaction(), tbl.skipWriteIndexOnLoad(),
                                     tbl.getRowStoreColumnsUniqueIds(rowStoreColumns),
                                     null,
                                     tbl.rowStorePageSize(),

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/CloudSchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/CloudSchemaChangeJobV2.java
@@ -251,7 +251,7 @@ public class CloudSchemaChangeJobV2 extends SchemaChangeJobV2 {
                                             tbl.getTimeSeriesCompactionTimeThresholdSeconds(),
                                             tbl.getTimeSeriesCompactionEmptyRowsetsThreshold(),
                                             tbl.getTimeSeriesCompactionLevelThreshold(),
-                                            tbl.disableAutoCompaction(),
+                                            tbl.disableAutoCompaction(), tbl.skipWriteIndexOnLoad(),
                                             tbl.getRowStoreColumnsUniqueIds(rowStoreColumns),
                                             tbl.getInvertedIndexFileStorageFormat(),
                                             tbl.rowStorePageSize(),

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/backup/CloudRestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/backup/CloudRestoreJob.java
@@ -398,7 +398,7 @@ public class CloudRestoreJob extends RestoreJob {
                                     localTbl.getTimeSeriesCompactionTimeThresholdSeconds(),
                                     localTbl.getTimeSeriesCompactionEmptyRowsetsThreshold(),
                                     localTbl.getTimeSeriesCompactionLevelThreshold(), localTbl.disableAutoCompaction(),
-                                    localTbl.getRowStoreColumnsUniqueIds(rowStoreColumns),
+                                    localTbl.skipWriteIndexOnLoad(), localTbl.getRowStoreColumnsUniqueIds(rowStoreColumns),
                                     localTbl.getInvertedIndexFileStorageFormat(),
                                     localTbl.rowStorePageSize(),
                                     localTbl.variantEnableFlattenNested(), clusterKeyUids,

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
@@ -183,7 +183,7 @@ public class CloudInternalCatalog extends InternalCatalog {
                         tbl.getTimeSeriesCompactionTimeThresholdSeconds(),
                         tbl.getTimeSeriesCompactionEmptyRowsetsThreshold(),
                         tbl.getTimeSeriesCompactionLevelThreshold(),
-                        tbl.disableAutoCompaction(),
+                        tbl.disableAutoCompaction(), tbl.skipWriteIndexOnLoad(),
                         tbl.getRowStoreColumnsUniqueIds(rowStoreColumns),
                         tbl.getInvertedIndexFileStorageFormat(),
                         tbl.rowStorePageSize(),
@@ -220,7 +220,7 @@ public class CloudInternalCatalog extends InternalCatalog {
             Long timeSeriesCompactionGoalSizeMbytes, Long timeSeriesCompactionFileCountThreshold,
             Long timeSeriesCompactionTimeThresholdSeconds, Long timeSeriesCompactionEmptyRowsetsThreshold,
             Long timeSeriesCompactionLevelThreshold, boolean disableAutoCompaction,
-            List<Integer> rowStoreColumnUniqueIds,
+            boolean skipWriteIndexOnLoad, List<Integer> rowStoreColumnUniqueIds,
             TInvertedIndexFileStorageFormat invertedIndexFileStorageFormat, long pageSize,
             boolean variantEnableFlattenNested, List<Integer> clusterKeyUids,
             long storagePageSize, EncryptionAlgorithmPB encryptionAlgorithm, long storageDictPageSize,
@@ -357,6 +357,7 @@ public class CloudInternalCatalog extends InternalCatalog {
             schemaBuilder.addAllRowStoreColumnUniqueIds(rowStoreColumnUniqueIds);
         }
         schemaBuilder.setDisableAutoCompaction(disableAutoCompaction);
+        schemaBuilder.setSkipWriteIndexOnLoad(skipWriteIndexOnLoad);
 
         if (invertedIndexFileStorageFormat != null) {
             if (invertedIndexFileStorageFormat == TInvertedIndexFileStorageFormat.V1) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -932,8 +932,7 @@ public class PropertyAnalyzer {
         }
         properties.remove(PROPERTIES_SKIP_WRITE_INDEX_ON_LOAD);
         if (value.equalsIgnoreCase("true")) {
-            throw new AnalysisException("Property " + PROPERTIES_SKIP_WRITE_INDEX_ON_LOAD
-                    + " is forbidden now.");
+            return true;
         } else if (value.equalsIgnoreCase("false")) {
             return false;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/ModifyTablePropertiesOp.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/ModifyTablePropertiesOp.java
@@ -248,11 +248,6 @@ public class ModifyTablePropertiesOp extends AlterTableOp {
             this.needTableStable = false;
             this.opType = AlterOpType.MODIFY_TABLE_PROPERTY_SYNC;
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_SKIP_WRITE_INDEX_ON_LOAD)) {
-            if (properties.get(PropertyAnalyzer.PROPERTIES_SKIP_WRITE_INDEX_ON_LOAD).equalsIgnoreCase("true")) {
-                throw new AnalysisException(
-                        "Property "
-                                + PropertyAnalyzer.PROPERTIES_SKIP_WRITE_INDEX_ON_LOAD + " is forbidden now");
-            }
             if (!properties.get(PropertyAnalyzer.PROPERTIES_SKIP_WRITE_INDEX_ON_LOAD).equalsIgnoreCase("true")
                     && !properties.get(PropertyAnalyzer.PROPERTIES_SKIP_WRITE_INDEX_ON_LOAD)
                             .equalsIgnoreCase("false")) {

--- a/regression-test/suites/ann_index_p0/test_skip_write_index_on_load.groovy
+++ b/regression-test/suites/ann_index_p0/test_skip_write_index_on_load.groovy
@@ -17,18 +17,17 @@
 
 // Test skip_write_index_on_load property for ANN index
 // When enabled, ANN index construction is skipped during data loading
-// and built during compaction
+// and built during compaction or via BUILD INDEX
 //
 // Verification strategy using show_nested_index_file API:
 // 1. skip_write_index_on_load=true + before compaction: no ann.faiss
 // 2. skip_write_index_on_load=true + after compaction: ann.faiss exists
 // 3. skip_write_index_on_load=false: ann.faiss exists immediately after insert
+// 4. skip_write_index_on_load=true + BUILD INDEX: ann.faiss exists after BUILD INDEX
+// 5. Query correctness: l2_distance_approximate returns valid results
+// 6. Inverted index preservation: inverted index is NOT skipped (only ANN is skipped)
 
 suite("test_skip_write_index_on_load") {
-    if (isCloudMode()) {
-        return
-    }
-
     // Setup backend mappings
     def backendId_to_backendIP = [:]
     def backendId_to_backendHttpPort = [:]
@@ -98,6 +97,10 @@ suite("test_skip_write_index_on_load") {
         sql "INSERT INTO ${tableName} VALUES ${generateInsertValues(100, 10000 + batch, batch * 100)}"
     }
 
+    // Query to trigger sync in cloud mode
+    def count = sql "SELECT count(*) FROM ${tableName}"
+    logger.info("Inserted ${count[0][0]} rows")
+
     // Get tablet info
     def tablets = sql_return_maparray "SHOW TABLETS FROM ${tableName}"
     def tabletId = tablets[0].TabletId
@@ -155,6 +158,10 @@ suite("test_skip_write_index_on_load") {
         sql "INSERT INTO ${normalTableName} VALUES ${generateInsertValues(100, 10000 + batch, batch * 100)}"
     }
 
+    // Query to trigger sync in cloud mode
+    def normalCount = sql "SELECT count(*) FROM ${normalTableName}"
+    logger.info("Inserted ${normalCount[0][0]} rows into normal table")
+
     // Get tablet info
     def normalTablets = sql_return_maparray "SHOW TABLETS FROM ${normalTableName}"
     def normalTabletId = normalTablets[0].TabletId
@@ -202,6 +209,10 @@ suite("test_skip_write_index_on_load") {
         sql "INSERT INTO ${buildIndexTableName} VALUES ${generateInsertValues(100, 20000 + batch, batch * 100)}"
     }
 
+    // Query to trigger sync in cloud mode
+    def buildCount = sql "SELECT count(*) FROM ${buildIndexTableName}"
+    logger.info("Inserted ${buildCount[0][0]} rows into build index table")
+
     // Get tablet info
     def buildTablets = sql_return_maparray "SHOW TABLETS FROM ${buildIndexTableName}"
     def buildTabletId = buildTablets[0].TabletId
@@ -215,8 +226,8 @@ suite("test_skip_write_index_on_load") {
         "Case 4 pre-check FAILED: index file should be empty before BUILD INDEX")
     logger.info("Case 4 pre-check: no ANN index before BUILD INDEX")
 
-    // Execute BUILD INDEX
-    sql "BUILD INDEX idx_emb ON ${buildIndexTableName}"
+    // Execute BUILD INDEX (use BUILD INDEX ON table for cloud mode compatibility)
+    sql "BUILD INDEX ON ${buildIndexTableName}"
 
     // Wait for BUILD INDEX to complete
     def maxWaitSeconds = 120
@@ -254,10 +265,96 @@ suite("test_skip_write_index_on_load") {
         "Case 4 FAILED: ann.faiss should exist after BUILD INDEX")
     logger.info("Case 4 PASSED: BUILD INDEX successfully built ANN index")
 
+    // ============================================================
+    // Case 5: Query correctness test - verify ANN queries work
+    // Expected: l2_distance_approximate returns correct results
+    // ============================================================
+    logger.info("Case 5: Query correctness test - verify ANN queries work after index is built")
+
+    // Query the table where ANN index was built via compaction (Case 2)
+    // Use a known vector and verify results are reasonable
+    def queryResult = sql """
+        SELECT id FROM ${tableName}
+        ORDER BY l2_distance_approximate(embedding, [50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0])
+        LIMIT 5
+    """
+    logger.info("Query result from compacted table: ${queryResult}")
+    assertTrue(queryResult.size() == 5, "Case 5 FAILED: Expected 5 results from ANN query")
+    logger.info("Case 5 PASSED: ANN query returns correct number of results")
+
+    // ============================================================
+    // Case 6: Inverted index preservation test
+    // Expected: inverted index is built even when skip_write_index_on_load=true
+    // (skip_write_index_on_load only affects ANN index, not inverted index)
+    // ============================================================
+    logger.info("Case 6: Verify inverted index is NOT skipped when skip_write_index_on_load=true")
+
+    def mixedTableName = "tbl_mixed_index"
+    sql "drop table if exists ${mixedTableName}"
+    sql """
+    CREATE TABLE ${mixedTableName} (
+        id INT NOT NULL,
+        embedding ARRAY<FLOAT> NOT NULL,
+        text_col VARCHAR(100),
+        INDEX idx_emb (`embedding`) USING ANN PROPERTIES(
+            "index_type"="hnsw",
+            "metric_type"="l2_distance",
+            "dim"="8"
+        ),
+        INDEX idx_text (`text_col`) USING INVERTED
+    ) ENGINE=OLAP
+    DUPLICATE KEY(id)
+    DISTRIBUTED BY HASH(id) BUCKETS 1
+    PROPERTIES (
+        "replication_num" = "1",
+        "disable_auto_compaction" = "true",
+        "skip_write_index_on_load" = "true"
+    );
+    """
+
+    // Insert data with text
+    def random = new Random(30000)
+    def mixedValues = []
+    for (int i = 0; i < 100; i++) {
+        def vec = (0..<8).collect { (random.nextFloat() * 100).round(6) }
+        mixedValues << "(${i}, [${vec.join(',')}], 'text_${i}')"
+    }
+    sql "INSERT INTO ${mixedTableName} VALUES ${mixedValues.join(',')}"
+
+    // Query to trigger sync
+    def mixedCount = sql "SELECT count(*) FROM ${mixedTableName}"
+    logger.info("Inserted ${mixedCount[0][0]} rows into mixed index table")
+
+    // Get tablet info
+    def mixedTablets = sql_return_maparray "SHOW TABLETS FROM ${mixedTableName}"
+    def mixedTabletId = mixedTablets[0].TabletId
+    def mixedBackendId = mixedTablets[0].BackendId
+    def mixedBeIp = backendId_to_backendIP.get(mixedBackendId)
+    def mixedBePort = backendId_to_backendHttpPort.get(mixedBackendId)
+
+    // Check index files
+    def mixedIndexResponse = showNestedIndexFile(mixedBeIp, mixedBePort, mixedTabletId)
+
+    // ANN index should NOT exist (skip_write_index_on_load=true)
+    assertFalse(mixedIndexResponse.contains("ann.faiss"),
+        "Case 6 FAILED: ann.faiss should NOT exist when skip_write_index_on_load=true")
+
+    // Inverted index SHOULD exist (not affected by skip_write_index_on_load)
+    // The inverted index file pattern for text columns typically contains the column name or index id
+    assertTrue(mixedIndexResponse.contains("idx_text") || !mixedIndexResponse.contains("is empty"),
+        "Case 6 FAILED: inverted index should exist even when skip_write_index_on_load=true")
+
+    // Verify inverted index works by running a MATCH query
+    def matchResult = sql "SELECT count(*) FROM ${mixedTableName} WHERE text_col MATCH 'text_50'"
+    logger.info("MATCH query result: ${matchResult}")
+    assertTrue(matchResult[0][0] >= 1, "Case 6 FAILED: MATCH query should return results")
+    logger.info("Case 6 PASSED: Inverted index is preserved and works correctly")
+
     // Cleanup
     sql "drop table if exists ${tableName}"
     sql "drop table if exists ${normalTableName}"
     sql "drop table if exists ${buildIndexTableName}"
+    sql "drop table if exists ${mixedTableName}"
 
     logger.info("All test cases passed!")
 }

--- a/regression-test/suites/ann_index_p0/test_skip_write_index_on_load.groovy
+++ b/regression-test/suites/ann_index_p0/test_skip_write_index_on_load.groovy
@@ -1,0 +1,176 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Test skip_write_index_on_load property for ANN index
+// When enabled, ANN index construction is skipped during data loading
+// and built during compaction
+//
+// Verification strategy using show_nested_index_file API:
+// 1. skip_write_index_on_load=true + before compaction: no ann.faiss
+// 2. skip_write_index_on_load=true + after compaction: ann.faiss exists
+// 3. skip_write_index_on_load=false: ann.faiss exists immediately after insert
+
+suite("test_skip_write_index_on_load") {
+    if (isCloudMode()) {
+        return
+    }
+
+    // Setup backend mappings
+    def backendId_to_backendIP = [:]
+    def backendId_to_backendHttpPort = [:]
+    getBackendIpHttpPort(backendId_to_backendIP, backendId_to_backendHttpPort)
+
+    // Helper to call show_nested_index_file API
+    def showNestedIndexFile = { ip, port, tabletId ->
+        def (code, out, err) = http_client("GET", String.format("http://%s:%s/api/show_nested_index_file?tablet_id=%s", ip, port, tabletId))
+        logger.info("show_nested_index_file response: ${out}")
+        return out
+    }
+
+    // Helper to check if ANN index exists
+    def hasAnnIndex = { ip, port, tabletId ->
+        def out = showNestedIndexFile(ip, port, tabletId)
+        return out.contains("ann.faiss")
+    }
+
+    // Helper to check if index file is empty
+    def isIndexFileEmpty = { ip, port, tabletId ->
+        def out = showNestedIndexFile(ip, port, tabletId)
+        return out.contains("is empty")
+    }
+
+    // Generate dataset for testing
+    def generateInsertValues = { int count, int seed, int startId = 0 ->
+        def random = new Random(seed)
+        def values = []
+        for (int i = 0; i < count; i++) {
+            def vec = (0..<8).collect { (random.nextFloat() * 100).round(6) }
+            values << "(${startId + i}, [${vec.join(',')}])"
+        }
+        return values.join(',')
+    }
+
+    def tableName = "tbl_skip_ann_index"
+    def normalTableName = "tbl_normal_ann_index"
+
+    // ============================================================
+    // Case 1: skip_write_index_on_load=true, before compaction
+    // Expected: no ann.faiss in index file
+    // ============================================================
+    logger.info("Case 1: skip_write_index_on_load=true, verify no ANN index before compaction")
+
+    sql "drop table if exists ${tableName}"
+    sql """
+    CREATE TABLE ${tableName} (
+        id INT NOT NULL,
+        embedding ARRAY<FLOAT> NOT NULL,
+        INDEX idx_emb (`embedding`) USING ANN PROPERTIES(
+            "index_type"="hnsw",
+            "metric_type"="l2_distance",
+            "dim"="8"
+        )
+    ) ENGINE=OLAP
+    DUPLICATE KEY(id)
+    DISTRIBUTED BY HASH(id) BUCKETS 1
+    PROPERTIES (
+        "replication_num" = "1",
+        "disable_auto_compaction" = "true",
+        "skip_write_index_on_load" = "true"
+    );
+    """
+
+    // Insert data in multiple batches
+    for (int batch = 0; batch < 5; batch++) {
+        sql "INSERT INTO ${tableName} VALUES ${generateInsertValues(100, 10000 + batch, batch * 100)}"
+    }
+
+    // Get tablet info
+    def tablets = sql_return_maparray "SHOW TABLETS FROM ${tableName}"
+    def tabletId = tablets[0].TabletId
+    def backendId = tablets[0].BackendId
+    def beIp = backendId_to_backendIP.get(backendId)
+    def bePort = backendId_to_backendHttpPort.get(backendId)
+    logger.info("Tablet ID: ${tabletId}, Backend: ${beIp}:${bePort}")
+
+    // Verify: no ANN index before compaction
+    assertTrue(isIndexFileEmpty(beIp, bePort, tabletId),
+        "Case 1 FAILED: index file should be empty when skip_write_index_on_load=true")
+    logger.info("Case 1 PASSED: no ANN index before compaction")
+
+    // ============================================================
+    // Case 2: skip_write_index_on_load=true, after compaction
+    // Expected: ann.faiss exists in index file
+    // ============================================================
+    logger.info("Case 2: skip_write_index_on_load=true, verify ANN index after compaction")
+
+    trigger_and_wait_compaction(tableName, "full")
+
+    // Verify: ANN index exists after compaction
+    assertTrue(hasAnnIndex(beIp, bePort, tabletId),
+        "Case 2 FAILED: ann.faiss should exist after compaction")
+    logger.info("Case 2 PASSED: ANN index exists after compaction")
+
+    // ============================================================
+    // Case 3: skip_write_index_on_load=false (default)
+    // Expected: ann.faiss exists immediately after insert
+    // ============================================================
+    logger.info("Case 3: skip_write_index_on_load=false, verify ANN index exists after insert")
+
+    sql "drop table if exists ${normalTableName}"
+    sql """
+    CREATE TABLE ${normalTableName} (
+        id INT NOT NULL,
+        embedding ARRAY<FLOAT> NOT NULL,
+        INDEX idx_emb (`embedding`) USING ANN PROPERTIES(
+            "index_type"="hnsw",
+            "metric_type"="l2_distance",
+            "dim"="8"
+        )
+    ) ENGINE=OLAP
+    DUPLICATE KEY(id)
+    DISTRIBUTED BY HASH(id) BUCKETS 1
+    PROPERTIES (
+        "replication_num" = "1",
+        "disable_auto_compaction" = "true",
+        "skip_write_index_on_load" = "false"
+    );
+    """
+
+    // Insert same data
+    for (int batch = 0; batch < 5; batch++) {
+        sql "INSERT INTO ${normalTableName} VALUES ${generateInsertValues(100, 10000 + batch, batch * 100)}"
+    }
+
+    // Get tablet info
+    def normalTablets = sql_return_maparray "SHOW TABLETS FROM ${normalTableName}"
+    def normalTabletId = normalTablets[0].TabletId
+    def normalBackendId = normalTablets[0].BackendId
+    def normalBeIp = backendId_to_backendIP.get(normalBackendId)
+    def normalBePort = backendId_to_backendHttpPort.get(normalBackendId)
+    logger.info("Normal table Tablet ID: ${normalTabletId}, Backend: ${normalBeIp}:${normalBePort}")
+
+    // Verify: ANN index exists immediately after insert
+    assertTrue(hasAnnIndex(normalBeIp, normalBePort, normalTabletId),
+        "Case 3 FAILED: ann.faiss should exist immediately when skip_write_index_on_load=false")
+    logger.info("Case 3 PASSED: ANN index exists immediately after insert")
+
+    // Cleanup
+    sql "drop table if exists ${tableName}"
+    sql "drop table if exists ${normalTableName}"
+
+    logger.info("All test cases passed!")
+}

--- a/regression-test/suites/ann_index_p0/test_skip_write_index_on_load.groovy
+++ b/regression-test/suites/ann_index_p0/test_skip_write_index_on_load.groovy
@@ -168,9 +168,96 @@ suite("test_skip_write_index_on_load") {
         "Case 3 FAILED: ann.faiss should exist immediately when skip_write_index_on_load=false")
     logger.info("Case 3 PASSED: ANN index exists immediately after insert")
 
+    // ============================================================
+    // Case 4: skip_write_index_on_load=true, BUILD INDEX can force build
+    // Expected: ann.faiss exists after BUILD INDEX
+    // This verifies that BUILD INDEX can generate ANN index even when
+    // skip_write_index_on_load=true (not only compaction)
+    // ============================================================
+    logger.info("Case 4: skip_write_index_on_load=true, verify BUILD INDEX can force build ANN index")
+
+    def buildIndexTableName = "tbl_build_index_ann"
+    sql "drop table if exists ${buildIndexTableName}"
+    sql """
+    CREATE TABLE ${buildIndexTableName} (
+        id INT NOT NULL,
+        embedding ARRAY<FLOAT> NOT NULL,
+        INDEX idx_emb (`embedding`) USING ANN PROPERTIES(
+            "index_type"="hnsw",
+            "metric_type"="l2_distance",
+            "dim"="8"
+        )
+    ) ENGINE=OLAP
+    DUPLICATE KEY(id)
+    DISTRIBUTED BY HASH(id) BUCKETS 1
+    PROPERTIES (
+        "replication_num" = "1",
+        "disable_auto_compaction" = "true",
+        "skip_write_index_on_load" = "true"
+    );
+    """
+
+    // Insert data
+    for (int batch = 0; batch < 3; batch++) {
+        sql "INSERT INTO ${buildIndexTableName} VALUES ${generateInsertValues(100, 20000 + batch, batch * 100)}"
+    }
+
+    // Get tablet info
+    def buildTablets = sql_return_maparray "SHOW TABLETS FROM ${buildIndexTableName}"
+    def buildTabletId = buildTablets[0].TabletId
+    def buildBackendId = buildTablets[0].BackendId
+    def buildBeIp = backendId_to_backendIP.get(buildBackendId)
+    def buildBePort = backendId_to_backendHttpPort.get(buildBackendId)
+    logger.info("Build index table Tablet ID: ${buildTabletId}, Backend: ${buildBeIp}:${buildBePort}")
+
+    // Verify: no ANN index before BUILD INDEX
+    assertTrue(isIndexFileEmpty(buildBeIp, buildBePort, buildTabletId),
+        "Case 4 pre-check FAILED: index file should be empty before BUILD INDEX")
+    logger.info("Case 4 pre-check: no ANN index before BUILD INDEX")
+
+    // Execute BUILD INDEX
+    sql "BUILD INDEX idx_emb ON ${buildIndexTableName}"
+
+    // Wait for BUILD INDEX to complete
+    def maxWaitSeconds = 120
+    def waitInterval = 2000
+    def waited = 0
+    def buildIndexSuccess = false
+
+    while (waited < maxWaitSeconds * 1000) {
+        def indexState = sql_return_maparray "SHOW BUILD INDEX FROM ${context.dbName} WHERE TableName='${buildIndexTableName}'"
+        logger.info("BUILD INDEX state: ${indexState}")
+
+        if (indexState.size() > 0) {
+            // Check the most recent job (last entry in the list)
+            def latestJob = indexState[indexState.size() - 1]
+            def state = latestJob.State
+            logger.info("Latest BUILD INDEX job state: ${state}, JobId: ${latestJob.JobId}")
+            if (state == "FINISHED") {
+                buildIndexSuccess = true
+                break
+            } else if (state == "CANCELLED") {
+                logger.warn("BUILD INDEX was cancelled: ${latestJob.Msg}")
+                break
+            }
+        }
+        sleep(waitInterval)
+        waited += waitInterval
+    }
+
+    assertTrue(buildIndexSuccess, "Case 4 FAILED: BUILD INDEX did not complete successfully")
+
+    // Verify: ANN index exists after BUILD INDEX
+    // This is the expected behavior - BUILD INDEX can force build ANN index
+    // even when skip_write_index_on_load=true
+    assertTrue(hasAnnIndex(buildBeIp, buildBePort, buildTabletId),
+        "Case 4 FAILED: ann.faiss should exist after BUILD INDEX")
+    logger.info("Case 4 PASSED: BUILD INDEX successfully built ANN index")
+
     // Cleanup
     sql "drop table if exists ${tableName}"
     sql "drop table if exists ${normalTableName}"
+    sql "drop table if exists ${buildIndexTableName}"
 
     logger.info("All test cases passed!")
 }


### PR DESCRIPTION
## Summary

This PR adds support for the `skip_write_index_on_load` table property for ANN (Approximate Nearest Neighbor) indexes. When enabled, ANN index construction is skipped during data loading (INSERT/StreamLoad) and deferred to compaction or BUILD INDEX, significantly improving write throughput.

### Key Changes

1. **Skip ANN index during write** (`segment_writer.cpp`, `vertical_segment_writer.cpp`)
   - Check `skip_write_index_on_load` property before creating ANN index writer
   - Write empty index file placeholder when skipping

2. **Build ANN index during compaction** (`segment.cpp`, `segment_iterator.cpp`)
   - Load ANN index data from source segments during compaction
   - Build complete ANN index in output segment

3. **Support BUILD INDEX for empty ANN indexes** (`index_builder.cpp`)
   - Handle `INVERTED_INDEX_BYPASS` error for empty index files
   - Allow BUILD INDEX to create ANN index when `skip_write_index_on_load=true`

4. **Accurate index existence detection** (`tablet.cpp`, `cloud_tablet.cpp`)
   - Use `IndexFileReader::index_file_exist()` API to check actual index presence
   - Fast path optimization: check `index_size` for V2 format, `fs->exists()` for V1

5. **Cloud mode support** (`cloud_tablet.cpp`, `engine_cloud_index_change_task.cpp`)
   - Same functionality for cloud deployment mode

### Test Plan

Added comprehensive regression test (`test_skip_write_index_on_load.groovy`) with 4 test cases:
- Case 1: `skip_write_index_on_load=true` - verify no ANN index before compaction
- Case 2: `skip_write_index_on_load=true` - verify ANN index exists after compaction
- Case 3: `skip_write_index_on_load=false` - verify ANN index exists immediately
- Case 4: BUILD INDEX successfully builds ANN index when `skip_write_index_on_load=true`

### Check List (For Author)

- Test
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test
    - [ ] No need to test

- Behavior changed:
    - [x] Yes. Added support for `skip_write_index_on_load` property for ANN indexes

- Does this need documentation?
    - [x] Yes. Document the `skip_write_index_on_load` property for ANN indexes

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label

🤖 Generated with [Claude Code](https://claude.com/claude-code)