### PR TITLE
[enhancement](variable) newSessionVariable uses read lock instead of write lock to reduce lock contention

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -262,11 +262,11 @@ public class VariableMgr {
     }
 
     public static SessionVariable newSessionVariable() {
-        wlock.lock();
+        rlock.lock();
         try {
             return cloneSessionVariable(defaultSessionVariable);
         } finally {
-            wlock.unlock();
+            rlock.unlock();
         }
     }
 


### PR DESCRIPTION
newSessionVariable just read field of defaultSessionVariable and won't change it, so use read lock to reduce lock contention

```
"thrift-server-pool-47" #534 daemon prio=5 os_prio=0 cpu=3837.23ms elapsed=895.28s tid=0x00007ebbc002fcf0 nid=0x3244aa waiting on condition  [0x00007eb705ad9000]
   java.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@17.0.9/Native Method)
        - parking to wait for  <0x00007ec62e946238> (a java.util.concurrent.locks.ReentrantReadWriteLock$NonfairSync)
        at java.util.concurrent.locks.LockSupport.park(java.base@17.0.9/LockSupport.java:211)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@17.0.9/AbstractQueuedSynchronizer.java:715)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@17.0.9/AbstractQueuedSynchronizer.java:938)
        at java.util.concurrent.locks.ReentrantReadWriteLock$WriteLock.lock(java.base@17.0.9/ReentrantReadWriteLock.java:959)
        at org.apache.doris.qe.VariableMgr.newSessionVariable(VariableMgr.java:259)
        at org.apache.doris.qe.ConnectContext.init(ConnectContext.java:384)
        at org.apache.doris.qe.ConnectContext.<init>(ConnectContext.java:422)
        at org.apache.doris.qe.ConnectContext.<init>(ConnectContext.java:402)
        at org.apache.doris.qe.ConnectContext.<init>(ConnectContext.java:398)
        at org.apache.doris.load.StreamLoadHandler.setCloudCluster(StreamLoadHandler.java:118)
        at org.apache.doris.service.FrontendServiceImpl.streamLoadPut(FrontendServiceImpl.java:2127)
        at jdk.internal.reflect.GeneratedMethodAccessor24.invoke(Unknown Source)
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(java.base@17.0.9/DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(java.base@17.0.9/Method.java:568)
        at org.apache.doris.service.FeServer.lambda$start$0(FeServer.java:60)
        at org.apache.doris.service.FeServer$$Lambda$316/0x00007ec0b880cb60.invoke(Unknown Source)
        at jdk.proxy2.$Proxy46.streamLoadPut(jdk.proxy2/Unknown Source)
        at org.apache.doris.thrift.FrontendService$Processor$streamLoadPut.getResult(FrontendService.java:4832)
        at org.apache.doris.thrift.FrontendService$Processor$streamLoadPut.getResult(FrontendService.java:4812)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38)
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:250)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@17.0.9/ThreadPoolExecutor.java:1136)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@17.0.9/ThreadPoolExecutor.java:635)
        at java.lang.Thread.run(java.base@17.0.9/Thread.java:840)

"thrift-server-pool-48" #535 daemon prio=5 os_prio=0 cpu=3502.35ms elapsed=895.28s tid=0x00007ebbc0030d60 nid=0x3244ab waiting on condition  [0x00007eb7059d8000]
   java.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@17.0.9/Native Method)
        - parking to wait for  <0x00007ec62e946238> (a java.util.concurrent.locks.ReentrantReadWriteLock$NonfairSync)
        at java.util.concurrent.locks.LockSupport.park(java.base@17.0.9/LockSupport.java:211)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@17.0.9/AbstractQueuedSynchronizer.java:715)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@17.0.9/AbstractQueuedSynchronizer.java:938)
        at java.util.concurrent.locks.ReentrantReadWriteLock$WriteLock.lock(java.base@17.0.9/ReentrantReadWriteLock.java:959)
        at org.apache.doris.qe.VariableMgr.newSessionVariable(VariableMgr.java:259)
        at org.apache.doris.qe.ConnectContext.init(ConnectContext.java:384)
        at org.apache.doris.qe.ConnectContext.<init>(ConnectContext.java:422)
        at org.apache.doris.qe.ConnectContext.<init>(ConnectContext.java:402)
        at org.apache.doris.qe.ConnectContext.<init>(ConnectContext.java:398)
        at org.apache.doris.load.StreamLoadHandler.setCloudCluster(StreamLoadHandler.java:118)
        at org.apache.doris.service.FrontendServiceImpl.streamLoadPut(FrontendServiceImpl.java:2127)
        at jdk.internal.reflect.GeneratedMethodAccessor24.invoke(Unknown Source)
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(java.base@17.0.9/DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(java.base@17.0.9/Method.java:568)
        at org.apache.doris.service.FeServer.lambda$start$0(FeServer.java:60)
        at org.apache.doris.service.FeServer$$Lambda$316/0x00007ec0b880cb60.invoke(Unknown Source)
        at jdk.proxy2.$Proxy46.streamLoadPut(jdk.proxy2/Unknown Source)
        at org.apache.doris.thrift.FrontendService$Processor$streamLoadPut.getResult(FrontendService.java:4832)
        at org.apache.doris.thrift.FrontendService$Processor$streamLoadPut.getResult(FrontendService.java:4812)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38)
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:250)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@17.0.9/ThreadPoolExecutor.java:1136)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@17.0.9/ThreadPoolExecutor.java:635)
        at java.lang.Thread.run(java.base@17.0.9/Thread.java:840)
```