### PR TITLE
[fix](recycler) Return success when tablet already recycled in parallel recycle_rowsets

### DIFF
--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -1752,7 +1752,10 @@ int InstanceRecycler::abort_job_for_related_rowset(const RowsetMetaCloudPB& rows
 
     TabletIndexPB tablet_idx;
     int ret = get_tablet_idx(txn_kv_.get(), instance_id_, rowset_meta.tablet_id(), tablet_idx);
-    if (ret != 0) {
+    if (ret == 1) {
+        // tablet maybe recycled, directly return 0
+        return 0;
+    } else if (ret != 0) {
         LOG(WARNING) << "failed to get tablet index, tablet_id=" << rowset_meta.tablet_id()
                      << " instance_id=" << instance_id_ << " ret=" << ret;
         return ret;


### PR DESCRIPTION
### What problem does this PR solve?

When `recycle_rowsets` and `recycle_tablet` run in parallel, the tablet may have already been recycled by `recycle_tablet`. In this case, `recycle_rowsets` calling `abort_job_for_related_rowset` will attempt to retrieve information about the no-longer-existing tablet.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

