### PR TITLE
[optimize](regression-case) Reduce the too_many_versions_detection case's run time

### DIFF
--- a/regression-test/suites/load/insert/test_too_many_versions_detection.groovy
+++ b/regression-test/suites/load/insert/test_too_many_versions_detection.groovy
@@ -16,7 +16,7 @@
 // under the License.
 import java.sql.SQLException
 
-suite("too_many_versions_detection") {
+suite("too_many_versions_detection", "nonConcurrent") {
     def backendId_to_backendIP = [:]
     def backendId_to_backendHttpPort = [:]
     getBackendIpHttpPort(backendId_to_backendIP, backendId_to_backendHttpPort);

--- a/regression-test/suites/load/insert/test_too_many_versions_detection.groovy
+++ b/regression-test/suites/load/insert/test_too_many_versions_detection.groovy
@@ -20,6 +20,7 @@ suite("too_many_versions_detection", "nonConcurrent") {
     def backendId_to_backendIP = [:]
     def backendId_to_backendHttpPort = [:]
     getBackendIpHttpPort(backendId_to_backendIP, backendId_to_backendHttpPort);
+    
     def set_be_config = { key, value ->
         for (String backend_id: backendId_to_backendIP.keySet()) {
             def (code, out, err) = update_be_config(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), key, value)
@@ -27,30 +28,56 @@ suite("too_many_versions_detection", "nonConcurrent") {
         }
     }
 
-    set_be_config("max_tablet_version_num", "200")
-
-    sql """ DROP TABLE IF EXISTS t """
-
-    sql """
-        create table t(a int)
-        DUPLICATE KEY(a)
-        DISTRIBUTED BY HASH(a)
-        BUCKETS 10 PROPERTIES("replication_num" = "1", "disable_auto_compaction" = "true");
-    """
-
-    for (int i = 1; i <= 200; i++) {
-        sql """ INSERT INTO t VALUES (${i}) """
+    def get_be_param = { paramName ->
+        def paramValue = ""
+        for (String id in backendId_to_backendIP.keySet()) {
+            def beIp = backendId_to_backendIP.get(id)
+            def bePort = backendId_to_backendHttpPort.get(id)
+            def (code, out, err) = curl("GET", String.format("http://%s:%s/api/show_config?conf_item=%s", beIp, bePort, paramName))
+            logger.info("get config: code=" + code + ", out=" + out + ", err=" + err)
+            assertTrue(code == 0)
+            assertTrue(out.contains(paramName))
+            def resultList = parseJson(out)[0]
+            assertTrue(resultList.size() == 4)
+            paramValue = resultList[2]
+            break // only need to get from one BE
+        }
+        return paramValue
     }
 
+    // Read and save original config value
+    def originalMaxTabletVersionNum = get_be_param("max_tablet_version_num")
+    logger.info("Original max_tablet_version_num: ${originalMaxTabletVersionNum}")
+    
     try {
-        sql """ INSERT INTO t VALUES (201) """
-        assertTrue(false, "Expected TOO_MANY_VERSION error but none occurred")
-    } catch (SQLException e) {
-        logger.info("Exception caught: ${e.getMessage()}")
-        def expectedError = "failed to init rowset builder. version count: 201, exceed limit: 200, tablet:"
-        assertTrue(e.getMessage().contains(expectedError),
-            "Expected TOO_MANY_VERSION error with message containing '${expectedError}', but got: ${e.getMessage()}")
-    }
+        set_be_config("max_tablet_version_num", "200")
 
-    sql """ DROP TABLE IF EXISTS t """
+        sql """ DROP TABLE IF EXISTS t """
+
+        sql """
+            create table t(a int)
+            DUPLICATE KEY(a)
+            DISTRIBUTED BY HASH(a)
+            BUCKETS 10 PROPERTIES("replication_num" = "1", "disable_auto_compaction" = "true");
+        """
+
+        for (int i = 1; i <= 200; i++) {
+            sql """ INSERT INTO t VALUES (${i}) """
+        }
+
+        try {
+            sql """ INSERT INTO t VALUES (201) """
+            assertTrue(false, "Expected TOO_MANY_VERSION error but none occurred")
+        } catch (SQLException e) {
+            logger.info("Exception caught: ${e.getMessage()}")
+            def expectedError = "failed to init rowset builder. version count: 201, exceed limit: 200, tablet:"
+            assertTrue(e.getMessage().contains(expectedError),
+                "Expected TOO_MANY_VERSION error with message containing '${expectedError}', but got: ${e.getMessage()}")
+        }
+
+        sql """ DROP TABLE IF EXISTS t """
+    } finally {
+        // Restore original config
+        set_be_config("max_tablet_version_num", originalMaxTabletVersionNum)
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: https://github.com/apache/doris/commit/b0123faa0e67db295e0cc7da7b785e56838e62fb

Problem Summary:

set max_tablet_version_num to be 200 to avoid executing 2000 times insert into values

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

