### PR TITLE
[opt](memo) reuse GroupPlan in Group to reduce memory usage

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/HyperGraph.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/HyperGraph.java
@@ -400,8 +400,9 @@ public class HyperGraph {
                 Group group = ((GroupPlan) plan).getGroup();
                 GroupExpression groupExpression = group.getLogicalExpressions().get(0);
                 return buildForMv(groupExpression.getPlan()
-                        .withChildren(
-                                groupExpression.children().stream().map(GroupPlan::new).collect(Collectors.toList())));
+                        .withChildren(groupExpression.children().stream()
+                                .map(Group::getGroupPlan)
+                                .collect(Collectors.toList())));
             }
             // process Project
             if (isValidProject(plan)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/PlanReceiver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/PlanReceiver.java
@@ -102,8 +102,8 @@ public class PlanReceiver implements AbstractReceiver {
         }
 
         Memo memo = jobContext.getCascadesContext().getMemo();
-        GroupPlan leftPlan = new GroupPlan(planTable.get(left));
-        GroupPlan rightPlan = new GroupPlan(planTable.get(right));
+        GroupPlan leftPlan = planTable.get(left).getGroupPlan();
+        GroupPlan rightPlan = planTable.get(right).getGroupPlan();
 
         // First, we implement all possible physical plans
         // In this step, we don't generate logical expression because they are useless in DPhyp.
@@ -205,7 +205,7 @@ public class PlanReceiver implements AbstractReceiver {
     public void addGroup(long bitmap, Group group) {
         Preconditions.checkArgument(LongBitmap.getCardinality(bitmap) == 1);
         usdEdges.put(bitmap, new BitSet());
-        Plan plan = proposeProject(new GroupPlan(group), new ArrayList<>(), bitmap, bitmap);
+        Plan plan = proposeProject(group.getGroupPlan(), new ArrayList<>(), bitmap, bitmap);
         if (!(plan instanceof GroupPlan)) {
             CopyInResult copyInResult = jobContext.getCascadesContext().getMemo().copyIn(plan, null, false, planTable);
             group = copyInResult.correspondingExpression.getOwnerGroup();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.DistributionSpec;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
+import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
@@ -63,6 +64,7 @@ public class Group {
     private final List<GroupExpression> physicalExpressions = Lists.newArrayList();
     private final Map<GroupExpression, GroupExpression> enforcers = Maps.newHashMap();
     private final Map<DistributionSpec, GroupExpression> enforcerSpecs = Maps.newHashMap();
+    private final GroupPlan groupPlan;
     private boolean isStatsReliable = true;
     private LogicalProperties logicalProperties;
 
@@ -92,6 +94,7 @@ public class Group {
         this.groupId = groupId;
         addGroupExpression(groupExpression);
         this.logicalProperties = logicalProperties;
+        this.groupPlan = new GroupPlan(this);
     }
 
     /**
@@ -102,6 +105,7 @@ public class Group {
     public Group(GroupId groupId, LogicalProperties logicalProperties) {
         this.groupId = groupId;
         this.logicalProperties = logicalProperties;
+        this.groupPlan = new GroupPlan(this);
     }
 
     public GroupId getGroupId() {
@@ -174,6 +178,10 @@ public class Group {
 
     public List<GroupExpression> getPhysicalExpressions() {
         return physicalExpressions;
+    }
+
+    public GroupPlan getGroupPlan() {
+        return groupPlan;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -746,7 +746,7 @@ public class Memo {
 
         ImmutableList.Builder<Plan> groupPlanChildren = ImmutableList.builderWithExpectedSize(childrenGroups.size());
         for (Group childrenGroup : childrenGroups) {
-            groupPlanChildren.add(new GroupPlan(childrenGroup));
+            groupPlanChildren.add(childrenGroup.getGroupPlan());
         }
         return plan.withChildren(groupPlanChildren.build());
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/GroupExpressionMatching.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/GroupExpressionMatching.java
@@ -20,7 +20,6 @@ package org.apache.doris.nereids.pattern;
 import org.apache.doris.nereids.memo.Group;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
-import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 
 import com.google.common.collect.ImmutableList;
@@ -111,7 +110,7 @@ public class GroupExpressionMatching implements Iterable<Plan> {
 
                     if (childrenPlan.isEmpty()) {
                         if (pattern instanceof SubTreePattern) {
-                            childrenPlan = ImmutableList.of(new GroupPlan(childGroup));
+                            childrenPlan = ImmutableList.of(childGroup.getGroupPlan());
                         } else {
                             // current pattern is match but children patterns not match
                             return;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/GroupMatching.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/GroupMatching.java
@@ -35,7 +35,7 @@ public class GroupMatching {
     public static List<Plan> getAllMatchingPlans(Pattern pattern, Group group) {
         List<Plan> matchingPlans = new ArrayList<>();
         if (pattern.isGroup() || pattern.isMultiGroup()) {
-            GroupPlan groupPlan = new GroupPlan(group);
+            GroupPlan groupPlan = group.getGroupPlan();
             if (((Pattern<Plan>) pattern).matchPredicates(groupPlan)) {
                 matchingPlans.add(groupPlan);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/DistributionSpec.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/DistributionSpec.java
@@ -44,7 +44,7 @@ public abstract class DistributionSpec {
         // If we don't set LogicalProperties explicitly, node will compute a applicable LogicalProperties for itself.
         PhysicalDistribute<GroupPlan> distribution = new PhysicalDistribute<>(
                 this,
-                new GroupPlan(child));
+                child.getGroupPlan());
         return new GroupExpression(distribution, Lists.newArrayList(child));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/OrderSpec.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/OrderSpec.java
@@ -19,7 +19,6 @@ package org.apache.doris.nereids.properties;
 
 import org.apache.doris.nereids.memo.Group;
 import org.apache.doris.nereids.memo.GroupExpression;
-import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.SortPhase;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalQuickSort;
 
@@ -67,7 +66,7 @@ public class OrderSpec {
     public GroupExpression addLocalQuickSortEnforcer(Group child) {
         return new GroupExpression(
                 new PhysicalQuickSort<>(orderKeys, SortPhase.LOCAL_SORT, child.getLogicalProperties(),
-                        new GroupPlan(child)),
+                        child.getGroupPlan()),
                 Lists.newArrayList(child)
         );
     }
@@ -78,7 +77,7 @@ public class OrderSpec {
     public GroupExpression addGlobalQuickSortEnforcer(Group child) {
         return new GroupExpression(
                 new PhysicalQuickSort<>(orderKeys, SortPhase.MERGE_SORT, child.getLogicalProperties(),
-                        new GroupPlan(child)),
+                        child.getGroupPlan()),
                 Lists.newArrayList(child)
         );
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulatorTest.java
@@ -100,6 +100,8 @@ public class ChildrenPropertiesRegulatorTest {
             List<GroupExpression> children;
             Group childGroup = Mockito.mock(Group.class);
             Mockito.when(childGroup.getLogicalProperties()).thenReturn(Mockito.mock(LogicalProperties.class));
+            GroupPlan childGroupPlan = new GroupPlan(childGroup);
+            Mockito.when(childGroup.getGroupPlan()).thenReturn(childGroupPlan);
             GroupExpression child = Mockito.mock(GroupExpression.class);
             Mockito.when(child.getOutputProperties(Mockito.any())).thenReturn(PhysicalProperties.MUST_SHUFFLE);
             Mockito.when(child.getOwnerGroup()).thenReturn(childGroup);
@@ -159,6 +161,8 @@ public class ChildrenPropertiesRegulatorTest {
             List<GroupExpression> children;
             Group childGroup = Mockito.mock(Group.class);
             Mockito.when(childGroup.getLogicalProperties()).thenReturn(Mockito.mock(LogicalProperties.class));
+            GroupPlan childGroupPlan = new GroupPlan(childGroup);
+            Mockito.when(childGroup.getGroupPlan()).thenReturn(childGroupPlan);
             GroupExpression child = Mockito.mock(GroupExpression.class);
             Mockito.when(child.getOutputProperties(Mockito.any())).thenReturn(PhysicalProperties.MUST_SHUFFLE);
             Mockito.when(child.getOwnerGroup()).thenReturn(childGroup);


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

This pull request refactors how `GroupPlan` instances are created and accessed throughout the codebase. Instead of creating new `GroupPlan` objects from a `Group`, the code now consistently uses a single `GroupPlan` instance per `Group` via a new `getGroupPlan()` method. This improves memory efficiency, code clarity, and ensures consistency across the planner and matcher logic.

### Core API and Data Model Changes

* Added a private `GroupPlan` field to the `Group` class and initialized it in constructors; exposed it via a new `getGroupPlan()` method. This ensures each `Group` has a unique, reusable `GroupPlan` instance. [[1]](diffhunk://#diff-dc5e6a82ea2e54bd9bcf8da1b1b65d59758b5104ecf25221b6f839c8e427df99R64) [[2]](diffhunk://#diff-dc5e6a82ea2e54bd9bcf8da1b1b65d59758b5104ecf25221b6f839c8e427df99R94) [[3]](diffhunk://#diff-dc5e6a82ea2e54bd9bcf8da1b1b65d59758b5104ecf25221b6f839c8e427df99R105) [[4]](diffhunk://#diff-dc5e6a82ea2e54bd9bcf8da1b1b65d59758b5104ecf25221b6f839c8e427df99R180-R183)

### Refactoring: Use of GroupPlan

* Refactored all usages where a new `GroupPlan` was constructed from a `Group` to instead use the `getGroupPlan()` method, including planner logic, memoization, and pattern matching. This change appears in files such as `HyperGraph.java`, `PlanReceiver.java`, `Memo.java`, `GroupExpressionMatching.java`, `GroupMatching.java`, `DistributionSpec.java`, and `OrderSpec.java`. [[1]](diffhunk://#diff-a583cc64e3dacdc4f5fd7445414c9d48cd94f5fb0d9eaa7d1a3a6bc69e7e347bL403-R405) [[2]](diffhunk://#diff-4155b70e30cabf577ca7a18b53f766032da352e3b9acd98c16f286914e60f637L105-R106) [[3]](diffhunk://#diff-4155b70e30cabf577ca7a18b53f766032da352e3b9acd98c16f286914e60f637L208-R208) [[4]](diffhunk://#diff-6356d1436a9d19acaceecf79d32bf1f019c7f633ab0c470fcc255658c6c1dfdbL749-R749) [[5]](diffhunk://#diff-3b4089396e40458dc54492577936ce188647b9adbeedbc074035a03f9291e33cL114-R113) [[6]](diffhunk://#diff-03ca03179036b9059c752f23ce675b979ee53159683200c7e7b8b3d622be03dcL38-R38) [[7]](diffhunk://#diff-242ee2c60ac7e4b4dc3e395a5a46cca2186251c3ba99146105a20beae4b30ba3L47-R47) [[8]](diffhunk://#diff-486239be77f8aea72f636d2c4e38ff0c3c83e747cdc3390a5836624f8240f5a5L70-R69) [[9]](diffhunk://#diff-486239be77f8aea72f636d2c4e38ff0c3c83e747cdc3390a5836624f8240f5a5L81-R80)

These changes collectively improve the consistency and efficiency of plan representation in the query optimizer.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

