### PR TITLE
[Feature](aggregation) support aggregate_function_null_v2 

### DIFF
--- a/be/src/pipeline/exec/aggregation_sink_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_sink_operator.cpp
@@ -302,9 +302,6 @@ Status AggSinkLocalState::_merge_with_serialized_key_helper(vectorized::Block* b
                 int col_id = AggSharedState::get_slot_column_id(
                         Base::_shared_state->aggregate_evaluators[i]);
                 auto column = block->get_by_position(col_id).column;
-                if (column->is_nullable()) {
-                    column = ((vectorized::ColumnNullable*)column.get())->get_nested_column_ptr();
-                }
 
                 size_t buffer_size =
                         Base::_shared_state->aggregate_evaluators[i]->function()->size_of_data() *
@@ -354,10 +351,6 @@ Status AggSinkLocalState::_merge_with_serialized_key_helper(vectorized::Block* b
                                 Base::_shared_state->aggregate_evaluators[i]);
                     }
                     auto column = block->get_by_position(col_id).column;
-                    if (column->is_nullable()) {
-                        column = ((vectorized::ColumnNullable*)column.get())
-                                         ->get_nested_column_ptr();
-                    }
 
                     size_t buffer_size = Base::_shared_state->aggregate_evaluators[i]
                                                  ->function()
@@ -412,9 +405,6 @@ Status AggSinkLocalState::_merge_without_key(vectorized::Block* block) {
             int col_id = AggSharedState::get_slot_column_id(
                     Base::_shared_state->aggregate_evaluators[i]);
             auto column = block->get_by_position(col_id).column;
-            if (column->is_nullable()) {
-                column = ((vectorized::ColumnNullable*)column.get())->get_nested_column_ptr();
-            }
 
             SCOPED_TIMER(_deserialize_data_timer);
             Base::_shared_state->aggregate_evaluators[i]

--- a/be/src/pipeline/exec/aggregation_source_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_source_operator.cpp
@@ -500,9 +500,6 @@ Status AggLocalState::merge_with_serialized_key_helper(vectorized::Block* block)
     for (int i = 0; i < Base::_shared_state->aggregate_evaluators.size(); ++i) {
         auto col_id = Base::_shared_state->probe_expr_ctxs.size() + i;
         auto column = block->get_by_position(col_id).column;
-        if (column->is_nullable()) {
-            column = ((vectorized::ColumnNullable*)column.get())->get_nested_column_ptr();
-        }
 
         size_t buffer_size =
                 Base::_shared_state->aggregate_evaluators[i]->function()->size_of_data() * rows;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -550,6 +550,11 @@ public:
         return _query_options.__isset.enable_parallel_scan && _query_options.enable_parallel_scan;
     }
 
+    bool enable_aggregate_function_null_v2() const {
+        return _query_options.__isset.enable_aggregate_function_null_v2 &&
+               _query_options.enable_aggregate_function_null_v2;
+    }
+
     bool is_read_csv_empty_line_as_null() const {
         return _query_options.__isset.read_csv_empty_line_as_null &&
                _query_options.read_csv_empty_line_as_null;

--- a/be/src/vec/aggregate_functions/aggregate_function_array_agg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_array_agg.h
@@ -324,26 +324,11 @@ public:
         this->data(place).insert_result_into(to);
     }
 
-    void deserialize_and_merge_from_column(AggregateDataPtr __restrict place, const IColumn& column,
-                                           Arena& arena) const override {
-        const size_t num_rows = column.size();
-        for (size_t i = 0; i != num_rows; ++i) {
-            this->data(place).deserialize_and_merge(column, i);
-        }
-    }
-
     void deserialize_and_merge_vec(const AggregateDataPtr* places, size_t offset,
                                    AggregateDataPtr rhs, const IColumn* column, Arena& arena,
                                    const size_t num_rows) const override {
         for (size_t i = 0; i != num_rows; ++i) {
             this->data(places[i] + offset).deserialize_and_merge(*column, i);
-        }
-    }
-
-    void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena& arena,
-                                 size_t num_rows) const override {
-        for (size_t i = 0; i != num_rows; ++i) {
-            this->data(places).deserialize_and_merge(column, i);
         }
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_avg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_avg.h
@@ -234,14 +234,6 @@ public:
         }
     }
 
-    void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena&,
-                                 size_t num_rows) const {
-        auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
-        DCHECK(col.size() >= num_rows) << "source column's size should greater than num_rows";
-        auto* data = col.get_data().data();
-        memcpy(places, data, sizeof(Data) * num_rows);
-    }
-
     void serialize_to_column(const std::vector<AggregateDataPtr>& places, size_t offset,
                              MutableColumnPtr& dst, const size_t num_rows) const override {
         auto& col = assert_cast<ColumnFixedLengthObject&>(*dst);
@@ -284,15 +276,17 @@ public:
     void deserialize_and_merge_vec(const AggregateDataPtr* places, size_t offset,
                                    AggregateDataPtr rhs, const IColumn* column, Arena& arena,
                                    const size_t num_rows) const override {
-        this->deserialize_from_column(rhs, *column, arena, num_rows);
-        this->merge_vec(places, offset, rhs, arena, num_rows);
+        const auto& col = assert_cast<const ColumnFixedLengthObject&>(*column);
+        const auto* data = col.get_data().data();
+        this->merge_vec(places, offset, AggregateDataPtr(data), arena, num_rows);
     }
 
     void deserialize_and_merge_vec_selected(const AggregateDataPtr* places, size_t offset,
                                             AggregateDataPtr rhs, const IColumn* column,
                                             Arena& arena, const size_t num_rows) const override {
-        this->deserialize_from_column(rhs, *column, arena, num_rows);
-        this->merge_vec_selected(places, offset, rhs, arena, num_rows);
+        const auto& col = assert_cast<const ColumnFixedLengthObject&>(*column);
+        const auto* data = col.get_data().data();
+        this->merge_vec_selected(places, offset, AggregateDataPtr(data), arena, num_rows);
     }
 
     void serialize_without_key_to_column(ConstAggregateDataPtr __restrict place,

--- a/be/src/vec/aggregate_functions/aggregate_function_avg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_avg.h
@@ -235,7 +235,7 @@ public:
     }
 
     void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena&,
-                                 size_t num_rows) const override {
+                                 size_t num_rows) const {
         auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
         DCHECK(col.size() >= num_rows) << "source column's size should greater than num_rows";
         auto* data = col.get_data().data();
@@ -265,20 +265,6 @@ public:
             auto& state = *reinterpret_cast<Data*>(&data[sizeof(Data) * i]);
             state.sum = typename Data::ResultType(src_data[i]);
             state.count = 1;
-        }
-    }
-
-    NO_SANITIZE_UNDEFINED void deserialize_and_merge_from_column(AggregateDataPtr __restrict place,
-                                                                 const IColumn& column,
-                                                                 Arena&) const override {
-        auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
-        const size_t num_rows = column.size();
-        DCHECK(col.size() >= num_rows) << "source column's size should greater than num_rows";
-        auto* data = reinterpret_cast<const Data*>(col.get_data().data());
-
-        for (size_t i = 0; i != num_rows; ++i) {
-            this->data(place).sum += data[i].sum;
-            this->data(place).count += data[i].count;
         }
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap.h
@@ -187,17 +187,6 @@ public:
         }
     }
 
-    void deserialize_and_merge_from_column(AggregateDataPtr __restrict place, const IColumn& column,
-                                           Arena&) const override {
-        const auto& col = assert_cast<const ColumnBitmap&>(column);
-        const size_t num_rows = column.size();
-        const auto* data = col.get_data().data();
-
-        for (size_t i = 0; i != num_rows; ++i) {
-            this->data(place).merge(data[i]);
-        }
-    }
-
     void deserialize_and_merge_from_column_range(AggregateDataPtr __restrict place,
                                                  const IColumn& column, size_t begin, size_t end,
                                                  Arena&) const override {

--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap_agg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap_agg.h
@@ -146,17 +146,6 @@ public:
         }
     }
 
