### PR TITLE
[Optimize](NestedLoopJoin) if the build side is small, iterate the build side first.

### DIFF
--- a/be/src/pipeline/dependency.h
+++ b/be/src/pipeline/dependency.h
@@ -647,8 +647,8 @@ struct PartitionedHashJoinSharedState
 
 struct NestedLoopJoinSharedState : public JoinSharedState {
     ENABLE_FACTORY_CREATOR(NestedLoopJoinSharedState)
-    // if true, left child has no more rows to process
-    bool left_side_eos = false;
+    // if true, probe child has no more rows to process
+    bool probe_side_eos = false;
     // Visited flags for each row in build side.
     vectorized::MutableColumns build_side_visited_flags;
     // List of build blocks, constructed in prepare()

--- a/be/src/pipeline/exec/nested_loop_join_build_operator.cpp
+++ b/be/src/pipeline/exec/nested_loop_join_build_operator.cpp
@@ -66,8 +66,8 @@ NestedLoopJoinBuildSinkOperatorX::NestedLoopJoinBuildSinkOperatorX(ObjectPool* p
                                                                    const DescriptorTbl& descs)
         : JoinBuildSinkOperatorX<NestedLoopJoinBuildSinkLocalState>(pool, operator_id, dest_id,
                                                                     tnode, descs),
-          _is_output_left_side_only(tnode.nested_loop_join_node.__isset.is_output_left_side_only &&
-                                    tnode.nested_loop_join_node.is_output_left_side_only),
+          _is_output_probe_side_only(tnode.nested_loop_join_node.__isset.is_output_left_side_only &&
+                                     tnode.nested_loop_join_node.is_output_left_side_only),
           _row_descriptor(descs, tnode.row_tuples) {}
 
 Status NestedLoopJoinBuildSinkOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {
@@ -113,11 +113,11 @@ Status NestedLoopJoinBuildSinkOperatorX::sink(doris::RuntimeState* state, vector
 
     if (eos) {
         // optimize `in bitmap`, see https://github.com/apache/doris/issues/14338
-        if (_is_output_left_side_only && ((_join_op == TJoinOp::type::LEFT_SEMI_JOIN &&
-                                           local_state._shared_state->build_blocks.empty()) ||
-                                          (_join_op == TJoinOp::type::LEFT_ANTI_JOIN &&
-                                           !local_state._shared_state->build_blocks.empty()))) {
-            local_state._shared_state->left_side_eos = true;
+        if (_is_output_probe_side_only && ((_join_op == TJoinOp::type::LEFT_SEMI_JOIN &&
+                                            local_state._shared_state->build_blocks.empty()) ||
+                                           (_join_op == TJoinOp::type::LEFT_ANTI_JOIN &&
+                                            !local_state._shared_state->build_blocks.empty()))) {
+            local_state._shared_state->probe_side_eos = true;
         }
         local_state._dependency->set_ready_to_read();
     }

--- a/be/src/pipeline/exec/nested_loop_join_build_operator.h
+++ b/be/src/pipeline/exec/nested_loop_join_build_operator.h
@@ -80,7 +80,7 @@ private:
 
     vectorized::VExprContextSPtrs _filter_src_expr_ctxs;
 
-    const bool _is_output_left_side_only;
+    const bool _is_output_probe_side_only;
     RowDescriptor _row_descriptor;
 };
 

--- a/be/src/pipeline/exec/nested_loop_join_probe_operator.cpp
+++ b/be/src/pipeline/exec/nested_loop_join_probe_operator.cpp
@@ -22,6 +22,7 @@
 #include "common/cast_set.h"
 #include "common/exception.h"
 #include "pipeline/exec/operator.h"
+#include "vec/columns/column.h"
 #include "vec/columns/column_filter_helper.h"
 #include "vec/core/block.h"
 
@@ -36,7 +37,7 @@ NestedLoopJoinProbeLocalState::NestedLoopJoinProbeLocalState(RuntimeState* state
         : JoinProbeLocalState<NestedLoopJoinSharedState, NestedLoopJoinProbeLocalState>(state,
                                                                                         parent),
           _matched_rows_done(false),
-          _left_block_pos(0) {}
+          _probe_block_pos(0) {}
 
 Status NestedLoopJoinProbeLocalState::init(RuntimeState* state, LocalStateInfo& info) {
     RETURN_IF_ERROR(JoinProbeLocalState::init(state, info));
@@ -88,58 +89,249 @@ void NestedLoopJoinProbeLocalState::_update_additional_flags(vectorized::Block* 
 void NestedLoopJoinProbeLocalState::_reset_with_next_probe_row() {
     // TODO: need a vector of left block to register the _probe_row_visited_flags
     _current_build_pos = 0;
-    _left_block_pos++;
+    _probe_block_pos++;
+}
+
+// process_probe_block and process_build_block are similar.
+// One generates build rows based on a probe row; the other generates
+// probe rows based on a build row. Their implementation approach and
+// code structure are similar.
+
+void process_probe_block(int64_t probe_block_pos, vectorized::Block& block,
+                         const vectorized::Block& probe_block, size_t probe_side_columns,
+                         const vectorized::Block& build_block, size_t build_side_columns) {
+    auto dst_columns = block.mutate_columns();
+    const size_t max_added_rows = build_block.rows();
+    for (size_t i = 0; i < probe_side_columns; ++i) {
+        const vectorized::ColumnWithTypeAndName& src_column = probe_block.get_by_position(i);
+        if (!src_column.column->is_nullable() && dst_columns[i]->is_nullable()) {
+            auto origin_sz = dst_columns[i]->size();
+            assert_cast<vectorized::ColumnNullable*>(dst_columns[i].get())
+                    ->get_nested_column_ptr()
+                    ->insert_many_from(*src_column.column, probe_block_pos, max_added_rows);
+            assert_cast<vectorized::ColumnNullable*>(dst_columns[i].get())
+                    ->get_null_map_column()
+                    .get_data()
+                    .resize_fill(origin_sz + max_added_rows, 0);
+        } else {
+            // TODO: for cross join, maybe could insert one row, and wrap for a const column
+            dst_columns[i]->insert_many_from(*src_column.column, probe_block_pos, max_added_rows);
+        }
+    }
+    for (size_t i = 0; i < build_side_columns; ++i) {
+        const vectorized::ColumnWithTypeAndName& src_column = build_block.get_by_position(i);
+        if (!src_column.column->is_nullable() &&
+            dst_columns[probe_side_columns + i]->is_nullable()) {
+            auto origin_sz = dst_columns[probe_side_columns + i]->size();
+            assert_cast<vectorized::ColumnNullable*>(dst_columns[probe_side_columns + i].get())
+                    ->get_nested_column_ptr()
+                    ->insert_range_from(*src_column.column.get(), 0, max_added_rows);
+            assert_cast<vectorized::ColumnNullable*>(dst_columns[probe_side_columns + i].get())
+                    ->get_null_map_column()
+                    .get_data()
+                    .resize_fill(origin_sz + max_added_rows, 0);
+        } else {
+            dst_columns[probe_side_columns + i]->insert_range_from(*src_column.column.get(), 0,
+                                                                   max_added_rows);
+        }
+    }
+    block.set_columns(std::move(dst_columns));
+}
+
+void process_build_block(int64_t build_block_pos, vectorized::Block& block,
+                         const vectorized::Block& build_block, size_t build_side_columns,
+                         const vectorized::Block& probe_block, size_t probe_side_columns) {
+    auto dst_columns = block.mutate_columns();
+    const size_t max_added_rows = probe_block.rows();
+    for (size_t i = 0; i < probe_side_columns; ++i) {
+        const vectorized::ColumnWithTypeAndName& src_column = probe_block.get_by_position(i);
+        if (!src_column.column->is_nullable() && dst_columns[i]->is_nullable()) {
+            auto origin_sz = dst_columns[i]->size();
+            assert_cast<vectorized::ColumnNullable*>(dst_columns[i].get())
+                    ->get_nested_column_ptr()
+                    ->insert_range_from(*src_column.column.get(), 0, max_added_rows);
+            assert_cast<vectorized::ColumnNullable*>(dst_columns[i].get())
+                    ->get_null_map_column()
+                    .get_data()
+                    .resize_fill(origin_sz + max_added_rows, 0);
+        } else {
+            dst_columns[i]->insert_range_from(*src_column.column.get(), 0, max_added_rows);
+        }
+    }
+    for (size_t i = 0; i < build_side_columns; ++i) {
+        const vectorized::ColumnWithTypeAndName& src_column = build_block.get_by_position(i);
+        if (!src_column.column->is_nullable() &&
+            dst_columns[probe_side_columns + i]->is_nullable()) {
+            auto origin_sz = dst_columns[probe_side_columns + i]->size();
+            assert_cast<vectorized::ColumnNullable*>(dst_columns[probe_side_columns + i].get())
+                    ->get_nested_column_ptr()
+                    ->insert_many_from(*src_column.column, build_block_pos, max_added_rows);
+            assert_cast<vectorized::ColumnNullable*>(dst_columns[probe_side_columns + i].get())
+                    ->get_null_map_column()
+                    .get_data()
+                    .resize_fill(origin_sz + max_added_rows, 0);
+        } else {
+            dst_columns[probe_side_columns + i]->insert_many_from(*src_column.column,
+                                                                  build_block_pos, max_added_rows);
+        }
+    }
+    block.set_columns(std::move(dst_columns));
+}
+
+template <bool set_build_side_flag, bool set_probe_side_flag>
+void NestedLoopJoinProbeLocalState::_generate_block_base_probe(RuntimeState* state,
+                                                               vectorized::Block* probe_block) {
+    auto& p = _parent->cast<NestedLoopJoinProbeOperatorX>();
+    while (_join_block.rows() < state->batch_size()) {
+        while (_current_build_pos == _shared_state->build_blocks.size() ||
+               _probe_block_pos == probe_block->rows()) {
+            // if probe block is empty(), do not need disprocess the probe block rows
+            if (probe_block->rows() > _probe_block_pos) {
+                _probe_side_process_count++;
+            }
+
+            _reset_with_next_probe_row();
+            if (_probe_block_pos < probe_block->rows()) {
+                if constexpr (set_probe_side_flag) {
+                    _probe_offset_stack.push(cast_set<uint16_t, size_t, false>(_join_block.rows()));
+                }
+            } else {
+                if (_shared_state->probe_side_eos) {
+                    _matched_rows_done = true;
+                } else {
+                    _need_more_input_data = true;
+                }
+                break;
+            }
+        }
+
+        // Do not have probe row need to be disposed
+        if (_matched_rows_done || _need_more_input_data) {
+            break;
+        }
+
+        const auto& now_process_build_block = _shared_state->build_blocks[_current_build_pos++];
+        if constexpr (set_build_side_flag) {
+            _build_offset_stack.push(cast_set<uint16_t, size_t, false>(_join_block.rows()));
+        }
+
+        SCOPED_TIMER(_output_temp_blocks_timer);
+        process_probe_block(_probe_block_pos, _join_block, *probe_block, p._num_probe_side_columns,
+                            now_process_build_block, p._num_build_side_columns);
+    }
+}
+
+// When the build side is small, generate data based on the build side.
+// Currently a simple heuristic is used: check whether build_blocks.size() == 1
+bool NestedLoopJoinProbeLocalState::use_generate_block_base_build() const {
+    return _shared_state->build_blocks.size() == 1;
+}
+
+// for inner join only
+// Generating data based on the build side follows the same logic
+// as generating data based on the probe side.
+// Only inner join calls this function, so both set_build_side_flag
+// and set_probe_side_flag are false.
+void NestedLoopJoinProbeLocalState::_generate_block_base_build(RuntimeState* state,
+                                                               vectorized::Block* probe_block) {
+    DCHECK(use_generate_block_base_build());
+    auto& p = _parent->cast<NestedLoopJoinProbeOperatorX>();
+    const auto& build_block = _shared_state->build_blocks[0];
+    const size_t build_rows = build_block.rows();
+    const auto probe_rows = static_cast<int>(probe_block->rows());
+
+    // If the probe block is empty, return directly
+    /// TODO: Reconsider this logic; it may need to be handled outside
+    if (probe_rows == 0) {
+        if (_shared_state->probe_side_eos) {
+            _matched_rows_done = true;
+        } else {
+            _need_more_input_data = true;
+        }
+        return;
+    }
+
+    while (_join_block.rows() < state->batch_size()) {
+        // The current build row has processed the entire probe block; move to the next build row
+        if (_probe_block_pos == probe_rows) {
+            // Move to the next build row and reset the probe position
+            _current_build_row_pos++;
+            _probe_block_pos = 0;
+
+            // All build rows have finished processing the current probe block
+            if (_current_build_row_pos >= build_rows) {
+                if (_shared_state->probe_side_eos) {
+                    _matched_rows_done = true;
+                } else {
+                    _need_more_input_data = true;
+                    // Reset build row position to prepare for the next probe block
+                    _current_build_row_pos = 0;
+                }
+                break;
+            }
+        }
+
+        // No data needs to be processed
+        if (_matched_rows_done || _need_more_input_data) {
+            break;
+        }
+
+        // Based on the current build row, add the entire probe block's data
+        SCOPED_TIMER(_output_temp_blocks_timer);
+        process_build_block(_current_build_row_pos, _join_block, build_block,
+                            p._num_build_side_columns, *probe_block, p._num_probe_side_columns);
+
+        // Mark the current probe block as processed; the next loop will move to the next build row
+        _probe_block_pos = probe_rows;
+    }
+}
+
+// for inner join only
+Status NestedLoopJoinProbeLocalState::generate_inner_join_block_data(RuntimeState* state) {
+    _probe_block_start_pos = _probe_block_pos;
+    _probe_side_process_count = 0;
+    DCHECK(!_need_more_input_data || !_matched_rows_done);
+    auto& p = _parent->cast<NestedLoopJoinProbeOperatorX>();
+    auto* probe_block = _child_block.get();
+
+    if (!_matched_rows_done && !_need_more_input_data) {
+        if (use_generate_block_base_build()) {
+            _generate_block_base_build(state, probe_block);
+        } else {
+            _generate_block_base_probe<false, false>(state, probe_block);
+            // Note: Here the condition is build_blocks.size() == 0; we won't discuss this in
+            // _generate_block_base_build because use_generate_block_base_build requires size == 1
+            if (_probe_side_process_count && p._is_mark_join &&
+                _shared_state->build_blocks.empty()) {
+                _append_probe_data_with_null(_join_block);
+            }
+        }
+    }
+
+    RETURN_IF_ERROR(
+            (_do_filtering_and_update_visited_flags<false, false, false>(&_join_block, true)));
+    _update_additional_flags(&_join_block);
+
+    COUNTER_UPDATE(_probe_rows_counter, _join_block.rows());
+    return Status::OK();
 }
 
 template <typename JoinOpType, bool set_build_side_flag, bool set_probe_side_flag>
-Status NestedLoopJoinProbeLocalState::generate_join_block_data(RuntimeState* state,
-                                                               JoinOpType& join_op_variants) {
-    auto& p = _parent->cast<NestedLoopJoinProbeOperatorX>();
+Status NestedLoopJoinProbeLocalState::generate_other_join_block_data(RuntimeState* state,
+                                                                     JoinOpType& join_op_variants) {
     constexpr bool ignore_null = JoinOpType::value == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN;
-    _left_block_start_pos = _left_block_pos;
-    _left_side_process_count = 0;
+    _probe_block_start_pos = _probe_block_pos;
+    _probe_side_process_count = 0;
     DCHECK(!_need_more_input_data || !_matched_rows_done);
+
+    auto& p = _parent->cast<NestedLoopJoinProbeOperatorX>();
+    auto* probe_block = _child_block.get();
 
     if (!_matched_rows_done && !_need_more_input_data) {
         // We should try to join rows if there still are some rows from probe side.
         // _probe_offset_stack and _build_offset_stack use u16 for storage
         // because on the FE side, it is guaranteed that the batch size will not exceed 65535 (the maximum value for u16).s
-        while (_join_block.rows() < state->batch_size()) {
-            while (_current_build_pos == _shared_state->build_blocks.size() ||
-                   _left_block_pos == _child_block->rows()) {
-                // if left block is empty(), do not need disprocess the left block rows
-                if (_child_block->rows() > _left_block_pos) {
-                    _left_side_process_count++;
-                }
-
-                _reset_with_next_probe_row();
-                if (_left_block_pos < _child_block->rows()) {
-                    if constexpr (set_probe_side_flag) {
-                        _probe_offset_stack.push(
-                                cast_set<uint16_t, size_t, false>(_join_block.rows()));
-                    }
-                } else {
-                    if (_shared_state->left_side_eos) {
-                        _matched_rows_done = true;
-                    } else {
-                        _need_more_input_data = true;
-                    }
-                    break;
-                }
-            }
-
-            // Do not have left row need to be disposed
-            if (_matched_rows_done || _need_more_input_data) {
-                break;
-            }
-
-            const auto& now_process_build_block = _shared_state->build_blocks[_current_build_pos++];
-            if constexpr (set_build_side_flag) {
-                _build_offset_stack.push(cast_set<uint16_t, size_t, false>(_join_block.rows()));
-            }
-            _process_left_child_block(_join_block, now_process_build_block);
-        }
-
+        _generate_block_base_probe<set_build_side_flag, set_probe_side_flag>(state, probe_block);
         {
             SCOPED_TIMER(_finish_probe_phase_timer);
             if constexpr (set_probe_side_flag) {
@@ -152,13 +344,13 @@ Status NestedLoopJoinProbeLocalState::generate_join_block_data(RuntimeState* sta
                 // `_left_side_process_count`, means all rows from build
                 // side have been joined with _left_side_process_count, we should output current
                 // probe row with null from build side.
-                if (_left_side_process_count) {
+                if (_probe_side_process_count) {
                     _finalize_current_phase<false, JoinOpType::value == TJoinOp::LEFT_SEMI_JOIN>(
                             _join_block, state->batch_size());
                 }
-            } else if (_left_side_process_count && p._is_mark_join &&
+            } else if (_probe_side_process_count && p._is_mark_join &&
                        _shared_state->build_blocks.empty()) {
-                _append_left_data_with_null(_join_block);
+                _append_probe_data_with_null(_join_block);
             }
         }
     }
@@ -249,9 +441,9 @@ void NestedLoopJoinProbeLocalState::_finalize_current_phase(vectorized::Block& b
     } else {
         if (!p._is_mark_join) {
             auto new_size = column_size;
-            DCHECK_LE(_left_block_start_pos + _left_side_process_count, _child_block->rows());
-            for (int j = _left_block_start_pos;
-                 j < _left_block_start_pos + _left_side_process_count; ++j) {
+            DCHECK_LE(_probe_block_start_pos + _probe_side_process_count, _child_block->rows());
+            for (int j = _probe_block_start_pos;
+                 j < _probe_block_start_pos + _probe_side_process_count; ++j) {
                 if (_cur_probe_row_visited_flags[j] == IsSemi) {
                     new_size++;
                     for (size_t i = 0; i < p._num_probe_side_columns; ++i) {
@@ -280,29 +472,29 @@ void NestedLoopJoinProbeLocalState::_finalize_current_phase(vectorized::Block& b
             }
         } else {
             vectorized::ColumnFilterHelper mark_column(*dst_columns[dst_columns.size() - 1]);
-            mark_column.reserve(mark_column.size() + _left_side_process_count);
-            DCHECK_LE(_left_block_start_pos + _left_side_process_count, _child_block->rows());
-            for (int j = _left_block_start_pos;
-                 j < _left_block_start_pos + _left_side_process_count; ++j) {
+            mark_column.reserve(mark_column.size() + _probe_side_process_count);
+            DCHECK_LE(_probe_block_start_pos + _probe_side_process_count, _child_block->rows());
+            for (int j = _probe_block_start_pos;
+                 j < _probe_block_start_pos + _probe_side_process_count; ++j) {
                 mark_column.insert_value(IsSemi == _cur_probe_row_visited_flags[j]);
             }
             for (size_t i = 0; i < p._num_probe_side_columns; ++i) {
                 const vectorized::ColumnWithTypeAndName src_column =
                         _child_block->get_by_position(i);
                 DCHECK(p._join_op != TJoinOp::FULL_OUTER_JOIN);
-                dst_columns[i]->insert_range_from(*src_column.column, _left_block_start_pos,
-                                                  _left_side_process_count);
+                dst_columns[i]->insert_range_from(*src_column.column, _probe_block_start_pos,
+                                                  _probe_side_process_count);
             }
             for (size_t i = 0; i < p._num_build_side_columns; ++i) {
                 dst_columns[p._num_probe_side_columns + i]->insert_many_defaults(
-                        _left_side_process_count);
+                        _probe_side_process_count);
             }
         }
     }
     block.set_columns(std::move(dst_columns));
 }
 
-void NestedLoopJoinProbeLocalState::_append_left_data_with_null(vectorized::Block& block) const {
+void NestedLoopJoinProbeLocalState::_append_probe_data_with_null(vectorized::Block& block) const {
     auto& p = _parent->cast<NestedLoopJoinProbeOperatorX>();
     auto dst_columns = block.mutate_columns();
     DCHECK(p._is_mark_join);
@@ -314,72 +506,23 @@ void NestedLoopJoinProbeLocalState::_append_left_data_with_null(vectorized::Bloc
                    p._join_op == TJoinOp::FULL_OUTER_JOIN);
             assert_cast<vectorized::ColumnNullable*>(dst_columns[i].get())
                     ->get_nested_column_ptr()
-                    ->insert_range_from(*src_column.column, _left_block_start_pos,
-                                        _left_side_process_count);
+                    ->insert_range_from(*src_column.column, _probe_block_start_pos,
+                                        _probe_side_process_count);
             assert_cast<vectorized::ColumnNullable*>(dst_columns[i].get())
                     ->get_null_map_column()
                     .get_data()
                     .resize_fill(origin_sz + 1, 0);
         } else {
-            dst_columns[i]->insert_range_from(*src_column.column, _left_block_start_pos,
-                                              _left_side_process_count);
+            dst_columns[i]->insert_range_from(*src_column.column, _probe_block_start_pos,
+                                              _probe_side_process_count);
         }
     }
     for (size_t i = 0; i < p._num_build_side_columns; ++i) {
-        dst_columns[p._num_probe_side_columns + i]->insert_many_defaults(_left_side_process_count);
+        dst_columns[p._num_probe_side_columns + i]->insert_many_defaults(_probe_side_process_count);
     }
     auto& mark_column = *dst_columns[dst_columns.size() - 1];
     vectorized::ColumnFilterHelper(mark_column)
-            .resize_fill(mark_column.size() + _left_side_process_count, 0);
-    block.set_columns(std::move(dst_columns));
-}
-
-void NestedLoopJoinProbeLocalState::_process_left_child_block(
-        vectorized::Block& block, const vectorized::Block& now_process_build_block) const {
-    SCOPED_TIMER(_output_temp_blocks_timer);
-    auto& p = _parent->cast<NestedLoopJoinProbeOperatorX>();
-    auto dst_columns = block.mutate_columns();
-    const size_t max_added_rows = now_process_build_block.rows();
-    for (size_t i = 0; i < p._num_probe_side_columns; ++i) {
-        const vectorized::ColumnWithTypeAndName& src_column = _child_block->get_by_position(i);
-        if (!src_column.column->is_nullable() && dst_columns[i]->is_nullable()) {
-            auto origin_sz = dst_columns[i]->size();
-            DCHECK(p._join_op == TJoinOp::RIGHT_OUTER_JOIN ||
-                   p._join_op == TJoinOp::FULL_OUTER_JOIN);
-            assert_cast<vectorized::ColumnNullable*>(dst_columns[i].get())
-                    ->get_nested_column_ptr()
-                    ->insert_many_from(*src_column.column, _left_block_pos, max_added_rows);
-            assert_cast<vectorized::ColumnNullable*>(dst_columns[i].get())
-                    ->get_null_map_column()
-                    .get_data()
-                    .resize_fill(origin_sz + max_added_rows, 0);
-        } else {
-            // TODO: for cross join, maybe could insert one row, and wrap for a const column
-            dst_columns[i]->insert_many_from(*src_column.column, _left_block_pos, max_added_rows);
-        }
-    }
-    for (size_t i = 0; i < p._num_build_side_columns; ++i) {
-        const vectorized::ColumnWithTypeAndName& src_column =
-                now_process_build_block.get_by_position(i);
-        if (!src_column.column->is_nullable() &&
-            dst_columns[p._num_probe_side_columns + i]->is_nullable()) {
-            auto origin_sz = dst_columns[p._num_probe_side_columns + i]->size();
-            DCHECK(p._join_op == TJoinOp::LEFT_OUTER_JOIN ||
-                   p._join_op == TJoinOp::FULL_OUTER_JOIN);
-            assert_cast<vectorized::ColumnNullable*>(
-                    dst_columns[p._num_probe_side_columns + i].get())
-                    ->get_nested_column_ptr()
-                    ->insert_range_from(*src_column.column.get(), 0, max_added_rows);
-            assert_cast<vectorized::ColumnNullable*>(
-                    dst_columns[p._num_probe_side_columns + i].get())
-                    ->get_null_map_column()
-                    .get_data()
-                    .resize_fill(origin_sz + max_added_rows, 0);
-        } else {
-            dst_columns[p._num_probe_side_columns + i]->insert_range_from(*src_column.column.get(),
-                                                                          0, max_added_rows);
-        }
-    }
+            .resize_fill(mark_column.size() + _probe_side_process_count, 0);
     block.set_columns(std::move(dst_columns));
 }
 
@@ -387,10 +530,10 @@ NestedLoopJoinProbeOperatorX::NestedLoopJoinProbeOperatorX(ObjectPool* pool, con
                                                            int operator_id,
                                                            const DescriptorTbl& descs)
         : JoinProbeOperatorX<NestedLoopJoinProbeLocalState>(pool, tnode, operator_id, descs),
-          _is_output_left_side_only(tnode.nested_loop_join_node.__isset.is_output_left_side_only &&
-                                    tnode.nested_loop_join_node.is_output_left_side_only),
+          _is_output_probe_side_only(tnode.nested_loop_join_node.__isset.is_output_left_side_only &&
+                                     tnode.nested_loop_join_node.is_output_left_side_only),
           _old_version_flag(!tnode.__isset.nested_loop_join_node) {
-    _keep_origin = _is_output_left_side_only;
+    _keep_origin = _is_output_probe_side_only;
 }
 
 Status NestedLoopJoinProbeOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {
@@ -423,7 +566,7 @@ Status NestedLoopJoinProbeOperatorX::prepare(RuntimeState* state) {
 bool NestedLoopJoinProbeOperatorX::need_more_input_data(RuntimeState* state) const {
     auto& local_state =
             state->get_local_state(operator_id())->cast<NestedLoopJoinProbeLocalState>();
-    return local_state._need_more_input_data and !local_state._shared_state->left_side_eos and
+    return local_state._need_more_input_data and !local_state._shared_state->probe_side_eos and
            local_state._join_block.rows() == 0;
 }
 
@@ -436,16 +579,26 @@ Status NestedLoopJoinProbeOperatorX::push(doris::RuntimeState* state, vectorized
     local_state._cur_probe_row_visited_flags.resize(block->rows());
     std::fill(local_state._cur_probe_row_visited_flags.begin(),
               local_state._cur_probe_row_visited_flags.end(), 0);
-    local_state._left_block_pos = 0;
+    local_state._probe_block_pos = 0;
     local_state._need_more_input_data = false;
-    local_state._shared_state->left_side_eos = eos;
+    local_state._shared_state->probe_side_eos = eos;
 
-    if (!_is_output_left_side_only) {
+    if (!_is_output_probe_side_only) {
         auto func = [&](auto&& join_op_variants, auto set_build_side_flag,
                         auto set_probe_side_flag) {
-            return local_state.generate_join_block_data<std::decay_t<decltype(join_op_variants)>,
-                                                        set_build_side_flag, set_probe_side_flag>(
-                    state, join_op_variants);
+            using JoinOpType = std::decay_t<decltype(join_op_variants)>;
+
+            if constexpr (JoinOpType::value == TJoinOp::INNER_JOIN ||
+                          JoinOpType::value == TJoinOp::CROSS_JOIN) {
+                DCHECK(!set_build_side_flag && !set_probe_side_flag)
+                        << "Inner Join should not set visited flags but set_build_side_flag: "
+                        << set_build_side_flag << ", set_probe_side_flag: " << set_probe_side_flag;
+                return local_state.generate_inner_join_block_data(state);
+            } else {
+                return local_state.generate_other_join_block_data<JoinOpType, set_build_side_flag,
+                                                                  set_probe_side_flag>(
+                        state, join_op_variants);
+            }
         };
         SCOPED_TIMER(local_state._loop_join_timer);
         RETURN_IF_ERROR(
@@ -459,11 +612,11 @@ Status NestedLoopJoinProbeOperatorX::push(doris::RuntimeState* state, vectorized
 Status NestedLoopJoinProbeOperatorX::pull(RuntimeState* state, vectorized::Block* block,
                                           bool* eos) const {
     auto& local_state = get_local_state(state);
-    if (_is_output_left_side_only) {
+    if (_is_output_probe_side_only) {
         SCOPED_PEAK_MEM(&local_state._estimate_memory_usage);
         RETURN_IF_ERROR(local_state._build_output_block(local_state._child_block.get(), block));
-        *eos = local_state._shared_state->left_side_eos;
-        local_state._need_more_input_data = !local_state._shared_state->left_side_eos;
+        *eos = local_state._shared_state->probe_side_eos;
+        local_state._need_more_input_data = !local_state._shared_state->probe_side_eos;
     } else {
         SCOPED_PEAK_MEM(&local_state._estimate_memory_usage);
         *eos = ((_match_all_build || _is_right_semi_anti)
@@ -487,10 +640,20 @@ Status NestedLoopJoinProbeOperatorX::pull(RuntimeState* state, vectorized::Block
         if (!(*eos) and !local_state._need_more_input_data) {
             auto func = [&](auto&& join_op_variants, auto set_build_side_flag,
                             auto set_probe_side_flag) {
-                return local_state
-                        .generate_join_block_data<std::decay_t<decltype(join_op_variants)>,
-                                                  set_build_side_flag, set_probe_side_flag>(
-                                state, join_op_variants);
+                using JoinOpType = std::decay_t<decltype(join_op_variants)>;
+
+                if constexpr (JoinOpType::value == TJoinOp::INNER_JOIN ||
+                              JoinOpType::value == TJoinOp::CROSS_JOIN) {
+                    DCHECK(!set_build_side_flag && !set_probe_side_flag)
+                            << "Inner Join should not set visited flags but set_build_side_flag: "
+                            << set_build_side_flag
+                            << ", set_probe_side_flag: " << set_probe_side_flag;
+                    return local_state.generate_inner_join_block_data(state);
+                } else {
+                    return local_state.generate_other_join_block_data<
+                            std::decay_t<decltype(join_op_variants)>, set_build_side_flag,
+                            set_probe_side_flag>(state, join_op_variants);
+                }
             };
             SCOPED_TIMER(local_state._loop_join_timer);
             SCOPED_PEAK_MEM(&local_state._estimate_memory_usage);

--- a/be/src/pipeline/exec/nested_loop_join_probe_operator.h
+++ b/be/src/pipeline/exec/nested_loop_join_probe_operator.h
@@ -33,13 +33,19 @@ class RuntimeState;
 namespace pipeline {
 #include "common/compile_check_begin.h"
 class NestedLoopJoinProbeOperatorX;
+
+/// TODO: Long-term task — the current implementation of this class
+/// is not ideal. Many variables are in a global state, and changing
+/// one may affect other functions. In the future, we should pass the
+/// required variables through function parameters to avoid issues
+/// caused by global state.
 class NestedLoopJoinProbeLocalState final
         : public JoinProbeLocalState<NestedLoopJoinSharedState, NestedLoopJoinProbeLocalState> {
 public:
     using Parent = NestedLoopJoinProbeOperatorX;
     ENABLE_FACTORY_CREATOR(NestedLoopJoinProbeLocalState);
     NestedLoopJoinProbeLocalState(RuntimeState* state, OperatorXBase* parent);
-    ~NestedLoopJoinProbeLocalState() = default;
+    ~NestedLoopJoinProbeLocalState() override = default;
 
 #define CLEAR_BLOCK                                                  \
     for (size_t i = 0; i < column_to_keep; ++i) {                    \
@@ -48,18 +54,33 @@ public:
     Status init(RuntimeState* state, LocalStateInfo& info) override;
     Status open(RuntimeState* state) override;
     Status close(RuntimeState* state) override;
+
+    // For some complex join types, after generating data on the build/probe side,
+    // we need to update visited flags.
     template <typename JoinOpType, bool set_build_side_flag, bool set_probe_side_flag>
-    Status generate_join_block_data(RuntimeState* state, JoinOpType& join_op_variants);
+    Status generate_other_join_block_data(RuntimeState* state, JoinOpType& join_op_variants);
+
+    // Effective only for inner/cross join
+    Status generate_inner_join_block_data(RuntimeState* state);
+
+    // Generate data based on the probe side; applicable to all join types
+    template <bool set_build_side_flag, bool set_probe_side_flag>
+    void _generate_block_base_probe(RuntimeState* state, vectorized::Block* probe_block);
+
+    // Currently only inner join calls this; both set_build_side_flag and
+    // set_probe_side_flag are false, so visited flags will not be updated.
+    void _generate_block_base_build(RuntimeState* state, vectorized::Block* probe_block);
 
 private:
+    // Whether to generate data based on the build side
+    bool use_generate_block_base_build() const;
+
     friend class NestedLoopJoinProbeOperatorX;
     void _update_additional_flags(vectorized::Block* block);
     template <bool BuildSide, bool IsSemi>
     void _finalize_current_phase(vectorized::Block& block, size_t batch_size);
     void _reset_with_next_probe_row();
-    void _append_left_data_with_null(vectorized::Block& block) const;
-    void _process_left_child_block(vectorized::Block& block,
-                                   const vectorized::Block& now_process_build_block) const;
+    void _append_probe_data_with_null(vectorized::Block& block) const;
     template <typename Filter, bool SetBuildSideFlag, bool SetProbeSideFlag>
     void _do_filtering_and_update_visited_flags_impl(vectorized::Block* block,
                                                      uint32_t column_to_keep,
@@ -87,9 +108,9 @@ private:
             }
             if constexpr (SetProbeSideFlag) {
                 int64_t end = filter.size();
-                for (int i = _left_block_pos == _child_block->rows() ? _left_block_pos - 1
-                                                                     : _left_block_pos;
-                     i >= _left_block_start_pos; i--) {
+                for (int i = _probe_block_pos == _child_block->rows() ? _probe_block_pos - 1
+                                                                      : _probe_block_pos;
+                     i >= _probe_block_start_pos; i--) {
                     int64_t offset = 0;
                     if (!_probe_offset_stack.empty()) {
                         offset = _probe_offset_stack.top();
@@ -176,13 +197,15 @@ private:
     }
 
     bool _matched_rows_done;
-    int _left_block_start_pos = 0;
-    int _left_block_pos; // current scan pos in _left_block
-    int _left_side_process_count = 0;
+    int _probe_block_start_pos = 0;
+    int _probe_block_pos; // current scan pos in _probe_block
+    int _probe_side_process_count = 0;
     bool _need_more_input_data = true;
     // Visited flags for current row in probe side.
     std::vector<int8_t> _cur_probe_row_visited_flags;
     size_t _current_build_pos = 0;
+    size_t _current_build_row_pos =
+            0; // current row pos in build block, used by _generate_block_base_build
     vectorized::MutableColumns _dst_columns;
     std::stack<uint16_t> _build_offset_stack;
     std::stack<uint16_t> _probe_offset_stack;
@@ -230,7 +253,7 @@ public:
 
 private:
     friend class NestedLoopJoinProbeLocalState;
-    bool _is_output_left_side_only;
+    bool _is_output_probe_side_only;
     vectorized::VExprContextSPtrs _join_conjuncts;
     size_t _num_probe_side_columns = 0;
     size_t _num_build_side_columns = 0;


### PR DESCRIPTION
### What problem does this PR solve?

In NestedLoopJoin's generate_join_block_data, when the build-side data is very small (currently a single block), we will prefer to iterate the build first, then iterate the probe to produce the output rows.

This PR also renames some variables, replacing left/right names with probe/build wherever possible.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

