### PR TITLE
[fix](inverted index) implement phrase-level BM25 scoring with phrase frequency

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index/query/phrase_query.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index/query/phrase_query.cpp
@@ -170,7 +170,7 @@ void PhraseQuery::search_by_skiplist(roaring::Roaring& roaring) {
             roaring.add(doc);
             int32_t norm = visit_node(*_lead1, Norm {});
             float score = _phrase_similarity->score(phrase_freq, static_cast<int64_t>(norm));
-            std::cout << "phrase_freq: " << phrase_freq << ", norm: " << norm << ", score: " << score << std::endl;
+
             _context->collection_similarity->collect(doc, score);
         } else {
             if (!matches(doc)) {

--- a/be/src/olap/rowset/segment_v2/inverted_index/query/phrase_query.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index/query/phrase_query.h
@@ -51,6 +51,7 @@ private:
 
     int32_t do_next(int32_t doc);
     bool matches(int32_t doc);
+    float count_phrase_freq(int32_t doc);
 
     void init_exact_phrase_matcher(const InvertedIndexQueryInfo& query_info, bool is_similarity);
     void init_sloppy_phrase_matcher(const InvertedIndexQueryInfo& query_info, bool is_similarity);
@@ -78,7 +79,7 @@ private:
 
     std::vector<Matcher> _matchers;
 
-    std::vector<SimilarityPtr> _similarities;
+    SimilarityPtr _phrase_similarity;
 };
 
 } // namespace doris::segment_v2

--- a/be/src/olap/rowset/segment_v2/inverted_index/query/phrase_query/exact_phrase_matcher.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index/query/phrase_query/exact_phrase_matcher.cpp
@@ -89,4 +89,13 @@ bool ExactPhraseMatcher::advance_position(PostingsAndPosition& posting, int32_t 
     return true;
 }
 
+float ExactPhraseMatcher::phrase_freq(int32_t doc) {
+    reset(doc);
+    float freq = 0.0F;
+    while (next_match()) {
+        freq += 1.0F;
+    }
+    return freq;
+}
+
 } // namespace doris::segment_v2::inverted_index

--- a/be/src/olap/rowset/segment_v2/inverted_index/query/phrase_query/exact_phrase_matcher.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index/query/phrase_query/exact_phrase_matcher.h
@@ -27,6 +27,7 @@ public:
 
     void reset(int32_t doc);
     bool next_match();
+    float phrase_freq(int32_t doc);
 
 private:
     bool advance_position(PostingsAndPosition& posting, int32_t target);

--- a/be/src/olap/rowset/segment_v2/inverted_index/query/phrase_query/ordered_sloppy_phrase_matcher.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index/query/phrase_query/ordered_sloppy_phrase_matcher.cpp
@@ -81,4 +81,17 @@ bool OrderedSloppyPhraseMatcher::advance_position(PostingsAndPosition& posting, 
     return true;
 }
 
+float OrderedSloppyPhraseMatcher::sloppy_weight() const {
+    return 1.0F / (1.0F + static_cast<float>(_match_width));
+}
+
+float OrderedSloppyPhraseMatcher::phrase_freq(int32_t doc) {
+    reset(doc);
+    float freq = 0.0F;
+    while (next_match()) {
+        freq += sloppy_weight();
+    }
+    return freq;
+}
+
 } // namespace doris::segment_v2::inverted_index

--- a/be/src/olap/rowset/segment_v2/inverted_index/query/phrase_query/ordered_sloppy_phrase_matcher.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index/query/phrase_query/ordered_sloppy_phrase_matcher.h
@@ -27,6 +27,8 @@ public:
 
     void reset(int32_t doc);
     bool next_match();
+    float sloppy_weight() const;
+    float phrase_freq(int32_t doc);
 
 private:
     bool stretch_to_order(PostingsAndPosition* prev_posting);

--- a/be/src/olap/rowset/segment_v2/inverted_index/query/phrase_query/sloppy_phrase_matcher.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index/query/phrase_query/sloppy_phrase_matcher.cpp
@@ -315,5 +315,18 @@ bool SloppyPhraseMatcher::init_complex() {
     return true;
 }
 
+float SloppyPhraseMatcher::sloppy_weight() const {
+    return 1.0F / (1.0F + static_cast<float>(_match_length));
+}
+
+float SloppyPhraseMatcher::phrase_freq(int32_t doc) {
+    reset(doc);
+    float freq = 0.0F;
+    while (next_match()) {
+        freq += sloppy_weight();
+    }
+    return freq;
+}
+
 #include "common/compile_check_end.h"
 } // namespace doris::segment_v2::inverted_index

