### PR TITLE
[fix](fe) Suppress stack trace for backend heartbeat connection refused exceptions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -795,8 +795,14 @@ public class DynamicPartitionScheduler extends MasterDaemon {
                         clearCreatePartitionFailedMsg(olapTable.getId());
                     } catch (Exception e) {
                         recordCreatePartitionFailedMsg(db.getFullName(), tableName, e.getMessage(), olapTable.getId());
-                        LOG.warn("db [{}-{}], table [{}-{}]'s dynamic partition has error",
-                                db.getId(), db.getName(), olapTable.getId(), olapTable.getName(), e);
+                        String errMsg = e.getMessage();
+                        if (errMsg != null && errMsg.contains("available backend")) {
+                            LOG.warn("db [{}-{}], table [{}-{}]'s dynamic partition has error: {}",
+                                    db.getId(), db.getName(), olapTable.getId(), olapTable.getName(), errMsg);
+                        } else {
+                            LOG.warn("db [{}-{}], table [{}-{}]'s dynamic partition has error",
+                                    db.getId(), db.getName(), olapTable.getId(), olapTable.getName(), e);
+                        }
                         if (executeFirstTime) {
                             throw new DdlException(e.getMessage());
                         }

--- a/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -26,6 +26,7 @@ import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.Version;
 import org.apache.doris.common.util.DebugPointUtil;
+import org.apache.doris.common.util.Util;
 import org.apache.doris.common.util.MasterDaemon;
 import org.apache.doris.persist.HbPackage;
 import org.apache.doris.resource.Tag;
@@ -374,7 +375,13 @@ public class HeartbeatMgr extends MasterDaemon {
                                     ? "Unknown error" : result.getStatus().getErrorMsgs().get(0));
                 }
             } catch (Exception e) {
-                LOG.warn("backend heartbeat got exception", e);
+                Throwable rootCause = Util.getRootCause(e);
+                if (rootCause instanceof java.net.ConnectException) {
+                    LOG.warn("backend heartbeat got exception, host: {}, error: {}",
+                            backend.getHost(), Util.getRootCauseMessage(e));
+                } else {
+                    LOG.warn("backend heartbeat got exception", e);
+                }
                 return new BackendHbResponse(backendId, backend.getHost(), backend.getLastUpdateMs(),
                         Strings.isNullOrEmpty(e.getMessage()) ? "got exception" : e.getMessage());
             } finally {


### PR DESCRIPTION
## Summary
- Suppress verbose stack trace logging for `ConnectException` during backend heartbeat failures
- Only log host and error message for connection refused errors (expected when backend is down)
- Preserve full stack trace for other unexpected exceptions that need investigation

## Test plan
- [ ] Manual testing with backend down to verify log output is cleaner
- [ ] Verify other exceptions still log full stack trace

🤖 Generated with [Claude Code](https://claude.ai/code)