### PR TITLE
[Fix](func) fix element_at return err when short-circuit evaluation passes empty input

### DIFF
--- a/be/src/vec/functions/array/function_array_element.h
+++ b/be/src/vec/functions/array/function_array_element.h
@@ -278,13 +278,6 @@ private:
         auto val_arr =
                 ColumnArray::create(map_column.get_values_ptr(), map_column.get_offsets_ptr());
 
-        const auto& offsets = map_column.get_offsets();
-        const size_t rows = offsets.size();
-        if (rows <= 0) {
-            return nullptr;
-        }
-        if (key_arr->is_nullable()) {
-        }
         ColumnPtr matched_indices = _get_mapped_idx(*key_arr, arguments[1]);
         if (!matched_indices) {
             return nullptr;

--- a/regression-test/data/doc/sql-manual/basic-elements/data-types/map-md.out
+++ b/regression-test/data/doc/sql-manual/basic-elements/data-types/map-md.out
@@ -102,6 +102,10 @@ value1
 -- !sql --
 20
 
+-- !element_at_short_circuit_evaluation_test --
+\N
+\N
+
 -- !sql --
 0
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

The `element_at` branch is completely short-circuited, causing `rows == 0`. The original line of code throws an error when `rows <= 0`

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

