### PR TITLE
[feat](fe) add recovery_journal_id to truncate bdbje logs

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -33,6 +33,7 @@ OPTS="$(getopt \
     -l 'image:' \
     -l 'version' \
     -l 'metadata_failure_recovery' \
+    -l 'recovery_journal_id:' \
     -l 'console' \
     -l 'cluster_snapshot:' \
     -- "$@")"
@@ -46,6 +47,7 @@ IMAGE_PATH=''
 IMAGE_TOOL=''
 OPT_VERSION=''
 METADATA_FAILURE_RECOVERY=''
+RECOVERY_JOURNAL_ID=''
 CLUSTER_SNAPSHOT=''
 while true; do
     case "$1" in
@@ -64,6 +66,10 @@ while true; do
     --metadata_failure_recovery)
         METADATA_FAILURE_RECOVERY="-r"
         shift
+        ;;
+    --recovery_journal_id)
+        RECOVERY_JOURNAL_ID="--recovery_journal_id $2"
+        shift 2
         ;;
     --helper)
         HELPER="$2"
@@ -418,12 +424,12 @@ if [[ "${IMAGE_TOOL}" -eq 1 ]]; then
         echo "Internal error, USE IMAGE_TOOL like: ./start_fe.sh --image image_path"
     fi
 elif [[ "${RUN_DAEMON}" -eq 1 ]]; then
-    nohup ${LIMIT:+${LIMIT}} "${JAVA}" ${final_java_opt:+${final_java_opt}} -XX:-OmitStackTraceInFastThrow -XX:OnOutOfMemoryError="kill -9 %p" ${coverage_opt:+${coverage_opt}} org.apache.doris.DorisFE ${HELPER:+${HELPER}} "${METADATA_FAILURE_RECOVERY}" "${CLUSTER_SNAPSHOT}" "$@" >>"${STDOUT_LOGGER}" 2>&1 </dev/null &
+    nohup ${LIMIT:+${LIMIT}} "${JAVA}" ${final_java_opt:+${final_java_opt}} -XX:-OmitStackTraceInFastThrow -XX:OnOutOfMemoryError="kill -9 %p" ${coverage_opt:+${coverage_opt}} org.apache.doris.DorisFE ${HELPER:+${HELPER}} "${METADATA_FAILURE_RECOVERY}" "${RECOVERY_JOURNAL_ID:+${RECOVERY_JOURNAL_ID}}" "${CLUSTER_SNAPSHOT}" "$@" >>"${STDOUT_LOGGER}" 2>&1 </dev/null &
 elif [[ "${RUN_CONSOLE}" -eq 1 ]]; then
     export DORIS_LOG_TO_STDERR=1
-    ${LIMIT:+${LIMIT}} "${JAVA}" ${final_java_opt:+${final_java_opt}} -XX:-OmitStackTraceInFastThrow -XX:OnOutOfMemoryError="kill -9 %p" ${coverage_opt:+${coverage_opt}} org.apache.doris.DorisFE ${HELPER:+${HELPER}} ${OPT_VERSION:+${OPT_VERSION}} "${METADATA_FAILURE_RECOVERY}" "${CLUSTER_SNAPSHOT}" "$@" >>"${STDOUT_LOGGER}" </dev/null
+    ${LIMIT:+${LIMIT}} "${JAVA}" ${final_java_opt:+${final_java_opt}} -XX:-OmitStackTraceInFastThrow -XX:OnOutOfMemoryError="kill -9 %p" ${coverage_opt:+${coverage_opt}} org.apache.doris.DorisFE ${HELPER:+${HELPER}} ${OPT_VERSION:+${OPT_VERSION}} "${METADATA_FAILURE_RECOVERY}" "${RECOVERY_JOURNAL_ID:+${RECOVERY_JOURNAL_ID}}" "${CLUSTER_SNAPSHOT}" "$@" >>"${STDOUT_LOGGER}" </dev/null
 else