-    void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena&,
-                                 size_t num_rows) const override {
-        auto& col = assert_cast<const ColumnBitmap&>(column);
-        DCHECK(col.size() >= num_rows) << "source column's size should greater than num_rows";
-        auto* src = col.get_data().data();
-        auto* data = &(this->data(places));
-        for (size_t i = 0; i != num_rows; ++i) {
-            data[i].value = src[i];
-        }
-    }
-
     void serialize_to_column(const std::vector<AggregateDataPtr>& places, size_t offset,
                              MutableColumnPtr& dst, const size_t num_rows) const override {
         auto& col = assert_cast<ColumnBitmap&>(*dst);
@@ -164,17 +153,6 @@ public:
         auto* data = col.get_data().data();
         for (size_t i = 0; i != num_rows; ++i) {
             data[i] = this->data(places[i] + offset).value;
-        }
-    }
-
-    void deserialize_and_merge_from_column(AggregateDataPtr __restrict place, const IColumn& column,
-                                           Arena&) const override {
-        auto& col = assert_cast<const ColumnBitmap&>(column);
-        const size_t num_rows = column.size();
-        auto* data = col.get_data().data();
-
-        for (size_t i = 0; i != num_rows; ++i) {
-            this->data(place).value |= data[i];
         }
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_count.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_count.h
@@ -87,12 +87,6 @@ public:
         assert_cast<ColumnInt64&>(to).get_data().push_back(data(place).count);
     }
 
-    void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena&,
-                                 size_t num_rows) const {
-        auto data = assert_cast<const ColumnFixedLengthObject&>(column).get_data().data();
-        memcpy(places, data, sizeof(Data) * num_rows);
-    }
-
     void serialize_to_column(const std::vector<AggregateDataPtr>& places, size_t offset,
                              MutableColumnPtr& dst, const size_t num_rows) const override {
         auto& col = assert_cast<ColumnFixedLengthObject&>(*dst);
@@ -134,17 +128,17 @@ public:
     void deserialize_and_merge_vec(const AggregateDataPtr* places, size_t offset,
                                    AggregateDataPtr rhs, const IColumn* column, Arena& arena,
                                    const size_t num_rows) const override {
-        this->deserialize_from_column(rhs, *column, arena, num_rows);
-        DEFER({ this->destroy_vec(rhs, num_rows); });
-        this->merge_vec(places, offset, rhs, arena, num_rows);
+        const auto& col = assert_cast<const ColumnFixedLengthObject&>(*column);
+        const auto* data = col.get_data().data();
+        this->merge_vec(places, offset, AggregateDataPtr(data), arena, num_rows);
     }
 
     void deserialize_and_merge_vec_selected(const AggregateDataPtr* places, size_t offset,
                                             AggregateDataPtr rhs, const IColumn* column,
                                             Arena& arena, const size_t num_rows) const override {
-        this->deserialize_from_column(rhs, *column, arena, num_rows);
-        DEFER({ this->destroy_vec(rhs, num_rows); });
-        this->merge_vec_selected(places, offset, rhs, arena, num_rows);
+        const auto& col = assert_cast<const ColumnFixedLengthObject&>(*column);
+        const auto* data = col.get_data().data();
+        this->merge_vec_selected(places, offset, AggregateDataPtr(data), arena, num_rows);
     }
 
     void serialize_without_key_to_column(ConstAggregateDataPtr __restrict place,
@@ -232,12 +226,6 @@ public:
         }
     }
 
-    void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena&,
-                                 size_t num_rows) const {
-        auto data = assert_cast<const ColumnFixedLengthObject&>(column).get_data().data();
-        memcpy(places, data, sizeof(Data) * num_rows);
-    }
-
     void serialize_to_column(const std::vector<AggregateDataPtr>& places, size_t offset,
                              MutableColumnPtr& dst, const size_t num_rows) const override {
         auto& col = assert_cast<ColumnFixedLengthObject&>(*dst);
@@ -281,17 +269,17 @@ public:
     void deserialize_and_merge_vec(const AggregateDataPtr* places, size_t offset,
                                    AggregateDataPtr rhs, const IColumn* column, Arena& arena,
                                    const size_t num_rows) const override {
-        this->deserialize_from_column(rhs, *column, arena, num_rows);
-        DEFER({ this->destroy_vec(rhs, num_rows); });
-        this->merge_vec(places, offset, rhs, arena, num_rows);
+        const auto& col = assert_cast<const ColumnFixedLengthObject&>(*column);
+        const auto* data = col.get_data().data();
+        this->merge_vec(places, offset, AggregateDataPtr(data), arena, num_rows);
     }
 
     void deserialize_and_merge_vec_selected(const AggregateDataPtr* places, size_t offset,
                                             AggregateDataPtr rhs, const IColumn* column,
                                             Arena& arena, const size_t num_rows) const override {
-        this->deserialize_from_column(rhs, *column, arena, num_rows);
-        DEFER({ this->destroy_vec(rhs, num_rows); });
-        this->merge_vec_selected(places, offset, rhs, arena, num_rows);
+        const auto& col = assert_cast<const ColumnFixedLengthObject&>(*column);
+        const auto* data = col.get_data().data();
+        this->merge_vec_selected(places, offset, AggregateDataPtr(data), arena, num_rows);
     }
 
     void serialize_without_key_to_column(ConstAggregateDataPtr __restrict place,

--- a/be/src/vec/aggregate_functions/aggregate_function_count.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_count.h
@@ -88,7 +88,7 @@ public:
     }
 
     void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena&,
-                                 size_t num_rows) const override {
+                                 size_t num_rows) const {
         auto data = assert_cast<const ColumnFixedLengthObject&>(column).get_data().data();
         memcpy(places, data, sizeof(Data) * num_rows);
     }
@@ -116,16 +116,6 @@ public:
         for (size_t i = 0; i != num_rows; ++i) {
             auto& state = *reinterpret_cast<Data*>(&data[sizeof(Data) * i]);
             state.count = 1;
-        }
-    }
-
-    void deserialize_and_merge_from_column(AggregateDataPtr __restrict place, const IColumn& column,
-                                           Arena&) const override {
-        auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
-        const size_t num_rows = column.size();
-        auto* data = reinterpret_cast<const Data*>(col.get_data().data());
-        for (size_t i = 0; i != num_rows; ++i) {
-            AggregateFunctionCount::data(place).count += data[i].count;
         }
     }
 
@@ -243,7 +233,7 @@ public:
     }
 
     void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena&,
-                                 size_t num_rows) const override {
+                                 size_t num_rows) const {
         auto data = assert_cast<const ColumnFixedLengthObject&>(column).get_data().data();
         memcpy(places, data, sizeof(Data) * num_rows);
     }
@@ -272,16 +262,6 @@ public:
         for (size_t i = 0; i < num_rows; i++) {
             auto& state = *reinterpret_cast<Data*>(&data[sizeof(Data) * i]);
             state.count = !input_col.is_null_at(i);
-        }
-    }
-
-    void deserialize_and_merge_from_column(AggregateDataPtr __restrict place, const IColumn& column,
-                                           Arena&) const override {
-        auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
-        const size_t num_rows = column.size();
-        auto* data = reinterpret_cast<const Data*>(col.get_data().data());
-        for (size_t i = 0; i != num_rows; ++i) {
-            AggregateFunctionCountNotNullUnary::data(place).count += data[i].count;
         }
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_map.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_map.h
@@ -261,31 +261,11 @@ public:
         }
     }
 
