### PR TITLE
[fix](Test)Anonymous access must be explicitly specified to prevent the default ProviderChain from taking effect.

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/S3PropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/S3PropertiesTest.java
@@ -275,7 +275,7 @@ public class S3PropertiesTest {
         provider = s3Props.getAwsCredentialsProvider();
         Assertions.assertNotNull(provider);
         Assertions.assertTrue(provider instanceof AwsCredentialsProviderChain);
-        Assertions.assertEquals("software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider,software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider,software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider,software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider,software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider,software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider", s3Props.getHadoopStorageConfig().get("fs.s3a.aws.credentials.provider"));
+        Assertions.assertEquals("software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider,software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider,software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider,software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider", s3Props.getHadoopStorageConfig().get("fs.s3a.aws.credentials.provider"));
 
     }
 

--- a/regression-test/suites/aws_iam_role_p0/test_tvf_anonymous.groovy
+++ b/regression-test/suites/aws_iam_role_p0/test_tvf_anonymous.groovy
@@ -27,13 +27,14 @@ suite("test_tvf_anonymous") {
     def uri = context.config.otherConfigs.get("anymousS3Uri")
     def expectDataCount = context.config.otherConfigs.get("anymousS3ExpectDataCount");
     //aws_credentials_provider_version
-    sql """ ADMIN SET FRONTEND CONFIG ("aws_credentials_provider_version"="v1"); """
+   // sql """ ADMIN SET FRONTEND CONFIG ("aws_credentials_provider_version"="v1"); """
 
     def result = sql """
         SELECT count(1) FROM S3 (                  
         "uri"="${uri}",
          "format" = "csv",     
           "s3.region" = "${region}",  
+           "s3.credentials_provider_type"="ANONYMOUS",
            "s3.endpoint" = "https://s3.${region}.amazonaws.com", 
            "column_separator" = ","              );
         """
@@ -47,6 +48,7 @@ suite("test_tvf_anonymous") {
         "uri"="${uri}",
          "format" = "csv",     
           "s3.region" = "${region}",  
+           "s3.credentials_provider_type"="ANONYMOUS",
            "s3.endpoint" = "https://s3.${region}.amazonaws.com", 
            "column_separator" = ","              );
         """


### PR DESCRIPTION


### What problem does this PR solve?
When using the default AWS credentials provider chain, some providers (e.g. WebIdentityTokenCredentialsProvider
or EC2ContainerCredentialsProvider) may fail by design in non-container or non-IRSA environments.
These failures can introduce unnecessary errors and make tests flaky.

This PR improves the default credentials provider handling by:
1. Filtering out credential providers that are known to fail in the current runtime environment.
2. Avoiding side effects between concurrent test cases caused by mixed usage of
   aws_credentials_provider_version = v1 and v2.
3. Isolating catalog instances by using distinct catalog names to prevent shared state conflicts
   when tests are executed in parallel.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