-    ${LIMIT:+${LIMIT}} "${JAVA}" ${final_java_opt:+${final_java_opt}} -XX:-OmitStackTraceInFastThrow -XX:OnOutOfMemoryError="kill -9 %p" ${coverage_opt:+${coverage_opt}} org.apache.doris.DorisFE ${HELPER:+${HELPER}} ${OPT_VERSION:+${OPT_VERSION}} "${METADATA_FAILURE_RECOVERY}" "${CLUSTER_SNAPSHOT}" "$@" >>"${STDOUT_LOGGER}" 2>&1 </dev/null
+    ${LIMIT:+${LIMIT}} "${JAVA}" ${final_java_opt:+${final_java_opt}} -XX:-OmitStackTraceInFastThrow -XX:OnOutOfMemoryError="kill -9 %p" ${coverage_opt:+${coverage_opt}} org.apache.doris.DorisFE ${HELPER:+${HELPER}} ${OPT_VERSION:+${OPT_VERSION}} "${METADATA_FAILURE_RECOVERY}" "${RECOVERY_JOURNAL_ID:+${RECOVERY_JOURNAL_ID}}" "${CLUSTER_SNAPSHOT}" "$@" >>"${STDOUT_LOGGER}" 2>&1 </dev/null
 fi
 
 if [[ "${OPT_VERSION}" != "" ]]; then

