### PR TITLE
[feat](tools) Add RocksDB storage engine support for fdb_ctl

### DIFF
--- a/tools/fdb/fdb_ctl.sh
+++ b/tools/fdb/fdb_ctl.sh
@@ -52,6 +52,7 @@ fi
 
 # TODO verify config
 
+FDB_STORAGE_ENGINE=${FDB_STORAGE_ENGINE:-"ssd"}
 FDB_CLUSTER_DESC=${FDB_CLUSTER_DESC:-"doris-fdb"}
 
 # A dir to provide FDB binary pkgs
@@ -434,7 +435,7 @@ function start() {
         echo "Try create database in fdb ${fdb_mode}"
 
         "${FDB_HOME}/fdbcli" -C "${FDB_HOME}/conf/fdb.cluster" \
-            --exec "configure new ${fdb_mode} ssd" ||
+            --exec "configure new ${fdb_mode} ${FDB_STORAGE_ENGINE}" ||
             "${FDB_HOME}/fdbcli" -C "${FDB_HOME}/conf/fdb.cluster" --exec "status" ||
             (echo "failed to start fdb, please check that all nodes have same FDB_CLUSTER_ID" &&
                 exit 1)

--- a/tools/fdb/fdb_vars.sh
+++ b/tools/fdb/fdb_vars.sh
@@ -67,7 +67,13 @@ FDB_PORT=4500
 
 # Define the FoundationDB version
 # shellcheck disable=2034
-FDB_VERSION="7.1.38"
+FDB_VERSION="7.3.69"
+
+# Define the FoundationDB storage engine. Allowed:
+# - ssd: sqlite engine
+# - ssd-rocksdb-v1: rocksdb engine
+# shellcheck disable=2034
+FDB_STORAGE_ENGINE="ssd-rocksdb-v1"
 
 # Users who run the fdb processes, default is the current user
 # shellcheck disable=2034


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

- Upgrade FoundationDB from 7.1.38 to 7.3.69
- Add FDB_STORAGE_ENGINE configuration to support both SQLite and RocksDB engines
- Configure RocksDB-specific knobs when ssd-rocksdb-v1 storage engine is selected


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

