### PR TITLE
[refine](function)In functions, ensure that an empty input column returns an empty column.

### DIFF
--- a/be/src/vec/functions/function_const.h
+++ b/be/src/vec/functions/function_const.h
@@ -92,8 +92,7 @@ private:
                         uint32_t result, size_t input_rows_count) const override {
         block.get_by_position(result).column =
                 block.get_by_position(result).type->create_column_const(
-                        input_rows_count == 0 ? 1 : input_rows_count,
-                        Field::create_field<TYPE_DOUBLE>(Impl::value));
+                        input_rows_count, Field::create_field<TYPE_DOUBLE>(Impl::value));
         return Status::OK();
     }
 };


### PR DESCRIPTION
### What problem does this PR solve?

Some function implementations may not handle the case where input_rows_count is 0
(e.g., some functions access the 0th row of input columns during execution).
Additionally, some UDF functions may hang if they write 0 rows and then try to read.
Therefore, before executing the function, we first check if input_rows_count is 0.
If it is 0, we directly return an empty result column to avoid executing the function body.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

