### PR TITLE
[fix](build) fix duplicate symbol errors when compiling BE UT with Clang

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -715,10 +715,10 @@ endif ()
 
 if (MAKE_TEST)
     add_compile_options(-DGTEST_USE_OWN_TR1_TUPLE=0)
-    # Only add GCC-style coverage when NOT using Clang coverage
+    # Only add GCC-style coverage when using GCC compiler
     # to avoid duplicate symbol errors (e.g., __gcov_fork, __gcov_reset)
     # between libgcov.a and libclang_rt.profile-x86_64.a
-    if (NOT (ENABLE_CLANG_COVERAGE STREQUAL "ON" AND COMPILER_CLANG))
+    if (COMPILER_GCC)
         add_compile_options(-fprofile-arcs -ftest-coverage)
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage")
         if (NOT OS_MACOSX)


### PR DESCRIPTION
Problem:
When running `./run-be-ut.sh` without the `--coverage` flag using Clang compiler, the build fails with duplicate symbol errors:

  ld.lld: error: duplicate symbol: __gcov_fork
  >>> defined in libgcov.a(libgcov-interface.o)
  >>> defined in libclang_rt.profile-x86_64.a(GCDAProfiling.o)

Root cause analysis:
PR #59543 introduced a condition in be/CMakeLists.txt to guard GCC-style coverage flags (`-fprofile-arcs -ftest-coverage -lgcov`):

  if (NOT (ENABLE_CLANG_COVERAGE STREQUAL "ON" AND COMPILER_CLANG))

The intent was to skip GCC coverage when Clang coverage is active. However, this condition has a logic flaw. When using Clang without `--coverage`:

  - ENABLE_CLANG_COVERAGE = OFF (default, set in run-be-ut.sh line 88)
  - COMPILER_CLANG = true

The condition evaluates as:
  NOT (OFF AND true) = NOT (false) = true

So GCC coverage flags are still added even when using Clang. Clang then implicitly links libclang_rt.profile (which provides its own implementation of __gcov_fork, __gcov_reset, etc.), causing duplicate symbol conflicts with the explicitly linked libgcov.a.

Before PR #59543, coverage flags were unconditionally added for all compilers in MAKE_TEST mode — which also had the same issue with Clang.

Fix:
Replace the condition with `if (COMPILER_GCC)` so that GCC-style coverage flags are only added when actually using GCC compiler. This cleanly separates the two coverage mechanisms:
  - GCC compiler → automatic GCC coverage via -fprofile-arcs + libgcov
  - Clang compiler → no coverage by default; use --coverage flag to enable Clang coverage via -fprofile-instr-generate

| Scenario             | Before #59543 | After #59543 (bug) | This fix    |
|----------------------|---------------|--------------------|-------------|
| GCC, no --coverage   | GCC coverage  | GCC coverage       | GCC coverage|
| GCC, --coverage      | GCC coverage  | GCC coverage       | GCC coverage|
| Clang, no --coverage | GCC cov (bad) | GCC cov (bad)      | No coverage |
| Clang, --coverage    | GCC+Clang(bad)| Clang coverage     | Clang cov   |

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

