### PR TITLE
[fix](filecache) avoid string_view::data() in file_cache_action (#60101)

### DIFF
--- a/be/src/http/action/file_cache_action.cpp
+++ b/be/src/http/action/file_cache_action.cpp
@@ -55,22 +55,26 @@ constexpr static std::string_view RELEASE = "release";
 constexpr static std::string_view BASE_PATH = "base_path";
 constexpr static std::string_view RELEASED_ELEMENTS = "released_elements";
 constexpr static std::string_view DUMP = "dump";
+constexpr static std::string_view LIST_BASE_PATHS = "list_base_paths";
+constexpr static std::string_view CHECK_CONSISTENCY = "check_consistency";
+constexpr static std::string_view RELOAD = "reload";
 constexpr static std::string_view VALUE = "value";
 
 Status FileCacheAction::_handle_header(HttpRequest* req, std::string* json_metrics) {
-    req->add_output_header(HttpHeaders::CONTENT_TYPE, HEADER_JSON.data());
-    std::string operation = req->param(OP.data());
+    const std::string header_json(HEADER_JSON);
+    req->add_output_header(HttpHeaders::CONTENT_TYPE, header_json.c_str());
+    std::string operation = req->param(std::string(OP));
     Status st = Status::OK();
     if (operation == RELEASE) {
         size_t released = 0;
-        const std::string& base_path = req->param(BASE_PATH.data());
+        const std::string& base_path = req->param(std::string(BASE_PATH));
         if (!base_path.empty()) {
             released = io::FileCacheFactory::instance()->try_release(base_path);
         } else {
             released = io::FileCacheFactory::instance()->try_release();
         }
         EasyJson json;
-        json[RELEASED_ELEMENTS.data()] = released;
+        json[std::string(RELEASED_ELEMENTS)] = released;
         *json_metrics = json.ToString();
     } else if (operation == CLEAR) {
         DBUG_EXECUTE_IF("FileCacheAction._handle_header.ignore_clear", {
@@ -78,8 +82,8 @@ Status FileCacheAction::_handle_header(HttpRequest* req, std::string* json_metri
             st = Status::OK();
             return st;
         });
-        const std::string& sync = req->param(SYNC.data());
-        const std::string& segment_path = req->param(VALUE.data());
+        const std::string& sync = req->param(std::string(SYNC));
+        const std::string& segment_path = req->param(std::string(VALUE));
         if (segment_path.empty()) {
             io::FileCacheFactory::instance()->clear_file_caches(to_lower(sync) == "true");
         } else {
@@ -88,7 +92,7 @@ Status FileCacheAction::_handle_header(HttpRequest* req, std::string* json_metri
             cache->remove_if_cached(hash);
         }
     } else if (operation == RESET) {
-        std::string capacity = req->param(CAPACITY.data());
+        std::string capacity = req->param(std::string(CAPACITY));
         int64_t new_capacity = 0;
         bool parse = true;
         try {
@@ -102,24 +106,24 @@ Status FileCacheAction::_handle_header(HttpRequest* req, std::string* json_metri
                     "the interval (0, INT64_MAX]",
                     capacity);
         } else {
-            const std::string& path = req->param(PATH.data());
+            const std::string& path = req->param(std::string(PATH));
             auto ret = io::FileCacheFactory::instance()->reset_capacity(path, new_capacity);
             LOG(INFO) << ret;
         }
     } else if (operation == HASH) {
-        const std::string& segment_path = req->param(VALUE.data());
+        const std::string& segment_path = req->param(std::string(VALUE));
         if (segment_path.empty()) {
-            st = Status::InvalidArgument("missing parameter: {} is required", VALUE.data());
+            st = Status::InvalidArgument("missing parameter: {} is required", VALUE);
         } else {
             io::UInt128Wrapper ret = io::BlockFileCache::hash(segment_path);
             EasyJson json;
-            json[HASH.data()] = ret.to_string();
+            json[std::string(HASH)] = ret.to_string();
             *json_metrics = json.ToString();
         }
     } else if (operation == LIST_CACHE) {
-        const std::string& segment_path = req->param(VALUE.data());
+        const std::string& segment_path = req->param(std::string(VALUE));
         if (segment_path.empty()) {
-            st = Status::InvalidArgument("missing parameter: {} is required", VALUE.data());
+            st = Status::InvalidArgument("missing parameter: {} is required", VALUE);
         } else {
             io::UInt128Wrapper cache_hash = io::BlockFileCache::hash(segment_path);
             std::vector<std::string> cache_files =
@@ -135,6 +139,66 @@ Status FileCacheAction::_handle_header(HttpRequest* req, std::string* json_metri
         }
     } else if (operation == DUMP) {
         io::FileCacheFactory::instance()->dump_all_caches();
+    } else if (operation == LIST_BASE_PATHS) {
+        auto all_cache_base_path = io::FileCacheFactory::instance()->get_base_paths();
+        EasyJson json;
+        std::ranges::for_each(all_cache_base_path,
+                              [&json](auto& x) { json.PushBack(std::move(x)); });
+        *json_metrics = json.ToString();
+    } else if (operation == CHECK_CONSISTENCY) {
+        const std::string& cache_base_path = req->param(std::string(BASE_PATH));
+        if (cache_base_path.empty()) {
+            st = Status::InvalidArgument("missing parameter: {} is required", BASE_PATH);
+        } else {
+            auto* block_file_cache = io::FileCacheFactory::instance()->get_by_path(cache_base_path);
+            if (block_file_cache == nullptr) {
+                st = Status::InvalidArgument("file cache not found for base_path: {}",
+                                             cache_base_path);
+            } else {
+                std::vector<std::string> inconsistencies;
+                RETURN_IF_ERROR(block_file_cache->report_file_cache_inconsistency(inconsistencies));
+                EasyJson json;
+                std::ranges::for_each(inconsistencies,
+                                      [&json](auto& x) { json.PushBack(std::move(x)); });
+                *json_metrics = json.ToString();
+            }
+        }
+    } else if (operation == RELOAD) {
+#ifdef BE_TEST
+        std::string doris_home = getenv("DORIS_HOME");
+        std::string conffile = std::string(doris_home) + "/conf/be.conf";
+        if (!doris::config::init(conffile.c_str(), true, true, true)) {
+            return Status::InternalError("Error reading config file");
+        }
+
+        std::string custom_conffile = doris::config::custom_config_dir + "/be_custom.conf";
+        if (!doris::config::init(custom_conffile.c_str(), true, false, false)) {
+            return Status::InternalError("Error reading custom config file");
+        }
+
+        if (!doris::config::enable_file_cache) {
+            return Status::InternalError("config::enbale_file_cache should be true!");
+        }
+
+        std::unordered_set<std::string> cache_path_set;
+        std::vector<doris::CachePath> cache_paths;
+        RETURN_IF_ERROR(doris::parse_conf_cache_paths(doris::config::file_cache_path, cache_paths));
+
+        std::vector<CachePath> cache_paths_no_dup;
+        cache_paths_no_dup.reserve(cache_paths.size());
+        for (const auto& cache_path : cache_paths) {
+            if (cache_path_set.contains(cache_path.path)) {
+                LOG(WARNING) << fmt::format("cache path {} is duplicate", cache_path.path);
+                continue;
+            }
+            cache_path_set.emplace(cache_path.path);
+            cache_paths_no_dup.emplace_back(cache_path);
+        }
+        RETURN_IF_ERROR(
+                doris::io::FileCacheFactory::instance()->reload_file_cache(cache_paths_no_dup));
+#else
+        return Status::InternalError("Do not use reload in production environment!!!!");
+#endif
     } else {
         st = Status::InternalError("invalid operation: {}", operation);
     }

--- a/be/src/http/action/file_cache_action.cpp
+++ b/be/src/http/action/file_cache_action.cpp
@@ -55,9 +55,6 @@ constexpr static std::string_view RELEASE = "release";
 constexpr static std::string_view BASE_PATH = "base_path";
 constexpr static std::string_view RELEASED_ELEMENTS = "released_elements";
 constexpr static std::string_view DUMP = "dump";
-constexpr static std::string_view LIST_BASE_PATHS = "list_base_paths";
-constexpr static std::string_view CHECK_CONSISTENCY = "check_consistency";
-constexpr static std::string_view RELOAD = "reload";
 constexpr static std::string_view VALUE = "value";
 
 Status FileCacheAction::_handle_header(HttpRequest* req, std::string* json_metrics) {
@@ -139,66 +136,6 @@ Status FileCacheAction::_handle_header(HttpRequest* req, std::string* json_metri
         }
     } else if (operation == DUMP) {
         io::FileCacheFactory::instance()->dump_all_caches();
-    } else if (operation == LIST_BASE_PATHS) {
-        auto all_cache_base_path = io::FileCacheFactory::instance()->get_base_paths();
-        EasyJson json;
-        std::ranges::for_each(all_cache_base_path,
-                              [&json](auto& x) { json.PushBack(std::move(x)); });
-        *json_metrics = json.ToString();
-    } else if (operation == CHECK_CONSISTENCY) {
-        const std::string& cache_base_path = req->param(std::string(BASE_PATH));
-        if (cache_base_path.empty()) {
-            st = Status::InvalidArgument("missing parameter: {} is required", BASE_PATH);
-        } else {
-            auto* block_file_cache = io::FileCacheFactory::instance()->get_by_path(cache_base_path);
-            if (block_file_cache == nullptr) {
-                st = Status::InvalidArgument("file cache not found for base_path: {}",
-                                             cache_base_path);
-            } else {
-                std::vector<std::string> inconsistencies;
-                RETURN_IF_ERROR(block_file_cache->report_file_cache_inconsistency(inconsistencies));
-                EasyJson json;
-                std::ranges::for_each(inconsistencies,
-                                      [&json](auto& x) { json.PushBack(std::move(x)); });
-                *json_metrics = json.ToString();
-            }
-        }
-    } else if (operation == RELOAD) {
-#ifdef BE_TEST
-        std::string doris_home = getenv("DORIS_HOME");
-        std::string conffile = std::string(doris_home) + "/conf/be.conf";
-        if (!doris::config::init(conffile.c_str(), true, true, true)) {
-            return Status::InternalError("Error reading config file");
-        }
-
-        std::string custom_conffile = doris::config::custom_config_dir + "/be_custom.conf";
-        if (!doris::config::init(custom_conffile.c_str(), true, false, false)) {
-            return Status::InternalError("Error reading custom config file");
-        }
-
-        if (!doris::config::enable_file_cache) {
-            return Status::InternalError("config::enbale_file_cache should be true!");
-        }
-
-        std::unordered_set<std::string> cache_path_set;
-        std::vector<doris::CachePath> cache_paths;
-        RETURN_IF_ERROR(doris::parse_conf_cache_paths(doris::config::file_cache_path, cache_paths));
-
-        std::vector<CachePath> cache_paths_no_dup;
-        cache_paths_no_dup.reserve(cache_paths.size());
-        for (const auto& cache_path : cache_paths) {
-            if (cache_path_set.contains(cache_path.path)) {
-                LOG(WARNING) << fmt::format("cache path {} is duplicate", cache_path.path);
-                continue;
-            }
-            cache_path_set.emplace(cache_path.path);
-            cache_paths_no_dup.emplace_back(cache_path);
-        }
-        RETURN_IF_ERROR(
-                doris::io::FileCacheFactory::instance()->reload_file_cache(cache_paths_no_dup));
-#else
-        return Status::InternalError("Do not use reload in production environment!!!!");
-#endif
     } else {
         st = Status::InternalError("invalid operation: {}", operation);
     }


### PR DESCRIPTION
std::string_view::data() does not guarantee a null-terminated string, which can cause out-of-bounds reads, undefined behavior, crashes, or even information leaks.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