-    void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena&,
-                                 size_t num_rows) const override {
-        const auto& col = assert_cast<const ColumnMap&>(column);
-        auto* data = &(this->data(places));
-        for (size_t i = 0; i != num_rows; ++i) {
-            auto map = col[i].get<TYPE_MAP>();
-            data->add(map[0], map[1]);
-        }
-    }
-
     void serialize_to_column(const std::vector<AggregateDataPtr>& places, size_t offset,
                              MutableColumnPtr& dst, const size_t num_rows) const override {
         for (size_t i = 0; i != num_rows; ++i) {
             Data& data_ = this->data(places[i] + offset);
             data_.insert_result_into(*dst);
-        }
-    }
-
-    void deserialize_and_merge_from_column(AggregateDataPtr __restrict place, const IColumn& column,
-                                           Arena&) const override {
-        auto& col = assert_cast<const ColumnMap&>(column);
-        const size_t num_rows = column.size();
-        for (size_t i = 0; i != num_rows; ++i) {
-            auto map = col[i].get<TYPE_MAP>();
-            this->data(place).add(map[0], map[1]);
         }
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_map_v2.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_map_v2.h
@@ -235,31 +235,11 @@ public:
         }
     }
 
-    void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena&,
-                                 size_t num_rows) const override {
-        const auto& col = assert_cast<const ColumnMap&>(column);
-        auto* data = &(this->data(places));
-        for (size_t i = 0; i != num_rows; ++i) {
-            auto map = col[i].get<TYPE_MAP>();
-            data->add(map[0], map[1]);
-        }
-    }
-
     void serialize_to_column(const std::vector<AggregateDataPtr>& places, size_t offset,
                              MutableColumnPtr& dst, const size_t num_rows) const override {
         for (size_t i = 0; i != num_rows; ++i) {
             Data& data_ = this->data(places[i] + offset);
             data_.insert_result_into(*dst);
-        }
-    }
-
-    void deserialize_and_merge_from_column(AggregateDataPtr __restrict place, const IColumn& column,
-                                           Arena&) const override {
-        const auto& col = assert_cast<const ColumnMap&>(column);
-        const size_t num_rows = column.size();
-        for (size_t i = 0; i != num_rows; ++i) {
-            auto map = col[i].get<TYPE_MAP>();
-            this->data(place).add(map[0], map[1]);
         }
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max.h
@@ -806,7 +806,7 @@ public:
     }
 
     void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena& arena,
-                                 size_t num_rows) const override {
+                                 size_t num_rows) const {
         if constexpr (Data::IsFixedLength) {
             const auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
             auto* column_data = reinterpret_cast<const Data*>(col.get_data().data());
@@ -815,7 +815,8 @@ public:
                 data[i] = column_data[i];
             }
         } else {
-            Base::deserialize_from_column(places, column, arena, num_rows);
+            this->deserialize_vec(places, assert_cast<const ColumnString*>(&column), arena,
+                                  num_rows);
         }
     }
 
@@ -844,20 +845,6 @@ public:
             }
         } else {
             Base::streaming_agg_serialize_to_column(columns, dst, num_rows, arena);
-        }
-    }
-
-    void deserialize_and_merge_from_column(AggregateDataPtr __restrict place, const IColumn& column,
-                                           Arena& arena) const override {
-        if constexpr (Data::IsFixedLength) {
-            const auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
-            auto* column_data = reinterpret_cast<const Data*>(col.get_data().data());
-            const size_t num_rows = column.size();
-            for (size_t i = 0; i != num_rows; ++i) {
-                this->data(place).change_if_better(column_data[i], arena);
-            }
-        } else {
-            Base::deserialize_and_merge_from_column(place, column, arena);
         }
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max.h
@@ -770,6 +770,8 @@ public:
 
     DataTypePtr get_return_type() const override { return type; }
 
+    bool is_trivial() const override { return Data::IsFixedLength; }
+
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena& arena) const override {
         this->data(place).change_if_better(*columns[0], row_num, arena);
@@ -803,21 +805,6 @@ public:
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         this->data(place).insert_result_into(to);
-    }
-
-    void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena& arena,
-                                 size_t num_rows) const {
-        if constexpr (Data::IsFixedLength) {
-            const auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
-            auto* column_data = reinterpret_cast<const Data*>(col.get_data().data());
-            Data* data = reinterpret_cast<Data*>(places);
-            for (size_t i = 0; i != num_rows; ++i) {
-                data[i] = column_data[i];
-            }
-        } else {
-            this->deserialize_vec(places, assert_cast<const ColumnString*>(&column), arena,
-                                  num_rows);
-        }
     }
 
     void serialize_to_column(const std::vector<AggregateDataPtr>& places, size_t offset,
@@ -867,17 +854,31 @@ public:
     void deserialize_and_merge_vec(const AggregateDataPtr* places, size_t offset,
                                    AggregateDataPtr rhs, const IColumn* column, Arena& arena,
                                    const size_t num_rows) const override {
-        this->deserialize_from_column(rhs, *column, arena, num_rows);
-        DEFER({ this->destroy_vec(rhs, num_rows); });
-        this->merge_vec(places, offset, rhs, arena, num_rows);
+        if constexpr (Data::IsFixedLength) {
+            const auto& col = assert_cast<const ColumnFixedLengthObject&>(*column);
+            const auto* data = col.get_data().data();
+            this->merge_vec(places, offset, AggregateDataPtr(data), arena, num_rows);
+        } else {
+            this->deserialize_vec(rhs, assert_cast<const ColumnString*>(column), arena,
+                                  num_rows);
+            DEFER({ this->destroy_vec(rhs, num_rows); });
+            this->merge_vec(places, offset, rhs, arena, num_rows);
+        }
     }
 
     void deserialize_and_merge_vec_selected(const AggregateDataPtr* places, size_t offset,
                                             AggregateDataPtr rhs, const IColumn* column,
                                             Arena& arena, const size_t num_rows) const override {
-        this->deserialize_from_column(rhs, *column, arena, num_rows);
-        DEFER({ this->destroy_vec(rhs, num_rows); });
-        this->merge_vec_selected(places, offset, rhs, arena, num_rows);
+        if constexpr (Data::IsFixedLength) {
+            const auto& col = assert_cast<const ColumnFixedLengthObject&>(*column);
+            const auto* data = col.get_data().data();
+            this->merge_vec_selected(places, offset, AggregateDataPtr(data), arena, num_rows);
+        } else {
+            this->deserialize_vec(rhs, assert_cast<const ColumnString*>(column), arena,
+                                  num_rows);
+            DEFER({ this->destroy_vec(rhs, num_rows); });
+            this->merge_vec_selected(places, offset, rhs, arena, num_rows);
+        }
     }
 
     void serialize_without_key_to_column(ConstAggregateDataPtr __restrict place,

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max.h
@@ -859,8 +859,7 @@ public:
             const auto* data = col.get_data().data();
             this->merge_vec(places, offset, AggregateDataPtr(data), arena, num_rows);
         } else {
-            this->deserialize_vec(rhs, assert_cast<const ColumnString*>(column), arena,
-                                  num_rows);
+            this->deserialize_vec(rhs, assert_cast<const ColumnString*>(column), arena, num_rows);
             DEFER({ this->destroy_vec(rhs, num_rows); });
             this->merge_vec(places, offset, rhs, arena, num_rows);
         }
@@ -874,8 +873,7 @@ public:
             const auto* data = col.get_data().data();
             this->merge_vec_selected(places, offset, AggregateDataPtr(data), arena, num_rows);
         } else {
-            this->deserialize_vec(rhs, assert_cast<const ColumnString*>(column), arena,
-                                  num_rows);
+            this->deserialize_vec(rhs, assert_cast<const ColumnString*>(column), arena, num_rows);
             DEFER({ this->destroy_vec(rhs, num_rows); });
             this->merge_vec_selected(places, offset, rhs, arena, num_rows);
         }

