### PR TITLE
[Bug](scan) fix coredump in attach_profile_counter defer

### DIFF
--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -368,10 +368,10 @@ Status ScanLocalState<Derived>::_normalize_predicate(vectorized::VExprContext* c
                             if (pdt != PushDownType::UNACCEPTABLE && root->is_rf_wrapper() &&
                                 !_eos) {
                                 if (_slot_id_to_predicates[slot->id()].empty()) {
-                                    return Status::InternalError(
-                                            "No predicate generated for runtime filter "
-                                            "from expr: {}",
-                                            root->debug_string());
+                                    throw Exception(ErrorCode::INTERNAL_ERROR,
+                                                    "No predicate generated for runtime filter "
+                                                    "from expr: {}",
+                                                    root->debug_string());
                                 }
                                 auto* rf_expr =
                                         assert_cast<vectorized::VRuntimeFilterWrapper*>(root.get());


### PR DESCRIPTION
### What problem does this PR solve?
This pull request introduces an additional check when attaching profile counters to runtime filter predicates during predicate normalization in the scan operator. Specifically, it ensures that if predicate pushdown is short-circuited (indicated by `_eos` being true), the code does not attempt to access or attach profile counters to potentially empty predicate lists, which could prevent internal errors.

**Predicate normalization and error handling:**

* In `scan_operator.cpp`, updated the `_normalize_predicate` method to check for the `_eos` flag and ensure that the predicate list for a slot is not empty before attaching a profile counter, returning an internal error if no predicate is found for a runtime filter expression.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

