### PR TITLE
[opt](variant) Optimize VARIANT doc mode load/compaction and add benchmarks

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1148,6 +1148,7 @@ DEFINE_mInt64(variant_threshold_rows_to_estimate_sparse_column, "2048");
 DEFINE_mInt32(variant_max_json_key_length, "255");
 DEFINE_mBool(variant_throw_exeception_on_invalid_json, "false");
 DEFINE_mBool(enable_vertical_compact_variant_subcolumns, "true");
+DEFINE_mBool(enable_variant_doc_compaction_sparse_write, "true");
 
 DEFINE_Validator(variant_max_json_key_length,
                  [](const int config) -> bool { return config > 0 && config <= 65535; });

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1393,6 +1393,7 @@ DECLARE_mInt32(variant_max_json_key_length);
 DECLARE_mBool(variant_throw_exeception_on_invalid_json);
 // Enable vertical compact subcolumns of variant column
 DECLARE_mBool(enable_vertical_compact_variant_subcolumns);
+DECLARE_mBool(enable_variant_doc_compaction_sparse_write);
 
 DECLARE_mBool(enable_merge_on_write_correctness_check);
 // USED FOR DEBUGING

--- a/be/src/olap/rowset/segment_v2/column_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/column_writer.cpp
@@ -79,7 +79,10 @@ public:
         size_t raw_est = raw_bytes + raw_overhead + kReserveSlackBytes;
         size_t reserve_bytes = std::min(raw_est, run_bytes_est);
         if (_bitmap_buf.capacity() < reserve_bytes) {
-            _bitmap_buf.reserve(reserve_bytes);
+            const size_t cap = _bitmap_buf.capacity();
+            const size_t grow = cap + cap / 2;
+            const size_t new_cap = std::max(reserve_bytes, grow);
+            _bitmap_buf.reserve(new_cap);
         }
     }
 

--- a/be/src/olap/rowset/segment_v2/variant/variant_column_writer_impl.cpp
+++ b/be/src/olap/rowset/segment_v2/variant/variant_column_writer_impl.cpp
@@ -19,6 +19,7 @@
 #include <fmt/core.h>
 #include <gen_cpp/segment_v2.pb.h>
 
+#include <algorithm>
 #include <memory>
 #include <set>
 
@@ -43,6 +44,7 @@
 #include "vec/common/variant_util.h"
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_factory.hpp"
+#include "vec/data_types/data_type_nullable.h"
 #include "vec/json/path_in_data.h"
 #include "vec/olap/olap_data_convertor.h"
 
@@ -158,6 +160,236 @@ Status convert_and_write_column(vectorized::OlapBlockDataConvertor* converter,
     converter->clear_source_content(column_id);
     return Status::OK();
 }
