### PR TITLE
[fix](packed-file) Fix packed file cache cleanup issue

### DIFF
--- a/be/src/io/fs/packed_file_system.cpp
+++ b/be/src/io/fs/packed_file_system.cpp
@@ -20,6 +20,7 @@
 #include <utility>
 
 #include "common/status.h"
+#include "io/fs/file_reader.h"
 #include "io/fs/packed_file_reader.h"
 #include "io/fs/packed_file_writer.h"
 
@@ -69,18 +70,37 @@ Status PackedFileSystem::open_file_impl(const Path& file, FileReaderSPtr* reader
         // File is in packed file, open packed file and wrap with PackedFileReader
         const auto& index = it->second;
         FileReaderSPtr inner_reader;
-        // Create a new FileReaderOptions with the correct file size
-        FileReaderOptions local_opts = opts ? *opts : FileReaderOptions();
-        // Set file_size to packed file size to avoid head object request
-        local_opts.file_size = index.packed_file_size;
-        LOG(INFO) << "open packed file: " << index.packed_file_path << ", file: " << file.native()
-                  << ", offset: " << index.offset << ", size: " << index.size
-                  << ", packed_file_size: " << index.packed_file_size;
-        RETURN_IF_ERROR(
-                _inner_fs->open_file(Path(index.packed_file_path), &inner_reader, &local_opts));
 
-        *reader = std::make_shared<PackedFileReader>(std::move(inner_reader), file, index.offset,
-                                                     index.size);
+        // Create options for opening the packed file
+        // Disable cache at this layer - we'll add cache wrapper around PackedFileReader instead
+        // This ensures cache key is based on segment path, not packed file path
+        FileReaderOptions inner_opts = opts ? *opts : FileReaderOptions();
+        inner_opts.file_size = index.packed_file_size;
+        inner_opts.cache_type = FileCachePolicy::NO_CACHE;
+
+        VLOG_DEBUG << "open packed file: " << index.packed_file_path << ", file: " << file.native()
+                   << ", offset: " << index.offset << ", size: " << index.size
+                   << ", packed_file_size: " << index.packed_file_size;
+        RETURN_IF_ERROR(
+                _inner_fs->open_file(Path(index.packed_file_path), &inner_reader, &inner_opts));
+
+        // Create PackedFileReader with segment path
+        // PackedFileReader.path() returns segment path, not packed file path
+        auto packed_reader = std::make_shared<PackedFileReader>(std::move(inner_reader), file,
+                                                                index.offset, index.size);
+
+        // If cache is requested, wrap PackedFileReader with CachedRemoteFileReader
+        // This ensures:
+        // 1. Cache key = hash(segment_path.filename()) - matches cleanup key
+        // 2. Cache size = segment size - correct boundary
+        // 3. Each segment has independent cache entry - no interference during cleanup
+        if (opts && opts->cache_type != FileCachePolicy::NO_CACHE) {
+            FileReaderOptions cache_opts = *opts;
+            cache_opts.file_size = index.size; // Use segment size for cache
+            *reader = DORIS_TRY(create_cached_file_reader(packed_reader, cache_opts));
+        } else {
+            *reader = packed_reader;
+        }
     } else {
         RETURN_IF_ERROR(_inner_fs->open_file(file, reader, opts));
     }
@@ -88,7 +108,7 @@ Status PackedFileSystem::open_file_impl(const Path& file, FileReaderSPtr* reader
 }
 
 Status PackedFileSystem::exists_impl(const Path& path, bool* res) const {
-    LOG(INFO) << "packed file system exist, rowset id " << _append_info.rowset_id;
+    VLOG_DEBUG << "packed file system exist, rowset id " << _append_info.rowset_id;
     if (!_index_map_initialized) {
         return Status::InternalError("PackedFileSystem index map is not initialized");
     }

--- a/be/test/io/fs/packed_file_concurrency_test.cpp
+++ b/be/test/io/fs/packed_file_concurrency_test.cpp
@@ -677,7 +677,9 @@ TEST_F(MergeFileConcurrencyTest, ConcurrentWriteReadCorrectness) {
             std::uniform_int_distribution<int> read_size_dist(4 * 1024, 32 * 1024);
 
             for (int iter = 0; iter < kIterationPerThread; ++iter) {
-                std::string path = fmt::format("/tablet_{}/rowset_{}/file_{}", tid, iter, iter);
+                // Use unique file names to avoid cache key conflicts between threads
+                // since CachedRemoteFileReader uses path().filename() for cache hash
+                std::string path = fmt::format("/tablet_{}/rowset_{}/file_t{}_i{}", tid, iter, tid, iter);
 
                 PackedAppendContext append_info;
                 append_info.resource_id = resource_ids[tid];

--- a/be/test/io/fs/packed_file_concurrency_test.cpp
+++ b/be/test/io/fs/packed_file_concurrency_test.cpp
@@ -679,7 +679,8 @@ TEST_F(MergeFileConcurrencyTest, ConcurrentWriteReadCorrectness) {
             for (int iter = 0; iter < kIterationPerThread; ++iter) {
                 // Use unique file names to avoid cache key conflicts between threads
                 // since CachedRemoteFileReader uses path().filename() for cache hash
-                std::string path = fmt::format("/tablet_{}/rowset_{}/file_t{}_i{}", tid, iter, tid, iter);
+                std::string path =
+                        fmt::format("/tablet_{}/rowset_{}/file_t{}_i{}", tid, iter, tid, iter);
 
                 PackedAppendContext append_info;
                 append_info.resource_id = resource_ids[tid];

--- a/be/test/io/fs/packed_file_concurrency_test.cpp
+++ b/be/test/io/fs/packed_file_concurrency_test.cpp
@@ -718,11 +718,13 @@ TEST_F(MergeFileConcurrencyTest, ConcurrentWriteReadCorrectness) {
                 opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
                 opts.is_doris_table = true;
                 ASSERT_TRUE(reader_fs.open_file(Path(path), &reader, &opts).ok());
-                auto* merge_reader = dynamic_cast<PackedFileReader*>(reader.get());
-                ASSERT_NE(merge_reader, nullptr);
-                auto* cached_reader =
-                        dynamic_cast<CachedRemoteFileReader*>(merge_reader->_inner_reader.get());
+                // After the fix, CachedRemoteFileReader wraps PackedFileReader (not vice versa)
+                // This ensures cache key uses segment path for proper cleanup
+                auto* cached_reader = dynamic_cast<CachedRemoteFileReader*>(reader.get());
                 ASSERT_NE(cached_reader, nullptr);
+                auto* merge_reader =
+                        dynamic_cast<PackedFileReader*>(cached_reader->get_remote_reader());
+                ASSERT_NE(merge_reader, nullptr);
 
                 IOContext io_ctx;
                 size_t verified = 0;


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Previously, file cache used packed file path as cache key, which caused cache entries to be orphaned when stale rowsets were cleaned up (cleanup uses segment path as key).

This fix moves the cache layer from inner reader to PackedFileReader wrapper level, ensuring:
1. Cache key = hash(segment_path.filename()) - matches cleanup key
2. Cache size = segment size - correct boundary
3. Each segment has independent cache entry - no interference


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

