### PR TITLE
[Feature](execution) support adjuct filter order by cost

### DIFF
--- a/be/src/pipeline/exec/aggregation_sink_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_sink_operator.cpp
@@ -733,8 +733,7 @@ AggSinkOperatorX::AggSinkOperatorX(ObjectPool* pool, int operator_id, int dest_i
           _is_first_phase(tnode.agg_node.__isset.is_first_phase && tnode.agg_node.is_first_phase),
           _pool(pool),
           _limit(tnode.limit),
-          _have_conjuncts((tnode.__isset.vconjunct && !tnode.vconjunct.nodes.empty()) ||
-                          (tnode.__isset.conjuncts && !tnode.conjuncts.empty())),
+          _have_conjuncts(tnode.__isset.conjuncts && !tnode.conjuncts.empty()),
           _is_colocate(tnode.agg_node.__isset.is_colocate && tnode.agg_node.is_colocate),
           _agg_fn_output_row_descriptor(descs, tnode.row_tuples) {}
 

--- a/be/src/pipeline/exec/streaming_aggregation_operator.cpp
+++ b/be/src/pipeline/exec/streaming_aggregation_operator.cpp
@@ -824,7 +824,6 @@ StreamingAggOperatorX::StreamingAggOperatorX(ObjectPool* pool, int operator_id,
           _output_tuple_id(tnode.agg_node.output_tuple_id),
           _needs_finalize(tnode.agg_node.need_finalize),
           _is_first_phase(tnode.agg_node.__isset.is_first_phase && tnode.agg_node.is_first_phase),
-          _have_conjuncts(tnode.__isset.vconjunct && !tnode.vconjunct.nodes.empty()),
           _agg_fn_output_row_descriptor(descs, tnode.row_tuples) {}
 
 void StreamingAggOperatorX::update_operator(const TPlanNode& tnode,

--- a/be/src/pipeline/exec/streaming_aggregation_operator.h
+++ b/be/src/pipeline/exec/streaming_aggregation_operator.h
@@ -264,7 +264,6 @@ private:
     std::vector<vectorized::AggFnEvaluator*> _aggregate_evaluators;
     bool _can_short_circuit = false;
     std::vector<size_t> _make_nullable_keys;
-    bool _have_conjuncts;
     RowDescriptor _agg_fn_output_row_descriptor;
 
     // For sort limit

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -125,6 +125,11 @@ public:
                                                            : _query_options.mem_limit / 20;
     }
 
+    bool enable_adjust_conjunct_order_by_cost() const {
+        return _query_options.__isset.enable_adjust_conjunct_order_by_cost &&
+               _query_options.enable_adjust_conjunct_order_by_cost;
+    }
+
     int32_t max_column_reader_num() const {
         return _query_options.__isset.max_column_reader_num ? _query_options.max_column_reader_num
                                                             : 20000;

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
@@ -188,6 +188,12 @@ Status RowGroupReader::init(
                                  _lazy_read_ctx.missing_columns_conjuncts.end());
         RETURN_IF_ERROR(_rewrite_dict_predicates());
     }
+    // _state is nullptr in some ut.
+    if (_state && _state->enable_adjust_conjunct_order_by_cost()) {
+        std::ranges::sort(_filter_conjuncts, [](const auto& a, const auto& b) {
+            return a->execute_cost() < b->execute_cost();
+        });
+    }
     return Status::OK();
 }
 

--- a/be/src/vec/exprs/vcolumn_ref.h
+++ b/be/src/vec/exprs/vcolumn_ref.h
@@ -89,6 +89,8 @@ public:
         return out.str();
     }
 
+    double execute_cost() const override { return 0.0; }
+
 private:
     int _column_id;
     std::atomic<int> _gap = 0;

--- a/be/src/vec/exprs/vcompound_pred.h
+++ b/be/src/vec/exprs/vcompound_pred.h
@@ -330,6 +330,14 @@ public:
         return Status::OK();
     }
 
