### PR TITLE
[fix](load) fix quorum success invalid in move-memtable-on-sink load path

### DIFF
--- a/be/src/runtime/load_stream.cpp
+++ b/be/src/runtime/load_stream.cpp
@@ -757,6 +757,7 @@ void LoadStream::_dispatch(StreamId id, const PStreamHeader& hdr, butil::IOBuf* 
         }
     } break;
     case PStreamHeader::CLOSE_LOAD: {
+        DBUG_EXECUTE_IF("LoadStream.close_load.block", DBUG_BLOCK);
         std::vector<int64_t> success_tablet_ids;
         FailedTablets failed_tablets;
         std::vector<PTabletID> tablets_to_commit(hdr.tablets().begin(), hdr.tablets().end());

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -104,11 +104,11 @@ Status VTabletWriterV2::_incremental_open_streams(
                     tablet.set_tablet_id(tablet_id);
                     new_backends.insert(node);
                     _tablets_for_node[node].emplace(tablet_id, tablet);
+                    _tablets_by_node[node].emplace(tablet_id);
                     if (known_indexes.contains(index.index_id)) [[likely]] {
                         continue;
                     }
                     _indexes_from_node[node].emplace_back(tablet);
-                    _tablets_by_node[node].emplace(tablet_id);
                     known_indexes.insert(index.index_id);
                     VLOG_DEBUG << "incremental open stream (" << partition->id << ", " << tablet_id
                                << ")";
@@ -347,11 +347,11 @@ Status VTabletWriterV2::_build_tablet_node_mapping() {
                         // ignore fake tablet for auto partition
                         continue;
                     }
+                    _tablets_by_node[node].emplace(tablet_id);
                     if (known_indexes.contains(index.index_id)) [[likely]] {
                         continue;
                     }
                     _indexes_from_node[node].emplace_back(tablet);
-                    _tablets_by_node[node].emplace(tablet_id);
                     known_indexes.insert(index.index_id);
                 }
                 _build_tablet_replica_info(tablet_id, partition);


### PR DESCRIPTION
## Description

In `VTabletWriterV2`, the `_quorum_success()` function always returns `false` even when
all streams have finished successfully, making the quorum success write feature effectively
non-functional.

## Root Cause

In both `_build_tablet_node_mapping()` and `_incremental_open_streams()`,
`_tablets_by_node[node].emplace(tablet_id)` is guarded by the `known_indexes` check:

```cpp
if (known_indexes.contains(index.index_id)) [[likely]] {
    continue;
}
_indexes_from_node[node].emplace_back(tablet);
_tablets_by_node[node].emplace(tablet_id);
known_indexes.insert(index.index_id);
```

The known_indexes set is shared across all partitions, tablets, and nodes. Once an
index_id is inserted after processing the first tablet's first node, all subsequent
tablets (and all other nodes of the same tablet) with the same index_id skip the
_tablets_by_node update.

For example, with 1 index, 3 tablets [T1, T2, T3], and 3 replicas [N1, N2, N3]:

Only _tablets_by_node[N1] = {T1} gets populated
T1 on N2/N3, and T2/T3 on all nodes are skipped
This causes _quorum_success() to compute finished_tablets_replica incorrectly:

finished_tablets_replica[T1] = 1 (only counted from N1)
finished_tablets_replica[T2] = 0, finished_tablets_replica[T3] = 0
With a quorum requirement of 2 (for 3 replicas), the check always fails.

The known_indexes optimization was intended only for _indexes_from_node (to avoid
sending duplicate schema info per index), but it incorrectly also blocked the
_tablets_by_node population.

Note: vtablet_writer.cpp does NOT have this issue — its _tablets_by_channel is
populated without the known_indexes guard.

## Fix
Move _tablets_by_node[node].emplace(tablet_id) before the known_indexes check in
both _build_tablet_node_mapping() and _incremental_open_streams(), so that every
tablet on every node is correctly recorded.

