### PR TITLE
[fix](datetime) throw exception for date_floor/ceil instead of return NULL

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/TimeRoundSeries.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/TimeRoundSeries.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.expressions.functions.executable;
 
 import org.apache.doris.nereids.annotation.Developing;
+import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.ExecFunction;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeLiteral;
@@ -53,7 +54,8 @@ public class TimeRoundSeries {
     private static LocalDateTime getDateCeilOrFloor(DATE tag, LocalDateTime date, int period, LocalDateTime origin,
             boolean getCeil) {
         if (period < 1) {
-            return null;
+            throw new AnalysisException("Operation " + tag.name().toLowerCase()
+                    + (getCeil ? "_ceil" : "_floor") + " of " + period + " out of range");
         }
 
         DateTimeV2Literal dt = (DateTimeV2Literal) DateTimeV2Literal.fromJavaDateType(date);

--- a/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_floor_ceil.groovy
+++ b/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_floor_ceil.groovy
@@ -309,4 +309,42 @@ suite("test_date_floor_ceil") {
     testFoldConst("SELECT YEAR_CEIL('2001-01-01 0:00:00.000001', 10);");
     testFoldConst("SELECT YEAR_CEIL('2001-01-01 0:00:00.000001', '1970-01-01');");
     testFoldConst("SELECT YEAR_CEIL('2001-01-01 0:00:00.000001', 10, '1970-01-01');");
+
+    // period < 1 should throw exception (FE constant folding path)
+    test {
+        sql "select date_floor('2007-01-02', interval 0 month);"
+        exception "out of range"
+    }
+    test {
+        sql "select date_ceil('2007-01-02', interval 0 month);"
+        exception "out of range"
+    }
+    test {
+        sql "select month_floor('2023-07-14 15:30:45', 0);"
+        exception "out of range"
+    }
+    test {
+        sql "select date_floor('2023-07-14 15:30:45', interval -1 month);"
+        exception "out of range"
+    }
+
+    // period < 1 should throw exception (BE path, the original bug scenario)
+    sql """set debug_skip_fold_constant = true"""
+    test {
+        sql "select date_floor('2007-01-02', interval 0 month);"
+        exception "out of range"
+    }
+    test {
+        sql "select date_ceil('2007-01-02', interval 0 month);"
+        exception "out of range"
+    }
+    test {
+        sql "select month_floor('2023-07-14 15:30:45', 0);"
+        exception "out of range"
+    }
+    test {
+        sql "select date_floor('2023-07-14 15:30:45', interval -1 month);"
+        exception "out of range"
+    }
+    sql """set debug_skip_fold_constant = false"""
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

before:
```
select date_floor('2007-01-02', interval 0 month);
+--------------------------------------------+
| date_floor('2007-01-02', interval 0 month) |
+--------------------------------------------+
| NULL                                       |
+--------------------------------------------+
```
now:
```sql
select date_floor('2007-01-02', interval 0 month);
Operation month_floor of 2007-01-02 00:00:00, 0, 0001-01-01 00:00:00 out of range
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

