### PR TITLE
[fix](query cache) query cache shouldn't be hitted when session variable changed or use udf

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -1264,7 +1264,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         }
         updateLegacyPlanIdToPhysicalPlan(inputPlanFragment.getPlanRoot(), aggregate);
 
-        if (context.getConnectContext().getSessionVariable().getEnableQueryCache()) {
+        if (!ConnectContext.get().getSessionVariable().getEnableQueryCache()) {
             setQueryCacheCandidate(aggregate, aggregationNode);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -1264,7 +1264,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         }
         updateLegacyPlanIdToPhysicalPlan(inputPlanFragment.getPlanRoot(), aggregate);
 
-        if (!ConnectContext.get().getSessionVariable().getEnableQueryCache()) {
+        if (ConnectContext.get().getSessionVariable().getEnableQueryCache()) {
             setQueryCacheCandidate(aggregate, aggregationNode);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -34,6 +34,7 @@ import org.apache.doris.analysis.SortInfo;
 import org.apache.doris.analysis.TableSample;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.analysis.TupleId;
+import org.apache.doris.catalog.AliasFunction;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OdbcTable;
@@ -101,9 +102,11 @@ import org.apache.doris.nereids.trees.expressions.SessionVarGuardExpr;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.WindowFrame;
+import org.apache.doris.nereids.trees.expressions.functions.Udf;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateParam;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.GroupingScalarFunction;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.UniqueFunction;
 import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.AggMode;
 import org.apache.doris.nereids.trees.plans.AggPhase;
@@ -231,6 +234,7 @@ import org.apache.doris.thrift.TRuntimeFilterType;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -251,7 +255,9 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -507,7 +513,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         List<Expr> partitionExprs = olapTableSink.getPartitionExprList().stream()
                 .map(e -> ExpressionTranslator.translate(e, context)).collect(Collectors.toList());
         Map<Long, Expr> syncMvWhereClauses = new HashMap<>();
-        for (Map.Entry<Long, Expression> entry : olapTableSink.getSyncMvWhereClauses().entrySet()) {
+        for (Entry<Long, Expression> entry : olapTableSink.getSyncMvWhereClauses().entrySet()) {
             syncMvWhereClauses.put(entry.getKey(), ExpressionTranslator.translate(entry.getValue(), context));
         }
         OlapTableSink sink;
@@ -1257,6 +1263,11 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
             aggregationNode.setCardinality((long) aggregate.getStats().getRowCount());
         }
         updateLegacyPlanIdToPhysicalPlan(inputPlanFragment.getPlanRoot(), aggregate);
+
+        if (context.getConnectContext().getSessionVariable().getEnableQueryCache()) {
+            setQueryCacheCandidate(aggregate, aggregationNode);
+        }
+
         return inputPlanFragment;
     }
 
@@ -2457,7 +2468,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
                 context.getTopnFilterContext().translateSource(topN, sortNode);
                 TopnFilter filter = context.getTopnFilterContext().getTopnFilter(topN);
                 List<Pair<Integer, Integer>> targets = new ArrayList<>();
-                for (Map.Entry<ScanNode, Expr> entry : filter.legacyTargets.entrySet()) {
+                for (Entry<ScanNode, Expr> entry : filter.legacyTargets.entrySet()) {
                     Set<SlotRef> inputSlots = entry.getValue().getInputSlotRef();
                     if (inputSlots.size() != 1) {
                         LOG.warn("topn filter targets error: " + inputSlots);
@@ -2548,7 +2559,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
                 .collect(ImmutableList.toImmutableList());
 
         // outputSlots's order must match preRepeatExprs, then grouping id, then grouping function slots
-        ImmutableList.Builder<Slot> outputSlotsBuilder
+        Builder<Slot> outputSlotsBuilder
                 = ImmutableList.builderWithExpectedSize(repeat.getOutputExpressions().size() + 1);
         outputSlotsBuilder.addAll(preRepeatExpressions);
         outputSlotsBuilder.add(repeat.getGroupingId().toSlot());
@@ -3220,5 +3231,84 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
             child = child.child(0);
         }
         return child instanceof PhysicalRelation;
+    }
+
+    private boolean setQueryCacheCandidate(
+            PhysicalHashAggregate<? extends Plan> aggregate, AggregationNode aggregationNode) {
+        if (hasUndeterministicExpression(aggregate)) {
+            return false;
+        }
+
+        PlanNode child = aggregationNode.getChild(0);
+        if (child instanceof AggregationNode) {
+            if (((AggregationNode) child).isQueryCacheCandidate()) {
+                aggregationNode.setQueryCacheCandidate(true);
+                return true;
+            }
+        } else if (child instanceof OlapScanNode) {
+            aggregationNode.setQueryCacheCandidate(true);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean hasUndeterministicExpression(Plan plan) {
+        String cacheKey = "hasUndeterministicExpression";
+        Optional<Boolean> hasUndeterministicExpressionCache = plan.getMutableState(cacheKey);
+        if (hasUndeterministicExpressionCache.isPresent()) {
+            return hasUndeterministicExpressionCache.get();
+        }
+        boolean result;
+        if (plan instanceof PhysicalHashAggregate) {
+            PhysicalHashAggregate<? extends Plan> aggregate = (PhysicalHashAggregate<? extends Plan>) plan;
+            if (hasUndeterministicExpression(aggregate.getGroupByExpressions())
+                    || hasUndeterministicExpression(aggregate.getOutputExpressions())) {
+                result = true;
+            } else {
+                result = hasUndeterministicExpression(aggregate.child());
+            }
+        } else if (plan instanceof PhysicalFilter) {
+            PhysicalFilter<? extends Plan> filter = (PhysicalFilter<? extends Plan>) plan;
+            if (hasUndeterministicExpression(filter.getExpressions())) {
+                result = true;
+            } else {
+                result = hasUndeterministicExpression(filter.child());
+            }
+        } else if (plan instanceof PhysicalProject) {
+            PhysicalProject<? extends Plan> project = (PhysicalProject<? extends Plan>) plan;
+            if (hasUndeterministicExpression(project.getProjects())) {
+                result = true;
+            } else {
+                result = hasUndeterministicExpression(project.child());
+            }
+        } else if (plan instanceof PhysicalOlapScan) {
+            result = false;
+        } else {
+            // unsupported for query cache
+            result = true;
+        }
+        plan.setMutableState(cacheKey, result);
+        return result;
+    }
+
+    private boolean hasUndeterministicExpression(Collection<? extends Expression> expressions) {
+        for (Expression groupByExpression : expressions) {
+            if (groupByExpression.containsType(AliasFunction.class, Udf.class, UniqueFunction.class)) {
+                return true;
+            }
+
+            boolean nonDeterministic = groupByExpression.anyMatch(e -> {
+                if (e instanceof Expression) {
+                    if (!((Expression) e).isDeterministic()) {
+                        return true;
+                    }
+                }
+                return false;
+            });
+            if (nonDeterministic) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/AggregationNode.java
@@ -60,6 +60,8 @@ public class AggregationNode extends PlanNode {
 
     private SortInfo sortByGroupKey;
 
+    private boolean queryCacheCandidate;
+
     /**
      * Create an agg node that is not an intermediate node.
      * isIntermediate is true if it is a slave node in a 2-part agg plan.
@@ -243,5 +245,13 @@ public class AggregationNode extends PlanNode {
 
     public void setSortByGroupKey(SortInfo sortByGroupKey) {
         this.sortByGroupKey = sortByGroupKey;
+    }
+
+    public boolean isQueryCacheCandidate() {
+        return queryCacheCandidate;
+    }
+
+    public void setQueryCacheCandidate(boolean queryCacheCandidate) {
+        this.queryCacheCandidate = queryCacheCandidate;
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryCacheNormalizerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryCacheNormalizerTest.java
@@ -113,6 +113,7 @@ public class QueryCacheNormalizerTest extends TestWithFeService {
         createTables(nonPart, part1, part2, multiLeveParts);
 
         connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
+        connectContext.getSessionVariable().setEnableQueryCache(true);
     }
 
     @Test

--- a/regression-test/suites/query_p0/cache/query_cache.groovy
+++ b/regression-test/suites/query_p0/cache/query_cache.groovy
@@ -20,6 +20,8 @@ import java.util.stream.Collectors
 suite("query_cache") {
     def tableName = "table_3_undef_partitions2_keys3_properties4_distributed_by53"
 
+    sql "set enable_sql_cache=false"
+
     def test = {
         sql "set enable_query_cache=false"
 

--- a/regression-test/suites/query_p0/cache/query_cache_with_context.groovy
+++ b/regression-test/suites/query_p0/cache/query_cache_with_context.groovy
@@ -27,22 +27,22 @@ suite("query_cache_with_context") {
         set enable_query_cache=true;
         """
 
-    def test_session_variable_change = {
-        def getDigest = { def sqlStr ->
-            AtomicReference<String> result = new AtomicReference<>()
-            explain {
-                sql sqlStr
+    def getDigest = { def sqlStr ->
+        AtomicReference<String> result = new AtomicReference<>()
+        explain {
+            sql sqlStr
 
-                check {exp ->
-                    def digests = exp.split("\n").findAll { line -> line.contains("DIGEST") }
-                    if (!digests.isEmpty()) {
-                        result.set(digests.get(0).split(":")[1].trim())
-                    }
+            check {exp ->
+                def digests = exp.split("\n").findAll { line -> line.contains("DIGEST") }
+                if (!digests.isEmpty()) {
+                    result.set(digests.get(0).split(":")[1].trim())
                 }
             }
-            return result.get()
         }
+        return result.get()
+    }
 
+    def test_session_variable_change = {
         sql "set enable_decimal256=true"
         def digest1 = getDigest("select id from query_cache_with_context group by id")
         sql "set enable_decimal256=false"

--- a/regression-test/suites/query_p0/cache/query_cache_with_context.groovy
+++ b/regression-test/suites/query_p0/cache/query_cache_with_context.groovy
@@ -1,0 +1,65 @@
+import java.util.concurrent.atomic.AtomicReference
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("query_cache_with_context") {
+    multi_sql """
+        set enable_sql_cache=false;
+        set enable_query_cache=false;
+        drop table if exists query_cache_with_context;
+        create table query_cache_with_context(id int, value decimal(26, 4)) properties('replication_num'='1');
+        insert into query_cache_with_context values(1, 1), (2, 2), (3, 3);
+        set enable_query_cache=true;
+        """
+
+    def test_session_variable_change = {
+        def getDigest = { def sqlStr ->
+            AtomicReference<String> result = new AtomicReference<>()
+            explain {
+                sql sqlStr
+
+                check {exp ->
+                    def digests = exp.split("\n").findAll { line -> line.contains("DIGEST") }
+                    if (!digests.isEmpty()) {
+                        result.set(digests.get(0).split(":")[1].trim())
+                    }
+                }
+            }
+            return result.get()
+        }
+
+        sql "set enable_decimal256=true"
+        def digest1 = getDigest("select id from query_cache_with_context group by id")
+        sql "set enable_decimal256=false"
+        def digest2 = getDigest("select id from query_cache_with_context group by id")
+        assertNotEquals(digest1, digest2)
+    }()
+
+    def test_udf_function = {
+        def jarPath = """${context.config.suitePath}/javaudf_p0/jars/java-udf-case-jar-with-dependencies.jar"""
+        scp_udf_file_to_all_be(jarPath)
+        sql("DROP FUNCTION IF EXISTS test_udf_with_query_cache(string, int, int);")
+        sql """ CREATE FUNCTION test_udf_with_query_cache(string, int, int) RETURNS string PROPERTIES (
+                                "file"="file://${jarPath}",
+                                "symbol"="org.apache.doris.udf.StringTest",
+                                "type"="JAVA_UDF"
+                            ); """
+        String digest = getDigest("select test_udf_with_query_cache(id, 2, 3) from query_cache_with_context group by 1")
+        assertEquals(null, digest)
+    }()
+}


### PR DESCRIPTION
### What problem does this PR solve?

query cache shouldn't be hitted when session variable changed or use udf

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

