### PR TITLE
[enhance](memtable) support dynamic modification of flush thread pool size

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -44,6 +44,10 @@
 #include "common/status.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_system.h"
+#include "olap/memtable_flush_executor.h"
+#include "olap/storage_engine.h"
+#include "runtime/exec_env.h"
+#include "runtime/workload_group/workload_group_manager.h"
 #include "util/cpu_info.h"
 
 namespace doris::config {
@@ -803,12 +807,12 @@ DEFINE_mInt32(storage_flood_stage_usage_percent, "90"); // 90%
 // The min bytes that should be left of a data dir
 DEFINE_mInt64(storage_flood_stage_left_capacity_bytes, "1073741824"); // 1GB
 // number of thread for flushing memtable per store
-DEFINE_Int32(flush_thread_num_per_store, "6");
+DEFINE_mInt32(flush_thread_num_per_store, "6");
 // number of thread for flushing memtable per store, for high priority load task
-DEFINE_Int32(high_priority_flush_thread_num_per_store, "6");
+DEFINE_mInt32(high_priority_flush_thread_num_per_store, "6");
 // number of threads = min(flush_thread_num_per_store * num_store,
 //                         max_flush_thread_num_per_cpu * num_cpu)
-DEFINE_Int32(max_flush_thread_num_per_cpu, "4");
+DEFINE_mInt32(max_flush_thread_num_per_cpu, "4");
 
 // config for tablet meta checkpoint
 DEFINE_mInt32(tablet_meta_checkpoint_min_new_rowsets_num, "10");
@@ -2076,6 +2080,22 @@ void update_config(const std::string& field, const std::string& value) {
     if ("sys_log_level" == field) {
         // update log level
         update_logging(field, value);
+    } else if ("flush_thread_num_per_store" == field ||
+               "high_priority_flush_thread_num_per_store" == field ||
+               "max_flush_thread_num_per_cpu" == field) {
+        // update memtable flush thread pool size
+        auto* exec_env = ExecEnv::GetInstance();
+        if (exec_env != nullptr) {
+            auto* flush_executor = exec_env->storage_engine().memtable_flush_executor();
+            if (flush_executor != nullptr) {
+                flush_executor->update_memtable_flush_threads();
+            }
+            // update workload groups' memtable flush thread pools
+            auto* wg_mgr = exec_env->workload_group_mgr();
+            if (wg_mgr != nullptr) {
+                wg_mgr->update_memtable_flush_threads();
+            }
+        }
     }
 }
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -842,12 +842,12 @@ DECLARE_mInt32(storage_flood_stage_usage_percent); // 90%
 // The min bytes that should be left of a data dir
 DECLARE_mInt64(storage_flood_stage_left_capacity_bytes); // 1GB
 // number of thread for flushing memtable per store
-DECLARE_Int32(flush_thread_num_per_store);
+DECLARE_mInt32(flush_thread_num_per_store);
 // number of thread for flushing memtable per store, for high priority load task
-DECLARE_Int32(high_priority_flush_thread_num_per_store);
+DECLARE_mInt32(high_priority_flush_thread_num_per_store);
 // number of threads = min(flush_thread_num_per_store * num_store,
 //                         max_flush_thread_num_per_cpu * num_cpu)
-DECLARE_Int32(max_flush_thread_num_per_cpu);
+DECLARE_mInt32(max_flush_thread_num_per_cpu);
 
 // config for tablet meta checkpoint
 DECLARE_mInt32(tablet_meta_checkpoint_min_new_rowsets_num);

--- a/be/src/olap/memtable_flush_executor.h
+++ b/be/src/olap/memtable_flush_executor.h
@@ -163,10 +163,13 @@ public:
 
     ThreadPool* flush_pool() { return _flush_pool.get(); }
 
+    void update_memtable_flush_threads();
+
 private:
     std::unique_ptr<ThreadPool> _flush_pool;
     std::unique_ptr<ThreadPool> _high_prio_flush_pool;
     std::atomic<int> _flushing_task_count = 0;
+    int _num_disk = 0;
 };
 
 } // namespace doris

