### PR TITLE
[Fix](tvf) fix httptvf read large file in no range mode

### DIFF
--- a/be/src/io/fs/http_file_reader.cpp
+++ b/be/src/io/fs/http_file_reader.cpp
@@ -165,6 +165,22 @@ Status HttpFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_r
         return Status::OK();
     }
 
+    // For non-Range mode, prioritize full file cache
+    if (!_range_supported && _full_file_cached) {
+        if (offset >= _full_file_cache.size()) {
+            *bytes_read = 0;
+            return Status::OK();
+        }
+
+        size_t available = _full_file_cache.size() - offset;
+        size_t copy_len = std::min(available, to_read);
+        std::memcpy(result.data, _full_file_cache.data() + offset, copy_len);
+        *bytes_read = copy_len;
+
+        VLOG(2) << "Full file cache hit: copied " << copy_len << " bytes from offset " << offset;
+        return Status::OK();
+    }
+
     // Try to serve from buffer cache
     if (offset >= _buffer_start && offset < _buffer_end) {
         size_t buffer_idx = offset - _buffer_start;
@@ -273,25 +289,24 @@ Status HttpFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_r
                 http_status, buf.size(), _url);
     }
 
-    // Handle non-Range mode: when _range_supported is false, we download full file
-    if (!_range_supported && offset > 0) {
-        // We're in non-Range mode and need data from middle of file
-        // The full file should have been downloaded
-        if (offset >= buf.size()) {
+    // Handle non-Range mode: cache the full file on first download
+    if (!_range_supported && !_full_file_cached) {
+        // Cache the complete file content for subsequent reads
+        _full_file_cache = std::move(buf);
+        _full_file_cached = true;
+
+        VLOG(2) << "Cached full file: " << _full_file_cache.size() << " bytes";
+
+        // Serve the requested portion from cache
+        if (offset >= _full_file_cache.size()) {
             *bytes_read = buffer_offset;
             return Status::OK();
         }
 
-        size_t slice_len = std::min<size_t>(remaining, buf.size() - offset);
-        std::memcpy(result.data + buffer_offset, buf.data() + offset, slice_len);
-        buffer_offset += slice_len;
-
-        size_t cached = std::min(slice_len, (size_t)READ_BUFFER_SIZE);
-        std::memcpy(_read_buffer.get(), buf.data() + offset, cached);
-        _buffer_start = offset;
-        _buffer_end = offset + cached;
-
-        *bytes_read = buffer_offset;
+        size_t available = _full_file_cache.size() - offset;
+        size_t copy_len = std::min(available, remaining);
+        std::memcpy(result.data + buffer_offset, _full_file_cache.data() + offset, copy_len);
+        *bytes_read = buffer_offset + copy_len;
         return Status::OK();
     }
 
@@ -330,6 +345,11 @@ Status HttpFileReader::close() {
     _read_buffer.reset();
     _buffer_start = 0;
     _buffer_end = 0;
+
+    // Release full file cache
+    _full_file_cache.clear();
+    _full_file_cache.shrink_to_fit();
+    _full_file_cached = false;
 
     // Release HttpClient resources
     _client.reset();

--- a/be/src/io/fs/http_file_reader.h
+++ b/be/src/io/fs/http_file_reader.h
@@ -82,6 +82,10 @@ private:
     // Configuration for non-Range request handling
     bool _enable_range_request = true;                         // Whether Range request is required
     size_t _max_request_size_bytes = DEFAULT_MAX_REQUEST_SIZE; // Max size for non-Range downloads
+
+    // Full file cache for non-Range mode to avoid repeated downloads
+    std::string _full_file_cache;   // Cache complete file content
+    bool _full_file_cached = false; // Whether full file has been cached
 };
 
 } // namespace doris::io

--- a/regression-test/data/external_table_p0/tvf/test_http_tvf.out
+++ b/regression-test/data/external_table_p0/tvf/test_http_tvf.out
@@ -136,6 +136,9 @@ struct_arr_map	struct<aa:array<text>,mm:map<date,text>>	Yes	false	\N	NONE
 id	int	Yes	false	\N	NONE
 m	map<text,text>	Yes	false	\N	NONE
 
+-- !sql_norange --
+200
+
 -- !sql13 --
 1	1.1234	12.123456	123.123456789876	12	1234.123456789	123
 2	1234.1234	123456789123.123456	12345678912345678912345678.123456789876	123456789	123456789123456789.123456780	987654321

--- a/regression-test/suites/external_table_p0/tvf/test_http_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_http_tvf.groovy
@@ -158,6 +158,16 @@ suite("test_http_tvf", "p2") {
         exception """exceeds maximum allowed size (1000 bytes"""
     }
 
+    // non range and large than readBuffer(1MB)
+    qt_sql_norange """
+        SELECT count(1) FROM
+        HTTP(
+            "uri" = "https://raw.githubusercontent.com/apache/doris/refs/tags/4.0.2-rc02/regression-test/data/datatype_p0/nested_types/query/test_nested_type_with_resize.csv",
+            "format" = "csv",
+            "http.enable.range.request"="false"
+        );
+    """
+
     qt_sql13 """
         select * from
         http(


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: https://github.com/apache/doris/pull/57242

Currently, when reading using the NoRange method, if the file is large (Size exceeds the ReadBuffer, default 1MB), the following error will occur:
```
mysql> SELECT count(1) FROM
    -> HTTP(
    ->     "uri" = "https://raw.githubusercontent.com/apache/doris/refs/tags/4.0.2-rc02/regression-test/data/datatype_p0/nested_types/query/test_nested_type_with_resize.csv",
    ->     "format" = "csv",
    ->     "http.enable.range.request"="false" 
    -> ) limit 1;
ERROR 1105 (HY000): errCode = 2, detailMessage = Can not build FunctionGenTable 'http'. error: errCode = 2, detailMessage = (10.16.10.6)[INTERNAL_ERROR]HTTP response larger than requested buffer
mysql> 
```


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

