### PR TITLE
[fix](cloud) query fails when smooth upgrade primary BE not alive yet

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
@@ -579,7 +579,12 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
         secondaryClusterToBackends.remove(cluster);
     }
 
-    private void updateClusterToSecondaryBe(String cluster, long beId) {
+    /**
+     * Set secondary BE for the cluster. Used as query fallback when primary is unavailable.
+     * Also used during smooth upgrade: after migrating primary from old BE to new BE,
+     * set old BE as secondary so queries can still use old BE until new BE is alive.
+     */
+    public void updateClusterToSecondaryBe(String cluster, long beId) {
         long changeTimestamp = System.currentTimeMillis();
         if (LOG.isDebugEnabled()) {
             LOG.debug("add to secondary clusterId {}, beId {}, changeTimestamp {}, replica info {}",

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletRebalancer.java
@@ -1651,8 +1651,13 @@ public class CloudTabletRebalancer extends MasterDaemon {
                 if (db.getTableNullable(cloudReplica.getTableId()) == null) {
                     continue;
                 }
-                // update replica location info
+                // update replica location info: primary -> new BE (dstBe)
                 cloudReplica.updateClusterToPrimaryBe(clusterId, dstBe);
+                // Set old BE (srcBe) as secondary so queries can fall back to it when new BE
+                // is not alive yet (e.g. new BE heartbeat not registered). Otherwise
+                // hashReplicaToBe would exclude both: old BE (isSmoothUpgradeSrc) and new BE
+                // (not alive), causing COMPUTE_GROUPS_NO_ALIVE_BE.
+                cloudReplica.updateClusterToSecondaryBe(clusterId, srcBe);
                 UpdateCloudReplicaInfo info = new UpdateCloudReplicaInfo(cloudReplica.getDbId(),
                         cloudReplica.getTableId(), cloudReplica.getPartitionId(), cloudReplica.getIndexId(),
                         tablet.getId(), cloudReplica.getId(), clusterId, dstBe);


### PR DESCRIPTION
### What problem does this PR solve?

Root cause:
1. On the same host, old BE (e.g. heartbeat 9050) and new BE (e.g. 9051) run
   in parallel during smooth upgrade.
2. migrateTablets updates CloudReplica primary from old BE to new BE. At that
   time the new BE may not have registered or sent heartbeats, so it is not
   alive in FE.
3. updateClusterToPrimaryBe(clusterId, dstBe) also clears secondary for that
   cluster, so no fallback BE is left.
4. On query: primary (new BE) is not alive -> getSecondaryBackend() returns
   null -> code falls back to hashReplicaToBe().
5. hashReplicaToBe() only considers BEs with
   be.isQueryAvailable() && !be.isSmoothUpgradeSrc(). The old BE is excluded
   as smooth-upgrade source; the new BE is excluded because it is not alive.
   Result: no available BE and COMPUTE_GROUPS_NO_ALIVE_BE.

Fix:
- After switching primary to the new BE in migrateTablets, set the old BE
  (srcBe) as secondary for that cluster.
- Expose updateClusterToSecondaryBe in CloudReplica so the rebalancer can set
  this fallback.
- Queries then use primary when possible and fall back to secondary (old BE)
  when primary is not alive; isQueryAvailable() does not exclude the old BE
  by isSmoothUpgradeSrc(), so the old BE can still serve reads until the new
  BE becomes alive.


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

