### PR TITLE
[enhance](multi-catalog) Split metadata scan ranges per split

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/tvf/source/MetadataScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/tvf/source/MetadataScanNode.java
@@ -90,11 +90,10 @@ public class MetadataScanNode extends ExternalScanNode {
             scanRangeLocations.add(locations);
         } else {
             // need to split ranges to send to backends
-            List<Backend> backends = Lists.newArrayList(backendPolicy.getBackends());
             List<String> splits = metaScanRange.getSerializedSplits();
             for (int i = 0; i < splits.size(); i++) {
                 String split = splits.get(i);
-                Backend backend = backends.get(i % backends.size());
+                Backend backend = backendPolicy.getNextBe();
 
                 TMetaScanRange subRange = metaScanRange.deepCopy();
                 subRange.setSerializedSplits(Lists.newArrayList(split));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/tvf/source/MetadataScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/tvf/source/MetadataScanNode.java
@@ -92,21 +92,14 @@ public class MetadataScanNode extends ExternalScanNode {
             // need to split ranges to send to backends
             List<Backend> backends = Lists.newArrayList(backendPolicy.getBackends());
             List<String> splits = metaScanRange.getSerializedSplits();
-            int numSplitsPerBE = Math.max(1, splits.size() / backends.size());
+            for (int i = 0; i < splits.size(); i++) {
+                String split = splits.get(i);
+                Backend backend = backends.get(i % backends.size());
 
-            for (int i = 0; i < backends.size(); i++) {
-                int from = i * numSplitsPerBE;
-                if (from >= splits.size()) {
-                    continue; // no splits for this backend
-                }
-                int to = Math.min((i + 1) * numSplitsPerBE, splits.size());
-
-                // set splited task to TMetaScanRange
                 TMetaScanRange subRange = metaScanRange.deepCopy();
-                subRange.setSerializedSplits(splits.subList(from, to));
+                subRange.setSerializedSplits(Lists.newArrayList(split));
 
                 TScanRangeLocation location = new TScanRangeLocation();
-                Backend backend = backends.get(i);
                 location.setBackendId(backend.getId());
                 location.setServer(new TNetworkAddress(backend.getHost(), backend.getBePort()));
 


### PR DESCRIPTION
### What problem does this PR solve?

- related pr: #54804 

Metadata scans (e.g., Iceberg all_files) can produce many splits, but the prior logic grouped them into at most one scan range per backend, which capped `NumScanners` and `MaxScanConcurrency` at 1 in common cases. This change aligns metadata scans with per-split assignment used by file scans, enabling higher parallelism.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

