### PR TITLE
[enhancement](memtable) merge redundant mutex locks in _flush_memtable_async

### DIFF
--- a/be/src/olap/memtable_writer.cpp
+++ b/be/src/olap/memtable_writer.cpp
@@ -160,9 +160,6 @@ Status MemTableWriter::_flush_memtable_async() {
         std::lock_guard<std::mutex> l(_mem_table_ptr_lock);
         memtable = _mem_table;
         _mem_table = nullptr;
-    }
-    {
-        std::lock_guard<std::mutex> l(_mem_table_ptr_lock);
         memtable->update_mem_type(MemType::WRITE_FINISHED);
         _freezed_mem_tables.push_back(memtable);
     }


### PR DESCRIPTION
## Proposed changes

In `MemTableWriter::_flush_memtable_async()`, there are two consecutive `lock_guard` blocks locking the same mutex `_mem_table_ptr_lock` with no operations in between, which is redundant.

Before:
{
    std::lock_guard<std::mutex> l(_mem_table_ptr_lock);
    memtable = _mem_table;
    _mem_table = nullptr;
}
{
    std::lock_guard<std::mutex> l(_mem_table_ptr_lock);  // redundant lock
    memtable->update_mem_type(MemType::WRITE_FINISHED);
    _freezed_mem_tables.push_back(memtable);
}

After
{
    std::lock_guard<std::mutex> l(_mem_table_ptr_lock);
    memtable = _mem_table;
    _mem_table = nullptr;
    memtable->update_mem_type(MemType::WRITE_FINISHED);
    _freezed_mem_tables.push_back(memtable);
}


### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

