### PR TITLE
[fix](udf) Allow users to override special built-in functions with UDFs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
@@ -564,10 +564,10 @@ public class ExpressionAnalyzer extends SubExprAnalyzer<ExpressionRewriteContext
                     }
                 }
             } catch (AnalysisException e) {
-                // If user set preferUdfOverBuiltin=true,
-                // we should try finding UDF, user may override built-in function with UDF.
-                // We can't find it and exception is thrown, and we should ignore it can continue finding function.
-                // If preferUdfOverBuiltin=false, throw exception directly.
+                // If `prefer_udf_over_builtin` is enabled, we ignore the AnalysisException                                                                                                                    │
+                // when special built-in function binding fails. This allows the analyzer to                                                                                                                   │
+                // fall back to the function registry, permitting users to override these                                                                                                                      │
+                // built-in functions with their own UDFs.
                 boolean preferUdfOverBuiltin = ConnectContext.get() == null ? false
                         : ConnectContext.get().getSessionVariable().preferUdfOverBuiltin;
                 if (!preferUdfOverBuiltin) {


### PR DESCRIPTION
### What problem does this PR solve?

This commit modifies the `ExpressionAnalyzer` to handle cases where a user wants to override special built-in functions (like arithmetic, format, or datetime functions) with their own UDFs.

Previously, the analyzer would throw an `AnalysisException` immediately if binding to these specific built-in implementations failed, preventing any subsequent UDF lookup.

Now, if the session variable `prefer_udf_over_builtin` is set to true, the analyzer catches the `AnalysisException` during the built-in binding attempt and allows the process to continue, enabling th
subsequent lookup for a matching UDF in the function registry.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

