### PR TITLE
[fix](regression-case) Fix routineload case : test_routine_load_timeout_value

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/KafkaTaskInfo.java
@@ -125,7 +125,9 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         if (!isEof) {
             long maxBatchIntervalS = Math.max(routineLoadJob.getMaxBatchIntervalS(),
                     Config.routine_load_adaptive_min_batch_interval_sec);
-            this.timeoutMs = maxBatchIntervalS * Config.routine_load_task_timeout_multiplier * 1000;
+            long timeoutSec = maxBatchIntervalS * Config.routine_load_task_timeout_multiplier;
+            long realTimeoutSec = Math.max(timeoutSec, Config.routine_load_task_min_timeout_sec);
+            this.timeoutMs = realTimeoutSec * 1000;
         } else {
             this.timeoutMs = routineLoadJob.getTimeout() * 1000;
         }

--- a/regression-test/suites/load_p0/routine_load/test_routine_load_timeout_value.groovy
+++ b/regression-test/suites/load_p0/routine_load/test_routine_load_timeout_value.groovy
@@ -78,6 +78,10 @@ suite("test_routine_load_timeout_value","nonConcurrent") {
         // create table
         def jobName = "test_routine_load_timeout_value"
         def tableName = "test_routine_load_timeout_value"
+
+        // Set routine_load_adaptive_min_batch_interval_sec to a small value to avoid affecting timeout test
+        sql "ADMIN SET FRONTEND CONFIG ('routine_load_adaptive_min_batch_interval_sec' = '5')"
+
         try {
             sql """
             CREATE TABLE IF NOT EXISTS ${tableName}
@@ -210,6 +214,8 @@ suite("test_routine_load_timeout_value","nonConcurrent") {
         } finally {
             sql "stop routine load for ${jobName}"
             sql "DROP TABLE IF EXISTS ${tableName} FORCE"
+            // Restore routine_load_adaptive_min_batch_interval_sec to default value
+            sql "ADMIN SET FRONTEND CONFIG ('routine_load_adaptive_min_batch_interval_sec' = '360')"
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: https://github.com/apache/doris/pull/56930
Problem Summary:

Under the condition where `isEof = false`, the calculation of the timeout in `updateAdaptiveTimeout `also needs to take into account `Config.routine_load_task_min_timeout_sec`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