+    double execute_cost() const override {
+        double cost = 0.3;
+        for (const auto& child : _children) {
+            cost += child->execute_cost();
+        }
+        return cost;
+    }
+
 private:
     static inline constexpr uint8_t apply_and_null(UInt8 a, UInt8 l_null, UInt8 b, UInt8 r_null) {
         // (<> && false) is false, (true && NULL) is NULL

--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -27,6 +27,7 @@
 #include <ostream>
 
 #include "common/config.h"
+#include "common/exception.h"
 #include "common/logging.h"
 #include "common/status.h"
 #include "common/utils.h"
@@ -668,6 +669,18 @@ Status VectorizedFnCall::evaluate_ann_range_search(
 
     ann_index_stats = *stats;
     return Status::OK();
+}
+
+double VectorizedFnCall::execute_cost() const {
+    if (!_function) {
+        throw Exception(
+                Status::InternalError("Function is null in expression: {}", this->debug_string()));
+    }
+    double cost = _function->execute_cost();
+    for (const auto& child : _children) {
+        cost += child->execute_cost();
+    }
+    return cost;
 }
 
 #include "common/compile_check_end.h"

--- a/be/src/vec/exprs/vectorized_fn_call.h
+++ b/be/src/vec/exprs/vectorized_fn_call.h
@@ -66,6 +66,7 @@ public:
     const std::string& expr_name() const override;
     std::string function_name() const;
     std::string debug_string() const override;
+    double execute_cost() const override;
     bool is_blockable() const override {
         return _function->is_blockable() ||
                std::any_of(_children.begin(), _children.end(),

--- a/be/src/vec/exprs/vexpr.h
+++ b/be/src/vec/exprs/vexpr.h
@@ -299,6 +299,14 @@ public:
         return expr;
     }
 
+    virtual double execute_cost() const {
+        double cost = 1.0;
+        for (const auto& child : _children) {
+            cost += child->execute_cost();
+        }
+        return cost;
+    }
+
     // If this expr is a RuntimeFilterWrapper, this method will return an underlying rf expression
     virtual VExprSPtr get_impl() const { return {}; }
 

--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -474,5 +474,14 @@ uint64_t VExprContext::get_digest(uint64_t seed) const {
     return _root->get_digest(seed);
 }
 
+double VExprContext::execute_cost() const {
+    if (_root == nullptr) {
+        // When there is no expression root, treat the cost as a base value.
+        // This avoids null dereferences while keeping a deterministic cost.
+        return 0.0;
+    }
+    return _root->execute_cost();
+}
+
 #include "common/compile_check_end.h"
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/vexpr_context.h
+++ b/be/src/vec/exprs/vexpr_context.h
@@ -201,7 +201,9 @@ public:
 
     [[nodiscard]] Status execute_const_expr(ColumnWithTypeAndName& result);
 
-    VExprSPtr root() const { return _root; }
+    double execute_cost() const;
+
+    VExprSPtr root() { return _root; }
     void set_root(const VExprSPtr& expr) { _root = expr; }
     void set_index_context(std::shared_ptr<IndexExecContext> index_context) {
         _index_context = std::move(index_context);

--- a/be/src/vec/exprs/vliteral.h
+++ b/be/src/vec/exprs/vliteral.h
@@ -56,6 +56,8 @@ public:
     const std::string& expr_name() const override { return _expr_name; }
     std::string debug_string() const override;
 
+    double execute_cost() const override { return 0.0; }
+
     MOCK_FUNCTION std::string value(const DataTypeSerDe::FormatOptions& options) const;
 
     const ColumnPtr& get_column_ptr() const { return _column_ptr; }

--- a/be/src/vec/exprs/vruntimefilter_wrapper.h
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.h
@@ -64,6 +64,8 @@ public:
     const VExprSPtrs& children() const override { return _impl->children(); }
     TExprNodeType::type node_type() const override { return _impl->node_type(); }
 
+    double execute_cost() const override { return _impl->execute_cost(); }
+
     Status execute_filter(VExprContext* context, const Block* block,
                           uint8_t* __restrict result_filter_data, size_t rows, bool accept_null,
                           bool* can_filter_all) const override;

--- a/be/src/vec/exprs/vslot_ref.h
+++ b/be/src/vec/exprs/vslot_ref.h
@@ -72,6 +72,8 @@ public:
 
     uint64_t get_digest(uint64_t seed) const override;
 
+    double execute_cost() const override { return 0.0; }
+
 private:
     int _slot_id;
     int _column_id;

--- a/be/src/vec/functions/function.h
+++ b/be/src/vec/functions/function.h
@@ -171,6 +171,8 @@ public:
     virtual const DataTypes& get_argument_types() const = 0;
     virtual const DataTypePtr& get_return_type() const = 0;
 
+    virtual double execute_cost() const { return 1.0; }
+
     /// Do preparations and return executable.
     /// sample_block should contain data types of arguments and values of constants, if relevant.
     virtual PreparedFunctionPtr prepare(FunctionContext* context, const Block& sample_block,
@@ -451,6 +453,8 @@ public:
                                 uint32_t /*result*/) const override {
         return function;
     }
+
+    double execute_cost() const override { return function->execute_cost(); }
 
     Status open(FunctionContext* context, FunctionContext::FunctionStateScope scope) override {
         return function->open(context, scope);

--- a/be/src/vec/functions/functions_comparison.h
+++ b/be/src/vec/functions/functions_comparison.h
@@ -272,6 +272,8 @@ public:
 
     FunctionComparison() = default;
 
+    double execute_cost() const override { return 0.5; }
+
 private:
     template <PrimitiveType PT>
     Status execute_num_type(Block& block, uint32_t result, const ColumnPtr& col_left_ptr,

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -3192,6 +3192,9 @@ public class SessionVariable implements Serializable, Writable {
     })
     public boolean enablePhraseQuerySequentialOpt = true;
 
+    @VariableMgr.VarAttr(name = "enable_adjust_conjunct_order_by_cost", needForward = true)
+    public boolean enableAdjustConjunctOrderByCost = true;
+
     @VariableMgr.VarAttr(name = REQUIRE_SEQUENCE_IN_INSERT, needForward = true, description = {
             "该变量用于控制，使用了 sequence 列的 unique key 表，insert into 操作是否要求必须提供每一行的 sequence 列的值",
             "This variable controls whether the INSERT INTO operation on unique key tables with a sequence"
@@ -5246,6 +5249,7 @@ public class SessionVariable implements Serializable, Writable {
         } else {
             tResult.setFileCacheQueryLimitPercent(Config.file_cache_query_limit_max_percent);
         }
+        tResult.setEnableAdjustConjunctOrderByCost(enableAdjustConjunctOrderByCost);
 
         // Set Iceberg write target file size
         tResult.setIcebergWriteTargetFileSizeBytes(icebergWriteTargetFileSizeBytes);

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -428,6 +428,8 @@ struct TQueryOptions {
 
   195: optional bool enable_left_semi_direct_return_opt;
 
+  200: optional bool enable_adjust_conjunct_order_by_cost;
+
   // For cloud, to control if the content would be written into file cache
   // In write path, to control if the content would be written into file cache.
   // In read path, read from file cache or remote storage when execute query.


### PR DESCRIPTION
### What problem does this PR solve?
tpch external 187s -> 180s
tpcds external 380s -> 370s


This pull request introduces a mechanism to estimate and utilize the execution cost of conjunct (predicate) expressions, enabling the system to dynamically reorder conjuncts for improved query performance when the new session variable `enable_adjust_conjunct_order_by_cost` is enabled. The changes span the addition of cost estimation methods to expression classes, integration of cost-based sorting in several operator initialization and runtime paths, and the introduction of the new session variable in both backend and frontend.

**Key changes include:**

### Predicate Execution Cost Estimation

* Added a virtual `execute_cost()` method to the base expression class `VExpr` and implemented or overridden it in various expression types (`VLiteral`, `VSlotRef`, `VColumnRef`, `VCompoundPred`, `VectorizedFnCall`, `VRuntimeFilterWrapper`, and function classes like `FunctionComparison`), providing a mechanism to estimate the computational cost of evaluating each predicate. (`[[1]](diffhunk://#diff-4150da5bf9ad89014e38f3a83e742a52468701b366ca4e4c6b09068c7dac283aR279-R286)`, `[[2]](diffhunk://#diff-17d34fd4d8b4a91c6eb1e3238715ce5e1c58b4968faea7d88ed22cfe0e348a91R59-R60)`, `[[3]](diffhunk://#diff-7eee9b0f155e5dd8d9d3a10dd72f7fb395cc0f65ff7f5de9ff5166599281d33fR75-R76)`, `[[4]](diffhunk://#diff-32461b08211d014e6636fd1cba54dc37cfb4916c13b47ac8ad36cb989a0b2031R92-R93)`, `Fd3c42dfL347R347`, `[[5]](diffhunk://#diff-01445f9862bc32606a103e5801fca9bd284f7dc2b9e1a6b7f28ec385d2ef2f24R67)`, `[[6]](diffhunk://#diff-dca2c0f573793d20c2dba5fe846bbadd82080fdea00051785cf0ea1ca41578bfR643-R655)`, `[[7]](diffhunk://#diff-93a2e196a10e91c528edefa02f02abb5b6ee621a3e1cbcc2d6a5ca7075a6061dR173-R174)`, `[[8]](diffhunk://#diff-f698d8639284042c1bb81cee0ae26a702114342abd4fa3bdfee4a51f62744f28R275-R276)`, `[[9]](diffhunk://#diff-f7878a776d3726dd835f26223f373f4d2e54f5080fa239868438adbe8bb911ffR67-R68)`, `[[10]](diffhunk://#diff-08b2eb65f6fe3da674c54840194c031f1309e06587938f5d31b04f2f9f4e9c68L204-R206)`, `[[11]](diffhunk://#diff-c0aab1f4c7a9ee63428155fea5d63afda8b47794f881392f71a47a619b334761R476-R484)`)

### Cost-Based Predicate Reordering

* Integrated cost-based sorting of conjuncts (using `std::ranges::sort` and `execute_cost()`) in several operator and scan initialization and runtime methods, so that when `enable_adjust_conjunct_order_by_cost` is true, predicates are evaluated in increasing order of estimated cost. This affects scan operators, aggregation operators, and Parquet group readers. (`[[1]](diffhunk://#diff-8922a03a948ba6a44dda51be21f535e0f5b8725b37b2f10facc90f2476b82aebL202-L214)`, `[[2]](diffhunk://#diff-ac38473f151ccd99db4ed80dfbfa176f4f957ae2f5335ce8fbb4f5dbb0e932e9L80-R87)`, `[[3]](diffhunk://#diff-ac38473f151ccd99db4ed80dfbfa176f4f957ae2f5335ce8fbb4f5dbb0e932e9R194-R199)`, `[[4]](diffhunk://#diff-d09145594c823444cca71879eb6515950211b548d7cbef65f0caf5c1d88f296fR191-R196)`)

### Session Variable and Query Option

* Introduced the session variable `enable_adjust_conjunct_order_by_cost` (default true) to control whether cost-based predicate reordering is enabled, and ensured it is forwarded and included in query options for both backend and frontend. (`[[1]](diffhunk://#diff-efeb89760ec70cdad5ae9c6169e213b9efa84fccb6ede73f626bf6583bd82333R128-R132)`, `[[2]](diffhunk://#diff-b8d4d6b7e84c9f48322536f241d11f98401524e08aba36b0c92be9589f43a4a3R3090-R3092)`, `[[3]](diffhunk://#diff-b8d4d6b7e84c9f48322536f241d11f98401524e08aba36b0c92be9589f43a4a3R5065)`)

### Code Cleanup and Refactoring

* Removed legacy handling of `vconjunct` in aggregation and streaming aggregation operators, simplifying conjunct management and aligning with the new cost-based mechanism. (`[[1]](diffhunk://#diff-df21df88282293d1bbe3223e0d95dcc5afc01da571e3a7c1d9dc9377a758d5daL737-R737)`, `[[2]](diffhunk://#diff-5f2882c1f711fc0954459c6b98a1dcde9b688bb5634be71ce6f585332d8b6497L828)`, `[[3]](diffhunk://#diff-81893b8013f0ade85a4aca0bcf807655fc08a57e7a6cc8531278cdc5330fae9eL265)`)
* Minor improvements such as renaming profile info strings for clarity (e.g., "RemainedDownPredicates" to "RemainedPredicates"). (`[be/src/pipeline/exec/scan_operator.cppL315-R327](diffhunk://#diff-ac38473f151ccd99db4ed80dfbfa176f4f957ae2f5335ce8fbb4f5dbb0e932e9L315-R327)`)

These changes collectively enable more efficient predicate evaluation, which can reduce query execution time, especially for complex queries with multiple predicates of varying computational cost.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

