### PR TITLE
[fix](iceberg) fix invalid cast to IcebergExternalCatalog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -30,7 +30,6 @@ import org.apache.doris.datasource.hudi.source.HudiCachedFsViewProcessor;
 import org.apache.doris.datasource.hudi.source.HudiCachedMetaClientProcessor;
 import org.apache.doris.datasource.hudi.source.HudiMetadataCacheMgr;
 import org.apache.doris.datasource.hudi.source.HudiPartitionProcessor;
-import org.apache.doris.datasource.iceberg.IcebergExternalCatalog;
 import org.apache.doris.datasource.iceberg.IcebergMetadataCache;
 import org.apache.doris.datasource.maxcompute.MaxComputeMetadataCache;
 import org.apache.doris.datasource.maxcompute.MaxComputeMetadataCacheMgr;
@@ -203,7 +202,7 @@ public class ExternalMetaCacheMgr {
         return hudiMetadataCacheMgr;
     }
 
-    public IcebergMetadataCache getIcebergMetadataCache(IcebergExternalCatalog catalog) {
+    public IcebergMetadataCache getIcebergMetadataCache(ExternalCatalog catalog) {
         IcebergMetadataCache cache = icebergCacheMap.get(catalog.getId());
         if (cache == null) {
             synchronized (icebergCacheMap) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
@@ -40,7 +40,6 @@ import org.apache.doris.datasource.TablePartitionValues;
 import org.apache.doris.datasource.hudi.HudiSchemaCacheKey;
 import org.apache.doris.datasource.hudi.HudiSchemaCacheValue;
 import org.apache.doris.datasource.hudi.HudiUtils;
-import org.apache.doris.datasource.iceberg.IcebergExternalCatalog;
 import org.apache.doris.datasource.iceberg.IcebergMvccSnapshot;
 import org.apache.doris.datasource.iceberg.IcebergSchemaCacheKey;
 import org.apache.doris.datasource.iceberg.IcebergUtils;
@@ -814,8 +813,8 @@ public class HMSExternalTable extends ExternalTable implements MTMVRelatedTableI
                 if (GlobalVariable.enableFetchIcebergStats) {
                     return StatisticsUtil.getIcebergColumnStats(colName,
                             Env.getCurrentEnv().getExtMetaCacheMgr()
-                                .getIcebergMetadataCache((IcebergExternalCatalog) this.getCatalog())
-                                .getIcebergTable(this));
+                                    .getIcebergMetadataCache(this.getCatalog())
+                                    .getIcebergTable(this));
                 } else {
                     break;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataCache.java
@@ -54,14 +54,14 @@ import java.util.concurrent.ExecutorService;
 public class IcebergMetadataCache {
     private static final Logger LOG = LogManager.getLogger(IcebergMetadataCache.class);
     private final ExecutorService executor;
-    private final IcebergExternalCatalog catalog;
+    private final ExternalCatalog catalog;
     private LoadingCache<IcebergMetadataCacheKey, List<Snapshot>> snapshotListCache;
     private LoadingCache<IcebergMetadataCacheKey, Table> tableCache;
     private LoadingCache<IcebergMetadataCacheKey, IcebergSnapshotCacheValue> snapshotCache;
     private LoadingCache<IcebergMetadataCacheKey, View> viewCache;
     private IcebergManifestCache manifestCache;
 
-    public IcebergMetadataCache(IcebergExternalCatalog catalog, ExecutorService executor) {
+    public IcebergMetadataCache(ExternalCatalog catalog, ExecutorService executor) {
         this.executor = executor;
         this.catalog = catalog;
         init();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
@@ -727,7 +727,7 @@ public class IcebergUtils {
     public static Table getIcebergTable(ExternalTable dorisTable) {
         return Env.getCurrentEnv()
                 .getExtMetaCacheMgr()
-                .getIcebergMetadataCache((IcebergExternalCatalog) dorisTable.getCatalog()).getIcebergTable(dorisTable);
+                .getIcebergMetadataCache(dorisTable.getCatalog()).getIcebergTable(dorisTable);
     }
 
     public static org.apache.iceberg.types.Type dorisTypeToIcebergType(Type type) {
@@ -981,7 +981,7 @@ public class IcebergUtils {
         // Meanwhile, it will trigger iceberg metadata cache to load the table, so we can get it next time.
         Table icebergTable = Env.getCurrentEnv()
                 .getExtMetaCacheMgr()
-                .getIcebergMetadataCache((IcebergExternalCatalog) tbl.getCatalog())
+                .getIcebergMetadataCache(tbl.getCatalog())
                 .getIcebergTable(tbl);
         Snapshot snapshot = icebergTable.currentSnapshot();
         if (snapshot == null) {
@@ -1489,7 +1489,7 @@ public class IcebergUtils {
         } else {
             // Otherwise, use the latest snapshot and the latest schema.
             return Env.getCurrentEnv().getExtMetaCacheMgr()
-                    .getIcebergMetadataCache((IcebergExternalCatalog) dorisTable.getCatalog())
+                    .getIcebergMetadataCache(dorisTable.getCatalog())
                     .getSnapshotCache(dorisTable);
         }
     }
@@ -1514,7 +1514,7 @@ public class IcebergUtils {
 
     public static View getIcebergView(ExternalTable dorisTable) {
         IcebergMetadataCache metadataCache = Env.getCurrentEnv().getExtMetaCacheMgr()
-                .getIcebergMetadataCache((IcebergExternalCatalog) dorisTable.getCatalog());
+                .getIcebergMetadataCache(dorisTable.getCatalog());
         return metadataCache.getIcebergView(dorisTable);
     }
 
@@ -1548,7 +1548,7 @@ public class IcebergUtils {
     public static IcebergManifestCache getManifestCache(ExternalCatalog catalog) {
         return Env.getCurrentEnv()
                 .getExtMetaCacheMgr()
-                .getIcebergMetadataCache((IcebergExternalCatalog) catalog)
+                .getIcebergMetadataCache(catalog)
                 .getManifestCache();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergApiSource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergApiSource.java
@@ -22,7 +22,6 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.datasource.ExternalCatalog;
-import org.apache.doris.datasource.iceberg.IcebergExternalCatalog;
 import org.apache.doris.datasource.iceberg.IcebergExternalTable;
 import org.apache.doris.datasource.iceberg.IcebergUtils;
 import org.apache.doris.planner.ColumnRange;
@@ -56,7 +55,7 @@ public class IcebergApiSource implements IcebergSource {
         }
         this.icebergExtTable = table;
         this.originTable = Env.getCurrentEnv().getExtMetaCacheMgr()
-                .getIcebergMetadataCache((IcebergExternalCatalog) table.getCatalog()).getIcebergTable(icebergExtTable);
+                .getIcebergMetadataCache(table.getCatalog()).getIcebergTable(icebergExtTable);
         this.desc = desc;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergHMSSource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergHMSSource.java
@@ -24,7 +24,6 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.hive.HMSExternalTable;
-import org.apache.doris.datasource.iceberg.IcebergExternalCatalog;
 import org.apache.doris.datasource.iceberg.IcebergUtils;
 
 public class IcebergHMSSource implements IcebergSource {
@@ -38,7 +37,7 @@ public class IcebergHMSSource implements IcebergSource {
         this.desc = desc;
         this.icebergTable =
             Env.getCurrentEnv().getExtMetaCacheMgr()
-                    .getIcebergMetadataCache((IcebergExternalCatalog) hmsTable.getCatalog()).getIcebergTable(hmsTable);
+                    .getIcebergMetadataCache(hmsTable.getCatalog()).getIcebergTable(hmsTable);
     }
 
     @Override


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Hive Catalog can also access Iceberg Table, so not all catalog got from table
is IcebergExternalCatalog, it can be HMSExternalCatalog.
This PR fix it to avoid `java.lang.ClassCastException`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

