### PR TITLE
[Exec](performance) change colocate execution parallel num

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -163,6 +163,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String DISABLE_STREAMING_PREAGGREGATIONS = "disable_streaming_preaggregations";
     public static final String ENABLE_DISTINCT_STREAMING_AGGREGATION = "enable_distinct_streaming_aggregation";
     public static final String DISABLE_COLOCATE_PLAN = "disable_colocate_plan";
+    public static final String COLOCATE_MAX_PARALLEL_NUM = "colocate_max_parallel_num";
     public static final String ENABLE_BUCKET_SHUFFLE_JOIN = "enable_bucket_shuffle_join";
     public static final String PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM = "parallel_fragment_exec_instance_num";
     public static final String PARALLEL_PIPELINE_TASK_NUM = "parallel_pipeline_task_num";
@@ -1286,6 +1287,9 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM, needForward = true, fuzzy = false,
                         setter = "setFragmentInstanceNum", varType = VariableAnnotation.DEPRECATED)
     public int parallelExecInstanceNum = 8;
+
+    @VariableMgr.VarAttr(name = COLOCATE_MAX_PARALLEL_NUM, needForward = true, fuzzy = false)
+    public int colocateMaxParallelNum = 128;
 
     @VariableMgr.VarAttr(name = PARALLEL_PIPELINE_TASK_NUM, fuzzy = true, needForward = true,
                         setter = "setPipelineTaskNum")

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/LocalShuffleWithBucketJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/LocalShuffleWithBucketJoinTest.java
@@ -67,7 +67,7 @@ public class LocalShuffleWithBucketJoinTest extends TestWithFeService {
         PipelineDistributedPlan distributedPlan
                 = (PipelineDistributedPlan) distributedPlans.get(0);
         List<AssignedJob> instances = distributedPlan.getInstanceJobs();
-        Assertions.assertEquals(beNum * parallelPipelineTaskNum, instances.size());
+        Assertions.assertEquals(beNum * bucketNum, instances.size());
         Assertions.assertTrue(instances.stream().allMatch(LocalShuffleBucketJoinAssignedJob.class::isInstance));
 
         long assignedBucketInstanceNum = instances.stream().map(LocalShuffleBucketJoinAssignedJob.class::cast)
@@ -80,7 +80,7 @@ public class LocalShuffleWithBucketJoinTest extends TestWithFeService {
             workerToInstances.put(instance.getAssignedWorker(), instance);
         }
         for (Collection<AssignedJob> instancePerBe : workerToInstances.asMap().values()) {
-            Assertions.assertEquals(parallelPipelineTaskNum, instancePerBe.size());
+            Assertions.assertEquals(bucketNum, instancePerBe.size());
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Previously, the parallelism for colocate execution was calculated based on bucket count, which might not fully utilize available resources. This PR changes the parallelism calculation logic to:

1. Use tablet count instead of bucket count for more accurate resource utilization
2. Add a new session variable colocate_max_parallel_num to control the maximum parallelism
3. Calculate parallelism as min(max(tablet_num, fragment.getParallelExecNum()), colocate_max_parallel_num) to ensure both resource utilization and system stability

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

