### PR TITLE
[fix](local exchange) Do global shuffle for shuffled join/set operator

### DIFF
--- a/be/src/pipeline/exec/hashjoin_build_sink.h
+++ b/be/src/pipeline/exec/hashjoin_build_sink.h
@@ -149,7 +149,8 @@ public:
                _join_distribution == TJoinDistributionType::COLOCATE;
     }
     bool followed_by_shuffled_operator() const override {
-        return is_shuffled_operator() && !is_colocated_operator();
+        return (is_shuffled_operator() && !is_colocated_operator()) ||
+               _followed_by_shuffled_operator;
     }
     std::vector<bool>& is_null_safe_eq_join() { return _is_null_safe_eq_join; }
 

--- a/be/src/pipeline/exec/hashjoin_build_sink.h
+++ b/be/src/pipeline/exec/hashjoin_build_sink.h
@@ -148,6 +148,9 @@ public:
         return _join_distribution == TJoinDistributionType::BUCKET_SHUFFLE ||
                _join_distribution == TJoinDistributionType::COLOCATE;
     }
+    bool followed_by_shuffled_operator() const override {
+        return is_shuffled_operator() && !is_colocated_operator();
+    }
     std::vector<bool>& is_null_safe_eq_join() { return _is_null_safe_eq_join; }
 
     bool allow_left_semi_direct_return(RuntimeState* state) const {

--- a/be/src/pipeline/exec/hashjoin_probe_operator.h
+++ b/be/src/pipeline/exec/hashjoin_probe_operator.h
@@ -155,6 +155,9 @@ public:
         return _join_distribution == TJoinDistributionType::BUCKET_SHUFFLE ||
                _join_distribution == TJoinDistributionType::COLOCATE;
     }
+    bool followed_by_shuffled_operator() const override {
+        return is_shuffled_operator() && !is_colocated_operator();
+    }
 
     bool need_finalize_variant_column() const { return _need_finalize_variant_column; }
 

--- a/be/src/pipeline/exec/hashjoin_probe_operator.h
+++ b/be/src/pipeline/exec/hashjoin_probe_operator.h
@@ -156,7 +156,8 @@ public:
                _join_distribution == TJoinDistributionType::COLOCATE;
     }
     bool followed_by_shuffled_operator() const override {
-        return is_shuffled_operator() && !is_colocated_operator();
+        return (is_shuffled_operator() && !is_colocated_operator()) ||
+               _followed_by_shuffled_operator;
     }
 
     bool need_finalize_variant_column() const { return _need_finalize_variant_column; }

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -167,12 +167,14 @@ public:
      */
     [[nodiscard]] virtual bool is_shuffled_operator() const { return false; }
     /**
-     * Return True if this operator is followed by a shuffled operator.
+     * For multiple children's operators, return true if this is a shuffled operator or this is followed by a shuffled operator (HASH JOIN and SET OPERATION).
+     *
+     * For single child's operators, return true if this operator is followed by a shuffled operator.
      * For example, in the plan fragment:
      *   `UNION` -> `SHUFFLED HASH JOIN`
      * The `SHUFFLED HASH JOIN` is a shuffled operator so the UNION operator is followed by a shuffled operator.
      */