+
+namespace {
+// Per-path sparse materialization result from a VARIANT doc-value column.
+// - subcolumn stores the decoded values for rows listed in rowids (dense, no gaps).
+// - rowids records which input rows have a non-null value for this path.
+// - non_null_count is used to build variant statistics quickly.
+struct SubcolumnSparseData {
+    vectorized::ColumnVariant::Subcolumn subcolumn {0, true, false};
+    std::vector<uint32_t> rowids;
+    uint32_t non_null_count = 0;
+};
+
+using DocSparseSubcolumns = phmap::flat_hash_map<StringRef, SubcolumnSparseData, StringRefHash>;
+using DocValuePathStats = phmap::flat_hash_map<StringRef, uint32_t, StringRefHash>;
+
+struct SubcolumnWriteEntry {
+    std::string_view path;
+    vectorized::ColumnVariant::Subcolumn* subcolumn = nullptr;
+    // nullptr means dense materialization; otherwise sparse row ids for this path.
+    const std::vector<uint32_t>* rowids = nullptr;
+};
+
+struct SubcolumnWritePlan {
+    using DenseSubcolumns =
+            phmap::flat_hash_map<std::string_view, vectorized::ColumnVariant::Subcolumn>;
+
+    // Owns materialized subcolumns and a flattened iteration view for finalize().
+    DocSparseSubcolumns sparse_subcolumns;
+    DenseSubcolumns dense_subcolumns;
+    std::vector<SubcolumnWriteEntry> entries;
+    DocValuePathStats stats;
+};
+
+// Build per-path non-null counts from the serialized doc-value representation.
+void build_doc_value_stats(const vectorized::ColumnVariant& variant, DocValuePathStats* stats) {
+    auto [column_key, column_value] = variant.get_doc_value_data_paths_and_values();
+    (void)column_value;
+    const auto& column_offsets = variant.serialized_doc_value_column_offsets();
+    const size_t num_rows = column_offsets.size();
+
+    stats->clear();
+    stats->reserve(column_key->size());
+    for (size_t row = 0; row < num_rows; ++row) {
+        const size_t start = column_offsets[row - 1];
+        const size_t end = column_offsets[row];
+        for (size_t j = start; j < end; ++j) {
+            const StringRef path = column_key->get_data_at(j);
+            auto it = stats->try_emplace(path, 0).first;
+            ++it->second;
+        }
+    }
+}
+
+// Materialize sparse subcolumns for each path and build per-path non-null counts.
+// For each row, we decode only present (path, value) pairs and append them to the
+// corresponding subcolumn, while recording the row id to allow gap filling later.
+void build_sparse_subcolumns_and_stats(const vectorized::ColumnVariant& variant,
+                                       DocSparseSubcolumns* subcolumns, DocValuePathStats* stats) {
+    auto [column_key, column_value] = variant.get_doc_value_data_paths_and_values();
+    const auto& column_offsets = variant.serialized_doc_value_column_offsets();
+    const size_t num_rows = column_offsets.size();
+
+    subcolumns->clear();
+    stats->clear();
+    subcolumns->reserve(column_key->size());
+
+    for (size_t row = 0; row < num_rows; ++row) {
+        const size_t start = column_offsets[row - 1];
+        const size_t end = column_offsets[row];
+        for (size_t i = start; i < end; ++i) {
+            const StringRef path = column_key->get_data_at(i);
+            auto& data = subcolumns->try_emplace(path).first->second;
+            data.rowids.push_back(cast_set<uint32_t>(row));
+            data.subcolumn.deserialize_from_binary_column(column_value, i);
+            ++data.non_null_count;
+        }
+    }
+
+    stats->reserve(subcolumns->size());
+    for (const auto& [path, data] : *subcolumns) {
+        stats->try_emplace(path, data.non_null_count);
+    }
+}
+
+SubcolumnWritePlan build_subcolumn_write_plan(const vectorized::ColumnVariant& variant,
+                                              size_t num_rows,
+                                              int64_t variant_doc_materialization_min_rows) {
+    SubcolumnWritePlan plan;
+    // Below threshold: skip materialization and let finalize() compute stats on demand.
+    if (num_rows < static_cast<size_t>(variant_doc_materialization_min_rows)) {
+        return plan;
+    }
+
+    if (config::enable_variant_doc_compaction_sparse_write) {
+        build_sparse_subcolumns_and_stats(variant, &plan.sparse_subcolumns, &plan.stats);
+        plan.entries.reserve(plan.sparse_subcolumns.size());
+        for (auto& [path, sparse] : plan.sparse_subcolumns) {
+            SubcolumnWriteEntry entry;
+            // StringRef points to variant storage; valid for the plan's lifetime.
+            entry.path = std::string_view(path.data, path.size);
+            entry.subcolumn = &sparse.subcolumn;
+            entry.rowids = &sparse.rowids;
+            plan.entries.push_back(entry);
+        }
+        return plan;
+    }
+
+    build_doc_value_stats(variant, &plan.stats);
+    plan.dense_subcolumns = vectorized::variant_util::materialize_docs_to_subcolumns_map(variant);
+    plan.entries.reserve(plan.dense_subcolumns.size());
+    for (auto& [path, subcolumn] : plan.dense_subcolumns) {
+        SubcolumnWriteEntry entry;
+        entry.path = path;
+        entry.subcolumn = &subcolumn;
+        entry.rowids = nullptr;
+        plan.entries.push_back(entry);
+    }
+    return plan;
+}
+
+// Convert a sparse (values_column, rowids) pair into storage format and append to writer.
+// Missing rows (gaps between rowids) are appended as nulls, so the output has total_rows.
+Status append_sparse_converted_column(const TabletColumn& tablet_column, ColumnWriter* writer,
+                                      vectorized::OlapBlockDataConvertor* converter, int cid,
+                                      const vectorized::DataTypePtr& type,
+                                      const vectorized::ColumnPtr& values_column,
+                                      const std::vector<uint32_t>& rowids, size_t total_rows) {
+    DCHECK_EQ(values_column->size(), rowids.size());
+    const size_t cell_size = writer->get_field()->size();
+
+    auto base_type = type;
+    if (base_type->is_nullable()) {
+        base_type = assert_cast<const vectorized::DataTypeNullable&>(*base_type).get_nested_type();
+    }
+    if (base_type->get_primitive_type() == PrimitiveType::TYPE_ARRAY) {
+        // ARRAY convertor output is not a contiguous “cell_size-strided” buffer. It is a pointer-based
+        // structure (size/offsets/item_ptr/...), so slicing it via `data_base + cell_size * idx`
+        // can lead to out-of-bounds access.
+        // Also, filling gaps via `writer->append_nulls()` relies on an implicit offsets contract
+        // (offsets must provide `num_rows + 1` entries), which is easy to violate and can trigger
+        // memory issues.
+        // To make the behavior safe and consistent, we first materialize a full column by filling
+        // gaps, then convert once and write via `append_nullable()`, so offsets are generated by
+        // the convertor in a unified way.
+        vectorized::MutableColumnPtr full_column = values_column->clone_empty();
+        full_column->reserve(total_rows);
+
+        size_t next_row = 0;
+        size_t value_idx = 0;
+        while (value_idx < rowids.size()) {
+            const size_t row = rowids[value_idx];
+            DCHECK_GE(row, next_row);
+            const size_t gap = row - next_row;
+            if (gap > 0) {
+                DCHECK(tablet_column.is_nullable());
+                full_column->insert_many_defaults(gap);
+            }
+
+            size_t run_len = 1;
+            while (value_idx + run_len < rowids.size() &&
+                   rowids[value_idx + run_len] == row + run_len) {
+                ++run_len;
+            }
+            full_column->insert_range_from(*values_column, value_idx, run_len);
+            value_idx += run_len;
+            next_row = row + run_len;
+        }
+        if (next_row < total_rows) {
+            DCHECK(tablet_column.is_nullable());
+            full_column->insert_many_defaults(total_rows - next_row);
+        }
+
+        converter->add_column_data_convertor(tablet_column);
+        RETURN_IF_ERROR(converter->set_source_content_with_specifid_column(
+                {full_column->get_ptr(), type, ""}, 0, total_rows, cid));
+        auto [st, converted] = converter->convert_column_data(cid);
+        RETURN_IF_ERROR(st);
+        const uint8_t* data_ptr = reinterpret_cast<const uint8_t*>(converted->get_data());
+        RETURN_IF_ERROR(writer->append_nullable(converted->get_nullmap(), &data_ptr, total_rows));
+        converter->clear_source_content(cid);
+        return Status::OK();
+    }
+
+    if (rowids.empty()) {
+        DCHECK(tablet_column.is_nullable());
+        return writer->append_nulls(total_rows);
+    }
+
+    converter->add_column_data_convertor(tablet_column);
+    RETURN_IF_ERROR(converter->set_source_content_with_specifid_column({values_column, type, ""}, 0,
+                                                                       rowids.size(), cid));
+    auto [st, converted] = converter->convert_column_data(cid);
+    RETURN_IF_ERROR(st);
+
+    const uint8_t* nullmap_base = converted->get_nullmap();
+    const uint8_t* data_base = reinterpret_cast<const uint8_t*>(converted->get_data());
+    auto append_gaps = [&](size_t gap) -> Status {
+        if (gap == 0) {
+            return Status::OK();
+        }
+        DCHECK(tablet_column.is_nullable());
+        return writer->append_nulls(gap);
+    };
+
+    size_t next_row = 0;
+    size_t value_idx = 0;
+    while (value_idx < rowids.size()) {
+        const size_t row = rowids[value_idx];
+        DCHECK_GE(row, next_row);
+        RETURN_IF_ERROR(append_gaps(row - next_row));
+
+        size_t run_len = 1;
+        while (value_idx + run_len < rowids.size() &&
+               rowids[value_idx + run_len] == row + run_len) {
+            ++run_len;
+        }
+
+        const uint8_t* run_nullmap = nullmap_base ? nullmap_base + value_idx : nullptr;
+        const uint8_t* run_data = data_base + (cell_size * value_idx);
+        RETURN_IF_ERROR(writer->append(run_nullmap, run_data, run_len));
+
+        value_idx += run_len;
+        next_row = row + run_len;
+    }
+
+    RETURN_IF_ERROR(append_gaps(total_rows - next_row));
+    converter->clear_source_content(cid);
+    return Status::OK();
+}
+} // namespace
 
 Status UnifiedSparseColumnWriter::init(const TabletColumn* parent_column, int bucket_num,
                                        int& column_id, const ColumnWriterOptions& base_opts,
@@ -292,7 +524,7 @@ Status UnifiedSparseColumnWriter::append_single_sparse(
 
     // Build path frequency statistics with upper bound limit to avoid
     // large memory and metadata size. Persist to meta for readers.
-    std::unordered_map<StringRef, size_t> path_counts;
+    phmap::flat_hash_map<StringRef, size_t, StringRefHash> path_counts;
     const auto [paths, _] = src.get_sparse_data_paths_and_values();
     size_t limit = parent_column.variant_max_sparse_column_statistics_size();
     for (size_t i = 0; i != paths->size(); ++i) {
@@ -324,6 +556,14 @@ Status UnifiedSparseColumnWriter::append_bucket_sparse(
     const int bucket_num = static_cast<int>(_bucket_writers.size());
     const auto [paths_col, values_col] = src.get_sparse_data_paths_and_values();
     const auto& offsets = src.serialized_sparse_column_offsets();
+    phmap::flat_hash_map<StringRef, uint32_t, StringRefHash> path_to_bucket;
+    path_to_bucket.reserve(std::min<size_t>(paths_col->size(), 8192));
+    const size_t limit = parent_column.variant_max_sparse_column_statistics_size();
+    std::vector<phmap::flat_hash_map<StringRef, size_t, StringRefHash>> bucket_path_counts(
+            bucket_num);
+    for (int b = 0; b < bucket_num; ++b) {
+        bucket_path_counts[b].reserve(std::min<size_t>(limit, 1024));
+    }
 
     std::vector<vectorized::MutableColumnPtr> tmp_maps(bucket_num);
     for (int b = 0; b < bucket_num; ++b) {
@@ -335,19 +575,38 @@ Status UnifiedSparseColumnWriter::append_bucket_sparse(
         auto& m = assert_cast<vectorized::ColumnMap&>(*tmp_maps[b]);
         m.get_offsets().reserve(num_rows);
     }
-    for (ssize_t row = 0; row < static_cast<ssize_t>(num_rows); ++row) {
-        size_t start = offsets[row - 1];
-        size_t end = offsets[row];
+    std::vector<vectorized::ColumnString*> bucket_keys(bucket_num);
+    std::vector<vectorized::ColumnString*> bucket_values(bucket_num);
+    std::vector<vectorized::ColumnArray::Offsets64*> bucket_offsets(bucket_num);
+    for (int b = 0; b < bucket_num; ++b) {
+        auto& m = assert_cast<vectorized::ColumnMap&>(*tmp_maps[b]);
+        bucket_keys[b] = &assert_cast<vectorized::ColumnString&>(m.get_keys());
+        bucket_values[b] = &assert_cast<vectorized::ColumnString&>(m.get_values());
+        bucket_offsets[b] = &m.get_offsets();
+    }
+    for (size_t row = 0; row < num_rows; ++row) {
+        const size_t start = offsets[row - 1];
+        const size_t end = offsets[row];
         for (size_t i = start; i < end; ++i) {
             StringRef path = paths_col->get_data_at(i);
-            uint32_t b = vectorized::variant_util::variant_binary_shard_of(path, bucket_num);
-            auto& map_col = assert_cast<vectorized::ColumnMap&>(*tmp_maps[b]);
-            map_col.get_keys_ptr()->assume_mutable()->insert_from(*paths_col, i);
-            map_col.get_values_ptr()->assume_mutable()->insert_from(*values_col, i);
+            uint32_t b = 0;
+            if (auto it = path_to_bucket.find(path); it != path_to_bucket.end()) {
+                b = it->second;
+            } else {
+                b = vectorized::variant_util::variant_binary_shard_of(path, bucket_num);
+                path_to_bucket.emplace(path, b);
+            }
+            bucket_keys[b]->insert_data(path.data, path.size);
+            bucket_values[b]->insert_from(*values_col, i);
+            auto& path_counts = bucket_path_counts[b];
+            if (auto it = path_counts.find(path); it != path_counts.end()) {
+                ++it->second;
+            } else if (path_counts.size() < limit) {
+                path_counts.emplace(path, 1);
+            }
         }
         for (int b = 0; b < bucket_num; ++b) {
-            auto& map_col = assert_cast<vectorized::ColumnMap&>(*tmp_maps[b]);
-            map_col.get_offsets().push_back(map_col.get_keys().size());
+            bucket_offsets[b]->push_back(bucket_keys[b]->size());
         }
     }
     for (int b = 0; b < bucket_num; ++b) {
@@ -364,22 +623,9 @@ Status UnifiedSparseColumnWriter::append_bucket_sparse(
         converter->clear_source_content(this_col_id);
         _bucket_opts[b].meta->set_num_rows(num_rows);
     }
-    // per-bucket statistics
     for (int b = 0; b < bucket_num; ++b) {
-        auto& map_col = assert_cast<vectorized::ColumnMap&>(*tmp_maps[b]);
-        const auto& keys = assert_cast<const vectorized::ColumnString&>(map_col.get_keys());
-        std::unordered_map<StringRef, size_t> bucket_path_counts;
-        bucket_path_counts.reserve(1024);
-        size_t limit = parent_column.variant_max_sparse_column_statistics_size();
-        for (size_t i = 0; i < keys.size(); ++i) {
-            StringRef k = keys.get_data_at(i);
-            if (auto it = bucket_path_counts.find(k); it != bucket_path_counts.end())
-                ++it->second;
-            else if (bucket_path_counts.size() < limit)
-                bucket_path_counts.emplace(k, 1);
-        }
         segment_v2::VariantStatistics bucket_stats;
-        for (const auto& [k, cnt] : bucket_path_counts) {
+        for (const auto& [k, cnt] : bucket_path_counts[b]) {
             bucket_stats.sparse_column_non_null_size.emplace(k.to_string(),
                                                              static_cast<int64_t>(cnt));
         }
@@ -422,24 +668,45 @@ Status VariantDocWriter::append_data(const TabletColumn* parent_column,
         auto& map_col = assert_cast<vectorized::ColumnMap&>(*tmp_maps[b]);
         map_col.get_offsets().reserve(num_rows);
     }
+    std::vector<vectorized::ColumnString*> bucket_keys(_bucket_num);
+    std::vector<vectorized::ColumnString*> bucket_values(_bucket_num);
+    std::vector<vectorized::ColumnArray::Offsets64*> bucket_offsets(_bucket_num);
+    for (int b = 0; b < _bucket_num; ++b) {
+        auto& m = assert_cast<vectorized::ColumnMap&>(*tmp_maps[b]);
+        bucket_keys[b] = &assert_cast<vectorized::ColumnString&>(m.get_keys());
+        bucket_values[b] = &assert_cast<vectorized::ColumnString&>(m.get_values());
+        bucket_offsets[b] = &m.get_offsets();
+    }
 
-    std::vector<std::unordered_map<StringRef, uint32_t>> bucket_path_counts(_bucket_num);
+    std::vector<phmap::flat_hash_map<StringRef, uint32_t, StringRefHash>> bucket_path_counts(
+            _bucket_num);
+    const size_t limit = parent_column->variant_max_sparse_column_statistics_size();
+    for (int b = 0; b < _bucket_num; ++b) {
+        bucket_path_counts[b].reserve(std::min<size_t>(limit, 1024));
+    }
+    phmap::flat_hash_map<StringRef, uint32_t, StringRefHash> path_to_bucket;
+    path_to_bucket.reserve(std::min<size_t>(paths_col->size(), 8192));
 
     for (size_t row = 0; row < num_rows; ++row) {
-        const ssize_t srow = static_cast<ssize_t>(row);
-        size_t start = offsets[srow - 1];
-        size_t end = offsets[srow];
+        const size_t start = offsets[row - 1];
+        const size_t end = offsets[row];
         for (size_t i = start; i < end; ++i) {
             StringRef path = paths_col->get_data_at(i);
-            uint32_t bucket = vectorized::variant_util::variant_binary_shard_of(path, _bucket_num);
-            auto& map_col = assert_cast<vectorized::ColumnMap&>(*tmp_maps[bucket]);
-            map_col.get_keys_ptr()->assume_mutable()->insert_from(*paths_col, i);
-            map_col.get_values_ptr()->assume_mutable()->insert_from(*values_col, i);
-            bucket_path_counts[bucket][path]++;
+            uint32_t bucket = 0;
+            auto it = path_to_bucket.find(path);
+            if (it != path_to_bucket.end()) {
+                bucket = it->second;
+            } else {
+                bucket = vectorized::variant_util::variant_binary_shard_of(path, _bucket_num);
+                path_to_bucket.emplace_hint(it, path, bucket);
+                // the stats only used to indicate path exist or not, so the count is not accurate make sense
+                bucket_path_counts[bucket][path] = 1;
+            }
+            bucket_keys[bucket]->insert_data(path.data, path.size);
+            bucket_values[bucket]->insert_from(*values_col, i);
         }
         for (int b = 0; b < _bucket_num; ++b) {
-            auto& map_col = assert_cast<vectorized::ColumnMap&>(*tmp_maps[b]);
-            map_col.get_offsets().push_back(map_col.get_keys().size());
+            bucket_offsets[b]->push_back(bucket_keys[b]->size());
         }
     }
 
@@ -662,7 +929,6 @@ Status VariantColumnWriterImpl::_process_binary_column(
     if (_tablet_column->variant_enable_doc_mode()) {
         _binary_writer = std::make_unique<VariantDocWriter>();
         bucket_num = std::max(1, _tablet_column->variant_doc_hash_shard_count());
-        ptr->sort_doc_value_column();
     } else {
         _binary_writer = std::make_unique<UnifiedSparseColumnWriter>();
         bucket_num = std::max(1, _tablet_column->variant_sparse_hash_shard_count());
@@ -1055,99 +1321,113 @@ Status VariantDocCompactWriter::append_nullable(const uint8_t* null_map, const u
     RETURN_IF_ERROR(append_data(ptr, num_rows));
     return Status::OK();
 }
-Status VariantDocCompactWriter::finalize() {
-    auto* variant_column = assert_cast<vectorized::ColumnVariant*>(_column.get());
 
-    const auto& parent_column =
-            _opts.rowset_ctx->tablet_schema->column_by_uid(_tablet_column->parent_unique_id());
+bool VariantDocCompactWriter::_is_invalid_array_type(const vectorized::DataTypePtr& type) const {
+    return vectorized::variant_util::get_base_type_of_array(type)->get_primitive_type() ==
+           PrimitiveType::INVALID_TYPE;
+}
 
-    size_t num_rows = variant_column->size();
-    auto converter = std::make_unique<vectorized::OlapBlockDataConvertor>();
-    int column_id = 0;
-    int64_t variant_doc_materialization_min_rows =
-            parent_column.variant_doc_materialization_min_rows();
-    if (num_rows >= static_cast<size_t>(variant_doc_materialization_min_rows)) {
-        auto subcolumns =
-                vectorized::variant_util::materialize_docs_to_subcolumns_map(*variant_column);
+Status VariantDocCompactWriter::_write_materialized_subcolumn(
+        const TabletColumn& parent_column, std::string_view path,
+        vectorized::ColumnVariant::Subcolumn& subcolumn, size_t num_rows,
+        vectorized::OlapBlockDataConvertor* converter, int& column_id,
+        const std::vector<uint32_t>* rowids) {
+    const auto& least_common_type = subcolumn.get_least_common_type();
+    if (_is_invalid_array_type(least_common_type)) {
+        return Status::OK();
+    }
 
-        auto generate_column_info = [&](std::string_view path,
-                                        const vectorized::ColumnVariant::Subcolumn& subcolumn) {
-            const std::string& column_name =
-                    parent_column.name_lower_case() + "." + std::string(path);
-            const vectorized::DataTypePtr& final_data_type_from_object =
-                    subcolumn.get_least_common_type();
-            vectorized::PathInData full_path = vectorized::PathInData(column_name);
-            // set unique_id and parent_unique_id, will use unique_id to get iterator correct
-            auto column = vectorized::variant_util::get_column_by_type(
-                    final_data_type_from_object, column_name,
-                    vectorized::variant_util::ExtraInfo {
-                            .unique_id = -1,
-                            .parent_unique_id = parent_column.unique_id(),
-                            .path_info = full_path});
-            return column;
-        };
-
-        _subcolumns_indexes.resize(subcolumns.size());
-
-        for (auto& [path, subcolumn] : subcolumns) {
-            const auto& least_common_type = subcolumn.get_least_common_type();
-            if (vectorized::variant_util::get_base_type_of_array(least_common_type)
-                        ->get_primitive_type() == PrimitiveType::INVALID_TYPE) {
-                continue;
-            }
-            subcolumn.finalize();
-            TabletColumn tablet_column;
-            TabletSchema::SubColumnInfo sub_column_info;
-            vectorized::ColumnPtr current_column = subcolumn.get_finalized_column_ptr()->get_ptr();
-            vectorized::DataTypePtr current_type = subcolumn.get_least_common_type();
-            if (vectorized::variant_util::generate_sub_column_info(
-                        *_opts.rowset_ctx->tablet_schema, parent_column.unique_id(),
-                        std::string(path), &sub_column_info)) {
-                tablet_column = std::move(sub_column_info.column);
-                _subcolumns_indexes[column_id] = std::move(sub_column_info.indexes);
-                vectorized::DataTypePtr storage_type =
-                        vectorized::DataTypeFactory::instance().create_data_type(tablet_column);
-                if (!storage_type->equals(*current_type)) {
-                    RETURN_IF_ERROR(vectorized::variant_util::cast_column(
-                            {current_column, current_type, ""}, storage_type, &current_column));
-                }
-                current_type = std::move(storage_type);
-            } else {
-                tablet_column = generate_column_info(path, subcolumn);
-                const auto& indexes =
-                        _opts.rowset_ctx->tablet_schema->inverted_indexs(parent_column.unique_id());
-                vectorized::variant_util::inherit_index(indexes, _subcolumns_indexes[column_id],
-                                                        tablet_column);
-            }
-
-            int current_column_id = column_id++;
-            int64_t none_null_value_size = subcolumn.get_non_null_value_size();
-
-            ColumnWriterOptions opts;
-            opts.meta = _opts.footer->add_columns();
-            opts.index_file_writer = _opts.index_file_writer;
-            opts.compression_type = _opts.compression_type;
-            opts.rowset_ctx = _opts.rowset_ctx;
-            opts.file_writer = _opts.file_writer;
-            std::unique_ptr<ColumnWriter> writer;
-            vectorized::variant_util::inherit_column_attributes(parent_column, tablet_column);
-
-            bool need_record_none_null_value_size = true;
-
-            RETURN_IF_ERROR(_create_column_writer(
-                    current_column_id, tablet_column, _opts.rowset_ctx->tablet_schema,
-                    _opts.index_file_writer, &writer, _subcolumns_indexes[current_column_id], &opts,
-                    none_null_value_size, need_record_none_null_value_size));
-            _subcolumn_writers.push_back(std::move(writer));
-            _subcolumn_opts.push_back(opts);
-            _subcolumn_opts[current_column_id].meta->set_num_rows(num_rows);
-
-            RETURN_IF_ERROR(convert_and_write_column(converter.get(), tablet_column, current_type,
-                                                     _subcolumn_writers[current_column_id].get(),
-                                                     current_column, num_rows, current_column_id));
+    subcolumn.finalize();
+    vectorized::ColumnPtr current_column = subcolumn.get_finalized_column_ptr()->get_ptr();
+    vectorized::DataTypePtr current_type = subcolumn.get_least_common_type();
+    if (rowids != nullptr) {
+        DCHECK_EQ(current_column->size(), rowids->size());
+        if (rowids->size() != num_rows && !current_type->is_nullable()) {
+            current_type = vectorized::make_nullable(current_type);
+            current_column = vectorized::make_nullable(current_column);
         }
     }
 
+    const int current_column_id = column_id++;
+    const int64_t none_null_value_size = subcolumn.get_non_null_value_size();
+    TabletColumn tablet_column;
+    RETURN_IF_ERROR(_prepare_subcolumn_writer(parent_column, path, subcolumn, current_column,
+                                              current_type, none_null_value_size, current_column_id,
+                                              num_rows, &tablet_column));
+
+    if (rowids != nullptr) {
+        return append_sparse_converted_column(
+                tablet_column, _subcolumn_writers[current_column_id].get(), converter,
+                current_column_id, current_type, current_column, *rowids, num_rows);
+    }
+
+    return convert_and_write_column(converter, tablet_column, current_type,
+                                    _subcolumn_writers[current_column_id].get(), current_column,
+                                    num_rows, current_column_id);
+}
+
+Status VariantDocCompactWriter::_prepare_subcolumn_writer(
+        const TabletColumn& parent_column, std::string_view path,
+        const vectorized::ColumnVariant::Subcolumn& subcolumn,
+        vectorized::ColumnPtr& current_column, vectorized::DataTypePtr& current_type,
+        int64_t none_null_value_size, int current_column_id, size_t num_rows,
+        TabletColumn* out_tablet_column) {
+    TabletColumn tablet_column;
+    TabletSchema::SubColumnInfo sub_column_info;
+    if (vectorized::variant_util::generate_sub_column_info(*_opts.rowset_ctx->tablet_schema,
+                                                           parent_column.unique_id(),
+                                                           std::string(path), &sub_column_info)) {
+        tablet_column = std::move(sub_column_info.column);
+        _subcolumns_indexes[current_column_id] = std::move(sub_column_info.indexes);
+        vectorized::DataTypePtr storage_type =
+                vectorized::DataTypeFactory::instance().create_data_type(tablet_column);
+        if (!storage_type->equals(*current_type)) {
+            RETURN_IF_ERROR(vectorized::variant_util::cast_column(
+                    {current_column, current_type, ""}, storage_type, &current_column));
+        }
+        current_type = std::move(storage_type);
+    } else {
+        const std::string& column_name = parent_column.name_lower_case() + "." + std::string(path);
+        const vectorized::DataTypePtr& final_data_type_from_object =
+                subcolumn.get_least_common_type();
+        vectorized::PathInData full_path = vectorized::PathInData(column_name);
+        // set unique_id and parent_unique_id, will use unique_id to get iterator correct
+        tablet_column = vectorized::variant_util::get_column_by_type(
+                final_data_type_from_object, column_name,
+                vectorized::variant_util::ExtraInfo {.unique_id = -1,
+                                                     .parent_unique_id = parent_column.unique_id(),
+                                                     .path_info = full_path});
+        const auto& indexes =
+                _opts.rowset_ctx->tablet_schema->inverted_indexs(parent_column.unique_id());
+        vectorized::variant_util::inherit_index(indexes, _subcolumns_indexes[current_column_id],
+                                                tablet_column);
+    }
+
+    ColumnWriterOptions opts;
+    opts.meta = _opts.footer->add_columns();
+    opts.index_file_writer = _opts.index_file_writer;
+    opts.compression_type = _opts.compression_type;
+    opts.rowset_ctx = _opts.rowset_ctx;
+    opts.file_writer = _opts.file_writer;
+    std::unique_ptr<ColumnWriter> writer;
+    vectorized::variant_util::inherit_column_attributes(parent_column, tablet_column);
+
+    bool need_record_none_null_value_size = true;
+
+    RETURN_IF_ERROR(_create_column_writer(current_column_id, tablet_column,
+                                          _opts.rowset_ctx->tablet_schema, _opts.index_file_writer,
+                                          &writer, _subcolumns_indexes[current_column_id], &opts,
+                                          none_null_value_size, need_record_none_null_value_size));
+    _subcolumn_writers.push_back(std::move(writer));
+    _subcolumn_opts.push_back(opts);
+    _subcolumn_opts[current_column_id].meta->set_num_rows(num_rows);
+    *out_tablet_column = std::move(tablet_column);
+    return Status::OK();
+}
+
+Status VariantDocCompactWriter::_write_doc_value_column(
+        const TabletColumn& parent_column, vectorized::ColumnVariant* variant_column,
+        vectorized::OlapBlockDataConvertor* converter, int column_id, size_t num_rows) {
     std::string doc_value_column_path = _tablet_column->path_info_ptr()->get_path();
     size_t pos = doc_value_column_path.rfind("b");
     int bucket_value = std::stoi(doc_value_column_path.substr(pos + 1));
@@ -1169,24 +1449,42 @@ Status VariantDocCompactWriter::finalize() {
     RETURN_IF_ERROR(
             _doc_value_column_writer->append(column->get_nullmap(), column->get_data(), num_rows));
     converter->clear_source_content(column_id);
+    return Status::OK();
+}
+Status VariantDocCompactWriter::finalize() {
+    auto* variant_column = assert_cast<vectorized::ColumnVariant*>(_column.get());
+
+    const auto& parent_column =
+            _opts.rowset_ctx->tablet_schema->column_by_uid(_tablet_column->parent_unique_id());
+
+    size_t num_rows = variant_column->size();
+    auto converter = std::make_unique<vectorized::OlapBlockDataConvertor>();
+    int column_id = 0;
+    int64_t variant_doc_materialization_min_rows =
+            parent_column.variant_doc_materialization_min_rows();
+    DocValuePathStats column_stats;
+
+    SubcolumnWritePlan plan = build_subcolumn_write_plan(*variant_column, num_rows,
+                                                         variant_doc_materialization_min_rows);
+    _subcolumns_indexes.resize(plan.entries.size());
+    for (auto& entry : plan.entries) {
+        RETURN_IF_ERROR(_write_materialized_subcolumn(parent_column, entry.path, *entry.subcolumn,
+                                                      num_rows, converter.get(), column_id,
+                                                      entry.rowids));
+    }
+    column_stats = std::move(plan.stats);
+
+    RETURN_IF_ERROR(_write_doc_value_column(parent_column, variant_column, converter.get(),
+                                            column_id, num_rows));
 
     _opts.meta->set_num_rows(num_rows);
-
-    auto [column_key, column_value] = variant_column->get_doc_value_data_paths_and_values();
-    const auto& column_offsets = variant_column->serialized_doc_value_column_offsets();
-    std::map<StringRef, uint32_t> column_stats;
-    for (int64_t i = 0; i < num_rows; ++i) {
-        size_t start = column_offsets[i - 1];
-        size_t end = column_offsets[i];
-        for (size_t j = start; j < end; ++j) {
-            const auto& key = column_key->get_data_at(j);
-            column_stats[key] += 1;
-        }
+    if (column_stats.empty()) {
+        build_doc_value_stats(*variant_column, &column_stats);
     }
     auto* stats = _opts.meta->mutable_variant_statistics();
     auto* doc_value_column_non_null_size = stats->mutable_doc_value_column_non_null_size();
     for (const auto& [k, cnt] : column_stats) {
-        (*doc_value_column_non_null_size)[k.to_string()] = cnt;
+        (*doc_value_column_non_null_size)[std::string(k)] = cnt;
     }
     _is_finalized = true;
     return Status::OK();

--- a/be/src/olap/rowset/segment_v2/variant/variant_column_writer_impl.h
+++ b/be/src/olap/rowset/segment_v2/variant/variant_column_writer_impl.h
@@ -20,6 +20,7 @@
 #include <gen_cpp/segment_v2.pb.h>
 
 #include <unordered_map>
+#include <vector>
 
 #include "common/status.h"
 #include "olap/rowset/segment_v2/column_writer.h"
@@ -234,6 +235,25 @@ public:
     Status finalize();
 
 private:
+    Status _write_materialized_subcolumn(const TabletColumn& parent_column, std::string_view path,
+                                         vectorized::ColumnVariant::Subcolumn& subcolumn,
+                                         size_t num_rows,
+                                         vectorized::OlapBlockDataConvertor* converter,
+                                         int& column_id, const std::vector<uint32_t>* rowids);
+
+    Status _prepare_subcolumn_writer(const TabletColumn& parent_column, std::string_view path,
+                                     const vectorized::ColumnVariant::Subcolumn& subcolumn,
+                                     vectorized::ColumnPtr& current_column,
+                                     vectorized::DataTypePtr& current_type,
+                                     int64_t none_null_value_size, int current_column_id,
+                                     size_t num_rows, TabletColumn* out_tablet_column);
+
+    bool _is_invalid_array_type(const vectorized::DataTypePtr& type) const;
+    Status _write_doc_value_column(const TabletColumn& parent_column,
+                                   vectorized::ColumnVariant* variant_column,
+                                   vectorized::OlapBlockDataConvertor* converter, int column_id,
+                                   size_t num_rows);
+
     ordinal_t _next_rowid = 0;
     vectorized::MutableColumnPtr _column;
     const TabletColumn* _tablet_column = nullptr;

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -166,7 +166,8 @@ public:
     bool is_column_string64() const override { return sizeof(T) == sizeof(uint64_t); }
 
     void insert_from(const IColumn& src_, size_t n) override {
-        const ColumnStr<T>& src = assert_cast<const ColumnStr<T>&>(src_);
+        const ColumnStr<T>& src =
+                assert_cast<const ColumnStr<T>&, TypeCheckOnRelease::DISABLE>(src_);
         const size_t size_to_append =
                 src.offsets[n] - src.offsets[n - 1]; /// -1th index is Ok, see PaddedPODArray.
 

--- a/be/src/vec/columns/column_variant.h
+++ b/be/src/vec/columns/column_variant.h
@@ -211,6 +211,8 @@ public:
 
             explicit LeastCommonType(DataTypePtr type_, bool is_root = false);
 
+            static const LeastCommonType& nothing(bool is_root);
+
             const DataTypePtr& get() const { return type; }
 
             const DataTypePtr& get_base() const { return base_type; }
@@ -633,8 +635,6 @@ public:
                 subcolumns.size() - typed_path_count - nested_path_count - 1;
         return _max_subcolumns_count - current_subcolumns_count;
     }
-
-    void sort_doc_value_column();
 
     // doc snapshot mode: only root column, and doc snapshot column is not empty
     bool is_doc_mode() const;

--- a/be/src/vec/columns/subcolumn_tree.h
+++ b/be/src/vec/columns/subcolumn_tree.h
@@ -19,6 +19,8 @@
 // and modified by Doris
 
 #pragma once
+#include <parallel_hashmap/phmap.h>
+
 #include <memory>
 
 #include "runtime/exec_env.h"
@@ -47,7 +49,7 @@ public:
         Kind kind = TUPLE;
         const Node* parent = nullptr;
 
-        std::unordered_map<StringRef, std::shared_ptr<Node>, StringRefHash> children;
+        phmap::flat_hash_map<StringRef, std::shared_ptr<Node>, StringRefHash> children;
 
         NodeData data;
         PathInData path;

--- a/be/src/vec/common/field_visitors.h
+++ b/be/src/vec/common/field_visitors.h
@@ -58,6 +58,9 @@ typename std::decay_t<Visitor>::ResultType apply_visitor(Visitor&& visitor, F&& 
                 field.template get<TYPE_DATETIME>());
     case PrimitiveType::TYPE_DATE:
         return visitor.template apply<PrimitiveType::TYPE_DATE>(field.template get<TYPE_DATE>());
+    case PrimitiveType::TYPE_DATEV2:
+        return visitor.template apply<PrimitiveType::TYPE_DATEV2>(
+                field.template get<TYPE_DATEV2>());
     case PrimitiveType::TYPE_BOOLEAN:
         return visitor.template apply<PrimitiveType::TYPE_BOOLEAN>(
                 field.template get<TYPE_BOOLEAN>());
@@ -72,11 +75,24 @@ typename std::decay_t<Visitor>::ResultType apply_visitor(Visitor&& visitor, F&& 
     case PrimitiveType::TYPE_BIGINT:
         return visitor.template apply<PrimitiveType::TYPE_BIGINT>(
                 field.template get<TYPE_BIGINT>());
+    case PrimitiveType::TYPE_UINT32:
+        return visitor.template apply<PrimitiveType::TYPE_UINT32>(
+                field.template get<TYPE_UINT32>());
+    case PrimitiveType::TYPE_UINT64:
+        return visitor.template apply<PrimitiveType::TYPE_UINT64>(
+                field.template get<TYPE_UINT64>());
     case PrimitiveType::TYPE_FLOAT:
         return visitor.template apply<PrimitiveType::TYPE_FLOAT>(field.template get<TYPE_FLOAT>());
+    case PrimitiveType::TYPE_TIMEV2:
+        return visitor.template apply<PrimitiveType::TYPE_TIMEV2>(
+                field.template get<TYPE_TIMEV2>());
     case PrimitiveType::TYPE_DOUBLE:
         return visitor.template apply<PrimitiveType::TYPE_DOUBLE>(
                 field.template get<TYPE_DOUBLE>());
+    case PrimitiveType::TYPE_IPV4:
+        return visitor.template apply<PrimitiveType::TYPE_IPV4>(field.template get<TYPE_IPV4>());
+    case PrimitiveType::TYPE_IPV6:
+        return visitor.template apply<PrimitiveType::TYPE_IPV6>(field.template get<TYPE_IPV6>());
     case PrimitiveType::TYPE_STRING:
         return visitor.template apply<PrimitiveType::TYPE_STRING>(
                 field.template get<TYPE_STRING>());
@@ -85,11 +101,16 @@ typename std::decay_t<Visitor>::ResultType apply_visitor(Visitor&& visitor, F&& 
     case PrimitiveType::TYPE_VARCHAR:
         return visitor.template apply<PrimitiveType::TYPE_VARCHAR>(
                 field.template get<TYPE_VARCHAR>());
+    case PrimitiveType::TYPE_VARBINARY:
+        return visitor.template apply<PrimitiveType::TYPE_VARBINARY>(
+                field.template get<TYPE_VARBINARY>());
     case PrimitiveType::TYPE_ARRAY:
         return visitor.template apply<PrimitiveType::TYPE_ARRAY>(field.template get<TYPE_ARRAY>());
     case PrimitiveType::TYPE_STRUCT:
         return visitor.template apply<PrimitiveType::TYPE_STRUCT>(
                 field.template get<TYPE_STRUCT>());
+    case PrimitiveType::TYPE_MAP:
+        return visitor.template apply<PrimitiveType::TYPE_MAP>(field.template get<TYPE_MAP>());
     case PrimitiveType::TYPE_VARIANT:
         return visitor.template apply<PrimitiveType::TYPE_VARIANT>(
                 field.template get<TYPE_VARIANT>());
@@ -108,6 +129,14 @@ typename std::decay_t<Visitor>::ResultType apply_visitor(Visitor&& visitor, F&& 
     case PrimitiveType::TYPE_DECIMAL256:
         return visitor.template apply<PrimitiveType::TYPE_DECIMAL256>(
                 field.template get<TYPE_DECIMAL256>());
+    case PrimitiveType::TYPE_BITMAP:
+        return visitor.template apply<PrimitiveType::TYPE_BITMAP>(
+                field.template get<TYPE_BITMAP>());
+    case PrimitiveType::TYPE_HLL:
+        return visitor.template apply<PrimitiveType::TYPE_HLL>(field.template get<TYPE_HLL>());
+    case PrimitiveType::TYPE_QUANTILE_STATE:
+        return visitor.template apply<PrimitiveType::TYPE_QUANTILE_STATE>(
+                field.template get<TYPE_QUANTILE_STATE>());
     case PrimitiveType::TYPE_JSONB:
         return visitor.template apply<PrimitiveType::TYPE_JSONB>(field.template get<TYPE_JSONB>());
     default:

--- a/be/src/vec/common/variant_util.h
+++ b/be/src/vec/common/variant_util.h
@@ -255,7 +255,7 @@ Status parse_and_materialize_variant_columns(Block& block, const TabletSchema& t
 // Parse doc snapshot column (paths/values/offsets stored in ColumnVariant) into per-path subcolumns.
 // NOTE: Returned map keys are `std::string_view` pointing into the underlying doc snapshot paths
 // column, so the input `variant` must outlive the returned map.
-std::unordered_map<std::string_view, ColumnVariant::Subcolumn> materialize_docs_to_subcolumns_map(
+phmap::flat_hash_map<std::string_view, ColumnVariant::Subcolumn> materialize_docs_to_subcolumns_map(
         const ColumnVariant& variant);
 
 } // namespace  doris::vectorized::variant_util

--- a/be/test/olap/variant_doc_mode_compaction_test.cpp
+++ b/be/test/olap/variant_doc_mode_compaction_test.cpp
@@ -1,0 +1,502 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gen_cpp/Types_types.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "common/config.h"
+#include "common/status.h"
+#include "io/fs/local_file_system.h"
+#include "olap/cumulative_compaction.h"
+#include "olap/data_dir.h"
+#include "olap/olap_common.h"
+#include "olap/olap_define.h"
+#include "olap/options.h"
+#include "olap/rowset/beta_rowset.h"
+#include "olap/rowset/rowset.h"
+#include "olap/rowset/rowset_factory.h"
+#include "olap/rowset/rowset_reader.h"
+#include "olap/rowset/rowset_reader_context.h"
+#include "olap/rowset/rowset_writer.h"
+#include "olap/rowset/rowset_writer_context.h"
+#include "olap/rowset/segment_v2/index_writer.h"
+#include "olap/schema.h"
+#include "olap/storage_engine.h"
+#include "olap/tablet.h"
+#include "olap/tablet_meta.h"
+#include "olap/tablet_schema.h"
+#include "runtime/exec_env.h"
+#include "testutil/variant_util.h"
+#include "vec/columns/column.h"
+#include "vec/columns/column_string.h"
+#include "vec/columns/column_variant.h"
+#include "vec/core/block.h"
+#include "vec/core/field.h"
+#include "vec/data_types/data_type_string.h"
+
+namespace doris {
+namespace vectorized {
+using namespace ErrorCode;
+
+static constexpr uint32_t MAX_PATH_LEN = 1024;
+static StorageEngine* engine_ref = nullptr;
+static constexpr int32_t kRowsPerSegment = 400000;
+
+class VariantDocModeCompactionTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        char buffer[MAX_PATH_LEN];
+        ASSERT_NE(getcwd(buffer, MAX_PATH_LEN), nullptr);
+        absolute_dir = std::string(buffer) + std::string(kTestDir);
+        Status st;
+        bool exists = false;
+        ASSERT_TRUE(io::global_local_filesystem()->exists(absolute_dir, &exists).ok());
+        if (!exists) {
+            st = io::global_local_filesystem()->create_directory(absolute_dir);
+            ASSERT_TRUE(st.ok()) << st.to_string();
+        }
+        ASSERT_TRUE(io::global_local_filesystem()
+                            ->create_directory(absolute_dir + "/tablet_path")
+                            .ok());
+        cache_dir = std::string(buffer) + "/ut_dir/variant_doc_mode_compaction_test_cache";
+        ASSERT_TRUE(io::global_local_filesystem()->create_directory(cache_dir).ok());
+
+        ASSERT_TRUE(io::global_local_filesystem()->delete_directory(std::string(tmp_dir)).ok());
+        ASSERT_TRUE(io::global_local_filesystem()->create_directory(std::string(tmp_dir)).ok());
+        std::vector<StorePath> paths;
+        paths.emplace_back(std::string(tmp_dir), 1024000000);
+        auto tmp_file_dirs = std::make_unique<segment_v2::TmpFileDirs>(paths);
+        st = tmp_file_dirs->init();
+        ASSERT_TRUE(st.ok()) << st.to_json();
+        ExecEnv::GetInstance()->set_tmp_file_dir(std::move(tmp_file_dirs));
+
+        EngineOptions options;
+        auto engine = std::make_unique<StorageEngine>(options);
+        engine_ref = engine.get();
+        _data_dir = std::make_unique<DataDir>(*engine_ref, absolute_dir);
+        ASSERT_TRUE(_data_dir->init(true).ok());
+        ExecEnv::GetInstance()->set_storage_engine(std::move(engine));
+
+        config::enable_ordered_data_compaction = false;
+        config::segments_key_bounds_truncation_threshold = -1;
+        config::enable_vertical_compact_variant_subcolumns = true;
+        config::enable_compaction_checksum = false;
+        config::enable_stacktrace = true;
+    }
+
+    void TearDown() override {
+        // ASSERT_TRUE(io::global_local_filesystem()->delete_directory(absolute_dir).ok());
+        engine_ref = nullptr;
+        ExecEnv::GetInstance()->set_storage_engine(nullptr);
+    }
+
+    TabletSchemaSPtr create_schema() {
+        TabletSchemaSPtr tablet_schema = std::make_shared<TabletSchema>();
+        TabletSchemaPB tablet_schema_pb;
+        tablet_schema_pb.set_keys_type(KeysType::DUP_KEYS);
+        tablet_schema_pb.set_num_short_key_columns(1);
+        tablet_schema_pb.set_num_rows_per_row_block(1024);
+        tablet_schema_pb.set_compress_kind(COMPRESS_NONE);
+        tablet_schema_pb.set_next_column_unique_id(3);
+
+        ColumnPB* column_1 = tablet_schema_pb.add_column();
+        column_1->set_unique_id(1);
+        column_1->set_name("c1");
+        column_1->set_type("INT");
+        column_1->set_is_key(true);
+        column_1->set_length(4);
+        column_1->set_index_length(4);
+        column_1->set_is_nullable(false);
+        column_1->set_is_bf_column(false);
+
+        ColumnPB* column_2 = tablet_schema_pb.add_column();
+        column_2->set_unique_id(2);
+        column_2->set_name("v");
+        column_2->set_type("VARIANT");
+        column_2->set_is_key(false);
+        column_2->set_is_nullable(false);
+        column_2->set_variant_max_subcolumns_count(0);
+        column_2->set_variant_max_sparse_column_statistics_size(10000);
+        column_2->set_variant_sparse_hash_shard_count(32);
+        column_2->set_variant_enable_doc_mode(true);
+        column_2->set_variant_doc_materialization_min_rows(kRowsPerSegment);
+
+        tablet_schema->init_from_pb(tablet_schema_pb);
+        return tablet_schema;
+    }
+
+    TabletSharedPtr create_tablet(const TabletSchema& tablet_schema) {
+        std::vector<TColumn> cols;
+        std::unordered_map<uint32_t, uint32_t> col_ordinal_to_unique_id;
+        for (int i = 0; i < tablet_schema.num_columns(); ++i) {
+            const TabletColumn& column = tablet_schema.column(i);
+            TColumn col;
+            if (column.type() == FieldType::OLAP_FIELD_TYPE_VARIANT) {
+                col.column_type.type = TPrimitiveType::VARIANT;
+            } else {
+                col.column_type.type = TPrimitiveType::INT;
+            }
+            col.__set_column_name(column.name());
+            col.__set_is_key(column.is_key());
+            cols.push_back(col);
+            col_ordinal_to_unique_id[i] = column.unique_id();
+        }
+
+        TTabletSchema t_tablet_schema;
+        t_tablet_schema.__set_short_key_column_count(tablet_schema.num_short_key_columns());
+        t_tablet_schema.__set_schema_hash(3333);
+        t_tablet_schema.__set_keys_type(TKeysType::DUP_KEYS);
+        t_tablet_schema.__set_storage_type(TStorageType::COLUMN);
+        t_tablet_schema.__set_columns(cols);
+
+        TabletMetaSharedPtr tablet_meta(new TabletMeta(
+                2, 2, 2, 2, 2, 2, t_tablet_schema, 2, col_ordinal_to_unique_id, UniqueId(1, 2),
+                TTabletType::TABLET_TYPE_DISK, TCompressionType::LZ4F, 0, false));
+
+        TabletSharedPtr tablet(new Tablet(*engine_ref, tablet_meta, _data_dir.get()));
+        static_cast<void>(tablet->init());
+        return tablet;
+    }
+
+    void create_rowset_writer_context(TabletSchemaSPtr tablet_schema, const std::string& rowset_dir,
+                                      int64_t version, RowsetWriterContext* rowset_writer_context) {
+        RowsetId rowset_id;
+        rowset_id.init(version + 1000);
+        rowset_writer_context->rowset_id = rowset_id;
+        rowset_writer_context->rowset_type = BETA_ROWSET;
+        rowset_writer_context->data_dir = _data_dir.get();
+        rowset_writer_context->rowset_state = VISIBLE;
+        rowset_writer_context->tablet_schema = tablet_schema;
+        rowset_writer_context->tablet_path = rowset_dir;
+        rowset_writer_context->version = Version(version, version);
+        rowset_writer_context->segments_overlap = NONOVERLAPPING;
+        rowset_writer_context->max_rows_per_segment = kRowsPerSegment;
+    }
+
+    std::string generate_random_json(const std::vector<std::string>& key_pool, std::mt19937_64& rng,
+                                     uint32_t row_seed) {
+        std::uniform_int_distribution<int> kv_count_dist(10, 50);
+        std::uniform_int_distribution<int> key_idx_dist(0, static_cast<int>(key_pool.size() - 1));
+        int kv_count = kv_count_dist(rng);
+
+        std::array<int, 50> selected {};
+        int selected_size = 0;
+        while (selected_size < kv_count) {
+            int idx = key_idx_dist(rng);
+            bool dup = false;
+            for (int i = 0; i < selected_size; ++i) {
+                if (selected[i] == idx) {
+                    dup = true;
+                    break;
+                }
+            }
+            if (!dup) {
+                selected[selected_size++] = idx;
+            }
+        }
+
+        std::string json;
+        json.reserve(static_cast<size_t>(kv_count) * 20 + 2);
+        json.push_back('{');
+        for (int i = 0; i < kv_count; ++i) {
+            const auto& key = key_pool[selected[i]];
+            json.push_back('"');
+            json.append(key);
+            json.append("\":");
+            json.append(std::to_string(static_cast<uint32_t>(selected[i]) ^ row_seed));
+            if (i + 1 < kv_count) {
+                json.push_back(',');
+            }
+        }
+        json.push_back('}');
+        return json;
+    }
+
+    RowsetSharedPtr create_rowset_with_variant(TabletSchemaSPtr tablet_schema,
+                                               TabletSharedPtr tablet, int64_t version,
+                                               int64_t start_key,
+                                               const std::vector<std::string>& key_pool,
+                                               std::mt19937_64& rng, int64_t* import_elapsed_ms) {
+        RowsetWriterContext writer_context;
+        create_rowset_writer_context(tablet_schema, tablet->tablet_path(), version,
+                                     &writer_context);
+
+        auto res = RowsetFactory::create_rowset_writer(*engine_ref, writer_context, true);
+        EXPECT_TRUE(res.has_value()) << res.error();
+        auto rowset_writer = std::move(res).value();
+
+        vectorized::Block block = tablet_schema->create_block();
+        auto columns = block.mutate_columns();
+        auto* variant_col = assert_cast<ColumnVariant*>(columns[1].get());
+        auto raw_json_column = ColumnString::create();
+        raw_json_column->reserve(kRowsPerSegment);
+        for (uint32_t i = 0; i < kRowsPerSegment; ++i) {
+            int32_t c1 = static_cast<int32_t>(start_key + i);
+            columns[0]->insert_data(reinterpret_cast<const char*>(&c1), sizeof(c1));
+
+            std::string json = generate_random_json(key_pool, rng, static_cast<uint32_t>(c1));
+            raw_json_column->insert_data(json.data(), json.size());
+        }
+
+        variant_col->create_root(make_nullable(std::make_shared<DataTypeString>()),
+                                 std::move(raw_json_column));
+
+        auto import_start = std::chrono::steady_clock::now();
+        auto s = rowset_writer->add_block(&block);
+        EXPECT_TRUE(s.ok()) << s.to_json();
+        s = rowset_writer->flush();
+        EXPECT_TRUE(s.ok()) << s.to_json();
+
+        RowsetSharedPtr rowset;
+        EXPECT_EQ(Status::OK(), rowset_writer->build(rowset));
+        auto import_end = std::chrono::steady_clock::now();
+        if (import_elapsed_ms != nullptr) {
+            *import_elapsed_ms =
+                    std::chrono::duration_cast<std::chrono::milliseconds>(import_end - import_start)
+                            .count();
+        }
+        EXPECT_EQ(1, rowset->rowset_meta()->num_segments());
+        EXPECT_EQ(kRowsPerSegment, rowset->rowset_meta()->num_rows());
+        const auto& fs = io::global_local_filesystem();
+        RowsetId rowset_id_cached;
+        rowset_id_cached.init(version + 1000);
+        auto seg_path = local_segment_path(tablet->tablet_path(), rowset_id_cached.to_string(), 0);
+        auto cache_seg_path = local_segment_path(cache_dir, rowset_id_cached.to_string(), 0);
+        bool cache_exists = false;
+        static_cast<void>(fs->exists(cache_seg_path, &cache_exists));
+        if (!cache_exists) {
+            static_cast<void>(fs->link_file(seg_path, cache_seg_path));
+        }
+        return rowset;
+    }
+
+    RowsetSharedPtr load_rowset_from_local_segments(TabletSchemaSPtr tablet_schema,
+                                                    const TabletSharedPtr& tablet,
+                                                    int64_t version) {
+        RowsetId rowset_id;
+        rowset_id.init(version + 1000);
+        const auto& fs = io::global_local_filesystem();
+        auto seg_path = local_segment_path(tablet->tablet_path(), rowset_id.to_string(), 0);
+        bool seg_exists = false;
+        if (!fs->exists(seg_path, &seg_exists).ok() || !seg_exists) {
+            return nullptr;
+        }
+        int64_t file_size = 0;
+        if (!fs->file_size(seg_path, &file_size).ok()) {
+            return nullptr;
+        }
+        RowsetMetaSharedPtr rowset_meta = std::make_shared<RowsetMeta>();
+        rowset_meta->set_rowset_id(rowset_id);
+        rowset_meta->set_rowset_type(BETA_ROWSET);
+        rowset_meta->set_rowset_state(VISIBLE);
+        rowset_meta->set_tablet_id(tablet->tablet_id());
+        rowset_meta->set_tablet_schema_hash(tablet->schema_hash());
+        rowset_meta->set_tablet_uid(tablet->tablet_uid());
+        rowset_meta->set_version(Version(version, version));
+        rowset_meta->set_segments_overlap(NONOVERLAPPING);
+        rowset_meta->set_num_segments(1);
+        rowset_meta->set_num_rows(kRowsPerSegment);
+        rowset_meta->set_tablet_schema(tablet_schema);
+        rowset_meta->add_segments_file_size({static_cast<size_t>(file_size)});
+        rowset_meta->set_total_disk_size(file_size);
+        rowset_meta->set_data_disk_size(file_size);
+        rowset_meta->set_index_disk_size(0);
+        RowsetSharedPtr rowset;
+        EXPECT_TRUE(RowsetFactory::create_rowset(tablet_schema, tablet->tablet_path(), rowset_meta,
+                                                 &rowset)
+                            .ok());
+        return rowset;
+    }
+
+    void create_and_init_rowset_reader(Rowset* rowset, RowsetReaderContext& context,
+                                       RowsetReaderSharedPtr* result) {
+        auto s = rowset->create_reader(result);
+        ASSERT_TRUE(s.ok()) << s.to_json();
+        ASSERT_TRUE(*result != nullptr);
+        s = (*result)->init(&context);
+        ASSERT_TRUE(s.ok()) << s.to_json();
+    }
+
+private:
+    static constexpr std::string_view kTestDir = "/ut_dir/variant_doc_mode_compaction_test";
+    static constexpr std::string_view tmp_dir = "./ut_dir/variant_doc_mode_compaction_test/tmp";
+    std::string absolute_dir;
+    std::string cache_dir;
+    std::unique_ptr<DataDir> _data_dir;
+};
+
+// -------------Base line--------------------
+// ------------------------------------------
+// [==========] Running 1 test from 1 test suite.
+// [----------] Global test environment set-up.
+// [----------] 1 test from VariantDocModeCompactionTest
+// [ RUN      ] VariantDocModeCompactionTest.variant_doc_mode_compaction_merge_10_segments
+// variant import segment i=0 mode=generate elapsed_ms=8520
+// variant import segment i=1 mode=generate elapsed_ms=8416
+// variant import segment i=2 mode=generate elapsed_ms=8185
+// variant import segment i=3 mode=generate elapsed_ms=8036
+// variant import segment i=4 mode=generate elapsed_ms=8016
+// variant import segment i=5 mode=generate elapsed_ms=8106
+// variant import segment i=6 mode=generate elapsed_ms=8042
+// variant import segment i=7 mode=generate elapsed_ms=8091
+// variant import segment i=8 mode=generate elapsed_ms=8183
+// variant import segment i=9 mode=generate elapsed_ms=8058
+// variant import total_elapsed_ms=81653 wall_elapsed_ms=93160
+// variant start compaction
+// variant doc mode compaction elapsed_ms=80206
+// [       OK ] VariantDocModeCompactionTest.variant_doc_mode_compaction_merge_10_segments (173484 ms)
+// [----------] 1 test from VariantDocModeCompactionTest (173484 ms total)
+//
+// [----------] Global test environment tear-down
+// [==========] 1 test from 1 test suite ran. (173484 ms total)
+// [  PASSED  ] 1 test.
+// === Finished. Gtest output: /mnt/disk1/claude-max/tmp/doris/be/ut_build_RELEASE/gtest_output
+
+TEST_F(VariantDocModeCompactionTest, variant_doc_mode_compaction_merge_10_segments) {
+#ifndef NDEBUG
+    GTEST_SKIP() << "This test is slow and only runs in Release mode";
+#endif
+    TabletSchemaSPtr tablet_schema = create_schema();
+    TabletSharedPtr tablet = create_tablet(*tablet_schema);
+    ASSERT_TRUE(io::global_local_filesystem()->create_directory(tablet->tablet_path()).ok());
+
+    std::vector<std::string> key_pool;
+    key_pool.reserve(10000);
+    for (int i = 0; i < 10000; ++i) {
+        key_pool.emplace_back("k" + std::to_string(i));
+    }
+
+    std::mt19937_64 rng(42);
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    input_rowsets.reserve(10);
+    auto import_total_start = std::chrono::steady_clock::now();
+    int64_t import_total_ms = 0;
+    for (int i = 0; i < 10; ++i) {
+        int64_t version = i;
+        int64_t start_key = static_cast<int64_t>(i) * kRowsPerSegment;
+        int64_t import_elapsed_ms = 0;
+        std::string import_mode = "reuse_tablet";
+        RowsetSharedPtr rowset = load_rowset_from_local_segments(tablet_schema, tablet, version);
+        if (!rowset) {
+            import_mode = "reuse_cache";
+            const auto& fs = io::global_local_filesystem();
+            RowsetId rid;
+            rid.init(version + 1000);
+            auto cache_seg = local_segment_path(cache_dir, rid.to_string(), 0);
+            bool cache_exists = false;
+            if (fs->exists(cache_seg, &cache_exists).ok() && cache_exists) {
+                auto seg_path = local_segment_path(tablet->tablet_path(), rid.to_string(), 0);
+                static_cast<void>(fs->link_file(cache_seg, seg_path));
+                rowset = load_rowset_from_local_segments(tablet_schema, tablet, version);
+            }
+        }
+        if (!rowset) {
+            import_mode = "generate";
+            rowset = create_rowset_with_variant(tablet_schema, tablet, version, start_key, key_pool,
+                                                rng, &import_elapsed_ms);
+        }
+        import_total_ms += import_elapsed_ms;
+        std::cout << "variant import segment i=" << i << " mode=" << import_mode
+                  << " elapsed_ms=" << import_elapsed_ms << std::endl;
+        if (i == 0) {
+            RowsetReaderContext input_reader_context;
+            input_reader_context.tablet_schema = tablet_schema;
+            input_reader_context.need_ordered_result = false;
+            std::vector<uint32_t> input_return_columns = {1};
+            input_reader_context.return_columns = &input_return_columns;
+            RowsetReaderSharedPtr input_rs_reader;
+            create_and_init_rowset_reader(rowset.get(), input_reader_context, &input_rs_reader);
+
+            vectorized::Block input_block =
+                    tablet_schema->create_block_by_cids(input_return_columns);
+            auto st = input_rs_reader->next_batch(&input_block);
+            ASSERT_TRUE(st.ok()) << st.to_json();
+            ASSERT_EQ(1, input_block.columns());
+            ASSERT_GT(input_block.rows(), 0);
+            const auto& var =
+                    assert_cast<const ColumnVariant&>(*input_block.get_by_position(0).column);
+            ASSERT_GT(var.serialized_doc_value_column_offsets()[0], 0);
+        }
+        ASSERT_TRUE(tablet->add_rowset(rowset).ok());
+        input_rowsets.push_back(rowset);
+    }
+    auto import_total_end = std::chrono::steady_clock::now();
+    auto import_wall_ms = std::chrono::duration_cast<std::chrono::milliseconds>(import_total_end -
+                                                                                import_total_start)
+                                  .count();
+    std::cout << "variant import total_elapsed_ms=" << import_total_ms
+              << " wall_elapsed_ms=" << import_wall_ms << std::endl;
+
+    CumulativeCompaction cu_compaction(*engine_ref, tablet);
+    cu_compaction._input_rowsets = std::move(input_rowsets);
+
+    config::enable_variant_doc_compaction_sparse_write = true;
+    std::cout << "variant start compaction" << std::endl;
+    auto start = std::chrono::steady_clock::now();
+    auto st = cu_compaction.CompactionMixin::execute_compact();
+    auto end = std::chrono::steady_clock::now();
+    auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+    std::cout << "variant doc mode compaction elapsed_ms=" << elapsed_ms << std::endl;
+    if (!st.ok()) {
+        std::cout << st.to_string() << std::endl;
+        std::cout << doris::get_stack_trace(0) << std::endl;
+    }
+    ASSERT_TRUE(st.ok()) << st.to_json();
+
+    auto& out_rowset = cu_compaction._output_rowset;
+    ASSERT_TRUE(out_rowset != nullptr);
+    ASSERT_EQ(static_cast<int64_t>(kRowsPerSegment) * 10, out_rowset->rowset_meta()->num_rows());
+
+    RowsetReaderContext reader_context;
+    reader_context.tablet_schema = tablet_schema;
+    reader_context.need_ordered_result = false;
+    std::vector<uint32_t> return_columns = {0};
+    reader_context.return_columns = &return_columns;
+    RowsetReaderSharedPtr output_rs_reader;
+    create_and_init_rowset_reader(out_rowset.get(), reader_context, &output_rs_reader);
+
+    int64_t total_rows = 0;
+    Status s = Status::OK();
+    while (s.ok()) {
+        vectorized::Block output_block = tablet_schema->create_block_by_cids(return_columns);
+        s = output_rs_reader->next_batch(&output_block);
+        if (s.ok()) {
+            total_rows += output_block.rows();
+        }
+    }
+    ASSERT_TRUE(s.is<ErrorCode::END_OF_FILE>()) << s.to_json();
+    ASSERT_EQ(static_cast<int64_t>(kRowsPerSegment) * 10, total_rows);
+}
+
+} // namespace vectorized
+} // namespace doris

--- a/be/test/olap/variant_doc_mode_compaction_test.cpp
+++ b/be/test/olap/variant_doc_mode_compaction_test.cpp
@@ -63,6 +63,7 @@
 #include "vec/core/field.h"
 #include "vec/data_types/data_type_string.h"
 
+#ifndef NDEBUG
 namespace doris {
 namespace vectorized {
 using namespace ErrorCode;
@@ -106,11 +107,7 @@ protected:
         ASSERT_TRUE(_data_dir->init(true).ok());
         ExecEnv::GetInstance()->set_storage_engine(std::move(engine));
 
-        config::enable_ordered_data_compaction = false;
-        config::segments_key_bounds_truncation_threshold = -1;
-        config::enable_vertical_compact_variant_subcolumns = true;
-        config::enable_compaction_checksum = false;
-        config::enable_stacktrace = true;
+        // config::enable_ordered_data_compaction = false;
     }
 
     void TearDown() override {
@@ -382,9 +379,7 @@ private:
 // === Finished. Gtest output: /mnt/disk1/claude-max/tmp/doris/be/ut_build_RELEASE/gtest_output
 
 TEST_F(VariantDocModeCompactionTest, variant_doc_mode_compaction_merge_10_segments) {
-#ifndef NDEBUG
     GTEST_SKIP() << "This test is slow and only runs in Release mode";
-#endif
     TabletSchemaSPtr tablet_schema = create_schema();
     TabletSharedPtr tablet = create_tablet(*tablet_schema);
     ASSERT_TRUE(io::global_local_filesystem()->create_directory(tablet->tablet_path()).ok());
@@ -500,3 +495,5 @@ TEST_F(VariantDocModeCompactionTest, variant_doc_mode_compaction_merge_10_segmen
 
 } // namespace vectorized
 } // namespace doris
+
+#endif


### PR DESCRIPTION
Improve VARIANT doc-mode ingestion and compaction performance, and add a
write/compaction benchmark UT.

Key changes:
- Add config `enable_variant_doc_compaction_sparse_write` (default: true) to
  enable sparse writing for materialized subcolumns during doc-mode compaction.
- Optimize doc value column generation: deduplicate paths, sort paths once, and
  serialize values directly into the binary column to reduce allocations/copies.
- Optimize bucket sharding/stats collection with phmap and cached path->bucket
  mapping; remove per-row doc value sorting in writer.
- Refactor VariantDocCompactWriter finalize flow with an explicit write plan;
  skip invalid array types and fix doc materialization offset handling.
- Update variant-related UTs and add VariantDocModeCompactionTest to benchmark
  segment import and doc-mode compaction.

UT Testing:
- BE UT: VariantColumnWriterReaderTest.*, VariantUtilTest.*, ColumnVariantTest.*

Benchmark Testing(Release compile):
- BE UT (Release-only, slow): VariantDocModeCompactionTest.*

<img width="902" height="778" alt="image" src="https://github.com/user-attachments/assets/08fb9341-2620-484d-9cf9-f3a64c95d4bd" />
