### PR TITLE
[fix](datetime) Fix DATETIMEV2 parsing issue when scale is 0

### DIFF
--- a/be/src/olap/types.h
+++ b/be/src/olap/types.h
@@ -1253,7 +1253,8 @@ struct FieldTypeTraits<FieldType::OLAP_FIELD_TYPE_DATETIMEV2>
     static Status from_string(void* buf, const std::string& scan_key, const int precision,
                               const int scale) {
         DateV2Value<DateTimeV2ValueType> datetimev2_value;
-        std::string date_format = "%Y-%m-%d %H:%i:%s.%f";
+        // Use different format based on scale (0 = no fractional seconds, >0 = with fractional seconds)
+        const std::string date_format = (scale > 0) ? "%Y-%m-%d %H:%i:%s.%f" : "%Y-%m-%d %H:%i:%s";
 
         if (datetimev2_value.from_date_format_str(date_format.data(), date_format.size(),
                                                   scan_key.data(), scan_key.size())) {


### PR DESCRIPTION
When using DATETIMEV2 type with scale=0, queries fail to return data when filtering by timestamp without fractional seconds. This is because the from_string function always uses the format with fractional seconds (%Y-%m-%d %H:%i:%s.%f), which fails to parse timestamps without fractional seconds.

Example issue:
```sql
CREATE TABLE test_table (id INT, name VARCHAR(100)) UNIQUE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1  PROPERTIES ("replication_num" = "1");

INSERT INTO test_table VALUES (1, 'Alice');

ALTER TABLE test_table ADD COLUMN create_time DATETIME DEFAULT current_timestamp;

mysql> select * from test_table;
+------+-------+---------------------+
| id   | name  | create_time         |
+------+-------+---------------------+
|    1 | Alice | 2026-02-11 12:30:16 |
+------+-------+---------------------+

SELECT * FROM test_table WHERE create_time = '2026-02-11 12:30:16'; -- Returns no data
````

The fix adjusts the date format based on the scale parameter:

- scale = 0: Uses format "%Y-%m-%d %H:%i:%s" (no fractional seconds)
- scale > 0: Uses format "%Y-%m-%d %H:%i:%s.%f" (with fractional seconds)

This ensures proper parsing of timestamp strings that match the column's scale.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [X] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [X] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [X] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

