### PR TITLE
[opt](s3) use ak+sk combine in calculate hash value

### DIFF
--- a/be/src/util/s3_util.h
+++ b/be/src/util/s3_util.h
@@ -88,8 +88,8 @@ struct S3ClientConf {
 
     uint64_t get_hash() const {
         uint64_t hash_code = 0;
-        hash_code ^= crc32_hash(ak);
-        hash_code ^= crc32_hash(sk);
+        // Use crc32_hash(ak + sk) hash to prevent swapped AK/SK order from producing same result.
+        hash_code ^= crc32_hash(ak + sk);
         hash_code ^= crc32_hash(token);
         hash_code ^= crc32_hash(endpoint);
         hash_code ^= crc32_hash(region);


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:

because the S3ClientConf will calculate hash use eg: ak、sk、token，
and use the hash value  as key to maintain a cache,
if someone  swapped AK/SK order by mistake, it's will get connect failed
when get the ak/sk order correctly, it's still get connect failed, because it's have the same hash value.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

