### PR TITLE
[fix](compile) fix macOS compilation error due to missing f_frsize in statfs

### DIFF
--- a/be/src/io/cache/block_file_cache_factory.cpp
+++ b/be/src/io/cache/block_file_cache_factory.cpp
@@ -94,7 +94,11 @@ Status FileCacheFactory::create_file_cache(const std::string& cache_base_path,
             LOG_ERROR("").tag("file cache path", cache_base_path).tag("error", strerror(errno));
             return Status::IOError("{} statfs error {}", cache_base_path, strerror(errno));
         }
+#ifdef __APPLE__
+        const auto block_size = stat.f_bsize;
+#else
         const auto block_size = stat.f_frsize ? stat.f_frsize : stat.f_bsize;
+#endif
         size_t disk_capacity = static_cast<size_t>(static_cast<size_t>(stat.f_blocks) *
                                                    static_cast<size_t>(block_size));
         if (file_cache_settings.capacity == 0 || disk_capacity < file_cache_settings.capacity) {
@@ -289,7 +293,11 @@ std::string validate_capacity(const std::string& path, int64_t new_capacity,
         valid_capacity = 0; // caller will handle the error
         return ret;
     }
+#ifdef __APPLE__
+    const auto block_size = stat.f_bsize;
+#else
     const auto block_size = stat.f_frsize ? stat.f_frsize : stat.f_bsize;
+#endif
     size_t disk_capacity = static_cast<size_t>(static_cast<size_t>(stat.f_blocks) *
                                                static_cast<size_t>(block_size));
     if (new_capacity == 0 || disk_capacity < new_capacity) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

macOS `statfs` struct does not have the `f_frsize` member — it is Linux-specific (`statvfs` on Linux has `f_frsize`, but macOS `statfs` only has `f_bsize`). This causes a compilation error on macOS:

```
error: no member named 'f_frsize' in 'statfs'
    const auto block_size = stat.f_frsize ? stat.f_frsize : stat.f_bsize;
                            ~~~~ ^
```

The fix adds `#ifdef __APPLE__` guards to use `f_bsize` directly on macOS, while keeping the original `f_frsize` logic on Linux.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label