### PR TITLE
[feature](multi-catalog) Add max_file_split_num session var to limit splits

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/FileQueryScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/FileQueryScanNode.java
@@ -662,4 +662,18 @@ public abstract class FileQueryScanNode extends FileScanNode {
         }
         return realSplitSize;
     }
+
+    /**
+     * Enforce a maximum split count by raising the target split size when needed.
+     *
+     * <p>minSplitSizeForMaxNum = ceil(totalFileSize / maxFileSplitNum)
+     */
+    protected long applyMaxFileSplitNumLimit(long targetSplitSize, long totalFileSize) {
+        int maxFileSplitNum = sessionVariable.getMaxFileSplitNum();
+        if (maxFileSplitNum <= 0 || totalFileSize <= 0) {
+            return targetSplitSize;
+        }
+        long minSplitSizeForMaxNum = (totalFileSize + maxFileSplitNum - 1L) / (long) maxFileSplitNum;
+        return Math.max(targetSplitSize, minSplitSizeForMaxNum);
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/source/HiveScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/source/HiveScanNode.java
@@ -320,13 +320,32 @@ public class HiveScanNode extends FileQueryScanNode {
             int parallelNum = sessionVariable.getParallelExecInstanceNum();
             needSplit = FileSplitter.needSplitForCountPushdown(parallelNum, numBackends, totalFileNum);
         }
+        long totalFileSize = 0;
+        long maxBlockSize = 0;
+        if (needSplit && !isBatchMode() && sessionVariable.getMaxFileSplitNum() > 0) {
+            for (HiveMetaStoreCache.FileCacheValue fileCacheValue : fileCaches) {
+                if (fileCacheValue.getFiles() == null) {
+                    continue;
+                }
+                for (HiveMetaStoreCache.HiveFileStatus status : fileCacheValue.getFiles()) {
+                    totalFileSize += status.getLength();
+                    maxBlockSize = Math.max(maxBlockSize, status.getBlockSize());
+                }
+            }
+        }
+        long adjustedSplitSize = applyMaxFileSplitNumLimit(getRealFileSplitSize(maxBlockSize), totalFileSize);
+        boolean batchMode = isBatchMode();
+
         for (HiveMetaStoreCache.FileCacheValue fileCacheValue : fileCaches) {
             if (fileCacheValue.getFiles() != null) {
                 boolean isSplittable = fileCacheValue.isSplittable();
                 for (HiveMetaStoreCache.HiveFileStatus status : fileCacheValue.getFiles()) {
+                    long splitSize = needSplit
+                            ? (batchMode ? getRealFileSplitSize(status.getBlockSize()) : adjustedSplitSize)
+                            : Long.MAX_VALUE;
                     allFiles.addAll(FileSplitter.splitFile(status.getPath(),
                             // set block size to Long.MAX_VALUE to avoid splitting the file.
-                            getRealFileSplitSize(needSplit ? status.getBlockSize() : Long.MAX_VALUE),
+                            splitSize,
                             status.getBlockLocations(), status.getLength(), status.getModificationTime(),
                             isSplittable, fileCacheValue.getPartitionValues(),
                             new HiveSplitCreator(fileCacheValue.getAcidInfo())));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -433,16 +433,46 @@ public class IcebergScanNode extends FileQueryScanNode {
 
     private CloseableIterable<FileScanTask> planFileScanTask(TableScan scan) {
         if (!IcebergUtils.isManifestCacheEnabled(source.getCatalog())) {
-            long targetSplitSize = getRealFileSplitSize(0);
-            return TableScanUtil.splitFiles(scan.planFiles(), targetSplitSize);
+            try (CloseableIterable<FileScanTask> planned = scan.planFiles()) {
+                List<FileScanTask> tasks = new ArrayList<>();
+                long totalFileSize = 0;
+                for (FileScanTask t : planned) {
+                    tasks.add(t);
+                    totalFileSize += t.file().fileSizeInBytes();
+                }
+                long targetSplitSize = getRealFileSplitSize(0);
+                if (!isBatchMode()) {
+                    targetSplitSize = applyMaxFileSplitNumLimit(targetSplitSize, totalFileSize);
+                }
+                return TableScanUtil.splitFiles(CloseableIterable.withNoopClose(tasks), targetSplitSize);
+            } catch (Exception e) {
+                LOG.warn("Plan file scan task failed, fallback to original scan: " + e.getMessage(), e);
+                long targetSplitSize = getRealFileSplitSize(0);
+                return TableScanUtil.splitFiles(scan.planFiles(), targetSplitSize);
+            }
         }
         try {
             return planFileScanTaskWithManifestCache(scan);
         } catch (Exception e) {
             manifestCacheFailures++;
             LOG.warn("Plan with manifest cache failed, fallback to original scan: " + e.getMessage(), e);
-            long targetSplitSize = getRealFileSplitSize(0);
-            return TableScanUtil.splitFiles(scan.planFiles(), targetSplitSize);
+            try (CloseableIterable<FileScanTask> planned = scan.planFiles()) {
+                List<FileScanTask> tasks = new ArrayList<>();
+                long totalFileSize = 0;
+                for (FileScanTask t : planned) {
+                    tasks.add(t);
+                    totalFileSize += t.file().fileSizeInBytes();
+                }
+                long targetSplitSize = getRealFileSplitSize(0);
+                if (!isBatchMode()) {
+                    targetSplitSize = applyMaxFileSplitNumLimit(targetSplitSize, totalFileSize);
+                }
+                return TableScanUtil.splitFiles(CloseableIterable.withNoopClose(tasks), targetSplitSize);
+            } catch (Exception ex) {
+                LOG.warn("Split files failed, fallback to original split: " + ex.getMessage(), ex);
+                long targetSplitSize = getRealFileSplitSize(0);
+                return TableScanUtil.splitFiles(scan.planFiles(), targetSplitSize);
+            }
         }
     }
 
@@ -560,7 +590,14 @@ public class IcebergScanNode extends FileQueryScanNode {
         }
 
         // Split tasks into smaller chunks based on target split size for parallel processing
+        long totalFileSize = 0;
+        for (FileScanTask t : tasks) {
+            totalFileSize += t.file().fileSizeInBytes();
+        }
         long targetSplitSize = getRealFileSplitSize(0);
+        if (!isBatchMode()) {
+            targetSplitSize = applyMaxFileSplitNumLimit(targetSplitSize, totalFileSize);
+        }
         return TableScanUtil.splitFiles(CloseableIterable.withNoopClose(tasks), targetSplitSize);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/source/PaimonScanNode.java
@@ -323,6 +323,19 @@ public class PaimonScanNode extends FileQueryScanNode {
         Map<BinaryRow, Map<String, String>> partitionInfoMaps = new HashMap<>();
         // if applyCountPushdown is true, we can't split the DataSplit
         long realFileSplitSize = getRealFileSplitSize(applyCountPushdown ? Long.MAX_VALUE : 0);
+        if (!applyCountPushdown && sessionVariable.getMaxFileSplitNum() > 0) {
+            long totalFileSize = 0;
+            for (DataSplit dataSplit : dataSplits) {
+                Optional<List<RawFile>> optRawFiles = dataSplit.convertToRawFiles();
+                if (!supportNativeReader(optRawFiles)) {
+                    continue;
+                }
+                for (RawFile rawFile : optRawFiles.get()) {
+                    totalFileSize += rawFile.length();
+                }
+            }
+            realFileSplitSize = applyMaxFileSplitNumLimit(realFileSplitSize, totalFileSize);
+        }
         for (DataSplit dataSplit : dataSplits) {
             SplitStat splitStat = new SplitStat();
             splitStat.setRowCount(dataSplit.rowCount());

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/tvf/source/TVFScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/tvf/source/TVFScanNode.java
@@ -147,10 +147,21 @@ public class TVFScanNode extends FileQueryScanNode {
             needSplit = FileSplitter.needSplitForCountPushdown(parallelNum, numBackends, totalFileNum);
         }
 
+        long totalFileSize = 0;
+        long maxBlockSize = 0;
+        if (needSplit && sessionVariable.getMaxFileSplitNum() > 0) {
+            for (TBrokerFileStatus fileStatus : fileStatuses) {
+                totalFileSize += fileStatus.getSize();
+                maxBlockSize = Math.max(maxBlockSize, fileStatus.getBlockSize());
+            }
+        }
+        long adjustedSplitSize = applyMaxFileSplitNumLimit(getRealFileSplitSize(maxBlockSize), totalFileSize);
+
         for (TBrokerFileStatus fileStatus : fileStatuses) {
             try {
+                long splitSize = needSplit ? adjustedSplitSize : Long.MAX_VALUE;
                 splits.addAll(FileSplitter.splitFile(LocationPath.of(fileStatus.getPath()),
-                        getRealFileSplitSize(needSplit ? fileStatus.getBlockSize() : Long.MAX_VALUE),
+                        splitSize,
                         null, fileStatus.getSize(),
                         fileStatus.getModificationTime(), fileStatus.isSplitable, null,
                         FileSplitCreator.DEFAULT));

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -516,6 +516,9 @@ public class SessionVariable implements Serializable, Writable {
     // Split size for ExternalFileScanNode. Default value 0 means use the block size of HDFS/S3.
     public static final String FILE_SPLIT_SIZE = "file_split_size";
 
+    // In non-batch mode, the maximum number of splits allowed per table scan to avoid OOM.
+    public static final String MAX_FILE_SPLIT_NUM = "max_file_split_num";
+
     // Target file size in bytes for Iceberg write operations
     public static final String ICEBERG_WRITE_TARGET_FILE_SIZE_BYTES = "iceberg_write_target_file_size_bytes";
 
@@ -2188,6 +2191,13 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = FILE_SPLIT_SIZE, needForward = true)
     public long fileSplitSize = 0;
+
+    @VariableMgr.VarAttr(
+            name = MAX_FILE_SPLIT_NUM,
+            description = {"在非 batch 模式下，每个 table scan 最大允许的 split 数量，防止产生过多 split 导致 OOM。",
+                    "In non-batch mode, the maximum number of splits allowed per table scan to avoid OOM."},
+            needForward = true)
+    public int maxFileSplitNum = 100000;
 
     // Target file size for Iceberg write operations
     // Default 0 means use config::iceberg_sink_max_file_size
@@ -4246,6 +4256,14 @@ public class SessionVariable implements Serializable, Writable {
 
     public void setFileSplitSize(long fileSplitSize) {
         this.fileSplitSize = fileSplitSize;
+    }
+
+    public int getMaxFileSplitNum() {
+        return maxFileSplitNum;
+    }
+
+    public void setMaxFileSplitNum(int maxFileSplitNum) {
+        this.maxFileSplitNum = maxFileSplitNum;
     }
 
     public long getIcebergWriteTargetFileSizeBytes() {


### PR DESCRIPTION
Backport of #58759 to branch-4.0.

Adds session variable `max_file_split_num` and applies it to external table scans (Hive/Iceberg/Paimon/TVF) by raising the target split size when the total scanned file size would otherwise generate too many splits.

Notes:
- Manual backport due to 4.0.x conflicts (label dev/4.0.x-conflict on the original PR).
