### PR TITLE
[enhance] (auth) add option to disable login with empty pass

### DIFF
--- a/conf/ldap.conf
+++ b/conf/ldap.conf
@@ -42,9 +42,10 @@ ldap_user_basedn = ou=people,dc=domain,dc=com
 ldap_user_filter = (&(uid={login}))
 ldap_group_basedn = ou=group,dc=domain,dc=com
 
+# ldap_user_cache_timeout_s = 5 * 60;
+
 ## ldap_use_ssl - use secured connection to LDAP server if required (disabled by default)
 # ldap_use_ssl = false
-# ldap_user_cache_timeout_s = 5 * 60;
 
 # LDAP pool configuration
 # https://docs.spring.io/spring-ldap/docs/2.3.3.RELEASE/reference/#pool-configuration

--- a/conf/ldap.conf
+++ b/conf/ldap.conf
@@ -42,6 +42,8 @@ ldap_user_basedn = ou=people,dc=domain,dc=com
 ldap_user_filter = (&(uid={login}))
 ldap_group_basedn = ou=group,dc=domain,dc=com
 
+## ldap_use_ssl - use secured connection to LDAP server if required (disabled by default)
+# ldap_use_ssl = false
 # ldap_user_cache_timeout_s = 5 * 60;
 
 # LDAP pool configuration

--- a/conf/ldap.conf
+++ b/conf/ldap.conf
@@ -44,7 +44,7 @@ ldap_group_basedn = ou=group,dc=domain,dc=com
 
 # ldap_user_cache_timeout_s = 5 * 60;
 
-## ldap_use_ssl - use secured connection to LDAP server if required (disabled by default)
+## ldap_use_ssl - use secured connection to LDAP server if required (disabled by default). Note: When enabling SSL, ensure ldap_port is set appropriately (typically 636 for LDAPS instead of 389 for LDAP).
 # ldap_use_ssl = false
 
 # LDAP pool configuration

--- a/conf/ldap.conf
+++ b/conf/ldap.conf
@@ -47,6 +47,9 @@ ldap_group_basedn = ou=group,dc=domain,dc=com
 ## ldap_use_ssl - use secured connection to LDAP server if required (disabled by default). Note: When enabling SSL, ensure ldap_port is set appropriately (typically 636 for LDAPS instead of 389 for LDAP).
 # ldap_use_ssl = false
 
+## ldap_allow_empty_pass - allow to connect to ldap with empty pass (enabled by default)
+# ldap_allow_empty_pass = true
+
 # LDAP pool configuration
 # https://docs.spring.io/spring-ldap/docs/2.3.3.RELEASE/reference/#pool-configuration
 # ldap_pool_max_active = 8

--- a/fe/fe-common/src/main/java/org/apache/doris/common/ErrorCode.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/ErrorCode.java
@@ -1236,7 +1236,7 @@ public enum ErrorCode {
             "Command only support in cloud mode."),
 
     ERR_EMPTY_PASSWORD(6001, new byte[]{'4', '2', '0', '0', '0'},
-            "Access with empty password is prohibited for user %s because of current mode");     
+            "Access with empty password is prohibited for user %s because of current mode");
 
     // This is error code
     private final int code;

--- a/fe/fe-common/src/main/java/org/apache/doris/common/ErrorCode.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/ErrorCode.java
@@ -1233,7 +1233,10 @@ public enum ErrorCode {
     ERR_NO_CLUSTER_ERROR(5099, new byte[]{'4', '2', '0', '0', '0'}, "No compute group (cloud cluster) selected"),
 
     ERR_NOT_CLOUD_MODE(6000, new byte[]{'4', '2', '0', '0', '0'},
-            "Command only support in cloud mode.");
+            "Command only support in cloud mode."),
+
+    ERR_EMPTY_PASSWORD(6001, new byte[]{'4', '2', '0', '0', '0'},
+            "Access with empty password is prohibited for user %s because of current mode");     
 
     // This is error code
     private final int code;

