### PR TITLE
[fix](thirdparty) add Thrift_VERSION fallback in paimon-cpp arrow patch

### DIFF
--- a/thirdparty/patches/paimon-cpp-buildutils-static-deps.patch
+++ b/thirdparty/patches/paimon-cpp-buildutils-static-deps.patch
@@ -146,3 +146,37 @@ diff --git a/src/paimon/format/blob/blob_format_writer.cpp b/src/paimon/format/b
      }
  
      // write bin length
+
+diff --git a/cmake_modules/arrow.diff b/cmake_modules/arrow.diff
+--- a/cmake_modules/arrow.diff
++++ b/cmake_modules/arrow.diff
+@@ -196,3 +196,29 @@
+   int64_t pagesize_;
+   ParquetDataPageVersion parquet_data_page_version_;
+   ParquetVersion::type parquet_version_;
++diff --git a/cpp/cmake_modules/ThirdpartyToolchain.cmake b/cpp/cmake_modules/ThirdpartyToolchain.cmake
++index 9df922afa2..5c8b3d4d07 100644
++--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
++@@ -1789,7 +1789,20 @@ if(ARROW_WITH_THRIFT)
++                    REQUIRED_VERSION
++                    0.11.0)
++
++-  string(REPLACE "." ";" Thrift_VERSION_LIST ${Thrift_VERSION})
+++  if(NOT Thrift_VERSION)
+++    if(DEFINED thrift_PC_VERSION AND thrift_PC_VERSION)
+++      set(Thrift_VERSION "${thrift_PC_VERSION}")
+++    elseif(DEFINED ThriftAlt_VERSION AND ThriftAlt_VERSION)
+++      set(Thrift_VERSION "${ThriftAlt_VERSION}")
+++    elseif(DEFINED THRIFT_VERSION AND THRIFT_VERSION)
+++      set(Thrift_VERSION "${THRIFT_VERSION}")
+++    endif()
+++  endif()
+++  if(NOT Thrift_VERSION)
+++    message(FATAL_ERROR "Thrift_VERSION is empty after resolving Thrift dependency")
+++  endif()
+++
+++  string(REPLACE "." ";" Thrift_VERSION_LIST "${Thrift_VERSION}")
++  list(GET Thrift_VERSION_LIST 0 Thrift_VERSION_MAJOR)
++  list(GET Thrift_VERSION_LIST 1 Thrift_VERSION_MINOR)
++  list(GET Thrift_VERSION_LIST 2 Thrift_VERSION_PATCH)

--- a/thirdparty/patches/paimon-cpp-buildutils-static-deps.patch
+++ b/thirdparty/patches/paimon-cpp-buildutils-static-deps.patch
@@ -147,21 +147,20 @@ diff --git a/src/paimon/format/blob/blob_format_writer.cpp b/src/paimon/format/b
  
      // write bin length
 
-diff --git a/cmake_modules/arrow.diff b/cmake_modules/arrow.diff
 --- a/cmake_modules/arrow.diff
 +++ b/cmake_modules/arrow.diff
 @@ -196,3 +196,29 @@
-   int64_t pagesize_;
-   ParquetDataPageVersion parquet_data_page_version_;
-   ParquetVersion::type parquet_version_;
+    int64_t pagesize_;
+    ParquetDataPageVersion parquet_data_page_version_;
+    ParquetVersion::type parquet_version_;
 +diff --git a/cpp/cmake_modules/ThirdpartyToolchain.cmake b/cpp/cmake_modules/ThirdpartyToolchain.cmake
 +index 9df922afa2..5c8b3d4d07 100644
 +--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
 ++++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
 +@@ -1789,7 +1789,20 @@ if(ARROW_WITH_THRIFT)
-+                    REQUIRED_VERSION
-+                    0.11.0)
-+
++                     REQUIRED_VERSION
++                     0.11.0)
++ 
 +-  string(REPLACE "." ";" Thrift_VERSION_LIST ${Thrift_VERSION})
 ++  if(NOT Thrift_VERSION)
 ++    if(DEFINED thrift_PC_VERSION AND thrift_PC_VERSION)
@@ -177,6 +176,6 @@ diff --git a/cmake_modules/arrow.diff b/cmake_modules/arrow.diff
 ++  endif()
 ++
 ++  string(REPLACE "." ";" Thrift_VERSION_LIST "${Thrift_VERSION}")
-+  list(GET Thrift_VERSION_LIST 0 Thrift_VERSION_MAJOR)
-+  list(GET Thrift_VERSION_LIST 1 Thrift_VERSION_MINOR)
-+  list(GET Thrift_VERSION_LIST 2 Thrift_VERSION_PATCH)
++   list(GET Thrift_VERSION_LIST 0 Thrift_VERSION_MAJOR)
++   list(GET Thrift_VERSION_LIST 1 Thrift_VERSION_MINOR)
++   list(GET Thrift_VERSION_LIST 2 Thrift_VERSION_PATCH)


### PR DESCRIPTION
## Summary
- update `thirdparty/patches/paimon-cpp-buildutils-static-deps.patch`
- add `Thrift_VERSION` fallback resolution in the embedded `cmake_modules/arrow.diff` hunk
- keep a clear fatal error when no thrift version source is available

## Why
On different environments, thrift version metadata may be exposed via different variables (`thrift_PC_VERSION`, `ThriftAlt_VERSION`, or `THRIFT_VERSION`).
Without fallback, `Thrift_VERSION` can be empty and break Arrow configure.

## Testing
- rebuilt thirdparty package: `bash thirdparty/build-thirdparty.sh paimon_cpp`
- build completed successfully (`Finished to build all thirdparties`)
