### PR TITLE
[fix](filecache) add ttl mgr NOT_FOUND cleanup

### DIFF
--- a/be/src/io/cache/block_file_cache_ttl_mgr.h
+++ b/be/src/io/cache/block_file_cache_ttl_mgr.h
@@ -19,10 +19,12 @@
 
 #pragma once
 
+#include <bvar/bvar.h>
 #include <concurrentqueue.h>
 
 #include <atomic>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <unordered_set>
@@ -73,6 +75,8 @@ private:
     std::thread _tablet_id_flush_thread;
 
     std::mutex _ttl_info_mutex;
+
+    std::shared_ptr<bvar::Status<size_t>> _tablet_id_set_size_metrics;
 };
 
 } // namespace doris::io


### PR DESCRIPTION
This commit does the followings:
1. Drop missing tablet ids on NOT_FOUND to stop repeated TTL meta lookups and log spam
2. add bvar for tablet-id set size to monitor cleanup behavior

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

