### PR TITLE
[opt](table-function) Optimize explode with block fast path

### DIFF
--- a/be/src/exec/operator/table_function_operator.cpp
+++ b/be/src/exec/operator/table_function_operator.cpp
@@ -17,11 +17,17 @@
 
 #include "exec/operator/table_function_operator.h"
 
+#include <algorithm>
+#include <cstring>
 #include <limits>
 #include <memory>
+#include <numeric>
 
+#include "common/cast_set.h"
+#include "core/assert_cast.h"
 #include "core/block/block.h"
 #include "core/block/column_numbers.h"
+#include "core/column/column_nullable.h"
 #include "core/custom_allocator.h"
 #include "exec/operator/operator.h"
 #include "exprs/table_function/table_function_factory.h"
@@ -76,6 +82,7 @@ Status TableFunctionLocalState::open(RuntimeState* state) {
         RETURN_IF_ERROR(fn->open());
     }
     _cur_child_offset = -1;
+    _reset_block_fast_path_state();
     return Status::OK();
 }
 
@@ -160,6 +167,209 @@ bool TableFunctionLocalState::_is_inner_and_empty() {
     return false;
 }
 
+bool TableFunctionLocalState::_can_use_block_fast_path() const {
+    auto& p = _parent->cast<TableFunctionOperatorX>();
+    // Fast path is only valid when:
+    // - only one table function exists
+    // - there is an active child row to expand
+    // - the child block is non-empty
+    // - the table function can expose nested/offsets via prepare_block_fast_path()
+    return p._fn_num == 1 && _cur_child_offset != -1 && _child_block->rows() > 0 &&
+           _fns[0]->support_block_fast_path();
+}
+
+void TableFunctionLocalState::_reset_block_fast_path_state() {
+    _block_fast_path_prepared = false;
+    _block_fast_path_enabled = false;
+    _block_fast_path_ctx = {};
+    _block_fast_path_row = 0;
+    _block_fast_path_in_row_offset = 0;
+}
+
+Status TableFunctionLocalState::_prepare_block_fast_path(RuntimeState* state) {
+    if (_block_fast_path_prepared) {
+        return Status::OK();
+    }
+
+    RETURN_IF_ERROR(
+            _fns[0]->prepare_block_fast_path(_child_block.get(), state, &_block_fast_path_ctx));
+    if (_block_fast_path_ctx.offsets_ptr == nullptr ||
+        _block_fast_path_ctx.nested_col.get() == nullptr) {
+        return Status::InternalError("block fast path context is invalid");
+    }
+
+    const auto child_rows = cast_set<int64_t>(_block_fast_path_ctx.offsets_ptr->size());
+    if (child_rows != cast_set<int64_t>(_child_block->rows())) {
+        return Status::InternalError("block fast path offsets size mismatch");
+    }
+
+    _block_fast_path_row = _cur_child_offset;
+    _block_fast_path_in_row_offset = 0;
+    _block_fast_path_enabled = _has_contiguous_block_fast_path_suffix();
+    _block_fast_path_prepared = true;
+    return Status::OK();
+}
+
+bool TableFunctionLocalState::_has_contiguous_block_fast_path_suffix() const {
+    const auto& offsets = *_block_fast_path_ctx.offsets_ptr;
+    const auto child_rows = cast_set<int64_t>(offsets.size());
+    int64_t child_row = _block_fast_path_row;
+    uint64_t in_row_offset = _block_fast_path_in_row_offset;
+    uint64_t expected_next_nested_idx = 0;
+    bool found_nested_range = false;
+
+    while (child_row < child_rows) {
+        if (_block_fast_path_ctx.array_nullmap_data &&
+            _block_fast_path_ctx.array_nullmap_data[child_row]) {
+            child_row++;
+            in_row_offset = 0;
+            continue;
+        }
+
+        const uint64_t prev_off = child_row == 0 ? 0 : offsets[child_row - 1];
+        const uint64_t cur_off = offsets[child_row];
+        const uint64_t nested_len = cur_off - prev_off;
+        if (in_row_offset >= nested_len) {
+            child_row++;
+            in_row_offset = 0;
+            continue;
+        }
+
+        const uint64_t nested_start = prev_off + in_row_offset;
+        if (!found_nested_range) {
+            found_nested_range = true;
+        } else if (nested_start != expected_next_nested_idx) {
+            return false;
+        }
+        expected_next_nested_idx = cur_off;
+        child_row++;
+        in_row_offset = 0;
+    }
+
+    return true;
+}
+
+Status TableFunctionLocalState::_get_expanded_block_block_fast_path(
+        RuntimeState* state, std::vector<MutableColumnPtr>& columns) {
+    auto& p = _parent->cast<TableFunctionOperatorX>();
+    DCHECK(_block_fast_path_prepared);
+    DCHECK(_block_fast_path_enabled);
+
+    const auto remaining_capacity =
+            state->batch_size() - cast_set<int>(columns[p._child_slots.size()]->size());
+    if (remaining_capacity <= 0) {
+        return Status::OK();
+    }
+
+    const auto& offsets = *_block_fast_path_ctx.offsets_ptr;
+    const auto child_rows = cast_set<int64_t>(offsets.size());
+
+    std::vector<uint32_t> row_ids;
+    row_ids.reserve(remaining_capacity);
+    uint64_t first_nested_idx = 0;
+    uint64_t expected_next_nested_idx = 0;
+    bool found_nested_range = false;
+
+    int64_t child_row = _block_fast_path_row;
+    uint64_t in_row_offset = _block_fast_path_in_row_offset;
+    int produced_rows = 0;
+
+    while (produced_rows < remaining_capacity && child_row < child_rows) {
+        if (_block_fast_path_ctx.array_nullmap_data &&
+            _block_fast_path_ctx.array_nullmap_data[child_row]) {
+            // NULL array row: skip it here. Slow path will handle output semantics if needed.
+            child_row++;
+            in_row_offset = 0;
+            continue;
+        }
+
+        const uint64_t prev_off = child_row == 0 ? 0 : offsets[child_row - 1];
+        const uint64_t cur_off = offsets[child_row];
+        const uint64_t nested_len = cur_off - prev_off;
+
+        if (in_row_offset >= nested_len) {
+            child_row++;
+            in_row_offset = 0;
+            continue;
+        }
+
+        const uint64_t remaining_in_row = nested_len - in_row_offset;
+        const int take_count =
+                std::min<int>(remaining_capacity - produced_rows, cast_set<int>(remaining_in_row));
+        const uint64_t nested_start = prev_off + in_row_offset;
+
+        DCHECK_LE(nested_start + take_count, cur_off);
+        DCHECK_LE(nested_start + take_count, _block_fast_path_ctx.nested_col->size());
+
+        if (!found_nested_range) {
+            found_nested_range = true;
+            first_nested_idx = nested_start;
+            expected_next_nested_idx = nested_start;
+        }
+        DCHECK_EQ(nested_start, expected_next_nested_idx);
+
+        // Map each produced output row back to its source child row for copying non-table-function
+        // columns via insert_indices_from().
+        for (int j = 0; j < take_count; ++j) {
+            row_ids.push_back(cast_set<uint32_t>(child_row));
+        }
+
+        produced_rows += take_count;
+        expected_next_nested_idx += take_count;
+        in_row_offset += take_count;
+        if (in_row_offset >= nested_len) {
+            child_row++;
+            in_row_offset = 0;
+        }
+    }
+
+    if (produced_rows > 0) {
+        for (auto index : p._output_slot_indexs) {
+            auto src_column = _child_block->get_by_position(index).column;
+            columns[index]->insert_indices_from(*src_column, row_ids.data(),
+                                                row_ids.data() + produced_rows);
+        }
+
+        auto& out_col = columns[p._child_slots.size()];
+        if (out_col->is_nullable()) {
+            auto* out_nullable = assert_cast<ColumnNullable*>(out_col.get());
+            out_nullable->get_nested_column_ptr()->insert_range_from(
+                    *_block_fast_path_ctx.nested_col, first_nested_idx, produced_rows);
+            auto* nullmap_column =
+                    assert_cast<ColumnUInt8*>(out_nullable->get_null_map_column_ptr().get());
+            auto& nullmap_data = nullmap_column->get_data();
+            const size_t old_size = nullmap_data.size();
+            nullmap_data.resize(old_size + produced_rows);
+            if (_block_fast_path_ctx.nested_nullmap_data != nullptr) {
+                memcpy(nullmap_data.data() + old_size,
+                       _block_fast_path_ctx.nested_nullmap_data + first_nested_idx,
+                       produced_rows * sizeof(UInt8));
+            } else {
+                memset(nullmap_data.data() + old_size, 0, produced_rows * sizeof(UInt8));
+            }
+        } else {
+            out_col->insert_range_from(*_block_fast_path_ctx.nested_col, first_nested_idx,
+                                       produced_rows);
+        }
+    }
+
+    _block_fast_path_row = child_row;
+    _block_fast_path_in_row_offset = in_row_offset;
+    _cur_child_offset = child_row >= child_rows ? -1 : child_row;
+
+    if (child_row >= child_rows) {
+        for (TableFunction* fn : _fns) {
+            fn->process_close();
+        }
+        _child_block->clear_column_data(_parent->cast<TableFunctionOperatorX>()
+                                                ._child->row_desc()
+                                                .num_materialized_slots());
+        _reset_block_fast_path_state();
+    }
+
+    return Status::OK();
+}
+
 Status TableFunctionLocalState::get_expanded_block(RuntimeState* state, Block* output_block,
                                                    bool* eos) {
     SCOPED_TIMER(_process_rows_timer);
@@ -177,15 +387,29 @@ Status TableFunctionLocalState::get_expanded_block(RuntimeState* state, Block* o
             _fns[i]->set_nullable();
         }
     }
