### PR TITLE
[fix](memory) fix ThreadPoolExecutor leak in PublishVersionDaemon

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
@@ -71,9 +71,11 @@ public class PublishVersionDaemon extends MasterDaemon {
 
     public PublishVersionDaemon() {
         super("PUBLISH_VERSION", Config.publish_version_interval_ms);
-        for (int i = 0; i < Config.publish_thread_pool_num; i++) {
-            publishExecutors.add(ThreadPoolManager.newDaemonFixedThreadPool(1, Config.publish_queue_size,
-                    "PUBLISH_VERSION_EXEC-" + i, true));
+        if (publishExecutors.isEmpty()) {
+            for (int i = 0; i < Config.publish_thread_pool_num; i++) {
+                publishExecutors.add(ThreadPoolManager.newDaemonFixedThreadPool(1, Config.publish_queue_size,
+                        "PUBLISH_VERSION_EXEC-" + i, true));
+            }
         }
     }
 


### PR DESCRIPTION
`publishExecutors` is a static field, but the constructor appends new thread pools on every invocation without checking if they already exist.

The constructor is called each time a new Env instance is created, which happens periodically during Env checkpoint/journal replay (the checkpoint thread creates a new Env to replay the journal). Each call appends `publish_thread_pool_num` (default 128) pools to the static list, causing unbounded growth.

Heap dump analysis (branch-4.0, 12 rounds of p0 regression) confirmed:
- ThreadPoolExecutor: R1: 2,506 → R12: 12,236 (+388.3%), 11/11 strictly increasing
- dbExecutors backing array grew to Object[11070] (~86 Env replays × 128 pools)
- Each leaked pool retains threads, locks, and condition queues

Fix: skip pool creation if publishExecutors is already populated.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

