### PR TITLE
[feat](libhdfs3) support dfs.client.use.datanode.hostname for libhdfs3

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -524,6 +524,19 @@ if [[ " ${TP_ARCHIVES[*]} " =~ " KRB5 " ]]; then
     echo "Finished patching ${KRB5_SOURCE}"
 fi
 
+# patch libhdfs3
+if [[ " ${TP_ARCHIVES[*]} " =~ " HDFS3 " ]]; then
+    if [[ "${HDFS3_SOURCE}" == "doris-thirdparty-libhdfs3-v2.3.9" ]]; then
+        cd "${TP_SOURCE_DIR}/${HDFS3_SOURCE}"
+        if [[ ! -f "${PATCHED_MARK}" ]]; then
+            patch -p1 <"${TP_PATCH_DIR}/libhdfs3-v2.3.9-hostname.patch"
+            touch "${PATCHED_MARK}"
+        fi
+        cd -
+    fi
+    echo "Finished patching ${HDFS3_SOURCE}"
+fi
+
 # patch bitshuffle
 MACHINE_OS=$(uname -s)
 

--- a/thirdparty/patches/libhdfs3-v2.3.9-hostname.patch
+++ b/thirdparty/patches/libhdfs3-v2.3.9-hostname.patch
@@ -1,0 +1,74 @@
+diff --git a/src/client/RemoteBlockReader.cpp b/src/client/RemoteBlockReader.cpp
+--- a/src/client/RemoteBlockReader.cpp	2023-04-11 14:31:06
++++ b/src/client/RemoteBlockReader.cpp	2026-01-15 11:50:44
+@@ -30,6 +30,7 @@
+ #include "WriteBuffer.h"
+ 
+ #include <inttypes.h>
++#include <string>
+ #include <vector>
+ 
+ namespace Hdfs {
+@@ -43,6 +44,7 @@
+                                      SessionConfig& conf)
+     : sentStatus(false),
+       verify(verify),
++      useDatanodeHostname(conf.isUseDatanodeHostname()),
+       binfo(eb),
+       datanode(datanode),
+       checksumSize(0),
+@@ -81,7 +83,8 @@
+ 
+         if (!sock) {
+             sock = shared_ptr<Socket>(new TcpSocketImpl);
+-            sock->connect(dn.getIpAddr().c_str(), dn.getXferPort(),
++            const std::string host = useDatanodeHostname ? dn.getHostName() : dn.getIpAddr();
++            sock->connect(host.c_str(), dn.getXferPort(),
+                           connTimeout);
+             sock->setNoDelay(true);
+         }
+diff --git a/src/client/RemoteBlockReader.h b/src/client/RemoteBlockReader.h
+--- a/src/client/RemoteBlockReader.h	2023-04-11 14:31:06
++++ b/src/client/RemoteBlockReader.h	2026-01-15 11:50:16
+@@ -79,6 +79,7 @@
+ private:
+     bool sentStatus;
+     bool verify; //verify checksum or not.
++    bool useDatanodeHostname;
+     const ExtendedBlock & binfo;
+     DatanodeInfo & datanode;
+     int checksumSize;
+diff --git a/src/common/SessionConfig.cpp b/src/common/SessionConfig.cpp
+--- a/src/common/SessionConfig.cpp	2023-04-11 14:31:06
++++ b/src/common/SessionConfig.cpp	2026-01-15 11:50:09
+@@ -56,6 +56,8 @@
+         }, {
+             &readFromLocal, "dfs.client.read.shortcircuit", true
+         }, {
++            &useDatanodeHostname, "dfs.client.use.datanode.hostname", false
++        }, {
+             &addDatanode, "output.replace-datanode-on-failure", true
+         }, {
+             &notRetryAnotherNode, "input.notretry-another-node", false
+diff --git a/src/common/SessionConfig.h b/src/common/SessionConfig.h
+--- a/src/common/SessionConfig.h	2023-04-11 14:31:06
++++ b/src/common/SessionConfig.h	2026-01-15 11:49:40
+@@ -125,6 +125,10 @@
+         return readFromLocal;
+     }
+ 
++    bool isUseDatanodeHostname() const {
++        return useDatanodeHostname;
++    }
++
+     int32_t getMaxGetBlockInfoRetry() const {
+         return maxGetBlockInfoRetry;
+     }
+@@ -351,6 +355,7 @@
+      */
+     bool useMappedFile;
+     bool readFromLocal;
++    bool useDatanodeHostname;
+     bool notRetryAnotherNode;
+     bool legacyLocalBlockReader;
+     int32_t inputConnTimeout;


### PR DESCRIPTION
### What problem does this PR solve?

**Problem**
java hadoop client already support `dfs.client.use.datanode.hostname`, but libhdfs3 do not support it.
Here we support `dfs.client.use.datanode.hostname` on libhdfs3, then we could connect hdfs inside docker.


**How to use:**
Step1: In hive docker env, add this config in hdfs-site.xml
```
  <property>
    <name>dfs.datanode.use.datanode.hostname</name>
    <value>true</value>
  </property>
```

Step2: In mac, while create hive catalog, add following property:
```
'dfs.client.use.datanode.hostname' = 'true'
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

