### PR TITLE
[fix](query cache) fix query cache not hit when use sort and one phase aggregation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/normalize/QueryCacheNormalizer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/normalize/QueryCacheNormalizer.java
@@ -25,6 +25,7 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.common.Pair;
 import org.apache.doris.planner.AggregationNode;
+import org.apache.doris.planner.ExchangeNode;
 import org.apache.doris.planner.OlapScanNode;
 import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.planner.PlanNode;
@@ -128,6 +129,10 @@ public class QueryCacheNormalizer implements Normalizer {
                     return Optional.of(new CachePoint(planRoot, planRoot));
                 }
             }
+        } else if (planRoot instanceof ExchangeNode) {
+            return Optional.empty();
+        } else if (planRoot.getChildren().size() == 1) {
+            return doComputeCachePoint(planRoot.getChildren().get(0));
         }
         return Optional.empty();
     }


### PR DESCRIPTION
### What problem does this PR solve?

fix query cache not hit when one fragment contains sort and one phase aggregation

```
Exchange
   |
  Sort
   |
Aggregation
   |
  Scan
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

