### PR TITLE
[opt](table-function) Optimize explode with block fast path

### DIFF
--- a/be/src/pipeline/exec/table_function_operator.h
+++ b/be/src/pipeline/exec/table_function_operator.h
@@ -65,6 +65,9 @@ private:
     // >0: some of fns are eos
     int _find_last_fn_eos_idx() const;
     bool _is_inner_and_empty();
+    bool _can_use_block_fast_path() const;
+    Status _get_expanded_block_block_fast_path(RuntimeState* state,
+                                               std::vector<vectorized::MutableColumnPtr>& columns);
 
     Status _get_expanded_block_for_outer_conjuncts(RuntimeState* state,
                                                    vectorized::Block* output_block, bool* eos);
@@ -79,6 +82,11 @@ private:
     int _current_row_insert_times = 0;
     bool _child_eos = false;
     DorisVector<bool> _child_rows_has_output;
+
+    bool _block_fast_path_prepared = false;
+    vectorized::TableFunction::BlockFastPathContext _block_fast_path_ctx;
+    int64_t _block_fast_path_row = 0;
+    uint64_t _block_fast_path_in_row_offset = 0;
 
     RuntimeProfile::Counter* _init_function_timer = nullptr;
     RuntimeProfile::Counter* _process_rows_timer = nullptr;

