### PR TITLE
[Improvement] Support NDV function in InferAggNotNull rule

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InferAggNotNull.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InferAggNotNull.java
@@ -26,6 +26,7 @@ import org.apache.doris.nereids.trees.expressions.functions.agg.Avg;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Count;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Max;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Min;
+import org.apache.doris.nereids.trees.expressions.functions.agg.Ndv;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Sum;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.algebra.Filter;
@@ -50,11 +51,12 @@ public class InferAggNotNull extends OneRewriteRuleFactory {
                 .when(agg -> agg.getAggregateFunctions().size() == 1)
                 .when(agg -> {
                     Set<AggregateFunction> funcs = agg.getAggregateFunctions();
-                    return funcs.stream().allMatch(f -> f instanceof Count)
-                            || funcs.stream().allMatch(f -> f instanceof Avg)
-                            || funcs.stream().allMatch(f -> f instanceof Sum)
-                            || funcs.stream().allMatch(f -> f instanceof Max)
-                            || funcs.stream().allMatch(f -> f instanceof Min);
+                    return funcs.stream().allMatch(f -> f instanceof Count
+                            || f instanceof Avg
+                            || f instanceof Sum
+                            || f instanceof Max
+                            || f instanceof Min
+                            || f instanceof Ndv);
                 }).thenApply(ctx -> {
                     LogicalAggregate<Plan> agg = ctx.root;
                     Set<Expression> exprs = agg.getAggregateFunctions().stream().flatMap(f -> f.children().stream())


### PR DESCRIPTION
Add support for the NDV (Number of Distinct Values) function in the InferAggNotNull rule. Since NDV also excludes NULL values (consistent with COUNT(DISTINCT) semantics), it should benefit from the same optimization.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [X] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [X] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [X] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

