### PR TITLE
[bug](udf) udf should cache classloader in static load

### DIFF
--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/utils/ExpiringMap.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/utils/ExpiringMap.java
@@ -19,7 +19,6 @@ package org.apache.doris.common.jni.utils;
 
 import org.apache.log4j.Logger;
 
-import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -74,17 +73,12 @@ public class ExpiringMap<K, V> {
         expirationMap.remove(key);
         ttlMap.remove(key);
 
-        // Clean up resources if the value is UdfClassCache
-        if (value instanceof UdfClassCache) {
-            UdfClassCache cache = (UdfClassCache) value;
-            if (cache.classLoader != null) {
-                try {
-                    cache.classLoader.close();
-                    LOG.info("Closed ClassLoader for cached UDF: " + key);
-                } catch (IOException e) {
-                    LOG.warn("Failed to close ClassLoader for cached UDF: " + key, e);
-                }
-                cache.classLoader = null;
+        // Uniformly release resources for any AutoCloseable value,
+        if (value instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) value).close();
+            } catch (Exception e) {
+                LOG.warn("Failed to close cached resource: " + key, e);
             }
         }
     }

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/utils/ExpiringMap.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/utils/ExpiringMap.java
@@ -19,6 +19,7 @@ package org.apache.doris.common.jni.utils;
 
 import org.apache.log4j.Logger;
 
