### PR TITLE
[fix](runtime) Clear query_ctx_map_delay_delete in FragmentMgr::stop() to avoid UB

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -340,6 +340,10 @@ void FragmentMgr::stop() {
     _thread_pool->shutdown();
     // Only me can delete
     _query_ctx_map.clear();
+    // in one BE's graceful shutdown, cancel_worker will get related running queries via _get_all_running_queries_from_fe and cancel them.
+    // so clearing here will not make RF consumer hang. if we dont do this, in ~FragmentMgr() there may be QueryContext in _query_ctx_map_delay_delete
+    // destructred and remove it from _query_ctx_map_delay_delete which is destructring. it's UB.
+    _query_ctx_map_delay_delete.clear();
     _pipeline_map.clear();
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: https://github.com/apache/doris/pull/59262

Problem Summary:

During BE graceful shutdown, cancel_worker cancels running queries via _get_all_running_queries_from_fe, so clearing _query_ctx_map_delay_delete here won't cause RF consumer to hang. Without this clear, QueryContext destruction in ~FragmentMgr() may attempt to remove itself from _query_ctx_map_delay_delete while the map is being destructed, causing undefined behavior.

stack:
```
~FragmentMgr
    ~_query_ctx_map_delay_delete
        ~QueryContext
            FragmentMgr::remove_query_context
                _query_ctx_map_delay_delete.erase() ⚠️call function of object that is being destructed
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