--- a/be/src/vec/aggregate_functions/aggregate_function_null_v2.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_null_v2.h
@@ -332,7 +332,9 @@ public:
             const auto* __restrict null_map_data = nullable_col.get_null_map_data().data();
 
             for (size_t i = 0; i < num_rows; ++i) {
-                *(places[i] + offset) |= (!null_map_data[i]);
+                if (places[i]) {
+                    *(places[i] + offset) |= (!null_map_data[i]);
+                }
             }
             nested_function->deserialize_and_merge_vec_selected(places, offset + prefix_size, rhs,
                                                                 &nested_col, arena, num_rows);

--- a/be/src/vec/aggregate_functions/aggregate_function_null_v2.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_null_v2.h
@@ -1,0 +1,598 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// This file is copied from
+// https://github.com/ClickHouse/ClickHouse/blob/master/src/AggregateFunctions/AggregateFunctionNull.h
+// and modified by Doris
+
+#pragma once
+
+#include <glog/logging.h>
+
+#include <memory>
+
+#include "common/logging.h"
+#include "vec/aggregate_functions/aggregate_function.h"
+#include "vec/aggregate_functions/aggregate_function_distinct.h"
+#include "vec/columns/column.h"
+#include "vec/columns/column_nullable.h"
+#include "vec/common/assert_cast.h"
+#include "vec/common/string_buffer.hpp"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type_nullable.h"
+
+namespace doris::vectorized {
+#include "common/compile_check_begin.h"
+
+template <typename NestFunction, bool result_is_nullable, typename Derived>
+class AggregateFunctionNullBaseInlineV2 : public IAggregateFunctionHelper<Derived> {
+protected:
+    std::unique_ptr<NestFunction> nested_function;
+    size_t prefix_size;
+    bool is_window_function = false;
+
+    AggregateDataPtr nested_place(AggregateDataPtr __restrict place) const noexcept {
+        return place + prefix_size;
+    }
+
+    ConstAggregateDataPtr nested_place(ConstAggregateDataPtr __restrict place) const noexcept {
+        return place + prefix_size;
+    }
+
+    static void init(AggregateDataPtr __restrict place, bool is_window_function) noexcept {
+        init_flag(place);
+        init_null_count(place, is_window_function);
+    }
+
+    static void init_flag(AggregateDataPtr __restrict place) noexcept {
+        if constexpr (result_is_nullable) {
+            place[0] = false;
+        }
+    }
+
+    static void set_flag(AggregateDataPtr __restrict place) noexcept {
+        if constexpr (result_is_nullable) {
+            place[0] = true;
+        }
+    }
+
+    static bool get_flag(ConstAggregateDataPtr __restrict place) noexcept {
+        return result_is_nullable ? place[0] : true;
+    }
+
+    static void init_null_count(AggregateDataPtr __restrict place,
+                                bool is_window_function) noexcept {
+        if (is_window_function && result_is_nullable) {
+            unaligned_store<int32_t>(place + 1, 0);
+        }
+    }
+
+    static void update_null_count(AggregateDataPtr __restrict place, bool incremental,
+                                  bool is_window_function) noexcept {
+        if (is_window_function && result_is_nullable) {
+            auto null_count = unaligned_load<int32_t>(place + 1);
+            incremental ? null_count++ : null_count--;
+            unaligned_store<int32_t>(place + 1, null_count);
+        }
+    }
+
+    static int32_t get_null_count(ConstAggregateDataPtr __restrict place,
+                                  bool is_window_function) noexcept {
+        int32_t num = 0;
+        if (is_window_function && result_is_nullable) {
+            num = unaligned_load<int32_t>(place + 1);
+        }
+        return num;
+    }
+
+public:
+    AggregateFunctionNullBaseInlineV2(IAggregateFunction* nested_function_,
+                                      const DataTypes& arguments, bool is_window_function_)
+            : IAggregateFunctionHelper<Derived>(arguments),
+              nested_function {assert_cast<NestFunction*>(nested_function_)},
+              is_window_function(is_window_function_) {
+        DCHECK(nested_function_ != nullptr);
+        if constexpr (result_is_nullable) {
+            if (this->is_window_function) {
+                // flag|---null_count----|-------padding-------|--nested_data----|
+                size_t nested_align = nested_function->align_of_data();
+                prefix_size = 1 + sizeof(int32_t);
+                if (prefix_size % nested_align != 0) {
+                    prefix_size += (nested_align - (prefix_size % nested_align));
+                }
+            } else {
+                prefix_size = nested_function->align_of_data();
+            }
+        } else {
+            prefix_size = 0;
+        }
+    }
+
+    MutableColumnPtr create_serialize_column() const override {
+        if constexpr (result_is_nullable) {
+            return ColumnNullable::create(nested_function->create_serialize_column(),
+                                          ColumnUInt8::create());
+        }
+        return nested_function->create_serialize_column();
+    }
+
+    DataTypePtr get_serialized_type() const override {
+        if constexpr (result_is_nullable) {
+            return make_nullable(nested_function->get_serialized_type());
+        }
+        return nested_function->get_serialized_type();
+    }
+
+    void set_query_context(QueryContext* ctx) override {
+        return nested_function->set_query_context(ctx);
+    }
+
+    bool is_blockable() const override { return nested_function->is_blockable(); }
+
+    void set_version(const int version_) override {
+        IAggregateFunctionHelper<Derived>::set_version(version_);
+        nested_function->set_version(version_);
+    }
+
+    String get_name() const override { return "NullableV2(" + nested_function->get_name() + ")"; }
+
+    DataTypePtr get_return_type() const override {
+        return result_is_nullable ? make_nullable(nested_function->get_return_type())
+                                  : nested_function->get_return_type();
+    }
+
+    void create(AggregateDataPtr __restrict place) const override {
+        init(place, this->is_window_function);
+        nested_function->create(nested_place(place));
+    }
+
+    void destroy(AggregateDataPtr __restrict place) const noexcept override {
+        nested_function->destroy(nested_place(place));
+    }
+    void reset(AggregateDataPtr place) const override {
+        init(place, this->is_window_function);
+        nested_function->reset(nested_place(place));
+    }
+
+    bool is_trivial() const override { return false; }
+
+    size_t size_of_data() const override { return prefix_size + nested_function->size_of_data(); }
+
+    size_t align_of_data() const override {
+        if (this->is_window_function && result_is_nullable) {
+            return std::max(nested_function->align_of_data(), alignof(int32_t));
+        } else {
+            return nested_function->align_of_data();
+        }
+    }
+
+    void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
+               Arena& arena) const override {
+        if (get_flag(rhs)) {
+            set_flag(place);
+            nested_function->merge(nested_place(place), nested_place(rhs), arena);
+        }
+    }
+
+    void serialize(ConstAggregateDataPtr __restrict place, BufferWritable& buf) const override {
+        bool flag = get_flag(place);
+        if constexpr (result_is_nullable) {
+            buf.write_binary(flag);
+        }
+        if (flag) {
+            nested_function->serialize(nested_place(place), buf);
+        }
+    }
+
+    void deserialize(AggregateDataPtr __restrict place, BufferReadable& buf,
+                     Arena& arena) const override {
+        bool flag = true;
+        if constexpr (result_is_nullable) {
+            buf.read_binary(flag);
+        }
+        if (flag) {
+            set_flag(place);
+            nested_function->deserialize(nested_place(place), buf, arena);
+        }
+    }
+
+    void serialize_to_column(const std::vector<AggregateDataPtr>& places, size_t offset,
+                             MutableColumnPtr& dst, const size_t num_rows) const override {
+        if constexpr (result_is_nullable) {
+            auto& nullable_col = assert_cast<ColumnNullable&>(*dst);
+            auto& nested_col = nullable_col.get_nested_column();
+            auto& null_map = nullable_col.get_null_map_data();
+            MutableColumnPtr nested_col_ptr = nested_col.assume_mutable();
+
+            null_map.resize(num_rows);
+            uint8_t* __restrict null_map_data = null_map.data();
+            for (size_t i = 0; i < num_rows; ++i) {
+                null_map_data[i] = !get_flag(places[i] + offset);
+            }
+            nested_function->serialize_to_column(places, offset + prefix_size, nested_col_ptr,
+                                                 num_rows);
+        } else {
+            nested_function->serialize_to_column(places, offset, dst, num_rows);
+        }
+    }
+
+    void streaming_agg_serialize_to_column(const IColumn** columns, MutableColumnPtr& dst,
+                                           const size_t num_rows, Arena& arena) const override {
+        const auto* src_nullable_col = assert_cast<const ColumnNullable*>(columns[0]);
+        const auto* __restrict src_null_map_data = src_nullable_col->get_null_map_data().data();
+
+        size_t nested_size = nested_function->size_of_data();
+        std::vector<AggregateDataPtr> nested_places(num_rows);
+        std::vector<char> places_data(num_rows * nested_size);
+        for (size_t i = 0; i < num_rows; ++i) {
+            nested_places[i] = places_data.data() + i * nested_size;
+        }
+
+        if (!nested_function->is_trivial()) {
+            for (int i = 0; i < num_rows; ++i) {
+                try {
+                    nested_function->create(nested_places[i]);
+                } catch (...) {
+                    for (int j = 0; j < i; ++j) {
+                        nested_function->destroy(nested_places[j]);
+                    }
+                    throw;
+                }
+            }
+        }
+        Defer destroy_places = {[&]() {
+            if (!nested_function->is_trivial()) {
+                for (int i = 0; i < num_rows; ++i) {
+                    nested_function->destroy(nested_places[i]);
+                }
+            }
+        }};
+        const IColumn* src_nested_column =
+                src_nullable_col->get_nested_column().assume_mutable().get();
+        if (src_nullable_col->has_null()) {
+            for (size_t i = 0; i < num_rows; ++i) {
+                if (!src_null_map_data[i]) {
+                    nested_function->add(nested_places[i], &src_nested_column, i, arena);
+                }
+            }
+        } else {
+            nested_function->add_batch(num_rows, nested_places.data(), 0, &src_nested_column, arena,
+                                       false);
+        }
+
+        if constexpr (result_is_nullable) {
+            auto& dst_nullable_col = assert_cast<ColumnNullable&>(*dst);
+            MutableColumnPtr nested_col_ptr = dst_nullable_col.get_nested_column().assume_mutable();
+            dst_nullable_col.get_null_map_column().insert_range_from(
+                    src_nullable_col->get_null_map_column(), 0, num_rows);
+            nested_function->serialize_to_column(nested_places, 0, nested_col_ptr, num_rows);
+        } else {
+            nested_function->serialize_to_column(nested_places, 0, dst, num_rows);
+        }
+    }
+
+    void serialize_without_key_to_column(ConstAggregateDataPtr __restrict place,
+                                         IColumn& to) const override {
+        if constexpr (result_is_nullable) {
+            auto& nullable_col = assert_cast<ColumnNullable&>(to);
+            auto& nested_col = nullable_col.get_nested_column();
+            auto& null_map = nullable_col.get_null_map_data();
+
+            bool flag = get_flag(place);
+            if (flag) {
+                nested_function->serialize_without_key_to_column(nested_place(place), nested_col);
+                null_map.push_back(0);
+            } else {
+                nested_col.insert_default();
+                null_map.push_back(1);
+            }
+        } else {
+            nested_function->serialize_without_key_to_column(nested_place(place), to);
+        }
+    }
+
+    void deserialize_and_merge_vec(const AggregateDataPtr* places, size_t offset,
+                                   AggregateDataPtr rhs, const IColumn* column, Arena& arena,
+                                   const size_t num_rows) const override {
+        if constexpr (result_is_nullable) {
+            const auto& nullable_col = assert_cast<const ColumnNullable&>(*column);
+            const auto& nested_col = nullable_col.get_nested_column();
+            const auto* __restrict null_map_data = nullable_col.get_null_map_data().data();
+
+            for (size_t i = 0; i < num_rows; ++i) {
+                *(places[i] + offset) |= (!null_map_data[i]);
+            }
+            nested_function->deserialize_and_merge_vec(places, offset + prefix_size, rhs,
+                                                       &nested_col, arena, num_rows);
+        } else {
+            this->nested_function->deserialize_and_merge_vec(places, offset, rhs, column, arena,
+                                                             num_rows);
+        }
+    }
+
+    void deserialize_and_merge_vec_selected(const AggregateDataPtr* places, size_t offset,
+                                            AggregateDataPtr rhs, const IColumn* column,
+                                            Arena& arena, const size_t num_rows) const override {
+        if constexpr (result_is_nullable) {
+            const auto& nullable_col = assert_cast<const ColumnNullable&>(*column);
+            const auto& nested_col = nullable_col.get_nested_column();
+            const auto* __restrict null_map_data = nullable_col.get_null_map_data().data();
+
+            for (size_t i = 0; i < num_rows; ++i) {
+                *(places[i] + offset) |= (!null_map_data[i]);
+            }
+            nested_function->deserialize_and_merge_vec_selected(places, offset + prefix_size, rhs,
+                                                                &nested_col, arena, num_rows);
+        } else {
+            this->nested_function->deserialize_and_merge_vec_selected(places, offset, rhs, column,
+                                                                      arena, num_rows);
+        }
+    }
+
+    void deserialize_and_merge_from_column_range(AggregateDataPtr __restrict place,
+                                                 const IColumn& column, size_t begin, size_t end,
+                                                 Arena& arena) const override {
+        DCHECK(end <= column.size() && begin <= end)
+                << ", begin:" << begin << ", end:" << end << ", column.size():" << column.size();
+
+        if constexpr (result_is_nullable) {
+            const auto& nullable_col = assert_cast<const ColumnNullable&>(column);
+            const auto& nested_col = nullable_col.get_nested_column();
+            const auto& null_map = nullable_col.get_null_map_data();
+
+            for (size_t i = begin; i <= end; ++i) {
+                if (!null_map[i]) {
+                    set_flag(place);
+                    nested_function->deserialize_and_merge_from_column_range(
+                            nested_place(place), nested_col, i, i, arena);
+                }
+            }
+        } else {
+            nested_function->deserialize_and_merge_from_column_range(place, column, begin, end,
+                                                                     arena);
+        }
+    }
+
+    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+        if constexpr (result_is_nullable) {
+            auto& to_concrete = assert_cast<ColumnNullable&>(to);
+            if (get_flag(place)) {
+                nested_function->insert_result_into(nested_place(place),
+                                                    to_concrete.get_nested_column());
+                to_concrete.get_null_map_data().push_back(0);
+            } else {
+                to_concrete.insert_default();
+            }
+        } else {
+            nested_function->insert_result_into(nested_place(place), to);
+        }
+    }
+};
+
+template <typename NestFuction, bool result_is_nullable>
+class AggregateFunctionNullUnaryInlineV2 final
+        : public AggregateFunctionNullBaseInlineV2<
+                  NestFuction, result_is_nullable,
+                  AggregateFunctionNullUnaryInlineV2<NestFuction, result_is_nullable>> {
+public:
+    AggregateFunctionNullUnaryInlineV2(IAggregateFunction* nested_function_,
+                                       const DataTypes& arguments, bool is_window_function_)
+            : AggregateFunctionNullBaseInlineV2<
+                      NestFuction, result_is_nullable,
+                      AggregateFunctionNullUnaryInlineV2<NestFuction, result_is_nullable>>(
+                      nested_function_, arguments, is_window_function_) {}
+
+    void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
+             Arena& arena) const override {
+        const auto* column =
+                assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0]);
+        if (!column->is_null_at(row_num)) {
+            this->set_flag(place);
+            const IColumn* nested_column = &column->get_nested_column();
+            this->nested_function->add(this->nested_place(place), &nested_column, row_num, arena);
+        } else {
+            this->update_null_count(place, true, this->is_window_function);
+        }
+    }
+
+    IAggregateFunction* transmit_to_stable() override {
+        auto f = AggregateFunctionNullBaseInlineV2<
+                         NestFuction, result_is_nullable,
+                         AggregateFunctionNullUnaryInlineV2<NestFuction, result_is_nullable>>::
+                         nested_function->transmit_to_stable();
+        if (!f) {
+            return nullptr;
+        }
+        return new AggregateFunctionNullUnaryInlineV2<
+                typename FunctionStableTransfer<NestFuction>::FunctionStable, result_is_nullable>(
+                f, IAggregateFunction::argument_types, this->is_window_function);
+    }
+
+    void add_batch(size_t batch_size, AggregateDataPtr* __restrict places, size_t place_offset,
+                   const IColumn** columns, Arena& arena, bool agg_many) const override {
+        const auto* column = assert_cast<const ColumnNullable*>(columns[0]);
+        const IColumn* nested_column = &column->get_nested_column();
+        if (column->has_null()) {
+            const auto* __restrict null_map_data = column->get_null_map_data().data();
+            for (int i = 0; i < batch_size; ++i) {
+                if (!null_map_data[i]) {
+                    AggregateDataPtr __restrict place = places[i] + place_offset;
+                    this->set_flag(place);
+                    this->nested_function->add(this->nested_place(place), &nested_column, i, arena);
+                }
+            }
+        } else {
+            if constexpr (result_is_nullable) {
+                for (int i = 0; i < batch_size; ++i) {
+                    AggregateDataPtr __restrict place = places[i] + place_offset;
+                    place[0] |= 1;
+                    this->nested_function->add(this->nested_place(place), &nested_column, i, arena);
+                }
+            } else {
+                this->nested_function->add_batch(batch_size, places, place_offset, &nested_column,
+                                                 arena, agg_many);
+            }
+        }
+    }
+
+    void add_batch_single_place(size_t batch_size, AggregateDataPtr place, const IColumn** columns,
+                                Arena& arena) const override {
+        const auto* column = assert_cast<const ColumnNullable*>(columns[0]);
+        bool has_null = column->has_null();
+
+        if (has_null) {
+            for (size_t i = 0; i < batch_size; ++i) {
+                this->add(place, columns, i, arena);
+            }
+        } else {
+            this->set_flag(place);
+            const IColumn* nested_column = &column->get_nested_column();
+            this->nested_function->add_batch_single_place(batch_size, this->nested_place(place),
+                                                          &nested_column, arena);
+        }
+    }
+
+    void add_batch_range(size_t batch_begin, size_t batch_end, AggregateDataPtr place,
+                         const IColumn** columns, Arena& arena, bool has_null) override {
+        const auto* column = assert_cast<const ColumnNullable*>(columns[0]);
+
+        if (has_null) {
+            for (size_t i = batch_begin; i <= batch_end; ++i) {
+                this->add(place, columns, i, arena);
+            }
+        } else {
+            this->set_flag(place);
+            const IColumn* nested_column = &column->get_nested_column();
+            this->nested_function->add_batch_range(batch_begin, batch_end,
+                                                   this->nested_place(place), &nested_column, arena,
+                                                   false);
+        }
+    }
+
+    void add_range_single_place(int64_t partition_start, int64_t partition_end, int64_t frame_start,
+                                int64_t frame_end, AggregateDataPtr place, const IColumn** columns,
+                                Arena& arena, UInt8* use_null_result,
+                                UInt8* could_use_previous_result) const override {
+        auto current_frame_start = std::max<int64_t>(frame_start, partition_start);
+        auto current_frame_end = std::min<int64_t>(frame_end, partition_end);
+        if (current_frame_start >= current_frame_end) {
+            if (!*could_use_previous_result) {
+                this->init_flag(place);
+                *use_null_result = true;
+                return;
+            }
+        } else {
+            *use_null_result = false;
+            *could_use_previous_result = true;
+        }
+        const auto* column = assert_cast<const ColumnNullable*>(columns[0]);
+        bool has_null = column->has_null();
+        if (has_null) {
+            for (size_t i = current_frame_start; i < current_frame_end; ++i) {
+                this->add(place, columns, i, arena);
+            }
+        } else {
+            const IColumn* nested_column = &(column->get_nested_column());
+            this->set_flag(place);
+            this->nested_function->add_range_single_place(
+                    partition_start, partition_end, frame_start, frame_end,
+                    this->nested_place(place), &nested_column, arena, use_null_result,
+                    could_use_previous_result);
+        }
+    }
+
+    bool supported_incremental_mode() const override {
+        return this->nested_function->supported_incremental_mode();
+    }
+
+    void execute_function_with_incremental(int64_t partition_start, int64_t partition_end,
+                                           int64_t frame_start, int64_t frame_end,
+                                           AggregateDataPtr place, const IColumn** columns,
+                                           Arena& arena, bool previous_is_nul, bool end_is_nul,
+                                           bool has_null, UInt8* use_null_result,
+                                           UInt8* could_use_previous_result) const override {
+        int64_t current_frame_start = std::max<int64_t>(frame_start, partition_start);
+        int64_t current_frame_end = std::min<int64_t>(frame_end, partition_end);
+        if (current_frame_start >= current_frame_end) {
+            *use_null_result = true;
+            this->init_flag(place);
+            return;
+        }
+
+        DCHECK(columns[0]->is_nullable()) << columns[0]->get_name();
+        const auto* column = assert_cast<const ColumnNullable*>(columns[0]);
+        const IColumn* nested_column = &column->get_nested_column();
+
+        if (!column->has_null()) {
+            if (*could_use_previous_result) {
+                this->nested_function->execute_function_with_incremental(
+                        partition_start, partition_end, frame_start, frame_end,
+                        this->nested_place(place), &nested_column, arena, previous_is_nul,
+                        end_is_nul, false, use_null_result, could_use_previous_result);
+            } else {
+                this->nested_function->add_range_single_place(
+                        partition_start, partition_end, frame_start, frame_end,
+                        this->nested_place(place), &nested_column, arena, use_null_result,
+                        could_use_previous_result);
+            }
+            this->set_flag(place);
+            return;
+        }
+
+        const auto* __restrict null_map_data = column->get_null_map_data().data();
+        if (*could_use_previous_result) {
+            auto outcoming_pos = frame_start - 1;
+            auto incoming_pos = frame_end - 1;
+            bool is_previous_frame_start_null = false;
+            if (outcoming_pos >= partition_start && outcoming_pos < partition_end &&
+                null_map_data[outcoming_pos] == 1) {
+                is_previous_frame_start_null = true;
+                DCHECK_EQ(result_is_nullable, true);
+                DCHECK_EQ(this->is_window_function, true);
+                this->update_null_count(place, false, this->is_window_function);
+            }
+            bool is_current_frame_end_null = false;
+            if (incoming_pos >= partition_start && incoming_pos < partition_end &&
+                null_map_data[incoming_pos] == 1) {
+                is_current_frame_end_null = true;
+                DCHECK_EQ(result_is_nullable, true);
+                DCHECK_EQ(this->is_window_function, true);
+                this->update_null_count(place, true, this->is_window_function);
+            }
+            const IColumn* columns_tmp[2] {nested_column, &(*column->get_null_map_column_ptr())};
+            this->nested_function->execute_function_with_incremental(
+                    partition_start, partition_end, frame_start, frame_end,
+                    this->nested_place(place), columns_tmp, arena, is_previous_frame_start_null,
+                    is_current_frame_end_null, true, use_null_result, could_use_previous_result);
+            DCHECK_EQ(result_is_nullable, true);
+            DCHECK_EQ(this->is_window_function, true);
+            if (current_frame_end - current_frame_start ==
+                this->get_null_count(place, this->is_window_function)) {
+                this->init_flag(place);
+            } else {
+                this->set_flag(place);
+            }
+        } else {
+            this->add_range_single_place(partition_start, partition_end, frame_start, frame_end,
+                                         place, columns, arena, use_null_result,
+                                         could_use_previous_result);
+        }
+    }
+};
+
+} // namespace doris::vectorized
+
+#include "common/compile_check_end.h"

