### PR TITLE
[util](exec)Provide utilities for batching blocks.

### DIFF
--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -396,6 +396,8 @@ public:
     size_t rows() const;
     size_t columns() const { return _columns.size(); }
 
+    bool is_empty_column() const { return _columns.empty(); }
+
     bool empty() const { return rows() == 0; }
 
     MutableColumns& mutable_columns() { return _columns; }

--- a/be/src/vec/core/block_accumulator.cpp
+++ b/be/src/vec/core/block_accumulator.cpp
@@ -1,0 +1,157 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "block_accumulator.h"
+
+#include <glog/logging.h>
+
+#include "vec/core/block.h"
+
+namespace doris::vectorized {
+
+Status BlockAccumulator::push(Block&& block) {
+    size_t input_rows = block.rows();
+    for (size_t start = 0; start < input_rows;) {
+        size_t remain_rows = input_rows - start;
+        size_t need_rows = 0;
+        if (!_tmp_block.is_empty_column()) {
+            // If tmp_block is not empty, it means there was a previous block that didn't reach batch_size, need to continue adding data
+            need_rows = std::min(_batch_size - _tmp_block.rows(), remain_rows);
+            RETURN_IF_ERROR(_tmp_block.add_rows(&block, start, need_rows));
+        } else {
+            // If tmp_block is empty, can directly create a new tmp_block
+            need_rows = std::min(_batch_size, remain_rows);
+            _tmp_block = block.clone_empty();
+            RETURN_IF_ERROR(_tmp_block.add_rows(&block, start, need_rows));
+        }
+        if (_tmp_block.rows() >= _batch_size) {
+            // If tmp_block's row count reaches or exceeds batch_size, push it to the queue
+            // But theoretically it should not exceed batch_size
+            // Will be checked in push_tmp_block_to_queue()
+            RETURN_IF_ERROR(push_tmp_block_to_queue());
+        }
+        start += need_rows;
+    }
+    return Status::OK();
+}
+
+Status BlockAccumulator::set_finish() {
+    if (_tmp_block.rows() > 0) {
+        RETURN_IF_ERROR(push_tmp_block_to_queue());
+    }
+    return Status::OK();
+}
+
+Status BlockAccumulator::push_tmp_block_to_queue() {
+    if (_tmp_block.rows() > _batch_size) {
+        return Status::InternalError(
+                "tmp block rows exceed batch size , tmp block rows: {}, batch size: {}",
+                _tmp_block.rows(), _batch_size);
+    }
+    Block block = _tmp_block.to_block();
+    _queue.push_back(std::move(block));
+    _tmp_block.clear();
+    return Status::OK();
+}
+
+bool BlockAccumulator::pull(Block& block) {
+    if (_queue.empty()) {
+        return false;
+    }
+    block = std::move(_queue.front());
+    _queue.pop_front();
+    return true;
+}
+
+void BlockAccumulator::close() {
+    _queue.clear();
+    _tmp_block.clear();
+}
+
+Status PipelineBlockAccumulator::push(Block&& block) {
+    if (_is_finished) {
+        return Status::InternalError("cannot push data after finished");
+    }
+
+    if (!_in_block) {
+        // If there is no in_block currently, directly use the new block as in_block
+        _in_block = MutableBlock::create_unique(std::move(block));
+    } else if (_in_block->rows() + block.rows() >= _batch_size) {
+        // If current in_block plus the new block exceeds batch_size, first make current in_block as out_block
+        // Then use the new block as the new in_block
+        DCHECK_EQ(_out_block, nullptr);
+        _out_block = Block::create_unique(_in_block->to_block());
+        _in_block = MutableBlock::create_unique(std::move(block));
+    } else {
+        // Otherwise append the new block to the current in_block
+        RETURN_IF_ERROR(_in_block->merge(block));
+    }
+    return Status::OK();
+}
+
+Status PipelineBlockAccumulator::push_with_selector(Block&& block,
+                                                    const IColumn::Selector& selector) {
+    if (_is_finished) {
+        return Status::InternalError("cannot push data after finished");
+    }
+
+    if (!_in_block) {
+        // If there is no in_block currently, directly use the new block (with selector) as in_block
+        _in_block = MutableBlock::create_unique(block.clone_empty());
+        RETURN_IF_ERROR(block.append_to_block_by_selector(_in_block.get(), selector));
+    } else if (_in_block->rows() + block.rows() >= _batch_size) {
+        // If current in_block plus the new block exceeds batch_size, first make current in_block as out_block
+        // Then use the new block (with selector) as the new in_block
+        DCHECK_EQ(_out_block, nullptr);
+        _out_block = Block::create_unique(_in_block->to_block());
+        _in_block = MutableBlock::create_unique(block.clone_empty());
+        RETURN_IF_ERROR(block.append_to_block_by_selector(_in_block.get(), selector));
+    } else {
+        // Otherwise append the new block (with selector) to the current in_block
+        RETURN_IF_ERROR(block.append_to_block_by_selector(_in_block.get(), selector));
+    }
+    return Status::OK();
+}
+
+BlockUPtr PipelineBlockAccumulator::pull() {
+    if (_is_finished && _out_block == nullptr && _in_block != nullptr) {
+        auto result = Block::create_unique(_in_block->to_block());
+        _in_block = nullptr;
+        return result;
+    }
+    auto result = std::move(_out_block);
+    _out_block = nullptr;
+    return result;
+}
+
+bool PipelineBlockAccumulator::has_output() {
+    return _out_block != nullptr || (_is_finished && _in_block != nullptr);
+}
+
+bool PipelineBlockAccumulator::need_input() {
+    return !_is_finished && _out_block == nullptr;
+}
+
+bool PipelineBlockAccumulator::is_finished() {
+    return _is_finished && _out_block == nullptr && _in_block == nullptr;
+}
+
+void PipelineBlockAccumulator::set_finish() {
+    _is_finished = true;
+}
+
+}; // namespace doris::vectorized