-    [[nodiscard]] bool followed_by_shuffled_operator() const {
+    [[nodiscard]] virtual bool followed_by_shuffled_operator() const {
         return _followed_by_shuffled_operator;
     }
     /**

--- a/be/src/pipeline/exec/partitioned_hash_join_probe_operator.h
+++ b/be/src/pipeline/exec/partitioned_hash_join_probe_operator.h
@@ -167,6 +167,9 @@ public:
     bool is_colocated_operator() const override {
         return _inner_probe_operator->is_colocated_operator();
     }
+    bool followed_by_shuffled_operator() const override {
+        return _inner_probe_operator->followed_by_shuffled_operator();
+    }
 
     void update_operator(const TPlanNode& tnode, bool followed_by_shuffled_operator,
                          bool require_bucket_distribution) override {

--- a/be/src/pipeline/exec/partitioned_hash_join_sink_operator.h
+++ b/be/src/pipeline/exec/partitioned_hash_join_sink_operator.h
@@ -150,6 +150,9 @@ public:
     bool is_shuffled_operator() const override {
         return _inner_sink_operator->is_shuffled_operator();
     }
+    bool followed_by_shuffled_operator() const override {
+        return _inner_sink_operator->followed_by_shuffled_operator();
+    }
 
     void update_operator(const TPlanNode& tnode, bool followed_by_shuffled_operator,
                          bool require_bucket_distribution) override {

--- a/be/src/pipeline/exec/set_probe_sink_operator.h
+++ b/be/src/pipeline/exec/set_probe_sink_operator.h
@@ -118,6 +118,7 @@ public:
 
     bool is_shuffled_operator() const override { return true; }
     bool is_colocated_operator() const override { return _is_colocate; }
+    bool followed_by_shuffled_operator() const override { return !_is_colocate; }
 
 private:
     void _finalize_probe(SetProbeSinkLocalState<is_intersect>& local_state);

--- a/be/src/pipeline/exec/set_probe_sink_operator.h
+++ b/be/src/pipeline/exec/set_probe_sink_operator.h
@@ -118,7 +118,10 @@ public:
 
     bool is_shuffled_operator() const override { return true; }
     bool is_colocated_operator() const override { return _is_colocate; }
-    bool followed_by_shuffled_operator() const override { return !_is_colocate; }
+    bool followed_by_shuffled_operator() const override {
+        return (is_shuffled_operator() && !is_colocated_operator()) ||
+               Base::_followed_by_shuffled_operator;
+    }
 
 private:
     void _finalize_probe(SetProbeSinkLocalState<is_intersect>& local_state);

--- a/be/src/pipeline/exec/set_sink_operator.h
+++ b/be/src/pipeline/exec/set_sink_operator.h
@@ -122,6 +122,7 @@ public:
 
     bool is_shuffled_operator() const override { return true; }
     bool is_colocated_operator() const override { return _is_colocate; }
+    bool followed_by_shuffled_operator() const override { return !_is_colocate; }
 
 private:
     template <class HashTableContext, bool is_intersected>

--- a/be/src/pipeline/exec/set_sink_operator.h
+++ b/be/src/pipeline/exec/set_sink_operator.h
@@ -122,7 +122,10 @@ public:
 
     bool is_shuffled_operator() const override { return true; }
     bool is_colocated_operator() const override { return _is_colocate; }
-    bool followed_by_shuffled_operator() const override { return !_is_colocate; }
+    bool followed_by_shuffled_operator() const override {
+        return (is_shuffled_operator() && !is_colocated_operator()) ||
+               Base::_followed_by_shuffled_operator;
+    }
 
 private:
     template <class HashTableContext, bool is_intersected>


### PR DESCRIPTION
### What problem does this PR solve?

Make followed_by_shuffled_operator() virtual and override it in hash join and set operators to correctly report shuffle requirements.                                                                                          
                                                                                                                                                                                                                                 
  For multi-child operators (hash join, set operations), the method now returns true if the operator itself is shuffled (and not colocated), ensuring proper global shuffle behavior in local exchange.

  Changes:
  - Make followed_by_shuffled_operator() virtual in base OperatorX class
  - Override in HashJoinBuildSinkOperatorX and HashJoinProbeOperatorX to return is_shuffled_operator() && !is_colocated_operator()
  - Override in PartitionedHashJoinProbeOperatorX and PartitionedHashJoinSinkOperatorX to delegate to inner operator
  - Override in SetProbeSinkOperatorX and SetSinkOperatorX to return !_is_colocate

  This fixes incorrect data distribution when shuffled join/set operators are used in pipelines with local exchange.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

