### PR TITLE
make agg shuffle one key configurable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
@@ -485,7 +485,8 @@ public class RequestPropertyDeriver extends PlanVisitor<Void, PlanContext> {
                 // - For skew evaluation: compute ratio = rows_in_normal_node / rows_in_skewed_node
                 // - A key is considered acceptable if ratio > 2/3 (i.e., rows_in_normal_node / max_skewed_rows > 2)
                 // - Hot value analysis may be added in future iterations
-                if (agg.getGroupByExpressions().size() <= 5 || agg.hasSourceRepeat()) {
+                if (agg.getGroupByExpressions().size() <= connectContext.getSessionVariable().aggShuffleKeyOptThreshold
+                        || agg.hasSourceRepeat()) {
                     addRequestPropertyToChildren(PhysicalProperties.createHash(groupByExprIds, ShuffleType.REQUIRE));
                     return null;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -831,6 +831,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String SKEW_REWRITE_AGG_BUCKET_NUM = "skew_rewrite_agg_bucket_num";
     public static final String AGG_SHUFFLE_USE_PARENT_KEY = "agg_shuffle_use_parent_key";
     public static final String CHOOSE_ONE_AGG_SHUFFLE_KEY = "choose_one_agg_shuffle_key";
+    public static final String AGG_SHUFFLE_KEY_OPT_THRESHOLD = "agg_shuffle_key_opt_threshold";
 
     public static final String HOT_VALUE_COLLECT_COUNT = "hot_value_collect_count";
     @VariableMgr.VarAttr(name = HOT_VALUE_COLLECT_COUNT, needForward = true,
@@ -2693,6 +2694,9 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = CHOOSE_ONE_AGG_SHUFFLE_KEY, needForward = false)
     public boolean chooseOneAggShuffleKey = true;
+
+    @VariableMgr.VarAttr(name = AGG_SHUFFLE_KEY_OPT_THRESHOLD, needForward = false)
+    public int aggShuffleKeyOptThreshold = 5;
 
     @VariableMgr.VarAttr(name = ENABLE_PREFER_CACHED_ROWSET, needForward = false,
             description = {"是否启用 prefer cached rowset 功能",


### PR DESCRIPTION
This pull request adds a session variable agg_shuffle_key_opt_threshold to control the choose_one_shuffle_key optimization. Its default value is 5, meaning the optimization is only applied when the number of GROUP BY keys exceeds 5.