### PR TITLE
[fix](prune nested column) fix prune nested column maybe throw NullPointerException

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathPlanCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathPlanCollector.java
@@ -47,6 +47,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalUnion;
 import org.apache.doris.nereids.trees.plans.visitor.DefaultPlanVisitor;
 import org.apache.doris.nereids.types.NestedColumnPrunable;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 
@@ -222,7 +223,20 @@ public class AccessPathPlanCollector extends DefaultPlanVisitor<Void, StatementC
                 Slot innerSlot = (Slot) output.child(0);
                 Collection<CollectAccessPathResult> outerSlotAccessPaths = allSlotToAccessPaths.get(
                         output.getExprId().asInt());
-                allSlotToAccessPaths.putAll(innerSlot.getExprId().asInt(), outerSlotAccessPaths);
+                // for (CollectAccessPathResult outerSlotAccessPath : outerSlotAccessPaths) {
+                //     List<String> outerPath = outerSlotAccessPath.getPath();
+                //     List<String> replaceSlotNamePath = new ArrayList<>();
+                //     replaceSlotNamePath.add(innerSlot.getName());
+                //     replaceSlotNamePath.addAll(outerPath.subList(1, outerPath.size()));
+                //     allSlotToAccessPaths.put(
+                //             innerSlot.getExprId().asInt(),
+                //             new CollectAccessPathResult(replaceSlotNamePath, outerSlotAccessPath.isPredicate(), outerSlotAccessPath.getType())
+                //     );
+                // }
+                allSlotToAccessPaths.putAll(
+                                    innerSlot.getExprId().asInt(),
+                                    outerSlotAccessPaths
+                        );
             } else {
                 exprCollector.collect(output);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathPlanCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathPlanCollector.java
@@ -229,7 +229,11 @@ public class AccessPathPlanCollector extends DefaultPlanVisitor<Void, StatementC
                     replaceSlotNamePath.addAll(outerPath.subList(1, outerPath.size()));
                     allSlotToAccessPaths.put(
                             innerSlot.getExprId().asInt(),
-                            new CollectAccessPathResult(replaceSlotNamePath, outerSlotAccessPath.isPredicate(), outerSlotAccessPath.getType())
+                            new CollectAccessPathResult(
+                                    replaceSlotNamePath,
+                                    outerSlotAccessPath.isPredicate(),
+                                    outerSlotAccessPath.getType()
+                            )
                     );
                 }
             } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathPlanCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathPlanCollector.java
@@ -47,7 +47,6 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalUnion;
 import org.apache.doris.nereids.trees.plans.visitor.DefaultPlanVisitor;
 import org.apache.doris.nereids.types.NestedColumnPrunable;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 
@@ -223,20 +222,16 @@ public class AccessPathPlanCollector extends DefaultPlanVisitor<Void, StatementC
                 Slot innerSlot = (Slot) output.child(0);
                 Collection<CollectAccessPathResult> outerSlotAccessPaths = allSlotToAccessPaths.get(
                         output.getExprId().asInt());
-                // for (CollectAccessPathResult outerSlotAccessPath : outerSlotAccessPaths) {
-                //     List<String> outerPath = outerSlotAccessPath.getPath();
-                //     List<String> replaceSlotNamePath = new ArrayList<>();
-                //     replaceSlotNamePath.add(innerSlot.getName());
-                //     replaceSlotNamePath.addAll(outerPath.subList(1, outerPath.size()));
-                //     allSlotToAccessPaths.put(
-                //             innerSlot.getExprId().asInt(),
-                //             new CollectAccessPathResult(replaceSlotNamePath, outerSlotAccessPath.isPredicate(), outerSlotAccessPath.getType())
-                //     );
-                // }
-                allSlotToAccessPaths.putAll(
-                                    innerSlot.getExprId().asInt(),
-                                    outerSlotAccessPaths
-                        );
+                for (CollectAccessPathResult outerSlotAccessPath : outerSlotAccessPaths) {
+                    List<String> outerPath = outerSlotAccessPath.getPath();
+                    List<String> replaceSlotNamePath = new ArrayList<>();
+                    replaceSlotNamePath.add(innerSlot.getName());
+                    replaceSlotNamePath.addAll(outerPath.subList(1, outerPath.size()));
+                    allSlotToAccessPaths.put(
+                            innerSlot.getExprId().asInt(),
+                            new CollectAccessPathResult(replaceSlotNamePath, outerSlotAccessPath.isPredicate(), outerSlotAccessPath.getType())
+                    );
+                }
             } else {
                 exprCollector.collect(output);
             }


