### PR TITLE
branch-4.0: [Fix](RestCatalog)When vendor credentials are configured at the catalog level, S3-compatible storage must also support temporary credentials (#60232)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/COSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/COSProperties.java
@@ -51,21 +51,23 @@ public class COSProperties extends AbstractS3CompatibleProperties {
     protected String region = "";
 
     @Getter
-    @ConnectorProperty(names = {"cos.access_key", "s3.access_key", "AWS_ACCESS_KEY", "access_key", "ACCESS_KEY"},
+    @ConnectorProperty(names = {"cos.access_key", "s3.access_key", "s3.access-key-id", "AWS_ACCESS_KEY", "access_key",
+        "ACCESS_KEY"},
             required = false,
             sensitive = true,
             description = "The access key of COS.")
     protected String accessKey = "";
 
     @Getter
-    @ConnectorProperty(names = {"cos.secret_key", "s3.secret_key", "AWS_SECRET_KEY", "secret_key", "SECRET_KEY"},
+    @ConnectorProperty(names = {"cos.secret_key", "s3.secret_key", "s3.secret-access-key", "AWS_SECRET_KEY",
+        "secret_key", "SECRET_KEY"},
             required = false,
             sensitive = true,
             description = "The secret key of COS.")
     protected String secretKey = "";
 
     @Getter
-    @ConnectorProperty(names = {"cos.session_token", "s3.session_token", "session_token"},
+    @ConnectorProperty(names = {"cos.session_token", "s3.session_token", "s3.session-token",  "session_token"},
             required = false,
             description = "The session token of COS.")
     protected String sessionToken = "";

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/MinioProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/MinioProperties.java
@@ -39,21 +39,23 @@ public class MinioProperties extends AbstractS3CompatibleProperties {
     protected String region = "us-east-1";
 
     @Getter
-    @ConnectorProperty(names = {"minio.access_key", "AWS_ACCESS_KEY", "ACCESS_KEY", "access_key", "s3.access_key"},
+    @ConnectorProperty(names = {"minio.access_key", "s3.access-key-id", "AWS_ACCESS_KEY", "ACCESS_KEY",
+            "access_key", "s3.access_key"},
             required = false,
             sensitive = true,
             description = "The access key of Minio.")
     protected String accessKey = "";
 
     @Getter
-    @ConnectorProperty(names = {"minio.secret_key", "s3.secret_key", "AWS_SECRET_KEY", "secret_key", "SECRET_KEY"},
+    @ConnectorProperty(names = {"minio.secret_key", "s3.secret-access-key", "s3.secret_key", "AWS_SECRET_KEY",
+            "secret_key", "SECRET_KEY"},
             required = false,
             sensitive = true,
             description = "The secret key of Minio.")
     protected String secretKey = "";
 
     @Getter
-    @ConnectorProperty(names = {"minio.session_token", "s3.session_token", "session_token"},
+    @ConnectorProperty(names = {"minio.session_token", "s3.session-token", "s3.session_token", "session_token"},
             required = false,
             sensitive = true,
             description = "The session token of Minio.")

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OBSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OBSProperties.java
@@ -44,14 +44,16 @@ public class OBSProperties extends AbstractS3CompatibleProperties {
     protected String endpoint = "";
 
     @Getter
-    @ConnectorProperty(names = {"obs.access_key", "s3.access_key", "AWS_ACCESS_KEY", "access_key", "ACCESS_KEY"},
+    @ConnectorProperty(names = {"obs.access_key", "s3.access_key", "s3.access-key-id", "AWS_ACCESS_KEY",
+        "access_key", "ACCESS_KEY"},
             required = false,
             sensitive = true,
             description = "The access key of OBS.")
     protected String accessKey = "";
 
     @Getter
-    @ConnectorProperty(names = {"obs.secret_key", "s3.secret_key", "AWS_SECRET_KEY", "secret_key", "SECRET_KEY"},
+    @ConnectorProperty(names = {"obs.secret_key", "s3.secret_key", "s3.secret-access-key", "AWS_SECRET_KEY",
+        "secret_key", "SECRET_KEY"},
             required = false,
             sensitive = true,
             description = "The secret key of OBS.")
@@ -64,7 +66,7 @@ public class OBSProperties extends AbstractS3CompatibleProperties {
     protected String region;
 
     @Getter
-    @ConnectorProperty(names = {"obs.session_token", "s3.session_token", "session_token"},
+    @ConnectorProperty(names = {"obs.session_token", "s3.session_token", "s3.session-token", "session_token"},
             required = false,
             description = "The session token of OBS.")
     protected String sessionToken = "";

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
@@ -52,15 +52,16 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
     protected String endpoint = "";
 
     @Getter
-    @ConnectorProperty(names = {"oss.access_key", "s3.access_key", "AWS_ACCESS_KEY", "access_key", "ACCESS_KEY",
-            "dlf.access_key", "dlf.catalog.accessKeyId", "fs.oss.accessKeyId"},
+    @ConnectorProperty(names = {"oss.access_key", "s3.access_key", "s3.access-key-id", "AWS_ACCESS_KEY", "access_key",
+        "ACCESS_KEY", "dlf.access_key", "dlf.catalog.accessKeyId", "fs.oss.accessKeyId"},
             required = false,
             sensitive = true,
             description = "The access key of OSS.")
     protected String accessKey = "";
 
     @Getter
-    @ConnectorProperty(names = {"oss.secret_key", "s3.secret_key", "AWS_SECRET_KEY", "secret_key", "SECRET_KEY",
+    @ConnectorProperty(names = {"oss.secret_key", "s3.secret_key", "s3.secret-access-key", "AWS_SECRET_KEY",
+        "secret_key", "SECRET_KEY",
             "dlf.secret_key", "dlf.catalog.secret_key", "fs.oss.accessKeySecret"},
             required = false,
             sensitive = true,
@@ -80,7 +81,8 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
     protected String dlfAccessPublic = "false";
 
     @Getter
-    @ConnectorProperty(names = {"oss.session_token", "s3.session_token", "session_token", "fs.oss.securityToken"},
+    @ConnectorProperty(names = {"oss.session_token", "s3.session_token", "s3.session-token", "session_token",
+            "fs.oss.securityToken", "AWS_TOKEN"},
             required = false,
             sensitive = true,
             description = "The session token of OSS.")


### PR DESCRIPTION
…

#60232
(cherry picked from commit afb1da4686746d188bb72795bbcaa4e598924b22)
