### PR TITLE
[Chore](runtime-filter) replace DCHECK/CHECK with Error Status or Exceptions

### DIFF
--- a/be/src/runtime_filter/runtime_filter.cpp
+++ b/be/src/runtime_filter/runtime_filter.cpp
@@ -64,8 +64,7 @@ Status RuntimeFilter::_push_to_remote(RuntimeState* state, const TNetworkAddress
     if (len > 0) {
         if (data == nullptr) {
             return Status::InternalError(
-                    "data is nullptr after serialization with len > 0, filter: {}",
-                    debug_string());
+                    "data is nullptr after serialization with len > 0, filter: {}", debug_string());
         }
         merge_filter_callback->cntl_->request_attachment().append(data, len);
     }

--- a/be/src/runtime_filter/runtime_filter.cpp
+++ b/be/src/runtime_filter/runtime_filter.cpp
@@ -62,7 +62,11 @@ Status RuntimeFilter::_push_to_remote(RuntimeState* state, const TNetworkAddress
     RETURN_IF_ERROR(serialize(merge_filter_request.get(), &data, &len));
 
     if (len > 0) {
-        DCHECK(data != nullptr);
+        if (data == nullptr) {
+            return Status::InternalError(
+                    "data is nullptr after serialization with len > 0, filter: {}",
+                    debug_string());
+        }
         merge_filter_callback->cntl_->request_attachment().append(data, len);
     }
 

--- a/be/src/runtime_filter/runtime_filter.h
+++ b/be/src/runtime_filter/runtime_filter.h
@@ -70,7 +70,11 @@ public:
             auto in_filter = request->mutable_in_filter();
             RETURN_IF_ERROR(_to_protobuf(in_filter));
         } else if (real_runtime_filter_type == RuntimeFilterType::BLOOM_FILTER) {
-            DCHECK(data != nullptr);
+            if (data == nullptr) {
+                return Status::InternalError(
+                        "data is nullptr for bloom filter serialization, filter_id: {}",
+                        _wrapper->filter_id());
+            }
             RETURN_IF_ERROR(_to_protobuf(request->mutable_bloom_filter(), (char**)data, len));
         } else if (real_runtime_filter_type == RuntimeFilterType::MINMAX_FILTER ||
                    real_runtime_filter_type == RuntimeFilterType::MIN_FILTER ||
@@ -89,7 +93,12 @@ protected:
     RuntimeFilter(const TRuntimeFilterDesc* desc)
             : _has_remote_target(desc->has_remote_targets),
               _runtime_filter_type(get_runtime_filter_type(desc)) {
-        DCHECK_NE(desc->has_remote_targets, desc->has_local_targets);
+        if (desc->has_remote_targets == desc->has_local_targets) {
+            throw Exception(ErrorCode::INTERNAL_ERROR,
+                            "has_remote_targets ({}) should not equal has_local_targets ({}), "
+                            "filter_id: {}",
+                            desc->has_remote_targets, desc->has_local_targets, desc->filter_id);
+        }
     }
 
     virtual Status _init_with_desc(const TRuntimeFilterDesc* desc, const TQueryOptions* options);

--- a/be/src/runtime_filter/runtime_filter_consumer.cpp
+++ b/be/src/runtime_filter/runtime_filter_consumer.cpp
@@ -213,8 +213,7 @@ Status RuntimeFilterConsumer::_get_push_exprs(std::vector<vectorized::VRuntimeFi
         break;
     }
     default:
-        return Status::InternalError("unknown runtime filter type: {}",
-                                     int(real_filter_type));
+        return Status::InternalError("unknown runtime filter type: {}", int(real_filter_type));
     }
     return Status::OK();
 }

--- a/be/src/runtime_filter/runtime_filter_consumer.cpp
+++ b/be/src/runtime_filter/runtime_filter_consumer.cpp
@@ -114,7 +114,9 @@ Status RuntimeFilterConsumer::_get_push_exprs(std::vector<vectorized::VRuntimeFi
                                        _wrapper->minmax_func()->get_min(), min_literal));
         min_pred->add_child(probe_ctx->root());
         min_pred->add_child(min_literal);
