### PR TITLE
[Fix](dictionary) Fix empty InsertIntoDictionaryCommand originSql

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRuleMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRuleMgr.java
@@ -216,6 +216,9 @@ public class SqlBlockRuleMgr implements Writable {
      * Match SQL according to rules.
      **/
     public void matchSql(String originSql, String sqlHash, String user) throws AnalysisException {
+        if (originSql == null) {
+            return;
+        }
         if (Config.sql_block_rule_ignore_admin && (Auth.ROOT_USER.equals(user) || Auth.ADMIN_USER.equals(user))) {
             return;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/dictionary/DictionaryManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/dictionary/DictionaryManager.java
@@ -418,12 +418,12 @@ public class DictionaryManager extends MasterDaemon implements Writable {
         }
 
         // not use rerfresh command's executor to avoid potential problems.
-        StmtExecutor executor = InsertTask.makeStmtExecutor(ctx);
+        String insertSql = "insert into " + dictionary.getDbName() + "." + dictionary.getName() + " select * from "
+                + dictionary.getSourceCtlName() + "." + dictionary.getSourceDbName() + "."
+                + dictionary.getSourceTableName();
+        StmtExecutor executor = new StmtExecutor(ctx, insertSql);
         NereidsParser parser = new NereidsParser();
-        InsertIntoTableCommand baseCommand = (InsertIntoTableCommand) parser
-                .parseSingle("insert into " + dictionary.getDbName() + "." + dictionary.getName() + " select * from "
-                        + dictionary.getSourceCtlName() + "." + dictionary.getSourceDbName() + "."
-                        + dictionary.getSourceTableName());
+        InsertIntoTableCommand baseCommand = (InsertIntoTableCommand) parser.parseSingle(insertSql);
         LOG.info("Loading to dictionary {} with query {}. adaptive: {}", dictionary.getName(), ctx.queryId(),
                 adaptiveLoad);
         if (!baseCommand.getLabelName().isPresent()) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Dictionary refresh tasks build load command internally, which didn't set `originSql` of it. this may cause some usage fail because of dependency of not null `originSql`.

1. Change construct method to fix null `originSql` of dictionary refresh tasks.
2. add defensive check in `checkBlockSql` to avoid failure.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