--- a/be/src/vec/aggregate_functions/aggregate_function_sum.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sum.h
@@ -133,13 +133,6 @@ public:
         column.get_data().push_back(this->data(place).get());
     }
 
-    void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena&,
-                                 size_t num_rows) const {
-        auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
-        auto* data = col.get_data().data();
-        memcpy(places, data, sizeof(Data) * num_rows);
-    }
-
     void serialize_to_column(const std::vector<AggregateDataPtr>& places, size_t offset,
                              MutableColumnPtr& dst, const size_t num_rows) const override {
         auto& col = assert_cast<ColumnFixedLengthObject&>(*dst);
@@ -183,15 +176,17 @@ public:
     void deserialize_and_merge_vec(const AggregateDataPtr* places, size_t offset,
                                    AggregateDataPtr rhs, const IColumn* column, Arena& arena,
                                    const size_t num_rows) const override {
-        this->deserialize_from_column(rhs, *column, arena, num_rows);
-        this->merge_vec(places, offset, rhs, arena, num_rows);
+        const auto& col = assert_cast<const ColumnFixedLengthObject&>(*column);
+        const auto* data = col.get_data().data();
+        this->merge_vec(places, offset, AggregateDataPtr(data), arena, num_rows);
     }
 
     void deserialize_and_merge_vec_selected(const AggregateDataPtr* places, size_t offset,
                                             AggregateDataPtr rhs, const IColumn* column,
                                             Arena& arena, const size_t num_rows) const override {
-        this->deserialize_from_column(rhs, *column, arena, num_rows);
-        this->merge_vec_selected(places, offset, rhs, arena, num_rows);
+        const auto& col = assert_cast<const ColumnFixedLengthObject&>(*column);
+        const auto* data = col.get_data().data();
+        this->merge_vec_selected(places, offset, AggregateDataPtr(data), arena, num_rows);
     }
 
     void serialize_without_key_to_column(ConstAggregateDataPtr __restrict place,

--- a/be/src/vec/aggregate_functions/aggregate_function_sum.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sum.h
@@ -134,7 +134,7 @@ public:
     }
 
     void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena&,
-                                 size_t num_rows) const override {
+                                 size_t num_rows) const {
         auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
         auto* data = col.get_data().data();
         memcpy(places, data, sizeof(Data) * num_rows);
@@ -165,16 +165,6 @@ public:
         for (size_t i = 0; i != num_rows; ++i) {
             auto& state = *reinterpret_cast<Data*>(&dst_data[sizeof(Data) * i]);
             state.sum = typename PrimitiveTypeTraits<TResult>::CppType(src_data[i]);
-        }
-    }
-
-    void deserialize_and_merge_from_column(AggregateDataPtr __restrict place, const IColumn& column,
-                                           Arena&) const override {
-        auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
-        const size_t num_rows = column.size();
-        auto* data = reinterpret_cast<const Data*>(col.get_data().data());
-        for (size_t i = 0; i != num_rows; ++i) {
-            this->data(place).sum += data[i].sum;
         }
     }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_uniq_distribute_key.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_uniq_distribute_key.h
