### PR TITLE
[bugfix](arrowflight) should call done run in on_xxx method to make work in async mode

### DIFF
--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -671,8 +671,7 @@ void PInternalService::fetch_arrow_data(google::protobuf::RpcController* control
                                         PFetchArrowDataResult* result,
                                         google::protobuf::Closure* done) {
     bool ret = _arrow_flight_work_pool.try_offer([request, result, done]() {
-        brpc::ClosureGuard closure_guard(done);
-        auto ctx = vectorized::GetArrowResultBatchCtx::create_shared(result);
+        auto ctx = vectorized::GetArrowResultBatchCtx::create_shared(result, done);
         TUniqueId unique_id = UniqueId(request->finst_id()).to_thrift(); // query_id or instance_id
         std::shared_ptr<vectorized::ArrowFlightResultBlockBuffer> arrow_buffer;
         auto st = ExecEnv::GetInstance()->result_mgr()->find_buffer(unique_id, arrow_buffer);

--- a/be/src/vec/sink/varrow_flight_result_writer.cpp
+++ b/be/src/vec/sink/varrow_flight_result_writer.cpp
@@ -33,6 +33,7 @@ namespace doris::vectorized {
 void GetArrowResultBatchCtx::on_failure(const Status& status) {
     DCHECK(!status.ok()) << "status is ok, errmsg=" << status;
     status.to_protobuf(_result->mutable_status());
+    _done->Run();
 }
 
 void GetArrowResultBatchCtx::on_close(int64_t packet_seq, int64_t /* returned_rows */) {
@@ -40,6 +41,7 @@ void GetArrowResultBatchCtx::on_close(int64_t packet_seq, int64_t /* returned_ro
     status.to_protobuf(_result->mutable_status());
     _result->set_packet_seq(packet_seq);
     _result->set_eos(true);
+    _done->Run();
 }
 
 Status GetArrowResultBatchCtx::on_data(const std::shared_ptr<vectorized::Block>& block,
@@ -72,6 +74,8 @@ Status GetArrowResultBatchCtx::on_data(const std::shared_ptr<vectorized::Block>&
         _result->clear_block();
     }
     st.to_protobuf(_result->mutable_status());
+
+    _done->Run();
     return Status::OK();
 }
 

--- a/be/src/vec/sink/varrow_flight_result_writer.h
+++ b/be/src/vec/sink/varrow_flight_result_writer.h
@@ -35,7 +35,8 @@ class GetArrowResultBatchCtx {
 public:
     using ResultType = vectorized::Block;
     ENABLE_FACTORY_CREATOR(GetArrowResultBatchCtx)
-    GetArrowResultBatchCtx(PFetchArrowDataResult* result) : _result(result) {}
+    GetArrowResultBatchCtx(PFetchArrowDataResult* result, google::protobuf::Closure* done)
+            : _result(result), _done(done) {}
 #ifdef BE_TEST
     GetArrowResultBatchCtx() = default;
 #endif
@@ -53,6 +54,7 @@ private:
     int32_t _max_msg_size = std::numeric_limits<int32_t>::max();
 #endif
     PFetchArrowDataResult* _result = nullptr;
+    google::protobuf::Closure* _done = nullptr;
 };
 
 class ArrowFlightResultBlockBuffer final : public ResultBlockBuffer<GetArrowResultBatchCtx> {

--- a/be/test/vec/sink/get_result_batch_test.cpp
+++ b/be/test/vec/sink/get_result_batch_test.cpp
@@ -40,10 +40,10 @@ public:
 
 class MockClosure : public google::protobuf::Closure {
 public:
+    MockClosure() {}
     MockClosure(std::function<void()> cb) : _cb(cb) {}
     void Run() override { _cb(); }
 
-private:
     std::function<void()> _cb;
 };
 
@@ -126,7 +126,9 @@ TEST_F(GetResultBatchCtxTest, TestGetResultBatchCtx) {
 
 TEST_F(GetResultBatchCtxTest, TestGetArrowResultBatchCtx) {
     PFetchArrowDataResult result;
-    auto ctx = GetArrowResultBatchCtx::create_shared(&result);
+    MockClosure closure;
+    closure._cb = [&]() { std::cout << "cb" << std::endl; };
+    auto ctx = GetArrowResultBatchCtx::create_shared(&result, &closure);
 
     {
         // on_failure


### PR DESCRIPTION
### What problem does this PR solve?
there is a logic similar to our FE fetching data from the BE: if the data is not available, it will be added to a waiting queue. Once added to the waiting queue, the guard will invoke the run method automatically.
At this point, the data received by the client is actually undefined, yet the status of this undefined value is unexpectedly ok. As a result, the program attempts to read the block value, leading to a dirty read.
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

