### PR TITLE
[fix](move-memtable) fix close wait timeout if part of streams connection failed

### DIFF
--- a/regression-test/suites/fault_injection_p0/test_cancelled_stream_close_wait.groovy
+++ b/regression-test/suites/fault_injection_p0/test_cancelled_stream_close_wait.groovy
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.codehaus.groovy.runtime.IOGroovyMethods
+import org.apache.doris.regression.util.Http
+
+suite("test_cancelled_stream_close_wait", "nonConcurrent") {
+    if (!isCloudMode()) {
+        sql """ DROP TABLE IF EXISTS `baseall` """
+        sql """ DROP TABLE IF EXISTS `test` """
+        sql """
+            CREATE TABLE IF NOT EXISTS `baseall` (
+                `k0` boolean null comment "",
+                `k1` tinyint(4) null comment "",
+                `k2` smallint(6) null comment "",
+                `k3` int(11) null comment "",
+                `k4` bigint(20) null comment "",
+                `k5` decimal(9, 3) null comment "",
+                `k6` char(5) null comment "",
+                `k10` date null comment "",
+                `k11` datetime null comment "",
+                `k7` varchar(20) null comment "",
+                `k8` double max null comment "",
+                `k9` float sum null comment "",
+                `k12` string replace null comment "",
+                `k13` largeint(40) replace null comment ""
+            ) engine=olap
+            DISTRIBUTED BY HASH(`k1`) BUCKETS 5 properties("replication_num" = "1")
+            """
+        sql """
+            CREATE TABLE IF NOT EXISTS `test` (
+                `k0` boolean null comment "",
+                `k1` tinyint(4) null comment "",
+                `k2` smallint(6) null comment "",
+                `k3` int(11) null comment "",
+                `k4` bigint(20) null comment "",
+                `k5` decimal(9, 3) null comment "",
+                `k6` char(5) null comment "",
+                `k10` date null comment "",
+                `k11` datetime null comment "",
+                `k7` varchar(20) null comment "",
+                `k8` double max null comment "",
+                `k9` float sum null comment "",
+                `k12` string replace_if_not_null null comment "",
+                `k13` largeint(40) replace null comment ""
+            ) engine=olap
+            DISTRIBUTED BY HASH(`k1`) BUCKETS 5 properties("replication_num" = "1")
+            """
+
+        GetDebugPoint().clearDebugPointsForAllBEs()
+        streamLoad {
+            table "baseall"
+            db "regression_test_fault_injection_p0"
+            set 'column_separator', ','
+            file "baseall.txt"
+        }
+
+        // Test: Simulate one stream open failure within LoadStreamStubs.
+        // The first stream opens successfully, the second fails.
+        // This causes cancel() to be called on all streams.
+        // Without the fix, the successfully opened stream would cause close_wait timeout.
+        try {
+            GetDebugPoint().enableDebugPointForAllBEs("LoadStreamStubs.open.fail_one_stream")
+            def res = sql "insert into test select * from baseall where k1 <= 3"
+            logger.info(res.toString())
+            // Should fail due to stream open failure, not timeout
+            assertTrue(false, "Expected Exception to be thrown")
+        } catch(Exception e) {
+            logger.info(e.getMessage())
+            // Should fail quickly with stream open error, not timeout
+            assertTrue(!e.getMessage().contains("timed out"),
+                       "Should not timeout waiting for cancelled stream, got: " + e.getMessage())
+        } finally {
+            GetDebugPoint().disableDebugPointForAllBEs("LoadStreamStubs.open.fail_one_stream")
+        }
+
+        sql """ DROP TABLE IF EXISTS `baseall` """
+        sql """ DROP TABLE IF EXISTS `test` """
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Bug scenario:
1. LoadStreamStubs has multiple LoadStreamStub objects (stream_per_node >= 2)
2. First stream opens successfully (_is_open = true)
3. Second stream fails to open
4. LoadStreamStubs::open() calls cancel() on ALL streams (including the successful one)
5. The first stream now has: _is_open = true, _is_cancelled = true, _is_closing = false
6. Without the fix, close_finish_check() would mark it as not closed (stuck in unfinished_streams)
7. This causes close_wait to timeout


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