--- a/be/src/runtime/workload_group/workload_group.cpp
+++ b/be/src/runtime/workload_group/workload_group.cpp
@@ -26,8 +26,11 @@
 #include <ostream>
 #include <utility>
 
+#include "cloud/config.h"
+#include "common/config.h"
 #include "common/logging.h"
 #include "exec/schema_scanner/schema_scanner_helper.h"
+#include "io/cache/block_file_cache_factory.h"
 #include "io/fs/local_file_reader.h"
 #include "olap/storage_engine.h"
 #include "pipeline/task_queue.h"
@@ -746,6 +749,32 @@ void WorkloadGroup::try_stop_schedulers() {
         _memtable_flush_pool->shutdown();
         _memtable_flush_pool->wait();
     }
+}
+
+void WorkloadGroup::update_memtable_flush_threads() {
+    if (_memtable_flush_pool == nullptr) {
+        return;
+    }
+
+    int num_disk = 1;
+    int num_cpus = 0;
+#ifndef BE_TEST
+    if (config::is_cloud_mode()) {
+        num_disk = cast_set<int>(io::FileCacheFactory::instance()->get_cache_instance_size());
+    } else {
+        num_disk = ExecEnv::GetInstance()->storage_engine().get_disk_num();
+    }
+    num_cpus = std::thread::hardware_concurrency();
+#endif
+    num_disk = std::max(1, num_disk);
+    int min_threads = std::max(1, config::flush_thread_num_per_store);
+    int max_threads = num_cpus == 0 ? num_disk * min_threads
+                                    : std::min(num_disk * min_threads,
+                                               num_cpus * config::max_flush_thread_num_per_cpu);
+
+    // Update max_threads first to avoid constraint violation when increasing min_threads
+    static_cast<void>(_memtable_flush_pool->set_max_threads(max_threads));
+    static_cast<void>(_memtable_flush_pool->set_min_threads(min_threads));
 }
 
 #include "common/compile_check_end.h"

--- a/be/src/runtime/workload_group/workload_group.h
+++ b/be/src/runtime/workload_group/workload_group.h
@@ -193,6 +193,9 @@ public:
         // to avoid lock competition with the workload thread pool's update
         return _memtable_flush_pool.get();
     }
+
+    void update_memtable_flush_threads();
+
     void create_cgroup_cpu_ctl();
 
     std::weak_ptr<CgroupCpuCtl> get_cgroup_cpu_ctl_wptr();

--- a/be/src/runtime/workload_group/workload_group_manager.cpp
+++ b/be/src/runtime/workload_group/workload_group_manager.cpp
@@ -278,6 +278,13 @@ void WorkloadGroupMgr::refresh_workload_group_metrics() {
     }
 }
 
+void WorkloadGroupMgr::update_memtable_flush_threads() {
+    std::shared_lock<std::shared_mutex> r_lock(_group_mutex);
+    for (const auto& [id, wg] : _workload_groups) {
+        wg->update_memtable_flush_threads();
+    }
+}
+
 void WorkloadGroupMgr::add_paused_query(const std::shared_ptr<ResourceContext>& resource_ctx,
                                         int64_t reserve_size, const Status& status) {
     DCHECK(resource_ctx != nullptr);

--- a/be/src/runtime/workload_group/workload_group_manager.h
+++ b/be/src/runtime/workload_group/workload_group_manager.h
@@ -89,6 +89,8 @@ public:
 
     void refresh_workload_group_metrics();
 
+    void update_memtable_flush_threads();
+
     MOCK_FUNCTION void add_paused_query(const std::shared_ptr<ResourceContext>& resource_ctx,
                                         int64_t reserve_size, const Status& status);
 


### PR DESCRIPTION
### What problem does this PR solve?

Support dynamic modification of flush thread pool size.

Usage Example:
```
# Update flush thread pool size without restarting BE
curl "http://be_host:webserver_port/api/update_config?flush_thread_num_per_store=10"
curl "http://be_host:webserver_port/api/update_config?max_flush_thread_num_per_cpu=8"
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

