### PR TITLE
[opt](ann index) Introduce ann_topn_min_input_rows_ratio

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -797,12 +797,17 @@ Status SegmentIterator::_apply_ann_topn_predicate() {
 
     size_t pre_size = _row_bitmap.cardinality();
     size_t rows_of_segment = _segment->num_rows();
-    if (static_cast<double>(pre_size) < static_cast<double>(rows_of_segment) * 0.3) {
+    double min_input_rows_ratio = 0.3;
+    if (_opts.runtime_state) {
+        min_input_rows_ratio = _opts.runtime_state->query_options().ann_topn_min_input_rows_ratio;
+    }
+
+    if (static_cast<double>(pre_size) <
+        static_cast<double>(rows_of_segment) * min_input_rows_ratio) {
         VLOG_DEBUG << fmt::format(
-                "Ann topn predicate input rows {} < 30% of segment rows {}, will not use ann index "
-                "to "
-                "filter",
-                pre_size, rows_of_segment);
+                "Ann topn predicate input rows {} < {:.2f}% of segment rows {}, will not use ann "
+                "index to filter",
+                pre_size, min_input_rows_ratio * 100.0, rows_of_segment);
         // Disable index-only scan on ann indexed column.
         _need_read_data_indices[src_cid] = true;
         return Status::OK();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -906,6 +906,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String HNSW_CHECK_RELATIVE_DISTANCE = "hnsw_check_relative_distance";
     public static final String HNSW_BOUNDED_QUEUE = "hnsw_bounded_queue";
     public static final String IVF_NPROBE = "ivf_nprobe";
+    public static final String ANN_TOPN_MIN_INPUT_ROWS_RATIO = "ann_topn_min_input_rows_ratio";
 
     public static final String DEFAULT_VARIANT_MAX_SUBCOLUMNS_COUNT = "default_variant_max_subcolumns_count";
 
@@ -3215,6 +3216,12 @@ public class SessionVariable implements Serializable, Writable {
             description = {"IVF 索引的 nprobe 参数，控制搜索时访问的聚类数量",
                     "IVF index nprobe parameter, controls the number of clusters to search"})
     public int ivfNprobe = 1;
+    @VariableMgr.VarAttr(name = ANN_TOPN_MIN_INPUT_ROWS_RATIO, needForward = true,
+            checker = "checkAnnTopnMinInputRowsRatio",
+            description = {"ANN topn 使用 ANN 索引的最小输入行比例(0.0~1.0)。如果 segment 输入行数小于 segment 行数*该比例，则跳过 ANN 索引过滤",
+                "Minimum input-rows ratio (0.0~1.0) to enable ANN index for ANN topn predicate. "
+                    + "If input rows < segment rows * ratio, ANN index filtering will be skipped"})
+    public double annTopnMinInputRowsRatio = 0.3;
 
     @VariableMgr.VarAttr(
             name = DEFAULT_VARIANT_MAX_SUBCOLUMNS_COUNT,
@@ -5057,6 +5064,7 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setHnswCheckRelativeDistance(hnswCheckRelativeDistance);
         tResult.setHnswBoundedQueue(hnswBoundedQueue);
         tResult.setIvfNprobe(ivfNprobe);
+        tResult.setAnnTopnMinInputRowsRatio(annTopnMinInputRowsRatio);
         tResult.setMergeReadSliceSize(mergeReadSliceSizeBytes);
         tResult.setEnableExtendedRegex(enableExtendedRegex);
 
@@ -5941,4 +5949,17 @@ public class SessionVariable implements Serializable, Writable {
             LOG.error("failed to set affect query result variables", e);
         }
     }
+
+    public void checkAnnTopnMinInputRowsRatio(String newValue) {
+        double value = Double.parseDouble(newValue);
+        if (value < 0.0 || value > 1.0) {
+            UnsupportedOperationException exception =
+                    new UnsupportedOperationException(
+                            "ann_topn_min_input_rows_ratio can not be set to " + newValue
+                                    + ", it must be between 0.0 and 1.0");
+            LOG.warn("Check ann_topn_min_input_rows_ratio failed", exception);
+            throw exception;
+        }
+    }
+
 }

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -424,6 +424,9 @@ struct TQueryOptions {
   183: optional bool enable_use_hybrid_sort = false;
   184: optional i32 cte_max_recursion_depth;
 
+  // Minimum ratio (0.0~1.0) of input rows to segment rows to enable ANN index for ANN topn predicate.
+  // If input rows are smaller than (segment_rows * ratio), we skip ANN index filtering.
+  185: optional double ann_topn_min_input_rows_ratio = 0.3;
 
   // For cloud, to control if the content would be written into file cache
   // In write path, to control if the content would be written into file cache.


### PR DESCRIPTION
### What problem does this PR solve?

Currently if input rows of ann topn search is less than 30% of the segment, we will fall back to brute force search for a better recall.

This pr intruduces a new session var ann_topn_min_input_rows_ratio to make threshold configurable.


Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

