### PR TITLE
[Optimization](exec) convert the Hybridset into a Bitset when its value domain is small.

### DIFF
--- a/be/src/exprs/hybrid_set.h
+++ b/be/src/exprs/hybrid_set.h
@@ -20,9 +20,13 @@
 #include <gen_cpp/internal_service.pb.h>
 #include <pdqsort.h>
 
+#include <type_traits>
+
+#include "common/exception.h"
 #include "common/object_pool.h"
 #include "exprs/filter_base.h"
 #include "runtime/primitive_type.h"
+#include "runtime/runtime_state.h"
 #include "runtime_filter/utils.h"
 #include "vec/columns/column_nullable.h"
 #include "vec/columns/column_string.h"
@@ -175,6 +179,84 @@ private:
     size_t _size {};
 };
 
+// BitSet container is used as a storage container for integer data with a relatively small range.
+// Given its intended usage, we do not provide an iterator interface.
+template <typename T>
+class BitSetContainer {
+    static_assert(std::is_integral_v<T>);
+
+public:
+    using Self = BitSetContainer<T>;
+    using ElementType = T;
+
+    using Iterator = std::vector<T>::iterator; // fake iterator
+
+    BitSetContainer() = default;
+
+    ~BitSetContainer() = default;
+
+    void init_bitset(T min_value, T max_value) {
+        _min_value = min_value;
+        _max_value = max_value;
+        auto bitset_size = static_cast<size_t>(max_value - min_value + 1);
+        _bitset.resize(bitset_size, false);
+    }
+
+    void insert(const T& value) {
+        DCHECK(value >= _min_value && value <= _max_value)
+                << "value out of range in BitSetContainer: " << value
+                << ", min_value: " << _min_value << ", max_value: " << _max_value;
+
+        size_t index = get_index(value);
+        if (!_bitset[index]) {
+            _bitset[index] = true;
+            _size++;
+        }
+    }
+
+    void insert(Iterator begin, Iterator end) {
+        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
+                               "BitSetContainer does not support insert by iterator.");
+    }
+
+    // Use '|' instead of '||' has better performance by test.
+    ALWAYS_INLINE bool find(const T& value) const {
+        if (!check_range(value)) {
+            return false;
+        }
+        size_t index = get_index(value);
+        return _bitset[index];
+    }
+
+    size_t size() const { return _size; }
+
+    Iterator begin() {
+        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
+                               "BitSetContainer does not support begin iterator.");
+    }
+    Iterator end() {
+        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
+                               "BitSetContainer does not support end iterator.");
+    }
+
+    void clear() {
+        _bitset.clear();
+        _size = 0;
+        _min_value = 0;
+        _max_value = 0;
+    }
+
+private:
+    std::vector<bool> _bitset;
+    size_t _size {0};
+    T _min_value {0};
+    T _max_value {0};
+
+    size_t get_index(const T& value) const { return static_cast<size_t>(value - _min_value); }
+
+    bool check_range(const T& value) const { return value >= _min_value && value <= _max_value; }
+};
+
 template <typename T>
 struct IsFixedContainer : std::false_type {};
 
@@ -270,7 +352,17 @@ public:
     };
 
     virtual IteratorBase* begin() = 0;
+
+    virtual std::shared_ptr<HybridSetBase> try_convert_to_bitset(RuntimeState* state) {
+        return nullptr;
+    }
 };
+
+template <typename T>
+constexpr bool is_dynamic_container_v = false;
+
+template <typename T>
+constexpr bool is_dynamic_container_v<DynamicContainer<T>> = true;
 
 template <PrimitiveType T,
           typename _ContainerType = DynamicContainer<typename PrimitiveTypeTraits<T>::CppType>,
@@ -429,7 +521,70 @@ public:
         return HashUtil::crc_hash64(&_contain_null, sizeof(_contain_null), seed);
     }
 
+    std::shared_ptr<HybridSetBase> try_convert_to_bitset(RuntimeState* state) override {
+        if constexpr (is_dynamic_container_v<ContainerType>) {
+            return _try_convert_to_bitset_impl(state);
+        } else {
+            return nullptr;
+        }
+    }
+
 private:
