### PR TITLE
[Chore](dump) remove is_nereids flag on DumpTimeInfo

### DIFF
--- a/be/src/common/signal_handler.h
+++ b/be/src/common/signal_handler.h
@@ -244,9 +244,6 @@ void DumpTimeInfo() {
     formatter.AppendString("-");
     formatter.AppendUint64(query_id_lo, 16);
     formatter.AppendString(" ***\n");
-    formatter.AppendString("*** is nereids: ");
-    formatter.AppendUint64(is_nereids, 10);
-    formatter.AppendString(" ***\n");
     formatter.AppendString("*** tablet id: ");
     formatter.AppendUint64(tablet_id, 10);
     formatter.AppendString(" ***\n");


### PR DESCRIPTION
### What problem does this PR solve?
This pull request makes a small change to the `DumpTimeInfo` function in `signal_handler.h` by removing the output of the `is_nereids` field. This simplifies the debug output by omitting the "is nereids" information.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

