### PR TITLE
[fix](nereids) Fix table name case-sensitivity issue when binding columns for external tables

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
@@ -100,7 +100,6 @@ import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.nereids.util.TypeCoercionUtils;
 import org.apache.doris.nereids.util.Utils;
 import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.qe.GlobalVariable;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.qe.VariableVarConverters;
@@ -1001,12 +1000,17 @@ public class ExpressionAnalyzer extends SubExprAnalyzer<ExpressionRewriteContext
         }
     }
 
+    /**
+     * Always use case-insensitive comparison for table names.
+     */
     public static boolean sameTableName(String boundSlot, String unboundSlot) {
-        if (GlobalVariable.lowerCaseTableNames != 1) {
-            return boundSlot.equals(unboundSlot);
-        } else {
-            return boundSlot.equalsIgnoreCase(unboundSlot);
-        }
+        // Always use case-insensitive comparison for table names.
+        // This is necessary because:
+        // 1. External tables (Hive, Iceberg, etc.) store table names in lowercase in their metastore,
+        //    but users may reference them with original case in SQL.
+        // 2. Internal tables also typically use lowercase names.
+        // 3. This is consistent with how catalog and database names are compared (case-insensitive).
+        return boundSlot.equalsIgnoreCase(unboundSlot);
     }
 
     private boolean shouldBindSlotBy(int namePartSize, Slot boundSlot) {


### PR DESCRIPTION
…

## Proposed changes
Fix the issue where column binding fails for external tables (Hive, Iceberg, etc.) when users reference table names with original case in SQL.
 Problem
When querying external Hive tables, the following SQL fails: SELECT * FROM TPCH50.DIM_LINEITEM_CORE_OD001_V1
WHERE DIM_LINEITEM_CORE_OD001_V1.dt = '20260108' LIMIT 10; -- Error: Unknown column 'dt' in 'DIM_LINEITEM_CORE_OD001_V1' in FILTER clause But using an alias works:
SELECT * FROM TPCH50.DIM_LINEITEM_CORE_OD001_V1 AS DIM_LINEITEM_CORE_OD001_V1 WHERE DIM_LINEITEM_CORE_OD001_V1.dt = '20260108' LIMIT 10; -- Success
Root Cause
1. Hive Metastore stores table names in lowercase (e.g., dim_lineitem_core_od001_v1)
2. The slot qualifier uses table.getName() which returns the lowercase HMS table name
3. Users reference the table with original case in SQL (e.g., DIM_LINEITEM_CORE_OD001_V1.dt)
4. ExpressionAnalyzer.sameTableName() performs case-sensitive comparison when lower_case_table_names != 1, causing binding to fail Solution
Change sameTableName() to always use case-insensitive comparison for table names. This is consistent with:
- Catalog name comparison (already case-insensitive at line 1079)
- Database name comparison (already case-insensitive at line 1092)

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

