### PR TITLE
[fix](substring) Fix `substring_index`

### DIFF
--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -1905,7 +1905,7 @@ public:
         }
 
         for (size_t i = 0; i < input_rows_count; ++i) {
-            auto str = str_col->get_data_at(i);
+            auto str = str_col->get_data_at(content_const ? 0 : i);
             auto delimiter = delimiter_col->get_data_at(delimiter_const ? 0 : i);
             int32_t delimiter_size = delimiter.size;
 

--- a/regression-test/data/function_p0/test_substring_index.out
+++ b/regression-test/data/function_p0/test_substring_index.out
@@ -46,3 +46,7 @@
 -- !sql --
 				test|test	test|test
 
+-- !sql --
+
+
+

--- a/regression-test/suites/function_p0/test_substring_index.groovy
+++ b/regression-test/suites/function_p0/test_substring_index.groovy
@@ -134,4 +134,26 @@ suite("test_substring_index") {
     """
 
     sql "DROP TABLE IF EXISTS test_substring_index"
+
+    sql "DROP TABLE IF EXISTS test_substring_index2"
+    sql """
+    CREATE TABLE test_substring_index2 (
+        id INT,
+        str VARCHAR(100),
+        delimiter VARCHAR(10)
+    ) ENGINE=OLAP
+    DUPLICATE KEY(id)
+    DISTRIBUTED BY HASH(id) BUCKETS 1
+    PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1"
+    )
+    """
+
+    sql """
+    INSERT INTO test_substring_index2 VALUES
+        (1, NULL, NULL),
+        (2, NULL, NULL)
+    """
+    qt_sql """ SELECT  SUBSTRING_INDEX(IFNULL(a.str, ''), ',', a.id) from test_substring_index2 a """
+    sql "DROP TABLE IF EXISTS test_substring_index2"
 }


### PR DESCRIPTION
### What problem does this PR solve?

*** Query id: c1ff38c3dec047ae-bfce7919ca736eda ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1768984432 (unix time) try "date -d @1768984432" if you are using GNU date ***
*** Current BE git commitID: 22974f924b9 ***
*** SIGSEGV invalid permissions for mapped object (@0x7fa6ea546000) received by PID 4132275 (TID 4134631 OR 0x7f9e21ed7700) from PID 18446744073345982464; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/selectdb-core/be/src/common/signal_handler.h:421
 1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] in /opt/jdk/lib/server/[libjvm.so](http://libjvm.so/)
 2# JVM_handle_linux_signal in /opt/jdk/lib/server/[libjvm.so](http://libjvm.so/)
 3# 0x00007FAA529DFB50 in /lib64/libc.so.6
 4# __memchr_avx2 in /lib64/libc.so.6
 5# doris::vectorized::FunctionSubstringIndex::execute_impl(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, 
unsigned long, unsigned long) const at /root/selectdb-core/be/src/vec/functions/function_string.h:2066
 6# doris::vectorized::DefaultExecutable::execute_impl(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsig
ned long, unsigned long) const at /root/selectdb-core/be/src/vec/functions/function.h:472
...skipping...
 7# doris::vectorized::PreparedFunctionImpl::execute_without_low_cardinality_columns(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) const at /root/selectdb-core/be/src/vec/functions/function.cpp:246
 8# doris::vectorized::PreparedFunctionImpl::execute(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) const at /root/selectdb-core/be/src/vec/functions/function.cpp:252
 9# doris::vectorized::IFunctionBase::execute(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) const at /root/selectdb-core/be/src/vec/functions/function.h:195
10# doris::vectorized::VectorizedFnCall::_do_execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*, std::vector<unsigned long, std::allocator<unsigned long> >&) at /root/selectdb-core/be/src/vec/exprs/vectorized_fn_call.cpp:190
11# doris::vectorized::VectorizedFnCall::execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*) at /root/selectdb-core/be/src/vec/exprs/vectorized_fn_call.cpp:206
12# doris::vectorized::VectorizedFnCall::_do_execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*, std::vector<unsigned long, std::allocator<unsigned long> >&) at /root/selectdb-core/be/src/vec/exprs/vectorized_fn_call.cpp:181
13# doris::vectorized::VectorizedFnCall::execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*) at /root/selectdb-core/be/src/vec/exprs/vectorized_fn_call.cpp:206
14# doris::vectorized::VectorizedFnCall::_do_execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*, std::vector<unsigned long, std::allocator<unsigned long> >&) at /root/selectdb-core/be/src/vec/exprs/vectorized_fn_call.cpp:181
15# doris::vectorized::VectorizedFnCall::execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*) at /root/selectdb-core/be/src/vec/exprs/vectorized_fn_call.cpp:206
16# doris::vectorized::VExprContext::execute(doris::vectorized::Block*, int*) at /root/selectdb-core/be/src/vec/exprs/vexpr_context.cpp:55
17# doris::pipeline::OperatorXBase::do_projections(doris::RuntimeState*, doris::vectorized::Block*, doris::vectorized::Block*) const at /root/selectdb-core/be/src/pipeline/exec/operator.cpp:300
18# doris::pipeline::OperatorXBase::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) in /opt/selectdb/4.0.7.2025112812/be/lib/doris_be
19# doris::pipeline::StatefulOperatorX<doris::pipeline::HashJoinProbeLocalState>::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) in /opt/selectdb/4.0.7.2025112812/be/lib/doris_be
20# doris::pipeline::OperatorXBase::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /root/selectdb-core/be/src/pipeline/exec/operator.cpp:337
21# doris::pipeline::PipelineTask::execute(bool*) at /root/selectdb-core/be/src/pipeline/pipeline_task.cpp:409
22# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /root/selectdb-core/be/src/pipeline/task_scheduler.cpp:139
23# doris::ThreadPool::dispatch_thread() at /root/selectdb-core/be/src/util/threadpool.cpp:609
24# doris::Thread::supervise_thread(void*) at /root/selectdb-core/be/src/util/thread.cpp:499
25# start_thread in /lib64/libpthread.so.0
26# __clone in /lib64/libc.so.6

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