--- a/be/src/olap/rowset/segment_v2/inverted_index/query/phrase_query/sloppy_phrase_matcher.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index/query/phrase_query/sloppy_phrase_matcher.h
@@ -32,6 +32,8 @@ public:
     void reset(int32_t doc);
     bool next_match();
     bool advance_rpts(PhrasePositions* pp);
+    float sloppy_weight() const;
+    float phrase_freq(int32_t doc);
 
 private:
     bool advance_pp(PhrasePositions* pp);

--- a/be/src/olap/rowset/segment_v2/inverted_index/util/docid_set_iterator.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index/util/docid_set_iterator.h
@@ -79,5 +79,12 @@ struct NextPosition {
     }
 };
 
+struct Norm {
+    template <typename T>
+    int32_t operator()(const T& iter) const {
+        return iter->norm();
+    }
+};
+
 #include "common/compile_check_end.h"
 } // namespace doris::segment_v2

--- a/be/src/olap/rowset/segment_v2/inverted_index/util/mock_iterator.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index/util/mock_iterator.h
@@ -89,6 +89,8 @@ public:
         return current_doc->second[pos_idx++];
     }
 
+    int32_t norm() const MOCK_DEFINE(override) { return 1; }
+
     bool read_range(DocRange* doc_range) const MOCK_DEFINE(override) {
         if (!doc_range) {
             return false;

--- a/be/src/olap/rowset/segment_v2/inverted_index/util/union_term_iterator.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index/util/union_term_iterator.h
@@ -129,7 +129,6 @@ public:
             top = _docs_queue->update_top();
         } while (top->doc_id() == doc);
         return top->doc_id();
-        return 0;
     }
 
     int32_t advance(int32_t target) const {
@@ -142,6 +141,11 @@ public:
     }
 
     int32_t doc_freq() const { return _cost; }
+
+    int32_t norm() const {
+        throw Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
+                        "UnionTermIterator does not support scoring");
+    }
 
 private:
     int32_t _cost = 0;

