### PR TITLE
[refine](expr)Check the column returned after each expression execution.

### DIFF
--- a/be/src/vec/exprs/lambda_function/lambda_function.h
+++ b/be/src/vec/exprs/lambda_function/lambda_function.h
@@ -38,7 +38,7 @@ public:
     }
 
     virtual doris::Status execute(VExprContext* context, const doris::vectorized::Block* block,
-                                  Selector* selector, size_t count, ColumnPtr& result_column,
+                                  const Selector* selector, size_t count, ColumnPtr& result_column,
                                   const DataTypePtr& result_type,
                                   const VExprSPtrs& children) const = 0;
 

--- a/be/src/vec/exprs/lambda_function/varray_filter_function.cpp
+++ b/be/src/vec/exprs/lambda_function/varray_filter_function.cpp
@@ -53,8 +53,8 @@ public:
     std::string get_name() const override { return name; }
 
     doris::Status execute(VExprContext* context, const doris::vectorized::Block* block,
-                          Selector* expr_selector, size_t output_count, ColumnPtr& result_column,
-                          const DataTypePtr& result_type,
+                          const Selector* expr_selector, size_t output_count,
+                          ColumnPtr& result_column, const DataTypePtr& result_type,
                           const VExprSPtrs& children) const override {
         ///* array_filter(array, array<boolean>) *///
 

--- a/be/src/vec/exprs/lambda_function/varray_map_function.cpp
+++ b/be/src/vec/exprs/lambda_function/varray_map_function.cpp
@@ -77,9 +77,9 @@ public:
 
     std::string get_name() const override { return name; }
 
-    Status execute(VExprContext* context, const vectorized::Block* block, Selector* expr_selector,
-                   size_t count, ColumnPtr& result_column, const DataTypePtr& result_type,
-                   const VExprSPtrs& children) const override {
+    Status execute(VExprContext* context, const vectorized::Block* block,
+                   const Selector* expr_selector, size_t count, ColumnPtr& result_column,
+                   const DataTypePtr& result_type, const VExprSPtrs& children) const override {
         LambdaArgs args_info;
         // collect used slot ref in lambda function body
         std::vector<int>& output_slot_ref_indexs = args_info.output_slot_ref_indexs;

--- a/be/src/vec/exprs/lambda_function/varray_sort_function.cpp
+++ b/be/src/vec/exprs/lambda_function/varray_sort_function.cpp
@@ -67,9 +67,9 @@ public:
 
     std::string get_name() const override { return name; }
 
-    Status execute(VExprContext* context, const vectorized::Block* block, Selector* expr_selector,
-                   size_t count, ColumnPtr& result_column, const DataTypePtr& result_type,
-                   const VExprSPtrs& children) const override {
+    Status execute(VExprContext* context, const vectorized::Block* block,
+                   const Selector* expr_selector, size_t count, ColumnPtr& result_column,
+                   const DataTypePtr& result_type, const VExprSPtrs& children) const override {
         ///* array_sort(lambda, arg) *///
 
         DCHECK_EQ(children.size(), 2);

--- a/be/src/vec/exprs/short_circuit_evaluation_expr.cpp
+++ b/be/src/vec/exprs/short_circuit_evaluation_expr.cpp
@@ -89,8 +89,8 @@ std::string ShortCircuitExpr::debug_string() const {
 // These are issues with the exprs themselves, but for convenience, we handle this case uniformly in short-circuit expr.
 /// TODO: Once all exprs support size-0 columns in the future, this function can be removed.
 [[nodiscard]] Status try_early_return_on_empty(const VExprSPtr& expr, VExprContext* context,
-                                               const Block* block, Selector* selector, size_t count,
-                                               ColumnPtr& result_columnn) {
+                                               const Block* block, const Selector* selector,
+                                               size_t count, ColumnPtr& result_columnn) {
     if (count == 0) {
         result_columnn = expr->execute_type(block)->create_column();
         DCHECK_EQ(result_columnn->size(), 0);
@@ -177,9 +177,9 @@ void execute_if_selector(const ColumnPtr& cond_column, const Selector* selector,
     condition_view.for_each(null_func, true_func, false_func);
 }
 
-Status ShortCircuitIfExpr::execute_column(VExprContext* context, const Block* block,
-                                          Selector* selector, size_t count,
-                                          ColumnPtr& result_column) const {
+Status ShortCircuitIfExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                               const Selector* selector, size_t count,
+                                               ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr) << debug_string();
     DCHECK(selector == nullptr || selector->size() == count);
     ColumnPtr cond_column;
@@ -255,9 +255,9 @@ void execute_case_selector(const ColumnPtr& cond_column, const Selector* executo
     }
 }
 
-Status ShortCircuitCaseExpr::execute_column(VExprContext* context, const Block* block,
-                                            Selector* selector, size_t count,
-                                            ColumnPtr& result_column) const {
+Status ShortCircuitCaseExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                                 const Selector* selector, size_t count,
+                                                 ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr) << debug_string();
     DCHECK(selector == nullptr || selector->size() == count);
 
@@ -274,7 +274,7 @@ Status ShortCircuitCaseExpr::execute_column(VExprContext* context, const Block* 
     std::vector<ColumnAndSelector> columns_and_selectors;
     columns_and_selectors.resize(num_branches);
 
-    Selector* executor_selector = selector;
+    const Selector* executor_selector = selector;
     size_t executor_count = count;
 
     Selector* current_selector = nullptr;
@@ -374,9 +374,9 @@ void execute_ifnull_selector(const ColumnPtr& cond_column, const Selector* selec
     condition_view.for_each(null_func, not_null_func);
 }
 
-Status ShortCircuitIfNullExpr::execute_column(VExprContext* context, const Block* block,
-                                              Selector* selector, size_t count,
-                                              ColumnPtr& result_column) const {
+Status ShortCircuitIfNullExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                                   const Selector* selector, size_t count,
+                                                   ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr) << debug_string();
     DCHECK(selector == nullptr || selector->size() == count);
     ColumnPtr expr1_column;
@@ -440,9 +440,9 @@ void execute_coalesce_selector(const ColumnPtr& cond_column, const Selector* exe
     }
 }
 
-Status ShortCircuitCoalesceExpr::execute_column(VExprContext* context, const Block* block,
-                                                Selector* selector, size_t count,
-                                                ColumnPtr& result_column) const {
+Status ShortCircuitCoalesceExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                                     const Selector* selector, size_t count,
+                                                     ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr) << debug_string();
     DCHECK(selector == nullptr || selector->size() == count);
 
@@ -450,7 +450,7 @@ Status ShortCircuitCoalesceExpr::execute_column(VExprContext* context, const Blo
     columns_and_selectors.resize(_children.size() +
                                  1); // the last one represents the selector for null output
 
-    Selector* executor_selector = selector;
+    const Selector* executor_selector = selector;
     size_t executor_count = count;
 
     Selector* current_selector = nullptr;

--- a/be/src/vec/exprs/short_circuit_evaluation_expr.h
+++ b/be/src/vec/exprs/short_circuit_evaluation_expr.h
@@ -64,8 +64,8 @@ public:
 
     const std::string& expr_name() const override { return IF_NAME; }
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
 
 private:
     inline static const std::string IF_NAME = "if";
@@ -76,8 +76,8 @@ public:
     ShortCircuitCaseExpr(const TExprNode& node);
     ~ShortCircuitCaseExpr() override = default;
     const std::string& expr_name() const override { return CASE_NAME; }
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
 
 private:
     const bool _has_else_expr;
@@ -91,8 +91,8 @@ public:
     ~ShortCircuitIfNullExpr() override = default;
 
     const std::string& expr_name() const override { return IFNULL_NAME; }
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
 
 private:
     inline static const std::string IFNULL_NAME = "ifnull";
@@ -104,8 +104,8 @@ public:
     ShortCircuitCoalesceExpr(const TExprNode& node) : ShortCircuitExpr(node) {}
     ~ShortCircuitCoalesceExpr() override = default;
     const std::string& expr_name() const override { return COALESCE_NAME; }
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
 
 private:
     inline static const std::string COALESCE_NAME = "coalesce";

--- a/be/src/vec/exprs/vbitmap_predicate.cpp
+++ b/be/src/vec/exprs/vbitmap_predicate.cpp
@@ -76,7 +76,7 @@ doris::Status vectorized::VBitmapPredicate::open(doris::RuntimeState* state,
 }
 
 Status VBitmapPredicate::_do_execute(VExprContext* context, const Block* block,
-                                     const uint8_t* __restrict filter, Selector* selector,
+                                     const uint8_t* __restrict filter, const Selector* selector,
                                      size_t count, ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr);
     DCHECK(!(filter != nullptr && selector != nullptr))
@@ -108,9 +108,9 @@ Status VBitmapPredicate::_do_execute(VExprContext* context, const Block* block,
     return Status::OK();
 }
 
-Status VBitmapPredicate::execute_column(VExprContext* context, const Block* block,
-                                        Selector* selector, size_t count,
-                                        ColumnPtr& result_column) const {
+Status VBitmapPredicate::execute_column_impl(VExprContext* context, const Block* block,
+                                             const Selector* selector, size_t count,
+                                             ColumnPtr& result_column) const {
     return _do_execute(context, block, nullptr, selector, count, result_column);
 }
 

--- a/be/src/vec/exprs/vbitmap_predicate.h
+++ b/be/src/vec/exprs/vbitmap_predicate.h
@@ -49,8 +49,8 @@ public:
 
     ~VBitmapPredicate() override = default;
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     Status execute_runtime_filter(VExprContext* context, const Block* block,
                                   const uint8_t* __restrict filter, size_t count,
                                   ColumnPtr& result_column, ColumnPtr* arg_column) const override;
@@ -78,7 +78,7 @@ public:
 
 private:
     Status _do_execute(VExprContext* context, const Block* block, const uint8_t* __restrict filter,
-                       Selector* selector, size_t count, ColumnPtr& result_column) const;
+                       const Selector* selector, size_t count, ColumnPtr& result_column) const;
     std::shared_ptr<BitmapFilterFuncBase> _filter;
     inline static const std::string EXPR_NAME = "bitmap_predicate";
 };

--- a/be/src/vec/exprs/vbloom_predicate.cpp
+++ b/be/src/vec/exprs/vbloom_predicate.cpp
@@ -71,7 +71,7 @@ void VBloomPredicate::close(VExprContext* context, FunctionContext::FunctionStat
 }
 
 Status VBloomPredicate::_do_execute(VExprContext* context, const Block* block,
-                                    const uint8_t* __restrict filter, Selector* selector,
+                                    const uint8_t* __restrict filter, const Selector* selector,
                                     size_t count, ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr);
     DCHECK(!(filter != nullptr && selector != nullptr))
@@ -95,9 +95,9 @@ Status VBloomPredicate::_do_execute(VExprContext* context, const Block* block,
     return Status::OK();
 }
 
-Status VBloomPredicate::execute_column(VExprContext* context, const Block* block,
-                                       Selector* selector, size_t count,
-                                       ColumnPtr& result_column) const {
+Status VBloomPredicate::execute_column_impl(VExprContext* context, const Block* block,
+                                            const Selector* selector, size_t count,
+                                            ColumnPtr& result_column) const {
     return _do_execute(context, block, nullptr, selector, count, result_column);
 }
 

--- a/be/src/vec/exprs/vbloom_predicate.h
+++ b/be/src/vec/exprs/vbloom_predicate.h
@@ -44,8 +44,8 @@ public:
     VBloomPredicate(const TExprNode& node);
     ~VBloomPredicate() override = default;
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
 
     Status execute_runtime_filter(VExprContext* context, const Block* block,
                                   const uint8_t* __restrict filter, size_t count,
@@ -64,7 +64,7 @@ public:
 
 private:
     Status _do_execute(VExprContext* context, const Block* block, const uint8_t* __restrict filter,
-                       Selector* selector, size_t count, ColumnPtr& result_column) const;
+                       const Selector* selector, size_t count, ColumnPtr& result_column) const;
 
     std::shared_ptr<BloomFilterFuncBase> _filter;
     inline static const std::string EXPR_NAME = "bloom_predicate";

--- a/be/src/vec/exprs/vcase_expr.cpp
+++ b/be/src/vec/exprs/vcase_expr.cpp
@@ -76,8 +76,9 @@ void VCaseExpr::close(VExprContext* context, FunctionContext::FunctionStateScope
     VExpr::close(context, scope);
 }
 
-Status VCaseExpr::execute_column(VExprContext* context, const Block* block, Selector* selector,
-                                 size_t count, ColumnPtr& result_column) const {
+Status VCaseExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                      const Selector* selector, size_t count,
+                                      ColumnPtr& result_column) const {
     if (is_const_and_have_executed()) { // const have execute in open function
         result_column = get_result_from_const(count);
         return Status::OK();

--- a/be/src/vec/exprs/vcase_expr.h
+++ b/be/src/vec/exprs/vcase_expr.h
@@ -53,8 +53,8 @@ class VCaseExpr final : public VExpr {
 public:
     VCaseExpr(const TExprNode& node);
     ~VCaseExpr() override = default;
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;

--- a/be/src/vec/exprs/vcast_expr.cpp
+++ b/be/src/vec/exprs/vcast_expr.cpp
@@ -104,8 +104,9 @@ void VCastExpr::close(VExprContext* context, FunctionContext::FunctionStateScope
     VExpr::close(context, scope);
 }
 
-Status VCastExpr::execute_column(VExprContext* context, const Block* block, Selector* selector,
-                                 size_t count, ColumnPtr& result_column) const {
+Status VCastExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                      const Selector* selector, size_t count,
+                                      ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr) << _open_finished << _expr_name;
     if (is_const_and_have_executed()) { // const have executed in open function
         result_column = get_result_from_const(count);
@@ -144,8 +145,9 @@ DataTypePtr TryCastExpr::original_cast_return_type() const {
     }
 }
 
-Status TryCastExpr::execute_column(VExprContext* context, const Block* block, Selector* selector,
-                                   size_t count, ColumnPtr& result_column) const {
+Status TryCastExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                        const Selector* selector, size_t count,
+                                        ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr) << _open_finished << _expr_name;
     if (is_const_and_have_executed()) { // const have executed in open function
         result_column = get_result_from_const(count);

--- a/be/src/vec/exprs/vcast_expr.h
+++ b/be/src/vec/exprs/vcast_expr.h
@@ -48,8 +48,8 @@ public:
 #endif
     VCastExpr(const TExprNode& node) : VExpr(node) {}
     ~VCastExpr() override = default;
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
@@ -92,8 +92,8 @@ public:
 
     TryCastExpr(const TExprNode& node)
             : VCastExpr(node), _original_cast_return_is_nullable(node.is_cast_nullable) {}
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     ~TryCastExpr() override = default;
     std::string cast_name() const override { return "TRY CAST"; }
 

--- a/be/src/vec/exprs/vcolumn_ref.h
+++ b/be/src/vec/exprs/vcolumn_ref.h
@@ -57,8 +57,8 @@ public:
         return Status::OK();
     }
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override {
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
         DCHECK(_open_finished || block == nullptr);
         auto origin_column = block->get_by_position(_column_id + _gap).column;
         result_column = filter_column_with_selector(origin_column, selector, count);

--- a/be/src/vec/exprs/vcompound_pred.h
+++ b/be/src/vec/exprs/vcompound_pred.h
@@ -152,13 +152,14 @@ public:
         return Status::OK();
     }
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override {
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
         if (fast_execute(context, selector, count, result_column)) {
             return Status::OK();
         }
         if (get_num_children() == 1 || _has_const_child()) {
-            return VectorizedFnCall::execute_column(context, block, selector, count, result_column);
+            return VectorizedFnCall::execute_column_impl(context, block, selector, count,
+                                                         result_column);
         }
 
         ColumnPtr lhs_column;

--- a/be/src/vec/exprs/vcondition_expr.cpp
+++ b/be/src/vec/exprs/vcondition_expr.cpp
@@ -445,9 +445,9 @@ Status VectorizedIfExpr::_execute_impl_internal(Block& block, const ColumnNumber
     }
 }
 
-Status VectorizedIfExpr::execute_column(VExprContext* context, const Block* block,
-                                        Selector* selector, size_t count,
-                                        ColumnPtr& result_column) const {
+Status VectorizedIfExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                             const Selector* selector, size_t count,
+                                             ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr) << debug_string();
     DCHECK_EQ(_children.size(), 3) << "IF expr must have three children";
 
@@ -486,9 +486,9 @@ Status VectorizedIfExpr::execute_column(VExprContext* context, const Block* bloc
     return Status::OK();
 }
 
-Status VectorizedIfNullExpr::execute_column(VExprContext* context, const Block* block,
-                                            Selector* selector, size_t count,
-                                            ColumnPtr& result_column) const {
+Status VectorizedIfNullExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                                 const Selector* selector, size_t count,
+                                                 ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr) << debug_string();
     DCHECK_EQ(_children.size(), 2) << "IFNULL expr must have two children";
 
@@ -638,9 +638,9 @@ Status filled_result_column(const DataTypePtr& data_type, MutableColumnPtr& resu
     return Status::OK();
 }
 
-Status VectorizedCoalesceExpr::execute_column(VExprContext* context, const Block* block,
-                                              Selector* selector, size_t count,
-                                              ColumnPtr& return_column) const {
+Status VectorizedCoalesceExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                                   const Selector* selector, size_t count,
+                                                   ColumnPtr& return_column) const {
     DataTypePtr result_type = _data_type;
     const auto input_rows_count = count;
 

--- a/be/src/vec/exprs/vcondition_expr.h
+++ b/be/src/vec/exprs/vcondition_expr.h
@@ -61,8 +61,8 @@ class VectorizedIfExpr : public VConditionExpr {
 public:
     VectorizedIfExpr(const TExprNode& node) : VConditionExpr(node) {}
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
 
     const std::string& expr_name() const override { return IF_NAME; }
     inline static const std::string IF_NAME = "if";
@@ -125,16 +125,16 @@ public:
     const std::string& expr_name() const override { return IF_NULL_NAME; }
     inline static const std::string IF_NULL_NAME = "ifnull";
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
 };
 
 class VectorizedCoalesceExpr : public VConditionExpr {
     ENABLE_FACTORY_CREATOR(VectorizedCoalesceExpr);
 
 public:
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     VectorizedCoalesceExpr(const TExprNode& node) : VConditionExpr(node) {}
     const std::string& expr_name() const override { return NAME; }
     inline static const std::string NAME = "coalesce";

--- a/be/src/vec/exprs/vdirect_in_predicate.h
+++ b/be/src/vec/exprs/vdirect_in_predicate.h
@@ -54,8 +54,8 @@ public:
         return Status::OK();
     }
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override {
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
         return _do_execute(context, block, nullptr, selector, count, result_column, nullptr);
     }
 
@@ -117,7 +117,7 @@ public:
 
 private:
     Status _do_execute(VExprContext* context, const Block* block, const uint8_t* __restrict filter,
-                       Selector* selector, size_t count, ColumnPtr& result_column,
+                       const Selector* selector, size_t count, ColumnPtr& result_column,
                        ColumnPtr* arg_column) const {
         DCHECK(_open_finished || block == nullptr);
         DCHECK(!(filter != nullptr && selector != nullptr))

--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -205,9 +205,9 @@ Status VectorizedFnCall::evaluate_inverted_index(VExprContext* context, uint32_t
     return _evaluate_inverted_index(context, _function, segment_num_rows);
 }
 
-Status VectorizedFnCall::_do_execute(VExprContext* context, const Block* block, Selector* selector,
-                                     size_t count, ColumnPtr& result_column,
-                                     ColumnPtr* arg_column) const {
+Status VectorizedFnCall::_do_execute(VExprContext* context, const Block* block,
+                                     const Selector* selector, size_t count,
+                                     ColumnPtr& result_column, ColumnPtr* arg_column) const {
     if (is_const_and_have_executed()) { // const have executed in open function
         result_column = get_result_from_const(count);
         return Status::OK();
@@ -297,9 +297,9 @@ Status VectorizedFnCall::execute_runtime_filter(VExprContext* context, const Blo
     return _do_execute(context, block, nullptr, count, result_column, arg_column);
 }
 
-Status VectorizedFnCall::execute_column(VExprContext* context, const Block* block,
-                                        Selector* selector, size_t count,
-                                        ColumnPtr& result_column) const {
+Status VectorizedFnCall::execute_column_impl(VExprContext* context, const Block* block,
+                                             const Selector* selector, size_t count,
+                                             ColumnPtr& result_column) const {
     return _do_execute(context, block, selector, count, result_column, nullptr);
 }
 

--- a/be/src/vec/exprs/vectorized_fn_call.h
+++ b/be/src/vec/exprs/vectorized_fn_call.h
@@ -53,8 +53,8 @@ public:
 #endif
     VectorizedFnCall(const TExprNode& node);
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     Status execute_runtime_filter(VExprContext* context, const Block* block,
                                   const uint8_t* __restrict filter, size_t count,
                                   ColumnPtr& result_column, ColumnPtr* arg_column) const override;
@@ -104,8 +104,8 @@ protected:
     std::string _function_name;
 
 private:
-    Status _do_execute(VExprContext* context, const Block* block, Selector* selector, size_t count,
-                       ColumnPtr& result_column, ColumnPtr* arg_column) const;
+    Status _do_execute(VExprContext* context, const Block* block, const Selector* selector,
+                       size_t count, ColumnPtr& result_column, ColumnPtr* arg_column) const;
 };
 
 #include "common/compile_check_end.h"

--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -987,7 +987,7 @@ size_t VExpr::estimate_memory(const size_t rows) {
     return estimate_size;
 }
 
-bool VExpr::fast_execute(VExprContext* context, Selector* selector, size_t count,
+bool VExpr::fast_execute(VExprContext* context, const Selector* selector, size_t count,
                          ColumnPtr& result_column) const {
     if (context->get_index_context() &&
         context->get_index_context()->get_index_result_column().contains(this)) {

--- a/be/src/vec/exprs/vexpr.h
+++ b/be/src/vec/exprs/vexpr.h
@@ -149,8 +149,28 @@ public:
     // In the future this interface will add an additional parameter, Selector, which specifies
     // which rows in the block should be evaluated.
     // If expr is executing constant expressions, then block should be nullptr.
-    virtual Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                                  size_t count, ColumnPtr& result_column) const = 0;
+
+    Status execute_column(VExprContext* context, const Block* block, const Selector* selector,
+                          size_t count, ColumnPtr& result_column) const {
+        RETURN_IF_ERROR(execute_column_impl(context, block, selector, count, result_column));
+        if (result_column->size() != count) {
+            return Status::InternalError(
+                    "Expr {} return column size {} not equal to expected size {}", expr_name(),
+                    result_column->size(), count);
+        }
+        DCHECK(selector == nullptr || selector->size() == count);
+
+#ifndef NDEBUG
+        RETURN_IF_ERROR(result_column->column_self_check());
+        auto result_type = execute_type(block);
+        RETURN_IF_ERROR(result_type->check_column(*result_column));
+#endif
+        return Status::OK();
+    }
+
+    virtual Status execute_column_impl(VExprContext* context, const Block* block,
+                                       const Selector* selector, size_t count,
+                                       ColumnPtr& result_column) const = 0;
 
     // Currently, due to fe planning issues, for slot-ref expressions the type of the returned Column may not match data_type.
     // Therefore we need a function like this to return the actual type produced by execution.
@@ -327,7 +347,7 @@ public:
     }
 
     // fast_execute can direct copy expr filter result which build by apply index in segment_iterator
-    bool fast_execute(VExprContext* context, Selector* selector, size_t count,
+    bool fast_execute(VExprContext* context, const Selector* selector, size_t count,
                       ColumnPtr& result_column) const;
 
     virtual bool can_push_down_to_index() const { return false; }

--- a/be/src/vec/exprs/vin_predicate.cpp
+++ b/be/src/vec/exprs/vin_predicate.cpp
@@ -113,8 +113,9 @@ Status VInPredicate::evaluate_inverted_index(VExprContext* context, uint32_t seg
     return _evaluate_inverted_index(context, _function, segment_num_rows);
 }
 
-Status VInPredicate::execute_column(VExprContext* context, const Block* block, Selector* selector,
-                                    size_t count, ColumnPtr& result_column) const {
+Status VInPredicate::execute_column_impl(VExprContext* context, const Block* block,
+                                         const Selector* selector, size_t count,
+                                         ColumnPtr& result_column) const {
     if (is_const_and_have_executed()) { // const have execute in open function
         result_column = get_result_from_const(count);
         return Status::OK();

--- a/be/src/vec/exprs/vin_predicate.h
+++ b/be/src/vec/exprs/vin_predicate.h
@@ -45,8 +45,8 @@ public:
     VInPredicate() = default;
 #endif
     ~VInPredicate() override = default;
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     size_t estimate_memory(const size_t rows) override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,

--- a/be/src/vec/exprs/vinfo_func.cpp
+++ b/be/src/vec/exprs/vinfo_func.cpp
@@ -55,8 +55,9 @@ VInfoFunc::VInfoFunc(const TExprNode& node) : VExpr(node) {
     this->_column_ptr = _data_type->create_column_const(1, field);
 }
 
-Status VInfoFunc::execute_column(VExprContext* context, const Block* block, Selector* selector,
-                                 size_t count, ColumnPtr& result_column) const {
+Status VInfoFunc::execute_column_impl(VExprContext* context, const Block* block,
+                                      const Selector* selector, size_t count,
+                                      ColumnPtr& result_column) const {
     result_column = _column_ptr->clone_resized(count);
     DCHECK_EQ(result_column->size(), count);
     return Status::OK();

--- a/be/src/vec/exprs/vinfo_func.h
+++ b/be/src/vec/exprs/vinfo_func.h
@@ -39,8 +39,8 @@ public:
     ~VInfoFunc() override = default;
 
     const std::string& expr_name() const override { return _expr_name; }
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
 
 private:
     const std::string _expr_name = "vinfofunc expr";

--- a/be/src/vec/exprs/virtual_slot_ref.cpp
+++ b/be/src/vec/exprs/virtual_slot_ref.cpp
@@ -103,8 +103,9 @@ Status VirtualSlotRef::open(RuntimeState* state, VExprContext* context,
     return Status::OK();
 }
 
-Status VirtualSlotRef::execute_column(VExprContext* context, const Block* block, Selector* selector,
-                                      size_t count, ColumnPtr& result_column) const {
+Status VirtualSlotRef::execute_column_impl(VExprContext* context, const Block* block,
+                                           const Selector* selector, size_t count,
+                                           ColumnPtr& result_column) const {
     if (_column_id >= 0 && _column_id >= block->columns()) {
         return Status::Error<ErrorCode::INTERNAL_ERROR>(
                 "input block not contain slot column {}, column_id={}, block={}", *_column_name,

--- a/be/src/vec/exprs/virtual_slot_ref.h
+++ b/be/src/vec/exprs/virtual_slot_ref.h
@@ -31,8 +31,8 @@ public:
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     const std::string& expr_name() const override;
     std::string expr_label() override;
     std::string debug_string() const override;

--- a/be/src/vec/exprs/vlambda_function_call_expr.h
+++ b/be/src/vec/exprs/vlambda_function_call_expr.h
@@ -63,8 +63,8 @@ public:
         return Status::OK();
     }
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override {
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
         DCHECK(_open_finished || block == nullptr);
         return _lambda_function->execute(context, block, selector, count, result_column, _data_type,
                                          _children);

--- a/be/src/vec/exprs/vlambda_function_expr.h
+++ b/be/src/vec/exprs/vlambda_function_expr.h
@@ -42,8 +42,8 @@ public:
         return Status::OK();
     }
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override {
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
         DCHECK(_open_finished || block == nullptr);
         return get_child(0)->execute_column(context, block, selector, count, result_column);
     }

--- a/be/src/vec/exprs/vliteral.cpp
+++ b/be/src/vec/exprs/vliteral.cpp
@@ -49,8 +49,9 @@ Status VLiteral::prepare(RuntimeState* state, const RowDescriptor& desc, VExprCo
     return Status::OK();
 }
 
-Status VLiteral::execute_column(VExprContext* context, const Block* block, Selector* selector,
-                                size_t count, ColumnPtr& result_column) const {
+Status VLiteral::execute_column_impl(VExprContext* context, const Block* block,
+                                     const Selector* selector, size_t count,
+                                     ColumnPtr& result_column) const {
     DCHECK(selector == nullptr || selector->size() == count);
     result_column = _column_ptr->clone_resized(count);
     DCHECK_EQ(result_column->size(), count);

--- a/be/src/vec/exprs/vliteral.h
+++ b/be/src/vec/exprs/vliteral.h
@@ -50,8 +50,8 @@ public:
 #endif
 
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
 
     const std::string& expr_name() const override { return _expr_name; }
     std::string debug_string() const override;

--- a/be/src/vec/exprs/vmatch_predicate.cpp
+++ b/be/src/vec/exprs/vmatch_predicate.cpp
@@ -156,9 +156,9 @@ const std::string& VMatchPredicate::get_analyzer_key() const {
     return _analyzer_ctx->analyzer_name;
 }
 
-Status VMatchPredicate::execute_column(VExprContext* context, const Block* block,
-                                       Selector* selector, size_t count,
-                                       ColumnPtr& result_column) const {
+Status VMatchPredicate::execute_column_impl(VExprContext* context, const Block* block,
+                                            const Selector* selector, size_t count,
+                                            ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr);
     if (fast_execute(context, selector, count, result_column)) {
         return Status::OK();

--- a/be/src/vec/exprs/vmatch_predicate.h
+++ b/be/src/vec/exprs/vmatch_predicate.h
@@ -49,8 +49,8 @@ class VMatchPredicate final : public VExpr {
 public:
     VMatchPredicate(const TExprNode& node);
     ~VMatchPredicate() override;
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;

--- a/be/src/vec/exprs/vruntimefilter_wrapper.cpp
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.cpp
@@ -85,10 +85,10 @@ void VRuntimeFilterWrapper::close(VExprContext* context,
     _impl->close(context, scope);
 }
 
-Status VRuntimeFilterWrapper::execute_column(VExprContext* context, const Block* block,
-                                             Selector* selector, size_t count,
-                                             ColumnPtr& result_column) const {
-    return Status::InternalError("Not implement VRuntimeFilterWrapper::execute_column");
+Status VRuntimeFilterWrapper::execute_column_impl(VExprContext* context, const Block* block,
+                                                  const Selector* selector, size_t count,
+                                                  ColumnPtr& result_column) const {
+    return Status::InternalError("Not implement VRuntimeFilterWrapper::execute_column_impl");
 }
 
 const std::string& VRuntimeFilterWrapper::expr_name() const {

--- a/be/src/vec/exprs/vruntimefilter_wrapper.h
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.h
@@ -53,8 +53,8 @@ public:
     VRuntimeFilterWrapper(const TExprNode& node, VExprSPtr impl, double ignore_thredhold,
                           bool null_aware, int filter_id);
     ~VRuntimeFilterWrapper() override = default;
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;

--- a/be/src/vec/exprs/vsearch.cpp
+++ b/be/src/vec/exprs/vsearch.cpp
@@ -136,8 +136,9 @@ const std::string& VSearchExpr::expr_name() const {
     return name;
 }
 
-Status VSearchExpr::execute_column(VExprContext* context, const Block* block, Selector* selector,
-                                   size_t count, ColumnPtr& result_column) const {
+Status VSearchExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                        const Selector* selector, size_t count,
+                                        ColumnPtr& result_column) const {
     if (fast_execute(context, selector, count, result_column)) {
         return Status::OK();
     }

--- a/be/src/vec/exprs/vsearch.h
+++ b/be/src/vec/exprs/vsearch.h
@@ -26,8 +26,8 @@ class VSearchExpr : public VExpr {
 public:
     VSearchExpr(const TExprNode& node);
     ~VSearchExpr() override = default;
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     const std::string& expr_name() const override;
     Status evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) override;
 

--- a/be/src/vec/exprs/vslot_ref.cpp
+++ b/be/src/vec/exprs/vslot_ref.cpp
@@ -86,8 +86,9 @@ Status VSlotRef::execute(VExprContext* context, Block* block, int* result_column
     return Status::OK();
 }
 
-Status VSlotRef::execute_column(VExprContext* context, const Block* block, Selector* selector,
-                                size_t count, ColumnPtr& result_column) const {
+Status VSlotRef::execute_column_impl(VExprContext* context, const Block* block,
+                                     const Selector* selector, size_t count,
+                                     ColumnPtr& result_column) const {
     if (_column_id >= 0 && _column_id >= block->columns()) {
         return Status::Error<ErrorCode::INTERNAL_ERROR>(
                 "input block not contain slot column {}, column_id={}, block={}", *_column_name,

--- a/be/src/vec/exprs/vslot_ref.h
+++ b/be/src/vec/exprs/vslot_ref.h
@@ -47,8 +47,8 @@ public:
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
     Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     DataTypePtr execute_type(const Block* block) const override;
 
     const std::string& expr_name() const override;

--- a/be/src/vec/exprs/vtopn_pred.h
+++ b/be/src/vec/exprs/vtopn_pred.h
@@ -84,8 +84,8 @@ public:
         return Status::OK();
     }
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override {
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
         if (!_predicate->has_value()) {
             result_column = create_always_true_column(count, _data_type->is_nullable());
             return Status::OK();

--- a/be/test/exprs/mock_vexpr.h
+++ b/be/test/exprs/mock_vexpr.h
@@ -31,9 +31,9 @@ public:
     MOCK_CONST_METHOD0(expr_name, const std::string&());
     MOCK_CONST_METHOD3(execute, Status(VExprContext* context, vectorized::Block* block,
                                        int* result_column_id));
-    MOCK_CONST_METHOD5(execute_column,
+    MOCK_CONST_METHOD5(execute_column_impl,
                        Status(VExprContext* context, const vectorized::Block* block,
-                              Selector* selector, size_t count, ColumnPtr& result_column));
+                              const Selector* selector, size_t count, ColumnPtr& result_column));
 }; // class MockVExpr
 
 } // namespace vectorized

--- a/be/test/exprs/virtual_slot_ref_test.cpp
+++ b/be/test/exprs/virtual_slot_ref_test.cpp
@@ -170,8 +170,9 @@ TEST_F(VirtualSlotRefTest, EqualsFunction_WithDifferentTypes) {
         Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
             return Status::OK();
         }
-        Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                              size_t count, ColumnPtr& result_column) const override {
+        Status execute_column_impl(VExprContext* context, const Block* block,
+                                   const Selector* selector, size_t count,
+                                   ColumnPtr& result_column) const override {
             return Status::OK();
         }
 
@@ -291,8 +292,9 @@ TEST_F(VirtualSlotRefTest, EqualsFunction_TestAllBranches) {
             return Status::OK();
         }
 
-        Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                              size_t count, ColumnPtr& result_column) const override {
+        Status execute_column_impl(VExprContext* context, const Block* block,
+                                   const Selector* selector, size_t count,
+                                   ColumnPtr& result_column) const override {
             return Status::OK();
         }
 
@@ -316,8 +318,9 @@ TEST_F(VirtualSlotRefTest, EqualsFunction_TestAllBranches) {
         Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
             return Status::OK();
         }
-        Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                              size_t count, ColumnPtr& result_column) const override {
+        Status execute_column_impl(VExprContext* context, const Block* block,
+                                   const Selector* selector, size_t count,
+                                   ColumnPtr& result_column) const override {
             return Status::OK();
         }
         const std::string& expr_name() const override {

--- a/be/test/olap/collection_statistics_test.cpp
+++ b/be/test/olap/collection_statistics_test.cpp
@@ -52,9 +52,9 @@ public:
         return Status::OK();
     }
 
-    Status execute_column(vectorized::VExprContext* context, const vectorized::Block* block,
-                          vectorized::Selector* selector, size_t count,
-                          vectorized::ColumnPtr& result_column) const override {
+    Status execute_column_impl(vectorized::VExprContext* context, const vectorized::Block* block,
+                               const vectorized::Selector* selector, size_t count,
+                               vectorized::ColumnPtr& result_column) const override {
         return Status::OK();
     }
 

--- a/be/test/vec/exprs/score_runtime_test.cpp
+++ b/be/test/vec/exprs/score_runtime_test.cpp
@@ -24,6 +24,8 @@
 
 #include "gen_cpp/Exprs_types.h"
 #include "gen_cpp/Opcodes_types.h"
+#include "vec/columns/column_nothing.h"
+#include "vec/data_types/data_type_nothing.h"
 #include "vec/exprs/vexpr_context.h"
 #include "vec/exprs/virtual_slot_ref.h"
 
@@ -40,9 +42,14 @@ public:
         return kName;
     }
 
+    DataTypePtr execute_type(const Block* block) const override {
+        return std::make_shared<DataTypeNothing>();
+    }
+
     Status execute(VExprContext*, Block*, int*) const override { return Status::OK(); }
     Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
                                size_t count, ColumnPtr& result_column) const override {
+        result_column = ColumnNothing::create(count);
         return Status::OK();
     }
 };

--- a/be/test/vec/exprs/score_runtime_test.cpp
+++ b/be/test/vec/exprs/score_runtime_test.cpp
@@ -41,8 +41,8 @@ public:
     }
 
     Status execute(VExprContext*, Block*, int*) const override { return Status::OK(); }
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override {
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
         return Status::OK();
     }
 };

--- a/be/test/vec/exprs/try_cast_expr_test.cpp
+++ b/be/test/vec/exprs/try_cast_expr_test.cpp
@@ -141,11 +141,11 @@ public:
         return Status::OK();
     }
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override {
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
         auto int_type = std::make_shared<DataTypeInt32>();
         auto int_column = int_type->create_column();
-        for (int i = 0; i < 3; i++) {
+        for (size_t i = 0; i < count; i++) {
             Int32 x = i;
             int_column->insert_data((const char*)&x, sizeof(Int32));
         }
@@ -184,6 +184,8 @@ TEST_F(TryCastExprTest, BasicTest1) {
             DataTypes {std::make_shared<DataTypeInt32>()}, std::make_shared<DataTypeInt32>());
 
     Block block;
+    block.insert(ColumnWithTypeAndName {ColumnNothing::create(3), std::make_shared<DataTypeInt32>(),
+                                        "mock_input_column"});
     int result_column_id = -1;
     try_cast_expr._original_cast_return_is_nullable = true;
     auto st = try_cast_expr.execute(context.get(), &block, &result_column_id);
@@ -196,6 +198,8 @@ TEST_F(TryCastExprTest, BasicTest2) {
             DataTypes {std::make_shared<DataTypeInt32>()}, std::make_shared<DataTypeInt32>());
 
     Block block;
+    block.insert(ColumnWithTypeAndName {ColumnNothing::create(3), std::make_shared<DataTypeInt32>(),
+                                        "mock_input_column"});
     int result_column_id = -1;
     try_cast_expr._original_cast_return_is_nullable = false;
     auto st = try_cast_expr.execute(context.get(), &block, &result_column_id);
@@ -208,6 +212,8 @@ TEST_F(TryCastExprTest, return_error) {
             DataTypes {std::make_shared<DataTypeInt32>()}, std::make_shared<DataTypeInt32>());
 
     Block block;
+    block.insert(ColumnWithTypeAndName {ColumnNothing::create(3), std::make_shared<DataTypeInt32>(),
+                                        "mock_input_column"});
     int result_column_id = -1;
     try_cast_expr._original_cast_return_is_nullable = false;
     auto st = try_cast_expr.execute(context.get(), &block, &result_column_id);

--- a/be/test/vec/exprs/vexpr_test.cpp
+++ b/be/test/vec/exprs/vexpr_test.cpp
@@ -418,106 +418,92 @@ TEST(TEST_VEXPR, LITERALTEST) {
     // bool
     {
         VLiteral literal(create_literal<TYPE_BOOLEAN>(true));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_BOOLEAN>();
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
+        auto v = (*result_column)[0].get<TYPE_BOOLEAN>();
         EXPECT_EQ(v, true);
         EXPECT_EQ("1", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_BOOLEAN, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_BOOLEAN, 0, 0), true);
         EXPECT_EQ("1", node->value());
     }
     // smallint
     {
         VLiteral literal(create_literal<TYPE_SMALLINT>(1024));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_SMALLINT>();
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
+        auto v = (*result_column)[0].get<TYPE_SMALLINT>();
         EXPECT_EQ(v, 1024);
         EXPECT_EQ("1024", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_SMALLINT, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_SMALLINT, 0, 0), true);
         EXPECT_EQ("1024", node->value());
     }
     // int
     {
         VLiteral literal(create_literal<TYPE_INT>(1024));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_INT>();
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
+        auto v = (*result_column)[0].get<TYPE_INT>();
         EXPECT_EQ(v, 1024);
         EXPECT_EQ("1024", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_INT, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_INT, 0, 0), true);
         EXPECT_EQ("1024", node->value());
     }
     // bigint
     {
         VLiteral literal(create_literal<TYPE_BIGINT>(1024));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_BIGINT>();
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
+        auto v = (*result_column)[0].get<TYPE_BIGINT>();
         EXPECT_EQ(v, 1024);
         EXPECT_EQ("1024", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_BIGINT, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_BIGINT, 0, 0), true);
         EXPECT_EQ("1024", node->value());
     }
     // large int
     {
         VLiteral literal(create_literal<TYPE_LARGEINT, __int128_t>(1024));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_LARGEINT>();
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
+        auto v = (*result_column)[0].get<TYPE_LARGEINT>();
         EXPECT_EQ(v, 1024);
         EXPECT_EQ("1024", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_LARGEINT, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_LARGEINT, 0, 0), true);
         EXPECT_EQ("1024", node->value());
     }
     // float
     {
         VLiteral literal(create_literal<TYPE_FLOAT, float>(1024.0f));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_FLOAT>();
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
+        auto v = (*result_column)[0].get<TYPE_FLOAT>();
         EXPECT_FLOAT_EQ(v, 1024.0f);
         EXPECT_EQ("1024", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_FLOAT, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_FLOAT, 0, 0), true);
         EXPECT_EQ("1024", node->value());
     }
     // double
     {
         VLiteral literal(create_literal<TYPE_DOUBLE, double>(1024.0));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_DOUBLE>();
-        EXPECT_FLOAT_EQ(v, 1024.0) << ctn.column->get_name();
-        EXPECT_EQ("1024", literal.value()) << ctn.column->get_name();
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
+        auto v = (*result_column)[0].get<TYPE_DOUBLE>();
+        EXPECT_FLOAT_EQ(v, 1024.0) << result_column->get_name();
+        EXPECT_EQ("1024", literal.value()) << result_column->get_name();
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_DOUBLE, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_DOUBLE, 0, 0), true);
         EXPECT_EQ("1024", node->value());
     }
     // datetime
@@ -527,14 +513,12 @@ TEST(TEST_VEXPR, LITERALTEST) {
         data_time_value.from_date_str(date, strlen(date));
         std::cout << data_time_value.type() << std::endl;
         VLiteral literal(create_literal<TYPE_DATETIME, std::string>(std::string(date)));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
         EXPECT_EQ("2021-04-07 00:00:00", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_DATETIME, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_DATETIME, 0, 0), true);
         EXPECT_EQ("2021-04-07 00:00:00", node->value());
     }
     // datetimev2
@@ -551,14 +535,12 @@ TEST(TEST_VEXPR, LITERALTEST) {
         std::string date = datetime_v2.to_string();
 
         VLiteral literal(create_literal<TYPE_DATETIMEV2, std::string>(date, 4));
-        Block block;
-        int ret = -1;
-        EXPECT_TRUE(literal.execute(nullptr, &block, &ret).ok());
+        ColumnPtr result_column;
+        EXPECT_TRUE(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column).ok());
         EXPECT_EQ("1997-11-18 09:12:47.0000", literal.value());
 
-        auto ctn = block.safe_get_by_position(ret);
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_DATETIMEV2, 0, 4), true);
+                create_texpr_node_from((*result_column)[0], TYPE_DATETIMEV2, 0, 4), true);
         EXPECT_EQ("1997-11-18 09:12:47.0000", node->value());
     }
     // timestamptz
@@ -582,14 +564,12 @@ TEST(TEST_VEXPR, LITERALTEST) {
         std::string tz_value_str = tz_value.to_string(tz, scale);
 
         VLiteral literal(create_literal<TYPE_TIMESTAMPTZ, std::string>(tz_value_str, scale));
-        Block block;
-        int ret = -1;
-        EXPECT_TRUE(literal.execute(nullptr, &block, &ret).ok());
+        ColumnPtr result_column;
+        EXPECT_TRUE(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column).ok());
         EXPECT_EQ("1997-11-18 01:12:46.999999+00:00", literal.value());
 
-        auto ctn = block.safe_get_by_position(ret);
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_TIMESTAMPTZ, 0, scale), true);
+                create_texpr_node_from((*result_column)[0], TYPE_TIMESTAMPTZ, 0, scale), true);
         EXPECT_EQ("1997-11-18 01:12:46.999999+00:00", node->value());
 
         node = std::make_shared<VLiteral>(
@@ -605,14 +585,12 @@ TEST(TEST_VEXPR, LITERALTEST) {
         __int64_t dt;
         memcpy(&dt, &date_time_value, sizeof(__int64_t));
         VLiteral literal(create_literal<TYPE_DATE, std::string>(std::string(date)));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
         EXPECT_EQ("2021-04-07", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_DATE, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_DATE, 0, 0), true);
         EXPECT_EQ("2021-04-07", node->value());
     }
     // datev2
@@ -623,16 +601,14 @@ TEST(TEST_VEXPR, LITERALTEST) {
         uint32_t dt;
         memcpy(&dt, &data_time_value, sizeof(uint32_t));
         VLiteral literal(create_literal<TYPE_DATEV2, std::string>(std::string(date)));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_DATEV2>();
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
+        auto v = (*result_column)[0].get<TYPE_DATEV2>();
         EXPECT_EQ(v, dt);
         EXPECT_EQ("2021-04-07", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_DATEV2, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_DATEV2, 0, 0), true);
         EXPECT_EQ("2021-04-07", node->value());
     }
     config::allow_zero_date = true;
@@ -664,56 +640,48 @@ TEST(TEST_VEXPR, LITERALTEST) {
     {
         std::string j = R"([null,true,false,100,6.18,"abc"])";
         VLiteral literal(create_literal<TYPE_JSONB, std::string>(j));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
         EXPECT_EQ(j, literal.value());
     }
     // string
     {
         std::string s = "I am Amory, 24";
         VLiteral literal(create_literal<TYPE_STRING, std::string>(std::string("I am Amory, 24")));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_STRING>();
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
+        auto v = (*result_column)[0].get<TYPE_STRING>();
         EXPECT_EQ(v, s);
         EXPECT_EQ(s, literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_STRING, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_STRING, 0, 0), true);
         EXPECT_EQ(s, node->value());
     }
     // decimalv2
     {
         VLiteral literal(create_literal<TYPE_DECIMALV2, std::string>(std::string("1234.56")));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_DECIMALV2>();
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
+        auto v = (*result_column)[0].get<TYPE_DECIMALV2>();
         EXPECT_FLOAT_EQ(((double)v.value()) / (std::pow(10, 9)), 1234.56);
         EXPECT_EQ("1234.560000000", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_DECIMALV2, 27, 9), true);
+                create_texpr_node_from((*result_column)[0], TYPE_DECIMALV2, 27, 9), true);
         EXPECT_EQ("1234.560000000", node->value());
     }
     // timev2
     {
         VLiteral literal(create_literal<TYPE_TIMEV2, double>(12123400, 4));
-        Block block;
-        int ret = -1;
-        EXPECT_TRUE(literal.execute(nullptr, &block, &ret).ok());
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_TIMEV2>();
+        ColumnPtr result_column;
+        EXPECT_TRUE(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column).ok());
+        auto v = (*result_column)[0].get<TYPE_TIMEV2>();
         EXPECT_FLOAT_EQ(v / 1000000, 12.1234);
         EXPECT_EQ("00:00:12.1234", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_TIMEV2, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_TIMEV2, 0, 0), true);
         EXPECT_EQ("00:00:12", node->value());
     }
     // deciaml32

--- a/be/test/vec/exprs/vsearch_expr_test.cpp
+++ b/be/test/vec/exprs/vsearch_expr_test.cpp
@@ -25,8 +25,10 @@
 #include "gen_cpp/Exprs_types.h"
 #include "gen_cpp/Types_types.h"
 #include "olap/rowset/segment_v2/index_iterator.h"
+#include "vec/columns/column_nothing.h"
 #include "vec/columns/column_vector.h"
 #include "vec/core/block.h"
+#include "vec/data_types/data_type_nothing.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
 #include "vec/exprs/vexpr_context.h"
@@ -70,8 +72,8 @@ public:
     }
 
     Status execute(VExprContext*, Block*, int*) const override { return Status::OK(); }
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override {
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
         return Status::OK();
     }
 };
@@ -483,6 +485,9 @@ TEST_F(VSearchExprTest, TestExecuteMethod) {
     Block block;
     int result_column_id = -1;
 
+    block.insert(ColumnWithTypeAndName {ColumnNothing::create(5),
+                                        std::make_shared<DataTypeNothing>(), "title"});
+
     // Create a basic VExprContext without inverted index context
     auto dummy_expr = VSearchExpr::create_shared(test_node);
     VExprContext context(dummy_expr);
@@ -841,21 +846,6 @@ TEST_F(VSearchExprTest, TestSingleChildBooleanClause) {
 
     auto vsearch_expr = VSearchExpr::create_shared(single_child_node);
     ASSERT_NE(nullptr, vsearch_expr);
-}
-
-TEST_F(VSearchExprTest, TestExecuteWithNullBlock) {
-    auto vsearch_expr = VSearchExpr::create_shared(test_node);
-
-    // Create a basic VExprContext without inverted index context
-    auto dummy_expr = VSearchExpr::create_shared(test_node);
-    VExprContext context(dummy_expr);
-
-    // Test with null block (should not crash)
-
-    ColumnPtr result_column;
-    auto status = vsearch_expr->execute_column(&context, nullptr, nullptr, 0, result_column);
-    EXPECT_FALSE(status.ok());
-    EXPECT_TRUE(status.code() == ErrorCode::INTERNAL_ERROR);
 }
 
 TEST_F(VSearchExprTest, TestEvaluateInvertedIndexWithWhitespaceOnlyDSL) {


### PR DESCRIPTION
### What problem does this PR solve?

After every call to execute_column, verify that the returned column is valid.
This PR also adds const to the Selector* selector parameter.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

