### PR TITLE
[fix](filecache) reset_range dose not update shadow queue causing lar…

### DIFF
--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -846,6 +846,17 @@ FileBlockCell* BlockFileCache::add_cell(const UInt128Wrapper& hash, const CacheC
         return nullptr; /// Empty files are not cached.
     }
 
+    VLOG_DEBUG << "Adding file block to cache. size=" << size << " hash=" << hash.to_string()
+               << " offset=" << offset << " cache_type=" << cache_type_to_string(context.cache_type)
+               << " expiration_time=" << context.expiration_time
+               << " tablet_id=" << context.tablet_id;
+
+    if (size > 1024 * 1024 * 1024) {
+        LOG(WARNING) << "File block size is too large for a block. size=" << size
+                     << " hash=" << hash.to_string() << " offset=" << offset
+                     << " stack:" << get_stack_trace();
+    }
+
     auto& offsets = _files[hash];
     auto itr = offsets.find(offset);
     if (itr != offsets.end()) {
@@ -1300,10 +1311,10 @@ void BlockFileCache::reset_range(const UInt128Wrapper& hash, size_t offset, size
     if (cell->queue_iterator) {
         auto& queue = get_queue(cell->file_block->cache_type());
         DCHECK(queue.contains(hash, offset, cache_lock));
-        auto iter = queue.get(hash, offset, cache_lock);
-        iter->size = new_size;
-        queue.cache_size -= old_size;
-        queue.cache_size += new_size;
+        queue.resize(*cell->queue_iterator, new_size, cache_lock);
+        _lru_recorder->record_queue_event(cell->file_block->cache_type(), CacheLRULogType::RESIZE,
+                                          cell->file_block->get_hash_value(),
+                                          cell->file_block->offset(), new_size);
     }
     _cur_cache_size -= old_size;
     _cur_cache_size += new_size;
@@ -1597,6 +1608,13 @@ void LRUQueue::remove_all(std::lock_guard<std::mutex>& /* cache_lock */) {
 
 void LRUQueue::move_to_end(Iterator queue_it, std::lock_guard<std::mutex>& /* cache_lock */) {
     queue.splice(queue.end(), queue, queue_it);
+}
+
+void LRUQueue::resize(Iterator queue_it, size_t new_size,
+                      std::lock_guard<std::mutex>& /* cache_lock */) {
+    cache_size -= queue_it->size;
+    queue_it->size = new_size;
+    cache_size += new_size;
 }
 bool LRUQueue::contains(const UInt128Wrapper& hash, size_t offset,
                         std::lock_guard<std::mutex>& /* cache_lock */) const {

--- a/be/src/io/cache/file_cache_common.h
+++ b/be/src/io/cache/file_cache_common.h
@@ -224,6 +224,8 @@ public:
 
     void move_to_end(Iterator queue_it, std::lock_guard<std::mutex>& cache_lock);
 
+    void resize(Iterator queue_it, size_t new_size, std::lock_guard<std::mutex>& cache_lock);
+
     std::string to_string(std::lock_guard<std::mutex>& cache_lock) const;
 
     bool contains(const UInt128Wrapper& hash, size_t offset,

--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -17,15 +17,24 @@
 
 #include "io/cache/fs_file_cache_storage.h"
 
+#include <fmt/core.h>
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+#include <sys/statvfs.h>
+
 #include <filesystem>
 #include <mutex>
 #include <system_error>
+#include <vector>
 
 #include "common/logging.h"
+#include "common/status.h"
 #include "cpp/sync_point.h"
 #include "io/cache/block_file_cache.h"
 #include "io/cache/file_block.h"
 #include "io/cache/file_cache_common.h"
+#include "io/cache/file_cache_storage.h"
 #include "io/fs/file_reader_writer_fwd.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_reader.h"
@@ -106,30 +115,38 @@ Status FSFileCacheStorage::init(BlockFileCache* _mgr) {
     _iterator_dir_retry_cnt = std::make_shared<bvar::LatencyRecorder>(
             _cache_base_path.c_str(), "file_cache_fs_storage_iterator_dir_retry_cnt");
     _cache_base_path = _mgr->_cache_base_path;
+    _meta_store = std::make_unique<CacheBlockMetaStore>(_cache_base_path + "/meta", 10000);
     _cache_background_load_thread = std::thread([this, mgr = _mgr]() {
-        auto mem_tracker = MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::OTHER,
-                                                            fmt::format("FileCacheVersionReader"));
-        SCOPED_ATTACH_TASK(mem_tracker);
-        Status st = upgrade_cache_dir_if_necessary();
-        if (!st.ok()) {
-            std::string msg = fmt::format(
-                    "file cache {} upgrade done with error. upgrade version failed. st={}",
-                    _cache_base_path, st.to_string());
-            if (doris::config::ignore_file_cache_dir_upgrade_failure) {
-                LOG(WARNING) << msg << " be conf: `ignore_file_cache_dir_upgrade_failure = true`"
-                             << " so we are ignoring the error (unsuccessful cache files will be "
-                                "removed)";
-                remove_old_version_directories();
-            } else {
-                LOG(WARNING) << msg << " please fix error and restart BE or"
-                             << " use be conf: `ignore_file_cache_dir_upgrade_failure = true`"
-                             << " to skip the error (unsuccessful cache files will be removed)";
-                throw doris::Exception(Status::InternalError(msg));
+        try {
+            auto mem_tracker = MemTrackerLimiter::create_shared(
+                    MemTrackerLimiter::Type::OTHER, fmt::format("FileCacheVersionReader"));
+            SCOPED_ATTACH_TASK(mem_tracker);
+            Status st = upgrade_cache_dir_if_necessary();
+            if (!st.ok()) {
+                std::string msg = fmt::format(
+                        "file cache {} upgrade done with error. upgrade version failed. st={}",
+                        _cache_base_path, st.to_string());
+                if (doris::config::ignore_file_cache_dir_upgrade_failure) {
+                    LOG(WARNING)
+                            << msg << " be conf: `ignore_file_cache_dir_upgrade_failure = true`"
+                            << " so we are ignoring the error (unsuccessful cache files will be "
+                               "removed)";
+                    remove_old_version_directories();
+                } else {
+                    LOG(WARNING) << msg << " please fix error and restart BE or"
+                                 << " use be conf: `ignore_file_cache_dir_upgrade_failure = true`"
+                                 << " to skip the error (unsuccessful cache files will be removed)";
+                    throw doris::Exception(Status::InternalError(msg));
+                }
             }
+            load_cache_info_into_memory(mgr);
+            mgr->_async_open_done = true;
+            LOG_INFO("file cache {} lazy load done.", _cache_base_path);
+        } catch (const std::exception& e) {
+            LOG(ERROR) << "Background cache loading thread failed with exception: " << e.what();
+        } catch (...) {
+            LOG(ERROR) << "Background cache loading thread failed with unknown exception";
         }
-        load_cache_info_into_memory(mgr);
-        mgr->_async_open_done = true;
-        LOG_INFO("file cache {} lazy load done.", _cache_base_path);
     });
     return Status::OK();
 }
@@ -142,12 +159,12 @@ Status FSFileCacheStorage::append(const FileCacheKey& key, const Slice& value) {
         if (auto iter = _key_to_writer.find(file_writer_map_key); iter != _key_to_writer.end()) {
             writer = iter->second.get();
         } else {
-            std::string dir = get_path_in_local_cache(key.hash, key.meta.expiration_time);
+            std::string dir = get_path_in_local_cache_v3(key.hash);
             auto st = fs->create_directory(dir, false);
             if (!st.ok() && !st.is<ErrorCode::ALREADY_EXIST>()) {
                 return st;
             }
-            std::string tmp_file = get_path_in_local_cache(dir, key.offset, key.meta.type, true);
+            std::string tmp_file = get_path_in_local_cache_v3(dir, key.offset, true);
             FileWriterPtr file_writer;
             FileWriterOptions opts {.sync_file_data = false};
             RETURN_IF_ERROR(fs->create_file(tmp_file, &file_writer, &opts));
@@ -159,7 +176,7 @@ Status FSFileCacheStorage::append(const FileCacheKey& key, const Slice& value) {
     return writer->append(value);
 }
 
-Status FSFileCacheStorage::finalize(const FileCacheKey& key) {
+Status FSFileCacheStorage::finalize(const FileCacheKey& key, const size_t size) {
     FileWriterPtr file_writer;
     {
         std::lock_guard lock(_mtx);
@@ -172,9 +189,18 @@ Status FSFileCacheStorage::finalize(const FileCacheKey& key) {
     if (file_writer->state() != FileWriter::State::CLOSED) {
         RETURN_IF_ERROR(file_writer->close());
     }
-    std::string dir = get_path_in_local_cache(key.hash, key.meta.expiration_time);
-    std::string true_file = get_path_in_local_cache(dir, key.offset, key.meta.type);
-    return fs->rename(file_writer->path(), true_file);
+    std::string dir = get_path_in_local_cache_v3(key.hash);
+    std::string true_file = get_path_in_local_cache_v3(dir, key.offset);
+    auto s = fs->rename(file_writer->path(), true_file);
+    if (!s.ok()) {
+        return s;
+    }
+
+    BlockMetaKey mkey(key.meta.tablet_id, UInt128Wrapper(key.hash), key.offset);
+    BlockMeta meta(key.meta.type, size, key.meta.expiration_time);
+    _meta_store->put(mkey, meta);
+
+    return Status::OK();
 }
 
 Status FSFileCacheStorage::read(const FileCacheKey& key, size_t value_offset, Slice buffer) {
@@ -182,29 +208,24 @@ Status FSFileCacheStorage::read(const FileCacheKey& key, size_t value_offset, Sl
     FileReaderSPtr file_reader = FDCache::instance()->get_file_reader(fd_key);
     if (!file_reader) {
         std::string file =
-                get_path_in_local_cache(get_path_in_local_cache(key.hash, key.meta.expiration_time),
-                                        key.offset, key.meta.type);
+                get_path_in_local_cache_v3(get_path_in_local_cache_v3(key.hash), key.offset);
         Status s = fs->open_file(file, &file_reader);
-
-        // handle the case that the file is not found but actually exists in other type format
-        // TODO(zhengyu): nasty! better eliminate the type encoding in file name in the future
-        if (!s.ok() && !s.is<ErrorCode::NOT_FOUND>()) {
-            LOG(WARNING) << "open file failed, file=" << file << ", error=" << s.to_string();
-            return s;                                         // return other error directly
-        } else if (!s.ok() && s.is<ErrorCode::NOT_FOUND>()) { // but handle NOT_FOUND error
-            auto candidates = get_path_in_local_cache_all_candidates(
-                    get_path_in_local_cache(key.hash, key.meta.expiration_time), key.offset);
-            for (auto& candidate : candidates) {
-                s = fs->open_file(candidate, &file_reader);
-                if (s.ok()) {
-                    break; // success with one of there candidates
+        if (!s.ok()) {
+            if (s.is<ErrorCode::NOT_FOUND>()) {
+                // Try to open file with old v2 format
+                std::string dir = get_path_in_local_cache_v2(key.hash, key.meta.expiration_time);
+                std::string v2_file = get_path_in_local_cache_v2(dir, key.offset, key.meta.type);
+                Status s2 = fs->open_file(v2_file, &file_reader);
+                if (!s2.ok()) {
+                    LOG(WARNING) << "open file failed with both v3 and v2 format, v3_file=" << file
+                                 << ", v2_file=" << v2_file << ", error=" << s2.to_string();
+                    return s2;
                 }
-            }
-            if (!s.ok()) { // still not found, return error
+            } else {
                 LOG(WARNING) << "open file failed, file=" << file << ", error=" << s.to_string();
                 return s;
             }
-        } // else, s.ok() means open file success
+        }
 
         FDCache::instance()->insert_file_reader(fd_key, file_reader);
     }
@@ -220,23 +241,20 @@ Status FSFileCacheStorage::read(const FileCacheKey& key, size_t value_offset, Sl
 }
 
 Status FSFileCacheStorage::remove(const FileCacheKey& key) {
-    std::string dir = get_path_in_local_cache(key.hash, key.meta.expiration_time);
-    std::string file = get_path_in_local_cache(dir, key.offset, key.meta.type);
+    std::string dir = get_path_in_local_cache_v3(key.hash);
+    std::string file = get_path_in_local_cache_v3(dir, key.offset);
     FDCache::instance()->remove_file_reader(std::make_pair(key.hash, key.offset));
     RETURN_IF_ERROR(fs->delete_file(file));
     // return OK not means the file is deleted, it may be not exist
-    // So for TTL, we make sure the old format will be removed well
-    if (key.meta.type == FileCacheType::TTL) {
-        bool exists {false};
-        // try to detect the file with old ttl format
-        file = get_path_in_local_cache_old_ttl_format(dir, key.offset, key.meta.type);
-        RETURN_IF_ERROR(fs->exists(file, &exists));
-        if (exists) {
-            VLOG(7) << "try to remove the file with old ttl format"
-                    << " file=" << file;
-            RETURN_IF_ERROR(fs->delete_file(file));
-        }
+
+    { // try to detect the file with old v2 format
+        dir = get_path_in_local_cache_v2(key.hash, key.meta.expiration_time);
+        file = get_path_in_local_cache_v2(dir, key.offset, key.meta.type);
+        RETURN_IF_ERROR(fs->delete_file(file));
     }
+
+    BlockMetaKey mkey(key.meta.tablet_id, UInt128Wrapper(key.hash), key.offset);
+    _meta_store->delete_key(mkey);
     std::vector<FileInfo> files;
     bool exists {false};
     RETURN_IF_ERROR(fs->list(dir, true, &files, &exists));
@@ -246,43 +264,28 @@ Status FSFileCacheStorage::remove(const FileCacheKey& key) {
     return Status::OK();
 }
 
-Status FSFileCacheStorage::change_key_meta_type(const FileCacheKey& key, const FileCacheType type) {
+Status FSFileCacheStorage::change_key_meta_type(const FileCacheKey& key, const FileCacheType type,
+                                                const size_t size) {
     // file operation
     if (key.meta.type != type) {
-        // TTL type file dose not need to change the suffix
-        bool expr = (key.meta.type != FileCacheType::TTL && type != FileCacheType::TTL);
-        if (!expr) {
-            LOG(WARNING) << "TTL type file dose not need to change the suffix"
-                         << " key=" << key.hash.to_string() << " offset=" << key.offset
-                         << " old_type=" << cache_type_to_string(key.meta.type)
-                         << " new_type=" << cache_type_to_string(type);
-        }
-        DCHECK(expr);
-        std::string dir = get_path_in_local_cache(key.hash, key.meta.expiration_time);
-        std::string original_file = get_path_in_local_cache(dir, key.offset, key.meta.type);
-        std::string new_file = get_path_in_local_cache(dir, key.offset, type);
-        RETURN_IF_ERROR(fs->rename(original_file, new_file));
+        BlockMetaKey mkey(key.meta.tablet_id, UInt128Wrapper(key.hash), key.offset);
+        BlockMeta meta(type, size, key.meta.expiration_time);
+        _meta_store->put(mkey, meta);
     }
     return Status::OK();
 }
 
-Status FSFileCacheStorage::change_key_meta_expiration(const FileCacheKey& key,
-                                                      const uint64_t expiration) {
-    // directory operation
-    if (key.meta.expiration_time != expiration) {
-        std::string original_dir = get_path_in_local_cache(key.hash, key.meta.expiration_time);
-        std::string new_dir = get_path_in_local_cache(key.hash, expiration);
-        // It will be concurrent, but we don't care who rename
-        Status st = fs->rename(original_dir, new_dir);
-        if (!st.ok() && !st.is<ErrorCode::NOT_FOUND>()) {
-            return st;
-        }
+std::string FSFileCacheStorage::get_path_in_local_cache_v3(const std::string& dir, size_t offset,
+                                                           bool is_tmp) {
+    if (is_tmp) {
+        return Path(dir) / (std::to_string(offset) + "_tmp");
+    } else {
+        return Path(dir) / std::to_string(offset);
     }
-    return Status::OK();
 }
 
-std::string FSFileCacheStorage::get_path_in_local_cache(const std::string& dir, size_t offset,
-                                                        FileCacheType type, bool is_tmp) {
+std::string FSFileCacheStorage::get_path_in_local_cache_v2(const std::string& dir, size_t offset,
+                                                           FileCacheType type, bool is_tmp) {
     if (is_tmp) {
         return Path(dir) / (std::to_string(offset) + "_tmp");
     } else if (type == FileCacheType::TTL) {
@@ -292,35 +295,24 @@ std::string FSFileCacheStorage::get_path_in_local_cache(const std::string& dir, 
     }
 }
 
-std::string FSFileCacheStorage::get_path_in_local_cache_old_ttl_format(const std::string& dir,
-                                                                       size_t offset,
-                                                                       FileCacheType type,
-                                                                       bool is_tmp) {
-    DCHECK(type == FileCacheType::TTL);
-    return Path(dir) / (std::to_string(offset) + cache_type_to_surfix(type));
-}
-
-std::vector<std::string> FSFileCacheStorage::get_path_in_local_cache_all_candidates(
-        const std::string& dir, size_t offset) {
-    std::vector<std::string> candidates;
-    std::string base = get_path_in_local_cache(dir, offset, FileCacheType::NORMAL);
-    candidates.push_back(base);
-    candidates.push_back(base + "_idx");
-    candidates.push_back(base + "_ttl");
-    candidates.push_back(base + "_disposable");
-    return candidates;
-}
-
-std::string FSFileCacheStorage::get_path_in_local_cache(const UInt128Wrapper& value,
-                                                        uint64_t expiration_time) const {
+std::string FSFileCacheStorage::get_path_in_local_cache_v3(const UInt128Wrapper& value) const {
     auto str = value.to_string();
     try {
-        if constexpr (USE_CACHE_VERSION2) {
-            return Path(_cache_base_path) / str.substr(0, KEY_PREFIX_LENGTH) /
-                   (str + "_" + std::to_string(expiration_time));
-        } else {
-            return Path(_cache_base_path) / (str + "_" + std::to_string(expiration_time));
-        }
+        return Path(_cache_base_path) / str.substr(0, KEY_PREFIX_LENGTH) / (str + "_0");
+    } catch (std::filesystem::filesystem_error& e) {
+        LOG_WARNING("fail to get_path_in_local_cache")
+                .tag("err", e.what())
+                .tag("key", value.to_string());
+        return "";
+    }
+}
+
+std::string FSFileCacheStorage::get_path_in_local_cache_v2(const UInt128Wrapper& value,
+                                                           uint64_t expiration_time) const {
+    auto str = value.to_string();
+    try {
+        return Path(_cache_base_path) / str.substr(0, KEY_PREFIX_LENGTH) /
+               (str + "_" + std::to_string(expiration_time));
     } catch (std::filesystem::filesystem_error& e) {
         LOG_WARNING("fail to get_path_in_local_cache")
                 .tag("err", e.what())
@@ -424,122 +416,31 @@ Status FSFileCacheStorage::collect_directory_entries(const std::filesystem::path
 }
 
 Status FSFileCacheStorage::upgrade_cache_dir_if_necessary() const {
-    /*
-     * If use version2 but was version 1, do upgrade:
-     *
-     * Action I:
-     *     version 1.0: cache_base_path / key / offset
-     *     version 2.0: cache_base_path / key_prefix / key / offset
-     *
-     * Action II:
-     *     add '_0' to hash dir
-     *
-     * Note: This is a sync operation with tons of IOs, so it may affect BE
-     * boot time heavily. Fortunately, Action I & II will only happen when
-     * upgrading (once in the cluster life time).
-     */
-
     std::string version;
-    std::error_code ec;
     int rename_count = 0;
     int failure_count = 0;
     auto start_time = std::chrono::steady_clock::now();
 
     RETURN_IF_ERROR(read_file_cache_version(&version));
 
-    LOG(INFO) << "Checking cache version upgrade. Current version: " << version
-              << ", target version: 2.0, need upgrade: "
-              << (USE_CACHE_VERSION2 && version != "2.0");
-    if (USE_CACHE_VERSION2 && version != "2.0") {
-        // move directories format as version 2.0
-        std::vector<std::string> file_list;
-        file_list.reserve(10000);
-        RETURN_IF_ERROR(collect_directory_entries(_cache_base_path, file_list));
-
-        // this directory_iterator should be a problem in concurrent access
-        for (const auto& file_path : file_list) {
-            try {
-                if (std::filesystem::is_directory(file_path)) {
-                    std::string cache_key = std::filesystem::path(file_path).filename().native();
-                    if (cache_key.size() > KEY_PREFIX_LENGTH) {
-                        if (cache_key.find('_') == std::string::npos) {
-                            cache_key += "_0";
-                        }
-                        std::string key_prefix =
-                                Path(_cache_base_path) / cache_key.substr(0, KEY_PREFIX_LENGTH);
-                        bool exists = false;
-                        auto exists_status = fs->exists(key_prefix, &exists);
-                        if (!exists_status.ok()) {
-                            LOG(WARNING) << "Failed to check directory existence: " << key_prefix
-                                         << ", error: " << exists_status.to_string();
-                            ++failure_count;
-                            continue;
-                        }
-                        if (!exists) {
-                            auto create_status = fs->create_directory(key_prefix);
-                            if (!create_status.ok() &&
-                                create_status.code() != TStatusCode::type::ALREADY_EXIST) {
-                                LOG(WARNING) << "Failed to create directory: " << key_prefix
-                                             << ", error: " << create_status.to_string();
-                                ++failure_count;
-                                continue;
-                            }
-                        }
-                        auto rename_status = Status::OK();
-                        const std::string new_file_path = key_prefix + "/" + cache_key;
-                        TEST_SYNC_POINT_CALLBACK(
-                                "FSFileCacheStorage::upgrade_cache_dir_if_necessary_rename",
-                                &file_path, &new_file_path);
-                        rename_status = fs->rename(file_path, new_file_path);
-                        if (rename_status.ok() ||
-                            rename_status.code() == TStatusCode::type::DIRECTORY_NOT_EMPTY) {
-                            ++rename_count;
-                        } else {
-                            LOG(WARNING)
-                                    << "Failed to rename directory from " << file_path << " to "
-                                    << new_file_path << ", error: " << rename_status.to_string();
-                            ++failure_count;
-                            continue;
-                        }
-                    }
-                }
-            } catch (const std::exception& e) {
-                LOG(WARNING) << "Error occurred while upgrading file cache directory: " << file_path
-                             << " err: " << e.what();
-                ++failure_count;
-            }
-        }
-
-        std::vector<std::string> rebuilt_file_list;
-        rebuilt_file_list.reserve(10000);
-        RETURN_IF_ERROR(collect_directory_entries(_cache_base_path, rebuilt_file_list));
-
-        for (const auto& key_it : rebuilt_file_list) {
-            if (!std::filesystem::is_directory(key_it)) {
-                // maybe version hits file
-                continue;
-            }
-            try {
-                if (Path(key_it).filename().native().size() != KEY_PREFIX_LENGTH) {
-                    LOG(WARNING) << "Unknown directory " << key_it << ", try to remove it";
-                    auto delete_status = fs->delete_directory(key_it);
-                    if (!delete_status.ok()) {
-                        LOG(WARNING) << "Failed to delete unknown directory: " << key_it
-                                     << ", error: " << delete_status.to_string();
-                        ++failure_count;
-                        continue;
-                    }
-                }
-            } catch (const std::exception& e) {
-                LOG(WARNING) << "Error occurred while upgrading file cache directory: " << key_it
-                             << " err: " << e.what();
-                ++failure_count;
-            }
-        }
-        if (auto st = write_file_cache_version(); !st.ok()) {
-            return Status::InternalError("Failed to write version hints for file cache, err={}",
-                                         st.to_string());
-        }
+    if (version == "1.0") {
+        LOG(ERROR) << "Cache version upgrade issue: Cannot upgrade directly from 1.0 to 3.0.Please "
+                      "upgrade to 2.0 first (>= doris-3.0.0),or clear the file cache directory to "
+                      "start anew "
+                      "(LOSING ALL THE CACHE).";
+        exit(-1);
+    } else if (version == "2.0") {
+        LOG(INFO) << "Cache will upgrade from 2.0 to 3.0 progressively during running. 2.0 data "
+                     "format will evict eventually.";
+        return Status::OK();
+    } else if (version == "3.0") {
+        LOG(INFO) << "Readly 3.0 format, no need to upgrade.";
+        return Status::OK();
+    } else {
+        LOG(ERROR) << "Cache version upgrade issue: current version " << version
+                   << " is not valid. Clear the file cache directory to start anew (LOSING ALL THE "
+                      "CACHE).";
+        exit(-1);
     }
 
     auto end_time = std::chrono::steady_clock::now();
@@ -551,15 +452,30 @@ Status FSFileCacheStorage::upgrade_cache_dir_if_necessary() const {
 }
 
 Status FSFileCacheStorage::write_file_cache_version() const {
-    if constexpr (USE_CACHE_VERSION2) {
-        std::string version_path = get_version_path();
-        Slice version("2.0");
-        FileWriterPtr version_writer;
-        RETURN_IF_ERROR(fs->create_file(version_path, &version_writer));
-        RETURN_IF_ERROR(version_writer->append(version));
-        return version_writer->close();
-    }
-    return Status::OK();
+    std::string version_path = get_version_path();
+
+    rapidjson::Document doc;
+    doc.SetObject();
+    rapidjson::Document::AllocatorType& allocator = doc.GetAllocator();
+
+    // Add version field to JSON
+    rapidjson::Value version_value;
+    version_value.SetString("3.0", allocator);
+    doc.AddMember("version", version_value, allocator);
+
+    // Serialize JSON to string
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    doc.Accept(writer);
+
+    // Combine version string with JSON for backward compatibility
+    std::string version_content = "3.0" + std::string(buffer.GetString(), buffer.GetSize());
+    Slice version_slice(version_content);
+
+    FileWriterPtr version_writer;
+    RETURN_IF_ERROR(fs->create_file(version_path, &version_writer));
+    RETURN_IF_ERROR(version_writer->append(version_slice));
+    return version_writer->close();
 }
 
 Status FSFileCacheStorage::read_file_cache_version(std::string* buffer) const {
@@ -567,7 +483,7 @@ Status FSFileCacheStorage::read_file_cache_version(std::string* buffer) const {
     bool exists = false;
     RETURN_IF_ERROR(fs->exists(version_path, &exists));
     if (!exists) {
-        *buffer = "1.0";
+        *buffer = "2.0"; // return 2.0 if not exist to utilize filesystem
         return Status::OK();
     }
     FileReaderSPtr version_reader;
@@ -578,6 +494,19 @@ Status FSFileCacheStorage::read_file_cache_version(std::string* buffer) const {
     size_t bytes_read = 0;
     RETURN_IF_ERROR(version_reader->read_at(0, Slice(buffer->data(), file_size), &bytes_read));
     RETURN_IF_ERROR(version_reader->close());
+
+    // Extract only the version number part (before JSON starts) for backward compatibility
+    // New format: "3.0{\"version\":\"3.0\"}", old format: "3.0"
+    std::string content = *buffer;
+    size_t json_start = content.find('{');
+    if (json_start != std::string::npos) {
+        // New format with JSON, extract version number only
+        *buffer = content.substr(0, json_start);
+    } else {
+        // Old format, keep as is
+        *buffer = content;
+    }
+
     auto st = Status::OK();
     TEST_SYNC_POINT_CALLBACK("FSFileCacheStorage::read_file_cache_version", &st);
     return st;
@@ -588,8 +517,9 @@ std::string FSFileCacheStorage::get_version_path() const {
 }
 
 Status FSFileCacheStorage::parse_filename_suffix_to_cache_type(
-        const std::shared_ptr<LocalFileSystem>& fs, const Path& file_path, long expiration_time,
-        size_t size, size_t* offset, bool* is_tmp, FileCacheType* cache_type) const {
+        const std::shared_ptr<LocalFileSystem>& input_fs, const Path& file_path,
+        long expiration_time, size_t size, size_t* offset, bool* is_tmp,
+        FileCacheType* cache_type) const {
     std::error_code ec;
     std::string offset_with_suffix = file_path.native();
     auto delim_pos1 = offset_with_suffix.find('_');
@@ -644,7 +574,7 @@ Status FSFileCacheStorage::parse_filename_suffix_to_cache_type(
     }
 
     if (size == 0 && !(*is_tmp)) {
-        auto st = fs->delete_file(file_path);
+        auto st = input_fs->delete_file(file_path);
         if (!st.ok()) {
             LOG_WARNING("delete file {} error", file_path.native()).error(st);
         }
@@ -653,7 +583,32 @@ Status FSFileCacheStorage::parse_filename_suffix_to_cache_type(
     return Status::OK();
 }
 
-void FSFileCacheStorage::load_cache_info_into_memory(BlockFileCache* _mgr) const {
+bool FSFileCacheStorage::handle_already_loaded_block(
+        BlockFileCache* mgr, const UInt128Wrapper& hash, size_t offset, size_t new_size,
+        int64_t tablet_id, std::lock_guard<std::mutex>& cache_lock) const {
+    auto file_it = mgr->_files.find(hash);
+    if (file_it == mgr->_files.end()) {
+        return false;
+    }
+
+    auto cell_it = file_it->second.find(offset);
+    if (cell_it == file_it->second.end()) {
+        return false;
+    }
+
+    auto block = cell_it->second.file_block;
+    if (tablet_id != 0 && block->tablet_id() == 0) {
+        block->set_tablet_id(tablet_id);
+    }
+
+    size_t old_size = block->range().size();
+    if (old_size != new_size) {
+        mgr->reset_range(hash, offset, old_size, new_size, cache_lock);
+    }
+    return true;
+}
+
+void FSFileCacheStorage::load_cache_info_into_memory_from_fs(BlockFileCache* _mgr) const {
     int scan_length = 10000;
     std::vector<BatchLoadArgs> batch_load_buffer;
     batch_load_buffer.reserve(scan_length);
@@ -662,8 +617,8 @@ void FSFileCacheStorage::load_cache_info_into_memory(BlockFileCache* _mgr) const
 
         auto f = [&](const BatchLoadArgs& args) {
             // in async load mode, a cell may be added twice.
-            if (_mgr->_files.contains(args.hash) && _mgr->_files[args.hash].contains(args.offset)) {
-                // TODO(zhengyu): update type&expiration if need
+            if (handle_already_loaded_block(_mgr, args.hash, args.offset, args.size,
+                                            args.ctx.tablet_id, cache_lock)) {
                 return;
             }
             // if the file is tmp, it means it is the old file and it should be removed
@@ -694,7 +649,7 @@ void FSFileCacheStorage::load_cache_info_into_memory(BlockFileCache* _mgr) const
             std::error_code ec;
             std::filesystem::directory_iterator offset_it(key_it->path(), ec);
             if (ec) [[unlikely]] {
-                LOG(WARNING) << "filesystem error, failed to remove file, file=" << key_it->path()
+                LOG(WARNING) << "filesystem error, failed to list dir, dir=" << key_it->path()
                              << " error=" << ec.message();
                 continue;
             }
@@ -732,98 +687,267 @@ void FSFileCacheStorage::load_cache_info_into_memory(BlockFileCache* _mgr) const
         }
     };
     std::error_code ec;
-    if constexpr (USE_CACHE_VERSION2) {
-        TEST_SYNC_POINT_CALLBACK("BlockFileCache::BeforeScan");
-        std::filesystem::directory_iterator key_prefix_it {_cache_base_path, ec};
-        if (ec) {
-            LOG(WARNING) << ec.message();
-            return;
+
+    TEST_SYNC_POINT_CALLBACK("BlockFileCache::BeforeScan");
+    std::filesystem::directory_iterator key_prefix_it {_cache_base_path, ec};
+    if (ec) {
+        LOG(WARNING) << ec.message();
+        return;
+    }
+    for (; key_prefix_it != std::filesystem::directory_iterator(); ++key_prefix_it) {
+        if (!key_prefix_it->is_directory()) {
+            // skip version file
+            continue;
         }
-        for (; key_prefix_it != std::filesystem::directory_iterator(); ++key_prefix_it) {
-            if (!key_prefix_it->is_directory()) {
-                // skip version file
-                continue;
-            }
-            if (key_prefix_it->path().filename().native().size() != KEY_PREFIX_LENGTH) {
-                LOG(WARNING) << "Unknown directory " << key_prefix_it->path().native()
-                             << ", try to remove it";
-                std::error_code ec;
-                std::filesystem::remove(key_prefix_it->path(), ec);
-                if (ec) {
-                    LOG(WARNING) << "failed to remove=" << key_prefix_it->path()
-                                 << " msg=" << ec.message();
-                }
-                continue;
-            }
-            std::filesystem::directory_iterator key_it {key_prefix_it->path(), ec};
+        if (key_prefix_it->path().filename().native() == "meta") {
+            // skip rocksdb dir
+            continue;
+        }
+        if (key_prefix_it->path().filename().native().size() != KEY_PREFIX_LENGTH) {
+            LOG(WARNING) << "Unknown directory " << key_prefix_it->path().native()
+                         << ", try to remove it";
+            std::filesystem::remove(key_prefix_it->path(), ec);
             if (ec) {
-                LOG(WARNING) << ec.message();
-                continue;
+                LOG(WARNING) << "failed to remove=" << key_prefix_it->path()
+                             << " msg=" << ec.message();
             }
-            scan_file_cache(key_it);
+            continue;
         }
-    } else {
-        std::filesystem::directory_iterator key_it {_cache_base_path, ec};
+        std::filesystem::directory_iterator key_it {key_prefix_it->path(), ec};
         if (ec) {
             LOG(WARNING) << ec.message();
-            return;
+            continue;
         }
         scan_file_cache(key_it);
     }
+
     if (!batch_load_buffer.empty()) {
         add_cell_batch_func();
     }
     TEST_SYNC_POINT_CALLBACK("BlockFileCache::TmpFile2");
 }
 
+Status FSFileCacheStorage::get_file_cache_infos(std::vector<FileCacheInfo>& infos,
+                                                std::lock_guard<std::mutex>& cache_lock) const {
+    std::error_code ec;
+    std::filesystem::directory_iterator key_prefix_it {_cache_base_path, ec};
+    if (ec) [[unlikely]] {
+        LOG(ERROR) << fmt::format("Failed to list dir {}, err={}", _cache_base_path, ec.message());
+        return Status::InternalError("Failed to list dir {}, err={}", _cache_base_path,
+                                     ec.message());
+    }
+    // Only supports version 2. For more details, refer to 'USE_CACHE_VERSION2'.
+    for (; key_prefix_it != std::filesystem::directory_iterator(); ++key_prefix_it) {
+        if (!key_prefix_it->is_directory()) {
+            // skip version file
+            continue;
+        }
+        if (key_prefix_it->path().filename().native().size() != KEY_PREFIX_LENGTH) {
+            LOG(WARNING) << "Unknown directory " << key_prefix_it->path().native();
+            continue;
+        }
+        std::filesystem::directory_iterator key_it {key_prefix_it->path(), ec};
+        if (ec) [[unlikely]] {
+            LOG(ERROR) << fmt::format("Failed to list dir {}, err={}",
+                                      key_prefix_it->path().filename().native(), ec.message());
+            return Status::InternalError("Failed to list dir {}, err={}",
+                                         key_prefix_it->path().filename().native(), ec.message());
+        }
+        for (; key_it != std::filesystem::directory_iterator(); ++key_it) {
+            auto key_with_suffix = key_it->path().filename().native();
+            auto delim_pos = key_with_suffix.find('_');
+            DCHECK(delim_pos != std::string::npos);
+            std::string key_str = key_with_suffix.substr(0, delim_pos);
+            std::string expiration_time_str = key_with_suffix.substr(delim_pos + 1);
+            long expiration_time = std::stoul(expiration_time_str);
+            auto hash = UInt128Wrapper(vectorized::unhex_uint<uint128_t>(key_str.c_str()));
+            std::filesystem::directory_iterator offset_it(key_it->path(), ec);
+            if (ec) [[unlikely]] {
+                LOG(ERROR) << fmt::format("Failed to list dir {}, err={}",
+                                          key_it->path().filename().native(), ec.message());
+                return Status::InternalError("Failed to list dir {}, err={}",
+                                             key_it->path().filename().native(), ec.message());
+            }
+            for (; offset_it != std::filesystem::directory_iterator(); ++offset_it) {
+                size_t size = offset_it->file_size(ec);
+                if (ec) [[unlikely]] {
+                    LOG(ERROR) << fmt::format("Failed to get file size, file name {}, err={}",
+                                              key_it->path().filename().native(), ec.message());
+                    return Status::InternalError("Failed to get file size, file name {}, err={}",
+                                                 key_it->path().filename().native(), ec.message());
+                }
+                size_t offset = 0;
+                bool is_tmp = false;
+                FileCacheType cache_type = FileCacheType::NORMAL;
+                RETURN_IF_ERROR(this->parse_filename_suffix_to_cache_type(
+                        fs, offset_it->path().filename().native(), expiration_time, size, &offset,
+                        &is_tmp, &cache_type));
+                infos.emplace_back(hash, expiration_time, size, offset, is_tmp, cache_type);
+            }
+        }
+    }
+    return Status::OK();
+}
+
+void FSFileCacheStorage::load_cache_info_into_memory_from_db(BlockFileCache* _mgr) const {
+    int scan_length = 10000;
+    std::vector<BatchLoadArgs> batch_load_buffer;
+    batch_load_buffer.reserve(scan_length);
+    auto add_cell_batch_func = [&]() {
+        SCOPED_CACHE_LOCK(_mgr->_mutex, _mgr);
+
+        auto f = [&](const BatchLoadArgs& args) {
+            // in async load mode, a cell may be added twice.
+            if (handle_already_loaded_block(_mgr, args.hash, args.offset, args.size,
+                                            args.ctx.tablet_id, cache_lock)) {
+                return;
+            }
+            _mgr->add_cell(args.hash, args.ctx, args.offset, args.size,
+                           FileBlock::State::DOWNLOADED, cache_lock);
+            return;
+        };
+        std::for_each(batch_load_buffer.begin(), batch_load_buffer.end(), f);
+        batch_load_buffer.clear();
+    };
+
+    auto iterator = _meta_store->get_all();
+    if (!iterator) {
+        LOG(WARNING) << "Failed to create iterator for meta store";
+        return;
+    }
+
+    while (iterator->valid()) {
+        BlockMetaKey meta_key = iterator->key();
+        BlockMeta meta_value = iterator->value();
+
+        // Check for deserialization errors
+        if (!iterator->get_last_key_error().ok() || !iterator->get_last_value_error().ok()) {
+            LOG(WARNING) << "Failed to deserialize cache block metadata: "
+                         << "key_error=" << iterator->get_last_key_error().to_string()
+                         << ", value_error=" << iterator->get_last_value_error().to_string();
+            iterator->next();
+            continue; // Skip invalid records
+        }
+
+        VLOG_DEBUG << "Processing cache block: tablet_id=" << meta_key.tablet_id
+                   << ", hash=" << meta_key.hash.low() << "-" << meta_key.hash.high()
+                   << ", offset=" << meta_key.offset << ", type=" << meta_value.type
+                   << ", size=" << meta_value.size << ", ttl=" << meta_value.ttl;
+
+        BatchLoadArgs args;
+        args.hash = meta_key.hash;
+        args.offset = meta_key.offset;
+        args.size = meta_value.size;
+        args.is_tmp = false;
+
+        CacheContext ctx;
+        ctx.cache_type = static_cast<FileCacheType>(meta_value.type);
+        ctx.expiration_time = meta_value.ttl;
+        ctx.tablet_id =
+                meta_key.tablet_id; //TODO(zhengyu): zero if loaded from v2, we can use this to decide whether the block is loaded from v2 or v3
+        args.ctx = ctx;
+
+        args.key_path = "";
+        args.offset_path = "";
+
+        batch_load_buffer.push_back(std::move(args));
+
+        if (batch_load_buffer.size() >= scan_length) {
+            add_cell_batch_func();
+            std::this_thread::sleep_for(std::chrono::microseconds(10));
+        }
+
+        iterator->next();
+    }
+
+    LOG(INFO) << "Finished loading cache info from meta store using RocksDB iterator";
+
+    if (!batch_load_buffer.empty()) {
+        add_cell_batch_func();
+    }
+    TEST_SYNC_POINT_CALLBACK("BlockFileCache::TmpFile2");
+}
+
+void FSFileCacheStorage::load_cache_info_into_memory(BlockFileCache* _mgr) const {
+    // First load from database
+    load_cache_info_into_memory_from_db(_mgr);
+
+    std::string version;
+    auto st = read_file_cache_version(&version);
+    if (!st.ok()) {
+        LOG(WARNING) << "Failed to read file cache version: " << st.to_string();
+        return;
+    }
+    if (version == "3.0") {
+        return;
+    }
+
+    // Count blocks loaded from database
+    size_t db_block_count = 0;
+    {
+        std::lock_guard<std::mutex> lock(_mgr->_mutex);
+        for (const auto& hash_entry : _mgr->_files) {
+            db_block_count += hash_entry.second.size();
+        }
+    }
+
+    // Estimate file count from filesystem using statfs
+    size_t estimated_file_count = estimate_file_count_from_statfs();
+
+    LOG(INFO) << "Cache loading statistics - DB blocks: " << db_block_count
+              << ", Estimated FS files: " << estimated_file_count;
+
+    // If the difference is more than threshold, load from filesystem as well
+    if (estimated_file_count > 100) {
+        double difference_ratio =
+                (static_cast<double>(estimated_file_count) - static_cast<double>(db_block_count)) /
+                static_cast<double>(estimated_file_count);
+
+        if (difference_ratio > config::file_cache_meta_store_vs_file_system_diff_num_threshold) {
+            LOG(WARNING) << "Significant difference between DB blocks (" << db_block_count
+                         << ") and estimated FS files (" << estimated_file_count
+                         << "), difference ratio: " << difference_ratio * 100 << "%"
+                         << ". Loading from filesystem as well.";
+            load_cache_info_into_memory_from_fs(_mgr);
+        } else {
+            LOG(INFO) << "DB and FS counts are consistent, difference ratio: "
+                      << difference_ratio * 100 << "%, skipping FS load.";
+            if (st = write_file_cache_version(); !st.ok()) {
+                LOG(WARNING) << "Failed to write version hints for file cache, err="
+                             << st.to_string();
+            }
+            // TODO(zhengyu): use anti-leak machinism to remove v2 format directory
+        }
+    } else {
+        LOG(INFO) << "FS contains low number of files, num = " << estimated_file_count
+                  << ", skipping FS load.";
+        if (st = write_file_cache_version(); !st.ok()) {
+            LOG(WARNING) << "Failed to write version hints for file cache, err=" << st.to_string();
+        }
+    }
+}
+
 void FSFileCacheStorage::load_blocks_directly_unlocked(BlockFileCache* mgr, const FileCacheKey& key,
                                                        std::lock_guard<std::mutex>& cache_lock) {
-    // async load, can't find key, need to check exist.
-    auto key_path = get_path_in_local_cache(key.hash, key.meta.expiration_time);
-    bool exists = false;
-    auto st = fs->exists(key_path, &exists);
-    if (auto st = fs->exists(key_path, &exists); !exists && st.ok()) {
+    BlockMetaKey mkey(key.meta.tablet_id, UInt128Wrapper(key.hash), key.offset);
+    auto block_meta = _meta_store->get(mkey);
+    if (!block_meta.has_value()) {
         // cache miss
-        return;
-    } else if (!st.ok()) [[unlikely]] {
-        LOG_WARNING("failed to exists file {}", key_path).error(st);
         return;
     }
 
     CacheContext context_original;
     context_original.query_id = TUniqueId();
-    context_original.expiration_time = key.meta.expiration_time;
-    std::error_code ec;
-    std::filesystem::directory_iterator check_it(key_path, ec);
-    if (ec) [[unlikely]] {
-        LOG(WARNING) << "fail to directory_iterator " << ec.message();
+    context_original.expiration_time = block_meta->ttl;
+    context_original.cache_type = static_cast<FileCacheType>(block_meta->type);
+    context_original.tablet_id = key.meta.tablet_id;
+
+    if (handle_already_loaded_block(mgr, key.hash, key.offset, block_meta->size, key.meta.tablet_id,
+                                    cache_lock)) {
         return;
-    }
-    for (; check_it != std::filesystem::directory_iterator(); ++check_it) {
-        size_t size = check_it->file_size(ec);
-        size_t offset = 0;
-        bool is_tmp = false;
-        FileCacheType cache_type = FileCacheType::NORMAL;
-        if (!parse_filename_suffix_to_cache_type(fs, check_it->path().filename().native(),
-                                                 context_original.expiration_time, size, &offset,
-                                                 &is_tmp, &cache_type)) {
-            continue;
-        }
-        if (!mgr->_files.contains(key.hash) || !mgr->_files[key.hash].contains(offset)) {
-            // if the file is tmp, it means it is the old file and it should be removed
-            if (is_tmp) {
-                std::error_code ec;
-                std::filesystem::remove(check_it->path(), ec);
-                if (ec) {
-                    LOG(WARNING) << fmt::format("cannot remove {}: {}", check_it->path().native(),
-                                                ec.message());
-                }
-            } else {
-                context_original.cache_type = cache_type;
-                mgr->add_cell(key.hash, context_original, offset, size,
-                              FileBlock::State::DOWNLOADED, cache_lock);
-            }
-        }
+    } else {
+        mgr->add_cell(key.hash, context_original, key.offset, block_meta->size,
+                      FileBlock::State::DOWNLOADED, cache_lock);
     }
 }
 
@@ -841,6 +965,7 @@ Status FSFileCacheStorage::clear(std::string& msg) {
     auto t0 = std::chrono::steady_clock::now();
     for (; key_it != std::filesystem::directory_iterator(); ++key_it) {
         if (!key_it->is_directory()) continue; // all file cache data is in sub-directories
+        if (key_it->path().filename().native() == "meta") continue;
         ++total;
         std::string cache_key = key_it->path().string();
         auto st = global_local_filesystem()->delete_directory(cache_key);
@@ -849,6 +974,7 @@ Status FSFileCacheStorage::clear(std::string& msg) {
         LOG(WARNING) << "failed to clear base_path=" << _cache_base_path
                      << " path_to_delete=" << cache_key << " error=" << st;
     }
+    _meta_store->clear();
     auto t1 = std::chrono::steady_clock::now();
     std::stringstream ss;
     ss << "finished clear file storage, path=" << _cache_base_path
@@ -863,14 +989,89 @@ Status FSFileCacheStorage::clear(std::string& msg) {
 }
 
 std::string FSFileCacheStorage::get_local_file(const FileCacheKey& key) {
-    return get_path_in_local_cache(get_path_in_local_cache(key.hash, key.meta.expiration_time),
-                                   key.offset, key.meta.type, false);
+    return get_path_in_local_cache_v3(get_path_in_local_cache_v3(key.hash), key.offset, false);
 }
 
 FSFileCacheStorage::~FSFileCacheStorage() {
     if (_cache_background_load_thread.joinable()) {
         _cache_background_load_thread.join();
     }
+}
+
+size_t FSFileCacheStorage::estimate_file_count_from_statfs() const {
+    struct statvfs vfs;
+    if (statvfs(_cache_base_path.c_str(), &vfs) != 0) {
+        LOG(WARNING) << "Failed to get filesystem statistics for path: " << _cache_base_path
+                     << ", error: " << strerror(errno);
+        return 0;
+    }
+
+    // Get total size of cache directory to estimate file count
+    std::error_code ec;
+    uintmax_t total_size = 0;
+    std::vector<std::filesystem::path> pending_dirs {std::filesystem::path(_cache_base_path)};
+    while (!pending_dirs.empty()) {
+        auto current_dir = pending_dirs.back();
+        pending_dirs.pop_back();
+
+        std::filesystem::directory_iterator it(current_dir, ec);
+        if (ec) {
+            LOG(WARNING) << "Failed to list directory while estimating file count, dir="
+                         << current_dir << ", err=" << ec.message();
+            ec.clear();
+            continue;
+        }
+
+        for (; it != std::filesystem::directory_iterator(); ++it) {
+            std::error_code status_ec;
+            auto entry_status = it->symlink_status(status_ec);
+            TEST_SYNC_POINT_CALLBACK(
+                    "FSFileCacheStorage::estimate_file_count_from_statfs::AfterEntryStatus",
+                    &status_ec);
+            if (status_ec) {
+                LOG(WARNING) << "Failed to stat entry while estimating file count, path="
+                             << it->path() << ", err=" << status_ec.message();
+                continue;
+            }
+
+            if (std::filesystem::is_directory(entry_status)) {
+                auto next_dir = it->path();
+                TEST_SYNC_POINT_CALLBACK(
+                        "FSFileCacheStorage::estimate_file_count_from_statfs::OnDirectory",
+                        &next_dir);
+                pending_dirs.emplace_back(next_dir);
+                continue;
+            }
+
+            if (std::filesystem::is_regular_file(entry_status)) {
+                std::error_code size_ec;
+                auto file_size = it->file_size(size_ec);
+                TEST_SYNC_POINT_CALLBACK(
+                        "FSFileCacheStorage::estimate_file_count_from_statfs::AfterFileSize",
+                        &size_ec);
+                if (size_ec) {
+                    LOG(WARNING) << "Failed to get file size while estimating file count, path="
+                                 << it->path() << ", err=" << size_ec.message();
+                    continue;
+                }
+                total_size += file_size;
+            }
+        }
+    }
+
+    if (total_size == 0) {
+        return 0;
+    }
+
+    // Estimate file count based on average file size
+    // Assuming average file size of 1MB for cache blocks
+    const uintmax_t average_file_size = 1024 * 1024; // 1MB
+    size_t estimated_file_count = total_size / average_file_size;
+
+    LOG(INFO) << "Estimated file count for cache path " << _cache_base_path
+              << ": total_size=" << total_size << ", estimated_files=" << estimated_file_count;
+
+    return estimated_file_count;
 }
 
 } // namespace doris::io

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -23,6 +23,7 @@
 #include <shared_mutex>
 #include <thread>
 
+#include "io/cache/cache_block_meta_store.h"
 #include "io/cache/file_cache_common.h"
 #include "io/cache/file_cache_storage.h"
 #include "io/fs/file_reader.h"
@@ -54,39 +55,40 @@ private:
 
 class FSFileCacheStorage : public FileCacheStorage {
 public:
-    /// use version 2 when USE_CACHE_VERSION2 = true, while use version 1 if false
     /// version 1.0: cache_base_path / key / offset
     /// version 2.0: cache_base_path / key_prefix / key / offset
-    static constexpr bool USE_CACHE_VERSION2 = true;
     static constexpr int KEY_PREFIX_LENGTH = 3;
 
     FSFileCacheStorage() = default;
     ~FSFileCacheStorage() override;
     Status init(BlockFileCache* _mgr) override;
     Status append(const FileCacheKey& key, const Slice& value) override;
-    Status finalize(const FileCacheKey& key) override;
+    Status finalize(const FileCacheKey& key, const size_t size) override;
     Status read(const FileCacheKey& key, size_t value_offset, Slice buffer) override;
     Status remove(const FileCacheKey& key) override;
-    Status change_key_meta_type(const FileCacheKey& key, const FileCacheType type) override;
-    Status change_key_meta_expiration(const FileCacheKey& key, const uint64_t expiration) override;
+    Status change_key_meta_type(const FileCacheKey& key, const FileCacheType type,
+                                const size_t size) override;
     void load_blocks_directly_unlocked(BlockFileCache* _mgr, const FileCacheKey& key,
                                        std::lock_guard<std::mutex>& cache_lock) override;
     Status clear(std::string& msg) override;
     std::string get_local_file(const FileCacheKey& key) override;
 
-    [[nodiscard]] static std::string get_path_in_local_cache(const std::string& dir, size_t offset,
-                                                             FileCacheType type,
-                                                             bool is_tmp = false);
+    [[nodiscard]] static std::string get_path_in_local_cache_v3(const std::string& dir,
+                                                                size_t offset, bool is_tmp = false);
 
-    [[nodiscard]] static std::string get_path_in_local_cache_old_ttl_format(const std::string& dir,
-                                                                            size_t offset,
-                                                                            FileCacheType type,
-                                                                            bool is_tmp = false);
+    [[nodiscard]] std::string get_path_in_local_cache_v3(const UInt128Wrapper&) const;
 
-    [[nodiscard]] std::string get_path_in_local_cache(const UInt128Wrapper&,
-                                                      uint64_t expiration_time) const;
+    [[nodiscard]] static std::string get_path_in_local_cache_v2(const std::string& dir,
+                                                                size_t offset, FileCacheType type,
+                                                                bool is_tmp = false);
+
+    [[nodiscard]] std::string get_path_in_local_cache_v2(const UInt128Wrapper&,
+                                                         uint64_t expiration_time) const;
 
     FileCacheStorageType get_type() override { return DISK; }
+
+    // Get the meta store instance (only available for DISK storage type)
+    CacheBlockMetaStore* get_meta_store() { return _meta_store.get(); }
 
 private:
     void remove_old_version_directories();
@@ -109,8 +111,18 @@ private:
 
     void load_cache_info_into_memory(BlockFileCache* _mgr) const;
 
-    [[nodiscard]] std::vector<std::string> get_path_in_local_cache_all_candidates(
-            const std::string& dir, size_t offset);
+    bool handle_already_loaded_block(BlockFileCache* mgr, const UInt128Wrapper& hash, size_t offset,
+                                     size_t new_size, int64_t tablet_id,
+                                     std::lock_guard<std::mutex>& cache_lock) const;
+
+private:
+    // Helper function to count files in cache directory using statfs
+    size_t estimate_file_count_from_statfs() const;
+    void load_cache_info_into_memory_from_fs(BlockFileCache* _mgr) const;
+    void load_cache_info_into_memory_from_db(BlockFileCache* _mgr) const;
+
+    Status get_file_cache_infos(std::vector<FileCacheInfo>& infos,
+                                std::lock_guard<std::mutex>& cache_lock) const override;
 
     std::string _cache_base_path;
     std::thread _cache_background_load_thread;
@@ -119,6 +131,7 @@ private:
     std::mutex _mtx;
     std::unordered_map<FileWriterMapKey, FileWriterPtr, FileWriterMapKeyHash> _key_to_writer;
     std::shared_ptr<bvar::LatencyRecorder> _iterator_dir_retry_cnt;
+    std::unique_ptr<CacheBlockMetaStore> _meta_store;
 };
 
 } // namespace doris::io

--- a/be/src/io/cache/lru_queue_recorder.cpp
+++ b/be/src/io/cache/lru_queue_recorder.cpp
@@ -62,6 +62,15 @@ void LRUQueueRecorder::replay_queue_event(FileCacheType type) {
                 }
                 break;
             }
+            case CacheLRULogType::RESIZE: {
+                auto it = shadow_queue.get(log->hash, log->offset, lru_log_lock);
+                if (it != std::list<LRUQueue::FileKeyAndOffset>::iterator()) {
+                    shadow_queue.resize(it, log->size, lru_log_lock);
+                } else {
+                    LOG(WARNING) << "RESIZE failed, doesn't exist in shadow queue";
+                }
+                break;
+            }
             default:
                 LOG(WARNING) << "Unknown CacheLRULogType: " << static_cast<int>(log->type);
                 break;

--- a/be/src/io/cache/lru_queue_recorder.h
+++ b/be/src/io/cache/lru_queue_recorder.h
@@ -31,7 +31,8 @@ enum class CacheLRULogType {
     ADD = 0, // all of the integer types
     REMOVE = 1,
     MOVETOBACK = 2,
-    INVALID = 3,
+    RESIZE = 3,
+    INVALID = 4,
 };
 
 struct CacheLRULog {

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -286,7 +286,7 @@ public:
                          int64_t level = 2, int64_t condition = 0, int64_t value = 0)
                 : Counter(type, value, level),
                   _condition(condition),
-                  _value(value),
+                  _stored_value(value),
                   _condition_func(condition_func) {}
 
         Counter* clone() const override {
@@ -296,13 +296,13 @@ public:
 
         int64_t value() const override {
             std::lock_guard<std::mutex> l(_mutex);
-            return _value;
+            return _stored_value;
         }
 
         void conditional_update(int64_t c, int64_t v) {
             std::lock_guard<std::mutex> l(_mutex);
             if (_condition_func(_condition, c)) {
-                _value = v;
+                _stored_value = v;
                 _condition = c;
             }
         }
@@ -310,7 +310,7 @@ public:
     private:
         mutable std::mutex _mutex;
         int64_t _condition;
-        int64_t _value;
+        int64_t _stored_value;
         ConditionCounterFunction _condition_func;
     };
 

--- a/be/test/io/cache/block_file_cache_test_meta_store.cpp
+++ b/be/test/io/cache/block_file_cache_test_meta_store.cpp
@@ -1,0 +1,728 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// This file is copied from
+// https://github.com/ClickHouse/ClickHouse/blob/master/src/Interpreters/tests/gtest_lru_file_cache.cpp
+// and modified by Doris
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+#endif
+
+#define private public
+#define protected public
+#include "block_file_cache_test_common.h"
+#undef private
+#undef protected
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+namespace doris::io {
+
+namespace {
+
+static size_t verify_meta_key_cnt = 0;
+
+void verify_meta_key(CacheBlockMetaStore& meta_store, int64_t tablet_id,
+                     const std::string& key_name, size_t offset, FileCacheType expected_type,
+                     uint64_t ttl, size_t size) {
+    verify_meta_key_cnt++;
+    std::cout << "verify_meta_key called " << verify_meta_key_cnt << " times" << std::endl;
+    BlockMetaKey mkey(tablet_id, io::BlockFileCache::hash(key_name), offset);
+    auto meta = meta_store.get(mkey);
+    ASSERT_TRUE(meta.has_value());
+    ASSERT_EQ(meta->type, expected_type);
+    ASSERT_EQ(meta->ttl, ttl);
+    ASSERT_EQ(meta->size, size);
+}
+
+} // namespace
+
+TEST_F(BlockFileCacheTest, version3_add_remove_restart) {
+    config::enable_evict_file_cache_in_advance = false;
+    config::file_cache_enter_disk_resource_limit_mode_percent = 99;
+    config::file_cache_background_lru_dump_interval_ms = 3000;
+    config::file_cache_background_lru_dump_update_cnt_threshold = 0;
+    config::file_cache_background_lru_dump_tail_record_num =
+            2; // only dump last 2, to check dump works with meta store
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    io::FileCacheSettings settings;
+
+    settings.ttl_queue_size = 5000000;
+    settings.ttl_queue_elements = 50000;
+    settings.query_queue_size = 5000000;
+    settings.query_queue_elements = 50000;
+    settings.index_queue_size = 5000000;
+    settings.index_queue_elements = 50000;
+    settings.disposable_queue_size = 5000000;
+    settings.disposable_queue_elements = 50000;
+    settings.capacity = 20000000;
+    settings.max_file_block_size = 100000;
+    settings.max_query_cache_size = 30;
+
+    uint64_t expiration_time = 120;
+
+    int i = 0;
+    { // cache1
+        io::BlockFileCache cache(cache_base_path, settings);
+        ASSERT_TRUE(cache.initialize());
+        for (; i < 100; i++) {
+            if (cache.get_async_open_success()) {
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        ASSERT_TRUE(cache.get_async_open_success());
+
+        io::CacheContext context1;
+        ReadStatistics rstats;
+        context1.stats = &rstats;
+        context1.cache_type = io::FileCacheType::NORMAL;
+        context1.query_id = query_id;
+        context1.tablet_id = 47;
+        auto key1 = io::BlockFileCache::hash("key1");
+
+        int64_t offset = 0;
+
+        for (; offset < 500000; offset += 100000) {
+            auto holder = cache.get_or_set(key1, offset, 100000, context1);
+            auto blocks = fromHolder(holder);
+            ASSERT_EQ(blocks.size(), 1);
+
+            assert_range(1, blocks[0], io::FileBlock::Range(offset, offset + 99999),
+                         io::FileBlock::State::EMPTY);
+            ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+            download(blocks[0]);
+            assert_range(2, blocks[0], io::FileBlock::Range(offset, offset + 99999),
+                         io::FileBlock::State::DOWNLOADED);
+
+            blocks.clear();
+        }
+        io::CacheContext context2;
+        context2.stats = &rstats;
+        context2.cache_type = io::FileCacheType::INDEX;
+        context2.query_id = query_id;
+        context2.tablet_id = 48;
+        auto key2 = io::BlockFileCache::hash("key2");
+
+        offset = 0;
+
+        for (; offset < 500000; offset += 100000) {
+            auto holder = cache.get_or_set(key2, offset, 100000, context2);
+            auto blocks = fromHolder(holder);
+            ASSERT_EQ(blocks.size(), 1);
+
+            assert_range(1, blocks[0], io::FileBlock::Range(offset, offset + 99999),
+                         io::FileBlock::State::EMPTY);
+            ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+            download(blocks[0]);
+            assert_range(2, blocks[0], io::FileBlock::Range(offset, offset + 99999),
+                         io::FileBlock::State::DOWNLOADED);
+
+            blocks.clear();
+        }
+        io::CacheContext context3;
+        context3.stats = &rstats;
+        context3.cache_type = io::FileCacheType::TTL;
+        context3.query_id = query_id;
+        context3.expiration_time = expiration_time;
+        context3.tablet_id = 49;
+        auto key3 = io::BlockFileCache::hash("key3");
+
+        offset = 0;
+
+        for (; offset < 500000; offset += 100000) {
+            auto holder = cache.get_or_set(key3, offset, 100000, context3);
+            auto blocks = fromHolder(holder);
+            ASSERT_EQ(blocks.size(), 1);
+
+            assert_range(1, blocks[0], io::FileBlock::Range(offset, offset + 99999),
+                         io::FileBlock::State::EMPTY);
+            ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+            download(blocks[0]);
+            assert_range(2, blocks[0], io::FileBlock::Range(offset, offset + 99999),
+                         io::FileBlock::State::DOWNLOADED);
+
+            blocks.clear();
+        }
+
+        io::CacheContext context4;
+        context4.stats = &rstats;
+        context4.cache_type = io::FileCacheType::DISPOSABLE;
+        context4.query_id = query_id;
+        context4.tablet_id = 50;
+        auto key4 = io::BlockFileCache::hash("key4");
+
+        offset = 0;
+
+        for (; offset < 500000; offset += 100000) {
+            auto holder = cache.get_or_set(key4, offset, 100000, context4);
+            auto blocks = fromHolder(holder);
+            ASSERT_EQ(blocks.size(), 1);
+
+            assert_range(1, blocks[0], io::FileBlock::Range(offset, offset + 99999),
+                         io::FileBlock::State::EMPTY);
+            ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+            download(blocks[0]);
+            assert_range(2, blocks[0], io::FileBlock::Range(offset, offset + 99999),
+                         io::FileBlock::State::DOWNLOADED);
+
+            blocks.clear();
+        }
+        ASSERT_EQ(cache.get_stats_unsafe()["disposable_queue_curr_size"], 500000);
+        ASSERT_EQ(cache.get_stats_unsafe()["ttl_queue_curr_size"], 500000);
+        ASSERT_EQ(cache.get_stats_unsafe()["index_queue_curr_size"], 500000);
+        ASSERT_EQ(cache.get_stats_unsafe()["normal_queue_curr_size"], 500000);
+
+        // check the meta store to see the content
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            // Check if storage is FSFileCacheStorage before accessing _meta_store
+            auto* fs_storage = dynamic_cast<FSFileCacheStorage*>(cache._storage.get());
+            ASSERT_NE(fs_storage, nullptr)
+                    << "Expected FSFileCacheStorage but got different storage type";
+
+            auto& meta_store = fs_storage->_meta_store;
+            verify_meta_key(*meta_store, 47, "key1", 0, FileCacheType::NORMAL, 0, 100000);
+            verify_meta_key(*meta_store, 47, "key1", 100000, FileCacheType::NORMAL, 0, 100000);
+            verify_meta_key(*meta_store, 47, "key1", 200000, FileCacheType::NORMAL, 0, 100000);
+            verify_meta_key(*meta_store, 47, "key1", 300000, FileCacheType::NORMAL, 0, 100000);
+            verify_meta_key(*meta_store, 47, "key1", 400000, FileCacheType::NORMAL, 0, 100000);
+            verify_meta_key(*meta_store, 48, "key2", 0, FileCacheType::INDEX, 0, 100000);
+            verify_meta_key(*meta_store, 48, "key2", 100000, FileCacheType::INDEX, 0, 100000);
+            verify_meta_key(*meta_store, 48, "key2", 200000, FileCacheType::INDEX, 0, 100000);
+            verify_meta_key(*meta_store, 48, "key2", 300000, FileCacheType::INDEX, 0, 100000);
+            verify_meta_key(*meta_store, 48, "key2", 400000, FileCacheType::INDEX, 0, 100000);
+            verify_meta_key(*meta_store, 49, "key3", 0, FileCacheType::TTL, expiration_time,
+                            100000);
+            verify_meta_key(*meta_store, 49, "key3", 100000, FileCacheType::TTL, expiration_time,
+                            100000);
+            verify_meta_key(*meta_store, 49, "key3", 200000, FileCacheType::TTL, expiration_time,
+                            100000);
+            verify_meta_key(*meta_store, 49, "key3", 300000, FileCacheType::TTL, expiration_time,
+                            100000);
+            verify_meta_key(*meta_store, 49, "key3", 400000, FileCacheType::TTL, expiration_time,
+                            100000);
+            verify_meta_key(*meta_store, 50, "key4", 0, FileCacheType::DISPOSABLE, 0, 100000);
+            verify_meta_key(*meta_store, 50, "key4", 100000, FileCacheType::DISPOSABLE, 0, 100000);
+            verify_meta_key(*meta_store, 50, "key4", 200000, FileCacheType::DISPOSABLE, 0, 100000);
+            verify_meta_key(*meta_store, 50, "key4", 300000, FileCacheType::DISPOSABLE, 0, 100000);
+            verify_meta_key(*meta_store, 50, "key4", 400000, FileCacheType::DISPOSABLE, 0, 100000);
+        }
+
+        // all queue are filled, let's check the lru log records
+        ASSERT_EQ(cache._lru_recorder->_ttl_lru_log_queue.size_approx(), 5);
+        ASSERT_EQ(cache._lru_recorder->_index_lru_log_queue.size_approx(), 5);
+        ASSERT_EQ(cache._lru_recorder->_normal_lru_log_queue.size_approx(), 5);
+        ASSERT_EQ(cache._lru_recorder->_disposable_lru_log_queue.size_approx(), 5);
+
+        // then check the log replay
+        std::this_thread::sleep_for(std::chrono::milliseconds(
+                2 * config::file_cache_background_lru_log_replay_interval_ms));
+        ASSERT_EQ(cache._lru_recorder->_shadow_ttl_queue.get_elements_num_unsafe(), 5);
+        ASSERT_EQ(cache._lru_recorder->_shadow_index_queue.get_elements_num_unsafe(), 5);
+        ASSERT_EQ(cache._lru_recorder->_shadow_normal_queue.get_elements_num_unsafe(), 5);
+        ASSERT_EQ(cache._lru_recorder->_shadow_disposable_queue.get_elements_num_unsafe(), 5);
+
+        // do some REMOVE
+        {
+            cache.remove_if_cached(key2); // remove all element from index queue
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(
+                2 * config::file_cache_background_lru_log_replay_interval_ms));
+        ASSERT_EQ(cache._lru_recorder->_shadow_ttl_queue.get_elements_num_unsafe(), 5);
+        ASSERT_EQ(cache._lru_recorder->_shadow_index_queue.get_elements_num_unsafe(), 0);
+        ASSERT_EQ(cache._lru_recorder->_shadow_normal_queue.get_elements_num_unsafe(), 5);
+        ASSERT_EQ(cache._lru_recorder->_shadow_disposable_queue.get_elements_num_unsafe(), 5);
+
+        // check the meta store to see the content
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            auto* fs_storage = dynamic_cast<FSFileCacheStorage*>(cache._storage.get());
+            ASSERT_NE(fs_storage, nullptr)
+                    << "Expected FSFileCacheStorage but got different storage type";
+
+            auto& meta_store = fs_storage->_meta_store;
+            verify_meta_key(*meta_store, 47, "key1", 0, FileCacheType::NORMAL, 0, 100000);
+            verify_meta_key(*meta_store, 47, "key1", 100000, FileCacheType::NORMAL, 0, 100000);
+            verify_meta_key(*meta_store, 47, "key1", 200000, FileCacheType::NORMAL, 0, 100000);
+            verify_meta_key(*meta_store, 47, "key1", 300000, FileCacheType::NORMAL, 0, 100000);
+            verify_meta_key(*meta_store, 47, "key1", 400000, FileCacheType::NORMAL, 0, 100000);
+
+            BlockMetaKey mkey(48, io::BlockFileCache::hash("key2"), 0);
+            auto meta = meta_store->get(mkey);
+            ASSERT_FALSE(meta.has_value());
+
+            verify_meta_key(*meta_store, 49, "key3", 0, FileCacheType::TTL, expiration_time,
+                            100000);
+            verify_meta_key(*meta_store, 49, "key3", 100000, FileCacheType::TTL, expiration_time,
+                            100000);
+            verify_meta_key(*meta_store, 49, "key3", 200000, FileCacheType::TTL, expiration_time,
+                            100000);
+            verify_meta_key(*meta_store, 49, "key3", 300000, FileCacheType::TTL, expiration_time,
+                            100000);
+            verify_meta_key(*meta_store, 49, "key3", 400000, FileCacheType::TTL, expiration_time,
+                            100000);
+            verify_meta_key(*meta_store, 50, "key4", 0, FileCacheType::DISPOSABLE, 0, 100000);
+            verify_meta_key(*meta_store, 50, "key4", 100000, FileCacheType::DISPOSABLE, 0, 100000);
+            verify_meta_key(*meta_store, 50, "key4", 200000, FileCacheType::DISPOSABLE, 0, 100000);
+            verify_meta_key(*meta_store, 50, "key4", 300000, FileCacheType::DISPOSABLE, 0, 100000);
+            verify_meta_key(*meta_store, 50, "key4", 400000, FileCacheType::DISPOSABLE, 0, 100000);
+        }
+        std::this_thread::sleep_for(
+                std::chrono::milliseconds(2 * config::file_cache_background_lru_dump_interval_ms));
+    }
+
+    { // cache2
+        // let's try restore
+        io::BlockFileCache cache2(cache_base_path, settings);
+        ASSERT_TRUE(cache2.initialize());
+        for (i = 0; i < 100; i++) {
+            if (cache2.get_async_open_success()) {
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        ASSERT_TRUE(cache2.get_async_open_success());
+
+        // check the size of cache2
+        ASSERT_EQ(cache2._ttl_queue.get_elements_num_unsafe(), 5);
+        ASSERT_EQ(cache2._index_queue.get_elements_num_unsafe(), 0);
+        ASSERT_EQ(cache2._normal_queue.get_elements_num_unsafe(), 5);
+        ASSERT_EQ(cache2._disposable_queue.get_elements_num_unsafe(), 5);
+        ASSERT_EQ(cache2._cur_cache_size, 1500000);
+
+        // check meta store
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            auto* fs_storage = dynamic_cast<FSFileCacheStorage*>(cache2._storage.get());
+            ASSERT_NE(fs_storage, nullptr)
+                    << "Expected FSFileCacheStorage but got different storage type";
+
+            auto& meta_store = fs_storage->_meta_store;
+            verify_meta_key(*meta_store, 47, "key1", 0, FileCacheType::NORMAL, 0, 100000);
+            verify_meta_key(*meta_store, 47, "key1", 100000, FileCacheType::NORMAL, 0, 100000);
+            verify_meta_key(*meta_store, 47, "key1", 200000, FileCacheType::NORMAL, 0, 100000);
+            verify_meta_key(*meta_store, 47, "key1", 300000, FileCacheType::NORMAL, 0, 100000);
+            verify_meta_key(*meta_store, 47, "key1", 400000, FileCacheType::NORMAL, 0, 100000);
+
+            BlockMetaKey mkey(48, io::BlockFileCache::hash("key2"), 0);
+            auto meta = meta_store->get(mkey);
+            ASSERT_FALSE(meta.has_value());
+
+            verify_meta_key(*meta_store, 49, "key3", 0, FileCacheType::TTL, expiration_time,
+                            100000);
+            verify_meta_key(*meta_store, 49, "key3", 100000, FileCacheType::TTL, expiration_time,
+                            100000);
+            verify_meta_key(*meta_store, 49, "key3", 200000, FileCacheType::TTL, expiration_time,
+                            100000);
+            verify_meta_key(*meta_store, 49, "key3", 300000, FileCacheType::TTL, expiration_time,
+                            100000);
+            verify_meta_key(*meta_store, 49, "key3", 400000, FileCacheType::TTL, expiration_time,
+                            100000);
+            verify_meta_key(*meta_store, 50, "key4", 0, FileCacheType::DISPOSABLE, 0, 100000);
+            verify_meta_key(*meta_store, 50, "key4", 100000, FileCacheType::DISPOSABLE, 0, 100000);
+            verify_meta_key(*meta_store, 50, "key4", 200000, FileCacheType::DISPOSABLE, 0, 100000);
+            verify_meta_key(*meta_store, 50, "key4", 300000, FileCacheType::DISPOSABLE, 0, 100000);
+            verify_meta_key(*meta_store, 50, "key4", 400000, FileCacheType::DISPOSABLE, 0, 100000);
+        }
+
+        // check blocks restored from lru dump get updated ttl and tablet_id
+        {
+            io::CacheContext context;
+            ReadStatistics rstats;
+            context.stats = &rstats;
+            context.cache_type = io::FileCacheType::TTL;
+            context.tablet_id = 49;
+            context.expiration_time = expiration_time;
+            auto key = io::BlockFileCache::hash("key3");
+
+            auto holder =
+                    cache2.get_or_set(key, 0, 100000, context); // offset = 0 is restore from dump
+            auto blocks = fromHolder(holder);
+            ASSERT_EQ(blocks.size(), 1);
+            auto block = blocks[0];
+            ASSERT_EQ(block->tablet_id(), 49);
+        }
+
+        // do some meta change - type
+        {
+            io::CacheContext context;
+            ReadStatistics rstats;
+            context.stats = &rstats;
+            context.cache_type = io::FileCacheType::NORMAL;
+            context.tablet_id = 47;
+            auto key = io::BlockFileCache::hash("key1");
+
+            auto holder = cache2.get_or_set(key, 300000, 100000, context);
+            auto blocks = fromHolder(holder);
+            ASSERT_EQ(blocks.size(), 1);
+            auto block = blocks[0];
+            ASSERT_EQ(block->tablet_id(), 47);
+
+            ASSERT_TRUE(blocks[0]->change_cache_type(io::FileCacheType::INDEX));
+        }
+        // check the meta
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            auto* fs_storage = dynamic_cast<FSFileCacheStorage*>(cache2._storage.get());
+            ASSERT_NE(fs_storage, nullptr)
+                    << "Expected FSFileCacheStorage but got different storage type";
+
+            auto& meta_store = fs_storage->_meta_store;
+            verify_meta_key(*meta_store, 47, "key1", 300000, FileCacheType::INDEX, 0, 100000);
+        }
+        // change ttl
+        {
+            io::CacheContext context;
+            ReadStatistics rstats;
+            context.stats = &rstats;
+            context.cache_type = io::FileCacheType::TTL;
+            context.tablet_id = 49;
+            context.expiration_time = expiration_time + 3600;
+            auto key = io::BlockFileCache::hash("key3");
+
+            auto holder =
+                    cache2.get_or_set(key, 0, 100000, context); // offset = 0 is restore from dump
+            auto blocks = fromHolder(holder);
+            ASSERT_EQ(blocks.size(), 1);
+            auto block = blocks[0];
+        }
+        // check the meta
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            auto* fs_storage = dynamic_cast<FSFileCacheStorage*>(cache2._storage.get());
+            ASSERT_NE(fs_storage, nullptr)
+                    << "Expected FSFileCacheStorage but got different storage type";
+
+            auto& meta_store = fs_storage->_meta_store;
+            verify_meta_key(
+                    *meta_store, 49, "key3", 0, FileCacheType::TTL, expiration_time,
+                    100000); // won't change ttl when get_or_set now as we introduce ttl mgr to manage ttl
+        }
+    }
+
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+}
+
+TEST_F(BlockFileCacheTest, clear_retains_meta_directory_and_clears_meta_entries) {
+    config::enable_evict_file_cache_in_advance = false;
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+
+    io::FileCacheSettings settings;
+    settings.ttl_queue_size = 5000000;
+    settings.ttl_queue_elements = 50000;
+    settings.query_queue_size = 5000000;
+    settings.query_queue_elements = 50000;
+    settings.index_queue_size = 5000000;
+    settings.index_queue_elements = 50000;
+    settings.disposable_queue_size = 5000000;
+    settings.disposable_queue_elements = 50000;
+    settings.capacity = 20000000;
+    settings.max_file_block_size = 100000;
+    settings.max_query_cache_size = 30;
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    for (int i = 0; i < 100; i++) {
+        if (cache.get_async_open_success()) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_TRUE(cache.get_async_open_success());
+
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::NORMAL;
+    context.query_id.hi = 1;
+    context.query_id.lo = 2;
+    context.tablet_id = 314;
+    auto key = io::BlockFileCache::hash("meta_clear_key");
+
+    auto holder = cache.get_or_set(key, 0, 100000, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 1);
+    assert_range(1, blocks[0], io::FileBlock::Range(0, 99999), io::FileBlock::State::EMPTY);
+    ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+    download(blocks[0]);
+    assert_range(2, blocks[0], io::FileBlock::Range(0, 99999), io::FileBlock::State::DOWNLOADED);
+    blocks.clear();
+
+    auto* fs_storage = dynamic_cast<FSFileCacheStorage*>(cache._storage.get());
+    ASSERT_NE(fs_storage, nullptr) << "Expected FSFileCacheStorage but got different storage type";
+    auto& meta_store = fs_storage->_meta_store;
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    verify_meta_key(*meta_store, context.tablet_id, "meta_clear_key", 0, FileCacheType::NORMAL, 0,
+                    100000);
+
+    cache.clear_file_cache_directly();
+
+    std::string meta_dir = cache.get_base_path() + "/meta";
+    ASSERT_TRUE(fs::exists(meta_dir));
+    ASSERT_TRUE(fs::is_directory(meta_dir));
+
+    BlockMetaKey mkey(context.tablet_id, key, 0);
+    auto meta = meta_store->get(mkey);
+    ASSERT_FALSE(meta.has_value());
+
+    auto iterator = meta_store->get_all();
+    if (iterator != nullptr) {
+        bool has_entry = false;
+        for (; iterator->valid(); iterator->next()) {
+            has_entry = true;
+            break;
+        }
+        ASSERT_FALSE(has_entry) << "Meta store still contains entries after clearing cache";
+    }
+
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+}
+
+TEST_F(BlockFileCacheTest, handle_already_loaded_block_updates_size_and_tablet) {
+    config::enable_evict_file_cache_in_advance = false;
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+
+    io::FileCacheSettings settings;
+    settings.ttl_queue_size = 5000000;
+    settings.ttl_queue_elements = 50000;
+    settings.query_queue_size = 5000000;
+    settings.query_queue_elements = 50000;
+    settings.index_queue_size = 5000000;
+    settings.index_queue_elements = 50000;
+    settings.disposable_queue_size = 5000000;
+    settings.disposable_queue_elements = 50000;
+    settings.capacity = 20000000;
+    settings.max_file_block_size = 100000;
+    settings.max_query_cache_size = 30;
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    for (int i = 0; i < 100; ++i) {
+        if (cache.get_async_open_success()) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_TRUE(cache.get_async_open_success());
+
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::NORMAL;
+    context.query_id.hi = 11;
+    context.query_id.lo = 12;
+    context.tablet_id = 0;
+    auto key = io::BlockFileCache::hash("sync_cached_block_meta_key");
+
+    constexpr size_t kOriginalSize = 100000;
+    auto holder = cache.get_or_set(key, 0, kOriginalSize, context);
+    auto blocks = fromHolder(holder);
+    ASSERT_EQ(blocks.size(), 1);
+    ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+    download(blocks[0], kOriginalSize);
+    blocks.clear();
+
+    auto* fs_storage = dynamic_cast<FSFileCacheStorage*>(cache._storage.get());
+    ASSERT_NE(fs_storage, nullptr) << "Expected FSFileCacheStorage but got different storage type";
+
+    constexpr size_t kNewSize = 2 * kOriginalSize;
+    constexpr int64_t kTabletId = 4242;
+    bool handled = false;
+    {
+        SCOPED_CACHE_LOCK(cache._mutex, (&cache));
+        handled = fs_storage->handle_already_loaded_block(&cache, key, 0, kNewSize, kTabletId,
+                                                          cache_lock);
+    }
+
+    ASSERT_TRUE(handled);
+    auto& cell = cache._files[key][0];
+    EXPECT_EQ(cell.file_block->tablet_id(), kTabletId);
+    EXPECT_EQ(cache._cur_cache_size, kNewSize);
+    EXPECT_EQ(cache._normal_queue.get_capacity_unsafe(), kNewSize);
+
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+}
+TEST_F(BlockFileCacheTest, estimate_file_count_skips_removed_directory) {
+    std::string test_dir = cache_base_path + "/estimate_file_count_removed_dir";
+    if (fs::exists(test_dir)) {
+        fs::remove_all(test_dir);
+    }
+    auto keep_dir = fs::path(test_dir) / "keep";
+    auto remove_dir = fs::path(test_dir) / "remove";
+    fs::create_directories(keep_dir);
+    fs::create_directories(remove_dir);
+
+    auto keep_file = keep_dir / "data.bin";
+    std::string one_mb(1024 * 1024, 'd');
+    {
+        std::ofstream ofs(keep_file, std::ios::binary);
+        ASSERT_TRUE(ofs.good());
+        for (int i = 0; i < 3; ++i) {
+            ofs.write(one_mb.data(), one_mb.size());
+            ASSERT_TRUE(ofs.good());
+        }
+    }
+
+    FSFileCacheStorage storage;
+    storage._cache_base_path = test_dir;
+
+    const std::string sync_point_name =
+            "FSFileCacheStorage::estimate_file_count_from_statfs::OnDirectory";
+    auto* sync_point = doris::SyncPoint::get_instance();
+    doris::SyncPoint::CallbackGuard guard(sync_point_name);
+    sync_point->set_call_back(
+            sync_point_name,
+            [remove_dir](std::vector<std::any>&& args) {
+                auto* path = doris::try_any_cast<std::filesystem::path*>(args[0]);
+                if (*path == remove_dir) {
+                    fs::remove_all(remove_dir);
+                }
+            },
+            &guard);
+    sync_point->enable_processing();
+
+    size_t estimated_files = storage.estimate_file_count_from_statfs();
+
+    sync_point->disable_processing();
+
+    ASSERT_EQ(3, estimated_files);
+    ASSERT_FALSE(fs::exists(remove_dir));
+
+    if (fs::exists(test_dir)) {
+        fs::remove_all(test_dir);
+    }
+}
+
+TEST_F(BlockFileCacheTest, estimate_file_count_handles_stat_failure) {
+    std::string test_dir = cache_base_path + "/estimate_file_count_stat_failure";
+    if (fs::exists(test_dir)) {
+        fs::remove_all(test_dir);
+    }
+    fs::create_directories(test_dir);
+
+    auto data_file = fs::path(test_dir) / "data.bin";
+    std::string one_mb(1024 * 1024, 'x');
+    {
+        std::ofstream ofs(data_file, std::ios::binary);
+        ASSERT_TRUE(ofs.good());
+        ofs.write(one_mb.data(), one_mb.size());
+        ASSERT_TRUE(ofs.good());
+    }
+
+    FSFileCacheStorage storage;
+    storage._cache_base_path = test_dir;
+
+    const std::string sync_point_name =
+            "FSFileCacheStorage::estimate_file_count_from_statfs::AfterEntryStatus";
+    auto* sync_point = doris::SyncPoint::get_instance();
+    doris::SyncPoint::CallbackGuard guard(sync_point_name);
+    sync_point->set_call_back(
+            sync_point_name,
+            [](std::vector<std::any>&& args) {
+                auto* ec = doris::try_any_cast<std::error_code*>(args[0]);
+                if (ec != nullptr) {
+                    *ec = std::make_error_code(std::errc::io_error);
+                }
+            },
+            &guard);
+    sync_point->enable_processing();
+
+    size_t estimated_files = storage.estimate_file_count_from_statfs();
+
+    sync_point->disable_processing();
+
+    ASSERT_EQ(0, estimated_files);
+
+    if (fs::exists(test_dir)) {
+        fs::remove_all(test_dir);
+    }
+}
+
+TEST_F(BlockFileCacheTest, estimate_file_count_handles_file_size_failure) {
+    std::string test_dir = cache_base_path + "/estimate_file_count_file_size_failure";
+    if (fs::exists(test_dir)) {
+        fs::remove_all(test_dir);
+    }
+    fs::create_directories(test_dir);
+
+    auto data_file = fs::path(test_dir) / "data.bin";
+    std::string one_mb(1024 * 1024, 'x');
+    {
+        std::ofstream ofs(data_file, std::ios::binary);
+        ASSERT_TRUE(ofs.good());
+        ofs.write(one_mb.data(), one_mb.size());
+        ASSERT_TRUE(ofs.good());
+    }
+
+    FSFileCacheStorage storage;
+    storage._cache_base_path = test_dir;
+
+    const std::string sync_point_name =
+            "FSFileCacheStorage::estimate_file_count_from_statfs::AfterFileSize";
+    auto* sync_point = doris::SyncPoint::get_instance();
+    doris::SyncPoint::CallbackGuard guard(sync_point_name);
+    sync_point->set_call_back(
+            sync_point_name,
+            [](std::vector<std::any>&& args) {
+                auto* ec = doris::try_any_cast<std::error_code*>(args[0]);
+                if (ec != nullptr) {
+                    *ec = std::make_error_code(std::errc::io_error);
+                }
+            },
+            &guard);
+    sync_point->enable_processing();
+
+    size_t estimated_files = storage.estimate_file_count_from_statfs();
+
+    sync_point->disable_processing();
+
+    ASSERT_EQ(0, estimated_files);
+
+    if (fs::exists(test_dir)) {
+        fs::remove_all(test_dir);
+    }
+}
+
+//TODO(zhengyu): check lazy load
+//TODO(zhengyu): check version2 start
+//TODO(zhengyu): check version2 version3 mixed start
+
+} // namespace doris::io

--- a/be/test/io/cache/lru_queue_test.cpp
+++ b/be/test/io/cache/lru_queue_test.cpp
@@ -115,3 +115,14 @@ TEST_F(LRUQueueTest, SameElementsDifferentOrder) {
 
     EXPECT_EQ(queue1->levenshtein_distance_from(*queue2, lock), 2);
 }
+
+TEST_F(LRUQueueTest, ResizeUpdatesCacheSize) {
+    std::mutex mutex;
+    std::lock_guard lock(mutex);
+
+    auto iter = queue1->add(UInt128Wrapper(123), 0, 1024, lock);
+    EXPECT_EQ(queue1->get_capacity(lock), 1024);
+
+    queue1->resize(iter, 2048, lock);
+    EXPECT_EQ(queue1->get_capacity(lock), 2048);
+}


### PR DESCRIPTION
…ge cache size (#59314)

shadown queue is copying the actual LRU queue and provide lockless acess. but the copying loses updating size when actual LRU queue is reseting range (when load data, we first allocate 1MB block for the data and reset the size to the real size when finalizing).

This commit does the following to fix this problem:
1. update the corresponding shadow queue element when resetting
2. calibrate size during initial loading into memory process

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