-    while (columns[p._child_slots.size()]->size() < state->batch_size()) {
+
+    bool use_slow_path = true;
+    if (_can_use_block_fast_path()) {
         RETURN_IF_CANCELLED(state);
-
-        if (_child_block->rows() == 0) {
-            break;
+        RETURN_IF_ERROR(_prepare_block_fast_path(state));
+        if (_block_fast_path_enabled) {
+            // Only use fast path when the remaining nested suffix stays contiguous for the rest of
+            // the child block. This keeps fast-path progress entirely inside local state and avoids
+            // re-synchronizing the table function cursor when a later batch would otherwise fall
+            // back to the row-wise path.
+            RETURN_IF_ERROR(_get_expanded_block_block_fast_path(state, columns));
+            use_slow_path = false;
         }
+    }
 
+    if (use_slow_path) {
         bool skip_child_row = false;
         while (columns[p._child_slots.size()]->size() < state->batch_size()) {
+            RETURN_IF_CANCELLED(state);
+
+            if (_child_block->rows() == 0) {
+                break;
+            }
             int idx = _find_last_fn_eos_idx();
             if (idx == 0 || skip_child_row) {
                 _copy_output_slots(columns, p);
@@ -463,6 +687,7 @@ void TableFunctionLocalState::process_next_child_row() {
                                                     .num_materialized_slots());
         }
         _cur_child_offset = -1;
+        _reset_block_fast_path_state();
         return;
     }
 

--- a/be/src/exec/operator/table_function_operator.h
+++ b/be/src/exec/operator/table_function_operator.h
@@ -65,6 +65,12 @@ private:
     // >0: some of fns are eos
     int _find_last_fn_eos_idx() const;
     bool _is_inner_and_empty();
+    bool _can_use_block_fast_path() const;
+    void _reset_block_fast_path_state();
+    Status _prepare_block_fast_path(RuntimeState* state);
+    bool _has_contiguous_block_fast_path_suffix() const;
+    Status _get_expanded_block_block_fast_path(RuntimeState* state,
+                                               std::vector<MutableColumnPtr>& columns);
 
     Status _get_expanded_block_for_outer_conjuncts(RuntimeState* state, Block* output_block,
                                                    bool* eos);
@@ -79,6 +85,12 @@ private:
     int _current_row_insert_times = 0;
     bool _child_eos = false;
     DorisVector<bool> _child_rows_has_output;
+
+    bool _block_fast_path_prepared = false;
+    bool _block_fast_path_enabled = false;
+    TableFunction::BlockFastPathContext _block_fast_path_ctx;
+    int64_t _block_fast_path_row = 0;
+    uint64_t _block_fast_path_in_row_offset = 0;
 
     RuntimeProfile::Counter* _init_function_timer = nullptr;
     RuntimeProfile::Counter* _process_rows_timer = nullptr;

--- a/be/src/exprs/function/array/function_array_utils.cpp
+++ b/be/src/exprs/function/array/function_array_utils.cpp
@@ -59,18 +59,9 @@ bool extract_column_array_info(const IColumn& src, ColumnArrayExecutionData& dat
         data.nested_type->get_primitive_type() != PrimitiveType::TYPE_VARIANT) {
         // set variant root column/type to from column/type
         auto variant = ColumnVariant::create(0, data.variant_enable_doc_mode);
-        auto root_col = data.nested_col->assume_mutable();
-        if (data.nested_type->is_nullable() && !root_col->is_nullable()) {
-            auto null_map = ColumnUInt8::create();
-            auto& null_map_data = null_map->get_data();
-            null_map_data.resize(root_col->size(), 0);
-            if (data.nested_nullmap_data != nullptr) {
-                std::copy(data.nested_nullmap_data, data.nested_nullmap_data + root_col->size(),
-                          null_map_data.begin());
-            }
-            root_col = ColumnNullable::create(std::move(root_col), std::move(null_map));
-        }
-        variant->create_root(data.nested_type, std::move(root_col));
+        auto nullable_nested_type = make_nullable(data.nested_type);
+        auto nullable_col = make_nullable(data.nested_col);
+        variant->create_root(nullable_nested_type, std::move(*nullable_col).mutate());
         data.nested_col = variant->get_ptr();
     }
     return true;

--- a/be/src/exprs/function/array/function_array_utils.cpp
+++ b/be/src/exprs/function/array/function_array_utils.cpp
@@ -59,9 +59,18 @@ bool extract_column_array_info(const IColumn& src, ColumnArrayExecutionData& dat
         data.nested_type->get_primitive_type() != PrimitiveType::TYPE_VARIANT) {
         // set variant root column/type to from column/type
         auto variant = ColumnVariant::create(0, data.variant_enable_doc_mode);
-        auto nullable_nested_type = make_nullable(data.nested_type);
-        auto nullable_col = make_nullable(data.nested_col);
-        variant->create_root(nullable_nested_type, std::move(*nullable_col).mutate());
+        auto root_col = data.nested_col->assume_mutable();
+        if (data.nested_type->is_nullable() && !root_col->is_nullable()) {
+            auto null_map = ColumnUInt8::create();
+            auto& null_map_data = null_map->get_data();
+            null_map_data.resize(root_col->size(), 0);
+            if (data.nested_nullmap_data != nullptr) {
+                std::copy(data.nested_nullmap_data, data.nested_nullmap_data + root_col->size(),
+                          null_map_data.begin());
+            }
+            root_col = ColumnNullable::create(std::move(root_col), std::move(null_map));
+        }
+        variant->create_root(data.nested_type, std::move(root_col));
         data.nested_col = variant->get_ptr();
     }
     return true;

--- a/be/src/exprs/table_function/table_function.h
+++ b/be/src/exprs/table_function/table_function.h
@@ -20,6 +20,7 @@
 #include <fmt/core.h>
 
 #include <cstddef>
+#include <cstdint>
 
 #include "common/status.h"
 #include "core/block/block.h"
@@ -33,6 +34,13 @@ constexpr auto COMBINATOR_SUFFIX_OUTER = "_outer";
 class TableFunction {
 public:
     virtual ~TableFunction() = default;
+
+    struct BlockFastPathContext {
+        const UInt8* array_nullmap_data = nullptr;
+        const IColumn::Offsets64* offsets_ptr = nullptr;
+        ColumnPtr nested_col = nullptr;
+        const UInt8* nested_nullmap_data = nullptr;
+    };
 
     virtual Status prepare() { return Status::OK(); }
 
@@ -57,6 +65,12 @@ public:
 
     virtual void get_same_many_values(MutableColumnPtr& column, int length = 0) = 0;
     virtual int get_value(MutableColumnPtr& column, int max_step) = 0;
+
+    virtual bool support_block_fast_path() const { return false; }
+    virtual Status prepare_block_fast_path(Block* /*block*/, RuntimeState* /*state*/,
+                                           BlockFastPathContext* /*ctx*/) {
+        return Status::NotSupported("table function {} doesn't support block fast path", _fn_name);
+    }
 
     virtual Status close() { return Status::OK(); }
 

--- a/be/src/exprs/table_function/vexplode.cpp
+++ b/be/src/exprs/table_function/vexplode.cpp
@@ -93,6 +93,25 @@ Status VExplodeTableFunction::process_init(Block* block, RuntimeState* state) {
     return Status::OK();
 }
 
+bool VExplodeTableFunction::support_block_fast_path() const {
+    return !_is_outer;
+}
+
+Status VExplodeTableFunction::prepare_block_fast_path(Block* /*block*/, RuntimeState* /*state*/,
+                                                      BlockFastPathContext* ctx) {
+    if (!support_block_fast_path()) {
+        return Status::NotSupported("vexplode doesn't support block fast path in current mode");
+    }
+    if (_detail.offsets_ptr == nullptr || _detail.nested_col.get() == nullptr) {
+        return Status::InternalError("vexplode block fast path not initialized");
+    }
+    ctx->array_nullmap_data = _detail.array_nullmap_data;
+    ctx->offsets_ptr = _detail.offsets_ptr;
+    ctx->nested_col = _detail.nested_col;
+    ctx->nested_nullmap_data = _detail.nested_nullmap_data;
+    return Status::OK();
+}
+
 void VExplodeTableFunction::process_row(size_t row_idx) {
     DCHECK(row_idx < _array_column->size());
     TableFunction::process_row(row_idx);

--- a/be/src/exprs/table_function/vexplode.h
+++ b/be/src/exprs/table_function/vexplode.h
@@ -46,6 +46,10 @@ public:
     void get_same_many_values(MutableColumnPtr& column, int length) override;
     int get_value(MutableColumnPtr& column, int max_step) override;
 
+    bool support_block_fast_path() const override;
+    Status prepare_block_fast_path(Block* block, RuntimeState* state,
+                                   BlockFastPathContext* ctx) override;
+
 private:
     Status _process_init_variant(Block* block, int value_column_idx);
     ColumnPtr _array_column;

--- a/be/src/exprs/table_function/vexplode_v2.cpp
+++ b/be/src/exprs/table_function/vexplode_v2.cpp
@@ -109,17 +109,12 @@ Status VExplodeV2TableFunction::process_init(Block* block, RuntimeState* state) 
 }
 
 bool VExplodeV2TableFunction::support_block_fast_path() const {
-    return !_is_outer && !_generate_row_index;
+    return !_is_outer && !_generate_row_index && _multi_detail.size() == 1;
 }
 
 Status VExplodeV2TableFunction::prepare_block_fast_path(Block* /*block*/, RuntimeState* /*state*/,
                                                         BlockFastPathContext* ctx) {
-    if (!support_block_fast_path()) {
-        return Status::NotSupported("vexplode doesn't support block fast path in current mode");
-    }
-    if (_multi_detail.size() != 1) {
-        return Status::NotSupported("vexplode block fast path only supports single parameter");
-    }
+    DCHECK(support_block_fast_path());
     const auto& detail = _multi_detail[0];
     if (detail.offsets_ptr == nullptr || detail.nested_col.get() == nullptr) {
         return Status::InternalError("vexplode block fast path not initialized");

--- a/be/src/exprs/table_function/vexplode_v2.cpp
+++ b/be/src/exprs/table_function/vexplode_v2.cpp
@@ -108,6 +108,29 @@ Status VExplodeV2TableFunction::process_init(Block* block, RuntimeState* state) 
     return Status::OK();
 }
 
+bool VExplodeV2TableFunction::support_block_fast_path() const {
+    return !_is_outer && !_generate_row_index;
+}
+
+Status VExplodeV2TableFunction::prepare_block_fast_path(Block* /*block*/, RuntimeState* /*state*/,
+                                                        BlockFastPathContext* ctx) {
+    if (!support_block_fast_path()) {
+        return Status::NotSupported("vexplode doesn't support block fast path in current mode");
+    }
+    if (_multi_detail.size() != 1) {
+        return Status::NotSupported("vexplode block fast path only supports single parameter");
+    }
+    const auto& detail = _multi_detail[0];
+    if (detail.offsets_ptr == nullptr || detail.nested_col.get() == nullptr) {
+        return Status::InternalError("vexplode block fast path not initialized");
+    }
+    ctx->array_nullmap_data = detail.array_nullmap_data;
+    ctx->offsets_ptr = detail.offsets_ptr;
+    ctx->nested_col = detail.nested_col;
+    ctx->nested_nullmap_data = detail.nested_nullmap_data;
+    return Status::OK();
+}
+
 void VExplodeV2TableFunction::process_row(size_t row_idx) {
     TableFunction::process_row(row_idx);
 

--- a/be/src/exprs/table_function/vexplode_v2.h
+++ b/be/src/exprs/table_function/vexplode_v2.h
@@ -46,6 +46,10 @@ public:
     void get_same_many_values(MutableColumnPtr& column, int length) override;
     int get_value(MutableColumnPtr& column, int max_step) override;
 
+    bool support_block_fast_path() const override;
+    Status prepare_block_fast_path(Block* block, RuntimeState* state,
+                                   BlockFastPathContext* ctx) override;
+
     void set_generate_row_index(bool generate_row_index) {
         _generate_row_index = generate_row_index;
     }

--- a/be/test/exec/operator/table_function_operator_test.cpp
+++ b/be/test/exec/operator/table_function_operator_test.cpp
@@ -26,13 +26,19 @@
 #include <vector>
 
 #include "core/block/block.h"
+#include "core/column/column_array.h"
+#include "core/column/column_nullable.h"
+#include "core/data_type/data_type_array.h"
+#include "core/data_type/data_type_nullable.h"
 #include "exec/operator/operator_helper.h"
+#include "exprs/function/array/function_array_utils.h"
 #include "testutil/column_helper.h"
 #include "testutil/creators.h"
 #include "testutil/mock/mock_descriptors.h"
 #include "testutil/mock/mock_literal_expr.h"
 #include "testutil/mock/mock_operators.h"
 #include "testutil/mock/mock_slot_ref.h"
+
 namespace doris {
 
 class MockTableFunctionChildOperator : public OperatorXBase {
@@ -86,6 +92,88 @@ public:
     }
 };
 
+class MockFastExplodeTableFunction : public TableFunction {
+public:
+    explicit MockFastExplodeTableFunction(bool* get_value_called)
+            : _get_value_called(get_value_called) {}
+
+    Status process_init(Block* block, RuntimeState* /*state*/) override {
+        // Expose array offsets / nested column for TableFunctionLocalState block fast path.
+        ColumnArrayExecutionData data;
+        auto array_col = block->get_by_position(1).column->convert_to_full_column_if_const();
+        if (!extract_column_array_info(*array_col, data)) {
+            return Status::InternalError("invalid array column");
+        }
+        _detail = data;
+        return Status::OK();
+    }
+
+    void process_row(size_t row_idx) override {
+        TableFunction::process_row(row_idx);
+        if (!_detail.array_nullmap_data || !_detail.array_nullmap_data[row_idx]) {
+            _array_offset = row_idx == 0 ? 0 : (*_detail.offsets_ptr)[row_idx - 1];
+            _cur_size = (*_detail.offsets_ptr)[row_idx] - _array_offset;
+        }
+    }
+
+    void process_close() override {
+        _detail.reset();
+        _array_offset = 0;
+    }
+
+    void get_same_many_values(MutableColumnPtr& column, int length) override {
+        column->insert_many_defaults(length);
+    }
+
+    int get_value(MutableColumnPtr& column, int max_step) override {
+        if (_get_value_called) {
+            // Slow path indicator: fast path tests expect this to remain false.
+            *_get_value_called = true;
+        }
+        max_step = std::min(max_step, cast_set<int>(_cur_size - _cur_offset));
+        const size_t pos = _array_offset + _cur_offset;
+        if (current_empty()) {
+            column->insert_default();
+            max_step = 1;
+        } else if (column->is_nullable()) {
+            auto* nullable_column = assert_cast<ColumnNullable*>(column.get());
+            nullable_column->get_nested_column_ptr()->insert_range_from(*_detail.nested_col, pos,
+                                                                        max_step);
+            auto* nullmap_column =
+                    assert_cast<ColumnUInt8*>(nullable_column->get_null_map_column_ptr().get());
+            const size_t old_size = nullmap_column->size();
+            nullmap_column->resize(old_size + max_step);
+            if (_detail.nested_nullmap_data != nullptr) {
+                memcpy(nullmap_column->get_data().data() + old_size,
+                       _detail.nested_nullmap_data + pos, max_step * sizeof(UInt8));
+            } else {
+                memset(nullmap_column->get_data().data() + old_size, 0, max_step * sizeof(UInt8));
+            }
+        } else {
+            column->insert_range_from(*_detail.nested_col, pos, max_step);
+        }
+        forward(max_step);
+        return max_step;
+    }
+
+    bool support_block_fast_path() const override { return true; }
+
+    Status prepare_block_fast_path(Block* /*block*/, RuntimeState* /*state*/,
+                                   BlockFastPathContext* ctx) override {
+        // NOTE: process_init() must be called before this to fill `_detail`.
+        ctx->array_nullmap_data = _detail.array_nullmap_data;
+        ctx->offsets_ptr = _detail.offsets_ptr;
+        ctx->nested_col = _detail.nested_col;
+        ctx->nested_nullmap_data = _detail.nested_nullmap_data;
+        return Status::OK();
+    }
+
+private:
+    bool* _get_value_called = nullptr;
+    ColumnArrayExecutionData _detail;
+    size_t _array_offset = 0;
+};
+
 struct MockTableFunctionLocalState : TableFunctionLocalState {
     MockTableFunctionLocalState(RuntimeState* state, OperatorXBase* parent)
             : TableFunctionLocalState(state, parent) {}
@@ -110,6 +198,53 @@ struct TableFunctionOperatorTest : public ::testing::Test {
         child_op = std::make_shared<MockTableFunctionChildOperator>();
         op->_child = child_op;
         fns.clear();
+    }
+
+    void prepare_fast_explode_operator(const DataTypePtr& child_array_type,
+                                       const DataTypePtr& output_type, bool* get_value_called,
+                                       std::vector<bool> output_slot_ids = {true, true, true}) {
+        auto int_type = std::make_shared<DataTypeInt32>();
+        op->_vfn_ctxs = MockSlotRef::create_mock_contexts(DataTypes {int_type});
+        auto fn = std::make_shared<MockFastExplodeTableFunction>(get_value_called);
+        fns.push_back(fn);
+        op->_fns.push_back(fn.get());
+        op->_output_slot_ids = std::move(output_slot_ids);
+
+        child_op->_mock_row_desc.reset(new MockRowDescriptor {{int_type, child_array_type}, &pool});
+        op->_mock_row_descriptor.reset(
+                new MockRowDescriptor {{int_type, child_array_type, output_type}, &pool});
+
+        op->_fn_num = 1;
+        EXPECT_TRUE(op->prepare(state.get()));
+
+        local_state_uptr = std::make_unique<MockTableFunctionLocalState>(state.get(), op.get());
+        local_state = local_state_uptr.get();
+        LocalStateInfo info {.parent_profile = &profile,
+                             .scan_ranges = {},
+                             .shared_state = nullptr,
+                             .shared_state_map = {},
+                             .task_idx = 0};
+        EXPECT_TRUE(local_state->init(state.get(), info));
+        state->resize_op_id_to_local_state(-100);
+        state->emplace_local_state(op->operator_id(), std::move(local_state_uptr));
+        EXPECT_TRUE(local_state->open(state.get()));
+    }
+
+    void push_child_block(Block block) {
+        *local_state->_child_block = std::move(block);
+        auto st = op->push(state.get(), local_state->_child_block.get(), true);
+        EXPECT_TRUE(st) << st.msg();
+    }
+
+    Block pull_child_block(bool* eos = nullptr) {
+        Block block;
+        bool local_eos = false;
+        auto st = op->pull(state.get(), &block, &local_eos);
+        EXPECT_TRUE(st) << st.msg();
+        if (eos != nullptr) {
+            *eos = local_eos;
+        }
+        return block;
     }
 
     std::shared_ptr<MockTableFunctionOperatorX> op;
@@ -215,6 +350,482 @@ TEST_F(TableFunctionOperatorTest, single_fn_test2) {
         std::cout << eos << std::endl;
         EXPECT_TRUE(ColumnHelper::block_equal(block, ColumnHelper::create_block<DataTypeInt32>(
                                                              {1, 1, 1, 1, 1}, {0, 0, 0, 0, 0})));
+    }
+}
+
+TEST_F(TableFunctionOperatorTest, block_fast_path_explode) {
+    bool get_value_called = false;
+    auto int_type = std::make_shared<DataTypeInt32>();
+    auto arr_type = std::make_shared<DataTypeArray>(int_type);
+    prepare_fast_explode_operator(arr_type, int_type, &get_value_called, {true, false, true});
+
+    {
+        auto id_col = ColumnHelper::create_column<DataTypeInt32>({10, 20, 30, 40});
+        auto nested = ColumnInt32::create();
+        nested->insert_value(1);
+        nested->insert_value(2);
+        nested->insert_value(3);
+        nested->insert_value(4);
+        auto offsets = ColumnArray::ColumnOffsets::create();
+        offsets->insert_value(1);
+        offsets->insert_value(3);
+        offsets->insert_value(3);
+        offsets->insert_value(4);
+        auto arr_col = ColumnArray::create(std::move(nested), std::move(offsets));
+
+        push_child_block(
+                Block({ColumnWithTypeAndName(id_col, int_type, "id"),
+                       ColumnWithTypeAndName(ColumnPtr(std::move(arr_col)), arr_type, "arr")}));
+    }
+
+    {
+        bool eos = false;
+        auto block = pull_child_block(&eos);
+        EXPECT_FALSE(get_value_called);
+
+        auto expected_id = ColumnHelper::create_column<DataTypeInt32>({10, 20, 20, 40});
+
+        auto expected_nested = ColumnInt32::create();
+        expected_nested->insert_value(1);
+        expected_nested->insert_value(2);
+        expected_nested->insert_value(3);
+        expected_nested->insert_value(2);
+        expected_nested->insert_value(3);
+        expected_nested->insert_value(4);
+        auto expected_offsets = ColumnArray::ColumnOffsets::create();
+        expected_offsets->insert_value(1);
+        expected_offsets->insert_value(3);
+        expected_offsets->insert_value(5);
+        expected_offsets->insert_value(6);
+        auto expected_arr =
+                ColumnArray::create(std::move(expected_nested), std::move(expected_offsets));
+
+        auto expected_out = ColumnHelper::create_column<DataTypeInt32>({1, 2, 3, 4});
+
+        auto int_type = std::make_shared<DataTypeInt32>();
+        auto arr_type = std::make_shared<DataTypeArray>(int_type);
+        Block expected({ColumnWithTypeAndName(expected_id, int_type, "id"),
+                        ColumnWithTypeAndName(ColumnPtr(std::move(expected_arr)), arr_type, "arr"),
+                        ColumnWithTypeAndName(expected_out, int_type, "x")});
+        EXPECT_TRUE(ColumnHelper::block_equal(block, expected));
+    }
+}
+
+TEST_F(TableFunctionOperatorTest, block_fast_path_explode_batch_truncate) {
+    state->batsh_size = 2;
+    bool get_value_called = false;
+    auto int_type = std::make_shared<DataTypeInt32>();
+    auto arr_type = std::make_shared<DataTypeArray>(int_type);
+    prepare_fast_explode_operator(arr_type, int_type, &get_value_called);
+
+    {
+        auto id_col = ColumnHelper::create_column<DataTypeInt32>({10, 20, 30, 40});
+        auto nested = ColumnInt32::create();
+        nested->insert_value(1);
+        nested->insert_value(2);
+        nested->insert_value(3);
+        nested->insert_value(4);
+        auto offsets = ColumnArray::ColumnOffsets::create();
+        offsets->insert_value(1);
+        offsets->insert_value(3);
+        offsets->insert_value(3);
+        offsets->insert_value(4);
+        auto arr_col = ColumnArray::create(std::move(nested), std::move(offsets));
+
+        push_child_block(
+                Block({ColumnWithTypeAndName(id_col, int_type, "id"),
+                       ColumnWithTypeAndName(ColumnPtr(std::move(arr_col)), arr_type, "arr")}));
+    }
+
+    {
+        bool eos = false;
+        auto block = pull_child_block(&eos);
+        EXPECT_FALSE(get_value_called);
+
+        auto expected_id = ColumnHelper::create_column<DataTypeInt32>({10, 20});
+        auto expected_nested = ColumnInt32::create();
+        expected_nested->insert_value(1);
+        expected_nested->insert_value(2);
+        expected_nested->insert_value(3);
+        auto expected_offsets = ColumnArray::ColumnOffsets::create();
+        expected_offsets->insert_value(1);
+        expected_offsets->insert_value(3);
+        auto expected_arr =
+                ColumnArray::create(std::move(expected_nested), std::move(expected_offsets));
+        auto expected_out = ColumnHelper::create_column<DataTypeInt32>({1, 2});
+
+        auto int_type = std::make_shared<DataTypeInt32>();
+        auto arr_type = std::make_shared<DataTypeArray>(int_type);
+        Block expected({ColumnWithTypeAndName(expected_id, int_type, "id"),
+                        ColumnWithTypeAndName(ColumnPtr(std::move(expected_arr)), arr_type, "arr"),
+                        ColumnWithTypeAndName(expected_out, int_type, "x")});
+        EXPECT_TRUE(ColumnHelper::block_equal(block, expected));
+    }
+
+    {
+        bool eos = false;
+        auto block = pull_child_block(&eos);
+
+        auto expected_id = ColumnHelper::create_column<DataTypeInt32>({20, 40});
+        auto expected_nested = ColumnInt32::create();
+        expected_nested->insert_value(2);
+        expected_nested->insert_value(3);
+        expected_nested->insert_value(4);
+        auto expected_offsets = ColumnArray::ColumnOffsets::create();
+        expected_offsets->insert_value(2);
+        expected_offsets->insert_value(3);
+        auto expected_arr =
+                ColumnArray::create(std::move(expected_nested), std::move(expected_offsets));
+        auto expected_out = ColumnHelper::create_column<DataTypeInt32>({3, 4});
+
+        auto int_type = std::make_shared<DataTypeInt32>();
+        auto arr_type = std::make_shared<DataTypeArray>(int_type);
+        Block expected({ColumnWithTypeAndName(expected_id, int_type, "id"),
+                        ColumnWithTypeAndName(ColumnPtr(std::move(expected_arr)), arr_type, "arr"),
+                        ColumnWithTypeAndName(expected_out, int_type, "x")});
+        EXPECT_TRUE(ColumnHelper::block_equal(block, expected));
+    }
+}
+
+TEST_F(TableFunctionOperatorTest, block_fast_path_explode_nullable_array_skip) {
+    bool get_value_called = false;
+    auto int_type = std::make_shared<DataTypeInt32>();
+    auto arr_type = std::make_shared<DataTypeArray>(int_type);
+    prepare_fast_explode_operator(arr_type, int_type, &get_value_called);
+
+    {
+        auto id_col = ColumnHelper::create_column<DataTypeInt32>({10, 20, 30});
+        auto nested = ColumnInt32::create();
+        nested->insert_value(1);
+        nested->insert_value(2);
+        auto offsets = ColumnArray::ColumnOffsets::create();
+        offsets->insert_value(1);
+        offsets->insert_value(1);
+        offsets->insert_value(2);
+        auto arr_col = ColumnArray::create(std::move(nested), std::move(offsets));
+
+        push_child_block(
+                Block({ColumnWithTypeAndName(id_col, int_type, "id"),
+                       ColumnWithTypeAndName(ColumnPtr(std::move(arr_col)), arr_type, "arr")}));
+    }
+
+    {
+        bool eos = false;
+        auto block = pull_child_block(&eos);
+        EXPECT_FALSE(get_value_called);
+
+        auto expected_id = ColumnHelper::create_column<DataTypeInt32>({10, 30});
+
+        auto expected_nested = ColumnInt32::create();
+        expected_nested->insert_value(1);
+        expected_nested->insert_value(2);
+        auto expected_offsets = ColumnArray::ColumnOffsets::create();
+        expected_offsets->insert_value(1);
+        expected_offsets->insert_value(2);
+        auto expected_arr =
+                ColumnArray::create(std::move(expected_nested), std::move(expected_offsets));
+
+        auto expected_out = ColumnHelper::create_column<DataTypeInt32>({1, 2});
+
+        auto int_type = std::make_shared<DataTypeInt32>();
+        auto arr_type = std::make_shared<DataTypeArray>(int_type);
+        Block expected({ColumnWithTypeAndName(expected_id, int_type, "id"),
+                        ColumnWithTypeAndName(ColumnPtr(std::move(expected_arr)), arr_type, "arr"),
+                        ColumnWithTypeAndName(expected_out, int_type, "x")});
+        EXPECT_TRUE(ColumnHelper::block_equal(block, expected));
+    }
+}
+
+TEST_F(TableFunctionOperatorTest, block_fast_path_explode_nullable_array_null_row) {
+    bool get_value_called = false;
+    auto int_type = std::make_shared<DataTypeInt32>();
+    auto arr_type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeArray>(int_type));
+    prepare_fast_explode_operator(arr_type, int_type, &get_value_called);
+
+    {
+        auto id_col = ColumnHelper::create_column<DataTypeInt32>({10, 20, 30});
+        auto nested = ColumnInt32::create();
+        nested->insert_value(1);
+        nested->insert_value(2);
+        auto offsets = ColumnArray::ColumnOffsets::create();
+        offsets->insert_value(1);
+        offsets->insert_value(1);
+        offsets->insert_value(2);
+        auto arr_data = ColumnArray::create(std::move(nested), std::move(offsets));
+        auto null_map = ColumnUInt8::create();
+        null_map->insert_value(0);
+        null_map->insert_value(1);
+        null_map->insert_value(0);
+        auto arr_col = ColumnNullable::create(std::move(arr_data), std::move(null_map));
+
+        push_child_block(
+                Block({ColumnWithTypeAndName(id_col, int_type, "id"),
+                       ColumnWithTypeAndName(ColumnPtr(std::move(arr_col)), arr_type, "arr")}));
+    }
+
+    {
+        bool eos = false;
+        auto block = pull_child_block(&eos);
+        EXPECT_FALSE(get_value_called);
+
+        auto expected_id = ColumnHelper::create_column<DataTypeInt32>({10, 30});
+        auto expected_nested = ColumnInt32::create();
+        expected_nested->insert_value(1);
+        expected_nested->insert_value(2);
+        auto expected_offsets = ColumnArray::ColumnOffsets::create();
+        expected_offsets->insert_value(1);
+        expected_offsets->insert_value(2);
+        auto expected_arr_data =
+                ColumnArray::create(std::move(expected_nested), std::move(expected_offsets));
+        auto expected_arr_null = ColumnUInt8::create();
+        expected_arr_null->insert_value(0);
+        expected_arr_null->insert_value(0);
+        auto expected_arr =
+                ColumnNullable::create(std::move(expected_arr_data), std::move(expected_arr_null));
+        auto expected_out = ColumnHelper::create_column<DataTypeInt32>({1, 2});
+
+        auto int_type = std::make_shared<DataTypeInt32>();
+        auto arr_type =
+                std::make_shared<DataTypeNullable>(std::make_shared<DataTypeArray>(int_type));
+        Block expected({ColumnWithTypeAndName(expected_id, int_type, "id"),
+                        ColumnWithTypeAndName(ColumnPtr(std::move(expected_arr)), arr_type, "arr"),
+                        ColumnWithTypeAndName(expected_out, int_type, "x")});
+        EXPECT_TRUE(ColumnHelper::block_equal(block, expected));
+    }
+}
+
+TEST_F(TableFunctionOperatorTest, block_fast_path_explode_nullable_array_misaligned_fallback) {
+    bool get_value_called = false;
+    auto int_type = std::make_shared<DataTypeInt32>();
+    auto arr_type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeArray>(int_type));
+    prepare_fast_explode_operator(arr_type, int_type, &get_value_called);
+
+    {
+        auto id_col = ColumnHelper::create_column<DataTypeInt32>({10, 20, 30});
+        auto nested = ColumnInt32::create();
+        nested->insert_value(1);
+        nested->insert_value(9);
+        nested->insert_value(2);
+        auto offsets = ColumnArray::ColumnOffsets::create();
+        offsets->insert_value(1);
+        offsets->insert_value(2);
+        offsets->insert_value(3);
+        auto arr_data = ColumnArray::create(std::move(nested), std::move(offsets));
+        auto null_map = ColumnUInt8::create();
+        null_map->insert_value(0);
+        null_map->insert_value(1);
+        null_map->insert_value(0);
+        auto arr_col = ColumnNullable::create(std::move(arr_data), std::move(null_map));
+
+        push_child_block(
+                Block({ColumnWithTypeAndName(id_col, int_type, "id"),
+                       ColumnWithTypeAndName(ColumnPtr(std::move(arr_col)), arr_type, "arr")}));
+    }
+
+    {
+        bool eos = false;
+        auto block = pull_child_block(&eos);
+        EXPECT_TRUE(get_value_called);
+
+        auto expected_id = ColumnHelper::create_column<DataTypeInt32>({10, 30});
+        auto expected_nested = ColumnInt32::create();
+        expected_nested->insert_value(1);
+        expected_nested->insert_value(2);
+        auto expected_offsets = ColumnArray::ColumnOffsets::create();
+        expected_offsets->insert_value(1);
+        expected_offsets->insert_value(2);
+        auto expected_arr_data =
+                ColumnArray::create(std::move(expected_nested), std::move(expected_offsets));
+        auto expected_arr_null = ColumnUInt8::create();
+        expected_arr_null->insert_value(0);
+        expected_arr_null->insert_value(0);
+        auto expected_arr =
+                ColumnNullable::create(std::move(expected_arr_data), std::move(expected_arr_null));
+        auto expected_out = ColumnHelper::create_column<DataTypeInt32>({1, 2});
+
+        auto int_type = std::make_shared<DataTypeInt32>();
+        auto arr_type =
+                std::make_shared<DataTypeNullable>(std::make_shared<DataTypeArray>(int_type));
+        Block expected({ColumnWithTypeAndName(expected_id, int_type, "id"),
+                        ColumnWithTypeAndName(ColumnPtr(std::move(expected_arr)), arr_type, "arr"),
+                        ColumnWithTypeAndName(expected_out, int_type, "x")});
+        EXPECT_TRUE(ColumnHelper::block_equal(block, expected));
+    }
+}
+
+TEST_F(TableFunctionOperatorTest,
+       block_fast_path_explode_nullable_array_partial_gap_uses_slow_path) {
+    state->batsh_size = 2;
+    bool get_value_called = false;
+    auto int_type = std::make_shared<DataTypeInt32>();
+    auto arr_type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeArray>(int_type));
+    prepare_fast_explode_operator(arr_type, int_type, &get_value_called);
+
+    {
+        auto id_col = ColumnHelper::create_column<DataTypeInt32>({10, 20, 30});
+        auto nested = ColumnInt32::create();
+        nested->insert_value(1);
+        nested->insert_value(2);
+        nested->insert_value(3);
+        nested->insert_value(9);
+        nested->insert_value(4);
+        auto offsets = ColumnArray::ColumnOffsets::create();
+        offsets->insert_value(3);
+        offsets->insert_value(4);
+        offsets->insert_value(5);
+        auto arr_data = ColumnArray::create(std::move(nested), std::move(offsets));
+        auto null_map = ColumnUInt8::create();
+        null_map->insert_value(0);
+        null_map->insert_value(1);
+        null_map->insert_value(0);
+        auto arr_col = ColumnNullable::create(std::move(arr_data), std::move(null_map));
+
+        push_child_block(
+                Block({ColumnWithTypeAndName(id_col, int_type, "id"),
+                       ColumnWithTypeAndName(ColumnPtr(std::move(arr_col)), arr_type, "arr")}));
+    }
+
+    {
+        bool eos = false;
+        auto block = pull_child_block(&eos);
+        EXPECT_TRUE(get_value_called);
+
+        auto expected_id = ColumnHelper::create_column<DataTypeInt32>({10, 10});
+        auto expected_nested = ColumnInt32::create();
+        expected_nested->insert_value(1);
+        expected_nested->insert_value(2);
+        expected_nested->insert_value(3);
+        expected_nested->insert_value(1);
+        expected_nested->insert_value(2);
+        expected_nested->insert_value(3);
+        auto expected_offsets = ColumnArray::ColumnOffsets::create();
+        expected_offsets->insert_value(3);
+        expected_offsets->insert_value(6);
+        auto expected_arr_data =
+                ColumnArray::create(std::move(expected_nested), std::move(expected_offsets));
+        auto expected_arr_null = ColumnUInt8::create();
+        expected_arr_null->insert_value(0);
+        expected_arr_null->insert_value(0);
+        auto expected_arr =
+                ColumnNullable::create(std::move(expected_arr_data), std::move(expected_arr_null));
+        auto expected_out = ColumnHelper::create_column<DataTypeInt32>({1, 2});
+
+        Block expected({ColumnWithTypeAndName(expected_id, int_type, "id"),
+                        ColumnWithTypeAndName(ColumnPtr(std::move(expected_arr)), arr_type, "arr"),
+                        ColumnWithTypeAndName(expected_out, int_type, "x")});
+        EXPECT_TRUE(ColumnHelper::block_equal(block, expected));
+    }
+
+    {
+        bool eos = false;
+        auto block = pull_child_block(&eos);
+
+        auto expected_id = ColumnHelper::create_column<DataTypeInt32>({10, 30});
+        auto expected_nested = ColumnInt32::create();
+        expected_nested->insert_value(1);
+        expected_nested->insert_value(2);
+        expected_nested->insert_value(3);
+        expected_nested->insert_value(4);
+        auto expected_offsets = ColumnArray::ColumnOffsets::create();
+        expected_offsets->insert_value(3);
+        expected_offsets->insert_value(4);
+        auto expected_arr_data =
+                ColumnArray::create(std::move(expected_nested), std::move(expected_offsets));
+        auto expected_arr_null = ColumnUInt8::create();
+        expected_arr_null->insert_value(0);
+        expected_arr_null->insert_value(0);
+        auto expected_arr =
+                ColumnNullable::create(std::move(expected_arr_data), std::move(expected_arr_null));
+        auto expected_out = ColumnHelper::create_column<DataTypeInt32>({3, 4});
+
+        Block expected({ColumnWithTypeAndName(expected_id, int_type, "id"),
+                        ColumnWithTypeAndName(ColumnPtr(std::move(expected_arr)), arr_type, "arr"),
+                        ColumnWithTypeAndName(expected_out, int_type, "x")});
+        EXPECT_TRUE(ColumnHelper::block_equal(block, expected));
+    }
+}
+
+TEST_F(TableFunctionOperatorTest, block_fast_path_explode_nullable_elements) {
+    bool get_value_called = false;
+    auto int_type = std::make_shared<DataTypeInt32>();
+    auto nested_type = std::make_shared<DataTypeNullable>(int_type);
+    auto arr_type = std::make_shared<DataTypeArray>(nested_type);
+    prepare_fast_explode_operator(arr_type, nested_type, &get_value_called);
+
+    {
+        auto id_col = ColumnHelper::create_column<DataTypeInt32>({10});
+
+        auto nested_data = ColumnInt32::create();
+        nested_data->insert_value(1);
+        nested_data->insert_value(0);
+        nested_data->insert_value(2);
+        auto nested_null = ColumnUInt8::create();
+        nested_null->insert_value(0);
+        nested_null->insert_value(1);
+        nested_null->insert_value(0);
+        auto nested = ColumnNullable::create(std::move(nested_data), std::move(nested_null));
+
+        auto offsets = ColumnArray::ColumnOffsets::create();
+        offsets->insert_value(3);
+        auto arr_col = ColumnArray::create(std::move(nested), std::move(offsets));
+
+        push_child_block(
+                Block({ColumnWithTypeAndName(id_col, int_type, "id"),
+                       ColumnWithTypeAndName(ColumnPtr(std::move(arr_col)), arr_type, "arr")}));
+    }
+
+    {
+        bool eos = false;
+        auto block = pull_child_block(&eos);
+        EXPECT_FALSE(get_value_called);
+
+        auto expected_id = ColumnHelper::create_column<DataTypeInt32>({10, 10, 10});
+
+        auto expected_nested_data = ColumnInt32::create();
+        expected_nested_data->insert_value(1);
+        expected_nested_data->insert_value(0);
+        expected_nested_data->insert_value(2);
+        expected_nested_data->insert_value(1);
+        expected_nested_data->insert_value(0);
+        expected_nested_data->insert_value(2);
+        expected_nested_data->insert_value(1);
+        expected_nested_data->insert_value(0);
+        expected_nested_data->insert_value(2);
+        auto expected_nested_null = ColumnUInt8::create();
+        expected_nested_null->insert_value(0);
+        expected_nested_null->insert_value(1);
+        expected_nested_null->insert_value(0);
+        expected_nested_null->insert_value(0);
+        expected_nested_null->insert_value(1);
+        expected_nested_null->insert_value(0);
+        expected_nested_null->insert_value(0);
+        expected_nested_null->insert_value(1);
+        expected_nested_null->insert_value(0);
+        auto expected_nested = ColumnNullable::create(std::move(expected_nested_data),
+                                                      std::move(expected_nested_null));
+        auto expected_offsets = ColumnArray::ColumnOffsets::create();
+        expected_offsets->insert_value(3);
+        expected_offsets->insert_value(6);
+        expected_offsets->insert_value(9);
+        auto expected_arr =
+                ColumnArray::create(std::move(expected_nested), std::move(expected_offsets));
+
+        auto expected_out_data = ColumnInt32::create();
+        expected_out_data->insert_value(1);
+        expected_out_data->insert_value(0);
+        expected_out_data->insert_value(2);
+        auto expected_out_null = ColumnUInt8::create();
+        expected_out_null->insert_value(0);
+        expected_out_null->insert_value(1);
+        expected_out_null->insert_value(0);
+        auto expected_out =
+                ColumnNullable::create(std::move(expected_out_data), std::move(expected_out_null));
+
+        Block expected(
+                {ColumnWithTypeAndName(expected_id, int_type, "id"),
+                 ColumnWithTypeAndName(ColumnPtr(std::move(expected_arr)), arr_type, "arr"),
+                 ColumnWithTypeAndName(ColumnPtr(std::move(expected_out)), nested_type, "x")});
+        EXPECT_TRUE(ColumnHelper::block_equal(block, expected));
     }
 }
 


### PR DESCRIPTION
- Add a block fast path for explode-like table functions to expand contiguous nested ranges without per-row get_value()
- Fall back to the original row-wise path when the nested range is non-contiguous or unsupported
- Add/extend unit tests to cover fast path and fallback cases

Test: ./run-be-ut.sh --run --filter='TableFunctionOperatorTest.*:UnnestTest.*'

Performance :
Simple Array: 10.1s -> 5.1s
Nested Array: 100.2s -> 20.1s

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