+    template <PrimitiveType U, typename ContainerU, typename ColumnU>
+    friend class HybridSet;
+
+    std::shared_ptr<HybridSetBase> _try_convert_to_bitset_impl(RuntimeState* state) {
+        if (state == nullptr) {
+            return nullptr;
+        }
+        if constexpr (T == TYPE_TINYINT || T == TYPE_SMALLINT || T == TYPE_INT ||
+                      T == TYPE_BIGINT) {
+            const size_t max_bitset_size = state->in_set_to_bitset_max_size();
+            const size_t max_range = state->in_set_to_bitset_max_range();
+
+            if (this->size() > static_cast<int>(max_bitset_size) || this->size() == 0) {
+                return nullptr;
+            }
+
+            ElementType min_value = std::numeric_limits<ElementType>::max();
+            ElementType max_value = std::numeric_limits<ElementType>::min();
+
+            // First pass: find min and max
+            for (auto it = _set.begin(); it != _set.end(); ++it) {
+                const ElementType& value = *it;
+                if (value < min_value) {
+                    min_value = value;
+                }
+                if (value > max_value) {
+                    max_value = value;
+                }
+            }
+
+            // Check if range is acceptable
+            auto range = static_cast<uint64_t>(max_value) - static_cast<uint64_t>(min_value);
+            if (range > max_range) {
+                return nullptr;
+            }
+
+            // Create bitset-based HybridSet
+            auto bitset_set =
+                    std::make_shared<HybridSet<T, BitSetContainer<ElementType>, ColumnType>>(
+                            _null_aware);
+
+            auto& set = bitset_set->_set;
+            set.init_bitset(min_value, max_value);
+
+            // Second pass: insert values
+            for (auto it = _set.begin(); it != _set.end(); ++it) {
+                set.insert(*it);
+            }
+            bitset_set->_contain_null = this->_contain_null;
+            return bitset_set;
+        } else {
+            return nullptr;
+        }
+    }
+
     ContainerType _set;
     ObjectPool _pool;
 };

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -696,13 +696,13 @@ Status ScanLocalState<Derived>::_normalize_in_predicate(
         }
         is_in = !tmp->is_not_in();
 
-        if (state->hybrid_set->contain_null() && tmp->is_not_in()) {
+        if (state->get_hybrid_set()->contain_null() && tmp->is_not_in()) {
             _eos = true;
             _scan_dependency->set_ready();
             return Status::OK();
         }
-        hybrid_set = state->hybrid_set;
-        iter = state->hybrid_set->begin();
+        hybrid_set = state->get_hybrid_set();
+        iter = state->get_hybrid_set()->begin();
     }
 
     if (iter) {

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -579,6 +579,18 @@ public:
                        : 0;
     }
 
+    int64_t in_set_to_bitset_max_size() const {
+        return _query_options.__isset.in_set_to_bitset_max_size
+                       ? _query_options.in_set_to_bitset_max_size
+                       : 0;
+    }
+
+    int64_t in_set_to_bitset_max_range() const {
+        return _query_options.__isset.in_set_to_bitset_max_range
+                       ? _query_options.in_set_to_bitset_max_range
+                       : 0;
+    }
+
     void set_be_exec_version(int32_t version) noexcept { _query_options.be_exec_version = version; }
 
     using LocalState = doris::pipeline::PipelineXLocalStateBase;

--- a/be/src/vec/exprs/vdirect_in_predicate.h
+++ b/be/src/vec/exprs/vdirect_in_predicate.h
@@ -43,6 +43,10 @@ public:
                    VExprContext* context) override {
         RETURN_IF_ERROR_OR_PREPARED(VExpr::prepare(state, row_desc, context));
         _prepare_finished = true;
+        _origin_filter = _filter;
+        if (auto bitset = _filter->try_convert_to_bitset(state)) {
+            _filter = bitset;
+        }
         return Status::OK();
     }
 
@@ -66,7 +70,7 @@ public:
 
     const std::string& expr_name() const override { return _expr_name; }
 
