### PR TITLE
[Enhancement](RE2) Silence RE2 stderr in regexp function

### DIFF
--- a/be/src/vec/functions/function_regexp.cpp
+++ b/be/src/vec/functions/function_regexp.cpp
@@ -64,7 +64,11 @@ struct RegexpExtractEngine {
     // Try to compile with RE2 first, fallback to Boost.Regex if RE2 fails
     static bool compile(const StringRef& pattern, std::string* error_str,
                         RegexpExtractEngine& engine, bool enable_extended_regex) {
-        engine.re2_regex = std::make_unique<re2::RE2>(re2::StringPiece(pattern.data, pattern.size));
+        re2::RE2::Options options;
+        options.set_log_errors(false); // avoid RE2 printing to stderr; we handle errors ourselves
+        engine.re2_regex =
+                std::make_unique<re2::RE2>(re2::StringPiece(pattern.data, pattern.size), options);
+
         if (engine.re2_regex->ok()) {
             return true;
         } else if (!enable_extended_regex) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: https://github.com/apache/doris/pull/57643

Problem Summary:

In Doris's regexp function, `RE2` is used for regular expression parsing. If parsing fails, an error will be generated in be.out. However, since we will try to fallback to `boost` for a second parsing, these errors in be.out may be noise. We should handle the errors ourselves rather than relying on RE2.

```text
/home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/re2-2021-02-02/re2/re2.cc:206: Error parsing '(?<=foo)(\d+)(?=bar)': invalid perl operator: (?<
/home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/re2-2021-02-02/re2/re2.cc:206: Error parsing '(?<=foo)(\d+)(?=bar)': invalid perl operator: (?<
/home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/re2-2021-02-02/re2/re2.cc:206: Error parsing '(?<=foo)(\d+)(?=bar)': invalid perl operator: (?<
/home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/re2-2021-02-02/re2/re2.cc:206: Error parsing '(?<=foo)(\d+)(?=bar)': invalid perl operator: (?<
/home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/re2-2021-02-02/re2/re2.cc:206: Error parsing '(?<=foo)(\d+)(?=bar)': invalid perl operator: (?<
/home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/re2-2021-02-02/re2/re2.cc:206: Error parsing '(?<=foo)(\d+)(?=bar)': invalid perl operator: (?<
/home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/re2-2021-02-02/re2/re2.cc:206: Error parsing '(?<=foo)(\d+)(?=bar)': invalid perl operator: (?<
/home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/re2-2021-02-02/re2/re2.cc:206: Error parsing '(?<=foo)(\d+)(?=bar)': invalid perl operator: (?<
/home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/re2-2021-02-02/re2/re2.cc:206: Error parsing '(?<=foo)(\d+)(?=bar)': invalid perl operator: (?<
/home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/re2-2021-02-02/re2/re2.cc:206: Error parsing '(?<=foo)(\d+)(?=bar)': invalid perl operator: (?<
/home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/re2-2021-02-02/re2/re2.cc:206: Error parsing '(?<=foo)(\d+)(?=bar)': invalid perl operator: (?<
/home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/re2-2021-02-02/re2/re2.cc:206: Error parsing '(EdgeCase\d)(?= EdgeCase|$)': invalid perl operator: (?=
/home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/re2-2021-02-02/re2/re2.cc:206: Error parsing '(EdgeCase\d)(?= EdgeCase|$)': invalid perl operator: (?=
...
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

