### PR TITLE
[Fix](profile) Split operators CloseTime from ExecTime

### DIFF
--- a/be/src/pipeline/exec/aggregation_source_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_source_operator.cpp
@@ -613,7 +613,6 @@ void AggLocalState::_emplace_into_hash_table(vectorized::AggregateDataPtr* place
 }
 
 Status AggLocalState::close(RuntimeState* state) {
-    SCOPED_TIMER(exec_time_counter());
     SCOPED_TIMER(_close_timer);
     if (_closed) {
         return Status::OK();

--- a/be/src/pipeline/exec/datagen_operator.cpp
+++ b/be/src/pipeline/exec/datagen_operator.cpp
@@ -103,7 +103,6 @@ Status DataGenLocalState::init(RuntimeState* state, LocalStateInfo& info) {
 }
 
 Status DataGenLocalState::close(RuntimeState* state) {
-    SCOPED_TIMER(exec_time_counter());
     SCOPED_TIMER(_close_timer);
     if (_closed) {
         return Status::OK();

--- a/be/src/pipeline/exec/distinct_streaming_aggregation_operator.cpp
+++ b/be/src/pipeline/exec/distinct_streaming_aggregation_operator.cpp
@@ -426,7 +426,6 @@ Status DistinctStreamingAggLocalState::close(RuntimeState* state) {
     if (_closed) {
         return Status::OK();
     }
-    SCOPED_TIMER(Base::exec_time_counter());
     SCOPED_TIMER(Base::_close_timer);
     /// _hash_table_size_counter may be null if prepare failed.
     if (_hash_table_size_counter && !_probe_expr_ctxs.empty()) {

--- a/be/src/pipeline/exec/exchange_source_operator.cpp
+++ b/be/src/pipeline/exec/exchange_source_operator.cpp
@@ -199,7 +199,6 @@ Status ExchangeSourceOperatorX::get_block(RuntimeState* state, vectorized::Block
 }
 
 Status ExchangeLocalState::close(RuntimeState* state) {
-    SCOPED_TIMER(exec_time_counter());
     SCOPED_TIMER(_close_timer);
     if (_closed) {
         return Status::OK();

--- a/be/src/pipeline/exec/hashjoin_probe_operator.cpp
+++ b/be/src/pipeline/exec/hashjoin_probe_operator.cpp
@@ -102,7 +102,6 @@ void HashJoinProbeLocalState::prepare_for_next() {
 }
 
 Status HashJoinProbeLocalState::close(RuntimeState* state) {
-    SCOPED_TIMER(exec_time_counter());
     SCOPED_TIMER(_close_timer);
     if (_closed) {
         return Status::OK();

--- a/be/src/pipeline/exec/multi_cast_data_stream_source.cpp
+++ b/be/src/pipeline/exec/multi_cast_data_stream_source.cpp
@@ -70,7 +70,6 @@ Status MultiCastDataStreamSourceLocalState::close(RuntimeState* state) {
     }
 
     SCOPED_TIMER(_close_timer);
-    SCOPED_TIMER(exec_time_counter());
     int64_t rf_time = 0;
     for (auto& dep : _filter_dependencies) {
         rf_time += dep->watcher_elapse_time();

--- a/be/src/pipeline/exec/nested_loop_join_probe_operator.cpp
+++ b/be/src/pipeline/exec/nested_loop_join_probe_operator.cpp
@@ -64,7 +64,6 @@ Status NestedLoopJoinProbeLocalState::open(RuntimeState* state) {
 }
 
 Status NestedLoopJoinProbeLocalState::close(RuntimeState* state) {
-    SCOPED_TIMER(exec_time_counter());
     SCOPED_TIMER(_close_timer);
     if (_closed) {
         return Status::OK();

--- a/be/src/pipeline/exec/partitioned_aggregation_source_operator.cpp
+++ b/be/src/pipeline/exec/partitioned_aggregation_source_operator.cpp
@@ -82,7 +82,6 @@ void PartitionedAggLocalState::update_profile(RuntimeProfile* child_profile) {
 #undef UPDATE_COUNTER_FROM_INNER
 
 Status PartitionedAggLocalState::close(RuntimeState* state) {
-    SCOPED_TIMER(exec_time_counter());
     SCOPED_TIMER(_close_timer);
     if (_closed) {
         return Status::OK();

--- a/be/src/pipeline/exec/partitioned_hash_join_probe_operator.cpp
+++ b/be/src/pipeline/exec/partitioned_hash_join_probe_operator.cpp
@@ -156,7 +156,6 @@ Status PartitionedHashJoinProbeLocalState::open(RuntimeState* state) {
                                                                                   _partitioner);
 }
 Status PartitionedHashJoinProbeLocalState::close(RuntimeState* state) {
-    SCOPED_TIMER(exec_time_counter());
     SCOPED_TIMER(_close_timer);
     if (_closed) {
         return Status::OK();

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -1267,7 +1267,6 @@ Status ScanLocalState<Derived>::close(RuntimeState* state) {
     COUNTER_UPDATE(exec_time_counter(), rf_time);
     SCOPED_TIMER(_close_timer);
 
-    SCOPED_TIMER(exec_time_counter());
     if (auto ctx = _scanner_ctx.load()) {
         ctx->stop_scanners(state);
         // _scanner_ctx may be accessed in debug_string concurrently

--- a/be/src/pipeline/exec/streaming_aggregation_operator.cpp
+++ b/be/src/pipeline/exec/streaming_aggregation_operator.cpp
@@ -988,7 +988,6 @@ Status StreamingAggLocalState::close(RuntimeState* state) {
     if (_closed) {
         return Status::OK();
     }
-    SCOPED_TIMER(Base::exec_time_counter());
     SCOPED_TIMER(Base::_close_timer);
     if (Base::_closed) {
         return Status::OK();

--- a/be/src/pipeline/exec/union_source_operator.cpp
+++ b/be/src/pipeline/exec/union_source_operator.cpp
@@ -193,7 +193,6 @@ Status UnionSourceOperatorX::get_next_const(RuntimeState* state, vectorized::Blo
 }
 
 Status UnionSourceLocalState::close(RuntimeState* state) {
-    SCOPED_TIMER(exec_time_counter());
     SCOPED_TIMER(_close_timer);
     if (_closed) {
         return Status::OK();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

After all actual task was finished by this operator, the close time shouldn't be added into ExecTime. it may make weird profiles like :

```
   - Total: 36sec636ms
......
               OLAP_SCAN_OPERATOR (id=4. nereids_id=1858. ...
                  - ExecTime: avg 16sec665ms, max 59sec941ms, min 4sec926ms
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

