### PR TITLE
[fix](cloud) Fix warm up cache not supporting packed file

### DIFF
--- a/be/src/olap/rowset/rowset_writer_context.h
+++ b/be/src/olap/rowset/rowset_writer_context.h
@@ -221,7 +221,9 @@ struct RowsetWriterContext {
             append_info.tablet_id = tablet_id;
             append_info.rowset_id = rowset_id.to_string();
             append_info.txn_id = txn_id;
-            append_info.expiration_time = file_cache_ttl_sec;
+            append_info.expiration_time = file_cache_ttl_sec > 0 && newest_write_timestamp > 0
+                                                  ? newest_write_timestamp + file_cache_ttl_sec
+                                                  : 0;
             fs = std::make_shared<io::PackedFileSystem>(fs, append_info);
         }
 

--- a/regression-test/suites/cloud_p0/balance/test_alter_compute_group_properties.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_alter_compute_group_properties.groovy
@@ -22,11 +22,19 @@ suite('test_alter_compute_group_properties', 'docker') {
     if (!isCloudMode()) {
         return;
     }
+
+    // Randomly enable or disable packed_file to test both scenarios
+    def enablePackedFile = new Random().nextBoolean()
+    logger.info("Running test with enable_packed_file=${enablePackedFile}")
+
     def options = new ClusterOptions()
     options.feConfigs += [
         'cloud_cluster_check_interval_second=1',
         'cloud_tablet_rebalancer_interval_second=1',
         'sys_log_verbose_modules=org',
+    ]
+    options.beConfigs += [
+        "enable_packed_file=${enablePackedFile}",
     ]
     options.setFeNum(1)
     options.setBeNum(1)

--- a/regression-test/suites/cloud_p0/balance/test_balance_metrics.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_balance_metrics.groovy
@@ -22,6 +22,11 @@ suite('test_balance_metrics', 'docker') {
     if (!isCloudMode()) {
         return;
     }
+
+    // Randomly enable or disable packed_file to test both scenarios
+    def enablePackedFile = new Random().nextBoolean()
+    logger.info("Running test with enable_packed_file=${enablePackedFile}")
+
     def options = new ClusterOptions()
     options.feConfigs += [
         'cloud_cluster_check_interval_second=1',
@@ -35,7 +40,8 @@ suite('test_balance_metrics', 'docker') {
         'report_tablet_interval_seconds=1',
         'schedule_sync_tablets_interval_s=18000',
         'disable_auto_compaction=true',
-        'sys_log_verbose_modules=*'
+        'sys_log_verbose_modules=*',
+        "enable_packed_file=${enablePackedFile}",
     ]
     options.setFeNum(1)
     options.setBeNum(1)

--- a/regression-test/suites/cloud_p0/balance/test_balance_use_compute_group_properties.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_balance_use_compute_group_properties.groovy
@@ -22,6 +22,11 @@ suite('test_balance_use_compute_group_properties', 'docker') {
     if (!isCloudMode()) {
         return;
     }
+
+    // Randomly enable or disable packed_file to test both scenarios
+    def enablePackedFile = new Random().nextBoolean()
+    logger.info("Running test with enable_packed_file=${enablePackedFile}")
+
     def options = new ClusterOptions()
     options.feConfigs += [
         'cloud_cluster_check_interval_second=1',
@@ -37,7 +42,7 @@ suite('test_balance_use_compute_group_properties', 'docker') {
         'schedule_sync_tablets_interval_s=18000',
         'disable_auto_compaction=true',
         'sys_log_verbose_modules=*',
-        'enable_packed_file=false',
+        "enable_packed_file=${enablePackedFile}",
     ]
     options.setFeNum(1)
     options.setBeNum(1)

--- a/regression-test/suites/cloud_p0/balance/test_balance_warm_up.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_balance_warm_up.groovy
@@ -22,6 +22,11 @@ suite('test_balance_warm_up', 'docker') {
     if (!isCloudMode()) {
         return;
     }
+
+    // Randomly enable or disable packed_file to test both scenarios
+    def enablePackedFile = new Random().nextBoolean()
+    logger.info("Running test with enable_packed_file=${enablePackedFile}")
+
     def options = new ClusterOptions()
     options.feConfigs += [
         'cloud_cluster_check_interval_second=1',
@@ -38,7 +43,7 @@ suite('test_balance_warm_up', 'docker') {
         'sys_log_verbose_modules=*',
         'cache_read_from_peer_expired_seconds=100',
         'enable_cache_read_from_peer=true',
-        'enable_packed_file=false',
+        "enable_packed_file=${enablePackedFile}",
     ]
     options.setFeNum(1)
     options.setBeNum(1)

--- a/regression-test/suites/cloud_p0/balance/test_balance_warm_up_sync_global_config.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_balance_warm_up_sync_global_config.groovy
@@ -22,6 +22,11 @@ suite('test_balance_warm_up_sync_cache', 'docker') {
     if (!isCloudMode()) {
         return;
     }
+
+    // Randomly enable or disable packed_file to test both scenarios
+    def enablePackedFile = new Random().nextBoolean()
+    logger.info("Running test with enable_packed_file=${enablePackedFile}")
+
     def options = new ClusterOptions()
     options.feConfigs += [
         'cloud_cluster_check_interval_second=1',
@@ -37,7 +42,7 @@ suite('test_balance_warm_up_sync_cache', 'docker') {
         'schedule_sync_tablets_interval_s=18000',
         'disable_auto_compaction=true',
         'sys_log_verbose_modules=*',
-        'enable_packed_file=false',
+        "enable_packed_file=${enablePackedFile}",
     ]
     options.setFeNum(1)
     options.setBeNum(1)

--- a/regression-test/suites/cloud_p0/balance/test_balance_warm_up_task_abnormal.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_balance_warm_up_task_abnormal.groovy
@@ -22,6 +22,11 @@ suite('test_balance_warm_up_task_abnormal', 'docker') {
     if (!isCloudMode()) {
         return;
     }
+
+    // Randomly enable or disable packed_file to test both scenarios
+    def enablePackedFile = new Random().nextBoolean()
+    logger.info("Running test with enable_packed_file=${enablePackedFile}")
+
     def options = new ClusterOptions()
     options.feConfigs += [
         'cloud_cluster_check_interval_second=1',
@@ -37,7 +42,7 @@ suite('test_balance_warm_up_task_abnormal', 'docker') {
         'schedule_sync_tablets_interval_s=18000',
         'disable_auto_compaction=true',
         'sys_log_verbose_modules=*',
-        'enable_packed_file=false',
+        "enable_packed_file=${enablePackedFile}",
     ]
     options.setFeNum(1)
     options.setBeNum(1)

--- a/regression-test/suites/cloud_p0/balance/test_balance_warm_up_use_peer_cache.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_balance_warm_up_use_peer_cache.groovy
@@ -22,6 +22,11 @@ suite('test_balance_warm_up_use_peer_cache', 'docker') {
     if (!isCloudMode()) {
         return;
     }
+
+    // Randomly enable or disable packed_file to test both scenarios
+    def enablePackedFile = new Random().nextBoolean()
+    logger.info("Running test with enable_packed_file=${enablePackedFile}")
+
     def options = new ClusterOptions()
     options.feConfigs += [
         'cloud_cluster_check_interval_second=1',
@@ -41,7 +46,7 @@ suite('test_balance_warm_up_use_peer_cache', 'docker') {
         'sys_log_verbose_modules=*',
         'cache_read_from_peer_expired_seconds=100',
         'enable_cache_read_from_peer=true',
-        'enable_packed_file=false',
+        "enable_packed_file=${enablePackedFile}",
     ]
     options.setFeNum(1)
     options.setBeNum(1)

--- a/regression-test/suites/cloud_p0/balance/test_balance_warm_up_with_compaction_use_peer_cache.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_balance_warm_up_with_compaction_use_peer_cache.groovy
@@ -22,6 +22,11 @@ suite('test_balance_warm_up_with_compaction_use_peer_cache', 'docker') {
     if (!isCloudMode()) {
         return;
     }
+
+    // Randomly enable or disable packed_file to test both scenarios
+    def enablePackedFile = new Random().nextBoolean()
+    logger.info("Running test with enable_packed_file=${enablePackedFile}")
+
     def options = new ClusterOptions()
     options.feConfigs += [
         'cloud_cluster_check_interval_second=1',
@@ -42,7 +47,7 @@ suite('test_balance_warm_up_with_compaction_use_peer_cache', 'docker') {
         'cumulative_compaction_min_deltas=5',
         'cache_read_from_peer_expired_seconds=100',
         'enable_cache_read_from_peer=true',
-        'enable_packed_file=false',
+        "enable_packed_file=${enablePackedFile}",
     ]
     options.setFeNum(1)
     options.setBeNum(1)

--- a/regression-test/suites/cloud_p0/balance/test_expanding_node_balance.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_expanding_node_balance.groovy
@@ -23,6 +23,10 @@ suite('test_expanding_node_balance', 'docker') {
         return;
     }
 
+    // Randomly enable or disable packed_file to test both scenarios
+    def enablePackedFile = new Random().nextBoolean()
+    logger.info("Running test with enable_packed_file=${enablePackedFile}")
+
     def clusterOptions = [
         new ClusterOptions(),
         new ClusterOptions(),
@@ -39,6 +43,9 @@ suite('test_expanding_node_balance', 'docker') {
             'cloud_warm_up_for_rebalance_type=peer_read_async_warmup',
             // disable Auto Analysis Job Executor
             'auto_check_statistics_in_minutes=60',
+        ]
+        options.beConfigs += [
+            "enable_packed_file=${enablePackedFile}",
         ]
         options.cloudMode = true
         options.setFeNum(1)

--- a/regression-test/suites/cloud_p0/balance/test_peer_read_async_warmup.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_peer_read_async_warmup.groovy
@@ -22,6 +22,11 @@ suite('test_peer_read_async_warmup', 'docker') {
     if (!isCloudMode()) {
         return;
     }
+
+    // Randomly enable or disable packed_file to test both scenarios
+    def enablePackedFile = new Random().nextBoolean()
+    logger.info("Running test with enable_packed_file=${enablePackedFile}")
+
     def options = new ClusterOptions()
     options.feConfigs += [
         'cloud_cluster_check_interval_second=1',
@@ -39,7 +44,7 @@ suite('test_peer_read_async_warmup', 'docker') {
         'disable_auto_compaction=true',
         'sys_log_verbose_modules=*',
         'enable_cache_read_from_peer=true',
-        'enable_packed_file=false',
+        "enable_packed_file=${enablePackedFile}",
     ]
     options.setFeNum(1)
     options.setBeNum(1)

--- a/regression-test/suites/cloud_p0/balance/test_warmup_rebalance.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_warmup_rebalance.groovy
@@ -22,6 +22,11 @@ suite('test_warmup_rebalance_in_cloud', 'multi_cluster, docker') {
     if (!isCloudMode()) {
         return;
     }
+
+    // Randomly enable or disable packed_file to test both scenarios
+    def enablePackedFile = new Random().nextBoolean()
+    logger.info("Running test with enable_packed_file=${enablePackedFile}")
+
     def options = new ClusterOptions()
     options.feConfigs += [
         'cloud_cluster_check_interval_second=1',
@@ -30,6 +35,9 @@ suite('test_warmup_rebalance_in_cloud', 'multi_cluster, docker') {
         'cloud_balance_tablet_percent_per_run=0.5',
         'sys_log_verbose_modules=org',
         'cloud_pre_heating_time_limit_sec=600'
+    ]
+    options.beConfigs += [
+        "enable_packed_file=${enablePackedFile}",
     ]
     options.setFeNum(2)
     options.setBeNum(3)

--- a/regression-test/suites/cloud_p0/cache/test_load_cache.groovy
+++ b/regression-test/suites/cloud_p0/cache/test_load_cache.groovy
@@ -33,6 +33,10 @@ changes to statistics are possible, only a reasonable range is required.
 */
 
 suite('test_load_cache', 'docker') {
+    // Randomly enable or disable packed_file to test both scenarios
+    def enablePackedFile = new Random().nextBoolean()
+    logger.info("Running test with enable_packed_file=${enablePackedFile}")
+
     def options = new ClusterOptions()
     options.feConfigs += [
         'cloud_cluster_check_interval_second=1',
@@ -41,6 +45,7 @@ suite('test_load_cache', 'docker') {
         'file_cache_enter_disk_resource_limit_mode_percent=99',
         'enable_evict_file_cache_in_advance=false',
         'file_cache_background_monitor_interval_ms=1000',
+        "enable_packed_file=${enablePackedFile}",
     ]
     options.cloudMode = true
     options.beNum = 1

--- a/regression-test/suites/cloud_p0/cache/test_topn_broadcast.groovy
+++ b/regression-test/suites/cloud_p0/cache/test_topn_broadcast.groovy
@@ -21,6 +21,9 @@ import org.apache.doris.regression.suite.ClusterOptions
 
 suite("test_topn_broadcast", "docker") {
 
+    // Randomly enable or disable packed_file to test both scenarios
+    def enablePackedFile = new Random().nextBoolean()
+    logger.info("Running test with enable_packed_file=${enablePackedFile}")
 
     def options = new ClusterOptions()
 
@@ -32,7 +35,8 @@ suite("test_topn_broadcast", "docker") {
     options.beConfigs += ['enable_file_cache=true', 'enable_java_support=false', 'file_cache_enter_disk_resource_limit_mode_percent=99',
                           'file_cache_background_lru_dump_interval_ms=2000', 'file_cache_background_lru_log_replay_interval_ms=500',
                           'disable_auto_compation=true', 'file_cache_enter_need_evict_cache_in_advance_percent=99',
-                          'file_cache_background_lru_dump_update_cnt_threshold=0'
+                          'file_cache_background_lru_dump_update_cnt_threshold=0',
+                          "enable_packed_file=${enablePackedFile}",
                         ]
 
     docker(options) {

--- a/regression-test/suites/cloud_p0/tablets/test_clean_stale_rs_file_cache.groovy
+++ b/regression-test/suites/cloud_p0/tablets/test_clean_stale_rs_file_cache.groovy
@@ -22,6 +22,11 @@ suite('test_clean_stale_rs_file_cache', 'docker') {
     if (!isCloudMode()) {
         return;
     }
+
+    // Randomly enable or disable packed_file to test both scenarios
+    def enablePackedFile = new Random().nextBoolean()
+    logger.info("Running test with enable_packed_file=${enablePackedFile}")
+
     def options = new ClusterOptions()
     options.feConfigs += [
         'cloud_cluster_check_interval_second=1',
@@ -35,7 +40,7 @@ suite('test_clean_stale_rs_file_cache', 'docker') {
         'tablet_rowset_stale_sweep_by_size=false',
         'tablet_rowset_stale_sweep_time_sec=60',
         'vacuum_stale_rowsets_interval_s=10',
-        'enable_packed_file=false',
+        "enable_packed_file=${enablePackedFile}",
     ]
     options.setFeNum(1)
     options.setBeNum(1)

--- a/regression-test/suites/cloud_p0/tablets/test_clean_stale_rs_index_file_cache.groovy
+++ b/regression-test/suites/cloud_p0/tablets/test_clean_stale_rs_index_file_cache.groovy
@@ -22,6 +22,11 @@ suite('test_clean_stale_rs_index_file_cache', 'docker') {
     if (!isCloudMode()) {
         return;
     }
+
+    // Randomly enable or disable packed_file to test both scenarios
+    def enablePackedFile = new Random().nextBoolean()
+    logger.info("Running test with enable_packed_file=${enablePackedFile}")
+
     def options = new ClusterOptions()
     options.feConfigs += [
         'cloud_cluster_check_interval_second=1',
@@ -35,7 +40,7 @@ suite('test_clean_stale_rs_index_file_cache', 'docker') {
         'tablet_rowset_stale_sweep_by_size=false',
         'tablet_rowset_stale_sweep_time_sec=60',
         'vacuum_stale_rowsets_interval_s=10',
-        'enable_packed_file=false',
+        "enable_packed_file=${enablePackedFile}",
     ]
     options.setFeNum(1)
     options.setBeNum(1)

--- a/regression-test/suites/cloud_p0/tablets/test_clean_tablet_when_drop_force_table.groovy
+++ b/regression-test/suites/cloud_p0/tablets/test_clean_tablet_when_drop_force_table.groovy
@@ -22,6 +22,11 @@ suite('test_clean_tablet_when_drop_force_table', 'docker') {
     if (!isCloudMode()) {
         return;
     }
+
+    // Randomly enable or disable packed_file to test both scenarios
+    def enablePackedFile = new Random().nextBoolean()
+    logger.info("Running test with enable_packed_file=${enablePackedFile}")
+
     def options = new ClusterOptions()
     options.feConfigs += [
         'cloud_cluster_check_interval_second=1',
@@ -35,7 +40,7 @@ suite('test_clean_tablet_when_drop_force_table', 'docker') {
         'write_buffer_size=10240',
         'write_buffer_size_for_agg=10240',
         'sys_log_verbose_modules=task_worker_pool',
-        'enable_packed_file=false',
+        "enable_packed_file=${enablePackedFile}",
     ]
     options.setFeNum(3)
     options.setBeNum(3)

--- a/regression-test/suites/cloud_p0/tablets/test_clean_tablet_when_rebalance.groovy
+++ b/regression-test/suites/cloud_p0/tablets/test_clean_tablet_when_rebalance.groovy
@@ -22,6 +22,11 @@ suite('test_clean_tablet_when_rebalance', 'docker') {
     if (!isCloudMode()) {
         return;
     }
+
+    // Randomly enable or disable packed_file to test both scenarios
+    def enablePackedFile = new Random().nextBoolean()
+    logger.info("Running test with enable_packed_file=${enablePackedFile}")
+
     def options = new ClusterOptions()
     def rehashTime = 100
     options.feConfigs += [
@@ -35,7 +40,7 @@ suite('test_clean_tablet_when_rebalance', 'docker') {
         'report_tablet_interval_seconds=1',
         'write_buffer_size=10240',
         'write_buffer_size_for_agg=10240',
-        'enable_packed_file=false',
+        "enable_packed_file=${enablePackedFile}",
     ]
     options.setFeNum(3)
     options.setBeNum(3)


### PR DESCRIPTION


### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

When enable_packed_file is enabled, the warm up functions fail to download cache data because they use storage_resource->fs (the raw FileSystem) instead of RowsetMeta::fs() which wraps the FileSystem with PackedFileSystem.

The PackedFileSystem correctly maps segment file paths to their actual locations within packed files. Without this mapping, the download fails because the segment files don't exist on S3 - they are packed into larger packed files.

This fix changes the file_system used in:
1. download_file_cache_block (block_file_cache_downloader.cpp)
2. _submit_segment_download_task (cloud_tablet.cpp)
3. _submit_inverted_index_download_task (cloud_tablet.cpp)

All now use RowsetMeta::fs() instead of storage_resource->fs to properly handle packed files.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