--- a/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
@@ -51,6 +51,7 @@ import io.netty.util.internal.logging.Log4JLoggerFactory;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.logging.log4j.LogManager;
@@ -351,6 +352,9 @@ public class DorisFE {
         options.addOption("m", "metaversion", true, "Specify the meta version to decode log value");
         options.addOption("r", FeConstants.METADATA_FAILURE_RECOVERY_KEY, false,
                 "Check if the specified metadata recover is valid");
+        options.addOption(Option.builder().longOpt(FeConstants.RECOVERY_JOURNAL_ID_KEY).hasArg()
+                .desc("Specify the recovery truncate journal id, and journals greater than this id will be removed")
+                .build());
         options.addOption("c", "cluster_snapshot", true, "Specify the cluster snapshot json file");
 
         CommandLine cmd = null;
@@ -387,6 +391,14 @@ public class DorisFE {
         }
         if (cmd.hasOption('r') || cmd.hasOption(FeConstants.METADATA_FAILURE_RECOVERY_KEY)) {
             System.setProperty(FeConstants.METADATA_FAILURE_RECOVERY_KEY, "true");
+        }
+        if (cmd.hasOption(FeConstants.RECOVERY_JOURNAL_ID_KEY)) {
+            String recoveryJournalId = cmd.getOptionValue(FeConstants.RECOVERY_JOURNAL_ID_KEY);
+            if (Strings.isNullOrEmpty(recoveryJournalId)) {
+                System.err.println("recovery_journal_id is missing");
+                System.exit(-1);
+            }
+            System.setProperty(FeConstants.RECOVERY_JOURNAL_ID_KEY, recoveryJournalId.trim());
         }
         if (cmd.hasOption('b') || cmd.hasOption("bdb")) {
             if (cmd.hasOption('l') || cmd.hasOption("listdb")) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
@@ -67,4 +67,5 @@ public class FeConstants {
     public static final String INTERNAL_FILE_CACHE_HOTSPOT_TABLE_NAME = "cloud_cache_hotspot";
 
     public static String METADATA_FAILURE_RECOVERY_KEY = "metadata_failure_recovery";
+    public static String RECOVERY_JOURNAL_ID_KEY = "recovery_journal_id";
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
@@ -386,9 +386,11 @@ public class BDBEnvironment {
 
         long deletedCount = 0;
         TupleBinding<Long> idBinding = TupleBinding.getPrimitiveBinding(Long.class);
+        com.sleepycat.je.Transaction txn = null;
         Cursor cursor = null;
         try {
-            cursor = db.openCursor(null, null);
+            txn = replicatedEnvironment.beginTransaction(null, null);
+            cursor = db.openCursor(txn, null);
             DatabaseEntry key = new DatabaseEntry();
             DatabaseEntry value = new DatabaseEntry();
             while (cursor.getNext(key, value, LockMode.DEFAULT) == OperationStatus.SUCCESS) {
@@ -398,10 +400,28 @@ public class BDBEnvironment {
                     deletedCount++;
                 }
             }
-        } finally {
+            // Close cursor before committing transaction
+            cursor.close();
+            cursor = null;
+            txn.commit();
+            txn = null;
+        } catch (Exception e) {
             if (cursor != null) {
-                cursor.close();
+                try {
+                    cursor.close();
+                } catch (Exception cursorCloseEx) {
+                    LOG.warn("failed to close cursor", cursorCloseEx);
+                }
             }
+            if (txn != null) {
+                try {
+                    txn.abort();
+                } catch (Exception abortEx) {
+                    LOG.warn("failed to abort transaction", abortEx);
+                }
+            }
+            LOG.warn("failed to truncate database {} to journal id {}", dbName, truncateToJournalId, e);
+            throw new IllegalStateException("failed to truncate database " + dbName, e);
         }
 
         return deletedCount;

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
@@ -26,8 +26,11 @@ import org.apache.doris.ha.HAProtocol;
 import org.apache.doris.system.Frontend;
 
 import com.google.common.collect.ImmutableList;
+import com.sleepycat.bind.tuple.TupleBinding;
+import com.sleepycat.je.Cursor;
 import com.sleepycat.je.Database;
 import com.sleepycat.je.DatabaseConfig;
+import com.sleepycat.je.DatabaseEntry;
 import com.sleepycat.je.DatabaseException;
 import com.sleepycat.je.DatabaseNotFoundException;
 import com.sleepycat.je.Durability;
@@ -35,6 +38,8 @@ import com.sleepycat.je.Durability.ReplicaAckPolicy;
 import com.sleepycat.je.Durability.SyncPolicy;
 import com.sleepycat.je.EnvironmentConfig;
 import com.sleepycat.je.EnvironmentFailureException;
+import com.sleepycat.je.LockMode;
+import com.sleepycat.je.OperationStatus;
 import com.sleepycat.je.rep.InsufficientLogException;
 import com.sleepycat.je.rep.NetworkRestore;
 import com.sleepycat.je.rep.NetworkRestoreConfig;
@@ -333,6 +338,73 @@ public class BDBEnvironment {
         } finally {
             lock.writeLock().unlock();
         }
+    }
+
+    // Remove journals whose id is greater than truncateToJournalId.
+    public void truncateJournalsGreaterThan(long truncateToJournalId) {
+        lock.writeLock().lock();
+        try {
+            List<Long> dbNames = getDatabaseNames();
+            if (dbNames == null || dbNames.isEmpty()) {
+                return;
+            }
+
+            Long minJournalId = dbNames.get(0);
+            Long targetDbName = null;
+            for (Long dbName : dbNames) {
+                if (dbName <= truncateToJournalId) {
+                    targetDbName = dbName;
+                } else {
+                    break;
+                }
+            }
+
+            if (targetDbName == null) {
+                throw new IllegalArgumentException("truncate journal id " + truncateToJournalId
+                        + " is smaller than min journal id " + minJournalId);
+            }
+
+            for (Long dbName : dbNames) {
+                if (dbName > truncateToJournalId) {
+                    removeDatabase(dbName.toString());
+                }
+            }
+
+            long deletedCount = truncateTailInDb(targetDbName.toString(), truncateToJournalId);
+            LOG.info("truncate journals greater than {} finished, targetDb {}, deleted {} keys in target db",
+                    truncateToJournalId, targetDbName, deletedCount);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private long truncateTailInDb(String dbName, long truncateToJournalId) {
+        Database db = openDatabase(dbName);
+        if (db == null) {
+            throw new IllegalStateException("failed to open target database " + dbName + " for truncate");
+        }
+
+        long deletedCount = 0;
+        TupleBinding<Long> idBinding = TupleBinding.getPrimitiveBinding(Long.class);
+        Cursor cursor = null;
+        try {
+            cursor = db.openCursor(null, null);
+            DatabaseEntry key = new DatabaseEntry();
+            DatabaseEntry value = new DatabaseEntry();
+            while (cursor.getNext(key, value, LockMode.READ_COMMITTED) == OperationStatus.SUCCESS) {
+                long journalId = idBinding.entryToObject(key);
+                if (journalId > truncateToJournalId) {
+                    cursor.delete();
+                    deletedCount++;
+                }
+            }
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+
+        return deletedCount;
     }
 
     // get journal db names and sort the names

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
@@ -391,7 +391,7 @@ public class BDBEnvironment {
             cursor = db.openCursor(null, null);
             DatabaseEntry key = new DatabaseEntry();
             DatabaseEntry value = new DatabaseEntry();
-            while (cursor.getNext(key, value, LockMode.READ_COMMITTED) == OperationStatus.SUCCESS) {
+            while (cursor.getNext(key, value, LockMode.DEFAULT) == OperationStatus.SUCCESS) {
                 long journalId = idBinding.entryToObject(key);
                 if (journalId > truncateToJournalId) {
                     cursor.delete();

--- a/fe/fe-core/src/test/java/org/apache/doris/journal/bdbje/BDBEnvironmentTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/journal/bdbje/BDBEnvironmentTest.java
@@ -153,7 +153,7 @@ public class BDBEnvironmentTest {
         Assertions.assertEquals(OperationStatus.SUCCESS, db.put(null, key, value));
 
         DatabaseEntry readValue = new DatabaseEntry();
-        Assertions.assertEquals(OperationStatus.SUCCESS, db.get(null, key, readValue, LockMode.READ_COMMITTED));
+        Assertions.assertEquals(OperationStatus.SUCCESS, db.get(null, key, readValue, LockMode.DEFAULT));
         Assertions.assertEquals(new String(value.getData()), new String(readValue.getData()));
 
         // Remove database
@@ -174,7 +174,7 @@ public class BDBEnvironmentTest {
         Database epochDb = bdbEnvironment.getEpochDB();
         Assertions.assertEquals(OperationStatus.SUCCESS, epochDb.put(null, key, value));
         DatabaseEntry readValue2 = new DatabaseEntry();
-        Assertions.assertEquals(OperationStatus.SUCCESS, epochDb.get(null, key, readValue2, LockMode.READ_COMMITTED));
+        Assertions.assertEquals(OperationStatus.SUCCESS, epochDb.get(null, key, readValue2, LockMode.DEFAULT));
         Assertions.assertEquals(new String(value.getData()), new String(readValue2.getData()));
 
         new MockUp<Env>() {
@@ -244,7 +244,7 @@ public class BDBEnvironmentTest {
         Assertions.assertEquals(OperationStatus.SUCCESS, db.put(null, key, value));
 
         DatabaseEntry readValue = new DatabaseEntry();
-        Assertions.assertEquals(OperationStatus.SUCCESS, db.get(null, key, readValue, LockMode.READ_COMMITTED));
+        Assertions.assertEquals(OperationStatus.SUCCESS, db.get(null, key, readValue, LockMode.DEFAULT));
         Assertions.assertEquals(new String(value.getData()), new String(readValue.getData()));
         bdbEnvironment.close();
 
@@ -254,7 +254,7 @@ public class BDBEnvironmentTest {
         Database db2 = bdbEnvironment2.openDatabase(dbName);
 
         DatabaseEntry readValue2 = new DatabaseEntry();
-        Assertions.assertEquals(OperationStatus.SUCCESS, db2.get(null, key, readValue2, LockMode.READ_COMMITTED));
+        Assertions.assertEquals(OperationStatus.SUCCESS, db2.get(null, key, readValue2, LockMode.DEFAULT));
         Assertions.assertEquals(new String(value.getData()), new String(readValue2.getData()));
         bdbEnvironment2.close();
     }
@@ -278,7 +278,7 @@ public class BDBEnvironmentTest {
         Assertions.assertEquals(OperationStatus.SUCCESS, db.put(null, key, value));
 
         DatabaseEntry readValue = new DatabaseEntry();
-        Assertions.assertEquals(OperationStatus.SUCCESS, db.get(null, key, readValue, LockMode.READ_COMMITTED));
+        Assertions.assertEquals(OperationStatus.SUCCESS, db.get(null, key, readValue, LockMode.DEFAULT));
         Assertions.assertEquals(new String(value.getData()), new String(readValue.getData()));
         bdbEnvironment.close();
 
@@ -286,7 +286,7 @@ public class BDBEnvironmentTest {
         bdbEnvironment.openReplicatedEnvironment(homeFile);
         Database db2 = bdbEnvironment.openDatabase(dbName);
         DatabaseEntry readValue2 = new DatabaseEntry();
-        Assertions.assertEquals(OperationStatus.SUCCESS, db2.get(null, key, readValue2, LockMode.READ_COMMITTED));
+        Assertions.assertEquals(OperationStatus.SUCCESS, db2.get(null, key, readValue2, LockMode.DEFAULT));
         Assertions.assertEquals(new String(value.getData()), new String(readValue2.getData()));
         bdbEnvironment.close();
     }
@@ -324,9 +324,9 @@ public class BDBEnvironmentTest {
         Database db11AfterTruncate = bdbEnvironment.openDatabase("11");
         Assertions.assertEquals(7, db11AfterTruncate.count());
         Assertions.assertEquals(OperationStatus.NOTFOUND,
-                db11AfterTruncate.get(null, longToEntry(18), new DatabaseEntry(), LockMode.READ_COMMITTED));
+                db11AfterTruncate.get(null, longToEntry(18), new DatabaseEntry(), LockMode.DEFAULT));
         Assertions.assertEquals(OperationStatus.SUCCESS,
-                db11AfterTruncate.get(null, longToEntry(17), new DatabaseEntry(), LockMode.READ_COMMITTED));
+                db11AfterTruncate.get(null, longToEntry(17), new DatabaseEntry(), LockMode.DEFAULT));
         bdbEnvironment.close();
     }
 
@@ -405,14 +405,14 @@ public class BDBEnvironmentTest {
             Assertions.assertEquals(1, followerEnvironment.getDatabaseNames().size());
             Database followerDb = followerEnvironment.openDatabase(dbName);
             DatabaseEntry readValue = new DatabaseEntry();
-            Assertions.assertEquals(OperationStatus.SUCCESS, followerDb.get(null, key, readValue, LockMode.READ_COMMITTED));
+            Assertions.assertEquals(OperationStatus.SUCCESS, followerDb.get(null, key, readValue, LockMode.DEFAULT));
             Assertions.assertEquals(new String(value.getData()), new String(readValue.getData()));
         }
 
         Assertions.assertEquals(1, observerEnvironment.getDatabaseNames().size());
         Database observerDb = observerEnvironment.openDatabase(dbName);
         DatabaseEntry readValue = new DatabaseEntry();
-        Assertions.assertEquals(OperationStatus.SUCCESS, observerDb.get(null, key, readValue, LockMode.READ_COMMITTED));
+        Assertions.assertEquals(OperationStatus.SUCCESS, observerDb.get(null, key, readValue, LockMode.DEFAULT));
         Assertions.assertEquals(new String(value.getData()), new String(readValue.getData()));
 
         observerEnvironment.close();
@@ -519,7 +519,7 @@ public class BDBEnvironmentTest {
             Assertions.assertEquals(1, entryPair.first.getDatabaseNames().size());
             Database followerDb = entryPair.first.openDatabase(beginDbName);
             DatabaseEntry readValue = new DatabaseEntry();
-            Assertions.assertEquals(OperationStatus.SUCCESS, followerDb.get(null, key, readValue, LockMode.READ_COMMITTED));
+            Assertions.assertEquals(OperationStatus.SUCCESS, followerDb.get(null, key, readValue, LockMode.DEFAULT));
             Assertions.assertEquals(new String(value.getData()), new String(readValue.getData()));
             followerDb.close();
         }
@@ -688,7 +688,7 @@ public class BDBEnvironmentTest {
             Assertions.assertEquals(1, entryPair.first.getDatabaseNames().size());
             Database followerDb = entryPair.first.openDatabase(beginDbName);
             DatabaseEntry readValue = new DatabaseEntry();
-            Assertions.assertEquals(OperationStatus.SUCCESS, followerDb.get(null, key, readValue, LockMode.READ_COMMITTED));
+            Assertions.assertEquals(OperationStatus.SUCCESS, followerDb.get(null, key, readValue, LockMode.DEFAULT));
             Assertions.assertEquals(new String(value.getData()), new String(readValue.getData()));
         }
 
@@ -737,6 +737,6 @@ public class BDBEnvironmentTest {
 
         key = new DatabaseEntry(new byte[]{1, 2, 3});
         DatabaseEntry readValue = new DatabaseEntry();
-        Assertions.assertEquals(OperationStatus.SUCCESS, masterDb.get(null, key, readValue, LockMode.READ_COMMITTED));
+        Assertions.assertEquals(OperationStatus.SUCCESS, masterDb.get(null, key, readValue, LockMode.DEFAULT));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/journal/bdbje/BDBEnvironmentTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/journal/bdbje/BDBEnvironmentTest.java
@@ -26,6 +26,7 @@ import org.apache.doris.system.Frontend;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.sleepycat.bind.tuple.TupleBinding;
 import com.sleepycat.je.Database;
 import com.sleepycat.je.DatabaseEntry;
 import com.sleepycat.je.Durability;
@@ -122,6 +123,13 @@ public class BDBEnvironmentTest {
         byte[] byteArray = new byte[32];
         new SecureRandom().nextBytes(byteArray);
         return byteArray;
+    }
+
+    private static DatabaseEntry longToEntry(long value) {
+        DatabaseEntry key = new DatabaseEntry();
+        TupleBinding<Long> idBinding = TupleBinding.getPrimitiveBinding(Long.class);
+        idBinding.objectToEntry(value, key);
+        return key;
     }
 
     // @Test
@@ -280,6 +288,64 @@ public class BDBEnvironmentTest {
         DatabaseEntry readValue2 = new DatabaseEntry();
         Assertions.assertEquals(OperationStatus.SUCCESS, db2.get(null, key, readValue2, LockMode.READ_COMMITTED));
         Assertions.assertEquals(new String(value.getData()), new String(readValue2.getData()));
+        bdbEnvironment.close();
+    }
+
+    @RepeatedTest(1)
+    public void testTruncateJournalsGreaterThan() throws Exception {
+        int port = findValidPort();
+        String selfNodeName = Env.genFeNodeName("127.0.0.1", port, false);
+        String selfNodeHostPort = "127.0.0.1:" + port;
+
+        File homeFile = new File(createTmpDir());
+        BDBEnvironment bdbEnvironment = new BDBEnvironment(true, false);
+        bdbEnvironment.setup(homeFile, selfNodeName, selfNodeHostPort, selfNodeHostPort);
+
+        Database db1 = bdbEnvironment.openDatabase("1");
+        Database db11 = bdbEnvironment.openDatabase("11");
+        Database db21 = bdbEnvironment.openDatabase("21");
+        for (long i = 1; i <= 10; i++) {
+            Assertions.assertEquals(OperationStatus.SUCCESS, db1.put(null, longToEntry(i), new DatabaseEntry(randomBytes())));
+        }
+        for (long i = 11; i <= 20; i++) {
+            Assertions.assertEquals(OperationStatus.SUCCESS, db11.put(null, longToEntry(i), new DatabaseEntry(randomBytes())));
+        }
+        for (long i = 21; i <= 30; i++) {
+            Assertions.assertEquals(OperationStatus.SUCCESS, db21.put(null, longToEntry(i), new DatabaseEntry(randomBytes())));
+        }
+
+        bdbEnvironment.truncateJournalsGreaterThan(17);
+
+        List<Long> dbNames = bdbEnvironment.getDatabaseNames();
+        Assertions.assertEquals(2, dbNames.size());
+        Assertions.assertEquals(1L, dbNames.get(0));
+        Assertions.assertEquals(11L, dbNames.get(1));
+
+        Database db11AfterTruncate = bdbEnvironment.openDatabase("11");
+        Assertions.assertEquals(7, db11AfterTruncate.count());
+        Assertions.assertEquals(OperationStatus.NOTFOUND,
+                db11AfterTruncate.get(null, longToEntry(18), new DatabaseEntry(), LockMode.READ_COMMITTED));
+        Assertions.assertEquals(OperationStatus.SUCCESS,
+                db11AfterTruncate.get(null, longToEntry(17), new DatabaseEntry(), LockMode.READ_COMMITTED));
+        bdbEnvironment.close();
+    }
+
+    @RepeatedTest(1)
+    public void testTruncateJournalsGreaterThanInvalidBound() throws Exception {
+        int port = findValidPort();
+        String selfNodeName = Env.genFeNodeName("127.0.0.1", port, false);
+        String selfNodeHostPort = "127.0.0.1:" + port;
+
+        File homeFile = new File(createTmpDir());
+        BDBEnvironment bdbEnvironment = new BDBEnvironment(true, false);
+        bdbEnvironment.setup(homeFile, selfNodeName, selfNodeHostPort, selfNodeHostPort);
+
+        Database db1 = bdbEnvironment.openDatabase("1");
+        Assertions.assertEquals(OperationStatus.SUCCESS, db1.put(null, longToEntry(1), new DatabaseEntry(randomBytes())));
+
+        IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> bdbEnvironment.truncateJournalsGreaterThan(0));
+        Assertions.assertTrue(exception.getMessage().contains("smaller than min journal id"));
         bdbEnvironment.close();
     }
 


### PR DESCRIPTION

It only works for metadata_failure_recovery mode


Problem Summary:
When using metadata failure recovery mode, sometimes the journal logs need to be truncated to a specific journal ID to recover from metadata corruption. This PR adds a new parameter `--recovery_journal_id` to allow users to specify the target journal ID, and all journals with IDs greater than this value will be removed.

### How to use

When the Frontend (FE) metadata is corrupted and needs to be recovered, follow these steps:

1. Stop the FE process
2. Start FE with both `--metadata_failure_recovery` and `--recovery_journal_id` parameters:

```bash
./start_fe.sh --metadata_failure_recovery --recovery_journal_id <journal_id>
```

For example, to recover to journal ID 12345:
```bash
./start_fe.sh --metadata_failure_recovery --recovery_journal_id 12345
```

3. The system will:
   - Remove all journal databases with IDs greater than the specified journal ID
   - Truncate the target journal database by deleting keys with IDs greater than the specified value
   - Start FE in metadata failure recovery mode

**Note**: This operation will permanently delete metadata journals. Make sure to backup your data before using this feature.
