### PR TITLE
[fix](cloud) Fix packed file write path bypassing encryption

### DIFF
--- a/be/src/io/fs/file_writer.h
+++ b/be/src/io/fs/file_writer.h
@@ -82,6 +82,10 @@ public:
 
     virtual State state() const = 0;
 
+    // Returns true if this file's data was written to a packed file.
+    // Used to determine whether to collect packed slice location from PackedFileManager.
+    virtual bool is_in_packed_file() const { return false; }
+
     FileCacheAllocatorBuilder* cache_builder() const {
         return _cache_builder == nullptr ? nullptr : _cache_builder.get();
     }

--- a/be/src/io/fs/packed_file_writer.h
+++ b/be/src/io/fs/packed_file_writer.h
@@ -57,6 +57,9 @@ public:
     // Returns empty index if file is not in merge file
     Status get_packed_slice_location(PackedSliceLocation* location) const;
 
+    // Returns true if this file's data was written to a packed file (not direct write)
+    bool is_in_packed_file() const override { return !_is_direct_write; }
+
 private:
     // Async close: submit data without waiting
     Status _close_async();

--- a/be/src/olap/rowset/rowset_writer_context.h
+++ b/be/src/olap/rowset/rowset_writer_context.h
@@ -194,12 +194,7 @@ struct RowsetWriterContext {
 #endif
         }
 
-        // Apply encryption if needed
-        if (algorithm.has_value()) {
-            fs = io::make_file_system(fs, algorithm.value());
-        }
-
-        // Apply packed file system for write path if enabled
+        // Apply packed file system first for write path if enabled
         // Create empty index_map for write path
         // Index information will be populated after write completes
         bool has_v1_inverted_index = tablet_schema != nullptr &&
@@ -227,6 +222,11 @@ struct RowsetWriterContext {
                                                   ? newest_write_timestamp + file_cache_ttl_sec
                                                   : 0;
             fs = std::make_shared<io::PackedFileSystem>(fs, append_info);
+        }
+
+        // Then apply encryption on top
+        if (algorithm.has_value()) {
+            fs = io::make_file_system(fs, algorithm.value());
         }
 
         // Cache the result to ensure consistency across multiple calls


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

The PackedFileSystem was wrapping the filesystem after encryption on the write path, which meant data written through PackedFileSystem bypassed encryption. On the read path, the encrypted layer would then attempt to decrypt unencrypted data, leading to data corruption.

Fix by swapping the order: apply PackedFileSystem first, then wrap with encryption on top, ensuring all data written through the packed path is properly encrypted.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

