### PR TITLE
[refactor](scan) extract scanner profile update logic and update on eos

### DIFF
--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -156,16 +156,19 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
     max_run_time_watch.start();
     scanner->update_wait_worker_timer();
     scanner->start_scan_cpu_timer();
+
+    auto update_scanner_profile = [&]() {
+        if (scanner->has_prepared()) {
+            // Counter update need prepare successfully, or it maybe core. For example, olap scanner
+            // will open tablet reader during prepare, if not prepare successfully, tablet reader == nullptr.
+            scanner->update_scan_cpu_timer();
+            scanner->update_realtime_counters();
+        }
+    };
     Defer defer_scanner(
             [&] { // WorkloadGroup Policy will check cputime realtime, so that should update the counter
                 // as soon as possible, could not update it on close.
-                if (scanner->has_prepared()) {
-                    // Counter update need prepare successfully, or it maybe core. For example, olap scanner
-                    // will open tablet reader during prepare, if not prepare successfully, tablet reader == nullptr.
-                    scanner->update_scan_cpu_timer();
-                    scanner->update_realtime_counters();
-                    scanner->start_wait_worker_timer();
-                }
+                update_scanner_profile();
             });
     Status status = Status::OK();
     bool eos = false;
@@ -325,6 +328,9 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
     }
 
     if (eos) {
+        // If eos, scanner will call _collect_profile_before_close to update profile, 
+        // so we need update_scanner_profile here
+        update_scanner_profile();
         scanner->mark_to_need_to_close();
     }
     scan_task->set_eos(eos);

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -157,19 +157,21 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
     scanner->update_wait_worker_timer();
     scanner->start_scan_cpu_timer();
 
+    // Counter update need prepare successfully, or it maybe core. For example, olap scanner
+    // will open tablet reader during prepare, if not prepare successfully, tablet reader == nullptr.
+    bool need_update_profile = scanner->has_prepared();
     auto update_scanner_profile = [&]() {
-        if (scanner->has_prepared()) {
-            // Counter update need prepare successfully, or it maybe core. For example, olap scanner
-            // will open tablet reader during prepare, if not prepare successfully, tablet reader == nullptr.
+        if (need_update_profile) {
             scanner->update_scan_cpu_timer();
             scanner->update_realtime_counters();
+            need_update_profile = false;
         }
     };
-    Defer defer_scanner(
-            [&] { // WorkloadGroup Policy will check cputime realtime, so that should update the counter
-                // as soon as possible, could not update it on close.
-                update_scanner_profile();
-            });
+    Defer defer_scanner([&] {
+        // WorkloadGroup Policy will check cputime realtime, so that should update the counter
+        // as soon as possible, could not update it on close.
+        update_scanner_profile();
+    });
     Status status = Status::OK();
     bool eos = false;
     ASSIGN_STATUS_IF_CATCH_EXCEPTION(
@@ -328,7 +330,7 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
     }
 
     if (eos) {
-        // If eos, scanner will call _collect_profile_before_close to update profile, 
+        // If eos, scanner will call _collect_profile_before_close to update profile,
         // so we need update_scanner_profile here
         update_scanner_profile();
         scanner->mark_to_need_to_close();


### PR DESCRIPTION
### What problem does this PR solve?
Extract the scanner profile update logic into a lambda to improve code reusability. Ensure that the scanner profile is updated specifically when 'eos' is reached before marking the scanner for closure, which prevents missing the final counter updates.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

