### PR TITLE
[fix](Hdfs) Guard HDFS init when Java support disabled

### DIFF
--- a/be/src/io/fs/hdfs/hdfs_mgr.cpp
+++ b/be/src/io/fs/hdfs/hdfs_mgr.cpp
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <thread>
 
+#include "common/config.h"
 #include "common/kerberos/kerberos_ticket_mgr.h"
 #include "common/logging.h"
 #include "io/fs/err_utils.h"
@@ -126,6 +127,13 @@ void HdfsMgr::_cleanup_loop() {
 
 Status HdfsMgr::get_or_create_fs(const THdfsParams& hdfs_params, const std::string& fs_name,
                                  std::shared_ptr<HdfsHandler>* fs_handler) {
+#ifdef USE_HADOOP_HDFS
+    if (!config::enable_java_support) {
+        return Status::InternalError(
+                "hdfs file system is not enabled, you can change be config enable_java_support to "
+                "true.");
+    }
+#endif
     uint64_t hash_code = _hdfs_hash_code(hdfs_params, fs_name);
 
     // First check without lock

--- a/be/src/io/fs/hdfs/hdfs_mgr.cpp
+++ b/be/src/io/fs/hdfs/hdfs_mgr.cpp
@@ -129,7 +129,7 @@ Status HdfsMgr::get_or_create_fs(const THdfsParams& hdfs_params, const std::stri
                                  std::shared_ptr<HdfsHandler>* fs_handler) {
 #ifdef USE_HADOOP_HDFS
     if (!config::enable_java_support) {
-        return Status::InternalError(
+        return Status::InvalidArgument(
                 "hdfs file system is not enabled, you can change be config enable_java_support to "
                 "true.");
     }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

With enable_java_support=false, Hive/HDFS access still reaches JNI and can hang in getJNIEnv, sometimes with StackOverflowError.

### Release note

Add an early enable_java_support guard in HdfsMgr::get_or_create_fs to return an error before JNI initialization.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

