### PR TITLE
[fix](cloud) Fix SingleFlight deadlock in CloudTabletMgr::get_tablet during warmup

### DIFF
--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -1689,6 +1689,10 @@ void CloudTablet::_add_rowsets_directly(std::vector<RowsetSharedPtr>& rowsets,
 #endif
     for (auto& rs : rowsets) {
         if (warmup_delta_data) {
+            // Pre-set encryption algorithm to avoid re-entrant get_tablet() call
+            // inside RowsetMeta::fs() which causes SingleFlight deadlock when the
+            // tablet is not yet cached (during initial load_tablet).
+            rs->rowset_meta()->set_encryption_algorithm(_tablet_meta->encryption_algorithm());
             bool warm_up_state_updated = false;
             // Warmup rowset data in background
             for (int seg_id = 0; seg_id < rs->num_segments(); ++seg_id) {

--- a/be/src/olap/rowset/rowset_meta.h
+++ b/be/src/olap/rowset/rowset_meta.h
@@ -455,6 +455,13 @@ public:
 
     std::string debug_string() const { return _rowset_meta_pb.ShortDebugString(); }
 
+    // Pre-set the encryption algorithm to avoid re-entrant get_tablet calls
+    // that can cause SingleFlight deadlock during tablet loading.
+    void set_encryption_algorithm(EncryptionAlgorithmPB algorithm) {
+        _determine_encryption_once.call(
+                [algorithm]() -> Result<EncryptionAlgorithmPB> { return algorithm; });
+    }
+
 private:
     bool _deserialize_from_pb(std::string_view value);
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
During initial tablet loading, the load_tablet lambda inside SingleFlight calls sync_tablet_rowsets -> _add_rowsets_directly -> _submit_segment_download_task -> rowset_meta->fs(), which internally calls ExecEnv::get_tablet() for the same tablet_id. Since the tablet hasn't been inserted into cache yet, this triggers a second SingleFlight lookup for the same key, causing event.wait() to deadlock (waiting for itself).

Fix by pre-setting the encryption algorithm on RowsetMeta before calling fs() in _submit_segment_download_task, so _determine_encryption_once returns the cached value without re-entering get_tablet.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

