### PR TITLE
[fix](test) fix unstable sql cache testing because meta default is eventual consistency

### DIFF
--- a/regression-test/suites/nereids_p0/cache/mtmv_with_sql_cache.groovy
+++ b/regression-test/suites/nereids_p0/cache/mtmv_with_sql_cache.groovy
@@ -56,12 +56,14 @@ suite("mtmv_with_sql_cache") {
         def judge_res = { def sql_str ->
 
             sql "set enable_sql_cache=true"
+            sql "set enable_strong_consistency_read=true"
             def directly_res = sql sql_str
             directly_res.sort { [it[0], it[1]] }
             sql "set enable_sql_cache=false"
             def sql_cache_res = sql sql_str
             sql_cache_res.sort { [it[0], it[1]] }
             sql "set enable_sql_cache=true"
+            sql "set enable_strong_consistency_read=true"
 
             assertTrue(directly_res.size() == sql_cache_res.size())
             for (int i = 0; i < directly_res.size(); i++) {
@@ -189,6 +191,7 @@ suite("mtmv_with_sql_cache") {
                             sql "set enable_nereids_planner=true"
                             sql "set enable_fallback_to_original_planner=false"
                             sql "set enable_sql_cache=true"
+                            sql "set enable_strong_consistency_read=true"
 
                             // Direct Query
                             assertNoCache "select * from ${mv_name1}"
@@ -293,6 +296,7 @@ suite("mtmv_with_sql_cache") {
                             sql "set enable_nereids_planner=true"
                             sql "set enable_fallback_to_original_planner=false"
                             sql "set enable_sql_cache=true"
+                            sql "set enable_strong_consistency_read=true"
 
                             // Direct Query
                             assertNoCache "select * from ${mv_name1}"
@@ -411,6 +415,7 @@ suite("mtmv_with_sql_cache") {
                             sql "set enable_nereids_planner=true"
                             sql "set enable_fallback_to_original_planner=false"
                             sql "set enable_sql_cache=true"
+                            sql "set enable_strong_consistency_read=true"
 
                             // Direct Query
                             assertNoCache "select * from ${mv_name1}"
@@ -515,6 +520,7 @@ suite("mtmv_with_sql_cache") {
                             sql "set enable_nereids_planner=true"
                             sql "set enable_fallback_to_original_planner=false"
                             sql "set enable_sql_cache=true"
+                            sql "set enable_strong_consistency_read=true"
 
                             // Direct Query
                             assertNoCache "select * from ${mv_name1}"
@@ -611,6 +617,7 @@ suite("mtmv_with_sql_cache") {
                             sql "set enable_nereids_planner=true"
                             sql "set enable_fallback_to_original_planner=false"
                             sql "set enable_sql_cache=true"
+                            sql "set enable_strong_consistency_read=true"
 
                             // Direct Query
                             assertNoCache "select * from ${mv_name1}"
@@ -714,6 +721,7 @@ suite("mtmv_with_sql_cache") {
                             sql "set enable_nereids_planner=true"
                             sql "set enable_fallback_to_original_planner=false"
                             sql "set enable_sql_cache=true"
+                            sql "set enable_strong_consistency_read=true"
 
                             // Direct Query
                             assertNoCache "select * from ${mv_name1}"
@@ -825,6 +833,7 @@ suite("mtmv_with_sql_cache") {
                             sql "set enable_nereids_planner=true"
                             sql "set enable_fallback_to_original_planner=false"
                             sql "set enable_sql_cache=true"
+                            sql "set enable_strong_consistency_read=true"
 
                             // Direct Query
                             assertNoCache "select * from ${mv_name1}"
@@ -937,6 +946,7 @@ suite("mtmv_with_sql_cache") {
                             sql "set enable_nereids_planner=true"
                             sql "set enable_fallback_to_original_planner=false"
                             sql "set enable_sql_cache=true"
+                            sql "set enable_strong_consistency_read=true"
 
                             // Direct Query
                             assertNoCache "select * from ${mv_name1}"

--- a/regression-test/suites/nereids_p0/cache/mv_with_sql_cache.groovy
+++ b/regression-test/suites/nereids_p0/cache/mv_with_sql_cache.groovy
@@ -44,6 +44,7 @@ suite("mv_with_sql_cache") {
         sql "set enable_nereids_planner=true"
         sql "set enable_fallback_to_original_planner=false"
         sql "set enable_sql_cache=true"
+        sql "set enable_strong_consistency_read=true"
 
         def assertHasCache = { String sqlStr ->
             explain {

--- a/regression-test/suites/nereids_p0/cache/parse_sql_from_sql_cache.groovy
+++ b/regression-test/suites/nereids_p0/cache/parse_sql_from_sql_cache.groovy
@@ -98,6 +98,7 @@ suite("parse_sql_from_sql_cache") {
                         sql "set enable_nereids_planner=true"
                         sql "set enable_fallback_to_original_planner=false"
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         assertNoCache "select * from test_use_plan_cache"
 
@@ -118,6 +119,7 @@ suite("parse_sql_from_sql_cache") {
                         sql "set enable_nereids_planner=true"
                         sql "set enable_fallback_to_original_planner=false"
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         assertNoCache "select * from test_use_plan_cache2"
                         sql "select * from test_use_plan_cache2"
@@ -144,6 +146,7 @@ suite("parse_sql_from_sql_cache") {
                         sql "set enable_nereids_planner=true"
                         sql "set enable_fallback_to_original_planner=false"
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         assertNoCache "select * from ${tb_name}"
                         sql "select * from ${tb_name}"
@@ -174,6 +177,7 @@ suite("parse_sql_from_sql_cache") {
                         sql "set enable_nereids_planner=true"
                         sql "set enable_fallback_to_original_planner=false"
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         assertNoCache "select * from test_use_plan_cache3"
                         sql "select * from test_use_plan_cache3"
@@ -203,6 +207,7 @@ suite("parse_sql_from_sql_cache") {
                         sql "set enable_nereids_planner=true"
                         sql "set enable_fallback_to_original_planner=false"
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         assertNoCache "select * from test_use_plan_cache4"
                         sql "select * from test_use_plan_cache4"
@@ -223,6 +228,7 @@ suite("parse_sql_from_sql_cache") {
                         sql "set enable_nereids_planner=true"
                         sql "set enable_fallback_to_original_planner=false"
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         assertNoCache "select * from test_use_plan_cache5"
                         sql "select * from test_use_plan_cache5"
@@ -249,6 +255,7 @@ suite("parse_sql_from_sql_cache") {
                         sql "set enable_nereids_planner=true"
                         sql "set enable_fallback_to_original_planner=false"
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         assertNoCache "select * from test_use_plan_cache6"
                         sql "select * from test_use_plan_cache6"
@@ -270,6 +277,7 @@ suite("parse_sql_from_sql_cache") {
                         sql "set enable_nereids_planner=true"
                         sql "set enable_fallback_to_original_planner=false"
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         assertNoCache "select * from test_use_plan_cache7"
                         sql "select * from test_use_plan_cache7"
@@ -291,6 +299,7 @@ suite("parse_sql_from_sql_cache") {
                         sql "set enable_nereids_planner=true"
                         sql "set enable_fallback_to_original_planner=false"
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         assertNoCache "select * from test_use_plan_cache8"
                         sql "select * from test_use_plan_cache8"
@@ -318,6 +327,7 @@ suite("parse_sql_from_sql_cache") {
                         sql "set enable_nereids_planner=true"
                         sql "set enable_fallback_to_original_planner=false"
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         assertNoCache "select * from test_use_plan_cache9_view"
                         sql "select * from test_use_plan_cache9_view"
@@ -341,6 +351,7 @@ suite("parse_sql_from_sql_cache") {
                         sql "set enable_nereids_planner=true"
                         sql "set enable_fallback_to_original_planner=false"
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         assertNoCache "select * from test_use_plan_cache10_view"
                         sql "select * from test_use_plan_cache10_view"
@@ -367,6 +378,7 @@ suite("parse_sql_from_sql_cache") {
                         sql "set enable_nereids_planner=true"
                         sql "set enable_fallback_to_original_planner=false"
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         assertNoCache "select * from test_use_plan_cache11_view"
                         sql "select * from test_use_plan_cache11_view"
@@ -399,6 +411,7 @@ suite("parse_sql_from_sql_cache") {
                         sql "set enable_nereids_planner=true"
                         sql "set enable_fallback_to_original_planner=false"
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         assertNoCache "select * from test_use_plan_cache12"
                         sql "select * from test_use_plan_cache12"
@@ -412,6 +425,7 @@ suite("parse_sql_from_sql_cache") {
                                 sql "set enable_nereids_planner=true"
                                 sql "set enable_fallback_to_original_planner=false"
                                 sql "set enable_sql_cache=true"
+                                sql "set enable_strong_consistency_read=true"
 
                                 assertNoCache "select * from test_use_plan_cache12"
                             }
@@ -450,6 +464,7 @@ suite("parse_sql_from_sql_cache") {
                                 sql "set enable_nereids_planner=true"
                                 sql "set enable_fallback_to_original_planner=false"
                                 sql "set enable_sql_cache=true"
+                                sql "set enable_strong_consistency_read=true"
 
                                 assertNoCache "select * from test_use_plan_cache13"
                                 sql "select * from test_use_plan_cache13"
@@ -472,6 +487,7 @@ suite("parse_sql_from_sql_cache") {
                                 sql "set enable_nereids_planner=true"
                                 sql "set enable_fallback_to_original_planner=false"
                                 sql "set enable_sql_cache=true"
+                                sql "set enable_strong_consistency_read=true"
 
                                 assertNoCache "select * from test_use_plan_cache13"
                             }
@@ -515,6 +531,7 @@ suite("parse_sql_from_sql_cache") {
                                 sql "set enable_nereids_planner=true"
                                 sql "set enable_fallback_to_original_planner=false"
                                 sql "set enable_sql_cache=true"
+                                sql "set enable_strong_consistency_read=true"
 
                                 assertNoCache "select * from test_use_plan_cache14"
                                 sql "select * from test_use_plan_cache14"
@@ -536,6 +553,7 @@ suite("parse_sql_from_sql_cache") {
                                 sql "set enable_nereids_planner=true"
                                 sql "set enable_fallback_to_original_planner=false"
                                 sql "set enable_sql_cache=true"
+                                sql "set enable_strong_consistency_read=true"
 
                                 assertNoCache "select * from test_use_plan_cache14"
                             }
@@ -570,6 +588,7 @@ suite("parse_sql_from_sql_cache") {
                                 sql "set enable_nereids_planner=true"
                                 sql "set enable_fallback_to_original_planner=false"
                                 sql "set enable_sql_cache=true"
+                                sql "set enable_strong_consistency_read=true"
 
                                 assertNoCache "select * from test_use_plan_cache15"
                                 sql "select * from test_use_plan_cache15"
@@ -587,6 +606,7 @@ suite("parse_sql_from_sql_cache") {
                                 sql "set enable_nereids_planner=true"
                                 sql "set enable_fallback_to_original_planner=false"
                                 sql "set enable_sql_cache=true"
+                                sql "set enable_strong_consistency_read=true"
 
                                 test {
                                     sql ("select * from ${dbName}.test_use_plan_cache15")
@@ -606,6 +626,7 @@ suite("parse_sql_from_sql_cache") {
                         sql "set enable_nereids_planner=true"
                         sql "set enable_fallback_to_original_planner=false"
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         assertNoCache "select random() from test_use_plan_cache16"
                         // create sql cache
@@ -634,6 +655,7 @@ suite("parse_sql_from_sql_cache") {
                         sql "set enable_nereids_planner=true"
                         sql "set enable_fallback_to_original_planner=false"
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         sql "set @custom_variable=10"
                         assertNoCache "select @custom_variable from test_use_plan_cache17 where id = 1 and value = 1"
@@ -756,6 +778,7 @@ suite("parse_sql_from_sql_cache") {
                             sql "set enable_nereids_planner=true"
                             sql "set enable_fallback_to_original_planner=false"
                             sql "set enable_sql_cache=true"
+                            sql "set enable_strong_consistency_read=true"
 
                             assertNoCache "select * from test_use_plan_cache18"
                             sql "select * from test_use_plan_cache18"
@@ -769,6 +792,7 @@ suite("parse_sql_from_sql_cache") {
                             sql "set enable_nereids_planner=true"
                             sql "set enable_fallback_to_original_planner=false"
                             sql "set enable_sql_cache=true"
+                            sql "set enable_strong_consistency_read=true"
 
                             assertNoCache "select * from test_use_plan_cache18"
                             sql "select * from test_use_plan_cache18"
@@ -786,6 +810,7 @@ suite("parse_sql_from_sql_cache") {
                         sql "set enable_nereids_planner=true"
                         sql "set enable_fallback_to_original_planner=false"
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         sql "set dry_run_query=true"
                         assertNoCache "select * from test_use_plan_cache19 order by 1, 2"
@@ -818,6 +843,7 @@ suite("parse_sql_from_sql_cache") {
                         sql "set enable_nereids_planner=true"
                         sql "set enable_fallback_to_original_planner=false"
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         int randomInt = (int) (Math.random() * 2000000000)
 
@@ -867,6 +893,7 @@ suite("parse_sql_from_sql_cache") {
                         sql "set enable_nereids_planner=true"
                         sql "set enable_fallback_to_original_planner=false"
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         assertNoCache "select * from test_use_plan_cache21"
                         def result1 = sql "select * from test_use_plan_cache21"
@@ -889,6 +916,7 @@ suite("parse_sql_from_sql_cache") {
                         sql "set enable_nereids_planner=true"
                         sql "set enable_fallback_to_original_planner=false"
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         assertNoCache "select /*+SET_VAR(disable_nereids_rules='')*/ /*comment2*/ * from test_use_plan_cache22 order by 1, 2"
                         sql "select /*+SET_VAR(disable_nereids_rules='')*/ /*comment1*/ * from test_use_plan_cache22 order by 1, 2"
@@ -906,6 +934,7 @@ suite("parse_sql_from_sql_cache") {
                         sql "set enable_nereids_planner=true"
                         sql "set enable_fallback_to_original_planner=false"
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         int randomInt = Math.random() * 2000000000
                         sql "select ${randomInt} from test_use_plan_cache23"
@@ -937,6 +966,7 @@ suite("parse_sql_from_sql_cache") {
                 extraThread("sql_cache_with_date_format", {
                     retryTestSqlCache(3, 1000) {
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
                         def result = sql "select FROM_UNIXTIME(UNIX_TIMESTAMP(), 'yyyy-MM-dd HH:mm:ss')"
                         assertNotEquals("yyyy-MM-dd HH:mm:ss", result[0][0])
                     }
@@ -999,6 +1029,7 @@ suite("parse_sql_from_sql_cache") {
                         sleep(10000)
 
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
                         sql "use ${dbName1}"
                         List<List<Object>> result1 = sql """
                             SELECT COUNT(*) FROM ${tableName}
@@ -1025,11 +1056,13 @@ suite("parse_sql_from_sql_cache") {
                         sleep(10000)
 
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
                         assertTrue((sql "select * from test_use_plan_cache24").size() > 0)
                         assertHasCache "select * from test_use_plan_cache24"
 
                         connect(context.config.jdbcUser, context.config.jdbcPassword, context.jdbcUrl) {
                             sql "set enable_sql_cache=true"
+                            sql "set enable_strong_consistency_read=true"
                             sql "create temporary table test_use_plan_cache24(a int, b boolean) properties('replication_num'='1')"
                             assertEquals(0, (sql "select * from test_use_plan_cache24").size())
                             assertNoCache "select * from test_use_plan_cache24"
@@ -1051,6 +1084,7 @@ suite("parse_sql_from_sql_cache") {
                         sleep(10000)
 
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         sql "select count(1) from test_use_plan_cache25 group by id order by id"
                         assertHasCache "select count(1) from test_use_plan_cache25 group by id order by id"
@@ -1071,6 +1105,7 @@ suite("parse_sql_from_sql_cache") {
                         sleep(10000)
 
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         sql "select count(1) from test_use_plan_cache26 group by id order by id"
                         assertHasCache "select count(1) from test_use_plan_cache26 group by id order by id"
@@ -1092,6 +1127,7 @@ suite("parse_sql_from_sql_cache") {
                         sleep(10000)
 
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         sql "select count(1) from test_use_plan_cache27 group by id order by id"
                         assertHasCache "select count(1) from test_use_plan_cache27 group by id order by id"
@@ -1108,6 +1144,7 @@ suite("parse_sql_from_sql_cache") {
                         sleep(10000)
 
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         sql "select count(1) from test_use_plan_cache28 group by id order by id"
                         assertHasCache "select count(1) from test_use_plan_cache28 group by id order by id"
@@ -1124,6 +1161,7 @@ suite("parse_sql_from_sql_cache") {
                         sleep(10000)
 
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         sql "select * from test_use_plan_cache29"
                         assertHasCache "select * from test_use_plan_cache29"
@@ -1141,6 +1179,7 @@ suite("parse_sql_from_sql_cache") {
                         sleep(10000)
 
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         sql "select * from test_use_plan_cache30"
                         assertHasCache "select * from test_use_plan_cache30"
@@ -1157,6 +1196,7 @@ suite("parse_sql_from_sql_cache") {
                         sleep(10000)
 
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         sql "select * from test_use_plan_cache31"
                         assertHasCache "select * from test_use_plan_cache31"
@@ -1175,6 +1215,7 @@ suite("parse_sql_from_sql_cache") {
                         sleep(10000)
 
                         sql "set enable_sql_cache=true"
+                        sql "set enable_strong_consistency_read=true"
 
                         sql "select * from test_use_plan_cache32_view"
                         assertHasCache "select * from test_use_plan_cache32_view"

--- a/regression-test/suites/nereids_p0/cache/prepare_stmt_with_sql_cache.groovy
+++ b/regression-test/suites/nereids_p0/cache/prepare_stmt_with_sql_cache.groovy
@@ -39,6 +39,7 @@ suite("prepare_stmt_with_sql_cache") {
 
         connect(context.config.jdbcUser, context.config.jdbcPassword, serverPrepareUrl) {
             sql "set enable_sql_cache=true"
+            sql "set enable_strong_consistency_read=true"
             for (def i in 0..<10) {
                 try (PreparedStatement pstmt = prepareStatement("select * from test_prepare_stmt_with_sql_cache where id=?")) {
                     pstmt.setInt(1, i)
@@ -55,6 +56,7 @@ suite("prepare_stmt_with_sql_cache") {
         connect(context.config.jdbcUser, context.config.jdbcPassword, context.config.jdbcUrl) {
             sql "use ${db}"
             sql "set enable_sql_cache=true"
+            sql "set enable_strong_consistency_read=true"
             test {
                 sql "select * from test_prepare_stmt_with_sql_cache where id=10"
                 result([[10]])
@@ -64,6 +66,7 @@ suite("prepare_stmt_with_sql_cache") {
         connect(context.config.jdbcUser, context.config.jdbcPassword, serverPrepareUrl) {
             sql "use ${db}"
             sql "set enable_sql_cache=true"
+            sql "set enable_strong_consistency_read=true"
             test {
                 sql "select * from test_prepare_stmt_with_sql_cache where id=10"
                 result(([[10]]))

--- a/regression-test/suites/nereids_rules_p0/mv/union_all_compensate/union_all_compensate.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/union_all_compensate/union_all_compensate.groovy
@@ -23,6 +23,7 @@ suite("union_all_compensate") {
         sql "set runtime_filter_mode=OFF";
         sql "SET ignore_shape_nodes='PhysicalDistribute,PhysicalProject'"
         sql "set enable_sql_cache=true"
+        sql "set enable_strong_consistency_read=true"
         sql "ADMIN SET ALL FRONTENDS CONFIG ('cache_last_version_interval_second' = '0')"
         sql "ADMIN SET ALL FRONTENDS CONFIG ('sql_cache_manage_num' = '10000')"
         sql "ADMIN SET ALL FRONTENDS CONFIG ('expire_sql_cache_in_fe_second' = '300')"
@@ -175,6 +176,7 @@ suite("union_all_compensate") {
 
         order_qt_query1_0_after_no_sql_cache "${query1_0}"
         sql "set enable_sql_cache=true"
+        sql "set enable_strong_consistency_read=true"
         order_qt_query1_0_after_use_sql_cache "${query1_0}"
 
         // Data modify
@@ -195,6 +197,7 @@ suite("union_all_compensate") {
         mv_rewrite_fail(query1_0, "test_agg_mv")
         order_qt_query1_1_after_no_sql_cache "${query1_0}"
         sql "set enable_sql_cache=true"
+        sql "set enable_strong_consistency_read=true"
         order_qt_query1_1_after_use_sql_cache "${query1_0}"
 
 
@@ -221,6 +224,7 @@ suite("union_all_compensate") {
                 is_partition_statistics_ready(db, ["test_table1", "test_table2", "test_agg_mv"]))
         order_qt_query2_0_after_no_sql_cache "${query2_0}"
         sql "set enable_sql_cache=true"
+        sql "set enable_strong_consistency_read=true"
         order_qt_query2_0_after_use_sql_cache "${query2_0}"
 
 
@@ -246,6 +250,7 @@ suite("union_all_compensate") {
         mv_rewrite_fail(query3_0, "test_agg_mv")
         order_qt_query3_0_after_no_sql_cache "${query3_0}"
         sql "set enable_sql_cache=true"
+        sql "set enable_strong_consistency_read=true"
         order_qt_query3_0_after_use_sql_cache "${query3_0}"
 
 
@@ -273,6 +278,7 @@ suite("union_all_compensate") {
                 is_partition_statistics_ready(db, ["test_table1", "test_table2", "test_agg_mv"]))
         order_qt_query4_0_after_no_sql_cache "${query4_0}"
         sql "set enable_sql_cache=true"
+        sql "set enable_strong_consistency_read=true"
         order_qt_query4_0_after_use_sql_cache "${query4_0}"
 
 
@@ -300,6 +306,7 @@ suite("union_all_compensate") {
                 is_partition_statistics_ready(db, ["test_table1", "test_table2", "test_agg_mv"]))
         order_qt_query5_0_after_no_sql_cache "${query5_0}"
         sql "set enable_sql_cache=true"
+        sql "set enable_strong_consistency_read=true"
         order_qt_query5_0_after_use_sql_cache "${query5_0}"
         sql """ DROP MATERIALIZED VIEW IF EXISTS test_agg_mv"""
 
@@ -359,6 +366,7 @@ suite("union_all_compensate") {
                 is_partition_statistics_ready(db, ["test_table1", "test_table2", "test_join_mv"]))
         order_qt_query6_0_after_no_sql_cache "${query6_0}"
         sql "set enable_sql_cache=true"
+        sql "set enable_strong_consistency_read=true"
         order_qt_query6_0_after_use_sql_cache "${query6_0}"
 
 
@@ -385,6 +393,7 @@ suite("union_all_compensate") {
                 is_partition_statistics_ready(db, ["test_table1", "test_table2", "test_join_mv"]))
         order_qt_query7_0_after_no_sql_cache "${query7_0}"
         sql "set enable_sql_cache=true"
+        sql "set enable_strong_consistency_read=true"
         order_qt_query7_0_after_use_sql_cache "${query7_0}"
         sql """ DROP MATERIALIZED VIEW IF EXISTS test_join_mv"""
 

--- a/regression-test/suites/nereids_rules_p0/mv/union_rewrite_grace_big/union_rewrite_grace_big.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/union_rewrite_grace_big/union_rewrite_grace_big.groovy
@@ -25,6 +25,7 @@ suite("union_rewrite_grace_big") {
       sql "use ${db}"
       sql "set runtime_filter_mode=OFF"
       sql "set enable_sql_cache=true"
+      sql "set enable_strong_consistency_read=true"
       sql "ADMIN SET ALL FRONTENDS CONFIG ('cache_last_version_interval_second' = '0')"
       sql "ADMIN SET ALL FRONTENDS CONFIG ('sql_cache_manage_num' = '10000')"
       sql "ADMIN SET ALL FRONTENDS CONFIG ('expire_sql_cache_in_fe_second' = '300')"
@@ -223,6 +224,7 @@ suite("union_rewrite_grace_big") {
               is_partition_statistics_ready(db, ["lineitem", "orders", mv_1_partition_name]))
       order_qt_query_3_0_after_no_sql_cache "${query_all_partition_sql}"
       sql "SET enable_sql_cache=true"
+      sql "set enable_strong_consistency_read=true"
       order_qt_query_3_0_after_use_sql_cache "${query_all_partition_sql}"
 
       sql "SET enable_materialized_view_rewrite=false"
@@ -235,6 +237,7 @@ suite("union_rewrite_grace_big") {
               is_partition_statistics_ready(db, ["lineitem", "orders", mv_1_partition_name]))
       order_qt_query_4_0_after_no_sql_cache "${query_partition_sql}"
       sql "SET enable_sql_cache=true"
+      sql "set enable_strong_consistency_read=true"
       order_qt_query_4_0_after_use_sql_cache "${query_partition_sql}"
 
       // base table add partition
@@ -258,6 +261,7 @@ suite("union_rewrite_grace_big") {
               is_partition_statistics_ready(db, ["lineitem", "orders", mv_1_partition_name]))
       order_qt_query_7_0_after_no_sql_cache "${query_all_partition_sql}"
       sql "SET enable_sql_cache=true"
+      sql "set enable_strong_consistency_read=true"
       order_qt_query_7_0_after_use_sql_cache "${query_all_partition_sql}"
 
       sql "SET enable_materialized_view_rewrite=false"
@@ -271,6 +275,7 @@ suite("union_rewrite_grace_big") {
       order_qt_query_8_0_after_no_sql_cache "${query_partition_sql}"
 
       sql "set enable_sql_cache=true"
+      sql "set enable_strong_consistency_read=true"
       // should rewrite successfully when union rewrite enable if doesn't query new partition
       mv_rewrite_success(query_partition_sql, mv_1_partition_name,
               is_partition_statistics_ready(db, ["lineitem", "orders", mv_1_partition_name]))
@@ -297,6 +302,7 @@ suite("union_rewrite_grace_big") {
       order_qt_query_11_0_after_no_sql_cache "${query_all_partition_sql}"
 
       sql "set enable_sql_cache=true"
+      sql "set enable_strong_consistency_read=true"
       order_qt_query_11_0_after_use_sql_cache "${query_all_partition_sql}"
 
       sql "SET enable_materialized_view_rewrite=false"
@@ -310,6 +316,7 @@ suite("union_rewrite_grace_big") {
 
       order_qt_query_12_0_after_no_sql_cache "${query_partition_sql}"
       sql "set enable_sql_cache=true"
+      sql "set enable_strong_consistency_read=true"
       order_qt_query_12_0_after_use_sql_cache "${query_partition_sql}"
       sql """ DROP MATERIALIZED VIEW IF EXISTS ${mv_1_partition_name}"""
 
@@ -443,6 +450,7 @@ suite("union_rewrite_grace_big") {
       mv_rewrite_fail(query_ttl_partition_sql, ttl_mv_name)
       order_qt_query_16_0_after_no_sql_cache "${query_ttl_partition_sql}"
       sql "set enable_sql_cache=true"
+      sql "set enable_strong_consistency_read=true"
       order_qt_query_16_0_after_use_sql_cache "${query_ttl_partition_sql}"
 
       sql """ DROP MATERIALIZED VIEW IF EXISTS ${ttl_mv_name}"""
@@ -530,6 +538,7 @@ suite("union_rewrite_grace_big") {
               is_partition_statistics_ready(db, ["lineitem", "orders", mv_1_partition_name]))
       order_qt_query_17_0_after_no_sql_cache "${query_roll_up_all_partition_sql}"
       sql "set enable_sql_cache=true"
+      sql "set enable_strong_consistency_read=true"
       order_qt_query_17_0_after_use_sql_cache "${query_roll_up_all_partition_sql}"
 
       sql "SET enable_materialized_view_rewrite=false"
@@ -542,6 +551,7 @@ suite("union_rewrite_grace_big") {
               is_partition_statistics_ready(db, ["lineitem", "orders", mv_1_partition_name]))
       order_qt_query_18_0_after_no_sql_cache "${query_roll_up_partition_sql}"
       sql "set enable_sql_cache=true"
+      sql "set enable_strong_consistency_read=true"
       order_qt_query_18_0_after_use_sql_cache "${query_roll_up_partition_sql}"
 
 
@@ -569,6 +579,7 @@ suite("union_rewrite_grace_big") {
               is_partition_statistics_ready(db, ["lineitem", "orders", mv_1_partition_name]))
       order_qt_query_19_0_after_no_sql_cache "${query_roll_up_all_partition_sql}"
       sql "set enable_sql_cache=true"
+      sql "set enable_strong_consistency_read=true"
       order_qt_query_19_0_after_use_sql_cache "${query_roll_up_all_partition_sql}"
 
       sql "SET enable_materialized_view_rewrite=false"
@@ -582,6 +593,7 @@ suite("union_rewrite_grace_big") {
 
       order_qt_query_20_0_after_no_sql_cache "${query_roll_up_partition_sql}"
       sql "set enable_sql_cache=true"
+      sql "set enable_strong_consistency_read=true"
       order_qt_query_20_0_after_use_sql_cache "${query_roll_up_partition_sql}"
 
 
@@ -600,6 +612,7 @@ suite("union_rewrite_grace_big") {
               is_partition_statistics_ready(db, ["lineitem", "orders", mv_1_partition_name]))
       order_qt_query_21_0_after_no_sql_cache "${query_roll_up_all_partition_sql}"
       sql "set enable_sql_cache=true"
+      sql "set enable_strong_consistency_read=true"
       order_qt_query_21_0_after_use_sql_cache "${query_roll_up_all_partition_sql}"
 
       sql "SET enable_materialized_view_rewrite=false"
@@ -612,6 +625,7 @@ suite("union_rewrite_grace_big") {
 
       order_qt_query_22_0_after_no_sql_cache "${query_roll_up_partition_sql}"
       sql "set enable_sql_cache=true"
+      sql "set enable_strong_consistency_read=true"
       order_qt_query_22_0_after_use_sql_cache "${query_roll_up_partition_sql}"
 
 

--- a/regression-test/suites/query_p0/cache/sql_cache.groovy
+++ b/regression-test/suites/query_p0/cache/sql_cache.groovy
@@ -257,6 +257,7 @@ suite("sql_cache") {
         // explain plan with sql cache
         connect {
             sql "set enable_sql_cache=true"
+            sql "set enable_strong_consistency_read=true"
             sql "select 100"
             sql "explain plan select 100"
         }
@@ -272,6 +273,7 @@ suite("sql_cache") {
 
         sql "unset variable all"
         sql "set enable_sql_cache=true"
+        sql "set enable_strong_consistency_read=true"
         sql "insert into test_sql_cache_with_session_variable values(1, 'hello', '2025-01-02 03:04:05')"
         sleep(10000)
 


### PR DESCRIPTION
doris's default is eventual consistency, and the observer may not see the latest metadata.

this will cause some strange case, e.g. alter table rename a column, and than query can not not see the new column, and the version id not change when the query, so hit the legacy sql cache and the testing failed.

this pr set enable_strong_consistency_read=true when test sql cache to avoid this problem

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

