### PR TITLE
[fix](Job)Fix NPE in InsertTask when task is canceled

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertTask.java
@@ -210,8 +210,14 @@ public class InsertTask extends AbstractTask {
                 return;
             }
             command.runWithUpdateInfo(ctx, stmtExecutor, loadStatistic);
-            if (ctx.getState().getStateType() != QueryState.MysqlStateType.OK) {
-                throw new JobException(ctx.getState().getErrorMessage());
+            ConnectContext localCtx = ctx;
+            if (isCanceled.get()) {
+                log.info("task has been canceled during execution, task id is {}", getTaskId());
+                return;
+            }
+            QueryState state = localCtx.getState();
+            if (localCtx.getState().getStateType() != QueryState.MysqlStateType.OK) {
+                throw new JobException(state.getErrorMessage());
             }
         } catch (Exception e) {
             log.warn("execute insert task error, job id is {}, task id is {},sql is {}", getJobId(),


### PR DESCRIPTION
When an insert task is canceled during execution, the shared `ctx` object may be set to null. Currently, after `command.runWithUpdateInfo(...)`, the code directly accesses `ctx.getState()`. If `ctx` is null or its state is null, this leads to a NullPointerException (NPE).

### Solution
- Cache the `ctx` reference to a local variable to avoid race conditions.
- Check both `ctx` and `ctx.getState()` for null before accessing.
- If the task was canceled or the state is null, safely return without throwing an exception.
- Maintain existing behavior: if the task completes with a non-OK state, still throw `JobException`.

### Impact
- Prevents NPE when a task is canceled during execution.
- Makes the insert task more robust in concurrent cancel scenarios.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

