### PR TITLE
[Fix](partition) fix concurrent visit of partition items

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -181,7 +181,7 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
     private KeysType keysType;
     @Setter
     @SerializedName(value = "pi", alternate = {"partitionInfo"})
-    private PartitionInfo partitionInfo;
+    private PartitionInfo partitionInfo; // should modify only under table's lock
     @SerializedName(value = "itp", alternate = {"idToPartition"})
     @Getter
     protected ConcurrentHashMap<Long, Partition> idToPartition = new ConcurrentHashMap<>();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/PartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/PartitionInfo.java
@@ -46,7 +46,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /*
- * Repository of a partition's related infos
+ * Repository of a partition's related infos. should modify only under table's lock.
  */
 public class PartitionInfo {
     private static final Logger LOG = LogManager.getLogger(PartitionInfo.class);
@@ -137,6 +137,7 @@ public class PartitionInfo {
         return sb.toString();
     }
 
+    // need read lock of table
     public Map<Long, PartitionItem> getIdToItem(boolean isTemp) {
         if (isTemp) {
             return idToTempItem;
@@ -196,6 +197,7 @@ public class PartitionInfo {
         }
     }
 
+    // need write lock of table
     public PartitionItem handleNewSinglePartitionDesc(SinglePartitionDesc desc,
                                                       long partitionId, boolean isTemp) throws DdlException {
         Preconditions.checkArgument(desc.isAnalyzed());


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: introduced by https://github.com/apache/doris/pull/56921

Problem Summary:

fix concurrency bug when dynamic partition visit partition items at the same time with modifying partitions:
```java
2026-01-12 15:31:46,108 ERROR (thrift-server-pool-31|451) [ProcessFunction.process():47] Internal error processing createPartition
java.lang.reflect.UndeclaredThrowableException
	at jdk.proxy2/jdk.proxy2.$Proxy27.createPartition(Unknown Source)
	at org.apache.doris.thrift.FrontendService$Processor$createPartition.getResult(FrontendService.java:4993)
	at org.apache.doris.thrift.FrontendService$Processor$createPartition.getResult(FrontendService.java:4973)
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38)
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:250)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.reflect.InvocationTargetException
	at jdk.internal.reflect.GeneratedMethodAccessor27.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.apache.doris.service.FeServer.lambda$start$0(FeServer.java:60)
	... 9 more
Caused by: java.util.ConcurrentModificationException
	at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1597)
	at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1630)
	at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1628)
	at java.base/java.util.AbstractCollection.toArray(AbstractCollection.java:146)
	at java.base/java.util.ArrayList.<init>(ArrayList.java:181)
	at org.apache.doris.clone.DynamicPartitionScheduler.getHistoricalPartitions(DynamicPartitionScheduler.java:209)
	at org.apache.doris.common.util.AutoBucketCalculator.calculateAutoBuckets(AutoBucketCalculator.java:142)
	at org.apache.doris.common.util.AutoBucketCalculator.calculateAutoBucketsWithBoundsCheck(AutoBucketCalculator.java:190)
	at org.apache.doris.analysis.PartitionExprUtil.getAddPartitionClauseFromPartitionValues(PartitionExprUtil.java:202)
	at org.apache.doris.service.FrontendServiceImpl.createPartition(FrontendServiceImpl.java:3622)
	... 13 more
```

all these visit operations should under table's lock.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

