### PR TITLE
[Fix](file-scanner) Fix query result is incorrect when non-deterministic func push down.

### DIFF
--- a/be/src/vec/exec/scan/file_scanner.cpp
+++ b/be/src/vec/exec/scan/file_scanner.cpp
@@ -331,9 +331,9 @@ Status FileScanner::_process_conjuncts() {
 
         std::vector<int> slot_ids;
         _get_slot_ids(cur_expr.get(), &slot_ids);
-        if (slot_ids.size() == 0) {
+        if (slot_ids.empty()) {
             _not_single_slot_filter_conjuncts.emplace_back(conjunct);
-            return Status::OK();
+            continue;
         }
         bool single_slot = true;
         for (int i = 1; i < slot_ids.size(); i++) {


### PR DESCRIPTION

### What problem does this PR solve?

Problem Summary:

### Release note

[Fix] (file-scanner) Fix query result is incorrect when non-deterministic func push down.

- After `rand()` is pushed down to the ORC FileScan, it becomes a ScanNode conjunct. Since `rand() < 1` has no column references, `VFileScanner::_process_conjuncts_for_dict_filter` hits `slot_ids.size() == 0 `and returns early.
- This early return prevents later predicates from being processed; immediately after, `_process_late_arrival_conjuncts` calls `_discard_conjuncts()` and clears the original predicates. As a result, predicates like `xxx IS NOT NULL` are dropped.
- Once dropped, the Parquet/ORC reader only applies the “earlier processed” predicates for filtering, so rows with `xxx = NULL `appear.

Therefore, the rand() pushdown triggers the early return in predicate handling, which discards other filters. That’s why NULLs only show up when rand() is pushed down.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