@@ -165,7 +165,7 @@ public:
     }
 
     void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena&,
-                                 size_t num_rows) const override {
+                                 size_t num_rows) const {
         auto data = reinterpret_cast<const UInt64*>(
                 assert_cast<const ColumnFixedLengthObject&>(column).get_data().data());
         for (size_t i = 0; i != num_rows; ++i) {
@@ -196,16 +196,6 @@ public:
         auto* data = reinterpret_cast<UInt64*>(dst_col.get_data().data());
         for (size_t i = 0; i != num_rows; ++i) {
             data[i] = 1;
-        }
-    }
-
-    void deserialize_and_merge_from_column(AggregateDataPtr __restrict place, const IColumn& column,
-                                           Arena&) const override {
-        auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
-        const size_t num_rows = column.size();
-        auto* data = reinterpret_cast<const UInt64*>(col.get_data().data());
-        for (size_t i = 0; i != num_rows; ++i) {
-            AggregateFunctionUniqDistributeKey::data(place).count += data[i];
         }
     }
 

--- a/be/src/vec/exprs/vectorized_agg_fn.cpp
+++ b/be/src/vec/exprs/vectorized_agg_fn.cpp
@@ -230,6 +230,8 @@ Status AggFnEvaluator::prepare(RuntimeState* state, const RowDescriptor& desc,
                     state->be_exec_version(),
                     {.is_window_function = _is_window_function,
                      .is_foreach = is_foreach,
+                     .enable_aggregate_function_null_v2 =
+                             state->enable_aggregate_function_null_v2(),
                      .column_names = std::move(column_names)});
         } else {
             _function = AggregateFunctionSimpleFactory::instance().get(
@@ -237,6 +239,8 @@ Status AggFnEvaluator::prepare(RuntimeState* state, const RowDescriptor& desc,
                     state->be_exec_version(),
                     {.is_window_function = _is_window_function,
                      .is_foreach = is_foreach,
+                     .enable_aggregate_function_null_v2 =
+                             state->enable_aggregate_function_null_v2(),
                      .column_names = std::move(column_names)});
         }
     }
