### PR TITLE
[fix](core)Fix a DCHECK failure when short-circuit evaluation and array_map are used together.

### DIFF
--- a/be/src/vec/exprs/lambda_function/varray_map_function.cpp
+++ b/be/src/vec/exprs/lambda_function/varray_map_function.cpp
@@ -285,7 +285,9 @@ public:
             //3. child[0]->execute(new_block)
 
             ColumnPtr res_col;
-            RETURN_IF_ERROR(children[0]->execute_column(context, &lambda_block, expr_selector,
+            // lambda body executes on the internal lambda_block, not the original block.
+            // The outer expr_selector is irrelevant here, so pass nullptr.
+            RETURN_IF_ERROR(children[0]->execute_column(context, &lambda_block, nullptr,
                                                         lambda_block.rows(), res_col));
             res_col = res_col->convert_to_full_column_if_const();
             res_type = children[0]->execute_type(&lambda_block);

--- a/regression-test/data/query_p0/sql_functions/conditional_functions/test_short_circuit_evaluation.out
+++ b/regression-test/data/query_p0/sql_functions/conditional_functions/test_short_circuit_evaluation.out
@@ -383,3 +383,10 @@
 9	9	-2	i	i	unknown
 10	10	100	j	t	no
 
+-- !with_array_map --
+\N
+\N
+\N
+[9, 9, 9]
+[16, 16, 16]
+

--- a/regression-test/suites/query_p0/sql_functions/conditional_functions/test_short_circuit_evaluation.groovy
+++ b/regression-test/suites/query_p0/sql_functions/conditional_functions/test_short_circuit_evaluation.groovy
@@ -655,4 +655,13 @@ suite("test_short_circuit_evaluation") {
 
     // Clean up
     sql "DROP TABLE IF EXISTS test_short_circuit_eval;"
+
+
+    sql """
+        set short_circuit_evaluation = true;
+    """
+
+    qt_with_array_map"""
+        select if(number < 3 , null, array_map(x -> x * x, array(number,number,number))) from numbers("number" = "5");
+    """
 }


### PR DESCRIPTION
### What problem does this PR solve?

array_map constructs a temporary block but incorrectly passed the selector.
```
 4# 0x000056376DFC5EC5 in /home/work/unlimit_teamcity/TeamCity/Agents/20260211180011agent_172.17.0.220_1/work/60183217f6ee2a9c/output/be/lib/doris_be
 5# 0x000056376DFB777A in /home/work/unlimit_teamcity/TeamCity/Agents/20260211180011agent_172.17.0.220_1/work/60183217f6ee2a9c/output/be/lib/doris_be
 6# google::LogMessage::SendToLog() in /home/work/unlimit_teamcity/TeamCity/Agents/20260211180011agent_172.17.0.220_1/work/60183217f6ee2a9c/output/be/lib/doris_be
 7# google::LogMessage::Flush() in /home/work/unlimit_teamcity/TeamCity/Agents/20260211180011agent_172.17.0.220_1/work/60183217f6ee2a9c/output/be/lib/doris_be
 8# google::LogMessageFatal::~LogMessageFatal() in /home/work/unlimit_teamcity/TeamCity/Agents/20260211180011agent_172.17.0.220_1/work/60183217f6ee2a9c/output/be/lib/doris_be
 9# doris::vectorized::VExpr::filter_column_with_selector(doris::COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn> const&, doris::vectorized::PODArray<unsigned int, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul> const*, unsigned long) at ../src/vec/exprs/vexpr.h:269
10# doris::vectorized::VSlotRef::execute_column(doris::vectorized::VExprContext*, doris::vectorized::Block const*, doris::vectorized::PODArray<unsigned int, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul>*, unsigned long, doris::COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>&) const at /root/doris/be/build_ASAN/../src/vec/exprs/vslot_ref.cpp:96
11# doris::vectorized::VCastExpr::execute_column(doris::vectorized::VExprContext*, doris::vectorized::Block const*, doris::vectorized::PODArray<unsigned int, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul>*, unsigned long, doris::COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>&) const at /root/doris/be/build_ASAN/../src/vec/exprs/vcast_expr.cpp:117
12# doris::vectorized::VectorizedFnCall::_do_execute(doris::vectorized::VExprContext*, doris::vectorized::Block const*, doris::vectorized::PODArray<unsigned int, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul>*, unsigned long, doris::COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>&, doris::COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>*) const at /root/doris/be/build_ASAN/../src/vec/exprs/vectorized_fn_call.cpp:242
13# doris::vectorized::VectorizedFnCall::execute_column(doris::vectorized::VExprContext*, doris::vectorized::Block const*, doris::vectorized::PODArray<unsigned int, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul>*, unsigned long, doris::COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>&) const at /root/doris/be/build_ASAN/../src/vec/exprs/vectorized_fn_call.cpp:302
14# doris::vectorized::VectorizedFnCall::_do_execute(doris::vectorized::VExprContext*, doris::vectorized::Block const*, doris::vectorized::PODArray<unsigned int, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul>*, unsigned long, doris::COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>&, doris::COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>*) const at /root/doris/be/build_ASAN/../src/vec/exprs/vectorized_fn_call.cpp:242
15# doris::vectorized::VectorizedFnCall::execute_column(doris::vectorized::VExprContext*, doris::vectorized::Block const*, doris::vectorized::PODArray<unsigned int, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul>*, unsigned long, doris::COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>&) const at /root/doris/be/build_ASAN/../src/vec/exprs/vectorized_fn_call.cpp:302
16# doris::vectorized::VLambdaFunctionExpr::execute_column(doris::vectorized::VExprContext*, doris::vectorized::Block const*, doris::vectorized::PODArray<unsigned int, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul>*, unsigned long, doris::COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>&) const at ../src/vec/exprs/vlambda_function_expr.h:48
17# doris::vectorized::ArrayMapFunction::execute(doris::vectorized::VExprContext*, doris::vectorized::Block const*, doris::vectorized::PODArray<unsigned int, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul>*, unsigned long, doris::COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>&, std::shared_ptr<doris::vectorized::IDataType const> const&, std::vector<std::shared_ptr<doris::vectorized::VExpr>, std::allocator<std::shared_ptr<doris::vectorized::VExpr> > > const&) const at /root/doris/be/build_ASAN/../src/vec/exprs/lambda_function/varray_map_function.cpp:288
18# doris::vectorized::VLambdaFunctionCallExpr::execute_column(doris::vectorized::VExprContext*, doris::vectorized::Block const*, doris::vectorized::PODArray<unsigned int, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul>*, unsigned long, doris::COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>&) const at ../src/vec/exprs/vlambda_function_call_expr.h:69
19# doris::vectorized::VectorizedFnCall::_do_execute(doris::vectorized::VExprContext*, doris::vectorized::Block const*, doris::vectorized::PODArray<unsigned int, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul>*, unsigned long, doris::COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>&, doris::COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>*) const at /root/doris/be/build_ASAN/../src/vec/exprs/vectorized_fn_call.cpp:242
20# doris::vectorized::VectorizedFnCall::execute_column(doris::vectorized::VExprContext*, doris::vectorized::Block const*, doris::vectorized::PODArray<unsigned int, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul>*, unsigned long, doris::COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>&) const at /root/doris/be/build_ASAN/../src/vec/exprs/vectorized_fn_call.cpp:302
21# doris::vectorized::VectorizedFnCall::_do_execute(doris::vectorized::VExprContext*, doris::vectorized::Block const*, doris::vectorized::PODArray<unsigned int, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul>*, unsigned long, doris::COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>&, doris::COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>*) const at /root/doris/be/build_ASAN/../src/vec/exprs/vectorized_fn_call.cpp:242
22# doris::vectorized::VectorizedFnCall::execute_column(doris::vectorized::VExprContext*, doris::vectorized::Block const*, doris::vectorized::PODArray<unsigned int, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul>*, unsigned long, doris::COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>&) const at /root/doris/be/build_ASAN/../src/vec/exprs/vectorized_fn_call.cpp:302
23# doris::vectorized::VExprContext::short_circuit_execute_conjuncts(std::vector<std::shared_ptr<doris::vectorized::VExprContext>, std::allocator<std::shared_ptr<doris::vectorized::VExprContext> > > const&, bool, doris::vectorized::Block const*, doris::vectorized::PODArray<unsigned char, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul>*, bool*) at /root/doris/be/build_ASAN/../src/vec/exprs/vexpr_context.cpp:265
24# doris::vectorized::VExprContext::execute_conjuncts(std::vector<std::shared_ptr<doris::vectorized::VExprContext>, std::allocator<std::shared_ptr<doris::vectorized::VExprContext> > > const&, std::vector<doris::vectorized::PODArray<unsigned char, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul>*, std::allocator<doris::vectorized::PODArray<unsigned char, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul>*> > const*, bool, doris::vectorized::Block const*, doris::vectorized::PODArray<unsigned char, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, false>, 16ul, 15ul>*, bool*) in /home/work/unlimit_teamcity/TeamCity/Agents/20260211180011agent_172.17.0.220_1/work/60183217f6ee2a9c/output/be/lib/doris_be
25# doris::vectorized::VExprContext::execute_conjuncts_and_filter_block(std::vector<std::shared_ptr<doris::vectorized::VExprContext>, std::allocator<std::shared_ptr<doris::vectorized::VExprContext> > > const&, doris::vectorized::Block*, std::vector<unsigned int, std::allocator<unsigned int> >&, int) at /root/doris/be/build_ASAN/../src/vec/exprs/vexpr_context.cpp:410
26# doris::vectorized::VExprContext::filter_block(std::vector<std::shared_ptr<doris::vectorized::VExprContext>, std::allocator<std::shared_ptr<doris::vectorized::VExprContext> > > const&, doris::vectorized::Block*, unsigned long) at /root/doris/be/build_ASAN/../src/vec/exprs/vexpr_context.cpp:217
27# doris::vectorized::Scanner::_filter_output_block(doris::vectorized::Block*) at /root/doris/be/build_ASAN/../src/vec/exec/scan/scanner.cpp:176
28# doris::vectorized::Scanner::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /root/doris/be/build_ASAN/../src/vec/exec/scan/scanner.cpp:153
29# doris::vectorized::Scanner::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) in /home/work/unlimit_teamcity/TeamCity/Agents/20260211180011agent_172.17.0.220_1/work/60183217f6ee2a9c/output/be/lib/doris_be
30# doris::vectorized::ScannerScheduler::_scanner_scan(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>) at /root/doris/be/build_ASAN/../src/vec/exec/scan/scanner_scheduler.cpp:177
31# std::_Function_handler<bool (), doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}>::_M_invoke(std::_Any_data const&) at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:292
32# doris::vectorized::ScannerSplitRunner::process_for(std::chrono::duration<long, std::ratio<1l, 1000000000l> >) at /root/doris/be/build_ASAN/../src/vec/exec/scan/scanner_scheduler.cpp:415
33# doris::vectorized::PrioritizedSplitRunner::process() in /home/work/unlimit_teamcity/TeamCity/Agents/20260211180011agent_172.17.0.220_1/work/60183217f6ee2a9c/output/be/lib/doris_be
34# doris::vectorized::TimeSharingTaskExecutor::_dispatch_thread() at /root/doris/be/build_ASAN/../src/vec/exec/executor/time_sharing/time_sharing_task_executor.cpp:568
35# doris::Thread::supervise_thread(void*) at /root/doris/be/build_ASAN/../src/util/thread.cpp:461
36# asan_thread_start(void*) in /home/work/unlimit_teamcity/TeamCity/Agents/20260211180011agent_172.17.0.220_1/work/60183217f6ee2a9c/output/be/lib/doris_be
37# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
38# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