+import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -47,9 +48,7 @@ public class ExpiringMap<K, V> {
     public V get(K key) {
         Long expirationTime = expirationMap.get(key);
         if (expirationTime == null || System.currentTimeMillis() > expirationTime) {
-            map.remove(key);
-            expirationMap.remove(key);
-            ttlMap.remove(key);
+            remove(key);
             return null;
         }
         // reset time again
@@ -64,18 +63,30 @@ public class ExpiringMap<K, V> {
             long now = System.currentTimeMillis();
             for (K key : expirationMap.keySet()) {
                 if (expirationMap.get(key) <= now) {
-                    map.remove(key);
-                    expirationMap.remove(key);
-                    ttlMap.remove(key);
+                    remove(key);
                 }
             }
         }, DEFAULT_INTERVAL_TIME, DEFAULT_INTERVAL_TIME, TimeUnit.MINUTES);
     }
 
     public void remove(K key) {
-        map.remove(key);
+        V value = map.remove(key);
         expirationMap.remove(key);
         ttlMap.remove(key);
+
+        // Clean up resources if the value is UdfClassCache
+        if (value instanceof UdfClassCache) {
+            UdfClassCache cache = (UdfClassCache) value;
+            if (cache.classLoader != null) {
+                try {
+                    cache.classLoader.close();
+                    LOG.info("Closed ClassLoader for cached UDF: " + key);
+                } catch (IOException e) {
+                    LOG.warn("Failed to close ClassLoader for cached UDF: " + key, e);
+                }
+                cache.classLoader = null;
+            }
+        }
     }
 
     public int size() {

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/utils/UdfClassCache.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/utils/UdfClassCache.java
@@ -20,6 +20,7 @@ package org.apache.doris.common.jni.utils;
 import com.esotericsoftware.reflectasm.MethodAccess;
 
 import java.lang.reflect.Method;
+import java.net.URLClassLoader;
 import java.util.HashMap;
 
 /**
@@ -42,4 +43,8 @@ public class UdfClassCache {
     // for java-udf  index is evaluate method index
     // for java-udaf index is add method index
     public int methodIndex;
+
+    // Keep a reference to the ClassLoader for static load mode
+    // This ensures the ClassLoader is not garbage collected and can load dependent classes
+    public URLClassLoader classLoader;
 }

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/utils/UdfClassCache.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/utils/UdfClassCache.java
@@ -18,7 +18,9 @@
 package org.apache.doris.common.jni.utils;
 
 import com.esotericsoftware.reflectasm.MethodAccess;
+import org.apache.log4j.Logger;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URLClassLoader;
 import java.util.HashMap;
@@ -26,7 +28,8 @@ import java.util.HashMap;
 /**
  * This class is used for caching the class of UDF.
  */
-public class UdfClassCache {
+public class UdfClassCache implements AutoCloseable {
+    private static final Logger LOG = Logger.getLogger(UdfClassCache.class);
     public Class<?> udfClass;
     // the index of evaluate() method in the class
     public MethodAccess methodAccess;
@@ -46,5 +49,19 @@ public class UdfClassCache {
 
     // Keep a reference to the ClassLoader for static load mode
     // This ensures the ClassLoader is not garbage collected and can load dependent classes
+    // Note: classLoader may be null when jarPath is empty (UDF loaded from custom_lib via
+    // system class loader), which must not be closed — null is intentional in that case.
     public URLClassLoader classLoader;
+
+    @Override
+    public void close() {
+        if (classLoader != null) {
+            try {
+                classLoader.close();
+            } catch (IOException e) {
+                LOG.warn("Failed to close ClassLoader", e);
+            }
+            classLoader = null;
+        }
+    }
 }

--- a/fe/be-java-extensions/java-udf/src/main/java/org/apache/doris/udf/BaseExecutor.java
+++ b/fe/be-java-extensions/java-udf/src/main/java/org/apache/doris/udf/BaseExecutor.java
@@ -40,7 +40,6 @@ import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.net.MalformedURLException;
 import java.net.URLClassLoader;
@@ -181,17 +180,11 @@ public abstract class BaseExecutor {
             outputTable.close();
         }
         if (!isStaticLoad) {
+            // close classLoader via UdfClassCache.close() if not in static load mode.
+            // In static load mode, the classLoader is cached and should not be closed here.
+            objCache.close();
             objCache.methodAccess = null;
-            // close classLoader if it's not in static load mode
-            // In static load mode, the classLoader is cached and should not be closed here
-            if (classLoader != null) {
-                try {
-                    classLoader.close();
-                } catch (IOException e) {
-                    LOG.warn("Error closing the URLClassloader.", e);
-                }
-                classLoader = null;
-            }
+            classLoader = null;
         }
     }
 

--- a/fe/be-java-extensions/java-udf/src/main/java/org/apache/doris/udf/BaseExecutor.java
+++ b/fe/be-java-extensions/java-udf/src/main/java/org/apache/doris/udf/BaseExecutor.java
@@ -139,6 +139,10 @@ public abstract class BaseExecutor {
         UdfClassCache cache = null;
         if (isStaticLoad) {
             cache = ScannerLoader.getUdfClassLoader(signature);
+            if (cache != null && cache.classLoader != null) {
+                // Reuse the cached classLoader to ensure dependent classes can be loaded
+                classLoader = cache.classLoader;
+            }
         }
         if (cache == null) {
             ClassLoader loader;
@@ -156,6 +160,7 @@ public abstract class BaseExecutor {
             cache.allMethods = new HashMap<>();
             cache.udfClass = Class.forName(className, true, loader);
             cache.methodAccess = MethodAccess.get(cache.udfClass);
+            cache.classLoader = classLoader;
             checkAndCacheUdfClass(cache, funcRetType, parameterTypes);
             if (isStaticLoad) {
                 ScannerLoader.cacheClassLoader(signature, cache, expirationTime);
@@ -171,24 +176,23 @@ public abstract class BaseExecutor {
      * Close the class loader we may have created.
      */
     public void close() {
-        if (classLoader != null) {
-            try {
-                classLoader.close();
-            } catch (IOException e) {
-                // Log and ignore.
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Error closing the URLClassloader.", e);
-                }
-            }
-        }
         // Close the output table if it exists.
         if (outputTable != null) {
             outputTable.close();
         }
-        // We are now un-usable (because the class loader has been
-        // closed), so null out method_ and classLoader_.
-        classLoader = null;
-        objCache.methodAccess = null;
+        if (!isStaticLoad) {
+            objCache.methodAccess = null;
+            // close classLoader if it's not in static load mode
+            // In static load mode, the classLoader is cached and should not be closed here
+            if (classLoader != null) {
+                try {
+                    classLoader.close();
+                } catch (IOException e) {
+                    LOG.warn("Error closing the URLClassloader.", e);
+                }
+                classLoader = null;
+            }
+        }
     }
 
     protected ColumnValueConverter getInputConverter(TPrimitiveType primitiveType, Class clz)

--- a/fe/be-java-extensions/java-udf/src/main/java/org/apache/doris/udf/UdafExecutor.java
+++ b/fe/be-java-extensions/java-udf/src/main/java/org/apache/doris/udf/UdafExecutor.java
@@ -72,9 +72,10 @@ public class UdafExecutor extends BaseExecutor {
      */
     @Override
     public void close() {
-        if (!isStaticLoad) {
-            super.close();
-        }
+        // Call parent's close method which handles classLoader and outputTable properly
+        // It will only close classLoader if not in static load mode
+        super.close();
+        // Clear the state map
         stateObjMap = null;
     }
 

--- a/fe/be-java-extensions/java-udf/src/main/java/org/apache/doris/udf/UdfExecutor.java
+++ b/fe/be-java-extensions/java-udf/src/main/java/org/apache/doris/udf/UdfExecutor.java
@@ -55,13 +55,9 @@ public class UdfExecutor extends BaseExecutor {
      */
     @Override
     public void close() {
-        // We are now un-usable (because the class loader has been
-        // closed), so null out method_ and classLoader_.
-        if (!isStaticLoad) {
-            super.close();
-        } else if (outputTable != null) {
-            outputTable.close();
-        }
+        // Call parent's close method which handles classLoader properly
+        // It will only close classLoader if not in static load mode
+        super.close();
     }
 
     public long evaluate(Map<String, String> inputParams, Map<String, String> outputParams) throws UdfRuntimeException {


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
before the UDF use static load will cache some values in UdfClassCache,
but not cache the classload, those will cause some NoClassDefFoundError
when users UDF have invoke some thirdparty class.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