--- a/be/test/olap/rowset/segment_v2/inverted_index/query/phrase_query/phrase_freq_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index/query/phrase_query/phrase_freq_test.cpp
@@ -1,0 +1,559 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "olap/rowset/segment_v2/inverted_index/query/phrase_query/exact_phrase_matcher.h"
+#include "olap/rowset/segment_v2/inverted_index/query/phrase_query/ordered_sloppy_phrase_matcher.h"
+#include "olap/rowset/segment_v2/inverted_index/query/phrase_query/sloppy_phrase_matcher.h"
+#include "olap/rowset/segment_v2/inverted_index/util/docid_set_iterator.h"
+#include "olap/rowset/segment_v2/inverted_index/util/mock_iterator.h"
+#include "olap/rowset/segment_v2/inverted_index/util/union_term_iterator.h"
+
+namespace doris::segment_v2 {
+
+using namespace inverted_index;
+
+class PhraseFreqTest : public ::testing::Test {
+protected:
+    DISI create_mock_disi(std::map<int32_t, std::vector<int32_t>> postings) {
+        auto mock = std::make_shared<MockIterator>();
+        mock->set_postings(postings);
+        return mock;
+    }
+};
+
+TEST_F(PhraseFreqTest, ExactPhraseMatcher_SingleMatch) {
+    auto disi1 = create_mock_disi({{1, {0}}});
+    auto disi2 = create_mock_disi({{1, {1}}});
+
+    std::vector<PostingsAndPosition> postings;
+    postings.emplace_back(disi1, 0);
+    postings.emplace_back(disi2, 1);
+
+    ExactPhraseMatcher matcher(std::move(postings));
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_FLOAT_EQ(freq, 1.0F);
+}
+
+TEST_F(PhraseFreqTest, ExactPhraseMatcher_MultipleMatches) {
+    auto disi1 = create_mock_disi({{1, {0, 2}}});
+    auto disi2 = create_mock_disi({{1, {1, 3}}});
+
+    std::vector<PostingsAndPosition> postings;
+    postings.emplace_back(disi1, 0);
+    postings.emplace_back(disi2, 1);
+
+    ExactPhraseMatcher matcher(std::move(postings));
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_FLOAT_EQ(freq, 2.0F);
+}
+
+TEST_F(PhraseFreqTest, ExactPhraseMatcher_NoMatch) {
+    auto disi1 = create_mock_disi({{1, {0}}});
+    auto disi2 = create_mock_disi({{1, {2}}});
+
+    std::vector<PostingsAndPosition> postings;
+    postings.emplace_back(disi1, 0);
+    postings.emplace_back(disi2, 1);
+
+    ExactPhraseMatcher matcher(std::move(postings));
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_FLOAT_EQ(freq, 0.0F);
+}
+
+TEST_F(PhraseFreqTest, ExactPhraseMatcher_ThreeTermPhrase) {
+    auto disi1 = create_mock_disi({{1, {1}}});
+    auto disi2 = create_mock_disi({{1, {2}}});
+    auto disi3 = create_mock_disi({{1, {3}}});
+
+    std::vector<PostingsAndPosition> postings;
+    postings.emplace_back(disi1, 0);
+    postings.emplace_back(disi2, 1);
+    postings.emplace_back(disi3, 2);
+
+    ExactPhraseMatcher matcher(std::move(postings));
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_FLOAT_EQ(freq, 1.0F);
+}
+
+TEST_F(PhraseFreqTest, OrderedSloppyPhraseMatcher_ExactMatch) {
+    auto disi1 = create_mock_disi({{1, {0}}});
+    auto disi2 = create_mock_disi({{1, {1}}});
+
+    std::vector<PostingsAndPosition> postings;
+    postings.emplace_back(disi1, 0);
+    postings.emplace_back(disi2, 1);
+
+    OrderedSloppyPhraseMatcher matcher(std::move(postings), 2);
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_FLOAT_EQ(freq, 1.0F);
+}
+
+TEST_F(PhraseFreqTest, OrderedSloppyPhraseMatcher_WithSlop) {
+    auto disi1 = create_mock_disi({{1, {0}}});
+    auto disi2 = create_mock_disi({{1, {2}}});
+
+    std::vector<PostingsAndPosition> postings;
+    postings.emplace_back(disi1, 0);
+    postings.emplace_back(disi2, 1);
+
+    OrderedSloppyPhraseMatcher matcher(std::move(postings), 2);
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_GT(freq, 0.0F);
+    EXPECT_LE(freq, 1.0F);
+}
+
+TEST_F(PhraseFreqTest, OrderedSloppyPhraseMatcher_SloppyWeight_AfterMatch) {
+    // Test sloppy_weight after next_match() returns true
+    // Positions: term1 at 0, term2 at 1 (exact match, match_width = 0)
+    auto disi1 = create_mock_disi({{1, {0}}});
+    auto disi2 = create_mock_disi({{1, {1}}});
+
+    std::vector<PostingsAndPosition> postings;
+    postings.emplace_back(disi1, 0);
+    postings.emplace_back(disi2, 1);
+
+    OrderedSloppyPhraseMatcher matcher(std::move(postings), 5);
+    matcher.reset(1);
+    ASSERT_TRUE(matcher.next_match());
+
+    // match_width = 0 for exact match, so weight = 1/(1+0) = 1.0
+    float weight = matcher.sloppy_weight();
+    EXPECT_FLOAT_EQ(weight, 1.0F);
+}
+
+TEST_F(PhraseFreqTest, OrderedSloppyPhraseMatcher_SloppyWeight_WithGap) {
+    // Test sloppy_weight with gap between terms
+    // Positions: term1 at 0, term2 at 3 (gap of 2, match_width = 2)
+    auto disi1 = create_mock_disi({{1, {0}}});
+    auto disi2 = create_mock_disi({{1, {3}}});
+
+    std::vector<PostingsAndPosition> postings;
+    postings.emplace_back(disi1, 0);
+    postings.emplace_back(disi2, 1);
+
+    OrderedSloppyPhraseMatcher matcher(std::move(postings), 5);
+    matcher.reset(1);
+    ASSERT_TRUE(matcher.next_match());
+
+    // match_width = 2, so weight = 1/(1+2) = 0.333...
+    float weight = matcher.sloppy_weight();
+    EXPECT_FLOAT_EQ(weight, 1.0F / 3.0F);
+}
+
+TEST_F(PhraseFreqTest, OrderedSloppyPhraseMatcher_ExceedsSlop) {
+    auto disi1 = create_mock_disi({{1, {0}}});
+    auto disi2 = create_mock_disi({{1, {5}}});
+
+    std::vector<PostingsAndPosition> postings;
+    postings.emplace_back(disi1, 0);
+    postings.emplace_back(disi2, 1);
+
+    OrderedSloppyPhraseMatcher matcher(std::move(postings), 2);
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_FLOAT_EQ(freq, 0.0F);
+}
+
+TEST_F(PhraseFreqTest, SloppyPhraseMatcher_ExactMatch) {
+    auto disi1 = create_mock_disi({{1, {0}}});
+    auto disi2 = create_mock_disi({{1, {1}}});
+
+    std::vector<PostingsAndFreq> postings;
+    postings.emplace_back(disi1, 0, std::vector<std::string>{"big"});
+    postings.emplace_back(disi2, 1, std::vector<std::string>{"red"});
+
+    SloppyPhraseMatcher matcher(postings, 2);
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_GT(freq, 0.0F);
+}
+
+TEST_F(PhraseFreqTest, SloppyPhraseMatcher_SloppyWeight_AfterMatch) {
+    // Test sloppy_weight after next_match() returns true
+    auto disi1 = create_mock_disi({{1, {0}}});
+    auto disi2 = create_mock_disi({{1, {1}}});
+
+    std::vector<PostingsAndFreq> postings;
+    postings.emplace_back(disi1, 0, std::vector<std::string>{"big"});
+    postings.emplace_back(disi2, 1, std::vector<std::string>{"red"});
+
+    SloppyPhraseMatcher matcher(postings, 5);
+    matcher.reset(1);
+    ASSERT_TRUE(matcher.next_match());
+
+    float weight = matcher.sloppy_weight();
+    EXPECT_GT(weight, 0.0F);
+    EXPECT_LE(weight, 1.0F);
+}
+
+TEST_F(PhraseFreqTest, SloppyPhraseMatcher_ReorderedTerms) {
+    auto disi1 = create_mock_disi({{1, {1}}});
+    auto disi2 = create_mock_disi({{1, {0}}});
+
+    std::vector<PostingsAndFreq> postings;
+    postings.emplace_back(disi1, 0, std::vector<std::string>{"big"});
+    postings.emplace_back(disi2, 1, std::vector<std::string>{"red"});
+
+    SloppyPhraseMatcher matcher(postings, 3);
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_GE(freq, 0.0F);
+}
+
+TEST_F(PhraseFreqTest, NormVisitor_MockIterator) {
+    auto mock = std::make_shared<MockIterator>();
+    mock->set_postings({{1, {0, 1, 2}}});
+
+    int32_t norm = mock->norm();
+    EXPECT_EQ(norm, 1);
+}
+
+TEST_F(PhraseFreqTest, NormVisitor_WithDISI) {
+    auto disi = create_mock_disi({{1, {0}}});
+
+    int32_t norm = visit_node(disi, Norm{});
+    EXPECT_EQ(norm, 1);
+}
+
+TEST_F(PhraseFreqTest, UnionTermIterator_NormThrowsException) {
+    auto mock1 = std::make_shared<MockIterator>();
+    mock1->set_postings({{1, {0}}});
+    auto mock2 = std::make_shared<MockIterator>();
+    mock2->set_postings({{1, {1}}});
+
+    std::vector<std::shared_ptr<MockIterator>> subs = {mock1, mock2};
+    UnionTermIterator<MockIterator> union_iter(subs);
+
+    EXPECT_THROW(union_iter.norm(), Exception);
+}
+
+TEST_F(PhraseFreqTest, ExactPhraseMatcher_MultipleDocuments) {
+    {
+        auto d1 = create_mock_disi({{1, {0}}});
+        auto d2 = create_mock_disi({{1, {1}}});
+        std::vector<PostingsAndPosition> postings;
+        postings.emplace_back(d1, 0);
+        postings.emplace_back(d2, 1);
+        ExactPhraseMatcher matcher(std::move(postings));
+        EXPECT_FLOAT_EQ(matcher.phrase_freq(1), 1.0F);
+    }
+
+    {
+        auto d1 = create_mock_disi({{3, {0, 2}}});
+        auto d2 = create_mock_disi({{3, {1, 3}}});
+        std::vector<PostingsAndPosition> postings;
+        postings.emplace_back(d1, 0);
+        postings.emplace_back(d2, 1);
+        ExactPhraseMatcher matcher(std::move(postings));
+        EXPECT_FLOAT_EQ(matcher.phrase_freq(3), 2.0F);
+    }
+}
+
+TEST_F(PhraseFreqTest, OrderedSloppyPhraseMatcher_MultipleMatches) {
+    auto disi1 = create_mock_disi({{1, {0, 3}}});
+    auto disi2 = create_mock_disi({{1, {2, 5}}});
+
+    std::vector<PostingsAndPosition> postings;
+    postings.emplace_back(disi1, 0);
+    postings.emplace_back(disi2, 1);
+
+    OrderedSloppyPhraseMatcher matcher(std::move(postings), 3);
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_GT(freq, 0.0F);
+}
+
+// ==================== Additional Coverage Tests ====================
+
+TEST_F(PhraseFreqTest, ExactPhraseMatcher_FourTermPhrase) {
+    // Test longer phrase matching
+    auto disi1 = create_mock_disi({{1, {0}}});
+    auto disi2 = create_mock_disi({{1, {1}}});
+    auto disi3 = create_mock_disi({{1, {2}}});
+    auto disi4 = create_mock_disi({{1, {3}}});
+
+    std::vector<PostingsAndPosition> postings;
+    postings.emplace_back(disi1, 0);
+    postings.emplace_back(disi2, 1);
+    postings.emplace_back(disi3, 2);
+    postings.emplace_back(disi4, 3);
+
+    ExactPhraseMatcher matcher(std::move(postings));
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_FLOAT_EQ(freq, 1.0F);
+}
+
+TEST_F(PhraseFreqTest, ExactPhraseMatcher_PartialMatch) {
+    // First two terms match but third doesn't
+    auto disi1 = create_mock_disi({{1, {0}}});
+    auto disi2 = create_mock_disi({{1, {1}}});
+    auto disi3 = create_mock_disi({{1, {5}}}); // Gap breaks the phrase
+
+    std::vector<PostingsAndPosition> postings;
+    postings.emplace_back(disi1, 0);
+    postings.emplace_back(disi2, 1);
+    postings.emplace_back(disi3, 2);
+
+    ExactPhraseMatcher matcher(std::move(postings));
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_FLOAT_EQ(freq, 0.0F);
+}
+
+TEST_F(PhraseFreqTest, ExactPhraseMatcher_OverlappingMatches) {
+    // Positions that could form overlapping phrases: "a b a b"
+    // Phrase "a b" appears at positions (0,1) and (2,3)
+    auto disi1 = create_mock_disi({{1, {0, 2}}});
+    auto disi2 = create_mock_disi({{1, {1, 3}}});
+
+    std::vector<PostingsAndPosition> postings;
+    postings.emplace_back(disi1, 0);
+    postings.emplace_back(disi2, 1);
+
+    ExactPhraseMatcher matcher(std::move(postings));
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_FLOAT_EQ(freq, 2.0F);
+}
+
+TEST_F(PhraseFreqTest, OrderedSloppyPhraseMatcher_ThreeTerms) {
+    // Three term phrase with slop
+    auto disi1 = create_mock_disi({{1, {0}}});
+    auto disi2 = create_mock_disi({{1, {2}}});
+    auto disi3 = create_mock_disi({{1, {4}}});
+
+    std::vector<PostingsAndPosition> postings;
+    postings.emplace_back(disi1, 0);
+    postings.emplace_back(disi2, 1);
+    postings.emplace_back(disi3, 2);
+
+    OrderedSloppyPhraseMatcher matcher(std::move(postings), 3);
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_GT(freq, 0.0F);
+}
+
+TEST_F(PhraseFreqTest, OrderedSloppyPhraseMatcher_ThreeTerms_ExceedsSlop) {
+    // Three term phrase exceeds slop
+    auto disi1 = create_mock_disi({{1, {0}}});
+    auto disi2 = create_mock_disi({{1, {5}}});
+    auto disi3 = create_mock_disi({{1, {10}}});
+
+    std::vector<PostingsAndPosition> postings;
+    postings.emplace_back(disi1, 0);
+    postings.emplace_back(disi2, 1);
+    postings.emplace_back(disi3, 2);
+
+    OrderedSloppyPhraseMatcher matcher(std::move(postings), 2);
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_FLOAT_EQ(freq, 0.0F);
+}
+
+TEST_F(PhraseFreqTest, OrderedSloppyPhraseMatcher_PhraseFreqAccumulation) {
+    // Multiple matches with different sloppy weights
+    // Match 1: positions 0, 1 (match_width=0, weight=1.0)
+    // Match 2: positions 3, 5 (match_width=1, weight=0.5)
+    auto disi1 = create_mock_disi({{1, {0, 3}}});
+    auto disi2 = create_mock_disi({{1, {1, 5}}});
+
+    std::vector<PostingsAndPosition> postings;
+    postings.emplace_back(disi1, 0);
+    postings.emplace_back(disi2, 1);
+
+    OrderedSloppyPhraseMatcher matcher(std::move(postings), 5);
+    float freq = matcher.phrase_freq(1);
+
+    // Expected: 1.0 + 0.5 = 1.5
+    EXPECT_FLOAT_EQ(freq, 1.5F);
+}
+
+TEST_F(PhraseFreqTest, SloppyPhraseMatcher_NoMatch) {
+    // Terms too far apart
+    auto disi1 = create_mock_disi({{1, {0}}});
+    auto disi2 = create_mock_disi({{1, {100}}});
+
+    std::vector<PostingsAndFreq> postings;
+    postings.emplace_back(disi1, 0, std::vector<std::string>{"hello"});
+    postings.emplace_back(disi2, 1, std::vector<std::string>{"world"});
+
+    SloppyPhraseMatcher matcher(postings, 2);
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_FLOAT_EQ(freq, 0.0F);
+}
+
+TEST_F(PhraseFreqTest, SloppyPhraseMatcher_ThreeTerms) {
+    auto disi1 = create_mock_disi({{1, {0}}});
+    auto disi2 = create_mock_disi({{1, {1}}});
+    auto disi3 = create_mock_disi({{1, {2}}});
+
+    std::vector<PostingsAndFreq> postings;
+    postings.emplace_back(disi1, 0, std::vector<std::string>{"the"});
+    postings.emplace_back(disi2, 1, std::vector<std::string>{"quick"});
+    postings.emplace_back(disi3, 2, std::vector<std::string>{"fox"});
+
+    SloppyPhraseMatcher matcher(postings, 3);
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_GT(freq, 0.0F);
+}
+
+TEST_F(PhraseFreqTest, SloppyPhraseMatcher_MultipleMatches) {
+    // Document with phrase appearing twice
+    auto disi1 = create_mock_disi({{1, {0, 5}}});
+    auto disi2 = create_mock_disi({{1, {1, 6}}});
+
+    std::vector<PostingsAndFreq> postings;
+    postings.emplace_back(disi1, 0, std::vector<std::string>{"hello"});
+    postings.emplace_back(disi2, 1, std::vector<std::string>{"world"});
+
+    SloppyPhraseMatcher matcher(postings, 2);
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_GT(freq, 1.0F); // Should have accumulated weight from multiple matches
+}
+
+TEST_F(PhraseFreqTest, ExactPhraseMatcher_Matches_Consistency) {
+    // Verify matches() and phrase_freq() are consistent
+    auto disi1 = create_mock_disi({{1, {0}}});
+    auto disi2 = create_mock_disi({{1, {1}}});
+
+    {
+        std::vector<PostingsAndPosition> postings;
+        postings.emplace_back(disi1, 0);
+        postings.emplace_back(disi2, 1);
+        ExactPhraseMatcher matcher(std::move(postings));
+        EXPECT_TRUE(matcher.matches(1));
+    }
+
+    // Reset iterators
+    disi1 = create_mock_disi({{1, {0}}});
+    disi2 = create_mock_disi({{1, {1}}});
+
+    {
+        std::vector<PostingsAndPosition> postings;
+        postings.emplace_back(disi1, 0);
+        postings.emplace_back(disi2, 1);
+        ExactPhraseMatcher matcher(std::move(postings));
+        EXPECT_GT(matcher.phrase_freq(1), 0.0F);
+    }
+}
+
+TEST_F(PhraseFreqTest, OrderedSloppyPhraseMatcher_Matches_Consistency) {
+    auto disi1 = create_mock_disi({{1, {0}}});
+    auto disi2 = create_mock_disi({{1, {2}}});
+
+    {
+        std::vector<PostingsAndPosition> postings;
+        postings.emplace_back(disi1, 0);
+        postings.emplace_back(disi2, 1);
+        OrderedSloppyPhraseMatcher matcher(std::move(postings), 3);
+        EXPECT_TRUE(matcher.matches(1));
+    }
+
+    disi1 = create_mock_disi({{1, {0}}});
+    disi2 = create_mock_disi({{1, {2}}});
+
+    {
+        std::vector<PostingsAndPosition> postings;
+        postings.emplace_back(disi1, 0);
+        postings.emplace_back(disi2, 1);
+        OrderedSloppyPhraseMatcher matcher(std::move(postings), 3);
+        EXPECT_GT(matcher.phrase_freq(1), 0.0F);
+    }
+}
+
+TEST_F(PhraseFreqTest, SloppyPhraseMatcher_Matches_Consistency) {
+    auto disi1 = create_mock_disi({{1, {0}}});
+    auto disi2 = create_mock_disi({{1, {1}}});
+
+    {
+        std::vector<PostingsAndFreq> postings;
+        postings.emplace_back(disi1, 0, std::vector<std::string>{"a"});
+        postings.emplace_back(disi2, 1, std::vector<std::string>{"b"});
+        SloppyPhraseMatcher matcher(postings, 2);
+        EXPECT_TRUE(matcher.matches(1));
+    }
+
+    disi1 = create_mock_disi({{1, {0}}});
+    disi2 = create_mock_disi({{1, {1}}});
+
+    {
+        std::vector<PostingsAndFreq> postings;
+        postings.emplace_back(disi1, 0, std::vector<std::string>{"a"});
+        postings.emplace_back(disi2, 1, std::vector<std::string>{"b"});
+        SloppyPhraseMatcher matcher(postings, 2);
+        EXPECT_GT(matcher.phrase_freq(1), 0.0F);
+    }
+}
+
+TEST_F(PhraseFreqTest, ExactPhraseMatcher_HighFrequencyTerms) {
+    // Test with terms appearing many times
+    auto disi1 = create_mock_disi({{1, {0, 2, 4, 6, 8}}});
+    auto disi2 = create_mock_disi({{1, {1, 3, 5, 7, 9}}});
+
+    std::vector<PostingsAndPosition> postings;
+    postings.emplace_back(disi1, 0);
+    postings.emplace_back(disi2, 1);
+
+    ExactPhraseMatcher matcher(std::move(postings));
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_FLOAT_EQ(freq, 5.0F);
+}
+
+TEST_F(PhraseFreqTest, OrderedSloppyPhraseMatcher_ZeroSlop) {
+    // Zero slop should behave like exact match
+    auto disi1 = create_mock_disi({{1, {0}}});
+    auto disi2 = create_mock_disi({{1, {1}}});
+
+    std::vector<PostingsAndPosition> postings;
+    postings.emplace_back(disi1, 0);
+    postings.emplace_back(disi2, 1);
+
+    OrderedSloppyPhraseMatcher matcher(std::move(postings), 0);
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_FLOAT_EQ(freq, 1.0F);
+}
+
+TEST_F(PhraseFreqTest, OrderedSloppyPhraseMatcher_ZeroSlop_NoMatch) {
+    // Zero slop with gap should not match
+    auto disi1 = create_mock_disi({{1, {0}}});
+    auto disi2 = create_mock_disi({{1, {2}}});
+
+    std::vector<PostingsAndPosition> postings;
+    postings.emplace_back(disi1, 0);
+    postings.emplace_back(disi2, 1);
+
+    OrderedSloppyPhraseMatcher matcher(std::move(postings), 0);
+    float freq = matcher.phrase_freq(1);
+
+    EXPECT_FLOAT_EQ(freq, 0.0F);
+}
+
+} // namespace doris::segment_v2

