### PR TITLE
[bugfix](k8s) fix Log4jConfig class loading before Config.init in console mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
@@ -118,9 +118,6 @@ public class DorisFE {
 
     // entrance for doris frontend
     public static void start(String dorisHomeDir, String pidDir, String[] args, StartupOptions options) {
-        if (System.getenv("DORIS_LOG_TO_STDERR") != null) {
-            Log4jConfig.foreground = true;
-        }
         if (Strings.isNullOrEmpty(dorisHomeDir)) {
             System.err.println("env DORIS_HOME is not set.");
             return;
@@ -153,6 +150,11 @@ public class DorisFE {
                 throw new IllegalArgumentException("Java version doesn't match");
             }
 
+            // Set foreground flag after Config.init() but before Log4jConfig class loading,
+            // so that Log4jConfig's static block can read the correct config values (e.g. log_rollover_strategy).
+            if (System.getenv("DORIS_LOG_TO_STDERR") != null) {
+                Log4jConfig.foreground = true;
+            }
             Log4jConfig.initLogging(dorisHomeDir + "/conf/");
             // Add shutdown hook for graceful exit
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
@@ -260,6 +262,7 @@ public class DorisFE {
             startMonitor();
 
             serverReady.set(true);
+
             // JVM will exit when shutdown hook is completed
             while (true) {
                 Thread.sleep(2000);

--- a/fe/fe-core/src/test/java/org/apache/doris/common/Log4jConfigTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/Log4jConfigTest.java
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+public class Log4jConfigTest {
+
+    /**
+     * Test that getXmlConfByStrategy correctly reads Config.log_rollover_strategy
+     * and generates the corresponding XML snippet.
+     *
+     * This is the core of the console mode bug fix: previously Log4jConfig's static
+     * block called getXmlConfByStrategy() before Config.init(), so it always saw
+     * the default "age" value. After the fix, the static block runs after Config.init(),
+     * ensuring the correct strategy is used.
+     */
+    @Test
+    public void testGetXmlConfByStrategyReadsConfig() throws Exception {
+        Field builderField = Log4jConfig.class.getDeclaredField("xmlConfTemplateBuilder");
+        builderField.setAccessible(true);
+        StringBuilder originalBuilder = (StringBuilder) builderField.get(null);
+
+        Method method = Log4jConfig.class.getDeclaredMethod(
+                "getXmlConfByStrategy", String.class, String.class);
+        method.setAccessible(true);
+
+        String origStrategy = Config.log_rollover_strategy;
+        try {
+            // Test size strategy
+            Config.log_rollover_strategy = "size";
+            StringBuilder sizeBuilder = new StringBuilder();
+            builderField.set(null, sizeBuilder);
+            method.invoke(null, "info_sys_accumulated_file_size", "sys_log_delete_age");
+            String sizeResult = sizeBuilder.toString();
+            Assert.assertTrue("Size strategy should use IfAccumulatedFileSize",
+                    sizeResult.contains("IfAccumulatedFileSize"));
+            Assert.assertFalse("Size strategy should not use IfLastModified",
+                    sizeResult.contains("IfLastModified"));
+
+            // Test age strategy
+            Config.log_rollover_strategy = "age";
+            StringBuilder ageBuilder = new StringBuilder();
+            builderField.set(null, ageBuilder);
+            method.invoke(null, "info_sys_accumulated_file_size", "sys_log_delete_age");
+            String ageResult = ageBuilder.toString();
+            Assert.assertTrue("Age strategy should use IfLastModified",
+                    ageResult.contains("IfLastModified"));
+            Assert.assertFalse("Age strategy should not use IfAccumulatedFileSize",
+                    ageResult.contains("IfAccumulatedFileSize"));
+        } finally {
+            // Restore original state
+            Config.log_rollover_strategy = origStrategy;
+            builderField.set(null, originalBuilder);
+        }
+    }
+}


### PR DESCRIPTION


When running FE in console mode, `Log4jConfig.foreground = true` was executed before `Config.init()`, which triggers Log4jConfig class loading too early. The static block in Log4jConfig calls `getXmlConfByStrategy()` reading `Config.log_rollover_strategy`, but fe.conf has not been loaded yet, so it always gets the default value "age" regardless of the actual config.

In daemon mode this is not an issue because Log4jConfig is first referenced at `initLogging()` which is called after `Config.init()`.

Fix: move the `Log4jConfig.foreground = true` assignment to after `Config.init()` and before `Log4jConfig.initLogging()`, ensuring the static block sees the correct config values from fe.conf.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

