### PR TITLE
[fix](move-memtable) fix StreamWrite EINVAL error when report tablet load info

### DIFF
--- a/be/src/runtime/load_stream.cpp
+++ b/be/src/runtime/load_stream.cpp
@@ -606,6 +606,9 @@ void LoadStream::_report_tablet_load_info(StreamId stream, int64_t index_id) {
         PLoadStreamResponse response;
         auto* tablet_load_infos = response.mutable_tablet_load_rowset_num_infos();
         _collect_tablet_load_info_from_tablets(write_tablet_ids, tablet_load_infos);
+        if (tablet_load_infos->empty()) {
+            return;
+        }
         buf.append(response.SerializeAsString());
         auto wst = _write_stream(stream, buf);
         if (!wst.ok()) {


### PR DESCRIPTION
## Summary

Fix a bug where `_report_tablet_load_info` writes an empty `IOBuf` to brpc stream,
causing `Socket::Write` to return EINVAL and log warnings like:

```
Fail to write to _fake_socket, Invalid argument
```

## Root Cause

`_report_tablet_load_info` is called on every `ADD_SEGMENT` request to report tablet
load info (version count) back to the sender for back-pressure control.

The call chain is:

1. `_report_tablet_load_info` gets `write_tablet_ids` from the index stream
2. `_collect_tablet_load_info_from_tablets` iterates over these tablet IDs
3. `collect_tablet_load_rowset_num_info` only adds an entry when `version_count`
   exceeds `max_version_config * load_back_pressure_version_threshold / 100`

In normal cases where no tablet hits the back-pressure threshold, `tablet_load_infos`
remains empty. A protobuf message with only an empty repeated field serializes to an
empty string (0 bytes). The empty `IOBuf` is then passed to `brpc::StreamWrite`, and
brpc's `Socket::Write` rejects empty data with EINVAL.

This error is harmless (the socket is not closed or failed, and subsequent writes
succeed), but it produces noisy WARNING logs on every `ADD_SEGMENT` request.

## Fix

Skip the `StreamWrite` call when `tablet_load_infos` is empty after collection,
since there is nothing to report.