### PR TITLE
[fix](orc)Modifying the orc reader makes error reporting more accurate.

### DIFF
--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -2158,12 +2158,6 @@ Status OrcReader::get_next_block(Block* block, size_t* read_rows, bool* eof) {
             _io_ctx->file_reader_stats->read_rows += _reader_metrics.ReadRowCount;
         }
     }
-    if (_orc_filter) {
-        RETURN_IF_ERROR(_orc_filter->get_status());
-    }
-    if (_string_dict_filter) {
-        RETURN_IF_ERROR(_string_dict_filter->get_status());
-    }
     return Status::OK();
 }
 

--- a/be/src/vec/exec/format/orc/vorc_reader.h
+++ b/be/src/vec/exec/format/orc/vorc_reader.h
@@ -252,14 +252,10 @@ private:
         ~ORCFilterImpl() override = default;
         void filter(orc::ColumnVectorBatch& data, uint16_t* sel, uint16_t size,
                     void* arg) const override {
-            if (_status.ok()) {
-                _status = _orcReader->filter(data, sel, size, arg);
-            }
+            THROW_IF_ERROR(_orcReader->filter(data, sel, size, arg));
         }
-        Status get_status() { return _status; }
 
     private:
-        mutable Status _status = Status::OK();
         OrcReader* _orcReader = nullptr;
     };
 
@@ -271,24 +267,17 @@ private:
         void fillDictFilterColumnNames(
                 std::unique_ptr<orc::StripeInformation> current_strip_information,
                 std::list<std::string>& column_names) const override {
-            if (_status.ok()) {
-                _status = _orc_reader->fill_dict_filter_column_names(
-                        std::move(current_strip_information), column_names);
-            }
+            THROW_IF_ERROR(_orc_reader->fill_dict_filter_column_names(
+                    std::move(current_strip_information), column_names));
         }
         void onStringDictsLoaded(
                 std::unordered_map<std::string, orc::StringDictionary*>& column_name_to_dict_map,
                 bool* is_stripe_filtered) const override {
-            if (_status.ok()) {
-                _status = _orc_reader->on_string_dicts_loaded(column_name_to_dict_map,
-                                                              is_stripe_filtered);
-            }
+            THROW_IF_ERROR(_orc_reader->on_string_dicts_loaded(column_name_to_dict_map,
+                                                               is_stripe_filtered));
         }
 
-        Status get_status() { return _status; }
-
     private:
-        mutable Status _status = Status::OK();
         OrcReader* _orc_reader = nullptr;
     };
 

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run13.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run13.hql
@@ -29,3 +29,10 @@ LOCATION
 
 msck repair table orc_all_types;
 
+
+drop table if exists hive_orc_next_batch_test;
+CREATE TABLE hive_orc_next_batch_test (id  INT, data STRING) STORED AS ORC;
+INSERT INTO hive_orc_next_batch_test VALUES
+  (1, '{"age":25,"city":"beijing","score":88}'),
+  (2,   '{"age":30,"city":"shanghai","score":92}');
+

--- a/regression-test/suites/external_table_p0/hive/test_hive_orc.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_orc.groovy
@@ -167,6 +167,27 @@ suite("test_hive_orc", "all_types,p0,external,hive,external_docker,external_dock
         return;
     }
 
+    def test_orc_nextbatch_error =  {
+        def tb_name  =  "hive_orc_next_batch_test";
+
+        hive_docker """ drop table if exists ${tb_name} """ 
+        hive_docker """  CREATE TABLE ${tb_name} (id  INT, data STRING) STORED AS ORC; """
+        hive_docker """ 
+        INSERT INTO ${tb_name} VALUES
+            (1, '{"age":25,"city":"beijing","score":88}'),
+            (2,   '{"age":30,"city":"shanghai","score":92}') """
+
+        try {
+            sql """select * from ${tb_name} where json_extract_double(data, '.age') = 25; """
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("Orc row reader nextBatch failed"))
+        }
+
+        def result = sql """ select * from ${tb_name} where json_extract_double(data, "\$.age")=25 """
+        assertTrue(result.size() == 1);
+    }
+
+
     for (String hivePrefix : ["hive2", "hive3"]) {
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
@@ -191,7 +212,8 @@ suite("test_hive_orc", "all_types,p0,external,hive,external_docker,external_dock
             predicate_pushdown()    
             test_topn()
             test_topn_abs()
-            
+            test_orc_nextbatch_error()
+
             sql """drop catalog if exists ${catalog_name}"""
 
             // test old create-catalog syntax for compatibility

--- a/regression-test/suites/external_table_p0/hive/test_hive_orc.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_orc.groovy
@@ -176,7 +176,8 @@ suite("test_hive_orc", "all_types,p0,external,hive,external_docker,external_dock
         INSERT INTO ${tb_name} VALUES
             (1, '{"age":25,"city":"beijing","score":88}'),
             (2,   '{"age":30,"city":"shanghai","score":92}') """
-
+        sleep(10000);
+        
         try {
             sql """select * from ${tb_name} where json_extract_double(data, '.age') = 25; """
         } catch (Exception e) {

--- a/regression-test/suites/external_table_p0/hive/test_hive_orc.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_orc.groovy
@@ -177,7 +177,6 @@ suite("test_hive_orc", "all_types,p0,external,hive,external_docker,external_dock
         }
 
         def result = sql """ select * from ${tb_name} where json_extract_double(data, "\$.age")=25 """
-        logger.info(result)
         assertTrue(result.size() == 1);
     }
 

--- a/regression-test/suites/external_table_p0/hive/test_hive_orc.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_orc.groovy
@@ -169,22 +169,15 @@ suite("test_hive_orc", "all_types,p0,external,hive,external_docker,external_dock
 
     def test_orc_nextbatch_error =  {
         def tb_name  =  "hive_orc_next_batch_test";
-
-        hive_docker """ drop table if exists ${tb_name} """ 
-        hive_docker """  CREATE TABLE ${tb_name} (id  INT, data STRING) STORED AS ORC; """
-        hive_docker """ 
-        INSERT INTO ${tb_name} VALUES
-            (1, '{"age":25,"city":"beijing","score":88}'),
-            (2,   '{"age":30,"city":"shanghai","score":92}') """
-        sleep(10000);
-        
         try {
             sql """select * from ${tb_name} where json_extract_double(data, '.age') = 25; """
         } catch (Exception e) {
-            assertTrue(e.getMessage().contains("Orc row reader nextBatch failed"))
+            logger.info(e.getMessage());
+            assertTrue(e.getMessage().contains("nextBatch failed"))
         }
 
         def result = sql """ select * from ${tb_name} where json_extract_double(data, "\$.age")=25 """
+        logger.info(result)
         assertTrue(result.size() == 1);
     }
 


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:

This pr modifying the error handling mechanism of the Orc third-party library when calling back Doris code, specifically by directly throwing exceptions, thus making error reporting more accurate.
For example: `select * from ${tb_name} where json_extract_double(data, '.age')`
The expected error would be:
`detailMessage = (127.0.0.1)[INTERNAL_ERROR]Orc row reader nextBatch failed. reason = [E33] Json path error: Invalid Json Path for value: .age.`
However, you receive:
`Check failed: filter.size() == offsets.size() (4064 vs. 8128)`


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

