### PR TITLE
 [Improve](broker) Modify the original TGT renewal logic to prevent high-concurrency access to the KDC

### DIFF
--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/BrokerFileSystem.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/BrokerFileSystem.java
@@ -32,7 +32,6 @@ public class BrokerFileSystem {
     private FileSystemIdentity identity;
     private FileSystem dfsFileSystem;
     private volatile long lastAccessTimestamp;
-    private long createTimestamp;
     private UUID fileSystemId;
 
     public BrokerFileSystem(FileSystemIdentity identity) {
@@ -40,14 +39,12 @@ public class BrokerFileSystem {
         this.lock = new ReentrantLock();
         this.dfsFileSystem = null;
         this.lastAccessTimestamp = System.currentTimeMillis();
-        this.createTimestamp = System.currentTimeMillis();
         this.fileSystemId = UUID.randomUUID();
     }
 
     public synchronized void setFileSystem(FileSystem fileSystem) {
         this.dfsFileSystem = fileSystem;
         this.lastAccessTimestamp = System.currentTimeMillis();
-        this.createTimestamp = System.currentTimeMillis();
     }
 
     public void closeFileSystem() {
@@ -85,12 +82,8 @@ public class BrokerFileSystem {
         return lock;
     }
 
-    public boolean isExpiredByLastAccessTime(long expirationIntervalSecs) {
-        return System.currentTimeMillis() - lastAccessTimestamp > expirationIntervalSecs * 1000;
-    }
-
-    public boolean isExpiredByCreateTime(long expirationIntervalSecs) {
-        return System.currentTimeMillis() - createTimestamp > expirationIntervalSecs * 1000;
+    public boolean isExpiredByLastAccessTime() {
+        return System.currentTimeMillis() - lastAccessTimestamp > BrokerConfig.client_expire_seconds * 1000L;
     }
 
     @Override


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

If the broker has Kerberos enabled, the expiration time of the file system is based on its creation time. Once the file system expires, re-authentication with the KDC  is required for every access to the broker. In cases where there is high concurrency of requests from the BE , the request load on the KDC will become extremely heavy.
when file system is expired  when broker enable kerberos.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

