### PR TITLE
[fix](cloud) Fix misleading CommittedVersion display in show partitions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudPartition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudPartition.java
@@ -358,6 +358,12 @@ public class CloudPartition extends Partition {
     }
 
     @Override
+    public long getCommittedVersion() {
+        // Cloud partition version is managed by meta-service, not resident in FE memory.
+        return -1;
+    }
+
+    @Override
     public long getNextVersion() {
         // use meta service visibleVersion
         if (LOG.isDebugEnabled()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudPartitionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudPartitionTest.java
@@ -44,6 +44,16 @@ public class CloudPartitionTest {
     }
 
     @Test
+    public void testGetCommittedVersion() {
+        CloudPartition part = createPartition(1, 2, 3);
+        // Cloud partition's committedVersion should return -1 (unknown),
+        // not the base class's nextVersion - 1 = -2
+        Assertions.assertEquals(-1, part.getCommittedVersion());
+        // Also verify nextVersion returns -1 for consistency
+        Assertions.assertEquals(-1, part.getNextVersion());
+    }
+
+    @Test
     public void testIsCachedVersionExpired() {
         // Create ConnectContext with SessionVariable
         ConnectContext ctx = new ConnectContext();


### PR DESCRIPTION
In cloud mode, CloudPartition sets nextVersion to -1 (unknown), but getCommittedVersion() inherited from Partition computes nextVersion - 1 which returns -2, a confusing value for users. Override getCommittedVersion() in CloudPartition to return -1 directly, consistent with the "unknown/managed by meta-service" semantics.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

