### PR TITLE
[Improve] kill query can send it to BE when not found in FE

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/utils/KillUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/utils/KillUtils.java
@@ -26,15 +26,14 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.Coordinator;
 import org.apache.doris.qe.FEOpExecutor;
 import org.apache.doris.qe.OriginStatement;
-import org.apache.doris.rpc.BackendServiceProxy;
+import org.apache.doris.qe.QeProcessorImpl;
 import org.apache.doris.service.ExecuteEnv;
-import org.apache.doris.system.Backend;
 import org.apache.doris.system.Frontend;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TStatusCode;
-import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -43,7 +42,6 @@ import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -132,30 +130,7 @@ public class KillUtils {
                 return;
             }
         }
-
-        // 3. Query not found in any FE, try cancel the query in BE.
-        TUniqueId tQueryId;
-        try {
-            tQueryId = DebugUtil.parseTUniqueIdFromString(queryId);
-        } catch (NumberFormatException e) {
-            throw new UserException(e.getMessage());
-        }
-        Collection<Backend> nodesToPublish = Env.getCurrentSystemInfo().getAllClusterBackendsNoException().values();
-        for (Backend be : nodesToPublish) {
-            if (be.isAlive()) {
-                try {
-                    BackendServiceProxy.getInstance().cancelPipelineXPlanFragmentAsync(be.getBrpcAddress(), tQueryId,
-                                new Status(TStatusCode.CANCELLED, "User Cancelled"));
-                } catch (Throwable t) {
-                    LOG.info("send kill query {} rpc to be {} failed", queryId, be);
-                }
-            }
-        }
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("not found query '{}' in any FE, try to kill it in BE. Messages: {}",
-                    queryId, errMsgs);
-        }
+        ErrorReport.reportDdlException(ErrorCode.ERR_NO_SUCH_QUERY, queryId);
     }
 
     /**
@@ -179,6 +154,15 @@ public class KillUtils {
             }
             killCtx.kill(false);
             ctx.getState().setOk();
+            return true;
+        }
+        // query not found in connect context, try to find in coordinator
+        if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ctx, PrivPredicate.ADMIN)) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_KILL_DENIED_ERROR, queryId);
+        }
+        Coordinator coordinator = QeProcessorImpl.INSTANCE.getCoordinator(DebugUtil.parseTUniqueIdFromString(queryId));
+        if (coordinator != null) {
+            coordinator.cancel(new Status(TStatusCode.CANCELLED, "User Cancelled"));
             return true;
         }
         return false;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/utils/KillUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/utils/KillUtilsTest.java
@@ -213,7 +213,7 @@ public class KillUtilsTest {
     // Test for killByQueryId when query is not found and ctx is proxy
     @Test
     public void testKillQueryByQueryIdNotFoundAndIsProxy() {
-        String queryId = "test_query_id";
+        String queryId = "2e67816f0b004552-9dc42570874200d6";
         ExecuteEnv mockExecEnv = Mockito.mock(ExecuteEnv.class);
         ConnectScheduler mockQueryScheduler = Mockito.mock(ConnectScheduler.class);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

some query not register in fe, so try to kill these in BE

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