--- a/fe/fe-common/src/main/java/org/apache/doris/common/LdapConfig.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/LdapConfig.java
@@ -165,7 +165,7 @@ public class LdapConfig extends ConfigBase {
     public static boolean ldap_use_ssl = false;
 
     /**
-     * The method constructs correct URL connection string for specified host and port depending on 
+     * The method constructs correct URL connection string for specified host and port depending on
      * value of ldap_use_ssl property.
      * If ldap_use_ssl property is true - LDAPS is used as protocol
      * If ldap_use_ssl_property is false or not specified - LDAP is used as protocol

--- a/fe/fe-common/src/main/java/org/apache/doris/common/LdapConfig.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/LdapConfig.java
@@ -161,7 +161,6 @@ public class LdapConfig extends ConfigBase {
     /**
      * Flag to enable usage of LDAPS.
      */
-    @Deprecated
     @ConfigBase.ConfField
     public static boolean ldap_use_ssl = false;
 }

--- a/fe/fe-common/src/main/java/org/apache/doris/common/LdapConfig.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/LdapConfig.java
@@ -163,4 +163,16 @@ public class LdapConfig extends ConfigBase {
      */
     @ConfigBase.ConfField
     public static boolean ldap_use_ssl = false;
+
+    /**
+     * The method constructs correct URL connection string for specified host and port depending on 
+     * value of ldap_use_ssl property.
+     * If ldap_use_ssl property is true - LDAPS is used as protocol
+     * If ldap_use_ssl_property is false or not specified - LDAP is used as protocol
+     * @param hostPortInAccessibleFormat
+     * @return
+     */
+    public static String getConnectionURL(String hostPortInAccessibleFormat) {
+        return ((LdapConfig.ldap_use_ssl ? "ldaps" : "ldap") + "://" + hostPortInAccessibleFormat);
+    }
 }

--- a/fe/fe-common/src/main/java/org/apache/doris/common/LdapConfig.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/LdapConfig.java
@@ -157,4 +157,11 @@ public class LdapConfig extends ConfigBase {
      */
     @ConfigBase.ConfField
     public static boolean ldap_pool_test_while_idle = true;
+
+    /**
+     * Flag to enable usage of LDAPS.
+     */
+    @Deprecated
+    @ConfigBase.ConfField
+    public static boolean ldap_use_ssl = false;
 }

--- a/fe/fe-common/src/main/java/org/apache/doris/common/LdapConfig.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/LdapConfig.java
@@ -175,4 +175,10 @@ public class LdapConfig extends ConfigBase {
     public static String getConnectionURL(String hostPortInAccessibleFormat) {
         return ((LdapConfig.ldap_use_ssl ? "ldaps" : "ldap") + "://" + hostPortInAccessibleFormat);
     }
+
+    /**
+     * Flag to enable login with empty pass.
+     */
+    @ConfigBase.ConfField
+    public static boolean ldap_allow_empty_pass = true;
 }

