### PR TITLE
[fix](query cache) AggregateNode compute digest of query cache should consider sortByGroupKey

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/AggregationNode.java
@@ -160,6 +160,9 @@ public class AggregationNode extends PlanNode {
 
         normalizedPlan.setNodeType(TPlanNodeType.AGGREGATION_NODE);
         normalizedPlan.setAggregationNode(normalizedAggregateNode);
+        if (sortByGroupKey != null) {
+            normalizedAggregateNode.setSortInfo(sortByGroupKey.toThrift());
+        }
     }
 
     @Override

--- a/gensrc/thrift/Normalization.thrift
+++ b/gensrc/thrift/Normalization.thrift
@@ -44,6 +44,7 @@ struct TNormalizedAggregateNode {
   6: optional bool use_streaming_preaggregation
   7: optional list<Exprs.TExpr> projectToAggIntermediateTuple
   8: optional list<Exprs.TExpr> projectToAggOutputTuple
+  9: optional PlanNodes.TSortInfo sortInfo
 }
 
 struct TNormalizedPlanNode {


### PR DESCRIPTION
AggregateNode compute digest of query cache should consider sortByGroupKey

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