-        DCHECK(null_aware == false) << "only min predicate do not support null aware";
+        if (null_aware) {
+            return Status::InternalError("only min predicate do not support null aware");
+        }
         container.push_back(vectorized::VRuntimeFilterWrapper::create_shared(
                 min_pred_node, min_pred, get_comparison_ignore_thredhold(), null_aware,
                 _wrapper->filter_id()));
@@ -131,7 +133,9 @@ Status RuntimeFilterConsumer::_get_push_exprs(std::vector<vectorized::VRuntimeFi
                                        _wrapper->minmax_func()->get_max(), max_literal));
         max_pred->add_child(probe_ctx->root());
         max_pred->add_child(max_literal);
-        DCHECK(null_aware == false) << "only max predicate do not support null aware";
+        if (null_aware) {
+            return Status::InternalError("only max predicate do not support null aware");
+        }
         container.push_back(vectorized::VRuntimeFilterWrapper::create_shared(
                 max_pred_node, max_pred, get_comparison_ignore_thredhold(), null_aware,
                 _wrapper->filter_id()));
@@ -200,22 +204,28 @@ Status RuntimeFilterConsumer::_get_push_exprs(std::vector<vectorized::VRuntimeFi
         auto bitmap_pred = vectorized::VBitmapPredicate::create_shared(node);
         bitmap_pred->set_filter(_wrapper->bitmap_filter_func());
         bitmap_pred->add_child(probe_ctx->root());
-        DCHECK(null_aware == false) << "bitmap predicate do not support null aware";
+        if (null_aware) {
+            return Status::InternalError("bitmap predicate do not support null aware");
+        }
         auto wrapper = vectorized::VRuntimeFilterWrapper::create_shared(
                 node, bitmap_pred, 0, null_aware, _wrapper->filter_id());
         container.push_back(wrapper);
         break;
     }
     default:
-        DCHECK(false);
-        break;
+        return Status::InternalError("unknown runtime filter type: {}",
+                                     int(real_filter_type));
     }
     return Status::OK();
 }
 
 void RuntimeFilterConsumer::collect_realtime_profile(RuntimeProfile* parent_operator_profile) {
     std::unique_lock<std::recursive_mutex> l(_rmtx);
-    DCHECK(parent_operator_profile != nullptr);
+    if (parent_operator_profile == nullptr) {
+        LOG(WARNING) << "parent_operator_profile is nullptr in "
+                        "RuntimeFilterConsumer::collect_realtime_profile";
+        return;
+    }
     int filter_id = -1;
     {
         // since debug_string will read from  RuntimeFilter::_wrapper

--- a/be/src/runtime_filter/runtime_filter_mgr.cpp
+++ b/be/src/runtime_filter/runtime_filter_mgr.cpp
@@ -126,7 +126,10 @@ Status RuntimeFilterMgr::get_local_merge_producer_filters(int filter_id,
                 filter_id);
     }
     *local_merge_filters = &iter->second;
-    DCHECK(iter->second.merger);
+    if (!iter->second.merger) {
+        return Status::InternalError(
+                "local merge context merger is nullptr for filter_id: {}", filter_id);
+    }
     return Status::OK();
 }
 