--- a/be/src/vec/core/block_accumulator.h
+++ b/be/src/vec/core/block_accumulator.h
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "block.h"
+
+namespace doris::vectorized {
+
+// Used to accumulate Blocks, ensuring each Block's row count reaches batch_size as much as possible.
+// Not thread-safe.
+// Usage: continuously push, finally call finish to indicate all data has been pushed.
+// Then call has_output and pull interfaces to get the accumulated Block.
+class BlockAccumulator {
+public:
+    BlockAccumulator(size_t batch_size) : _batch_size(batch_size) {}
+
+    Status push(Block&& block);
+
+    Status set_finish();
+
+    bool has_output() const { return !_queue.empty(); }
+
+    bool pull(Block& block);
+
+    void close();
+
+private:
+    Status push_tmp_block_to_queue();
+
+    std::list<Block> _queue;
+
+    MutableBlock _tmp_block;
+
+    const size_t _batch_size;
+};
+
+// Used for accumulation in pipeline mode. Unlike BlockAccumulator, it cannot continuously push data.
+// Use has_output() to determine if data can be pulled.
+// Use need_input() to determine if data can be pushed.
+// The correct usage flow is: keep pushing until need_input() returns false, then pull data.
+// Currently used in StatefulOperator: need_input() is called in need_more_input_data(), push() in push(), pull() in pull().
+// After set_finish() is called, it indicates all data has been pushed and no more data can be pushed.
+// Not thread-safe.
+
+///TODO: Consider memory reuse?
+class PipelineBlockAccumulator {
+public:
+    PipelineBlockAccumulator(size_t batch_size) : _batch_size(batch_size) {}
+
+    Status push(Block&& block);
+
+    Status push_with_selector(Block&& block, const IColumn::Selector& selector);
+
+    BlockUPtr pull();
+
+    bool has_output();
+
+    bool need_input();
+
+    void set_finish();
+
+    bool is_finished();
+
+    void close() {
+        _in_block = nullptr;
+        _out_block = nullptr;
+    }
+
+private:
+    std::unique_ptr<MutableBlock> _in_block;
+    std::unique_ptr<Block> _out_block;
+
+    const size_t _batch_size;
+    bool _is_finished = false;
+};
+
+}; // namespace doris::vectorized