@@ -295,13 +299,6 @@ Status AggFnEvaluator::execute_batch_add_selected(Block* block, size_t offset,
                                                   AggregateDataPtr* places, Arena& arena) {
     RETURN_IF_ERROR(_calc_argument_columns(block));
     _function->add_batch_selected(block->rows(), places, offset, _agg_columns.data(), arena);
-    return Status::OK();
-}
-
-Status AggFnEvaluator::streaming_agg_serialize(Block* block, BufferWritable& buf,
-                                               const size_t num_rows, Arena& arena) {
-    RETURN_IF_ERROR(_calc_argument_columns(block));
-    _function->streaming_agg_serialize(_agg_columns.data(), buf, num_rows, arena);
     return Status::OK();
 }
 

--- a/be/src/vec/exprs/vectorized_agg_fn.h
+++ b/be/src/vec/exprs/vectorized_agg_fn.h
@@ -82,9 +82,6 @@ public:
     Status execute_batch_add_selected(Block* block, size_t offset, AggregateDataPtr* places,
                                       Arena& arena);
 
-    Status streaming_agg_serialize(Block* block, BufferWritable& buf, const size_t num_rows,
-                                   Arena& arena);
-
     Status streaming_agg_serialize_to_column(Block* block, MutableColumnPtr& dst,
                                              const size_t num_rows, Arena& arena);
 

--- a/be/test/vec/aggregate_functions/agg_function_test.h
+++ b/be/test/vec/aggregate_functions/agg_function_test.h
@@ -163,18 +163,6 @@ private:
                 std::vector<AggregateDataPtr> places {place};
                 agg_fn->function()->serialize_to_column(places, 0, serialize_column, 1);
             }
-
-            {
-                Arena arena;
-                auto* place = reinterpret_cast<vectorized::AggregateDataPtr>(
-                        arena.alloc(agg_fn->function()->size_of_data()));
-
-                agg_fn->create(place);
-                Defer defer([&]() { agg_fn->destroy(place); });
-                agg_fn->function()->deserialize_from_column(place, *serialize_column, arena, 1);
-
-                check_result(place);
-            }
         }
 
         { // streaming_agg_serialize_to_column deserialize_and_merge_from_column_range

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -309,6 +309,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String USE_SERIAL_EXCHANGE = "use_serial_exchange";
 
     public static final String ENABLE_PARALLEL_SCAN = "enable_parallel_scan";
+    public static final String ENABLE_AGGREGATE_FUNCTION_NULL_V2 = "enable_aggregate_function_null_v2";
 
     public static final String ENABLE_NEW_SHUFFLE_HASH_METHOD = "enable_new_shuffle_hash_method";
 
@@ -1478,6 +1479,9 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = ENABLE_PARALLEL_SCAN, fuzzy = true, varType = VariableAnnotation.EXPERIMENTAL,
             needForward = true)
     private boolean enableParallelScan = true;
