### PR TITLE
Fix query_timeout validation to use AnalysisException

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -4841,16 +4841,21 @@ public class SessionVariable implements Serializable, Writable {
         return dropTableIfCtasFailed;
     }
 
-    public void checkQueryTimeoutValid(String newQueryTimeout) {
-        int value = Integer.valueOf(newQueryTimeout);
-        if (value <= 0) {
-            UnsupportedOperationException exception =
-                    new UnsupportedOperationException(
-                        "query_timeout can not be set to " + newQueryTimeout + ", it must be greater than 0");
-            LOG.warn("Check query_timeout failed", exception);
-            throw exception;
-        }
+    public void checkQueryTimeoutValid(String newQueryTimeout) throws AnalysisException {
+    int value;
+    try {
+        value = Integer.parseInt(newQueryTimeout);
+    } catch (NumberFormatException e) {
+        throw new AnalysisException(
+                "query_timeout must be a positive integer, but got: " + newQueryTimeout);
     }
+
+    if (value <= 0) {
+        throw new AnalysisException(
+                "query_timeout must be greater than 0, but got: " + newQueryTimeout);
+    }
+}
+
 
     public void checkMaxExecutionTimeMSValid(String newValue) {
         int value = Integer.valueOf(newValue);


### PR DESCRIPTION
What problem was fixed?
The session variable query_timeout validation currently throws UnsupportedOperationException
for invalid values. This is inconsistent with other FE validations and results in unclear
error handling for invalid user input.

Additionally, non-numeric values could cause an unhandled NumberFormatException.

How was it fixed?
Replaced UnsupportedOperationException with AnalysisException
Added explicit number format validation for query_timeout
Improved error messages for invalid values
Behavior changes
Before

Invalid query_timeout values threw UnsupportedOperationException
Non-numeric values could cause unclear runtime exceptions
After

Invalid values throw AnalysisException
Non-numeric input is handled gracefully with clear error messages
Impact
This change improves consistency of session variable validation and provides clearer
feedback to users without affecting existing valid configurations.