--- a/be/test/vec/core/block_accumulator_test.cpp
+++ b/be/test/vec/core/block_accumulator_test.cpp
@@ -1,0 +1,225 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/core/block_accumulator.h"
+
+#include <gtest/gtest.h>
+
+#include "testutil/column_helper.h"
+
+namespace doris::vectorized {
+
+static std::vector<int32_t> range_i32(int32_t start, int32_t end_inclusive) {
+    std::vector<int32_t> v;
+    v.reserve(end_inclusive - start + 1);
+    for (int32_t i = start; i <= end_inclusive; ++i) v.emplace_back(i);
+    return v;
+}
+
+TEST(BlockAccumulatorTest, BasicAccumulateAndFinish) {
+    const size_t batch_size = 16;
+    BlockAccumulator acc(batch_size);
+
+    // Input: 10 rows then 20 rows -> expect outputs: 16 rows, then 14 rows (on finish)
+    Block b1 = ColumnHelper::create_block<DataTypeInt32>(range_i32(1, 10));
+    Block b2 = ColumnHelper::create_block<DataTypeInt32>(range_i32(11, 30));
+
+    EXPECT_TRUE(acc.push(std::move(b1)).ok());
+    EXPECT_TRUE(acc.push(std::move(b2)).ok());
+    EXPECT_TRUE(acc.set_finish().ok());
+
+    EXPECT_TRUE(acc.has_output());
+    Block out1;
+    EXPECT_TRUE(acc.pull(out1));
+    Block expect1 = ColumnHelper::create_block<DataTypeInt32>(range_i32(1, 16));
+    EXPECT_TRUE(ColumnHelper::block_equal(out1, expect1));
+
+    EXPECT_TRUE(acc.has_output());
+    Block out2;
+    EXPECT_TRUE(acc.pull(out2));
+    Block expect2 = ColumnHelper::create_block<DataTypeInt32>(range_i32(17, 30));
+    EXPECT_TRUE(ColumnHelper::block_equal(out2, expect2));
+
+    EXPECT_FALSE(acc.has_output());
+    Block out3;
+    EXPECT_FALSE(acc.pull(out3));
+}
+
+TEST(BlockAccumulatorTest, ExactMultipleOfBatch) {
+    const size_t batch_size = 16;
+    BlockAccumulator acc(batch_size);
+
+    Block b1 = ColumnHelper::create_block<DataTypeInt32>(range_i32(1, 16));
+    Block b2 = ColumnHelper::create_block<DataTypeInt32>(range_i32(17, 32));
+
+    EXPECT_TRUE(acc.push(std::move(b1)).ok());
+    EXPECT_TRUE(acc.push(std::move(b2)).ok());
+    EXPECT_TRUE(acc.set_finish().ok());
+
+    EXPECT_TRUE(acc.has_output());
+    Block out1;
+    EXPECT_TRUE(acc.pull(out1));
+    Block expect1 = ColumnHelper::create_block<DataTypeInt32>(range_i32(1, 16));
+    EXPECT_TRUE(ColumnHelper::block_equal(out1, expect1));
+
+    EXPECT_TRUE(acc.has_output());
+    Block out2;
+    EXPECT_TRUE(acc.pull(out2));
+    Block expect2 = ColumnHelper::create_block<DataTypeInt32>(range_i32(17, 32));
+    EXPECT_TRUE(ColumnHelper::block_equal(out2, expect2));
+
+    EXPECT_FALSE(acc.has_output());
+}
+
+TEST(BlockAccumulatorTest, CloseClearsState) {
+    const size_t batch_size = 8;
+    BlockAccumulator acc(batch_size);
+
+    Block b = ColumnHelper::create_block<DataTypeInt32>(range_i32(1, 8));
+    EXPECT_TRUE(acc.push(std::move(b)).ok());
+    EXPECT_TRUE(acc.set_finish().ok());
+    EXPECT_TRUE(acc.has_output());
+
+    acc.close();
+    EXPECT_FALSE(acc.has_output());
+    Block out;
+    EXPECT_FALSE(acc.pull(out));
+}
+
+TEST(BlockAccumulatorTest, Test) {
+    const size_t batch_size = 8;
+    BlockAccumulator acc(batch_size);
+
+    Block b = ColumnHelper::create_block<DataTypeInt32>(range_i32(1, 4));
+
+    EXPECT_TRUE(acc.push(std::move(b)).ok());
+    EXPECT_FALSE(acc.has_output());
+
+    Block b2 = ColumnHelper::create_block<DataTypeInt32>(range_i32(5, 10));
+    EXPECT_TRUE(acc.push(std::move(b2)).ok());
+    EXPECT_TRUE(acc.has_output());
+
+    Block out1;
+    EXPECT_TRUE(acc.pull(out1));
+    Block expect1 = ColumnHelper::create_block<DataTypeInt32>(range_i32(1, 8));
+    EXPECT_TRUE(ColumnHelper::block_equal(out1, expect1));
+
+    EXPECT_FALSE(acc.has_output());
+
+    EXPECT_TRUE(acc.set_finish().ok());
+    EXPECT_TRUE(acc.has_output());
+
+    Block out2;
+    EXPECT_TRUE(acc.pull(out2));
+    Block expect2 = ColumnHelper::create_block<DataTypeInt32>(range_i32(9, 10));
+    EXPECT_TRUE(ColumnHelper::block_equal(out2, expect2));
+
+    EXPECT_FALSE(acc.has_output());
+}
+
+TEST(PipelineBlockAccumulatorTest, OutputOnThresholdThenFinalOnFinish) {
+    const size_t batch_size = 16;
+    PipelineBlockAccumulator acc(batch_size);
+
+    // Push 10 rows: no output yet
+    Block b1 = ColumnHelper::create_block<DataTypeInt32>(range_i32(1, 10));
+    EXPECT_TRUE(acc.push(std::move(b1)).ok());
+    EXPECT_FALSE(acc.has_output());
+    EXPECT_TRUE(acc.need_input());
+
+    // Push 20 rows: rows(10) + rows(20) >= 16 -> output first block (10 rows)
+    Block b2 = ColumnHelper::create_block<DataTypeInt32>(range_i32(11, 30));
+    EXPECT_TRUE(acc.push(std::move(b2)).ok());
+    EXPECT_TRUE(acc.has_output());
+
+    auto out1 = acc.pull();
+    EXPECT_NE(out1, nullptr);
+    Block expect_first = ColumnHelper::create_block<DataTypeInt32>(range_i32(1, 10));
+    EXPECT_TRUE(ColumnHelper::block_equal(*out1, expect_first));
+
+    // After consuming output, should need input if not finished
+    EXPECT_TRUE(acc.need_input());
+
+    // Finish: should have final output (the second block of 20 rows)
+    acc.set_finish();
+    EXPECT_TRUE(acc.has_output());
+    auto final_out = acc.pull();
+    EXPECT_NE(final_out, nullptr);
+    Block expect_final = ColumnHelper::create_block<DataTypeInt32>(range_i32(11, 30));
+    EXPECT_TRUE(ColumnHelper::block_equal(*final_out, expect_final));
+}
+
+TEST(PipelineBlockAccumulatorTest, MergeBelowThresholdThenFinish) {
+    const size_t batch_size = 16;
+    PipelineBlockAccumulator acc(batch_size);
+
+    // Two small blocks totaling below threshold: should merge, no immediate output
+    Block b1 = ColumnHelper::create_block<DataTypeInt32>(range_i32(1, 7));
+    Block b2 = ColumnHelper::create_block<DataTypeInt32>(range_i32(8, 12)); // total 12
+    EXPECT_TRUE(acc.push(std::move(b1)).ok());
+    EXPECT_FALSE(acc.has_output());
+    EXPECT_TRUE(acc.push(std::move(b2)).ok());
+    EXPECT_FALSE(acc.has_output());
+
+    // Finish: one final merged output with 12 rows
+    acc.set_finish();
+    EXPECT_TRUE(acc.has_output());
+    auto out = acc.pull();
+    EXPECT_NE(out, nullptr);
+    Block expect = ColumnHelper::create_block<DataTypeInt32>(range_i32(1, 12));
+    EXPECT_TRUE(ColumnHelper::block_equal(*out, expect));
+}
+
+TEST(PipelineBlockAccumulatorTest, pushWithSelector) {
+    const size_t batch_size = 8;
+    PipelineBlockAccumulator acc(batch_size);
+
+    Block b = ColumnHelper::create_block<DataTypeInt32>(range_i32(1, 10));
+    // Selector to pick rows 0, 2, 4, 6,
+    IColumn::Selector selector;
+    selector.push_back(0);
+    selector.push_back(2);
+    selector.push_back(4);
+    selector.push_back(6);
+
+    EXPECT_TRUE(acc.push_with_selector(std::move(b), selector).ok());
+    EXPECT_FALSE(acc.has_output());
+
+    acc.set_finish();
+    EXPECT_TRUE(acc.has_output());
+
+    auto out = acc.pull();
+    EXPECT_NE(out, nullptr);
+    Block expect = ColumnHelper::create_block<DataTypeInt32>({1, 3, 5, 7});
+
+    EXPECT_TRUE(ColumnHelper::block_equal(*out, expect));
+}
+
+TEST(PipelineBlockAccumulatorTest, error) {
+    const size_t batch_size = 8;
+    PipelineBlockAccumulator acc(batch_size);
+
+    acc.set_finish();
+
+    Block b = ColumnHelper::create_block<DataTypeInt32>(range_i32(1, 10));
+
+    EXPECT_FALSE(acc.push(std::move(b)).ok());
+
+    EXPECT_FALSE(acc.push_with_selector(std::move(b), IColumn::Selector {}).ok());
+}
+
+} // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?

Previously, some operators could internally produce blocks that were significantly smaller than the batch size (for example, join or stream aggregation). 
We used to accumulate blocks inside those operators to ensure the final output blocks were as close to the batch size as possible. 
This PR introduces utilities to handle that (which were previously maintained manually) and applies them to the DistinctStreamingAgg operator.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

