### PR TITLE
[fix](inverted index)  fix pinyin filter bug

### DIFF
--- a/regression-test/data/inverted_index_p0/analyzer/test_custom_analyzer.out
+++ b/regression-test/data/inverted_index_p0/analyzer/test_custom_analyzer.out
@@ -290,6 +290,21 @@
 -- !sql_ignore_offset_false_mixed --
 [{\n        "token": "liu"\n    }, {\n        "token": "lad"\n    }, {\n        "token": "a"\n    }, {\n        "token": "de"\n    }]
 
+-- !sql_bug1_mixed_tokenizer --
+[{\n        "token": "ALFliudehua"\n    }]
+
+-- !sql_bug1_mixed_filter --
+[{\n        "token": "ALFliudehua"\n    }]
+
+-- !sql_bug2_pure_english --
+[{\n        "token": "Lanky Kong"\n    }]
+
+-- !sql_bug2_pure_numbers --
+[{\n        "token": "12345"\n    }]
+
+-- !sql_bug2_chinese --
+[{\n        "token": "liudehua"\n    }]
+
 -- !sql_table_ignore_offset_1 --
 1	刘德华
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

1. Mixed “ALF Characters” was wrongly cut into [“ALF”, “Characters”] because the pinyin filter treated the space as a token boundary.
2. When keep_none_chinese=false, a pure-English token such as “Lanky Kong” produced an empty [] result; the expected ES-compatible behaviour is to return the original token unchanged.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