@@ -354,7 +357,11 @@ Status RuntimeFilterMergeControllerEntity::_send_rf_to_target(GlobalMergeContext
                                                               int64_t merge_time,
                                                               PUniqueId query_id,
                                                               int execution_timeout) {
-    DCHECK_GT(cnt_val.targetv2_info.size(), 0);
+    if (cnt_val.targetv2_info.empty()) {
+        return Status::InternalError(
+                "_send_rf_to_target called with empty targetv2_info, filter: {}",
+                cnt_val.merger ? cnt_val.merger->debug_string() : "unknown");
+    }
 
     if (cnt_val.done) {
         return Status::InternalError("Runtime filter has been sent",

--- a/be/src/runtime_filter/runtime_filter_mgr.cpp
+++ b/be/src/runtime_filter/runtime_filter_mgr.cpp
@@ -127,8 +127,8 @@ Status RuntimeFilterMgr::get_local_merge_producer_filters(int filter_id,
     }
     *local_merge_filters = &iter->second;
     if (!iter->second.merger) {
-        return Status::InternalError(
-                "local merge context merger is nullptr for filter_id: {}", filter_id);
+        return Status::InternalError("local merge context merger is nullptr for filter_id: {}",
+                                     filter_id);
     }
     return Status::OK();
 }

--- a/be/src/runtime_filter/runtime_filter_producer_helper.cpp
+++ b/be/src/runtime_filter/runtime_filter_producer_helper.cpp
@@ -74,7 +74,10 @@ Status RuntimeFilterProducerHelper::_insert(const vectorized::Block* block, size
     for (int i = 0; i < _producers.size(); i++) {
         auto filter = _producers[i];
         int result_column_id = _filter_expr_contexts[i]->get_last_result_column_id();
-        DCHECK_NE(result_column_id, -1);
+        if (result_column_id == -1) {
+            return Status::InternalError(
+                    "runtime filter producer _insert got invalid result_column_id -1");
+        }
         const auto& column = block->get_by_position(result_column_id).column;
         RETURN_IF_ERROR(filter->insert(column, start));
     }
@@ -108,12 +111,25 @@ Status RuntimeFilterProducerHelper::build(
 
     for (const auto& filter : _producers) {
         if (use_shared_table) {
-            DCHECK(_is_broadcast_join);
+            if (!_is_broadcast_join) {
+                return Status::InternalError(
+                        "use_shared_table is true but _is_broadcast_join is false");
+            }
             if (_should_build_hash_table) {
-                DCHECK(!runtime_filters.contains(filter->wrapper()->filter_id()));
+                if (runtime_filters.contains(filter->wrapper()->filter_id())) {
+                    return Status::InternalError(
+                            "runtime_filters already contains filter_id {} when building hash "
+                            "table",
+                            filter->wrapper()->filter_id());
+                }
                 runtime_filters[filter->wrapper()->filter_id()] = filter->wrapper();
             } else {
-                DCHECK(runtime_filters.contains(filter->wrapper()->filter_id()));
+                if (!runtime_filters.contains(filter->wrapper()->filter_id())) {
+                    return Status::InternalError(
+                            "runtime_filters does not contain filter_id {} when not building "
+                            "hash table",
+                            filter->wrapper()->filter_id());
+                }
                 filter->set_wrapper(runtime_filters[filter->wrapper()->filter_id()]);
             }
         }
@@ -147,8 +163,9 @@ Status RuntimeFilterProducerHelper::skip_process(RuntimeState* state) {
 
 void RuntimeFilterProducerHelper::collect_realtime_profile(
         RuntimeProfile* parent_operator_profile) {
-    DCHECK(parent_operator_profile != nullptr);
     if (parent_operator_profile == nullptr) {
+        LOG(WARNING) << "parent_operator_profile is nullptr in "
+                        "RuntimeFilterProducerHelper::collect_realtime_profile";
         return;
     }
 

--- a/be/src/runtime_filter/runtime_filter_producer_helper_cross.h
+++ b/be/src/runtime_filter/runtime_filter_producer_helper_cross.h
@@ -51,7 +51,12 @@ private:
         for (const auto& vexpr_ctx : _filter_expr_contexts) {
             int result_column_id = -1;
             RETURN_IF_ERROR(vexpr_ctx->execute(block, &result_column_id));
-            DCHECK_NE(result_column_id, -1) << vexpr_ctx->root()->debug_string();
+            if (result_column_id == -1) {
+                return Status::InternalError(
+                        "runtime filter cross join _process_block got invalid result_column_id "
+                        "-1, expr: {}",
+                        vexpr_ctx->root()->debug_string());
+            }
             block->get_by_position(result_column_id).column =
                     block->get_by_position(result_column_id)
                             .column->convert_to_full_column_if_const();

--- a/be/src/runtime_filter/runtime_filter_wrapper.cpp
+++ b/be/src/runtime_filter/runtime_filter_wrapper.cpp
@@ -163,8 +163,17 @@ Status RuntimeFilterWrapper::merge(const RuntimeFilterWrapper* other) {
         return Status::OK();
     }
 
-    DCHECK(other->_state == State::READY);
-    DCHECK(_filter_type == other->_filter_type);
+    if (other->_state != State::READY) {
+        return Status::InternalError(
+                "Cannot merge runtime filter: other filter state is {}, expected READY. this: {}, "
+                "other: {}",
+                to_string(other->_state), debug_string(), other->debug_string());
+    }
+    if (_filter_type != other->_filter_type) {
+        return Status::InternalError(
+                "Cannot merge runtime filter: filter type mismatch, this: {}, other: {}",
+                int(_filter_type), int(other->_filter_type));
+    }
 
     switch (_filter_type) {
     case RuntimeFilterType::IN_FILTER: {
@@ -288,7 +297,12 @@ Status RuntimeFilterWrapper::_assign(const PInFilter& in_filter, bool contain_nu
             StringParser::ParseResult result;
             auto int128_val = StringParser::string_to_int<int128_t>(string_val.c_str(),
                                                                     string_val.length(), &result);
-            DCHECK(result == StringParser::PARSE_SUCCESS);
+            if (result != StringParser::PARSE_SUCCESS) {
+                throw Exception(ErrorCode::INTERNAL_ERROR,
+                                "Failed to parse LARGEINT value '{}' in runtime filter in_filter "
+                                "assign",
+                                string_val);
+            }
             set->insert(&int128_val);
         });
         break;
@@ -361,7 +375,12 @@ Status RuntimeFilterWrapper::_assign(const PInFilter& in_filter, bool contain_nu
             StringParser::ParseResult result;
             auto int128_val = StringParser::string_to_int<int128_t>(string_val.c_str(),
                                                                     string_val.length(), &result);
-            DCHECK(result == StringParser::PARSE_SUCCESS);
+            if (result != StringParser::PARSE_SUCCESS) {
+                throw Exception(ErrorCode::INTERNAL_ERROR,
+                                "Failed to parse DECIMAL128I value '{}' in runtime filter "
+                                "in_filter assign",
+                                string_val);
+            }
             set->insert(&int128_val);
         });
         break;
@@ -372,7 +391,12 @@ Status RuntimeFilterWrapper::_assign(const PInFilter& in_filter, bool contain_nu
             StringParser::ParseResult result;
             auto int_val = StringParser::string_to_int<wide::Int256>(string_val.c_str(),
                                                                      string_val.length(), &result);
-            DCHECK(result == StringParser::PARSE_SUCCESS);
+            if (result != StringParser::PARSE_SUCCESS) {
+                throw Exception(ErrorCode::INTERNAL_ERROR,
+                                "Failed to parse DECIMAL256 value '{}' in runtime filter "
+                                "in_filter assign",
+                                string_val);
+            }
             set->insert(&int_val);
         });
         break;
@@ -401,7 +425,12 @@ Status RuntimeFilterWrapper::_assign(const PInFilter& in_filter, bool contain_nu
             StringParser::ParseResult result;
             auto int128_val = StringParser::string_to_int<uint128_t>(string_val.c_str(),
                                                                      string_val.length(), &result);
-            DCHECK(result == StringParser::PARSE_SUCCESS);
+            if (result != StringParser::PARSE_SUCCESS) {
+                throw Exception(ErrorCode::INTERNAL_ERROR,
+                                "Failed to parse IPV6 value '{}' in runtime filter in_filter "
+                                "assign",
+                                string_val);
+            }
             set->insert(&int128_val);
         });
         break;
@@ -416,7 +445,11 @@ Status RuntimeFilterWrapper::_assign(const PInFilter& in_filter, bool contain_nu
 
 Status RuntimeFilterWrapper::_assign(const PBloomFilter& bloom_filter,
                                      butil::IOBufAsZeroCopyInputStream* data, bool contain_null) {
-    DCHECK(_bloom_filter_func);
+    if (!_bloom_filter_func) {
+        return Status::InternalError(
+                "_bloom_filter_func is nullptr in _assign(PBloomFilter), filter_id: {}",
+                _filter_id);
+    }
     RETURN_IF_ERROR(_bloom_filter_func->assign(data, bloom_filter.filter_length(), contain_null));
     return Status::OK();
 }
@@ -456,10 +489,18 @@ Status RuntimeFilterWrapper::_assign(const PMinMaxFilter& minmax_filter, bool co
         StringParser::ParseResult result;
         auto min_val = StringParser::string_to_int<int128_t>(min_string_val.c_str(),
                                                              min_string_val.length(), &result);
-        DCHECK(result == StringParser::PARSE_SUCCESS);
+        if (result != StringParser::PARSE_SUCCESS) {
+            return Status::InternalError(
+                    "Failed to parse LARGEINT min value '{}' in minmax filter assign",
+                    min_string_val);
+        }
         auto max_val = StringParser::string_to_int<int128_t>(max_string_val.c_str(),
                                                              max_string_val.length(), &result);
-        DCHECK(result == StringParser::PARSE_SUCCESS);
+        if (result != StringParser::PARSE_SUCCESS) {
+            return Status::InternalError(
+                    "Failed to parse LARGEINT max value '{}' in minmax filter assign",
+                    max_string_val);
+        }
         return _minmax_func->assign(&min_val, &max_val);
     }
     case TYPE_FLOAT: {
@@ -517,10 +558,18 @@ Status RuntimeFilterWrapper::_assign(const PMinMaxFilter& minmax_filter, bool co
         StringParser::ParseResult result;
         auto min_val = StringParser::string_to_int<int128_t>(min_string_val.c_str(),
                                                              min_string_val.length(), &result);
-        DCHECK(result == StringParser::PARSE_SUCCESS);
+        if (result != StringParser::PARSE_SUCCESS) {
+            return Status::InternalError(
+                    "Failed to parse DECIMAL128I min value '{}' in minmax filter assign",
+                    min_string_val);
+        }
         auto max_val = StringParser::string_to_int<int128_t>(max_string_val.c_str(),
                                                              max_string_val.length(), &result);
-        DCHECK(result == StringParser::PARSE_SUCCESS);
+        if (result != StringParser::PARSE_SUCCESS) {
+            return Status::InternalError(
+                    "Failed to parse DECIMAL128I max value '{}' in minmax filter assign",
+                    max_string_val);
+        }
         return _minmax_func->assign(&min_val, &max_val);
     }
     case TYPE_DECIMAL256: {
@@ -529,10 +578,18 @@ Status RuntimeFilterWrapper::_assign(const PMinMaxFilter& minmax_filter, bool co
         StringParser::ParseResult result;
         auto min_val = StringParser::string_to_int<wide::Int256>(min_string_val.c_str(),
                                                                  min_string_val.length(), &result);
-        DCHECK(result == StringParser::PARSE_SUCCESS);
+        if (result != StringParser::PARSE_SUCCESS) {
+            return Status::InternalError(
+                    "Failed to parse DECIMAL256 min value '{}' in minmax filter assign",
+                    min_string_val);
+        }
         auto max_val = StringParser::string_to_int<wide::Int256>(max_string_val.c_str(),
                                                                  max_string_val.length(), &result);
-        DCHECK(result == StringParser::PARSE_SUCCESS);
+        if (result != StringParser::PARSE_SUCCESS) {
+            return Status::InternalError(
+                    "Failed to parse DECIMAL256 max value '{}' in minmax filter assign",
+                    max_string_val);
+        }
         return _minmax_func->assign(&min_val, &max_val);
     }
     case TYPE_VARCHAR:
@@ -553,10 +610,18 @@ Status RuntimeFilterWrapper::_assign(const PMinMaxFilter& minmax_filter, bool co
         StringParser::ParseResult result;
         auto min_val = StringParser::string_to_int<uint128_t>(min_string_val.c_str(),
                                                               min_string_val.length(), &result);
-        DCHECK(result == StringParser::PARSE_SUCCESS);
+        if (result != StringParser::PARSE_SUCCESS) {
+            return Status::InternalError(
+                    "Failed to parse IPV6 min value '{}' in minmax filter assign",
+                    min_string_val);
+        }
         auto max_val = StringParser::string_to_int<uint128_t>(max_string_val.c_str(),
                                                               max_string_val.length(), &result);
-        DCHECK(result == StringParser::PARSE_SUCCESS);
+        if (result != StringParser::PARSE_SUCCESS) {
+            return Status::InternalError(
+                    "Failed to parse IPV6 max value '{}' in minmax filter assign",
+                    max_string_val);
+        }
         return _minmax_func->assign(&min_val, &max_val);
     }
     default:
@@ -659,18 +724,29 @@ Status RuntimeFilterWrapper::assign(const T& request, butil::IOBufAsZeroCopyInpu
 
     switch (filter_type) {
     case PFilterType::IN_FILTER: {
-        DCHECK(request.has_in_filter());
+        if (!request.has_in_filter()) {
+            return Status::InternalError(
+                    "IN_FILTER type but request has no in_filter, filter_id: {}", _filter_id);
+        }
         return _assign(request.in_filter(), request.contain_null());
     }
     case PFilterType::BLOOM_FILTER: {
-        DCHECK(request.has_bloom_filter());
+        if (!request.has_bloom_filter()) {
+            return Status::InternalError(
+                    "BLOOM_FILTER type but request has no bloom_filter, filter_id: {}",
+                    _filter_id);
+        }
         _hybrid_set.reset(); // change in_or_bloom filter to bloom filter
         return _assign(request.bloom_filter(), data, request.contain_null());
     }
     case PFilterType::MIN_FILTER:
     case PFilterType::MAX_FILTER:
     case PFilterType::MINMAX_FILTER: {
-        DCHECK(request.has_minmax_filter());
+        if (!request.has_minmax_filter()) {
+            return Status::InternalError(
+                    "MINMAX_FILTER type but request has no minmax_filter, filter_id: {}",
+                    _filter_id);
+        }
         return _assign(request.minmax_filter(), request.contain_null());
     }
     default:

--- a/be/src/runtime_filter/runtime_filter_wrapper.cpp
+++ b/be/src/runtime_filter/runtime_filter_wrapper.cpp
@@ -612,15 +612,13 @@ Status RuntimeFilterWrapper::_assign(const PMinMaxFilter& minmax_filter, bool co
                                                               min_string_val.length(), &result);
         if (result != StringParser::PARSE_SUCCESS) {
             return Status::InternalError(
-                    "Failed to parse IPV6 min value '{}' in minmax filter assign",
-                    min_string_val);
+                    "Failed to parse IPV6 min value '{}' in minmax filter assign", min_string_val);
         }
         auto max_val = StringParser::string_to_int<uint128_t>(max_string_val.c_str(),
                                                               max_string_val.length(), &result);
         if (result != StringParser::PARSE_SUCCESS) {
             return Status::InternalError(
-                    "Failed to parse IPV6 max value '{}' in minmax filter assign",
-                    max_string_val);
+                    "Failed to parse IPV6 max value '{}' in minmax filter assign", max_string_val);
         }
         return _minmax_func->assign(&min_val, &max_val);
     }
@@ -733,8 +731,7 @@ Status RuntimeFilterWrapper::assign(const T& request, butil::IOBufAsZeroCopyInpu
     case PFilterType::BLOOM_FILTER: {
         if (!request.has_bloom_filter()) {
             return Status::InternalError(
-                    "BLOOM_FILTER type but request has no bloom_filter, filter_id: {}",
-                    _filter_id);
+                    "BLOOM_FILTER type but request has no bloom_filter, filter_id: {}", _filter_id);
         }
         _hybrid_set.reset(); // change in_or_bloom filter to bloom filter
         return _assign(request.bloom_filter(), data, request.contain_null());


### PR DESCRIPTION
### What problem does this PR solve?
This pull request replaces many `DCHECK` assertions with explicit error handling throughout the runtime filter codebase. The changes improve robustness by converting failed internal assumptions into meaningful error statuses or exceptions, which helps prevent silent failures and makes debugging easier.

Error handling improvements for runtime filter logic:

* Replaced `DCHECK` assertions with status checks and error returns for null pointers, invalid states, and filter type mismatches in `runtime_filter.cpp`, `runtime_filter.h`, `runtime_filter_consumer.cpp`, `runtime_filter_mgr.cpp`, and `runtime_filter_producer.cpp`. This includes checks for serialization data, filter dependencies, and filter merge conditions. [[1]](diffhunk://#diff-f505841d01d9ca521e7c6780854dff8251e0ca047a0f03185f5e85bce4a6c181L65-R69) [[2]](diffhunk://#diff-54fe6a4b716938b750ec08983ee9ea7c9c390ffc8a796f361fd6354c3cb3a8c2L73-R77) [[3]](diffhunk://#diff-54fe6a4b716938b750ec08983ee9ea7c9c390ffc8a796f361fd6354c3cb3a8c2L92-R101) [[4]](diffhunk://#diff-de54918fd984e65b76a54152ed551c23348819b572d4253d577d6c9650bc95cbL117-R119) [[5]](diffhunk://#diff-de54918fd984e65b76a54152ed551c23348819b572d4253d577d6c9650bc95cbL134-R138) [[6]](diffhunk://#diff-de54918fd984e65b76a54152ed551c23348819b572d4253d577d6c9650bc95cbL203-R228) [[7]](diffhunk://#diff-5354bacdeccbd2d6f61cee8d8206e6853f7505f353bfd33d556e05aba0a4db7fL129-R132) [[8]](diffhunk://#diff-5354bacdeccbd2d6f61cee8d8206e6853f7505f353bfd33d556e05aba0a4db7fL357-R364) [[9]](diffhunk://#diff-52614ca7b5c1da676f382429d3593900c0f2b449f57651f02cee47e72aa6736dL89-R93) [[10]](diffhunk://#diff-52614ca7b5c1da676f382429d3593900c0f2b449f57651f02cee47e72aa6736dL151-R158) [[11]](diffhunk://#diff-52614ca7b5c1da676f382429d3593900c0f2b449f57651f02cee47e72aa6736dL161-R171) [[12]](diffhunk://#diff-52614ca7b5c1da676f382429d3593900c0f2b449f57651f02cee47e72aa6736dL242-R255)

Error handling for producer and helper classes:

* Added error returns for invalid result column IDs and broadcast join conditions in `runtime_filter_producer_helper.cpp` and `runtime_filter_producer_helper_cross.h`. Checks ensure correct filter construction and insertion logic. [[1]](diffhunk://#diff-bddbf8ad6f2ca00f5bd80c7ff32db5ec5d57a8ceab20a80b72e9296ec5281d7eL77-R80) [[2]](diffhunk://#diff-bddbf8ad6f2ca00f5bd80c7ff32db5ec5d57a8ceab20a80b72e9296ec5281d7eL111-R132) [[3]](diffhunk://#diff-bddbf8ad6f2ca00f5bd80c7ff32db5ec5d57a8ceab20a80b72e9296ec5281d7eL150-R168) [[4]](diffhunk://#diff-c0909e54f288bc14f0c0057d7ea746384a62dfe8753d161b7d9d91eacc1859e9L54-R59)

Error handling for filter merging and assignment:

* Replaced assertions with error returns for filter state and type mismatches in `runtime_filter_wrapper.cpp` during merging. Added exceptions for failed string parsing in filter assignment for various types. Checks for null filter functions and parsing failures in min/max filter assignment. [[1]](diffhunk://#diff-d951fabc29ca512bccab5af3c0eb9ce9bc0d3a59585988014d6972e17fc0350cL166-R176) [[2]](diffhunk://#diff-d951fabc29ca512bccab5af3c0eb9ce9bc0d3a59585988014d6972e17fc0350cL291-R305) [[3]](diffhunk://#diff-d951fabc29ca512bccab5af3c0eb9ce9bc0d3a59585988014d6972e17fc0350cL364-R383) [[4]](diffhunk://#diff-d951fabc29ca512bccab5af3c0eb9ce9bc0d3a59585988014d6972e17fc0350cL375-R399) [[5]](diffhunk://#diff-d951fabc29ca512bccab5af3c0eb9ce9bc0d3a59585988014d6972e17fc0350cL404-R433) [[6]](diffhunk://#diff-d951fabc29ca512bccab5af3c0eb9ce9bc0d3a59585988014d6972e17fc0350cL419-R452) [[7]](diffhunk://#diff-d951fabc29ca512bccab5af3c0eb9ce9bc0d3a59585988014d6972e17fc0350cL459-R503)
### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

