### PR TITLE
[fix](compile) tmp work around

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -306,7 +306,8 @@ if (COMPILER_GCC)
                         -Wno-nonnull
                         -Wno-stringop-overread
                         -Wno-stringop-overflow
-                        -Wno-array-bounds)
+                        -Wno-array-bounds
+                        -Wno-maybe-uninitialized)
 endif ()
 
 if (COMPILER_CLANG)


### PR DESCRIPTION
  /root/doris/be/src/util/hash_util.hpp:375:36: error: 'kv_size' may be used uninitialized [-Werror=maybe-uninitialized]

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