+
+    @VariableMgr.VarAttr(name = ENABLE_AGGREGATE_FUNCTION_NULL_V2, fuzzy = true, needForward = true)
+    private boolean enableAggregateFunctionNullV2 = true;
 
     @VariableMgr.VarAttr(name = OPTIMIZE_INDEX_SCAN_PARALLELISM,
             needForward = true,
@@ -5108,6 +5112,7 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setCteMaxRecursionDepth(cteMaxRecursionDepth);
         tResult.setEnableParallelScan(enableParallelScan);
         tResult.setEnableLeftSemiDirectReturnOpt(enableLeftSemiDirectReturnOpt);
+        tResult.setEnableAggregateFunctionNullV2(enableAggregateFunctionNullV2);
         tResult.setParallelScanMaxScannersCount(parallelScanMaxScannersCount);
         tResult.setParallelScanMinRowsPerScanner(parallelScanMinRowsPerScanner);
         tResult.setOptimizeIndexScanParallelism(optimizeIndexScanParallelism);
@@ -5505,6 +5510,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public boolean getEnableParallelScan() {
         return enableParallelScan;
+    }
+
+    public boolean getEnableAggregateFunctionNullV2() {
+        return enableAggregateFunctionNullV2;
     }
 
     public boolean enableParallelResultSink() {

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -425,6 +425,7 @@ struct TQueryOptions {
   184: optional i32 cte_max_recursion_depth;
 
   185: optional bool enable_parquet_file_page_cache = true;
+  186: optional bool enable_aggregate_function_null_v2 = false;
 
   195: optional bool enable_left_semi_direct_return_opt;
 


### PR DESCRIPTION
### What problem does this PR solve?
sum
before:
STREAMING_AGGREGATION avg 4sec58ms, max 4sec481ms, min 3sec766ms
AGGREGATION_SINK      avg 11sec598ms, max 11sec733ms, min 11sec477ms
after:
STREAMING_AGGREGATION avg 2sec400ms, max 2sec660ms, min 2sec101ms
AGGREGATION_SINK      avg 11sec582ms, max 11sec722ms, min 11sec382ms

avg
before:
STREAMING_AGGREGATION avg 5sec37ms, max 5sec447ms, min 4sec591ms
AGGREGATION_SINK      avg 14sec298ms, max 14sec427ms, min 14sec180ms
after:
STREAMING_AGGREGATION avg 3sec43ms, max 3sec415ms, min 2sec838ms
AGGREGATION_SINK      avg 14sec67ms, max 14sec337ms, min 13sec902ms

This pull request refactors the aggregation function framework, primarily focusing on simplifying and unifying the deserialization and merging interfaces, as well as making improvements for better null handling and performance. The main changes remove redundant methods, consolidate logic, and introduce new configuration options.

**API and Interface Simplification:**

* Removed the `deserialize_from_column` and `deserialize_and_merge_from_column` virtual methods from the `IAggregateFunction` interface and its implementations, consolidating deserialization logic into `deserialize_and_merge_from_column_range` and providing a default wrapper for range-based deserialization. [[1]](diffhunk://#diff-c7bdf142116c49dcc34f63bea8dc12d418fd6dfedd7f43e27393d61f552e5266L169-L171) [[2]](diffhunk://#diff-c7bdf142116c49dcc34f63bea8dc12d418fd6dfedd7f43e27393d61f552e5266L181-R183) [[3]](diffhunk://#diff-c7bdf142116c49dcc34f63bea8dc12d418fd6dfedd7f43e27393d61f552e5266L564-L571) [[4]](diffhunk://#diff-92cbd4b807cf2772dbeb2e15c990a6f294c7400644dbacb34ef1af9db85594a9L327-L334) [[5]](diffhunk://#diff-92cbd4b807cf2772dbeb2e15c990a6f294c7400644dbacb34ef1af9db85594a9L343-L349) [[6]](diffhunk://#diff-505d65d575a270149a7573f84ce6e279d825efe602c32e5c6f7f7c3234fa9067L238-R238) [[7]](diffhunk://#diff-505d65d575a270149a7573f84ce6e279d825efe602c32e5c6f7f7c3234fa9067L271-L284) [[8]](diffhunk://#diff-4b9b0e2a479f215591138f801433000eb69a8962c7a390c7a46d5c2aa09cc3f9L190-L200) [[9]](diffhunk://#diff-9e5544bba64e0da947c606866b3f24cf045c54cec347c042854b1903a8d93057L149-L159) [[10]](diffhunk://#diff-9e5544bba64e0da947c606866b3f24cf045c54cec347c042854b1903a8d93057L170-L180) [[11]](diffhunk://#diff-a5dbb09237f197bffdcbd3bec4fdd089913ec143d96806618c8eeb4c5dbb8cfeL91-R91) [[12]](diffhunk://#diff-a5dbb09237f197bffdcbd3bec4fdd089913ec143d96806618c8eeb4c5dbb8cfeL122-L131)

* Unified and clarified the vectorized merge interfaces (`merge_vec`, `merge_vec_selected`) by adding `__restrict` qualifiers and improving parameter naming for clarity and potential performance gains. [[1]](diffhunk://#diff-c7bdf142116c49dcc34f63bea8dc12d418fd6dfedd7f43e27393d61f552e5266L134-R141) [[2]](diffhunk://#diff-c7bdf142116c49dcc34f63bea8dc12d418fd6dfedd7f43e27393d61f552e5266L519-R526)

**Null Handling and Configuration:**

* Added a new query option and runtime state method `enable_aggregate_function_null_v2` to control enhanced null handling in aggregate functions. [[1]](diffhunk://#diff-efeb89760ec70cdad5ae9c6169e213b9efa84fccb6ede73f626bf6583bd82333R553-R557) [[2]](diffhunk://#diff-c7bdf142116c49dcc34f63bea8dc12d418fd6dfedd7f43e27393d61f552e5266R49)

**Performance and Safety Improvements:**

* Improved destruction logic in `IAggregateFunctionHelper::destroy_vec` to skip trivial cases, potentially reducing unnecessary work.

* Refactored the streaming serialization interface, removing the old `streaming_agg_serialize` method in favor of a more consistent `streaming_agg_serialize_to_column`. [[1]](diffhunk://#diff-c7bdf142116c49dcc34f63bea8dc12d418fd6dfedd7f43e27393d61f552e5266L221-L223) [[2]](diffhunk://#diff-c7bdf142116c49dcc34f63bea8dc12d418fd6dfedd7f43e27393d61f552e5266L422-R425) [[3]](diffhunk://#diff-c7bdf142116c49dcc34f63bea8dc12d418fd6dfedd7f43e27393d61f552e5266L435-L440)

**Aggregation Operator Code Cleanup:**

* Removed unnecessary null-checking and unwrapping of nullable columns in aggregation sink and source operators, likely due to improved null handling in the aggregation framework. [[1]](diffhunk://#diff-df21df88282293d1bbe3223e0d95dcc5afc01da571e3a7c1d9dc9377a758d5daL305-L307) [[2]](diffhunk://#diff-df21df88282293d1bbe3223e0d95dcc5afc01da571e3a7c1d9dc9377a758d5daL357-L360) [[3]](diffhunk://#diff-df21df88282293d1bbe3223e0d95dcc5afc01da571e3a7c1d9dc9377a758d5daL415-L417) [[4]](diffhunk://#diff-d45f483806d3e0d0230fcb32c6c3b5da4a3eee517ac7c8664c3e79338817b44dL503-L505)

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

