### PR TITLE
[opt](nereids)pass ConnectContext to canUseNereidsDistributePlanner method instead of call ConnectContext.get()

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/EnvFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/EnvFactory.java
@@ -145,7 +145,7 @@ public class EnvFactory {
 
     public Coordinator createCoordinator(ConnectContext context, Planner planner,
                                          StatsErrorEstimator statsErrorEstimator) {
-        if (planner instanceof NereidsPlanner && SessionVariable.canUseNereidsDistributePlanner()) {
+        if (planner instanceof NereidsPlanner && SessionVariable.canUseNereidsDistributePlanner(context)) {
             return new NereidsCoordinator(context, (NereidsPlanner) planner, statsErrorEstimator);
         }
         return new Coordinator(context, planner, statsErrorEstimator);
@@ -153,7 +153,7 @@ public class EnvFactory {
 
     public Coordinator createCoordinator(ConnectContext context, Planner planner,
                                          StatsErrorEstimator statsErrorEstimator, long jobId) {
-        if (planner instanceof NereidsPlanner && SessionVariable.canUseNereidsDistributePlanner()) {
+        if (planner instanceof NereidsPlanner && SessionVariable.canUseNereidsDistributePlanner(context)) {
             return new NereidsCoordinator(context, (NereidsPlanner) planner, statsErrorEstimator, jobId);
         }
         return new Coordinator(context, planner, statsErrorEstimator);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -4703,6 +4703,19 @@ public class SessionVariable implements Serializable, Writable {
         return sessionVariable.enableNereidsDistributePlanner;
     }
 
+    /** canUseNereidsDistributePlanner */
+    public static boolean canUseNereidsDistributePlanner(ConnectContext connectContext) {
+        SessionVariable sessionVariable = connectContext.getSessionVariable();
+        StatementContext statementContext = connectContext.getStatementContext();
+        if (statementContext != null) {
+            StatementBase parsedStatement = statementContext.getParsedStatement();
+            if (!(parsedStatement instanceof LogicalPlanAdapter)) {
+                return false;
+            }
+        }
+        return sessionVariable.enableNereidsDistributePlanner;
+    }
+
     public boolean isEnableNereidsDistributePlanner() {
         return enableNereidsDistributePlanner;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -4689,18 +4689,11 @@ public class SessionVariable implements Serializable, Writable {
     /** canUseNereidsDistributePlanner */
     public static boolean canUseNereidsDistributePlanner() {
         ConnectContext connectContext = ConnectContext.get();
-        if (connectContext == null) {
+        if (connectContext != null) {
+            return canUseNereidsDistributePlanner(connectContext);
+        } else {
             return true;
         }
-        SessionVariable sessionVariable = connectContext.getSessionVariable();
-        StatementContext statementContext = connectContext.getStatementContext();
-        if (statementContext != null) {
-            StatementBase parsedStatement = statementContext.getParsedStatement();
-            if (!(parsedStatement instanceof LogicalPlanAdapter)) {
-                return false;
-            }
-        }
-        return sessionVariable.enableNereidsDistributePlanner;
     }
 
     /** canUseNereidsDistributePlanner */

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/NereidsCoordinatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/NereidsCoordinatorTest.java
@@ -82,7 +82,7 @@ public class NereidsCoordinatorTest extends TestWithFeService {
     }
 
     private NereidsPlanner plan(String sql) throws IOException {
-        return plan(sql, createDefaultCtx());
+        return plan(sql, connectContext);
     }
 
     private NereidsPlanner plan(String sql, ConnectContext connectContext) throws IOException {


### PR DESCRIPTION
this can make sure the planner always use the same ConnectContext

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