--- a/be/src/vec/columns/column_variant.cpp
+++ b/be/src/vec/columns/column_variant.cpp
@@ -2130,6 +2130,10 @@ void ColumnVariant::create_root(const DataTypePtr& type, MutableColumnPtr&& colu
     if (num_rows == 0) {
         num_rows = column->size();
     }
+    DCHECK_EQ(type->is_nullable(), column->is_nullable())
+            << "type nullable=" << type->is_nullable()
+            << " column nullable=" << column->is_nullable()
+            << " type=" << type->get_name();
     add_sub_column({}, std::move(column), type);
     if (serialized_sparse_column->empty()) {
         serialized_sparse_column->resize(num_rows);

--- a/be/src/vec/exec/scan/olap_scanner.cpp
+++ b/be/src/vec/exec/scan/olap_scanner.cpp
@@ -591,14 +591,15 @@ Status OlapScanner::_init_return_columns() {
         }
 
         const auto& column = tablet_schema->column(index);
+        int32_t unique_id = column.unique_id() > 0 ? column.unique_id() : column.parent_unique_id();
         if (!slot->all_access_paths().empty()) {
             _tablet_reader_params.all_access_paths.insert(
-                    {column.unique_id(), slot->all_access_paths()});
+                    {unique_id, slot->all_access_paths()});
         }
 
         if (!slot->predicate_access_paths().empty()) {
             _tablet_reader_params.predicate_access_paths.insert(
-                    {column.unique_id(), slot->predicate_access_paths()});
+                    {unique_id, slot->predicate_access_paths()});
         }
 
         if ((slot->type()->get_primitive_type() == PrimitiveType::TYPE_STRUCT ||

--- a/be/src/vec/exprs/table_function/vexplode.h
+++ b/be/src/vec/exprs/table_function/vexplode.h
@@ -46,6 +46,10 @@ public:
     void get_same_many_values(MutableColumnPtr& column, int length) override;
     int get_value(MutableColumnPtr& column, int max_step) override;
 
+    bool support_block_fast_path() const override;
+    Status prepare_block_fast_path(Block* block, RuntimeState* state,
+                                   BlockFastPathContext* ctx) override;
+
 private:
     Status _process_init_variant(Block* block, int value_column_idx);
     ColumnPtr _array_column;

--- a/be/src/vec/exprs/table_function/vexplode_v2.h
+++ b/be/src/vec/exprs/table_function/vexplode_v2.h
@@ -46,6 +46,10 @@ public:
     void get_same_many_values(MutableColumnPtr& column, int length) override;
     int get_value(MutableColumnPtr& column, int max_step) override;
 
+    bool support_block_fast_path() const override;
+    Status prepare_block_fast_path(Block* block, RuntimeState* state,
+                                   BlockFastPathContext* ctx) override;
+
     void set_generate_row_index(bool generate_row_index) {
         _generate_row_index = generate_row_index;
     }

--- a/be/test/pipeline/operator/table_function_operator_test.cpp
+++ b/be/test/pipeline/operator/table_function_operator_test.cpp
@@ -32,7 +32,12 @@
 #include "testutil/mock/mock_literal_expr.h"
 #include "testutil/mock/mock_operators.h"
 #include "testutil/mock/mock_slot_ref.h"
+#include "vec/columns/column_array.h"
+#include "vec/columns/column_nullable.h"
 #include "vec/core/block.h"
+#include "vec/data_types/data_type_array.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/functions/array/function_array_utils.h"
 namespace doris::pipeline {
 
 using namespace vectorized;
@@ -89,6 +94,89 @@ public:
         forward(max_step);
         return max_step;
     }
+};
+
+class MockFastExplodeTableFunction : public TableFunction {
+public:
+    explicit MockFastExplodeTableFunction(bool* get_value_called)
+            : _get_value_called(get_value_called) {}
+
+    Status process_init(Block* block, RuntimeState* /*state*/) override {
+        // Expose array offsets / nested column for TableFunctionLocalState block fast path.
+        vectorized::ColumnArrayExecutionData data;
+        auto array_col = block->get_by_position(1).column->convert_to_full_column_if_const();
+        if (!vectorized::extract_column_array_info(*array_col, data)) {
+            return Status::InternalError("invalid array column");
+        }
+        _detail = data;
+        return Status::OK();
+    }
+
+    void process_row(size_t row_idx) override {
+        TableFunction::process_row(row_idx);
+        if (!_detail.array_nullmap_data || !_detail.array_nullmap_data[row_idx]) {
+            _array_offset = row_idx == 0 ? 0 : (*_detail.offsets_ptr)[row_idx - 1];
+            _cur_size = (*_detail.offsets_ptr)[row_idx] - _array_offset;
+        }
+    }
+
+    void process_close() override {
+        _detail.reset();
+        _array_offset = 0;
+    }
+
+    void get_same_many_values(MutableColumnPtr& column, int length) override {
+        column->insert_many_defaults(length);
+    }
+
+    int get_value(MutableColumnPtr& column, int max_step) override {
+        if (_get_value_called) {
+            // Slow path indicator: fast path tests expect this to remain false.
+            *_get_value_called = true;
+        }
+        max_step = std::min(max_step, cast_set<int>(_cur_size - _cur_offset));
+        const size_t pos = _array_offset + _cur_offset;
+        if (current_empty()) {
+            column->insert_default();
+            max_step = 1;
+        } else if (column->is_nullable()) {
+            auto* nullable_column = assert_cast<ColumnNullable*>(column.get());
+            nullable_column->get_nested_column_ptr()->insert_range_from(*_detail.nested_col, pos,
+                                                                        max_step);
+            auto* nullmap_column = assert_cast<ColumnUInt8*>(
+                    nullable_column->get_null_map_column_ptr().get());
+            const size_t old_size = nullmap_column->size();
+            nullmap_column->resize(old_size + max_step);
+            if (_detail.nested_nullmap_data != nullptr) {
+                memcpy(nullmap_column->get_data().data() + old_size,
+                       _detail.nested_nullmap_data + pos, max_step * sizeof(UInt8));
+            } else {
+                memset(nullmap_column->get_data().data() + old_size, 0,
+                       max_step * sizeof(UInt8));
+            }
+        } else {
+            column->insert_range_from(*_detail.nested_col, pos, max_step);
+        }
+        forward(max_step);
+        return max_step;
+    }
+
+    bool support_block_fast_path() const override { return true; }
+
+    Status prepare_block_fast_path(Block* /*block*/, RuntimeState* /*state*/,
+                                   BlockFastPathContext* ctx) override {
+        // NOTE: process_init() must be called before this to fill `_detail`.
+        ctx->array_nullmap_data = _detail.array_nullmap_data;
+        ctx->offsets_ptr = _detail.offsets_ptr;
+        ctx->nested_col = _detail.nested_col;
+        ctx->nested_nullmap_data = _detail.nested_nullmap_data;
+        return Status::OK();
+    }
+
+private:
+    bool* _get_value_called = nullptr;
+    vectorized::ColumnArrayExecutionData _detail;
+    size_t _array_offset = 0;
 };
 
 struct MockTableFunctionLocalState : TableFunctionLocalState {
@@ -222,6 +310,618 @@ TEST_F(TableFunctionOperatorTest, single_fn_test2) {
         std::cout << eos << std::endl;
         EXPECT_TRUE(ColumnHelper::block_equal(block, ColumnHelper::create_block<DataTypeInt32>(
                                                              {1, 1, 1, 1, 1}, {0, 0, 0, 0, 0})));
+    }
+}
+
+TEST_F(TableFunctionOperatorTest, block_fast_path_explode) {
+    bool get_value_called = false;
+    {
+        op->_vfn_ctxs =
+                MockSlotRef::create_mock_contexts(DataTypes {std::make_shared<DataTypeInt32>()});
+        auto fn = std::make_shared<MockFastExplodeTableFunction>(&get_value_called);
+        fns.push_back(fn);
+        op->_fns.push_back(fn.get());
+        op->_output_slot_ids = {true, false, true};
+
+        child_op->_mock_row_desc.reset(new MockRowDescriptor {
+                {std::make_shared<vectorized::DataTypeInt32>(),
+                 std::make_shared<vectorized::DataTypeArray>(
+                         std::make_shared<vectorized::DataTypeInt32>())},
+                &pool});
+        op->_mock_row_descriptor.reset(new MockRowDescriptor {
+                {std::make_shared<vectorized::DataTypeInt32>(),
+                 std::make_shared<vectorized::DataTypeArray>(
+                         std::make_shared<vectorized::DataTypeInt32>()),
+                 std::make_shared<vectorized::DataTypeInt32>()},
+                &pool});
+
+        op->_fn_num = 1;
+        EXPECT_TRUE(op->prepare(state.get()));
+
+        local_state_uptr = std::make_unique<MockTableFunctionLocalState>(state.get(), op.get());
+        local_state = local_state_uptr.get();
+        LocalStateInfo info {.parent_profile = &profile,
+                             .scan_ranges = {},
+                             .shared_state = nullptr,
+                             .shared_state_map = {},
+                             .task_idx = 0};
+        EXPECT_TRUE(local_state->init(state.get(), info));
+        state->resize_op_id_to_local_state(-100);
+        state->emplace_local_state(op->operator_id(), std::move(local_state_uptr));
+        EXPECT_TRUE(local_state->open(state.get()));
+    }
+
+    {
+        auto id_col = ColumnHelper::create_column<DataTypeInt32>({10, 20, 30, 40});
+        auto nested = ColumnInt32::create();
+        nested->insert_value(1);
+        nested->insert_value(2);
+        nested->insert_value(3);
+        nested->insert_value(4);
+        auto offsets = ColumnArray::ColumnOffsets::create();
+        offsets->insert_value(1);
+        offsets->insert_value(3);
+        offsets->insert_value(3);
+        offsets->insert_value(4);
+        auto arr_col = ColumnArray::create(std::move(nested), std::move(offsets));
+
+        auto int_type = std::make_shared<DataTypeInt32>();
+        auto arr_type = std::make_shared<DataTypeArray>(int_type);
+        *local_state->_child_block = Block({ColumnWithTypeAndName(id_col, int_type, "id"),
+                                            ColumnWithTypeAndName(ColumnPtr(std::move(arr_col)),
+                                                                  arr_type, "arr")});
+        auto st = op->push(state.get(), local_state->_child_block.get(), true);
+        EXPECT_TRUE(st) << st.msg();
+    }
+
+    {
+        Block block;
+        bool eos = false;
+        auto st = op->pull(state.get(), &block, &eos);
+        EXPECT_TRUE(st) << st.msg();
+        EXPECT_FALSE(get_value_called);
+
+        auto expected_id = ColumnHelper::create_column<DataTypeInt32>({10, 20, 20, 40});
+
+        auto expected_nested = ColumnInt32::create();
+        expected_nested->insert_value(1);
+        expected_nested->insert_value(2);
+        expected_nested->insert_value(3);
+        expected_nested->insert_value(2);
+        expected_nested->insert_value(3);
+        expected_nested->insert_value(4);
+        auto expected_offsets = ColumnArray::ColumnOffsets::create();
+        expected_offsets->insert_value(1);
+        expected_offsets->insert_value(3);
+        expected_offsets->insert_value(5);
+        expected_offsets->insert_value(6);
+        auto expected_arr = ColumnArray::create(std::move(expected_nested), std::move(expected_offsets));
+
+        auto expected_out = ColumnHelper::create_column<DataTypeInt32>({1, 2, 3, 4});
+
+        auto int_type = std::make_shared<DataTypeInt32>();
+        auto arr_type = std::make_shared<DataTypeArray>(int_type);
+        Block expected({ColumnWithTypeAndName(expected_id, int_type, "id"),
+                        ColumnWithTypeAndName(ColumnPtr(std::move(expected_arr)), arr_type, "arr"),
+                        ColumnWithTypeAndName(expected_out, int_type, "x")});
+        EXPECT_TRUE(ColumnHelper::block_equal(block, expected));
+    }
+}
+
+TEST_F(TableFunctionOperatorTest, block_fast_path_explode_batch_truncate) {
+    state->batsh_size = 2;
+    bool get_value_called = false;
+    {
+        op->_vfn_ctxs =
+                MockSlotRef::create_mock_contexts(DataTypes {std::make_shared<DataTypeInt32>()});
+        auto fn = std::make_shared<MockFastExplodeTableFunction>(&get_value_called);
+        fns.push_back(fn);
+        op->_fns.push_back(fn.get());
+        op->_output_slot_ids = {true, true, true};
+
+        child_op->_mock_row_desc.reset(new MockRowDescriptor {
+                {std::make_shared<vectorized::DataTypeInt32>(),
+                 std::make_shared<vectorized::DataTypeArray>(
+                         std::make_shared<vectorized::DataTypeInt32>())},
+                &pool});
+        op->_mock_row_descriptor.reset(new MockRowDescriptor {
+                {std::make_shared<vectorized::DataTypeInt32>(),
+                 std::make_shared<vectorized::DataTypeArray>(
+                         std::make_shared<vectorized::DataTypeInt32>()),
+                 std::make_shared<vectorized::DataTypeInt32>()},
+                &pool});
+
+        op->_fn_num = 1;
+        EXPECT_TRUE(op->prepare(state.get()));
+
+        local_state_uptr = std::make_unique<MockTableFunctionLocalState>(state.get(), op.get());
+        local_state = local_state_uptr.get();
+        LocalStateInfo info {.parent_profile = &profile,
+                             .scan_ranges = {},
+                             .shared_state = nullptr,
+                             .shared_state_map = {},
+                             .task_idx = 0};
+        EXPECT_TRUE(local_state->init(state.get(), info));
+        state->resize_op_id_to_local_state(-100);
+        state->emplace_local_state(op->operator_id(), std::move(local_state_uptr));
+        EXPECT_TRUE(local_state->open(state.get()));
+    }
+
+    {
+        auto id_col = ColumnHelper::create_column<DataTypeInt32>({10, 20, 30, 40});
+        auto nested = ColumnInt32::create();
+        nested->insert_value(1);
+        nested->insert_value(2);
+        nested->insert_value(3);
+        nested->insert_value(4);
+        auto offsets = ColumnArray::ColumnOffsets::create();
+        offsets->insert_value(1);
+        offsets->insert_value(3);
+        offsets->insert_value(3);
+        offsets->insert_value(4);
+        auto arr_col = ColumnArray::create(std::move(nested), std::move(offsets));
+
+        auto int_type = std::make_shared<DataTypeInt32>();
+        auto arr_type = std::make_shared<DataTypeArray>(int_type);
+        *local_state->_child_block = Block({ColumnWithTypeAndName(id_col, int_type, "id"),
+                                            ColumnWithTypeAndName(ColumnPtr(std::move(arr_col)),
+                                                                  arr_type, "arr")});
+        auto st = op->push(state.get(), local_state->_child_block.get(), true);
+        EXPECT_TRUE(st) << st.msg();
+    }
+
+    {
+        Block block;
+        bool eos = false;
+        auto st = op->pull(state.get(), &block, &eos);
+        EXPECT_TRUE(st) << st.msg();
+        EXPECT_FALSE(get_value_called);
+
+        auto expected_id = ColumnHelper::create_column<DataTypeInt32>({10, 20});
+        auto expected_nested = ColumnInt32::create();
+        expected_nested->insert_value(1);
+        expected_nested->insert_value(2);
+        expected_nested->insert_value(3);
+        auto expected_offsets = ColumnArray::ColumnOffsets::create();
+        expected_offsets->insert_value(1);
+        expected_offsets->insert_value(3);
+        auto expected_arr = ColumnArray::create(std::move(expected_nested), std::move(expected_offsets));
+        auto expected_out = ColumnHelper::create_column<DataTypeInt32>({1, 2});
+
+        auto int_type = std::make_shared<DataTypeInt32>();
+        auto arr_type = std::make_shared<DataTypeArray>(int_type);
+        Block expected({ColumnWithTypeAndName(expected_id, int_type, "id"),
+                        ColumnWithTypeAndName(ColumnPtr(std::move(expected_arr)), arr_type, "arr"),
+                        ColumnWithTypeAndName(expected_out, int_type, "x")});
+        EXPECT_TRUE(ColumnHelper::block_equal(block, expected));
+    }
+
+    {
+        Block block;
+        bool eos = false;
+        auto st = op->pull(state.get(), &block, &eos);
+        EXPECT_TRUE(st) << st.msg();
+
+        auto expected_id = ColumnHelper::create_column<DataTypeInt32>({20, 40});
+        auto expected_nested = ColumnInt32::create();
+        expected_nested->insert_value(2);
+        expected_nested->insert_value(3);
+        expected_nested->insert_value(4);
+        auto expected_offsets = ColumnArray::ColumnOffsets::create();
+        expected_offsets->insert_value(2);
+        expected_offsets->insert_value(3);
+        auto expected_arr = ColumnArray::create(std::move(expected_nested), std::move(expected_offsets));
+        auto expected_out = ColumnHelper::create_column<DataTypeInt32>({3, 4});
+
+        auto int_type = std::make_shared<DataTypeInt32>();
+        auto arr_type = std::make_shared<DataTypeArray>(int_type);
+        Block expected({ColumnWithTypeAndName(expected_id, int_type, "id"),
+                        ColumnWithTypeAndName(ColumnPtr(std::move(expected_arr)), arr_type, "arr"),
+                        ColumnWithTypeAndName(expected_out, int_type, "x")});
+        EXPECT_TRUE(ColumnHelper::block_equal(block, expected));
+    }
+}
+
+TEST_F(TableFunctionOperatorTest, block_fast_path_explode_nullable_array_skip) {
+    bool get_value_called = false;
+    {
+        op->_vfn_ctxs =
+                MockSlotRef::create_mock_contexts(DataTypes {std::make_shared<DataTypeInt32>()});
+        auto fn = std::make_shared<MockFastExplodeTableFunction>(&get_value_called);
+        fns.push_back(fn);
+        op->_fns.push_back(fn.get());
+        op->_output_slot_ids = {true, true, true};
+
+        child_op->_mock_row_desc.reset(new MockRowDescriptor {
+                {std::make_shared<vectorized::DataTypeInt32>(),
+                 std::make_shared<vectorized::DataTypeArray>(
+                         std::make_shared<vectorized::DataTypeInt32>())},
+                &pool});
+        op->_mock_row_descriptor.reset(new MockRowDescriptor {
+                {std::make_shared<vectorized::DataTypeInt32>(),
+                 std::make_shared<vectorized::DataTypeArray>(
+                         std::make_shared<vectorized::DataTypeInt32>()),
+                 std::make_shared<vectorized::DataTypeInt32>()},
+                &pool});
+
+        op->_fn_num = 1;
+        EXPECT_TRUE(op->prepare(state.get()));
+
+        local_state_uptr = std::make_unique<MockTableFunctionLocalState>(state.get(), op.get());
+        local_state = local_state_uptr.get();
+        LocalStateInfo info {.parent_profile = &profile,
+                             .scan_ranges = {},
+                             .shared_state = nullptr,
+                             .shared_state_map = {},
+                             .task_idx = 0};
+        EXPECT_TRUE(local_state->init(state.get(), info));
+        state->resize_op_id_to_local_state(-100);
+        state->emplace_local_state(op->operator_id(), std::move(local_state_uptr));
+        EXPECT_TRUE(local_state->open(state.get()));
+    }
+
+    {
+        auto id_col = ColumnHelper::create_column<DataTypeInt32>({10, 20, 30});
+        auto nested = ColumnInt32::create();
+        nested->insert_value(1);
+        nested->insert_value(2);
+        auto offsets = ColumnArray::ColumnOffsets::create();
+        offsets->insert_value(1);
+        offsets->insert_value(1);
+        offsets->insert_value(2);
+        auto arr_col = ColumnArray::create(std::move(nested), std::move(offsets));
+
+        auto int_type = std::make_shared<DataTypeInt32>();
+        auto arr_type = std::make_shared<DataTypeArray>(int_type);
+        *local_state->_child_block = Block({ColumnWithTypeAndName(id_col, int_type, "id"),
+                                            ColumnWithTypeAndName(ColumnPtr(std::move(arr_col)),
+                                                                  arr_type, "arr")});
+        auto st = op->push(state.get(), local_state->_child_block.get(), true);
+        EXPECT_TRUE(st) << st.msg();
+    }
+
+    {
+        Block block;
+        bool eos = false;
+        auto st = op->pull(state.get(), &block, &eos);
+        EXPECT_TRUE(st) << st.msg();
+        EXPECT_FALSE(get_value_called);
+
+        auto expected_id = ColumnHelper::create_column<DataTypeInt32>({10, 30});
+
+        auto expected_nested = ColumnInt32::create();
+        expected_nested->insert_value(1);
+        expected_nested->insert_value(2);
+        auto expected_offsets = ColumnArray::ColumnOffsets::create();
+        expected_offsets->insert_value(1);
+        expected_offsets->insert_value(2);
+        auto expected_arr = ColumnArray::create(std::move(expected_nested), std::move(expected_offsets));
+
+        auto expected_out = ColumnHelper::create_column<DataTypeInt32>({1, 2});
+
+        auto int_type = std::make_shared<DataTypeInt32>();
+        auto arr_type = std::make_shared<DataTypeArray>(int_type);
+        Block expected({ColumnWithTypeAndName(expected_id, int_type, "id"),
+                        ColumnWithTypeAndName(ColumnPtr(std::move(expected_arr)), arr_type, "arr"),
+                        ColumnWithTypeAndName(expected_out, int_type, "x")});
+        EXPECT_TRUE(ColumnHelper::block_equal(block, expected));
+    }
+}
+
+TEST_F(TableFunctionOperatorTest, block_fast_path_explode_nullable_array_null_row) {
+    bool get_value_called = false;
+    {
+        op->_vfn_ctxs =
+                MockSlotRef::create_mock_contexts(DataTypes {std::make_shared<DataTypeInt32>()});
+        auto fn = std::make_shared<MockFastExplodeTableFunction>(&get_value_called);
+        fns.push_back(fn);
+        op->_fns.push_back(fn.get());
+        op->_output_slot_ids = {true, true, true};
+
+        auto int_type = std::make_shared<vectorized::DataTypeInt32>();
+        auto child_arr_type = std::make_shared<vectorized::DataTypeNullable>(
+                std::make_shared<vectorized::DataTypeArray>(int_type));
+        child_op->_mock_row_desc.reset(new MockRowDescriptor {
+                {int_type, child_arr_type},
+                &pool});
+        op->_mock_row_descriptor.reset(
+                new MockRowDescriptor {{int_type, child_arr_type, int_type}, &pool});
+
+        op->_fn_num = 1;
+        EXPECT_TRUE(op->prepare(state.get()));
+
+        local_state_uptr = std::make_unique<MockTableFunctionLocalState>(state.get(), op.get());
+        local_state = local_state_uptr.get();
+        LocalStateInfo info {.parent_profile = &profile,
+                             .scan_ranges = {},
+                             .shared_state = nullptr,
+                             .shared_state_map = {},
+                             .task_idx = 0};
+        EXPECT_TRUE(local_state->init(state.get(), info));
+        state->resize_op_id_to_local_state(-100);
+        state->emplace_local_state(op->operator_id(), std::move(local_state_uptr));
+        EXPECT_TRUE(local_state->open(state.get()));
+    }
+
+    {
+        auto id_col = ColumnHelper::create_column<DataTypeInt32>({10, 20, 30});
+        auto nested = ColumnInt32::create();
+        nested->insert_value(1);
+        nested->insert_value(2);
+        auto offsets = ColumnArray::ColumnOffsets::create();
+        offsets->insert_value(1);
+        offsets->insert_value(1);
+        offsets->insert_value(2);
+        auto arr_data = ColumnArray::create(std::move(nested), std::move(offsets));
+        auto null_map = ColumnUInt8::create();
+        null_map->insert_value(0);
+        null_map->insert_value(1);
+        null_map->insert_value(0);
+        auto arr_col = ColumnNullable::create(std::move(arr_data), std::move(null_map));
+
+        auto int_type = std::make_shared<DataTypeInt32>();
+        auto arr_type =
+                std::make_shared<DataTypeNullable>(std::make_shared<DataTypeArray>(int_type));
+        *local_state->_child_block = Block({ColumnWithTypeAndName(id_col, int_type, "id"),
+                                            ColumnWithTypeAndName(ColumnPtr(std::move(arr_col)),
+                                                                  arr_type, "arr")});
+        auto st = op->push(state.get(), local_state->_child_block.get(), true);
+        EXPECT_TRUE(st) << st.msg();
+    }
+
+    {
+        Block block;
+        bool eos = false;
+        auto st = op->pull(state.get(), &block, &eos);
+        EXPECT_TRUE(st) << st.msg();
+        EXPECT_FALSE(get_value_called);
+
+        auto expected_id = ColumnHelper::create_column<DataTypeInt32>({10, 30});
+        auto expected_nested = ColumnInt32::create();
+        expected_nested->insert_value(1);
+        expected_nested->insert_value(2);
+        auto expected_offsets = ColumnArray::ColumnOffsets::create();
+        expected_offsets->insert_value(1);
+        expected_offsets->insert_value(2);
+        auto expected_arr_data =
+                ColumnArray::create(std::move(expected_nested), std::move(expected_offsets));
+        auto expected_arr_null = ColumnUInt8::create();
+        expected_arr_null->insert_value(0);
+        expected_arr_null->insert_value(0);
+        auto expected_arr = ColumnNullable::create(std::move(expected_arr_data),
+                                                   std::move(expected_arr_null));
+        auto expected_out = ColumnHelper::create_column<DataTypeInt32>({1, 2});
+
+        auto int_type = std::make_shared<DataTypeInt32>();
+        auto arr_type =
+                std::make_shared<DataTypeNullable>(std::make_shared<DataTypeArray>(int_type));
+        Block expected({ColumnWithTypeAndName(expected_id, int_type, "id"),
+                        ColumnWithTypeAndName(ColumnPtr(std::move(expected_arr)), arr_type, "arr"),
+                        ColumnWithTypeAndName(expected_out, int_type, "x")});
+        EXPECT_TRUE(ColumnHelper::block_equal(block, expected));
+    }
+}
+
+TEST_F(TableFunctionOperatorTest, block_fast_path_explode_nullable_array_misaligned_fallback) {
+    bool get_value_called = false;
+    {
+        op->_vfn_ctxs =
+                MockSlotRef::create_mock_contexts(DataTypes {std::make_shared<DataTypeInt32>()});
+        auto fn = std::make_shared<MockFastExplodeTableFunction>(&get_value_called);
+        fns.push_back(fn);
+        op->_fns.push_back(fn.get());
+        op->_output_slot_ids = {true, true, true};
+
+        auto int_type = std::make_shared<vectorized::DataTypeInt32>();
+        auto child_arr_type = std::make_shared<vectorized::DataTypeNullable>(
+                std::make_shared<vectorized::DataTypeArray>(int_type));
+        child_op->_mock_row_desc.reset(new MockRowDescriptor {
+                {int_type, child_arr_type},
+                &pool});
+        op->_mock_row_descriptor.reset(
+                new MockRowDescriptor {{int_type, child_arr_type, int_type}, &pool});
+
+        op->_fn_num = 1;
+        EXPECT_TRUE(op->prepare(state.get()));
+
+        local_state_uptr = std::make_unique<MockTableFunctionLocalState>(state.get(), op.get());
+        local_state = local_state_uptr.get();
+        LocalStateInfo info {.parent_profile = &profile,
+                             .scan_ranges = {},
+                             .shared_state = nullptr,
+                             .shared_state_map = {},
+                             .task_idx = 0};
+        EXPECT_TRUE(local_state->init(state.get(), info));
+        state->resize_op_id_to_local_state(-100);
+        state->emplace_local_state(op->operator_id(), std::move(local_state_uptr));
+        EXPECT_TRUE(local_state->open(state.get()));
+    }
+
+    {
+        auto id_col = ColumnHelper::create_column<DataTypeInt32>({10, 20, 30});
+        auto nested = ColumnInt32::create();
+        nested->insert_value(1);
+        nested->insert_value(9);
+        nested->insert_value(2);
+        auto offsets = ColumnArray::ColumnOffsets::create();
+        offsets->insert_value(1);
+        offsets->insert_value(2);
+        offsets->insert_value(3);
+        auto arr_data = ColumnArray::create(std::move(nested), std::move(offsets));
+        auto null_map = ColumnUInt8::create();
+        null_map->insert_value(0);
+        null_map->insert_value(1);
+        null_map->insert_value(0);
+        auto arr_col = ColumnNullable::create(std::move(arr_data), std::move(null_map));
+
+        auto int_type = std::make_shared<DataTypeInt32>();
+        auto arr_type =
+                std::make_shared<DataTypeNullable>(std::make_shared<DataTypeArray>(int_type));
+        *local_state->_child_block = Block({ColumnWithTypeAndName(id_col, int_type, "id"),
+                                            ColumnWithTypeAndName(ColumnPtr(std::move(arr_col)),
+                                                                  arr_type, "arr")});
+        auto st = op->push(state.get(), local_state->_child_block.get(), true);
+        EXPECT_TRUE(st) << st.msg();
+    }
+
+    {
+        Block block;
+        bool eos = false;
+        auto st = op->pull(state.get(), &block, &eos);
+        EXPECT_TRUE(st) << st.msg();
+        EXPECT_TRUE(get_value_called);
+
+        auto expected_id = ColumnHelper::create_column<DataTypeInt32>({10, 30});
+        auto expected_nested = ColumnInt32::create();
+        expected_nested->insert_value(1);
+        expected_nested->insert_value(2);
+        auto expected_offsets = ColumnArray::ColumnOffsets::create();
+        expected_offsets->insert_value(1);
+        expected_offsets->insert_value(2);
+        auto expected_arr_data =
+                ColumnArray::create(std::move(expected_nested), std::move(expected_offsets));
+        auto expected_arr_null = ColumnUInt8::create();
+        expected_arr_null->insert_value(0);
+        expected_arr_null->insert_value(0);
+        auto expected_arr = ColumnNullable::create(std::move(expected_arr_data),
+                                                   std::move(expected_arr_null));
+        auto expected_out = ColumnHelper::create_column<DataTypeInt32>({1, 2});
+
+        auto int_type = std::make_shared<DataTypeInt32>();
+        auto arr_type =
+                std::make_shared<DataTypeNullable>(std::make_shared<DataTypeArray>(int_type));
+        Block expected({ColumnWithTypeAndName(expected_id, int_type, "id"),
+                        ColumnWithTypeAndName(ColumnPtr(std::move(expected_arr)), arr_type, "arr"),
+                        ColumnWithTypeAndName(expected_out, int_type, "x")});
+        EXPECT_TRUE(ColumnHelper::block_equal(block, expected));
+    }
+}
+
+TEST_F(TableFunctionOperatorTest, block_fast_path_explode_nullable_elements) {
+    bool get_value_called = false;
+    {
+        op->_vfn_ctxs =
+                MockSlotRef::create_mock_contexts(DataTypes {std::make_shared<DataTypeInt32>()});
+        auto fn = std::make_shared<MockFastExplodeTableFunction>(&get_value_called);
+        fns.push_back(fn);
+        op->_fns.push_back(fn.get());
+        op->_output_slot_ids = {true, true, true};
+
+        child_op->_mock_row_desc.reset(new MockRowDescriptor {
+                {std::make_shared<vectorized::DataTypeInt32>(),
+                 std::make_shared<vectorized::DataTypeArray>(
+                         std::make_shared<vectorized::DataTypeNullable>(
+                                 std::make_shared<vectorized::DataTypeInt32>()))},
+                &pool});
+        op->_mock_row_descriptor.reset(new MockRowDescriptor {
+                {std::make_shared<vectorized::DataTypeInt32>(),
+                 std::make_shared<vectorized::DataTypeArray>(
+                         std::make_shared<vectorized::DataTypeNullable>(
+                                 std::make_shared<vectorized::DataTypeInt32>())),
+                 std::make_shared<vectorized::DataTypeNullable>(
+                         std::make_shared<vectorized::DataTypeInt32>())},
+                &pool});
+
+        op->_fn_num = 1;
+        EXPECT_TRUE(op->prepare(state.get()));
+
+        local_state_uptr = std::make_unique<MockTableFunctionLocalState>(state.get(), op.get());
+        local_state = local_state_uptr.get();
+        LocalStateInfo info {.parent_profile = &profile,
+                             .scan_ranges = {},
+                             .shared_state = nullptr,
+                             .shared_state_map = {},
+                             .task_idx = 0};
+        EXPECT_TRUE(local_state->init(state.get(), info));
+        state->resize_op_id_to_local_state(-100);
+        state->emplace_local_state(op->operator_id(), std::move(local_state_uptr));
+        EXPECT_TRUE(local_state->open(state.get()));
+    }
+
+    {
+        auto id_col = ColumnHelper::create_column<DataTypeInt32>({10});
+
+        auto nested_data = ColumnInt32::create();
+        nested_data->insert_value(1);
+        nested_data->insert_value(0);
+        nested_data->insert_value(2);
+        auto nested_null = ColumnUInt8::create();
+        nested_null->insert_value(0);
+        nested_null->insert_value(1);
+        nested_null->insert_value(0);
+        auto nested = ColumnNullable::create(std::move(nested_data), std::move(nested_null));
+
+        auto offsets = ColumnArray::ColumnOffsets::create();
+        offsets->insert_value(3);
+        auto arr_col = ColumnArray::create(std::move(nested), std::move(offsets));
+
+        auto int_type = std::make_shared<DataTypeInt32>();
+        auto nested_type = std::make_shared<DataTypeNullable>(int_type);
+        auto arr_type = std::make_shared<DataTypeArray>(nested_type);
+        *local_state->_child_block = Block({ColumnWithTypeAndName(id_col, int_type, "id"),
+                                            ColumnWithTypeAndName(ColumnPtr(std::move(arr_col)),
+                                                                  arr_type, "arr")});
+        auto st = op->push(state.get(), local_state->_child_block.get(), true);
+        EXPECT_TRUE(st) << st.msg();
+    }
+
+    {
+        Block block;
+        bool eos = false;
+        auto st = op->pull(state.get(), &block, &eos);
+        EXPECT_TRUE(st) << st.msg();
+        EXPECT_FALSE(get_value_called);
+
+        auto expected_id = ColumnHelper::create_column<DataTypeInt32>({10, 10, 10});
+
+        auto expected_nested_data = ColumnInt32::create();
+        expected_nested_data->insert_value(1);
+        expected_nested_data->insert_value(0);
+        expected_nested_data->insert_value(2);
+        expected_nested_data->insert_value(1);
+        expected_nested_data->insert_value(0);
+        expected_nested_data->insert_value(2);
+        expected_nested_data->insert_value(1);
+        expected_nested_data->insert_value(0);
+        expected_nested_data->insert_value(2);
+        auto expected_nested_null = ColumnUInt8::create();
+        expected_nested_null->insert_value(0);
+        expected_nested_null->insert_value(1);
+        expected_nested_null->insert_value(0);
+        expected_nested_null->insert_value(0);
+        expected_nested_null->insert_value(1);
+        expected_nested_null->insert_value(0);
+        expected_nested_null->insert_value(0);
+        expected_nested_null->insert_value(1);
+        expected_nested_null->insert_value(0);
+        auto expected_nested =
+                ColumnNullable::create(std::move(expected_nested_data), std::move(expected_nested_null));
+        auto expected_offsets = ColumnArray::ColumnOffsets::create();
+        expected_offsets->insert_value(3);
+        expected_offsets->insert_value(6);
+        expected_offsets->insert_value(9);
+        auto expected_arr =
+                ColumnArray::create(std::move(expected_nested), std::move(expected_offsets));
+
+        auto expected_out_data = ColumnInt32::create();
+        expected_out_data->insert_value(1);
+        expected_out_data->insert_value(0);
+        expected_out_data->insert_value(2);
+        auto expected_out_null = ColumnUInt8::create();
+        expected_out_null->insert_value(0);
+        expected_out_null->insert_value(1);
+        expected_out_null->insert_value(0);
+        auto expected_out =
+                ColumnNullable::create(std::move(expected_out_data), std::move(expected_out_null));
+
+        auto int_type = std::make_shared<DataTypeInt32>();
+        auto nested_type = std::make_shared<DataTypeNullable>(int_type);
+        auto arr_type = std::make_shared<DataTypeArray>(nested_type);
+        auto out_type = std::make_shared<DataTypeNullable>(int_type);
+        Block expected({ColumnWithTypeAndName(expected_id, int_type, "id"),
+                        ColumnWithTypeAndName(ColumnPtr(std::move(expected_arr)), arr_type, "arr"),
+                        ColumnWithTypeAndName(ColumnPtr(std::move(expected_out)), out_type, "x")});
+        EXPECT_TRUE(ColumnHelper::block_equal(block, expected));
     }
 }
 

--- a/regression-test/suites/query_p0/sql_functions/table_function/explode.groovy
+++ b/regression-test/suites/query_p0/sql_functions/table_function/explode.groovy
@@ -181,12 +181,12 @@ suite("explode") {
     qt_test16 "select id,e1,e2,e3 from array_test as a lateral view explode_outer(a.array_string,a.array_int,a.array_int) tmp1 as e1,e2,e3;"
     qt_test17 "select id,e1,e2,e11,e12 from array_test as a lateral view explode_outer(a.array_int,a.array_string) tmp1 as e1,e2 lateral view explode_outer(a.array_int,a.array_string) tmp2 as e11,e12;"
 
-    qt_test18 "select id,e1 from array_test as a lateral view explode_variant_array(a.v_string['a']) tmp1 as e1;"
-    qt_test19 "select id,e1 from array_test as a lateral view explode_variant_array(a.v_int['a']) tmp1 as e1;"
-    qt_test20 "select id,e1,e2 from array_test as a lateral view explode_variant_array(a.v_int['a'],a.v_string['a']) tmp1 as e1,e2;"
-    qt_test21 "select id,e1,e2 from array_test as a lateral view explode_variant_array(a.v_string['a'],a.v_int['a']) tmp1 as e1,e2;"
-    qt_test22 "select id,e1,e2,e3 from array_test as a lateral view explode_variant_array(a.v_string['a'],a.v_int['a'],a.v_int['a']) tmp1 as e1,e2,e3;"
-    qt_test23 "select id,e1,e2,e11,e12 from array_test as a lateral view explode_variant_array(a.v_int['a'],a.v_string['a']) tmp1 as e1,e2 lateral view explode_variant_array(a.v_int['a'],a.v_string['a']) tmp2 as e11,e12;"
+    qt_test18 "select id,e1 from array_test as a lateral view explode(a.v_string['a']) tmp1 as e1;"
+    qt_test19 "select id,e1 from array_test as a lateral view explode(a.v_int['a']) tmp1 as e1;"
+    qt_test20 "select id,e1,e2 from array_test as a lateral view explode(a.v_int['a'],a.v_string['a']) tmp1 as e1,e2;"
+    qt_test21 "select id,e1,e2 from array_test as a lateral view explode(a.v_string['a'],a.v_int['a']) tmp1 as e1,e2;"
+    qt_test22 "select id,e1,e2,e3 from array_test as a lateral view explode(a.v_string['a'],a.v_int['a'],a.v_int['a']) tmp1 as e1,e2,e3;"
+    qt_test23 "select id,e1,e2,e11,e12 from array_test as a lateral view explode(a.v_int['a'],a.v_string['a']) tmp1 as e1,e2 lateral view explode(a.v_int['a'],a.v_string['a']) tmp2 as e11,e12;"
 
     sql "DROP TABLE IF EXISTS array_test2;"
     sql """


### PR DESCRIPTION
- Add a block fast path for explode-like table functions to expand contiguous nested ranges without per-row get_value()
- Fall back to the original row-wise path when the nested range is non-contiguous or unsupported
- Add/extend unit tests to cover fast path and fallback cases

Test: ./run-be-ut.sh --run --filter='TableFunctionOperatorTest.*:UnnestTest.*'

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

