### PR TITLE
[feat](cloud) Enable split config by default

### DIFF
--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -387,7 +387,7 @@ CONF_mString(ca_cert_file_paths,
              "/etc/pki/tls/certs/ca-bundle.crt;/etc/ssl/certs/ca-certificates.crt;"
              "/etc/ssl/ca-bundle.pem");
 
-CONF_Bool(enable_split_rowset_meta_pb, "false");
+CONF_Bool(enable_split_rowset_meta_pb, "true");
 CONF_Int32(split_rowset_meta_pb_size, "10000"); // split rowset meta pb size, default is 10K
 CONF_Bool(enable_split_tablet_schema_pb, "false");
 CONF_Int32(split_tablet_schema_pb_size, "10000"); // split tablet schema pb size, default is 10K


### PR DESCRIPTION
Enable enable_split_rowset_meta_pb and enable_split_tablet_schema_pb by default