### PR TITLE
[fix](s3) Treat no such key as empty response when listing objects

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
@@ -568,6 +568,8 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
         long startTime = System.nanoTime();
         String currentMaxFile = "";
         boolean hasLimits = fileSizeLimit > 0 || fileNumLimit > 0;
+        String bucket = "";
+        String finalPrefix = "";
         try {
             S3URI uri = S3URI.create(remotePath, isUsePathStyle, forceParsingByStandardUri);
             // Directory bucket check for limit scenario
@@ -575,7 +577,7 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
                 throw new RuntimeException("Not support glob with limit for directory bucket");
             }
 
-            String bucket = uri.getBucket();
+            bucket = uri.getBucket();
             String globPath = S3Util.extendGlobs(uri.getKey());
 
             if (LOG.isDebugEnabled()) {
@@ -591,7 +593,7 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
             }
 
             // For Directory Buckets, ensure proper prefix handling using standardized approach
-            String finalPrefix = listPrefix;
+            finalPrefix = listPrefix;
 
             if (!hasLimits && uri.useS3DirectoryBucket()) {
                 String adjustedPrefix = S3URI.getDirectoryPrefixForGlob(listPrefix);
@@ -679,8 +681,9 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
             }
             return new GlobListResult(Status.OK, currentMaxFile, bucket, finalPrefix);
         } catch (NoSuchKeyException e0) {
-            List<RemoteObject> remoteObjects = new ArrayList<>();
-            return new RemoteObjects(remoteObjects, false, "");
+            LOG.info("NoSuchKey error when listing objects, treat as empty response. bucket={}, prefix={}",
+                    bucket, finalPrefix);
+            return new GlobListResult(Status.OK, "", bucket, finalPrefix);
         } catch (Exception e) {
             LOG.warn("Errors while getting file status", e);
             return new GlobListResult(new Status(Status.ErrCode.COMMON_ERROR,

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
@@ -678,6 +678,9 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
                 LOG.debug("remotePath:{}, result:{}", remotePath, result);
             }
             return new GlobListResult(Status.OK, currentMaxFile, bucket, finalPrefix);
+        } catch (NoSuchKeyException e0) {
+            List<RemoteObject> remoteObjects = new ArrayList<>();
+            return new RemoteObjects(remoteObjects, false, "");
         } catch (Exception e) {
             LOG.warn("Errors while getting file status", e);
             return new GlobListResult(new Status(Status.ErrCode.COMMON_ERROR,


### PR DESCRIPTION
There are some object storage providers, e.g. TOS by  ByteDance Cloud (Volcano Engine), is not fully compatible with AWS S3 API, the HTTP response code is 200(AWS) vs 404(TOS) when list non-existing objects, which leads to unexpected exception thrown by S3 SDK.
