### PR TITLE
[fix](job) fix routine load task transaction timeout error

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskInfo.java
@@ -198,6 +198,9 @@ public abstract class RoutineLoadTaskInfo {
 
     abstract TRoutineLoadTask createRoutineLoadTask() throws UserException;
 
+    public void updateAdaptiveTimeout(RoutineLoadJob routineLoadJob) {
+    }
+
     // begin the txn of this task
     // return true if begin successfully, return false if begin failed.
     // throw exception if unrecoverable errors happen.

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskScheduler.java
@@ -165,6 +165,10 @@ public class RoutineLoadTaskScheduler extends MasterDaemon {
             throw e;
         }
 
+        // update adaptive timeout before beginTxn to ensure transaction timeout matches task timeout
+        RoutineLoadJob routineLoadJob = routineLoadManager.getJob(routineLoadTaskInfo.getJobId());
+        routineLoadTaskInfo.updateAdaptiveTimeout(routineLoadJob);
+
         // begin txn
         try {
             if (!routineLoadTaskInfo.beginTxn()) {

--- a/regression-test/suites/load_p0/routine_load/test_routine_load_adaptive_param.groovy
+++ b/regression-test/suites/load_p0/routine_load/test_routine_load_adaptive_param.groovy
@@ -77,6 +77,7 @@ suite("test_routine_load_adaptive_param","nonConcurrent") {
             logger.info("---test adaptively increase---")
             RoutineLoadTestUtils.sendTestDataToKafka(producer, kafkaCsvTpoics)
             RoutineLoadTestUtils.checkTaskTimeout(runSql, job, "3600")
+            RoutineLoadTestUtils.checkTxnTimeoutMatchesTaskTimeout(runSql, job, "3600000")
             RoutineLoadTestUtils.waitForTaskFinish(runSql, job, tableName, 2)
 
             // test restore adaptively


### PR DESCRIPTION
### What problem does this PR solve?

## Problem

When routine load uses adaptive batch interval (introduced in #56930), the FE transaction timeout does not match the BE task timeout, causing transactions to be aborted by `txnCleaner` while BE is still processing.

### Root Cause

In `RoutineLoadTaskScheduler.scheduleOneTask()`, the execution order is:
1. `beginTxn()` - creates transaction with **original** `timeoutMs`
2. `createRoutineLoadTask()` → `adaptiveBatchParam()` - updates `timeoutMs` to **adaptive** value

This causes a mismatch:
- FE transaction timeout: original value (e.g., 200 seconds)
- BE task timeout: adaptive value (e.g., 360 seconds)

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

