### PR TITLE
[fix](predicate) Fix coredump if exception occurs

### DIFF
--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -461,6 +461,9 @@ Status ScanLocalState<Derived>::_normalize_bloom_filter(
         if (pred) {
             DCHECK(*pdt != PushDownType::UNACCEPTABLE) << root->debug_string();
             predicates.emplace_back(pred);
+        } else {
+            // If exception occurs during processing, do not push down
+            *pdt = PushDownType::UNACCEPTABLE;
         }
     };
     DCHECK(TExprNodeType::BLOOM_PRED == root->node_type());
@@ -487,6 +490,9 @@ Status ScanLocalState<Derived>::_normalize_topn_filter(
         if (pred) {
             DCHECK(*pdt != PushDownType::UNACCEPTABLE) << root->debug_string();
             predicates.emplace_back(pred);
+        } else {
+            // If exception occurs during processing, do not push down
+            *pdt = PushDownType::UNACCEPTABLE;
         }
     };
     DCHECK(root->is_topn_filter());
@@ -511,6 +517,9 @@ Status ScanLocalState<Derived>::_normalize_bitmap_filter(
         if (pred) {
             DCHECK(*pdt != PushDownType::UNACCEPTABLE) << root->debug_string();
             predicates.emplace_back(pred);
+        } else {
+            // If exception occurs during processing, do not push down
+            *pdt = PushDownType::UNACCEPTABLE;
         }
     };
     DCHECK(TExprNodeType::BITMAP_PRED == root->node_type());
@@ -659,6 +668,9 @@ Status ScanLocalState<Derived>::_normalize_in_predicate(
         if (pred) {
             DCHECK(*pdt != PushDownType::UNACCEPTABLE) << root->debug_string();
             predicates.emplace_back(pred);
+        } else {
+            // If exception occurs during processing, do not push down
+            *pdt = PushDownType::UNACCEPTABLE;
         }
     };
 
@@ -757,6 +769,9 @@ Status ScanLocalState<Derived>::_normalize_binary_predicate(
         if (pred) {
             DCHECK(*pdt != PushDownType::UNACCEPTABLE) << root->debug_string();
             predicates.emplace_back(pred);
+        } else {
+            // If exception occurs during processing, do not push down
+            *pdt = PushDownType::UNACCEPTABLE;
         }
     };
 
@@ -934,6 +949,9 @@ Status ScanLocalState<Derived>::_normalize_is_null_predicate(
         if (pred) {
             DCHECK(*pdt != PushDownType::UNACCEPTABLE) << root->debug_string();
             predicates.emplace_back(pred);
+        } else {
+            // If exception occurs during processing, do not push down
+            *pdt = PushDownType::UNACCEPTABLE;
         }
     };
     DCHECK(!root->is_rf_wrapper()) << root->debug_string();


### PR DESCRIPTION
### What problem does this PR solve?

*** SIGSEGV address not mapped to object (@0xfffffffffffffff0) received by PID 12431 (TID 13514 OR 0x7f02981d1640) from PID 18446744073709551600; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/common/signal_handler.h:420
 1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 3# 0x00007F04AE099520 in /lib/x86_64-linux-gnu/libc.so.6
 4# doris::pipeline::ScanLocalState::_normalize_predicate(doris::vectorized::VExprContext*, std::shared_ptr const&, std::shared_ptr&)::{lambda(auto:1&)#1}::operator() >(doris::ColumnValueRange<(doris::PrimitiveType)25>&) const::{lambda()#1}::operator()() const at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/pipeline/exec/scan_operator.cpp:352
 5# doris::Defer::_normalize_predicate(doris::vectorized::VExprContext*, std::shared_ptr const&, std::shared_ptr&)::{lambda(auto:1&)#1}::operator() >(doris::ColumnValueRange<(doris::PrimitiveType)25>&) const::{lambda()#1}>::~Defer() at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/util/defer_op.h:76
 6# auto doris::pipeline::ScanLocalState::_normalize_predicate(doris::vectorized::VExprContext*, std::shared_ptr const&, std::shared_ptr&)::{lambda(auto:1&)#1}::operator() >(doris::ColumnValueRange<(doris::PrimitiveType)25>&) const in /mnt/hdd01/ci/doris-deploy-branch-4.0-local/be/lib/doris_be
 7# doris::pipeline::ScanLocalState::_normalize_predicate(doris::vectorized::VExprContext*, std::shared_ptr const&, std::shared_ptr&) at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/pipeline/exec/scan_operator.cpp:412
 8# doris::pipeline::ScanLocalState::_normalize_conjuncts(doris::RuntimeState*) at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/pipeline/exec/scan_operator.cpp:267
 9# doris::pipeline::OlapScanLocalState::_process_conjuncts(doris::RuntimeState*) at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/pipeline/exec/olap_scan_operator.cpp:366
10# doris::pipeline::ScanLocalState::open(doris::RuntimeState*) at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/pipeline/exec/scan_operator.cpp:158
11# doris::pipeline::OlapScanLocalState::open(doris::RuntimeState*) at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/pipeline/exec/olap_scan_operator.cpp:787
12# doris::pipeline::PipelineTask::_open() at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/pipeline/pipeline_task.cpp:269
13# doris::pipeline::PipelineTask::execute(bool*) at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/pipeline/pipeline_task.cpp:467
14# doris::pipeline::TaskScheduler::_do_work(int) at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/pipeline/task_scheduler.cpp:153
15# doris::ThreadPool::dispatch_thread() at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/util/threadpool.cpp:623
16# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_branch-4.0/doris/be/src/util/thread.cpp:461
17# start_thread at ./nptl/pthread_create.c:442

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