--- a/be/test/olap/rowset/segment_v2/inverted_index/query/phrase_query/phrase_freq_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index/query/phrase_query/phrase_freq_test.cpp
@@ -181,8 +181,8 @@ TEST_F(PhraseFreqTest, SloppyPhraseMatcher_ExactMatch) {
     auto disi2 = create_mock_disi({{1, {1}}});
 
     std::vector<PostingsAndFreq> postings;
-    postings.emplace_back(disi1, 0, std::vector<std::string>{"big"});
-    postings.emplace_back(disi2, 1, std::vector<std::string>{"red"});
+    postings.emplace_back(disi1, 0, std::vector<std::string> {"big"});
+    postings.emplace_back(disi2, 1, std::vector<std::string> {"red"});
 
     SloppyPhraseMatcher matcher(postings, 2);
     float freq = matcher.phrase_freq(1);
@@ -196,8 +196,8 @@ TEST_F(PhraseFreqTest, SloppyPhraseMatcher_SloppyWeight_AfterMatch) {
     auto disi2 = create_mock_disi({{1, {1}}});
 
     std::vector<PostingsAndFreq> postings;
-    postings.emplace_back(disi1, 0, std::vector<std::string>{"big"});
-    postings.emplace_back(disi2, 1, std::vector<std::string>{"red"});
+    postings.emplace_back(disi1, 0, std::vector<std::string> {"big"});
+    postings.emplace_back(disi2, 1, std::vector<std::string> {"red"});
 
     SloppyPhraseMatcher matcher(postings, 5);
     matcher.reset(1);
@@ -213,8 +213,8 @@ TEST_F(PhraseFreqTest, SloppyPhraseMatcher_ReorderedTerms) {
     auto disi2 = create_mock_disi({{1, {0}}});
 
     std::vector<PostingsAndFreq> postings;
-    postings.emplace_back(disi1, 0, std::vector<std::string>{"big"});
-    postings.emplace_back(disi2, 1, std::vector<std::string>{"red"});
+    postings.emplace_back(disi1, 0, std::vector<std::string> {"big"});
+    postings.emplace_back(disi2, 1, std::vector<std::string> {"red"});
 
     SloppyPhraseMatcher matcher(postings, 3);
     float freq = matcher.phrase_freq(1);
@@ -233,7 +233,7 @@ TEST_F(PhraseFreqTest, NormVisitor_MockIterator) {
 TEST_F(PhraseFreqTest, NormVisitor_WithDISI) {
     auto disi = create_mock_disi({{1, {0}}});
 
-    int32_t norm = visit_node(disi, Norm{});
+    int32_t norm = visit_node(disi, Norm {});
     EXPECT_EQ(norm, 1);
 }
 
@@ -397,8 +397,8 @@ TEST_F(PhraseFreqTest, SloppyPhraseMatcher_NoMatch) {
     auto disi2 = create_mock_disi({{1, {100}}});
 
     std::vector<PostingsAndFreq> postings;
-    postings.emplace_back(disi1, 0, std::vector<std::string>{"hello"});
-    postings.emplace_back(disi2, 1, std::vector<std::string>{"world"});
+    postings.emplace_back(disi1, 0, std::vector<std::string> {"hello"});
+    postings.emplace_back(disi2, 1, std::vector<std::string> {"world"});
 
     SloppyPhraseMatcher matcher(postings, 2);
     float freq = matcher.phrase_freq(1);
@@ -412,9 +412,9 @@ TEST_F(PhraseFreqTest, SloppyPhraseMatcher_ThreeTerms) {
     auto disi3 = create_mock_disi({{1, {2}}});
 
     std::vector<PostingsAndFreq> postings;
-    postings.emplace_back(disi1, 0, std::vector<std::string>{"the"});
-    postings.emplace_back(disi2, 1, std::vector<std::string>{"quick"});
-    postings.emplace_back(disi3, 2, std::vector<std::string>{"fox"});
+    postings.emplace_back(disi1, 0, std::vector<std::string> {"the"});
+    postings.emplace_back(disi2, 1, std::vector<std::string> {"quick"});
+    postings.emplace_back(disi3, 2, std::vector<std::string> {"fox"});
 
     SloppyPhraseMatcher matcher(postings, 3);
     float freq = matcher.phrase_freq(1);
@@ -428,8 +428,8 @@ TEST_F(PhraseFreqTest, SloppyPhraseMatcher_MultipleMatches) {
     auto disi2 = create_mock_disi({{1, {1, 6}}});
 
     std::vector<PostingsAndFreq> postings;
-    postings.emplace_back(disi1, 0, std::vector<std::string>{"hello"});
-    postings.emplace_back(disi2, 1, std::vector<std::string>{"world"});
+    postings.emplace_back(disi1, 0, std::vector<std::string> {"hello"});
+    postings.emplace_back(disi2, 1, std::vector<std::string> {"world"});
 
     SloppyPhraseMatcher matcher(postings, 2);
     float freq = matcher.phrase_freq(1);
@@ -493,8 +493,8 @@ TEST_F(PhraseFreqTest, SloppyPhraseMatcher_Matches_Consistency) {
 
     {
         std::vector<PostingsAndFreq> postings;
-        postings.emplace_back(disi1, 0, std::vector<std::string>{"a"});
-        postings.emplace_back(disi2, 1, std::vector<std::string>{"b"});
+        postings.emplace_back(disi1, 0, std::vector<std::string> {"a"});
+        postings.emplace_back(disi2, 1, std::vector<std::string> {"b"});
         SloppyPhraseMatcher matcher(postings, 2);
         EXPECT_TRUE(matcher.matches(1));
     }
@@ -504,8 +504,8 @@ TEST_F(PhraseFreqTest, SloppyPhraseMatcher_Matches_Consistency) {
 
     {
         std::vector<PostingsAndFreq> postings;
-        postings.emplace_back(disi1, 0, std::vector<std::string>{"a"});
-        postings.emplace_back(disi2, 1, std::vector<std::string>{"b"});
+        postings.emplace_back(disi1, 0, std::vector<std::string> {"a"});
+        postings.emplace_back(disi2, 1, std::vector<std::string> {"b"});
         SloppyPhraseMatcher matcher(postings, 2);
         EXPECT_GT(matcher.phrase_freq(1), 0.0F);
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

