### PR TITLE
[fix](memory) fix ThreadPoolExecutor leak in PublishVersionDaemon

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
@@ -71,9 +71,11 @@ public class PublishVersionDaemon extends MasterDaemon {
 
     public PublishVersionDaemon() {
         super("PUBLISH_VERSION", Config.publish_version_interval_ms);
-        for (int i = 0; i < Config.publish_thread_pool_num; i++) {
-            dbExecutors.add(ThreadPoolManager.newDaemonFixedThreadPool(1, Config.publish_queue_size,
-                    "PUBLISH_VERSION_EXEC-" + i, true));
+        if (dbExecutors.isEmpty()) {
+            for (int i = 0; i < Config.publish_thread_pool_num; i++) {
+                dbExecutors.add(ThreadPoolManager.newDaemonFixedThreadPool(1, Config.publish_queue_size,
+                        "PUBLISH_VERSION_EXEC-" + i, true));
+            }
         }
     }
 


### PR DESCRIPTION
dbExecutors is a static field, but the constructor appends new thread pools to it on every invocation without clearing old ones. Since PublishVersionDaemon extends MasterDaemon and gets re-instantiated on master switches, the static list keeps growing indefinitely.

Heap dump analysis shows the backing array grew to 11,070 slots (~86 constructor calls x 128 pools each), leaking ThreadPoolExecutor instances along with their threads, locks, and queues.

Fix: skip pool creation if dbExecutors is already populated.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

