### PR TITLE
branch-4.0: fix(test): update regex pattern for RowGroupsFiltered metric in parquet runtime filter test

### DIFF
--- a/regression-test/suites/external_table_p0/hive/test_parquet_join_runtime_filter.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_parquet_join_runtime_filter.groovy
@@ -41,7 +41,7 @@ suite("test_parquet_join_runtime_filter", "p0,external,hive,external_docker,exte
 
 
     def extractFilteredGroupsValue = { String profileText ->
-        def values = (profileText =~ /FilteredGroups:\s*(\d+)/).collect { it[1].toLong() }
+        def values = (profileText =~ /RowGroupsFiltered:\s*(\d+)/).collect { it[1].toLong() }
         return values.sort { a, b -> b <=> a }
     }
 
@@ -76,7 +76,7 @@ suite("test_parquet_join_runtime_filter", "p0,external,hive,external_docker,exte
     if (!"true".equalsIgnoreCase(enabled)) {
         return;
     }
-    for (String hivePrefix : ["hive2"]) {
+    for (String hivePrefix : ["hive3"]) {
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
         String hmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "test_parquet_join_runtime_filter"


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #58895

## Problem
  The test `test_parquet_join_runtime_filter` was failing because it was using an outdated regex pattern `FilteredGroups` to extract metrics from the query profile.

  ## Root Cause
  PR #58895 (cherry-picked to branch-4.0 as commit 3940c799ce5 on 2026-01-13) renamed several parquet reader profile metrics:
  - `FilteredGroups` → `RowGroupsFiltered`
  - `FilteredGroupsByMinMax` → `RowGroupsFilteredByMinMax`
  - `FilteredGroupsByBloomFilter` → `RowGroupsFilteredByBloomFilter`
  - `ReadGroups` → `RowGroupsReadNum`

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

