### PR TITLE
[feat](nereids)support choosing physical plan containing specific group IDs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -99,9 +99,12 @@ import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -316,8 +319,25 @@ public class NereidsPlanner extends Planner {
                 LOG.info("{}\nMemo is null", ConnectContext.get().getQueryIdentifier());
             }
         }
-        int nth = cascadesContext.getConnectContext().getSessionVariable().getNthOptimizedPlan();
-        PhysicalPlan physicalPlan = chooseNthPlan(getRoot(), requireProperties, nth);
+        Set<Integer> requiredGroupIds = cascadesContext.getConnectContext()
+                .getSessionVariable().getRequiredGroupIds();
+        PhysicalPlan physicalPlan;
+        if (!requiredGroupIds.isEmpty()) {
+            Map<Group, Set<Integer>> reachableCache = new HashMap<>();
+            computeReachableGroupIds(getRoot(), reachableCache);
+            // Validate all required groups are reachable from root
+            Set<Integer> rootReachable = reachableCache.get(getRoot());
+            Set<Integer> unreachable = new HashSet<>(requiredGroupIds);
+            unreachable.removeAll(rootReachable);
+            if (!unreachable.isEmpty()) {
+                throw new AnalysisException("Required group IDs not found in memo: " + unreachable);
+            }
+            physicalPlan = chooseBestPlanWithRequiredGroups(
+                    getRoot(), requireProperties, requiredGroupIds, reachableCache);
+        } else {
+            int nth = cascadesContext.getConnectContext().getSessionVariable().getNthOptimizedPlan();
+            physicalPlan = chooseNthPlan(getRoot(), requireProperties, nth);
+        }
 
         physicalPlan = postProcess(physicalPlan);
         if (cascadesContext.getConnectContext().getSessionVariable().dumpNereidsMemo) {
@@ -795,6 +815,129 @@ public class NereidsPlanner extends Planner {
             LOG.warn("Failed to choose best plan, memo structure:{}", cascadesContext.getMemo(), e);
             throw new AnalysisException("Failed to choose best plan: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * Memoized bottom-up DFS: compute all group IDs reachable from this group's subtree
+     * through physical GroupExpressions (including enforcers).
+     */
+    private static Set<Integer> computeReachableGroupIds(Group group, Map<Group, Set<Integer>> cache) {
+        Set<Integer> cached = cache.get(group);
+        if (cached != null) {
+            return cached;
+        }
+        Set<Integer> reachable = new HashSet<>();
+        reachable.add(group.getGroupId().asInt());
+        // Put in cache BEFORE recursing to break cycles (enforcers reference the same group)
+        cache.put(group, reachable);
+        for (GroupExpression ge : group.getPhysicalExpressions()) {
+            for (Group child : ge.children()) {
+                reachable.addAll(computeReachableGroupIds(child, cache));
+            }
+        }
+        for (GroupExpression enforcer : group.getEnforcers().values()) {
+            for (Group child : enforcer.children()) {
+                reachable.addAll(computeReachableGroupIds(child, cache));
+            }
+        }
+        return reachable;
+    }
+
+    /**
+     * Choose the cheapest physical plan that contains all required group IDs.
+     * At each group, picks the cheapest physical GroupExpression whose children's
+     * reachable sets collectively cover all remaining required groups, then distributes
+     * the remaining requirements among children and recurses.
+     */
+    private PhysicalPlan chooseBestPlanWithRequiredGroups(
+            Group group, PhysicalProperties properties,
+            Set<Integer> remaining, Map<Group, Set<Integer>> reachableCache) {
+        remaining = new HashSet<>(remaining);
+        remaining.remove(group.getGroupId().asInt());
+
+        if (remaining.isEmpty()) {
+            return chooseBestPlan(group, properties, cascadesContext);
+        }
+
+        GroupExpression chosenGE = null;
+        double chosenCost = Double.MAX_VALUE;
+
+        // Check all physical GEs in this group
+        for (GroupExpression ge : group.getPhysicalExpressions()) {
+            if (!ge.getLowestCostTable().containsKey(properties)) {
+                continue;
+            }
+            double geCost = ge.getCostByProperties(properties);
+            if (geCost >= chosenCost) {
+                continue;
+            }
+            Set<Integer> childReachable = new HashSet<>();
+            for (Group child : ge.children()) {
+                childReachable.addAll(reachableCache.getOrDefault(child, new HashSet()));
+            }
+            if (childReachable.containsAll(remaining)) {
+                chosenGE = ge;
+                chosenCost = geCost;
+            }
+        }
+
+        // Also check enforcers
+        for (GroupExpression enforcer : group.getEnforcers().values()) {
+            if (!enforcer.getLowestCostTable().containsKey(properties)) {
+                continue;
+            }
+            double eCost = enforcer.getCostByProperties(properties);
+            if (eCost >= chosenCost) {
+                continue;
+            }
+            Set<Integer> childReachable = new HashSet<>();
+            for (Group child : enforcer.children()) {
+                childReachable.addAll(reachableCache.getOrDefault(child, new HashSet()));
+            }
+            if (childReachable.containsAll(remaining)) {
+                chosenGE = enforcer;
+                chosenCost = eCost;
+            }
+        }
+
+        if (chosenGE == null) {
+            throw new AnalysisException("Cannot find physical plan containing required group IDs: "
+                    + remaining + " at group " + group.getGroupId());
+        }
+
+        // Handle enforcer marking (same as chooseBestPlan)
+        if ((chosenGE.getPlan() instanceof PhysicalDistribute
+                && group.getEnforcerSpecs().containsKey(
+                        ((PhysicalDistribute<?>) chosenGE.getPlan()).getDistributionSpec()))
+                || group.getEnforcers().containsKey(chosenGE)) {
+            group.addChosenEnforcerId(chosenGE.getId().asInt());
+            group.addChosenEnforcerProperties(properties);
+        } else {
+            group.setChosenProperties(properties);
+            group.setChosenGroupExpressionId(chosenGE.getId().asInt());
+        }
+
+        // Distribute remaining among children and recurse
+        List<PhysicalProperties> inputProps = chosenGE.getInputPropertiesList(properties);
+        List<Plan> planChildren = Lists.newArrayList();
+        for (int i = 0; i < chosenGE.arity(); i++) {
+            Group child = chosenGE.child(i);
+            Set<Integer> childReachable = reachableCache.getOrDefault(child, new HashSet());
+            Set<Integer> childRemaining = new HashSet<>(remaining);
+            childRemaining.retainAll(childReachable);
+            planChildren.add(chooseBestPlanWithRequiredGroups(
+                    child, inputProps.get(i), childRemaining, reachableCache));
+        }
+
+        Plan plan = chosenGE.getPlan().withChildren(planChildren);
+        if (!(plan instanceof PhysicalPlan)) {
+            throw new AnalysisException("Result plan must be PhysicalPlan");
+        }
+        plan = plan.withGroupExpression(Optional.of(chosenGE));
+        PhysicalPlan physicalPlan = ((PhysicalPlan) plan).withPhysicalPropertiesAndStats(
+                properties, group.getStatistics());
+        cost = chosenCost;
+        return physicalPlan;
     }
 
     private long getGarbageCollectionTime() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -376,6 +376,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String HBO_ROW_MATCHING_THRESHOLD = "hbo_row_matching_threshold";
     public static final String HBO_SKEW_RATIO_THRESHOLD = "hbo_skew_ratio_threshold";
     public static final String NTH_OPTIMIZED_PLAN = "nth_optimized_plan";
+    public static final String REQUIRED_GROUP_IDS = "required_group_ids";
 
     public static final String ENABLE_NEREIDS_PLANNER = "enable_nereids_planner";
     public static final String ENABLE_NEREIDS_DISTRIBUTE_PLANNER = "enable_nereids_distribute_planner";
@@ -1823,6 +1824,12 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = NTH_OPTIMIZED_PLAN)
     private int nthOptimizedPlan = 1;
 
+    @VariableMgr.VarAttr(name = REQUIRED_GROUP_IDS,
+            description = {"指定优化器必须选择包含这些 Group ID 的物理计划（逗号分隔的整数列表）",
+                    "Force the optimizer to choose a physical plan containing these Group IDs "
+                    + "(comma-separated integer list)"})
+    public String requiredGroupIds = "";
+
     @VariableMgr.VarAttr(name = LIMIT_ROWS_FOR_SINGLE_INSTANCE,
             description = {"当一个 ScanNode 上没有过滤条件，且 limit 值小于这个阈值时，"
                     + "系统会将这个算子的并发度调整为 1，以减少简单查询的扇出",
@@ -2857,6 +2864,33 @@ public class SessionVariable implements Serializable, Writable {
 
             }
             ids.add(res);
+        }
+        return ids;
+    }
+
+    public Set<Integer> getRequiredGroupIds() {
+        Set<Integer> ids = Sets.newLinkedHashSet();
+        if (requiredGroupIds.isEmpty()) {
+            return ImmutableSet.of();
+        }
+        for (String v : requiredGroupIds.split(",[\\s]*")) {
+            if (!v.isEmpty()) {
+                boolean isNumber = true;
+                for (int i = 0; i < v.length(); ++i) {
+                    char c = v.charAt(i);
+                    if (c < '0' || c > '9') {
+                        isNumber = false;
+                        break;
+                    }
+                }
+                if (isNumber) {
+                    try {
+                        ids.add(Integer.parseInt(v));
+                    } catch (Throwable t) {
+                        // ignore
+                    }
+                }
+            }
         }
         return ids;
     }


### PR DESCRIPTION
### What problem does this PR solve?
Introduce a new session variable required_group_ids to force the Nereids optimizer to pick the cheapest physical plan that includes all specified group IDs.

Key changes:

Added chooseBestPlanWithRequiredGroups to traverse the memo and find a plan covering the required IDs.
Added helper logic to compute reachable group IDs from the plan subtree.
Exposed required_group_ids as a session variable for easier debugging and testing.
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

