### PR TITLE
[feat](ci) add OSSF Scorecard workflow for supply-chain security

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,42 @@
+name: Scorecard supply-chain security
+on:
+  push:
+    branches: [ master ]
+  schedule:
+    - cron: '30 1 * * 6'
+
+permissions:
+    contents: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a #v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f #v6.0.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@6bc82e05fd0ea64601dd4b465378bbcf57de0314 #v4.32.1
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -5,8 +5,7 @@ on:
   schedule:
     - cron: '30 1 * * 6'
 
-permissions:
-    contents: read
+permissions: read-all
 
 jobs:
   analysis:


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #60508 

Related PR: #xxx

Problem Summary: The repository currently does not publish OpenSSF Scorecard results to the public Scorecard API (https://api.securityscorecards.dev/). As a result, users and downstream projects cannot easily discover or track the project’s security best-practice posture in a standardized, automated way. The absence of published results reduces visibility and makes it harder for consumers to assess the project using common tooling.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [X] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [X] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [X] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [X] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

---
### What problem was fixed
The repository currently does not publish OpenSSF Scorecard results to the public Scorecard API (https://api.securityscorecards.dev/). As a result, users and downstream projects cannot easily discover or track the project’s security best-practice posture in a standardized, automated way. 

### How it was fixed
This was addressed by adding an OpenSSF Scorecard GitHub Actions workflow that runs on scheduled intervals and on relevant branch updates. The workflow executes the Scorecard analysis, generates a SARIF report, and uploads the results to GitHub Code Scanning for visibility.

### Which behaviors were modified

Previous behavior:
No automated push of OpenSSF scorecard to the scorecard API.  

Current behavior:
Scorecard analysis runs automatically on a schedule and on selected branches.

### Why this was modified:
The absence of published results reduces visibility and makes it harder for consumers to assess the project using common tooling. So the scorecard workflow was added so that the project can be scored on various security criterias, and helps the user confidently use the project.

### Potential impact:
No impact on runtime behavior or production code. Improves overall project security posture and audit readiness.

### What features were added
Automated OpenSSF Scorecard scanning via GitHub Actions.