-    std::shared_ptr<HybridSetBase> get_set_func() const override { return _filter; }
+    std::shared_ptr<HybridSetBase> get_set_func() const override { return origin_filter(); }
 
     bool get_slot_in_expr(VExprSPtr& new_root) const {
         if (!get_child(0)->is_slot_ref()) {
@@ -109,7 +113,7 @@ public:
     uint64_t get_digest(uint64_t seed) const override {
         seed = _children[0]->get_digest(seed);
         if (seed) {
-            return _filter->get_digest(seed);
+            return origin_filter()->get_digest(seed);
         }
         return seed;
     }
@@ -146,6 +150,11 @@ private:
         return Status::OK();
     }
 
+    std::shared_ptr<HybridSetBase> origin_filter() const {
+        return _origin_filter == nullptr ? _filter : _origin_filter;
+    }
+
+    std::shared_ptr<HybridSetBase> _origin_filter = nullptr;
     std::shared_ptr<HybridSetBase> _filter;
     std::string _expr_name;
 };

--- a/be/src/vec/functions/in.h
+++ b/be/src/vec/functions/in.h
@@ -58,7 +58,7 @@ struct InState {
     bool use_set = true;
 
     std::shared_ptr<HybridSetBase> get_hybrid_set() {
-       return  origin_set == nullptr ? hybrid_set : origin_set;
+        return origin_set == nullptr ? hybrid_set : origin_set;
     }
 
 private:

--- a/be/src/vec/functions/in.h
+++ b/be/src/vec/functions/in.h
@@ -56,7 +56,17 @@ using ColumnString = ColumnStr<UInt32>;
 
 struct InState {
     bool use_set = true;
+
+    std::shared_ptr<HybridSetBase> get_hybrid_set() {
+       return  origin_set == nullptr ? hybrid_set : origin_set;
+    }
+
+private:
+    template <bool>
+    friend class FunctionIn;
+
     std::shared_ptr<HybridSetBase> hybrid_set;
+    std::shared_ptr<HybridSetBase> origin_set = nullptr;
 };
 
 template <bool negative>
@@ -131,6 +141,14 @@ public:
                 break;
             }
         }
+
+        if (state->use_set && state->hybrid_set) {
+            if (auto bitset = state->hybrid_set->try_convert_to_bitset(context->state())) {
+                state->origin_set = state->hybrid_set;
+                state->hybrid_set = bitset;
+            }
+        }
+
         return Status::OK();
     }
 

--- a/be/test/exprs/hybrid_set_test.cpp
+++ b/be/test/exprs/hybrid_set_test.cpp
@@ -26,6 +26,7 @@
 #include "exprs/create_predicate_function.h"
 #include "gtest/internal/gtest-internal.h"
 #include "testutil/column_helper.h"
