### PR TITLE
[fix](memory) fix Hadoop metrics2 memory leak causing FE OOM in exter…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
@@ -190,13 +190,6 @@ public class DorisFE {
 
             fuzzyConfigs();
 
-            // Disable Hadoop metrics2 to prevent memory leak.
-            // Each new Hadoop FileSystem instance registers metrics with the global DefaultMetricsSystem
-            // singleton, but never unregisters them on close(). This causes MetricCounterLong and
-            // MBeanAttributeInfo objects to accumulate unboundedly, eventually leading to OOM.
-            // Doris FE does not use Hadoop metrics, so it is safe to disable them entirely.
-            org.apache.hadoop.metrics2.lib.DefaultMetricsSystem.setMiniClusterMode(true);
-
             LOG.info("Doris FE starting...");
 
             FrontendOptions.init();

--- a/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
@@ -190,6 +190,12 @@ public class DorisFE {
 
             fuzzyConfigs();
 
+            // Replace Hadoop's DefaultMetricsSystem with a no-op to prevent memory leak.
+            // Each FileSystem.get() registers metrics (MetricCounterLong, MBeanAttributeInfo, etc.)
+            // that are never unregistered, causing unbounded growth. Doris FE does not use Hadoop metrics.
+            org.apache.hadoop.metrics2.lib.DefaultMetricsSystem
+                    .setInstance(new org.apache.doris.common.NopMetricsSystem());
+
             LOG.info("Doris FE starting...");
 
             FrontendOptions.init();

--- a/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
@@ -190,6 +190,13 @@ public class DorisFE {
 
             fuzzyConfigs();
 
+            // Disable Hadoop metrics2 to prevent memory leak.
+            // Each new Hadoop FileSystem instance registers metrics with the global DefaultMetricsSystem
+            // singleton, but never unregisters them on close(). This causes MetricCounterLong and
+            // MBeanAttributeInfo objects to accumulate unboundedly, eventually leading to OOM.
+            // Doris FE does not use Hadoop metrics, so it is safe to disable them entirely.
+            org.apache.hadoop.metrics2.lib.DefaultMetricsSystem.setMiniClusterMode(true);
+
             LOG.info("Doris FE starting...");
 
             FrontendOptions.init();

--- a/fe/fe-core/src/main/java/org/apache/doris/common/NopMetricsSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/NopMetricsSystem.java
@@ -1,0 +1,72 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import org.apache.hadoop.metrics2.MetricsSource;
+import org.apache.hadoop.metrics2.MetricsSink;
+import org.apache.hadoop.metrics2.MetricsSystem;
+
+/**
+ * A no-op MetricsSystem implementation to prevent Hadoop metrics2 memory leak.
+ *
+ * Each Hadoop FileSystem instance registers metrics with the global DefaultMetricsSystem,
+ * creating MetricsSourceAdapter and JMX MBeans that are never unregistered on close().
+ * Since Doris FE does not consume Hadoop metrics, we replace the default with this no-op
+ * to prevent unbounded accumulation of MetricCounterLong, MBeanAttributeInfo, etc.
+ */
+public class NopMetricsSystem extends MetricsSystem {
+
+    @Override
+    public MetricsSystem init(String prefix) {
+        return this;
+    }
+
+    @Override
+    public <T extends MetricsSource> T register(String name, String desc, T source) {
+        return source;
+    }
+
+    @Override
+    public void unregisterSource(String name) {}
+
+    @Override
+    public MetricsSource getSource(String name) {
+        return null;
+    }
+
+    @Override
+    public <T extends MetricsSink> T register(String name, String desc, T sink) {
+        return sink;
+    }
+
+    @Override
+    public void register(Callback callback) {}
+
+    @Override
+    public void publishMetricsNow() {}
+
+    @Override
+    public boolean shutdown() {
+        return true;
+    }
+
+    @Override
+    public String currentConfig() {
+        return "";
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemCache.java
@@ -23,11 +23,15 @@ import org.apache.doris.datasource.property.storage.StorageProperties;
 import org.apache.doris.fs.remote.RemoteFileSystem;
 
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Objects;
 import java.util.OptionalLong;
 
 public class FileSystemCache {
+
+    private static final Logger LOG = LogManager.getLogger(FileSystemCache.class);
 
     private final LoadingCache<FileSystemCacheKey, RemoteFileSystem> fileSystemCache;
 
@@ -39,7 +43,17 @@ public class FileSystemCache {
                 Config.max_remote_file_system_cache_num,
                 false,
                 null);
-        fileSystemCache = fsCacheFactory.buildCache(this::loadFileSystem);
+        // Use sync RemovalListener to close evicted RemoteFileSystem and release underlying resources
+        // (e.g., Hadoop FileSystem handles). Without this, evicted entries leak native resources.
+        fileSystemCache = fsCacheFactory.buildCacheWithSyncRemovalListener(this::loadFileSystem, (key, fs, cause) -> {
+            if (fs != null) {
+                try {
+                    fs.close();
+                } catch (Exception e) {
+                    LOG.warn("Failed to close RemoteFileSystem on cache eviction", e);
+                }
+            }
+        });
     }
 
     private RemoteFileSystem loadFileSystem(FileSystemCacheKey key) {

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -159,6 +160,16 @@ public class DFSFileSystem extends RemoteFileSystem {
                                 throw new RuntimeException(e);
                             }
                         });
+                        // Shutdown Hadoop's DefaultMetricsSystem to prevent MetricsSourceAdapter leak.
+                        // Each FileSystem.get() registers metrics sources in the global MetricsSystemImpl
+                        // that are never unregistered on FileSystem.close(), causing unbounded growth of
+                        // MetricCounterLong, MBeanAttributeInfo, etc. Doris FE does not consume Hadoop
+                        // metrics, so shutting down the metrics system is safe.
+                        try {
+                            DefaultMetricsSystem.shutdown();
+                        } catch (Exception e) {
+                            LOG.warn("Failed to shutdown Hadoop DefaultMetricsSystem", e);
+                        }
                         operations = new HDFSFileOperations(dfsFileSystem);
                         RemoteFSPhantomManager.registerPhantomReference(this);
                     } catch (Exception e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
@@ -47,7 +47,7 @@ import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
-import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -160,16 +160,6 @@ public class DFSFileSystem extends RemoteFileSystem {
                                 throw new RuntimeException(e);
                             }
                         });
-                        // Shutdown Hadoop's DefaultMetricsSystem to prevent MetricsSourceAdapter leak.
-                        // Each FileSystem.get() registers metrics sources in the global MetricsSystemImpl
-                        // that are never unregistered on FileSystem.close(), causing unbounded growth of
-                        // MetricCounterLong, MBeanAttributeInfo, etc. Doris FE does not consume Hadoop
-                        // metrics, so shutting down the metrics system is safe.
-                        try {
-                            DefaultMetricsSystem.shutdown();
-                        } catch (Exception e) {
-                            LOG.warn("Failed to shutdown Hadoop DefaultMetricsSystem", e);
-                        }
                         operations = new HDFSFileOperations(dfsFileSystem);
                         RemoteFSPhantomManager.registerPhantomReference(this);
                     } catch (Exception e) {


### PR DESCRIPTION
…nal table workloads

### What problem does this PR solve?
Each new Hadoop FileSystem instance (e.g., S3AFileSystem) registers metrics
with the global DefaultMetricsSystem singleton but never unregisters them on
close(). Since Doris disables the Hadoop FS cache, every cache miss creates a
new FileSystem, causing MetricCounterLong and MBeanAttributeInfo objects to
accumulate unboundedly until OOM.

Fix:
- Call DefaultMetricsSystem.setMiniClusterMode(true) at FE startup to prevent
  metrics registration entirely, as Doris does not use Hadoop metrics.
- Add a RemovalListener to FileSystemCache to close evicted RemoteFileSystem
  entries and release underlying Hadoop FileSystem resources.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

