### PR TITLE
[Fix](TabletHotspot) Fix race in `TabletHotspot::get_top_n_hot_partition`

### DIFF
--- a/be/src/cloud/cloud_tablet_hotspot.cpp
+++ b/be/src/cloud/cloud_tablet_hotspot.cpp
@@ -146,6 +146,7 @@ void TabletHotspot::get_top_n_hot_partition(std::vector<THotTableMessage>* hot_t
     constexpr int N = 50;
     int return_partitions = 0;
 
+    std::unique_lock lock(_last_partitions_mtx);
     get_return_partitions(day_hot_partitions, _last_day_hot_partitions, hot_tables,
                           return_partitions, N);
     get_return_partitions(week_hot_partitions, _last_week_hot_partitions, hot_tables,

--- a/be/src/cloud/cloud_tablet_hotspot.h
+++ b/be/src/cloud/cloud_tablet_hotspot.h
@@ -84,6 +84,8 @@ private:
     bool _closed {false};
     std::mutex _mtx;
     std::condition_variable _cond;
+
+    std::mutex _last_partitions_mtx;
     std::unordered_map<TabletHotspotMapKey, std::unordered_map<int64_t, TabletHotspotMapValue>,
                        MapKeyHash>
             _last_day_hot_partitions;


### PR DESCRIPTION
### What problem does this PR solve?

```
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/selectdb-core/be/src/common/signal_handler.h:421
 1# PosixSignals::chained_handler(int, siginfo_t*, void*) [clone .part.0] at src/hotspot/os/posix/signals_posix.cpp:454
 2# JVM_handle_linux_signal at src/hotspot/os/posix/signals_posix.cpp:641
 3# 0x00007F6D2FBC6520 in /lib/x86_64-linux-gnu/libc.so.6
 4# je_tcache_bin_flush_small at /root/selectdb-core/thirdparty/src/jemalloc-5.3.0/doris_build/../src/tcache.c:529
 5# je_free_default at /root/selectdb-core/thirdparty/src/jemalloc-5.3.0/doris_build/../src/jemalloc.c:3014
 6# std::_Hashtable<std::pair<long, long>, std::pair<std::pair<long, long> const, std::unordered_map<long, doris::TabletHotspotMapValue, std::hash<long>, std::equal_to<long>, std::allocator<std::pair<long co
nst, doris::TabletHotspotMapValue> > > >, std::allocator<std::pair<std::pair<long, long> const, std::unordered_map<long, doris::TabletHotspotMapValue, std::hash<long>, std::equal_to<long>, std::allocator<std
::pair<long const, doris::TabletHotspotMapValue> > > > >, std::__detail::_Select1st, std::equal_to<std::pair<long, long> >, doris::MapKeyHash, std::__detail::_Mod_range_hashing, std::__detail::_Default_range
d_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::_M_move_assign(std::_Hashtable<std::pair<long, long>, std::pair<std::pair<long, long> const, std::unordered
_map<long, doris::TabletHotspotMapValue, std::hash<long>, std::equal_to<long>, std::allocator<std::pair<long const, doris::TabletHotspotMapValue> > > >, std::allocator<std::pair<std::pair<long, long> const, 
std::unordered_map<long, doris::TabletHotspotMapValue, std::hash<long>, std::equal_to<long>, std::allocator<std::pair<long const, doris::TabletHotspotMapValue> > > > >, std::__detail::_Select1st, std::equal_
to<std::pair<long, long> >, doris::MapKeyHash, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true>
 >&&, std::integral_constant<bool, true>) at /root/tools/ldb-16/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/hashtable.h:1342
 7# doris::TabletHotspot::get_top_n_hot_partition(std::vector<doris::THotTableMessage, std::allocator<doris::THotTableMessage> >*) in /opt/selectdb/be/lib/doris_be
 8# doris::CloudBackendService::get_top_n_hot_partitions(doris::TGetTopNHotPartitionsResponse&, doris::TGetTopNHotPartitionsRequest const&) at /root/selectdb-core/be/src/cloud/cloud_backend_service.cpp:86
 9# doris::BackendServiceProcessor::process_get_top_n_hot_partitions(int, apache::thrift::protocol::TProtocol*, apache::thrift::protocol::TProtocol*, void*) at /root/selectdb-core/gensrc/build/gen_cpp/BackendService.cpp:8102
10# doris::BackendServiceProcessor::dispatchCall(apache::thrift::protocol::TProtocol*, apache::thrift::protocol::TProtocol*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, void*) in /opt/selectdb/be/lib/doris_be
11# apache::thrift::TDispatchProcessor::process(std::shared_ptr<apache::thrift::protocol::TProtocol>, std::shared_ptr<apache::thrift::protocol::TProtocol>, void*) in /opt/selectdb/be/lib/doris_be
12# apache::thrift::server::TConnectedClient::run() in /opt/selectdb/be/lib/doris_be
13# apache::thrift::server::TThreadedServer::TConnectedClientRunner::run() in /opt/selectdb/be/lib/doris_be
14# apache::thrift::concurrency::Thread::threadMain(std::shared_ptr<apache::thrift::concurrency::Thread>) in /opt/selectdb/be/lib/doris_be
15# void std::__invoke_impl<void, void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread> >(std::__invoke_other, void (*&&)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>&&) in /opt/selectdb/be/lib/doris_be
16# std::__invoke_result<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread> >::type std::__invoke<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread> >(void (*&&)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread>&&) in /opt/selectdb/be/lib/doris_be
17# void std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread> > >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) in /opt/selectdb/be/lib/doris_be
18# std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread> > >::operator()() in /opt/selectdb/be/lib/doris_be
19# std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread> > > >::_M_run() in /opt/sele
ctdb/be/lib/doris_be
20# execute_native_thread_routine at ../../../../../libstdc++-v3/src/c++11/thread.cc:84
21# 0x00007F6D2FC18AC3 in /lib/x86_64-linux-gnu/libc.so.6
22# __clone in /lib/x86_64-linux-gnu/libc.so.6 
```

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

