### PR TITLE
[fix](parquet)fix parquet reader cannot push down conjuncts for min-max filter

### DIFF
--- a/be/src/olap/accept_null_predicate.h
+++ b/be/src/olap/accept_null_predicate.h
@@ -121,6 +121,10 @@ public:
     bool evaluate_and(vectorized::ParquetPredicate::CachedPageIndexStat* statistic,
                       RowRanges* row_ranges) const override {
         _nested->evaluate_and(statistic, row_ranges);
+        vectorized::ParquetPredicate::PageIndexStat* stat = nullptr;
+        if (!(statistic->get_stat_func)(&stat, column_id())) {
+            return true;
+        }
 
         for (int page_id = 0; page_id < stat->num_of_pages; page_id++) {
             if (stat->has_null[page_id]) {

--- a/be/src/olap/accept_null_predicate.h
+++ b/be/src/olap/accept_null_predicate.h
@@ -114,6 +114,22 @@ public:
         return _nested->evaluate_and(statistic);
     }
 
+    bool evaluate_and(vectorized::ParquetPredicate::ColumnStat* statistic) const override {
+        return _nested->evaluate_and(statistic) || statistic->has_null;
+    }
+
+    bool evaluate_and(vectorized::ParquetPredicate::CachedPageIndexStat* statistic,
+                      RowRanges* row_ranges) const override {
+        _nested->evaluate_and(statistic, row_ranges);
+
+        for (int page_id = 0; page_id < stat->num_of_pages; page_id++) {
+            if (stat->has_null[page_id]) {
+                row_ranges->add(stat->ranges[page_id]);
+            }
+        }
+        return row_ranges->count() > 0;
+    }
+
     bool evaluate_del(const std::pair<WrapperField*, WrapperField*>& statistic) const override {
         return _nested->evaluate_del(statistic);
     }

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -227,7 +227,7 @@ public:
                       RowRanges* row_ranges) const override {
         vectorized::ParquetPredicate::PageIndexStat* stat = nullptr;
         if (!(statistic->get_stat_func)(&stat, column_id())) {
-            row_ranges = statistic->row_group_range;
+            row_ranges->add(statistic->row_group_range);
             return true;
         }
 

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -198,10 +198,13 @@ public:
         if ((*statistic->get_stat_func)(statistic, column_id())) {
             vectorized::Field min_field;
             vectorized::Field max_field;
-            if (!vectorized::ParquetPredicate::parse_min_max_value(
-                         statistic->col_schema, statistic->encoded_min_value,
-                         statistic->encoded_max_value, *statistic->ctz, &min_field, &max_field)
-                         .ok()) [[unlikely]] {
+            if (statistic->is_all_null) {
+                result = false;
+            } else if (!vectorized::ParquetPredicate::parse_min_max_value(
+                                statistic->col_schema, statistic->encoded_min_value,
+                                statistic->encoded_max_value, *statistic->ctz, &min_field,
+                                &max_field)
+                                .ok()) [[unlikely]] {
                 result = true;
             } else {
                 result = camp_field(min_field, max_field);

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -227,6 +227,7 @@ public:
                       RowRanges* row_ranges) const override {
         vectorized::ParquetPredicate::PageIndexStat* stat = nullptr;
         if (!(statistic->get_stat_func)(&stat, column_id())) {
+            row_ranges = statistic->row_group_range;
             return true;
         }
 

--- a/be/src/olap/in_list_predicate.h
+++ b/be/src/olap/in_list_predicate.h
@@ -311,7 +311,7 @@ public:
                       RowRanges* row_ranges) const override {
         vectorized::ParquetPredicate::PageIndexStat* stat = nullptr;
         if (!(statistic->get_stat_func)(&stat, column_id())) {
-            row_ranges = statistic->row_group_range;
+            row_ranges->add(statistic->row_group_range);
             return true;
         }
 

--- a/be/src/olap/in_list_predicate.h
+++ b/be/src/olap/in_list_predicate.h
@@ -311,6 +311,7 @@ public:
                       RowRanges* row_ranges) const override {
         vectorized::ParquetPredicate::PageIndexStat* stat = nullptr;
         if (!(statistic->get_stat_func)(&stat, column_id())) {
+            row_ranges = statistic->row_group_range;
             return true;
         }
 

--- a/be/src/olap/in_list_predicate.h
+++ b/be/src/olap/in_list_predicate.h
@@ -282,10 +282,13 @@ public:
         if ((*statistic->get_stat_func)(statistic, column_id())) {
             vectorized::Field min_field;
             vectorized::Field max_field;
-            if (!vectorized::ParquetPredicate::parse_min_max_value(
-                         statistic->col_schema, statistic->encoded_min_value,
-                         statistic->encoded_max_value, *statistic->ctz, &min_field, &max_field)
-                         .ok()) [[unlikely]] {
+            if (statistic->is_all_null) {
+                result = false;
+            } else if (!vectorized::ParquetPredicate::parse_min_max_value(
+                                statistic->col_schema, statistic->encoded_min_value,
+                                statistic->encoded_max_value, *statistic->ctz, &min_field,
+                                &max_field)
+                                .ok()) [[unlikely]] {
                 result = true;
             } else {
                 result = camp_field(min_field, max_field);

--- a/be/src/olap/null_predicate.h
+++ b/be/src/olap/null_predicate.h
@@ -97,7 +97,7 @@ public:
                       RowRanges* row_ranges) const override {
         vectorized::ParquetPredicate::PageIndexStat* stat = nullptr;
         if (!(statistic->get_stat_func)(&stat, column_id())) {
-            row_ranges = statistic->row_group_range;
+            row_ranges->add(statistic->row_group_range);
             return true;
         }
         for (int page_id = 0; page_id < stat->num_of_pages; page_id++) {

--- a/be/src/olap/null_predicate.h
+++ b/be/src/olap/null_predicate.h
@@ -97,6 +97,7 @@ public:
                       RowRanges* row_ranges) const override {
         vectorized::ParquetPredicate::PageIndexStat* stat = nullptr;
         if (!(statistic->get_stat_func)(&stat, column_id())) {
+            row_ranges = statistic->row_group_range;
             return true;
         }
         for (int page_id = 0; page_id < stat->num_of_pages; page_id++) {

--- a/be/src/olap/shared_predicate.h
+++ b/be/src/olap/shared_predicate.h
@@ -165,6 +165,24 @@ public:
         return _nested->get_search_str();
     }
 
+    bool evaluate_and(vectorized::ParquetPredicate::ColumnStat* statistic) const override {
+        std::shared_lock<std::shared_mutex> lock(*_mtx);
+        if (!_nested) {
+            // at the begining _nested will be null, so return true.
+            return true;
+        }
+        return _nested->evaluate_and(statistic);
+    }
+
+    bool evaluate_and(vectorized::ParquetPredicate::CachedPageIndexStat* statistic,
+                      RowRanges* row_ranges) const override {
+        if (!_nested) {
+            // at the begining _nested will be null, so return true.
+            return true;
+        }
+        return _nested->evaluate_and(statistic, row_ranges);
+    }
+
 private:
     uint16_t _evaluate_inner(const vectorized::IColumn& column, uint16_t* sel,
                              uint16_t size) const override {

--- a/be/src/olap/shared_predicate.h
+++ b/be/src/olap/shared_predicate.h
@@ -176,6 +176,8 @@ public:
 
     bool evaluate_and(vectorized::ParquetPredicate::CachedPageIndexStat* statistic,
                       RowRanges* row_ranges) const override {
+        std::shared_lock<std::shared_mutex> lock(*_mtx);
+
         if (!_nested) {
             // at the begining _nested will be null, so return true.
             return true;

--- a/be/src/olap/shared_predicate.h
+++ b/be/src/olap/shared_predicate.h
@@ -180,6 +180,7 @@ public:
 
         if (!_nested) {
             // at the begining _nested will be null, so return true.
+            row_ranges = statistic->row_group_range;
             return true;
         }
         return _nested->evaluate_and(statistic, row_ranges);

--- a/be/src/olap/shared_predicate.h
+++ b/be/src/olap/shared_predicate.h
@@ -180,7 +180,7 @@ public:
 
         if (!_nested) {
             // at the begining _nested will be null, so return true.
-            row_ranges = statistic->row_group_range;
+            row_ranges->add(statistic->row_group_range);
             return true;
         }
         return _nested->evaluate_and(statistic, row_ranges);

--- a/be/src/olap/tablet_reader.cpp
+++ b/be/src/olap/tablet_reader.cpp
@@ -524,12 +524,6 @@ Status TabletReader::_init_conditions_param(const ReaderParams& read_params) {
         }
     }
 
-    for (int id : read_params.topn_filter_source_node_ids) {
-        auto& runtime_predicate =
-                read_params.runtime_state->get_query_ctx()->get_runtime_predicate(id);
-        RETURN_IF_ERROR(runtime_predicate.set_tablet_schema(read_params.topn_filter_target_node_id,
-                                                            _tablet_schema));
-    }
     return Status::OK();
 }
 

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -583,6 +583,9 @@ bool ScanLocalState<Derived>::_is_predicate_acting_on_slot(const vectorized::VEx
     if (_slot_id_to_value_range.end() == sid_to_range) {
         return false;
     }
+    if (remove_nullable((*slot_desc)->type())->get_primitive_type() == TYPE_VARBINARY) {
+        return false;
+    }
     *range = &(sid_to_range->second);
     return true;
 }
@@ -1235,6 +1238,9 @@ Status ScanOperatorX<LocalStateType>::prepare(RuntimeState* state) {
                                                    .nodes[0]
                                                    .slot_ref.slot_id];
             DCHECK(s != nullptr);
+            if (remove_nullable(s->type())->get_primitive_type() == TYPE_VARBINARY) {
+                continue;
+            }
             auto col_name = s->col_name();
             cid = get_column_id(col_name);
         }

--- a/be/src/runtime/runtime_predicate.cpp
+++ b/be/src/runtime/runtime_predicate.cpp
@@ -67,8 +67,10 @@ Status RuntimePredicate::init_target(
         _contexts[target_node_id].col_name =
                 slot_id_to_slot_desc[get_texpr(target_node_id).nodes[0].slot_ref.slot_id]
                         ->col_name();
-        _contexts[target_node_id].predicate =
-                SharedPredicate::create_shared(cast_set<uint32_t>(column_id), "");
+        _contexts[target_node_id].col_data_type =
+                slot_id_to_slot_desc[get_texpr(target_node_id).nodes[0].slot_ref.slot_id]->type();
+        _contexts[target_node_id].predicate = SharedPredicate::create_shared(
+                cast_set<uint32_t>(column_id), _contexts[target_node_id].col_name);
     }
     _detected_target = true;
     return Status::OK();
@@ -211,13 +213,9 @@ Status RuntimePredicate::update(const Field& value) {
     }
     for (auto p : _contexts) {
         auto ctx = p.second;
-        if (!ctx.tablet_schema) {
-            continue;
-        }
-        const auto& column = *DORIS_TRY(ctx.tablet_schema->column(ctx.col_name));
         auto str_ref = _get_string_ref(_orderby_extrem, _type);
         std::shared_ptr<ColumnPredicate> pred =
-                _pred_constructor(ctx.predicate->column_id(), column.name(), column.get_vec_type(),
+                _pred_constructor(ctx.predicate->column_id(), ctx.col_name, ctx.col_data_type,
                                   str_ref, false, _predicate_arena);
 
         // For NULLS FIRST, wrap a AcceptNullPredicate to return true for NULL

--- a/be/src/vec/exec/format/parquet/parquet_predicate.h
+++ b/be/src/vec/exec/format/parquet/parquet_predicate.h
@@ -208,6 +208,7 @@ public:
         const cctz::time_zone* ctz;
         std::map<int, PageIndexStat> stats;
         std::function<bool(PageIndexStat**, int)> get_stat_func;
+        RowRange row_group_range;
     };
 
     // The encoded Parquet min-max value is parsed into `fields`;

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -1017,6 +1017,7 @@ Status ParquetReader::_process_page_index_filter(
         *ans = &sig_stat;
         return true;
     };
+    cached_page_index.row_group_range = {0, row_group.num_rows};
     cached_page_index.get_stat_func = get_stat_func;
 
     candidate_row_ranges->add({0, row_group.num_rows});

--- a/be/src/vec/exec/scan/file_scanner.cpp
+++ b/be/src/vec/exec/scan/file_scanner.cpp
@@ -1039,16 +1039,6 @@ Status FileScanner::_get_next_reader() {
             // see IcebergTableReader::init_row_filters for example.
             parquet_reader->set_push_down_agg_type(_get_push_down_agg_type());
 
-            std::function<Status(bool*, VExprContextSPtrs&)> update_late_rf =
-                    [&](bool* changed, VExprContextSPtrs& new_push_down_conjuncts) -> Status {
-                if (!_is_load) {
-                    RETURN_IF_ERROR(try_append_late_arrival_runtime_filter());
-                    RETURN_IF_ERROR(
-                            _process_late_arrival_conjuncts(changed, new_push_down_conjuncts));
-                }
-                return Status::OK();
-            };
-            parquet_reader->set_update_late_rf_func(std::move(update_late_rf));
             RETURN_IF_ERROR(_init_parquet_reader(std::move(parquet_reader), file_meta_cache_ptr));
 
             need_to_get_parsed_schema = true;


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
1. Fixed an issue where the Parquet reader's pushdown predicate row group min-max filter was ineffective due to a refactoring of the column predicate #59187. 

2. Removed tablet_schema from RuntimePredicate when performing topn runtime filters, making RuntimePredicate not limited to olap scan node.

3. Removed the feature in #59053 where the Parquet reader could obtain runtime filters in real time, for the purpose of unifying the implementation of olap and file scan node logic in the future.

4. Temporarily disable the topn runtime filter for VARBINARY type, as the implementation of this type in column predicate is incomplete, affecting pr #58721.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

