### PR TITLE
[fix](ddl) Reject $ in table names at create time

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
@@ -35,7 +35,7 @@ public class FeNameFormat {
     // please modify error msg when FeNameFormat.checkCommonName throw exception in CreateRoutineLoadStmt
     private static final String COMMON_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9\\-_]{0,63}$";
     private static final String UNDERSCORE_COMMON_NAME_REGEX = "^[_a-zA-Z][a-zA-Z0-9\\-_]{0,63}$";
-    private static final String TABLE_NAME_REGEX = "^[a-zA-Z0-9\\-_$]*$";
+    private static final String TABLE_NAME_REGEX = "^[a-zA-Z0-9\\-_]*$";
     private static final String USER_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9.\\-_]*$";
     private static final String REPOSITORY_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9\\-_]{0,255}$";
     private static final String COLUMN_NAME_REGEX
@@ -44,7 +44,7 @@ public class FeNameFormat {
     private static final String UNICODE_LABEL_REGEX = "^[\\-_A-Za-z0-9:\\p{L}]{1," + Config.label_regex_length + "}$";
     private static final String UNICODE_COMMON_NAME_REGEX = "^[a-zA-Z\\p{L}][a-zA-Z0-9\\-_\\p{L}]{0,63}$";
     private static final String UNICODE_UNDERSCORE_COMMON_NAME_REGEX = "^[_a-zA-Z\\p{L}][a-zA-Z0-9\\-_\\p{L}]{0,63}$";
-    private static final String UNICODE_TABLE_NAME_REGEX = "^[\\s\\S]*[\\S]$";
+    private static final String UNICODE_TABLE_NAME_REGEX = "^(?!.*\\$)[\\s\\S]*[\\S]$";
     private static final String UNICODE_USER_NAME_REGEX = "^[a-zA-Z\\p{L}][a-zA-Z0-9.\\-_\\p{L}]*$";
     private static final String UNICODE_COLUMN_NAME_REGEX
             = "^[\\s\\S]{0,255}[\\S]$";

--- a/fe/fe-core/src/test/java/org/apache/doris/common/FeNameFormatTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/FeNameFormatTest.java
@@ -89,7 +89,6 @@ public class FeNameFormatTest {
                 "a_1",       // Underscore + number
                 "B2",        // Uppercase letter + number
                 "1abc",      // Starts with digit
-                "abc$",      // Contains invalid symbol $
                 "-abc",      // Starts with hyphen
                 "_abc"       // Starts with underscore
         );
@@ -98,7 +97,8 @@ public class FeNameFormatTest {
                 "",          // Empty string
                 "x ",          // space character as last one
                 "x\t",         // table character as last one
-                "x\n"          // enter character as last one
+                "x\n",         // enter character as last one
+                "abc$"         // Contains invalid symbol $
         );
 
         List<String> unicodeValid = Lists.newArrayList(

--- a/regression-test/suites/ddl_p0/test_create_table.groovy
+++ b/regression-test/suites/ddl_p0/test_create_table.groovy
@@ -61,6 +61,19 @@ suite("sql_create_time_range_table") {
         exception "Disable to create table"
     }
 
+    test {
+        sql """
+            CREATE TABLE tbl\$refs (
+                k1 int,
+                k2 int
+            )
+            DUPLICATE KEY (`k1`)
+            DISTRIBUTED BY HASH(`k2`) BUCKETS 1
+            PROPERTIES ("replication_num" = "1");
+        """
+        exception "Incorrect table name"
+    }
+
     // DDL/DML return 1 row and 1 column, the only value is update row count
     assertTrue(result1.size() == 1)
     assertTrue(result1[0].size() == 1)


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

  - Background: Table names containing $ can be created but later fail on query, causing inconsistent behavior.
  - Change: Disallow $ in table names during validation (including Unicode name mode) so creation fails fast.
  - Tests:
      - FE unit test: CreateTableCommandTest covers tbl$refs creation failure.
      - Regression test: ddl_p0/test_create_table.groovy asserts “Incorrect table name”.
  - Impact: System table access (e.g. table$partitions / table$snapshots) is unaffected; only user table creation is restricted.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

