### PR TITLE
[fix](insert) fix insert failed when concurrent schema change

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
@@ -345,12 +345,13 @@ public class InsertIntoTableCommand extends Command implements NeedAuditEncrypti
             }
             OlapGroupCommitInsertExecutor.analyzeGroupCommit(
                     ctx, targetTableIf, this.logicalQuery.get(), this.insertCtx);
+
+            LogicalPlanAdapter logicalPlanAdapter
+                    = new LogicalPlanAdapter(logicalQuery.get(), ctx.getStatementContext());
+            return planInsertExecutor(ctx, stmtExecutor, logicalPlanAdapter, targetTableIf);
         } finally {
             targetTableIf.readUnlock();
         }
-
-        LogicalPlanAdapter logicalPlanAdapter = new LogicalPlanAdapter(logicalQuery.get(), ctx.getStatementContext());
-        return planInsertExecutor(ctx, stmtExecutor, logicalPlanAdapter, targetTableIf);
     }
 
     // we should select the factory type first, but we can not initial InsertExecutor at this time,


### PR DESCRIPTION
### What problem does this PR solve?

fix insert failed when concurrent schema change because the lock scope is small, introduced by #45045.

```
2025-12-22 18:31:27,916 WARN (mysql-nio-pool-20|395) [StmtExecutor.execute():546] Analyze failed. stmt[223, 6daf515a262f4708-959e9e3ef4590797]
org.apache.doris.common.NereidsException: errCode = 2, detailMessage = insert into cols should be corresponding to the query output
	at org.apache.doris.qe.StmtExecutor.executeByNereids(StmtExecutor.java:706)
	at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:541)
	at org.apache.doris.qe.StmtExecutor.queryRetry(StmtExecutor.java:500)
	at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:485)
	at org.apache.doris.qe.ConnectProcessor.executeQuery(ConnectProcessor.java:311)
	at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:198)
	at org.apache.doris.qe.MysqlConnectProcessor.handleQuery(MysqlConnectProcessor.java:231)
	at org.apache.doris.qe.MysqlConnectProcessor.dispatch(MysqlConnectProcessor.java:259)
	at org.apache.doris.qe.MysqlConnectProcessor.processOnce(MysqlConnectProcessor.java:403)
	at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: org.apache.doris.common.AnalysisException: errCode = 2, detailMessage = insert into cols should be corresponding to the query output
	... 13 more
Caused by: org.apache.doris.nereids.exceptions.AnalysisException: insert into cols should be corresponding to the query output
	at org.apache.doris.nereids.rules.analysis.BindSink.bindOlapTableSink(BindSink.java:194)
	at org.apache.doris.nereids.pattern.PatternMatcher$1.transform(PatternMatcher.java:96)
	at org.apache.doris.nereids.jobs.rewrite.TopDownVisitorRewriteJob.doRewrite(TopDownVisitorRewriteJob.java:114)
	at org.apache.doris.nereids.jobs.rewrite.TopDownVisitorRewriteJob.rewrite(TopDownVisitorRewriteJob.java:80)
	at org.apache.doris.nereids.jobs.rewrite.TopDownVisitorRewriteJob.execute(TopDownVisitorRewriteJob.java:56)
	at org.apache.doris.nereids.jobs.rewrite.AdaptiveTopDownRewriteJob.execute(AdaptiveTopDownRewriteJob.java:41)
	at org.apache.doris.nereids.jobs.executor.AbstractBatchJobExecutor.execute(AbstractBatchJobExecutor.java:167)
	at org.apache.doris.nereids.jobs.executor.Analyzer.lambda$execute$0(Analyzer.java:98)
	at org.apache.doris.nereids.util.MoreFieldsThread.keepFunctionSignature(MoreFieldsThread.java:127)
	at org.apache.doris.nereids.jobs.executor.Analyzer.execute(Analyzer.java:97)
	at org.apache.doris.nereids.jobs.executor.Analyzer.analyze(Analyzer.java:92)
	at org.apache.doris.nereids.NereidsPlanner.lambda$analyze$4(NereidsPlanner.java:414)
	at org.apache.doris.nereids.NereidsPlanner.keepOrShowPlanProcess(NereidsPlanner.java:1109)
	at org.apache.doris.nereids.NereidsPlanner.analyze(NereidsPlanner.java:414)
	at org.apache.doris.nereids.trees.plans.commands.insert.FastInsertIntoValuesPlanner.analyze(FastInsertIntoValuesPlanner.java:63)
	at org.apache.doris.nereids.NereidsPlanner.planWithoutLock(NereidsPlanner.java:288)
	at org.apache.doris.nereids.NereidsPlanner.planWithLock(NereidsPlanner.java:263)
	at org.apache.doris.nereids.NereidsPlanner.plan(NereidsPlanner.java:162)
	at org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand.planInsertExecutor(InsertIntoTableCommand.java:540)
	at org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand.initPlanOnce(InsertIntoTableCommand.java:353)
	at org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand.initPlan(InsertIntoTableCommand.java:259)
	at org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand.initPlan(InsertIntoTableCommand.java:226)
	at org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand.runInternal(InsertIntoTableCommand.java:569)
	at org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand.run(InsertIntoTableCommand.java:210)
	at org.apache.doris.qe.StmtExecutor.executeByNereids(StmtExecutor.java:678)
	... 12 more
```


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