--- a/fe/fe-common/src/main/java/org/apache/doris/common/LdapConfig.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/LdapConfig.java
@@ -165,12 +165,12 @@ public class LdapConfig extends ConfigBase {
     public static boolean ldap_use_ssl = false;
 
     /**
-     * The method constructs correct URL connection string for specified host and port depending on
-     * value of ldap_use_ssl property.
-     * If ldap_use_ssl property is true - LDAPS is used as protocol
-     * If ldap_use_ssl_property is false or not specified - LDAP is used as protocol
-     * @param hostPortInAccessibleFormat
-     * @return
+     * The method constructs the correct URL connection string for the specified host and port depending on
+     * the value of the {@code ldap_use_ssl} property.
+     * If {@code ldap_use_ssl} is true, LDAPS is used as the protocol.
+     * If {@code ldap_use_ssl} is false or not specified, LDAP is used as the protocol.
+     * @param hostPortInAccessibleFormat the host and port in accessible format (for example, "host:port")
+     * @return the LDAP or LDAPS connection URL string
      */
     public static String getConnectionURL(String hostPortInAccessibleFormat) {
         return ((LdapConfig.ldap_use_ssl ? "ldaps" : "ldap") + "://" + hostPortInAccessibleFormat);

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticator.java
@@ -21,6 +21,7 @@ import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.LdapConfig;
 import org.apache.doris.mysql.authenticate.AuthenticateRequest;
 import org.apache.doris.mysql.authenticate.AuthenticateResponse;
 import org.apache.doris.mysql.authenticate.Authenticator;
@@ -83,7 +84,7 @@ public class LdapAuthenticator implements Authenticator {
 
     /**
      * The LDAP authentication process is as follows:
-     * step1: Check the LDAP password.
+     * step1: Check the LDAP password (depending on value of property LdapConfig.ldap_allow_empty_pass login with empty pass can be prohibited).
      * step2: Get the LDAP groups privileges as a role, saved into ConnectContext.
      * step3: Set current userIdentity. If the user account does not exist in Doris, login as a temporary user.
      * Otherwise, login to the Doris account.
@@ -93,6 +94,13 @@ public class LdapAuthenticator implements Authenticator {
         String userName = qualifiedUser;
         if (LOG.isDebugEnabled()) {
             LOG.debug("user:{}", userName);
+        }
+
+        //not allow to login in case when empty password is specified but such mode is disabled by configuration
+        if (Strings.isNullOrEmpty(password) && !LdapConfig.ldap_allow_empty_pass) {
+            LOG.info("user:{} is not allowed to login with LDAP with empty password because of ldap_allow_empty_pass is {}", userName, LdapConfig.ldap_allow_empty_pass);
+            ErrorReport.report(ErrorCode.ERR_EMPTY_PASSWORD, qualifiedUser + "@" + remoteIp);
+            return AuthenticateResponse.failedResponse;
         }
 
         // check user password by ldap server.

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticator.java
@@ -84,7 +84,7 @@ public class LdapAuthenticator implements Authenticator {
 
     /**
      * The LDAP authentication process is as follows:
-     * step1: Check the LDAP password (depending on value of property LdapConfig.ldap_allow_empty_pass login with empty pass can be prohibited).
+     * step1: Check the LDAP password (if ldap_allow_empty_pass is false login with empty pass is prohibited).
      * step2: Get the LDAP groups privileges as a role, saved into ConnectContext.
      * step3: Set current userIdentity. If the user account does not exist in Doris, login as a temporary user.
      * Otherwise, login to the Doris account.
@@ -98,7 +98,8 @@ public class LdapAuthenticator implements Authenticator {
 
         //not allow to login in case when empty password is specified but such mode is disabled by configuration
         if (Strings.isNullOrEmpty(password) && !LdapConfig.ldap_allow_empty_pass) {
-            LOG.info("user:{} is not allowed to login with LDAP with empty password because of ldap_allow_empty_pass is {}", userName, LdapConfig.ldap_allow_empty_pass);
+            LOG.info("user:{} is not allowed to login to LDAP with empty password because ldap_allow_empty_pass:{}",
+                    userName, LdapConfig.ldap_allow_empty_pass);
             ErrorReport.report(ErrorCode.ERR_EMPTY_PASSWORD, qualifiedUser + "@" + remoteIp);
             return AuthenticateResponse.failedResponse;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
@@ -65,7 +65,7 @@ public class LdapClient {
 
         private void setLdapTemplateNoPool(String ldapPassword) {
             LdapContextSource contextSource = new LdapContextSource();
-            String url = this.getURL();
+            String url = LdapClient.getURL();
 
             contextSource.setUrl(url);
             contextSource.setUserDn(LdapConfig.ldap_admin_name);
@@ -77,7 +77,7 @@ public class LdapClient {
 
         private void setLdapTemplatePool(String ldapPassword) {
             LdapContextSource contextSource = new LdapContextSource();
-            String url = this.getURL();
+            String url = LdapClient.getURL();
 
             contextSource.setUrl(url);
             contextSource.setUserDn(LdapConfig.ldap_admin_name);
@@ -107,10 +107,6 @@ public class LdapClient {
             return this.ldapPassword == null || !this.ldapPassword.equals(ldapPassword);
         }
 
-        private String getURL() {
-            return ((LdapConfig.ldap_use_ssl ? "ldaps" : "ldap") + "://" + NetUtils
-                    .getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port));
-        }
     }
 
     private void init() {
@@ -231,9 +227,9 @@ public class LdapClient {
         }
     }
 
-    @VisibleForTesting
-    public String getURL() {
-        return clientInfo.getURL();
+    static String getURL() {
+        return ((LdapConfig.ldap_use_ssl ? "ldaps" : "ldap") + "://" + NetUtils
+                .getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port));
     }
 
     private String getUserFilter(String userFilter, String userName) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
@@ -108,8 +108,8 @@ public class LdapClient {
         }
 
         public String getURL() {
-            String url = (LdapConfig.ldap_use_ssl ? "ldaps" : "ldap") + "://" + NetUtils
-                    .getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port);
+            return ((LdapConfig.ldap_use_ssl ? "ldaps" : "ldap") + "://" + NetUtils
+                    .getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port));
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
@@ -66,7 +66,7 @@ public class LdapClient {
         private void setLdapTemplateNoPool(String ldapPassword) {
             LdapContextSource contextSource = new LdapContextSource();
             String url = LdapConfig.getConnectionURL(
-                NetUtils.getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port));
+                    NetUtils.getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port));
 
             contextSource.setUrl(url);
             contextSource.setUserDn(LdapConfig.ldap_admin_name);
@@ -79,7 +79,7 @@ public class LdapClient {
         private void setLdapTemplatePool(String ldapPassword) {
             LdapContextSource contextSource = new LdapContextSource();
             String url = LdapConfig.getConnectionURL(
-                NetUtils.getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port));
+                    NetUtils.getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port));
 
             contextSource.setUrl(url);
             contextSource.setUserDn(LdapConfig.ldap_admin_name);

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
@@ -65,7 +65,8 @@ public class LdapClient {
 
         private void setLdapTemplateNoPool(String ldapPassword) {
             LdapContextSource contextSource = new LdapContextSource();
-            String url = LdapClient.getURL();
+            String url = LdapConfig.getConnectionURL(
+                NetUtils.getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port));
 
             contextSource.setUrl(url);
             contextSource.setUserDn(LdapConfig.ldap_admin_name);
@@ -77,7 +78,8 @@ public class LdapClient {
 
         private void setLdapTemplatePool(String ldapPassword) {
             LdapContextSource contextSource = new LdapContextSource();
-            String url = LdapClient.getURL();
+            String url = LdapConfig.getConnectionURL(
+                NetUtils.getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port));
 
             contextSource.setUrl(url);
             contextSource.setUserDn(LdapConfig.ldap_admin_name);
@@ -225,11 +227,6 @@ public class LdapClient {
             ErrorReport.report(ErrorCode.ERROR_LDAP_CONFIGURATION_ERR);
             throw new RuntimeException(msg);
         }
-    }
-
-    static String getURL() {
-        return ((LdapConfig.ldap_use_ssl ? "ldaps" : "ldap") + "://" + NetUtils
-                .getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port));
     }
 
     private String getUserFilter(String userFilter, String userName) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
@@ -107,7 +107,7 @@ public class LdapClient {
             return this.ldapPassword == null || !this.ldapPassword.equals(ldapPassword);
         }
 
-        public String getURL() {
+        private String getURL() {
             return ((LdapConfig.ldap_use_ssl ? "ldaps" : "ldap") + "://" + NetUtils
                     .getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port));
         }
@@ -229,6 +229,11 @@ public class LdapClient {
             ErrorReport.report(ErrorCode.ERROR_LDAP_CONFIGURATION_ERR);
             throw new RuntimeException(msg);
         }
+    }
+
+    @VisibleForTesting
+    public String getURL() {
+        return clientInfo.getURL();
     }
 
     private String getUserFilter(String userFilter, String userName) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
@@ -65,7 +65,7 @@ public class LdapClient {
 
         private void setLdapTemplateNoPool(String ldapPassword) {
             LdapContextSource contextSource = new LdapContextSource();
-            String url = "ldap://" + NetUtils
+            String url = (LdapConfig.ldap_use_ssl ? "ldaps://" : "ldap://") + NetUtils
                     .getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port);
 
             contextSource.setUrl(url);
@@ -78,7 +78,7 @@ public class LdapClient {
 
         private void setLdapTemplatePool(String ldapPassword) {
             LdapContextSource contextSource = new LdapContextSource();
-            String url = "ldap://" + NetUtils
+            String url = (LdapConfig.ldap_use_ssl ? "ldaps://" : "ldap://") + NetUtils
                     .getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port);
 
             contextSource.setUrl(url);

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
@@ -65,8 +65,7 @@ public class LdapClient {
 
         private void setLdapTemplateNoPool(String ldapPassword) {
             LdapContextSource contextSource = new LdapContextSource();
-            String url = (LdapConfig.ldap_use_ssl ? "ldaps://" : "ldap://") + NetUtils
-                    .getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port);
+            String url = this.getURL();
 
             contextSource.setUrl(url);
             contextSource.setUserDn(LdapConfig.ldap_admin_name);
@@ -78,8 +77,7 @@ public class LdapClient {
 
         private void setLdapTemplatePool(String ldapPassword) {
             LdapContextSource contextSource = new LdapContextSource();
-            String url = (LdapConfig.ldap_use_ssl ? "ldaps://" : "ldap://") + NetUtils
-                    .getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port);
+            String url = this.getURL();
 
             contextSource.setUrl(url);
             contextSource.setUserDn(LdapConfig.ldap_admin_name);
@@ -107,6 +105,11 @@ public class LdapClient {
 
         public boolean checkUpdate(String ldapPassword) {
             return this.ldapPassword == null || !this.ldapPassword.equals(ldapPassword);
+        }
+
+        public String getURL() {
+            String url = (LdapConfig.ldap_use_ssl ? "ldaps" : "ldap") + "://" + NetUtils
+                    .getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
@@ -46,7 +46,6 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.MysqlPassword;
-import org.apache.doris.mysql.authenticate.AuthenticateResponse;
 import org.apache.doris.mysql.authenticate.AuthenticateType;
 import org.apache.doris.mysql.authenticate.ldap.LdapManager;
 import org.apache.doris.mysql.authenticate.ldap.LdapUserInfo;

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
@@ -38,6 +38,7 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.LdapConfig;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.PatternMatcherException;
 import org.apache.doris.common.UserException;
@@ -45,6 +46,7 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.MysqlPassword;
+import org.apache.doris.mysql.authenticate.AuthenticateResponse;
 import org.apache.doris.mysql.authenticate.AuthenticateType;
 import org.apache.doris.mysql.authenticate.ldap.LdapManager;
 import org.apache.doris.mysql.authenticate.ldap.LdapUserInfo;
@@ -227,6 +229,11 @@ public class Auth implements Writable {
             List<UserIdentity> currentUser) throws AuthenticationException {
         // Check the LDAP password when the user exists in the LDAP service.
         if (ldapManager.doesUserExist(remoteUser)) {
+            //not allow to login in case when empty password is specified but such mode is disabled by configuration
+            if (Strings.isNullOrEmpty(remotePasswd) && !LdapConfig.ldap_allow_empty_pass) {
+                throw new AuthenticationException(ErrorCode.ERR_EMPTY_PASSWORD, remoteUser + "@" + remoteHost);
+            }
+
             if (!ldapManager.checkUserPasswd(remoteUser, remotePasswd, remoteHost, currentUser)) {
                 throw new AuthenticationException(ErrorCode.ERR_ACCESS_DENIED_ERROR, remoteUser + "@" + remoteHost,
                         Strings.isNullOrEmpty(remotePasswd) ? "NO" : "YES");

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticatorTest.java
@@ -161,7 +161,7 @@ public class LdapAuthenticatorTest {
         //running test with specified value - false - ldap_allow_empty_pass is explicitly set to false
         LdapConfig.ldap_allow_empty_pass = false;
         response = ldapAuthenticator.authenticate(request);
-        Assert.assertFalse(response.isSuccess());   
+        Assert.assertFalse(response.isSuccess());
     }
 
     @After

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticatorTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.mysql.authenticate.ldap;
 
 import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.common.LdapConfig;
 import org.apache.doris.mysql.authenticate.AuthenticateRequest;
 import org.apache.doris.mysql.authenticate.AuthenticateResponse;
 import org.apache.doris.mysql.authenticate.password.ClearPassword;
@@ -27,6 +28,8 @@ import org.apache.doris.mysql.privilege.Auth;
 import com.google.common.collect.Lists;
 import mockit.Expectations;
 import mockit.Mocked;
+
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -142,5 +145,28 @@ public class LdapAuthenticatorTest {
     @Test
     public void testGetPasswordResolver() {
         Assert.assertTrue(ldapAuthenticator.getPasswordResolver() instanceof ClearPasswordResolver);
+    }
+
+    @Test
+    public void testEmptyPassword() throws IOException {
+        setCheckPassword(true);
+        setGetUserInDoris(true);
+        AuthenticateRequest request = new AuthenticateRequest(USER_NAME, new ClearPassword(""), IP);
+        //running test with non-specified value - ldap_allow_empty_pass should be true
+        AuthenticateResponse response = ldapAuthenticator.authenticate(request);
+        Assert.assertTrue(response.isSuccess());
+        //running test with specified value - true - ldap_allow_empty_pass is explicitly set to true
+        LdapConfig.ldap_allow_empty_pass = true;
+        response = ldapAuthenticator.authenticate(request);
+        Assert.assertTrue(response.isSuccess());
+        //running test with specified value - false - ldap_allow_empty_pass is explicitly set to false
+        LdapConfig.ldap_allow_empty_pass = false;
+        response = ldapAuthenticator.authenticate(request);
+        Assert.assertFalse(response.isSuccess());        
+    }
+
+    @After
+    public void tearDown() {
+        LdapConfig.ldap_allow_empty_pass = true; // restoring default value for other tests
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticatorTest.java
@@ -28,7 +28,6 @@ import org.apache.doris.mysql.privilege.Auth;
 import com.google.common.collect.Lists;
 import mockit.Expectations;
 import mockit.Mocked;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -162,7 +161,7 @@ public class LdapAuthenticatorTest {
         //running test with specified value - false - ldap_allow_empty_pass is explicitly set to false
         LdapConfig.ldap_allow_empty_pass = false;
         response = ldapAuthenticator.authenticate(request);
-        Assert.assertFalse(response.isSuccess());        
+        Assert.assertFalse(response.isSuccess());   
     }
 
     @After

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticatorTest.java
@@ -29,8 +29,8 @@ import com.google.common.collect.Lists;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticatorTest.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Lists;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -167,5 +168,10 @@ public class LdapAuthenticatorTest {
     @After
     public void tearDown() {
         LdapConfig.ldap_allow_empty_pass = true; // restoring default value for other tests
+    }
+
+    @Before
+    public void setUp() {
+        LdapConfig.ldap_allow_empty_pass = true; //restoring default value for other tests
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapClientTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapClientTest.java
@@ -111,7 +111,7 @@ public class LdapClientTest {
         //testing new case with specified property ldap_use_ssl as true
         LdapConfig.ldap_use_ssl = true;
         String secureUrl = LdapConfig.getConnectionURL(
-            NetUtils.getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port));
+                NetUtils.getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port));
         Assert.assertNotNull("connection URL should not be null", secureUrl);
         Assert.assertTrue("with ldap_use_ssl = true URL should start with ldaps, but received: " + secureUrl,
                           secureUrl.startsWith("ldaps://"));

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapClientTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapClientTest.java
@@ -95,4 +95,25 @@ public class LdapClientTest {
         };
         Assert.assertEquals(1, ldapClient.getGroups("zhangsan").size());
     }
+
+    @Test
+    public void testSecuredProtocolIsUsed() {
+        //testing default case with not specified property ldap_use_ssl or it is specified as false
+        String insecureUrl = ldapClient.getURL();
+        Assert.assertNotNull("connection URL should not be null", insecureUrl);
+        Assert.assertTrue("with ldap_use_ssl connection = false or not specified URL should start with ldap, but received: " + insecureUrl,
+                          insecureUrl.startsWith("ldap://"));
+
+        //testing new case with specified property ldap_use_ssl as true
+        LdapConfig.ldap_use_ssl = true;
+        String secureUrl = ldapClient.getURL();
+        Assert.assertNotNull("connection URL should not be null", secureUrl);
+        Assert.assertTrue("with ldap_use_ssl = true URL connection should start with ldaps, but received: " + secureUrl,
+                          secureUrl.startsWith("ldaps://"));
+    }
+
+    @After
+    public void tearDown() {
+        LdapConfig.ldap_use_ssl = false; // restoring default value for other tests
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapClientTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapClientTest.java
@@ -22,6 +22,8 @@ import org.apache.doris.common.LdapConfig;
 
 import mockit.Expectations;
 import mockit.Tested;
+
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapClientTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapClientTest.java
@@ -22,7 +22,6 @@ import org.apache.doris.common.LdapConfig;
 
 import mockit.Expectations;
 import mockit.Tested;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapClientTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapClientTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.mysql.authenticate.ldap;
 
 import org.apache.doris.common.Config;
 import org.apache.doris.common.LdapConfig;
+import org.apache.doris.common.util.NetUtils;
 
 import mockit.Expectations;
 import mockit.Tested;
@@ -100,16 +101,19 @@ public class LdapClientTest {
     @Test
     public void testSecuredProtocolIsUsed() {
         //testing default case with not specified property ldap_use_ssl or it is specified as false
-        String insecureUrl = LdapClient.getURL();
+        String insecureUrl = LdapConfig.getConnectionURL(
+                NetUtils.getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port));
+
         Assert.assertNotNull("connection URL should not be null", insecureUrl);
-        Assert.assertTrue("with ldap_use_ssl connection = false or not specified URL should start with ldap, but received: " + insecureUrl,
+        Assert.assertTrue("with ldap_use_ssl = false or not specified URL should start with ldap, but received: " + insecureUrl,
                           insecureUrl.startsWith("ldap://"));
 
         //testing new case with specified property ldap_use_ssl as true
         LdapConfig.ldap_use_ssl = true;
-        String secureUrl = LdapClient.getURL();
+        String secureUrl = LdapConfig.getConnectionURL(
+            NetUtils.getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port));
         Assert.assertNotNull("connection URL should not be null", secureUrl);
-        Assert.assertTrue("with ldap_use_ssl = true URL connection should start with ldaps, but received: " + secureUrl,
+        Assert.assertTrue("with ldap_use_ssl = true URL should start with ldaps, but received: " + secureUrl,
                           secureUrl.startsWith("ldaps://"));
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapClientTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapClientTest.java
@@ -100,14 +100,14 @@ public class LdapClientTest {
     @Test
     public void testSecuredProtocolIsUsed() {
         //testing default case with not specified property ldap_use_ssl or it is specified as false
-        String insecureUrl = ldapClient.getURL();
+        String insecureUrl = LdapClient.getURL();
         Assert.assertNotNull("connection URL should not be null", insecureUrl);
         Assert.assertTrue("with ldap_use_ssl connection = false or not specified URL should start with ldap, but received: " + insecureUrl,
                           insecureUrl.startsWith("ldap://"));
 
         //testing new case with specified property ldap_use_ssl as true
         LdapConfig.ldap_use_ssl = true;
-        String secureUrl = ldapClient.getURL();
+        String secureUrl = LdapClient.getURL();
         Assert.assertNotNull("connection URL should not be null", secureUrl);
         Assert.assertTrue("with ldap_use_ssl = true URL connection should start with ldaps, but received: " + secureUrl,
                           secureUrl.startsWith("ldaps://"));

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapClientTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapClientTest.java
@@ -45,6 +45,7 @@ public class LdapClientTest {
         LdapConfig.ldap_user_basedn = "dc=baidu,dc=com";
         LdapConfig.ldap_group_basedn = "ou=group,dc=baidu,dc=com";
         LdapConfig.ldap_user_filter = "(&(uid={login}))";
+        LdapConfig.ldap_use_ssl = false;
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

This PR adds new configuration property **ldap_allow_empty_pass** to prohibit option for existing user to login into LDAP with empty password.
If **ldap_allow_empty_pass**  in ldap.conf is not specified or specified as **true** - user can login with empty pass (existing behavior).
If **ldap_allow_empty_pass**  specified as **false** - login attempt with empty password will be rejected with corresponding error message.

**Could you please include this PR into 4.x and 3.1.x branches, please!**

Issue Number: close #60353

Related PR: #xxx

Problem Summary:

Currently for existing user it is possible to login into LDAP with empty password.
New configuration property disables such option, but default behavior still allows to login without specified password.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

1. ldap.conf and LdapConfig.java - new configuration **ldap_allow_empty_pass** property with default value **true** to keep existing behavior as default
2. ErrorCode.java - specific error message for case with empty password was added
3. LdapAuthenticator.java and Auth.java - additional check was added to validate two conditions
3.1 user has specified empty password
3.2 property  **ldap_allow_empty_pass**  is **false** and doesn't allow to login with empty password
If both conditions met - authentication is failed and new error is returned.
4. LdapAuthenticatorTest.java - introduced new test method to validate existing behavior (without specified **ldap_allow_empty_pass** property or true) and new one (with **ldap_use_ssl** property specified to false) to check that login is still successful in first case and failed in the second one.


- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

