### PR TITLE
[fix](jdbc) check old driver path before downloading from cloud

### DIFF
--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -654,9 +654,14 @@ Status JdbcConnector::_check_and_return_default_driver_url(const std::string& ur
         // from `DORIS_HOME/jdbc_drivers` to `DORIS_HOME/plugins/jdbc_drivers`,
         // so we need to check the old default dir for compatibility.
         std::string target_path = default_url + "/" + url;
+        std::string old_target_path = default_old_url + "/" + url;
         if (std::filesystem::exists(target_path)) {
             // File exists in new default directory
             *result_url = "file://" + target_path;
+            return Status::OK();
+        } else if (std::filesystem::exists(old_target_path)) {
+            // File exists in old default directory
+            *result_url = "file://" + old_target_path;
             return Status::OK();
         } else if (config::is_cloud_mode()) {
             // Cloud mode: try to download from cloud to new default directory
@@ -671,10 +676,9 @@ Status JdbcConnector::_check_and_return_default_driver_url(const std::string& ur
             // Download failed, log warning but continue to fallback
             LOG(WARNING) << "Failed to download JDBC driver from cloud: " << status.to_string()
                          << ", fallback to old directory";
+        } else {
+            return Status::InternalError("JDBC driver file does not exist: " + url);
         }
-
-        // Fallback to old default directory for compatibility
-        *result_url = "file://" + default_old_url + "/" + url;
     } else {
         // User specified custom directory - use directly
         *result_url = "file://" + config::jdbc_drivers_dir + "/" + url;

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/JdbcResourceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/JdbcResourceTest.java
@@ -220,7 +220,7 @@ public class JdbcResourceTest {
 
         String jarFile = "driver.jar";
         Assertions.assertThrows(RuntimeException.class, () -> {
-            String result = JdbcResource.getFullDriverUrl(jarFile);
+            JdbcResource.getFullDriverUrl(jarFile);
         });
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/JdbcResourceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/JdbcResourceTest.java
@@ -17,9 +17,7 @@
 
 package org.apache.doris.catalog;
 
-import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
-import org.apache.doris.common.EnvUtils;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
@@ -201,21 +199,6 @@ public class JdbcResourceTest {
     }
 
     @Test
-    public void testJdbcDriverPath() {
-        String driverPath = "postgresql-42.5.0.jar";
-        Config.jdbc_driver_secure_path = "";
-        Config.jdbc_drivers_dir = EnvUtils.getDorisHome() + "/plugins/jdbc_drivers";
-        String fullPath = JdbcResource.getFullDriverUrl(driverPath);
-        Assert.assertEquals("file://" + EnvUtils.getDorisHome() + "/jdbc_drivers/" + driverPath, fullPath);
-        Config.jdbc_driver_secure_path = "file:///jdbc/;http://jdbc";
-        String driverPath2 = "file:///postgresql-42.5.0.jar";
-        Exception exception = Assert.assertThrows(IllegalArgumentException.class, () -> {
-            JdbcResource.getFullDriverUrl(driverPath2);
-        });
-        Assert.assertEquals("Driver URL does not match any allowed paths: file:///postgresql-42.5.0.jar", exception.getMessage());
-    }
-
-    @Test
     public void testValidDriverUrls() {
         String fileUrl = "file://path/to/driver.jar";
         Assertions.assertDoesNotThrow(() -> {
@@ -236,9 +219,8 @@ public class JdbcResourceTest {
         });
 
         String jarFile = "driver.jar";
-        Assertions.assertDoesNotThrow(() -> {
+        Assertions.assertThrows(RuntimeException.class, () -> {
             String result = JdbcResource.getFullDriverUrl(jarFile);
-            Assert.assertTrue(result.startsWith("file://"));
         });
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Related: #54304

Problem Summary:

Before this change, when a JDBC driver was not found in the new default
directory, the code would fallback to the old directory unconditionally,
even if the driver didn't exist there. In cloud mode, it would try to
download from cloud but then fallback to old directory regardless of
download result.

This commit improves the driver lookup logic:
1. Check new default directory first (DORIS_HOME/plugins/jdbc_drivers)
2. Check old default directory (DORIS_HOME/jdbc_drivers)
3. In cloud mode, only download from cloud if not found in either directory
4. Return error immediately if driver not found (instead of fallback)

This avoids unnecessary cloud downloads when driver exists in old path,
and provides clearer error messages when driver is truly missing.

Changes:
- BE: vjdbc_connector.cpp - check old path before cloud download
- FE: JdbcResource.java - check old path and improve error messages

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

