### PR TITLE
[fix](recycler) Check snapshot reference before recycling packed file slices

### DIFF
--- a/cloud/src/recycler/recycler.h
+++ b/cloud/src/recycler/recycler.h
@@ -255,6 +255,7 @@ public:
         int64_t num_object_deleted = 0;   // packed-file objects deleted from storage (vault/HDFS)
         int64_t bytes_object_deleted = 0; // bytes deleted from storage objects
         int64_t rowset_scan_count = 0;    // rowset metas scanned during correction
+        int64_t num_slices_kept_by_snapshot = 0; // slices kept due to snapshot reference
     };
 
     explicit InstanceRecycler(std::shared_ptr<TxnKv> txn_kv, const InstanceInfoPB& instance,
@@ -516,6 +517,10 @@ private:
                             PackedFileRecycleStats* stats = nullptr);
     int check_recycle_and_tmp_rowset_exists(int64_t tablet_id, const std::string& rowset_id,
                                             int64_t txn_id, bool* recycle_exists, bool* tmp_exists);
+    // Check whether a rowset is still referenced by snapshots.
+    // Returns 0 on success, -1 on error. Sets has_snapshot_ref to true if ref_count > 1.
+    int check_rowset_snapshot_ref(int64_t tablet_id, const std::string& rowset_id,
+                                  bool* has_snapshot_ref);
     /**
      * Resolve which storage accessor should be used for a packed file.
      *


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
When a rowset is deleted from metadata but still referenced by snapshots , the packed file slices should not be marked as deleted.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

