### PR TITLE
[fix](filecache) avoid SIGSEGV in background LRU update when clear cache

### DIFF
--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -487,17 +487,23 @@ Status BlockFileCache::initialize_unlocked(std::lock_guard<std::mutex>& cache_lo
 
 void BlockFileCache::update_block_lru(FileBlockSPtr block,
                                       std::lock_guard<std::mutex>& cache_lock) {
-    FileBlockCell* cell = block->cell;
-    if (cell) {
-        if (cell->queue_iterator) {
-            auto& queue = get_queue(block->cache_type());
-            queue.move_to_end(*cell->queue_iterator, cache_lock);
-            _lru_recorder->record_queue_event(block->cache_type(), CacheLRULogType::MOVETOBACK,
-                                              block->_key.hash, block->_key.offset,
-                                              block->_block_range.size());
-        }
-        cell->update_atime();
+    if (!block) {
+        return;
     }
+
+    FileBlockCell* cell = get_cell(block->get_hash_value(), block->offset(), cache_lock);
+    if (!cell || cell->file_block.get() != block.get()) {
+        return;
+    }
+
+    if (cell->queue_iterator) {
+        auto& queue = get_queue(block->cache_type());
+        queue.move_to_end(*cell->queue_iterator, cache_lock);
+        _lru_recorder->record_queue_event(block->cache_type(), CacheLRULogType::MOVETOBACK,
+                                          block->_key.hash, block->_key.offset,
+                                          block->_block_range.size());
+    }
+    cell->update_atime();
 }
 
 void BlockFileCache::use_cell(const FileBlockCell& cell, FileBlocks* result, bool move_iter_flag,

--- a/be/src/io/cache/file_block.h
+++ b/be/src/io/cache/file_block.h
@@ -171,7 +171,7 @@ private:
     size_t _downloaded_size {0};
     bool _is_deleting {false};
 
-    FileBlockCell* cell;
+    FileBlockCell* cell {nullptr};
 };
 
 extern std::ostream& operator<<(std::ostream& os, const FileBlock::State& value);

--- a/be/test/io/cache/need_update_lru_blocks_test.cpp
+++ b/be/test/io/cache/need_update_lru_blocks_test.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <mutex>
 #include <vector>
 
 #include "io/cache/block_file_cache.h"
@@ -107,6 +108,44 @@ TEST(NeedUpdateLRUBlocksTest, ClearIsIdempotent) {
 
     std::vector<FileBlockSPtr> drained;
     EXPECT_EQ(0u, pending.drain(4, &drained));
+}
+
+TEST(NeedUpdateLRUBlocksTest, UpdateBlockLRUIgnoresNullAndCorruptedCellPointer) {
+    io::FileCacheSettings settings;
+    settings.capacity = 1024 * 1024;
+    settings.query_queue_size = 1024 * 1024;
+    settings.query_queue_elements = 10;
+    settings.max_file_block_size = 1024;
+    settings.max_query_cache_size = 1024 * 1024;
+    settings.storage = "memory";
+
+    io::BlockFileCache mgr("memory", settings);
+
+    {
+        std::lock_guard<std::mutex> cache_lock(mgr._mutex);
+        FileBlockSPtr null_block;
+        mgr.update_block_lru(null_block, cache_lock);
+    }
+
+    FileCacheKey key;
+    key.hash = io::BlockFileCache::hash("update_block_lru_corrupted_cell");
+    key.offset = 0;
+    key.meta.expiration_time = 0;
+    key.meta.type = FileCacheType::NORMAL;
+    key.meta.tablet_id = 0;
+
+    auto block =
+            std::make_shared<FileBlock>(key, /*size*/ 1, /*mgr*/ &mgr, FileBlock::State::EMPTY);
+    EXPECT_EQ(nullptr, block->cell);
+
+    // Simulate a corrupted/stale cell pointer. Previously update_block_lru()
+    // dereferenced block->cell directly and could crash.
+    block->cell = reinterpret_cast<FileBlockCell*>(0x1);
+
+    {
+        std::lock_guard<std::mutex> cache_lock(mgr._mutex);
+        mgr.update_block_lru(block, cache_lock);
+    }
 }
 
 } // namespace doris::io


### PR DESCRIPTION
The background LRU update thread (BlockFileCache::run_background_block_lru_update) uses cell which is a raw pointer owned by the cache’s internal _files map and may be unset during clearing cache.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

