### PR TITLE
[fix](paimon) Fix Paimon time-travel tag reads for expired snapshots

### DIFF
--- a/docker/thirdparties/docker-compose/iceberg/scripts/create_preinstalled_scripts/paimon/run09.sql
+++ b/docker/thirdparties/docker-compose/iceberg/scripts/create_preinstalled_scripts/paimon/run09.sql
@@ -108,3 +108,37 @@ INSERT INTO test_paimon_time_travel_db.tbl_time_travel VALUES
 (6006, 9006, '2024-02-16', 123.75, '987 Advanced Court, Silicon Valley, CA 94301', 'CANCELLED', true, 600);
 
 CALL sys.create_tag(table => 'test_paimon_time_travel_db.tbl_time_travel', tag => 't_6', snapshot => 6);
+
+-- table for expired snapshot tag time travel
+drop table if exists test_paimon_time_travel_db.tbl_time_travel_expired_tag;
+CREATE TABLE test_paimon_time_travel_db.tbl_time_travel_expired_tag (
+  id INT NOT NULL,
+  name STRING
+)
+USING paimon
+TBLPROPERTIES (
+  'bucket' = '1',
+  'primary-key' = 'id',
+  'file.format' = 'parquet'
+);
+
+-- snapshot 1
+INSERT INTO test_paimon_time_travel_db.tbl_time_travel_expired_tag VALUES
+(1, 'alpha'),
+(2, 'beta');
+CALL sys.create_tag(table => 'test_paimon_time_travel_db.tbl_time_travel_expired_tag', tag => 't_exp_1', snapshot => 1);
+
+-- snapshot 2
+INSERT INTO test_paimon_time_travel_db.tbl_time_travel_expired_tag VALUES
+(3, 'gamma'),
+(4, 'delta');
+CALL sys.create_tag(table => 'test_paimon_time_travel_db.tbl_time_travel_expired_tag', tag => 't_exp_2', snapshot => 2);
+
+-- snapshot 3
+INSERT INTO test_paimon_time_travel_db.tbl_time_travel_expired_tag VALUES
+(5, 'epsilon'),
+(6, 'zeta');
+CALL sys.create_tag(table => 'test_paimon_time_travel_db.tbl_time_travel_expired_tag', tag => 't_exp_3', snapshot => 3);
+
+-- expire snapshots so tag points to expired snapshot file
+CALL sys.expire_snapshots(table => 'test_paimon_time_travel_db.tbl_time_travel_expired_tag', retain_max => 1);

--- a/regression-test/data/external_table_p0/paimon/paimon_time_travel.out
+++ b/regression-test/data/external_table_p0/paimon/paimon_time_travel.out
@@ -535,6 +535,9 @@ true	389.20	5003	6003
 false	5
 true	7
 
+-- !expired_tag_count --
+2
+
 -- !branch_1_count_list --
 10
 
@@ -1098,4 +1101,3 @@ true	7
 6004	9004	2024-02-14	199.99	321 Future Lane, Innovation, WA 98001	PENDING	true	400
 6005	9005	2024-02-15	567.25	654 Progress Drive, Tech City, OR 97201	COMPLETED	false	500
 6006	9006	2024-02-16	123.75	987 Advanced Court, Silicon Valley, CA 94301	CANCELLED	true	600
-

--- a/regression-test/suites/external_table_p0/paimon/paimon_incr_read.groovy
+++ b/regression-test/suites/external_table_p0/paimon/paimon_incr_read.groovy
@@ -93,7 +93,7 @@ suite("test_paimon_incr_read", "p0,external,doris,external_docker,external_docke
             }
             test {
                 sql """select * from paimon_incr@incr('startSnapshotId'=1, 'endSnapshotId'=2) for version as of 1"""
-                exception "should not spec both snapshot and scan params"
+                exception "Can not specify scan params and table snapshot at same time"
             }
             test {
                 sql """select * from paimon_incr@incr('startSnapshotId'=-1)"""

--- a/regression-test/suites/external_table_p0/paimon/paimon_time_travel.groovy
+++ b/regression-test/suites/external_table_p0/paimon/paimon_time_travel.groovy
@@ -153,6 +153,9 @@ suite("paimon_time_travel", "p0,external,doris,external_docker,external_docker_d
             }
         }
 
+        // tag on expired snapshot should still be readable
+        qt_expired_tag_count """select count(*) from ${tableName}_expired_tag FOR VERSION AS OF 't_exp_1';"""
+
         List<List<Object>> branchesResult = sql """ select branch_name from ${tableName}\$branches order by branch_name;"""
         logger.info("Query result from ${tableName}\$branches: ${branchesResult}")
         assertTrue(branchesResult.size()==2)
@@ -339,6 +342,10 @@ suite("paimon_time_travel", "p0,external,doris,external_docker,external_docker_d
         test {
             sql """ select * from ${tableName} for version as of 'not_exists_tag'; """
             exception "can't find snapshot by tag: not_exists_tag"
+        }
+        test {
+            sql """ select * from ${tableName}_expired_tag for version as of 1; """
+            exception "can't find snapshot by id: 1"
         }
 
         // Use branch function to query tags


### PR DESCRIPTION
### What problem does this PR solve?

- Related PR: #53327 

## Problem
Queries like `FOR VERSION AS OF '<tag>'` fail when the tag points to a snapshot whose snapshot file has expired, even though the tag is still valid and data should be retained by tag.

## Root Cause
Doris always translated time-travel requests into `scan.snapshot-id`. Paimon validates snapshot-id against the current snapshot range; once a snapshot file is expired, it is out of range and the query fails. Tag-based reads should use `scan.tag-name` instead, which bypasses that snapshot range validation.

## Fix
Use `scan.tag-name` for tag-based time travel (`@tag` and `FOR VERSION AS OF '<tag>'`), and keep `scan.snapshot-id` only for numeric snapshot-id queries. Add regression coverage that:
- validates tag reads succeed after snapshot expiration
- validates direct snapshot-id reads against expired snapshots still fail

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