+#include "testutil/mock/mock_runtime_state.h"
 
 namespace doris {
 
@@ -724,6 +725,485 @@ TEST_F(HybridSetTest, StringValueSet) {
         string_value_set->to_pb(&in_filter);
     } catch (...) {
     }
+}
+
+// Test BitSetContainer
+TEST_F(HybridSetTest, BitSetContainerBasic) {
+    BitSetContainer<int32_t> container;
+
+    // Test init_bitset
+    container.init_bitset(0, 100);
+
+    // Test insert and find
+    container.insert(0);
+    container.insert(50);
+    container.insert(100);
+
+    EXPECT_EQ(container.size(), 3);
+
+    EXPECT_TRUE(container.find(0));
+    EXPECT_TRUE(container.find(50));
+    EXPECT_TRUE(container.find(100));
+    EXPECT_FALSE(container.find(1));
+    EXPECT_FALSE(container.find(49));
+    EXPECT_FALSE(container.find(99));
+
+    // Test out of range find
+    EXPECT_FALSE(container.find(-1));
+    EXPECT_FALSE(container.find(101));
+
+    // Test duplicate insert
+    container.insert(50);
+    EXPECT_EQ(container.size(), 3);
+
+    // Test clear
+    container.clear();
+    EXPECT_EQ(container.size(), 0);
+    EXPECT_FALSE(container.find(50));
+}
+
+TEST_F(HybridSetTest, BitSetContainerNegativeValues) {
+    BitSetContainer<int32_t> container;
+
+    // Test with negative range
+    container.init_bitset(-100, 100);
+
+    container.insert(-100);
+    container.insert(-50);
+    container.insert(0);
+    container.insert(50);
+    container.insert(100);
+
+    EXPECT_EQ(container.size(), 5);
+
+    EXPECT_TRUE(container.find(-100));
+    EXPECT_TRUE(container.find(-50));
+    EXPECT_TRUE(container.find(0));
+    EXPECT_TRUE(container.find(50));
+    EXPECT_TRUE(container.find(100));
+
+    EXPECT_FALSE(container.find(-101));
+    EXPECT_FALSE(container.find(101));
+    EXPECT_FALSE(container.find(-1));
+    EXPECT_FALSE(container.find(1));
+}
+
+TEST_F(HybridSetTest, BitSetContainerTypes) {
+    // Test with int8_t
+    {
+        BitSetContainer<int8_t> container;
+        container.init_bitset(-10, 10);
+        container.insert(-10);
+        container.insert(0);
+        container.insert(10);
+        EXPECT_EQ(container.size(), 3);
+        EXPECT_TRUE(container.find(-10));
+        EXPECT_TRUE(container.find(0));
+        EXPECT_TRUE(container.find(10));
+    }
+
+    // Test with int16_t
+    {
+        BitSetContainer<int16_t> container;
+        container.init_bitset(-1000, 1000);
+        container.insert(-1000);
+        container.insert(0);
+        container.insert(1000);
+        EXPECT_EQ(container.size(), 3);
+        EXPECT_TRUE(container.find(-1000));
+        EXPECT_TRUE(container.find(0));
+        EXPECT_TRUE(container.find(1000));
+    }
+
+    // Test with int64_t
+    {
+        BitSetContainer<int64_t> container;
+        container.init_bitset(-10000, 10000);
+        container.insert(-10000);
+        container.insert(0);
+        container.insert(10000);
+        EXPECT_EQ(container.size(), 3);
+        EXPECT_TRUE(container.find(-10000));
+        EXPECT_TRUE(container.find(0));
+        EXPECT_TRUE(container.find(10000));
+    }
+}
+
+// Test try_convert_to_bitset
+TEST_F(HybridSetTest, TryConvertToBitsetNullState) {
+    // Test with null state - should return nullptr
+    std::unique_ptr<HybridSetBase> set(create_set(PrimitiveType::TYPE_INT, false));
+
+    int32_t values[] = {1, 2, 3, 4, 5};
+    for (auto v : values) {
+        set->insert(&v);
+    }
+
+    auto result = set->try_convert_to_bitset(nullptr);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(HybridSetTest, TryConvertToBitsetSuccess) {
+    // Test successful conversion
+    std::unique_ptr<HybridSetBase> set(create_set(PrimitiveType::TYPE_INT, false));
+
+    int32_t values[] = {1, 5, 10, 15, 20};
+    for (auto v : values) {
+        set->insert(&v);
+    }
+
+    // Create MockRuntimeState with appropriate settings
+    MockRuntimeState state;
+    TQueryOptions query_options;
+    query_options.__set_in_set_to_bitset_max_size(100);
+    query_options.__set_in_set_to_bitset_max_range(100);
+    state.set_query_options(query_options);
+
+    auto bitset_set = set->try_convert_to_bitset(&state);
+    ASSERT_NE(bitset_set, nullptr);
+
+    // Verify the converted set has the same elements
+    EXPECT_EQ(bitset_set->size(), 5);
+    for (auto v : values) {
+        EXPECT_TRUE(bitset_set->find(&v));
+    }
+
+    // Verify elements not in the set
+    int32_t not_in_set[] = {0, 2, 3, 4, 6, 7, 8, 9, 11, 100};
+    for (auto v : not_in_set) {
+        EXPECT_FALSE(bitset_set->find(&v));
+    }
+}
+
+TEST_F(HybridSetTest, TryConvertToBitsetWithNullAware) {
+    // Test conversion preserves null awareness
+    std::unique_ptr<HybridSetBase> set(create_set(PrimitiveType::TYPE_INT, true));
+
+    int32_t values[] = {1, 2, 3};
+    for (auto v : values) {
+        set->insert(&v);
+    }
+    set->insert(static_cast<const void*>(nullptr)); // insert null
+
+    MockRuntimeState state;
+    TQueryOptions query_options;
+    query_options.__set_in_set_to_bitset_max_size(100);
+    query_options.__set_in_set_to_bitset_max_range(100);
+    state.set_query_options(query_options);
+
+    auto bitset_set = set->try_convert_to_bitset(&state);
+    ASSERT_NE(bitset_set, nullptr);
+
+    EXPECT_EQ(bitset_set->size(), 3);
+    EXPECT_TRUE(bitset_set->contain_null());
+
+    for (auto v : values) {
+        EXPECT_TRUE(bitset_set->find(&v));
+    }
+}
+
+TEST_F(HybridSetTest, TryConvertToBitsetTooLargeSize) {
+    // Test when set size exceeds max_bitset_size
+    std::unique_ptr<HybridSetBase> set(create_set(PrimitiveType::TYPE_INT, false));
+
+    for (int32_t i = 0; i < 20; ++i) {
+        set->insert(&i);
+    }
+
+    MockRuntimeState state;
+    TQueryOptions query_options;
+    query_options.__set_in_set_to_bitset_max_size(10); // max size is 10, but set has 20 elements
+    query_options.__set_in_set_to_bitset_max_range(100);
+    state.set_query_options(query_options);
+
+    auto result = set->try_convert_to_bitset(&state);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(HybridSetTest, TryConvertToBitsetTooLargeRange) {
+    // Test when value range exceeds max_range
+    std::unique_ptr<HybridSetBase> set(create_set(PrimitiveType::TYPE_INT, false));
+
+    int32_t values[] = {0, 1000}; // range is 1000
+    for (auto v : values) {
+        set->insert(&v);
+    }
+
+    MockRuntimeState state;
+    TQueryOptions query_options;
+    query_options.__set_in_set_to_bitset_max_size(100);
+    query_options.__set_in_set_to_bitset_max_range(500); // max range is 500, but actual range is 1000
+    state.set_query_options(query_options);
+
+    auto result = set->try_convert_to_bitset(&state);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(HybridSetTest, TryConvertToBitsetEmptySet) {
+    // Test with empty set
+    std::unique_ptr<HybridSetBase> set(create_set(PrimitiveType::TYPE_INT, false));
+
+    MockRuntimeState state;
+    TQueryOptions query_options;
+    query_options.__set_in_set_to_bitset_max_size(100);
+    query_options.__set_in_set_to_bitset_max_range(100);
+    state.set_query_options(query_options);
+
+    auto result = set->try_convert_to_bitset(&state);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(HybridSetTest, TryConvertToBitsetDifferentIntTypes) {
+    // Test with TINYINT
+    {
+        std::unique_ptr<HybridSetBase> set(create_set(PrimitiveType::TYPE_TINYINT, false));
+
+        int8_t values[] = {-10, 0, 10, 20};
+        for (auto v : values) {
+            set->insert(&v);
+        }
+
+        MockRuntimeState state;
+        TQueryOptions query_options;
+        query_options.__set_in_set_to_bitset_max_size(100);
+        query_options.__set_in_set_to_bitset_max_range(100);
+        state.set_query_options(query_options);
+
+        auto bitset_set = set->try_convert_to_bitset(&state);
+        ASSERT_NE(bitset_set, nullptr);
+        EXPECT_EQ(bitset_set->size(), 4);
+
+        for (auto v : values) {
+            EXPECT_TRUE(bitset_set->find(&v));
+        }
+    }
+
+    // Test with SMALLINT
+    {
+        std::unique_ptr<HybridSetBase> set(create_set(PrimitiveType::TYPE_SMALLINT, false));
+
+        int16_t values[] = {-100, 0, 100, 200};
+        for (auto v : values) {
+            set->insert(&v);
+        }
+
+        MockRuntimeState state;
+        TQueryOptions query_options;
+        query_options.__set_in_set_to_bitset_max_size(100);
+        query_options.__set_in_set_to_bitset_max_range(500);
+        state.set_query_options(query_options);
+
+        auto bitset_set = set->try_convert_to_bitset(&state);
+        ASSERT_NE(bitset_set, nullptr);
+        EXPECT_EQ(bitset_set->size(), 4);
+
+        for (auto v : values) {
+            EXPECT_TRUE(bitset_set->find(&v));
+        }
+    }
+
+    // Test with BIGINT
+    {
+        std::unique_ptr<HybridSetBase> set(create_set(PrimitiveType::TYPE_BIGINT, false));
+
+        int64_t values[] = {-1000, 0, 1000, 2000};
+        for (auto v : values) {
+            set->insert(&v);
+        }
+
+        MockRuntimeState state;
+        TQueryOptions query_options;
+        query_options.__set_in_set_to_bitset_max_size(100);
+        query_options.__set_in_set_to_bitset_max_range(5000);
+        state.set_query_options(query_options);
+
+        auto bitset_set = set->try_convert_to_bitset(&state);
+        ASSERT_NE(bitset_set, nullptr);
+        EXPECT_EQ(bitset_set->size(), 4);
+
+        for (auto v : values) {
+            EXPECT_TRUE(bitset_set->find(&v));
+        }
+    }
+}
+
+TEST_F(HybridSetTest, TryConvertToBitsetNonIntegerTypes) {
+    // Test with STRING - should return nullptr
+    {
+        std::unique_ptr<HybridSetBase> set(create_set(PrimitiveType::TYPE_STRING, false));
+
+        std::string s1 = "test1";
+        std::string s2 = "test2";
+        set->insert(&s1);
+        set->insert(&s2);
+
+        MockRuntimeState state;
+        TQueryOptions query_options;
+        query_options.__set_in_set_to_bitset_max_size(100);
+        query_options.__set_in_set_to_bitset_max_range(100);
+        state.set_query_options(query_options);
+
+        auto result = set->try_convert_to_bitset(&state);
+        EXPECT_EQ(result, nullptr);
+    }
+
+    // Test with FLOAT - should return nullptr
+    {
+        std::unique_ptr<HybridSetBase> set(create_set(PrimitiveType::TYPE_FLOAT, false));
+
+        float values[] = {1.0F, 2.0F, 3.0F};
+        for (auto v : values) {
+            set->insert(&v);
+        }
+
+        MockRuntimeState state;
+        TQueryOptions query_options;
+        query_options.__set_in_set_to_bitset_max_size(100);
+        query_options.__set_in_set_to_bitset_max_range(100);
+        state.set_query_options(query_options);
+
+        auto result = set->try_convert_to_bitset(&state);
+        EXPECT_EQ(result, nullptr);
+    }
+
+    // Test with DOUBLE - should return nullptr
+    {
+        std::unique_ptr<HybridSetBase> set(create_set(PrimitiveType::TYPE_DOUBLE, false));
+
+        double values[] = {1.0, 2.0, 3.0};
+        for (auto v : values) {
+            set->insert(&v);
+        }
+
+        MockRuntimeState state;
+        TQueryOptions query_options;
+        query_options.__set_in_set_to_bitset_max_size(100);
+        query_options.__set_in_set_to_bitset_max_range(100);
+        state.set_query_options(query_options);
+
+        auto result = set->try_convert_to_bitset(&state);
+        EXPECT_EQ(result, nullptr);
+    }
+}
+
+TEST_F(HybridSetTest, TryConvertToBitsetFindBatch) {
+    // Test find_batch on converted bitset
+    std::unique_ptr<HybridSetBase> set(create_set(PrimitiveType::TYPE_INT, false));
+
+    int32_t values[] = {1, 3, 5, 7, 9};
+    for (auto v : values) {
+        set->insert(&v);
+    }
+
+    MockRuntimeState state;
+    TQueryOptions query_options;
+    query_options.__set_in_set_to_bitset_max_size(100);
+    query_options.__set_in_set_to_bitset_max_range(100);
+    state.set_query_options(query_options);
+
+    auto bitset_set = set->try_convert_to_bitset(&state);
+    ASSERT_NE(bitset_set, nullptr);
+
+    // Create a column with test data
+    auto column = vectorized::ColumnInt32::create();
+    column->insert_value(0);
+    column->insert_value(1);
+    column->insert_value(2);
+    column->insert_value(3);
+    column->insert_value(4);
+    column->insert_value(5);
+    column->insert_value(6);
+    column->insert_value(7);
+    column->insert_value(8);
+    column->insert_value(9);
+
+    vectorized::ColumnUInt8::Container results(10, 0);
+    bitset_set->find_batch(*column, 10, results);
+
+    // Expected: 0->false, 1->true, 2->false, 3->true, 4->false, 5->true, 6->false, 7->true, 8->false, 9->true
+    EXPECT_EQ(results[0], 0);
+    EXPECT_EQ(results[1], 1);
+    EXPECT_EQ(results[2], 0);
+    EXPECT_EQ(results[3], 1);
+    EXPECT_EQ(results[4], 0);
+    EXPECT_EQ(results[5], 1);
+    EXPECT_EQ(results[6], 0);
+    EXPECT_EQ(results[7], 1);
+    EXPECT_EQ(results[8], 0);
+    EXPECT_EQ(results[9], 1);
+}
+
+TEST_F(HybridSetTest, TryConvertToBitsetFindBatchNegative) {
+    // Test find_batch_negative on converted bitset
+    std::unique_ptr<HybridSetBase> set(create_set(PrimitiveType::TYPE_INT, false));
+
+    int32_t values[] = {1, 3, 5};
+    for (auto v : values) {
+        set->insert(&v);
+    }
+
+    MockRuntimeState state;
+    TQueryOptions query_options;
+    query_options.__set_in_set_to_bitset_max_size(100);
+    query_options.__set_in_set_to_bitset_max_range(100);
+    state.set_query_options(query_options);
+
+    auto bitset_set = set->try_convert_to_bitset(&state);
+    ASSERT_NE(bitset_set, nullptr);
+
+    auto column = vectorized::ColumnInt32::create();
+    column->insert_value(0);
+    column->insert_value(1);
+    column->insert_value(2);
+    column->insert_value(3);
+    column->insert_value(4);
+    column->insert_value(5);
+
+    vectorized::ColumnUInt8::Container results(6, 0);
+    bitset_set->find_batch_negative(*column, 6, results);
+
+    // Expected: NOT IN results
+    // 0->true (not in set), 1->false (in set), 2->true, 3->false, 4->true, 5->false
+    EXPECT_EQ(results[0], 1);
+    EXPECT_EQ(results[1], 0);
+    EXPECT_EQ(results[2], 1);
+    EXPECT_EQ(results[3], 0);
+    EXPECT_EQ(results[4], 1);
+    EXPECT_EQ(results[5], 0);
+}
+
+TEST_F(HybridSetTest, BitSetContainerIteratorThrows) {
+    BitSetContainer<int32_t> container;
+    container.init_bitset(0, 10);
+
+    // Test that begin() throws
+    EXPECT_THROW(container.begin(), doris::Exception);
+
+    // Test that end() throws
+    EXPECT_THROW(container.end(), doris::Exception);
+
+    // Test that insert by iterator throws
+    std::vector<int32_t> values = {1, 2, 3};
+    EXPECT_THROW(container.insert(values.begin(), values.end()), doris::Exception);
+}
+
+TEST_F(HybridSetTest, TryConvertToBitsetFixedContainer) {
+    // Test with FixedContainer - should return nullptr
+    std::unique_ptr<HybridSetBase> set(create_set<3>(PrimitiveType::TYPE_INT, false));
+
+    int32_t values[] = {1, 2, 3};
+    for (auto v : values) {
+        set->insert(&v);
+    }
+
+    MockRuntimeState state;
+    TQueryOptions query_options;
+    query_options.__set_in_set_to_bitset_max_size(100);
+    query_options.__set_in_set_to_bitset_max_range(100);
+    state.set_query_options(query_options);
+
+    auto result = set->try_convert_to_bitset(&state);
+    EXPECT_EQ(result, nullptr);
 }
 
 } // namespace doris

--- a/be/test/exprs/hybrid_set_test.cpp
+++ b/be/test/exprs/hybrid_set_test.cpp
@@ -932,7 +932,8 @@ TEST_F(HybridSetTest, TryConvertToBitsetTooLargeRange) {
     MockRuntimeState state;
     TQueryOptions query_options;
     query_options.__set_in_set_to_bitset_max_size(100);
-    query_options.__set_in_set_to_bitset_max_range(500); // max range is 500, but actual range is 1000
+    query_options.__set_in_set_to_bitset_max_range(
+            500); // max range is 500, but actual range is 1000
     state.set_query_options(query_options);
 
     auto result = set->try_convert_to_bitset(&state);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -657,6 +657,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_USE_HYBRID_SORT = "enable_use_hybrid_sort";
 
+    public static final String IN_SET_TO_BITSET_MAX_SIZE = "in_set_to_bitset_max_size";
+
+    public static final String IN_SET_TO_BITSET_MAX_RANGE = "in_set_to_bitset_max_range";
+
     public static final String GENERATE_STATS_FACTOR = "generate_stats_factor";
 
     public static final String HUGE_TABLE_AUTO_ANALYZE_INTERVAL_IN_MILLIS
@@ -3018,6 +3022,24 @@ public class SessionVariable implements Serializable, Writable {
             needForward = true, fuzzy = true)
     public boolean enableUseHybridSort = true;
 
+    @VariableMgr.VarAttr(name = IN_SET_TO_BITSET_MAX_SIZE, description = {
+            "IN 谓词中元素数量不超过此阈值时，会尝试将 IN 集合转换为 BitSet 以提升查询性能。"
+                    + "如果元素过多，遍历原始集合以查找最大最小值会有额外开销。默认值为 1048576（1M）。",
+            "Maximum number of elements in the original IN filter to attempt bitset conversion. "
+                    + "If the set contains more elements than this threshold, we skip conversion to avoid "
+                    + "the overhead of iterating through all elements to find min/max values. "
+                    + "The default value is 1048576 (1M)." }, needForward = true, fuzzy = true)
+    public long inSetToBitsetMaxSize = 1048576;
+
+    @VariableMgr.VarAttr(name = IN_SET_TO_BITSET_MAX_RANGE, description = {
+            "IN 谓词中最大值与最小值之差（值域）不超过此阈值时，会尝试将 IN 集合转换为 BitSet。"
+                    + "如果值域过大，BitSet 会消耗过多内存（值域 / 8 字节）。默认值为 1048576（1M）。",
+            "Maximum value range (max_value - min_value) to attempt bitset conversion. "
+                    + "If the range exceeds this threshold, we skip conversion to avoid excessive "
+                    + "memory consumption by the bitset (range / 8 bytes). "
+                    + "The default value is 1048576 (1M)." }, needForward = true, fuzzy = true)
+    public long inSetToBitsetMaxRange = 1048576;
+
     @VariableMgr.VarAttr(name = USE_MAX_LENGTH_OF_VARCHAR_IN_CTAS, needForward = true, description = {
             "在 CTAS 中，如果 CHAR / VARCHAR 列不来自于源表，是否是将这一列的长度设置为 MAX，即 65533。默认为 true。",
             "In CTAS (Create Table As Select), if CHAR/VARCHAR columns do not originate from the source table,"
@@ -3449,6 +3471,31 @@ public class SessionVariable implements Serializable, Writable {
 
             randomInt = random.nextInt(99);
             this.enableUseHybridSort = randomInt % 3 != 0;
+
+            // Set in_set_to_bitset thresholds with fixed values
+            switch (random.nextInt(4)) {
+                case 0:
+                    // Small threshold: more aggressive conversion
+                    this.inSetToBitsetMaxSize = 1024;
+                    this.inSetToBitsetMaxRange = 1024;
+                    break;
+                case 1:
+                    // Medium threshold
+                    this.inSetToBitsetMaxSize = 65536;
+                    this.inSetToBitsetMaxRange = 65536;
+                    break;
+                case 2:
+                    // Large threshold: default behavior
+                    this.inSetToBitsetMaxSize = 1048576;
+                    this.inSetToBitsetMaxRange = 1048576;
+                    break;
+                case 3:
+                default:
+                    // Disable conversion
+                    this.inSetToBitsetMaxSize = 0;
+                    this.inSetToBitsetMaxRange = 0;
+                    break;
+            }
         }
 
         setFuzzyForCatalog(random);
@@ -5104,6 +5151,10 @@ public class SessionVariable implements Serializable, Writable {
 
         // Set Iceberg write target file size
         tResult.setIcebergWriteTargetFileSizeBytes(icebergWriteTargetFileSizeBytes);
+
+        // Set IN set to bitset conversion thresholds
+        tResult.setInSetToBitsetMaxSize(inSetToBitsetMaxSize);
+        tResult.setInSetToBitsetMaxRange(inSetToBitsetMaxRange);
 
         return tResult;
     }

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -424,6 +424,10 @@ struct TQueryOptions {
   183: optional bool enable_use_hybrid_sort = false;
   184: optional i32 cte_max_recursion_depth;
 
+  185: optional i64 in_set_to_bitset_max_size;
+
+  186: optional i64 in_set_to_bitset_max_range;
+
 
   // For cloud, to control if the content would be written into file cache
   // In write path, to control if the content would be written into file cache.


### PR DESCRIPTION
### What problem does this PR solve?

Currently our hybridset has two implementations: one uses a FixedContainer (instead of a hashset) when the number of elements is small, and the other is a normal hashset. Here we provide a third implementation: if the value domain is small, consider storing the data in a bitset (optimization only for integers).

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