### PR DESCRIPTION
### What problem does this PR solve?

fix prune nested column maybe throw NullPointerException, introduced by #58370

```sql
select k1 as k2 -- can not find s.k2, we should replace k2 to k1
from
(
  select struct_element(s, 'k1') k1
  from tbl
)t
```

```
java.lang.NullPointerException: Cannot invoke "org.apache.doris.nereids.rules.rewrite.NestedColumnPruning$DataTypeAccessTree.setAccessByPath(java.util.List, int, org.apache.doris.thrift.TAccessPathType)" because the return value of "java.util.Map.get(Object)" is null
	at org.apache.doris.nereids.rules.rewrite.NestedColumnPruning$DataTypeAccessTree.setAccessByPath(NestedColumnPruning.java:431)
	at org.apache.doris.nereids.rules.rewrite.NestedColumnPruning.pruneDataType(NestedColumnPruning.java:128)
	at org.apache.doris.nereids.rules.rewrite.NestedColumnPruning.rewriteRoot(NestedColumnPruning.java:86)
	at org.apache.doris.nereids.jobs.rewrite.CustomRewriteJob.execute(CustomRewriteJob.java:61)
	at org.apache.doris.nereids.jobs.executor.AbstractBatchJobExecutor.execute(AbstractBatchJobExecutor.java:167)
	at org.apache.doris.nereids.jobs.executor.Rewriter.lambda$execute$23(Rewriter.java:963)
	at org.apache.doris.nereids.util.MoreFieldsThread.keepFunctionSignature(MoreFieldsThread.java:127)
	at org.apache.doris.nereids.util.MoreFieldsThread.keepFunctionSignature(MoreFieldsThread.java:116)
	at org.apache.doris.nereids.jobs.executor.Rewriter.execute(Rewriter.java:962)
	at org.apache.doris.nereids.NereidsPlanner.lambda$rewrite$5(NereidsPlanner.java:434)
	at org.apache.doris.nereids.NereidsPlanner.keepOrShowPlanProcess(NereidsPlanner.java:1109)
	at org.apache.doris.nereids.NereidsPlanner.rewrite(NereidsPlanner.java:433)
	at org.apache.doris.nereids.NereidsPlanner.planWithoutLock(NereidsPlanner.java:297)
	at org.apache.doris.nereids.NereidsPlanner.planWithLock(NereidsPlanner.java:263)
	at org.apache.doris.nereids.NereidsPlanner.plan(NereidsPlanner.java:162)
	at org.apache.doris.qe.StmtExecutor.executeByNereids(StmtExecutor.java:748)
	at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:541)
	at org.apache.doris.qe.StmtExecutor.queryRetry(StmtExecutor.java:500)
	at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:485)
	at org.apache.doris.qe.ConnectProcessor.executeQuery(ConnectProcessor.java:311)
	at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:198)
	at org.apache.doris.qe.MysqlConnectProcessor.handleQuery(MysqlConnectProcessor.java:231)
	at org.apache.doris.qe.MysqlConnectProcessor.dispatch(MysqlConnectProcessor.java:259)
	at org.apache.doris.qe.MysqlConnectProcessor.processOnce(MysqlConnectProcessor.java:403)
	at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

