### PR TITLE
[opt](fe) opt the performance for TupleDescriptor.getSlot

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
@@ -29,12 +29,14 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 public class TupleDescriptor {
     private final TupleId id;
     private final String debugName; // debug only
     private final ArrayList<SlotDescriptor> slots;
+    private final HashMap<Integer, SlotDescriptor> idToSlotDesc;
 
     // underlying table, if there is one
     private TableIf table;
@@ -46,17 +48,20 @@ public class TupleDescriptor {
     public TupleDescriptor(TupleId id) {
         this.id = id;
         this.slots = new ArrayList<SlotDescriptor>();
+        this.idToSlotDesc = new HashMap<>();
         this.debugName = "";
     }
 
     public TupleDescriptor(TupleId id, String debugName) {
         this.id = id;
         this.slots = new ArrayList<SlotDescriptor>();
+        this.idToSlotDesc = new HashMap<>();
         this.debugName = debugName;
     }
 
     public void addSlot(SlotDescriptor desc) {
         slots.add(desc);
+        idToSlotDesc.putIfAbsent(desc.getId().asInt(), desc);
     }
 
     public TupleId getId() {
@@ -82,12 +87,7 @@ public class TupleDescriptor {
      * @return this slot's desc
      */
     public SlotDescriptor getSlot(int slotId) {
-        for (SlotDescriptor slotDesc : slots) {
-            if (slotDesc.getId().asInt() == slotId) {
-                return slotDesc;
-            }
-        }
-        return null;
+        return idToSlotDesc.get(slotId);
     }
 
     public ArrayList<SlotId> getAllSlotIds() {


### PR DESCRIPTION
### What problem does this PR solve?

like https://github.com/apache/doris/pull/60003, When there are large of columns(such as 3W columns) in table, TupleDescriptor.getSlot function will be the main performance bottleneck.

**Before**
```
- Init Scan Node Time: 1s94ms
```

**After**
```
- Init Scan Node Time: 145ms
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

