### PR TITLE
[fix] Improve COALESCE function statistics estimation accuracy

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/ExpressionEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/ExpressionEstimation.java
@@ -49,6 +49,7 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.Acos;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Ascii;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Asin;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Atan;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Coalesce;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.DayOfMonth;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.DayOfWeek;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.DayOfYear;
@@ -943,5 +944,76 @@ public class ExpressionEstimation extends ExpressionVisitor<ColumnStatistic, Sta
     @Override
     public ColumnStatistic visitSecondsDiff(SecondsDiff secondsDiff, Statistics context) {
         return dateDiff(1, secondsDiff, context);
+    }
+
+    @Override
+    public ColumnStatistic visitCoalesce(Coalesce coalesce, Statistics context) {
+        List<Expression> children = coalesce.children();
+        if (children.isEmpty()) {
+            return ColumnStatistic.UNKNOWN;
+        }
+        // Get the statistics of the first argument as the base
+        ColumnStatistic firstChildStats = children.get(0).accept(this, context);
+        if (firstChildStats.isUnKnown) {
+            return ColumnStatistic.UNKNOWN;
+        }
+
+        // For COALESCE function, mainly consider the handling of NULL values
+        // coalesce(a, b, c) returns the first non-NULL value
+        double rowCount = context.getRowCount();
+        double numNulls = firstChildStats.numNulls;
+        double ndv = firstChildStats.ndv;
+
+        // If there are multiple arguments, consider the impact of subsequent arguments on NULL replacement
+        if (children.size() > 1) {
+            // Calculate the probability that all arguments are NULL (approximate estimation)
+            double allNullProbability = firstChildStats.numNulls / rowCount;
+            for (int i = 1; i < children.size(); i++) {
+                ColumnStatistic childStats = children.get(i).accept(this, context);
+                if (!childStats.isUnKnown) {
+                    // The probability that subsequent arguments are also NULL (simplified estimation)
+                    double childNullProbability = childStats.numNulls / rowCount;
+                    allNullProbability *= childNullProbability;
+                }
+            }
+
+            // Final NULL count = number of rows where all arguments are NULL
+            numNulls = rowCount * allNullProbability;
+
+            // NDV estimation: consider the possible values of all arguments
+            // Use the maximum NDV of all arguments as the estimation
+            double maxNdv = ndv;
+            for (int i = 1; i < children.size(); i++) {
+                ColumnStatistic childStats = children.get(i).accept(this, context);
+                if (!childStats.isUnKnown) {
+                    maxNdv = Math.max(maxNdv, childStats.ndv);
+                }
+            }
+            ndv = maxNdv;
+        }
+
+        // Build new statistics
+        ColumnStatisticBuilder builder = new ColumnStatisticBuilder(firstChildStats);
+        builder.setNumNulls(numNulls)
+                .setNdv(ndv);
+
+        // For COALESCE function, min/max values should consider the range of all arguments
+        if (children.size() > 1) {
+            double minValue = firstChildStats.minValue;
+            double maxValue = firstChildStats.maxValue;
+
+            for (int i = 1; i < children.size(); i++) {
+                ColumnStatistic childStats = children.get(i).accept(this, context);
+                if (!childStats.isUnKnown) {
+                    minValue = Math.min(minValue, childStats.minValue);
+                    maxValue = Math.max(maxValue, childStats.maxValue);
+                }
+            }
+
+            builder.setMinValue(minValue)
+                    .setMaxValue(maxValue);
+        }
+
+        return builder.build();
     }
 }


### PR DESCRIPTION
### Problem
The COALESCE function did not generate proper statistical estimates, leading to inaccurate query planning. When COALESCE was used in queries, the optimizer could not accurately estimate:

- The number of NULL values
- The number of distinct values (NDV)
- Min/max value ranges
- Row count estimates

This could result in suboptimal execution plans and poor query performance.

### Solution

Added support for COALESCE function statistics estimation in the Nereids optimizer's ExpressionEstimation class. The implementation:

1. NULL Value Estimation: Calculates the probability that all COALESCE arguments are NULL by multiplying the NULL probabilities of each argument. The final NULL count is the row count multiplied by this probability.

2. NDV Estimation: Uses the maximum NDV of all COALESCE arguments as the estimated NDV, considering that COALESCE returns the first non-NULL value from any argument.

3. Min/Max Value Range: Considers the full range of all COALESCE arguments by taking the minimum of all minimum values and the maximum of all maximum values.

### Changes

- Added `Coalesce` import in `ExpressionEstimation.java`
- Implemented `visitCoalesce()` method to provide accurate statistics estimation for COALESCE expressions

### Impact

This change improves query planning accuracy for queries using COALESCE function, leading to better execution plans and improved query performance.

