### PR TITLE
[fix](iterator) Use explicit output schema in new_merge_iterator and new_union_iterator

### DIFF
--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -152,6 +152,9 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
     // create segment iterators
     VLOG_NOTICE << "read columns size: " << read_columns.size();
     _input_schema = std::make_shared<Schema>(_read_context->tablet_schema->columns(), read_columns);
+    _output_schema =
+            std::make_shared<Schema>(_read_context->tablet_schema->columns(),
+                                     *(_read_context->return_columns));
     if (_read_context->predicates != nullptr) {
         _read_options.column_predicates.insert(_read_options.column_predicates.end(),
                                                _read_context->predicates->begin(),
@@ -330,7 +333,8 @@ Status BetaRowsetReader::_init_iterator() {
         }
         _iterator = vectorized::new_merge_iterator(
                 std::move(iterators), sequence_loc, _read_context->is_unique,
-                _read_context->read_orderby_key_reverse, _read_context->merged_rows);
+                _read_context->read_orderby_key_reverse, _read_context->merged_rows,
+                _output_schema.get());
     } else {
         if (_read_context->read_orderby_key_reverse) {
             // reverse iterators to read backward for ORDER BY key DESC

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -340,7 +340,7 @@ Status BetaRowsetReader::_init_iterator() {
             // reverse iterators to read backward for ORDER BY key DESC
             std::reverse(iterators.begin(), iterators.end());
         }
-        _iterator = vectorized::new_union_iterator(std::move(iterators));
+        _iterator = vectorized::new_union_iterator(std::move(iterators), _output_schema.get());
     }
 
     auto s = _iterator->init(_read_options);

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -152,6 +152,8 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
     // create segment iterators
     VLOG_NOTICE << "read columns size: " << read_columns.size();
     _input_schema = std::make_shared<Schema>(_read_context->tablet_schema->columns(), read_columns);
+
+    // output schema must match return_columns (excludes extra columns like delete-predicate columns)
     _output_schema =
             std::make_shared<Schema>(_read_context->tablet_schema->columns(),
                                      *(_read_context->return_columns));

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -332,16 +332,16 @@ Status BetaRowsetReader::_init_iterator() {
                 }
             }
         }
-        _iterator = vectorized::new_merge_iterator(
-                std::move(iterators), sequence_loc, _read_context->is_unique,
-                _read_context->read_orderby_key_reverse, _read_context->merged_rows,
-                _output_schema.get());
+        _iterator = vectorized::new_merge_iterator(std::move(iterators), sequence_loc,
+                                                   _read_context->is_unique,
+                                                   _read_context->read_orderby_key_reverse,
+                                                   _read_context->merged_rows, _output_schema);
     } else {
         if (_read_context->read_orderby_key_reverse) {
             // reverse iterators to read backward for ORDER BY key DESC
             std::reverse(iterators.begin(), iterators.end());
         }
-        _iterator = vectorized::new_union_iterator(std::move(iterators), _output_schema.get());
+        _iterator = vectorized::new_union_iterator(std::move(iterators), _output_schema);
     }
 
     auto s = _iterator->init(_read_options);

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -154,9 +154,8 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
     _input_schema = std::make_shared<Schema>(_read_context->tablet_schema->columns(), read_columns);
 
     // output schema must match return_columns (excludes extra columns like delete-predicate columns)
-    _output_schema =
-            std::make_shared<Schema>(_read_context->tablet_schema->columns(),
-                                     *(_read_context->return_columns));
+    _output_schema = std::make_shared<Schema>(_read_context->tablet_schema->columns(),
+                                              *(_read_context->return_columns));
     if (_read_context->predicates != nullptr) {
         _read_options.column_predicates.insert(_read_options.column_predicates.end(),
                                                _read_context->predicates->begin(),

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -152,8 +152,8 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
     // create segment iterators
     VLOG_NOTICE << "read columns size: " << read_columns.size();
     _input_schema = std::make_shared<Schema>(_read_context->tablet_schema->columns(), read_columns);
-
-    // output schema must match return_columns (excludes extra columns like delete-predicate columns)
+    // output_schema only contains return_columns (excludes extra columns like delete-predicate columns).
+    // It is used by merge/union iterators to determine how many columns to copy to the output block.
     _output_schema = std::make_shared<Schema>(_read_context->tablet_schema->columns(),
                                               *(_read_context->return_columns));
     if (_read_context->predicates != nullptr) {

--- a/be/src/olap/rowset/beta_rowset_reader.h
+++ b/be/src/olap/rowset/beta_rowset_reader.h
@@ -147,6 +147,7 @@ private:
     std::vector<RowRanges> _segment_row_ranges;
 
     SchemaSPtr _input_schema;
+    SchemaSPtr _output_schema;
     RowsetReaderContext* _read_context = nullptr;
     BetaRowsetSharedPtr _rowset;
 

--- a/be/src/olap/rowset/beta_rowset_reader.h
+++ b/be/src/olap/rowset/beta_rowset_reader.h
@@ -146,7 +146,16 @@ private:
     std::pair<int64_t, int64_t> _segment_offsets;
     std::vector<RowRanges> _segment_row_ranges;
 
+    // _input_schema: includes return_columns + delete_predicate_columns.
+    // Used by SegmentIterator internally (iter->schema() returns this). SegmentIterator
+    // handles the extra delete predicate columns through _current_return_columns and
+    // _evaluate_short_circuit_predicate(), independent of the block structure.
+    // e.g. return_columns={c1, c2}, delete_pred on c3 => input_schema={c1, c2, c3}
     SchemaSPtr _input_schema;
+    // _output_schema: includes only return_columns (a subset of input_schema).
+    // Passed to VMergeIterator/VUnionIterator. block_reset() builds the internal block
+    // with this schema, and copy_rows() copies exactly these columns to the destination.
+    // e.g. return_columns={c1, c2} => output_schema={c1, c2}
     SchemaSPtr _output_schema;
     RowsetReaderContext* _read_context = nullptr;
     BetaRowsetSharedPtr _rowset;

--- a/be/src/olap/tablet_schema.cpp
+++ b/be/src/olap/tablet_schema.cpp
@@ -1862,10 +1862,10 @@ vectorized::Block TabletSchema::create_block(
     return block;
 }
 
-vectorized::Block TabletSchema::create_block(bool ignore_dropped_col) const {
+vectorized::Block TabletSchema::create_block() const {
     vectorized::Block block;
     for (const auto& col : _cols) {
-        if (ignore_dropped_col && is_dropped_column(*col)) {
+        if (is_dropped_column(*col)) {
             continue;
         }
 

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -578,7 +578,7 @@ public:
     vectorized::Block create_block(
             const std::vector<uint32_t>& return_columns,
             const std::unordered_set<uint32_t>* tablet_columns_need_convert_null = nullptr) const;
-    vectorized::Block create_block(bool ignore_dropped_col = true) const;
+    vectorized::Block create_block() const;
     void set_schema_version(int32_t version) { _schema_version = version; }
     void set_auto_increment_column(const std::string& auto_increment_column) {
         _auto_increment_column = auto_increment_column;

--- a/be/src/util/cpu_info.cpp
+++ b/be/src/util/cpu_info.cpp
@@ -56,7 +56,7 @@
 
 #include "absl/strings/substitute.h"
 #include "common/config.h"
-#include "common/env_config.h"
+// #include "common/env_config.h"
 #include "gflags/gflags.h"
 #include "util/cgroup_util.h"
 #include "util/pretty_printer.h"

--- a/be/src/util/cpu_info.cpp
+++ b/be/src/util/cpu_info.cpp
@@ -56,7 +56,7 @@
 
 #include "absl/strings/substitute.h"
 #include "common/config.h"
-// #include "common/env_config.h"
+#include "common/env_config.h"
 #include "gflags/gflags.h"
 #include "util/cgroup_util.h"
 #include "util/pretty_printer.h"

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -353,8 +353,7 @@ Status VMergeIterator::init(const StorageReadOptions& opts) {
     for (auto& iter : _origin_iters) {
         auto ctx = std::make_shared<VMergeIteratorContext>(std::move(iter), _sequence_id_idx,
                                                            _is_unique, _is_reverse,
-                                                           opts.read_orderby_key_columns,
-                                                           _schema);
+                                                           opts.read_orderby_key_columns, _schema);
         RETURN_IF_ERROR(ctx->init(opts));
         if (!ctx->valid()) {
             continue;
@@ -375,7 +374,8 @@ public:
     // Iterators' ownership it transferred to this class.
     // This class will delete all iterators when destructs
     // Client should not use iterators anymore.
-    VUnionIterator(std::vector<RowwiseIteratorUPtr>&& v) : _origin_iters(std::move(v)) {}
+    VUnionIterator(std::vector<RowwiseIteratorUPtr>&& v, const Schema* output_schema)
+            : _schema(output_schema), _origin_iters(std::move(v)) {}
 
     ~VUnionIterator() override = default;
 
@@ -394,7 +394,7 @@ public:
     }
 
 private:
-    const Schema* _schema = nullptr;
+    const Schema* _schema = nullptr; // output schema
     RowwiseIteratorUPtr _cur_iter = nullptr;
     StorageReadOptions _read_options;
     std::vector<RowwiseIteratorUPtr> _origin_iters;
@@ -404,6 +404,7 @@ Status VUnionIterator::init(const StorageReadOptions& opts) {
     if (_origin_iters.empty()) {
         return Status::OK();
     }
+    DCHECK(_schema != nullptr);
 
     // we use back() and pop_back() of std::vector to handle each iterator,
     // so reverse the vector here to keep result block of next_batch to be
@@ -413,7 +414,6 @@ Status VUnionIterator::init(const StorageReadOptions& opts) {
     _read_options = opts;
     _cur_iter = std::move(_origin_iters.back());
     RETURN_IF_ERROR(_cur_iter->init(_read_options));
-    _schema = &_cur_iter->schema();
     return Status::OK();
 }
 
@@ -429,6 +429,7 @@ Status VUnionIterator::next_batch(Block* block) {
                 _cur_iter = nullptr;
             }
         } else {
+            DCHECK_EQ(block->columns(), _schema->num_column_ids());
             return st;
         }
     }
@@ -453,11 +454,12 @@ RowwiseIteratorUPtr new_merge_iterator(std::vector<RowwiseIteratorUPtr>&& inputs
                                             is_reverse, merged_rows, output_schema);
 }
 
-RowwiseIteratorUPtr new_union_iterator(std::vector<RowwiseIteratorUPtr>&& inputs) {
+RowwiseIteratorUPtr new_union_iterator(std::vector<RowwiseIteratorUPtr>&& inputs,
+                                       const Schema* output_schema) {
     if (inputs.size() == 1) {
         return std::move(inputs[0]);
     }
-    return std::make_unique<VUnionIterator>(std::move(inputs));
+    return std::make_unique<VUnionIterator>(std::move(inputs), output_schema);
 }
 
 RowwiseIterator* new_vstatistics_iterator(std::shared_ptr<Segment> segment, const Schema& schema) {

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -150,7 +150,10 @@ Status VMergeIteratorContext::copy_rows(Block* block, bool advanced) {
         return Status::OK();
     }
     size_t output_cols = _output_schema->num_column_ids();
-    DCHECK_EQ(src.columns(), output_cols);
+    // src block may contain extra columns (e.g. delete-predicate columns) because 
+    // SegmentIterator reads with input_schema = return_columns + delete columns 
+    // to evaluate row filtering. We should only copy the requested output columns.
+    DCHECK_GE(src.columns(), output_cols);
     DCHECK_EQ(dst.columns(), output_cols);
 
     // copy a row to dst block column by column
@@ -429,7 +432,6 @@ Status VUnionIterator::next_batch(Block* block) {
                 _cur_iter = nullptr;
             }
         } else {
-            DCHECK_EQ(block->columns(), _schema->num_column_ids());
             return st;
         }
     }

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -344,13 +344,14 @@ Status VMergeIterator::init(const StorageReadOptions& opts) {
     if (_origin_iters.empty()) {
         return Status::OK();
     }
-    _schema = &(_origin_iters[0]->schema());
+    DCHECK(_schema != nullptr);
     _record_rowids = opts.record_rowids;
 
     for (auto& iter : _origin_iters) {
         auto ctx = std::make_shared<VMergeIteratorContext>(std::move(iter), _sequence_id_idx,
                                                            _is_unique, _is_reverse,
-                                                           opts.read_orderby_key_columns);
+                                                           opts.read_orderby_key_columns,
+                                                           _schema);
         RETURN_IF_ERROR(ctx->init(opts));
         if (!ctx->valid()) {
             continue;
@@ -441,12 +442,12 @@ Status VUnionIterator::current_block_row_locations(std::vector<RowLocation>* loc
 
 RowwiseIteratorUPtr new_merge_iterator(std::vector<RowwiseIteratorUPtr>&& inputs,
                                        int sequence_id_idx, bool is_unique, bool is_reverse,
-                                       uint64_t* merged_rows) {
+                                       uint64_t* merged_rows, const Schema* output_schema) {
     // when the size of inputs is 1, we also need to use VMergeIterator, because the
     // next_block_view function only be implemented in VMergeIterator. The reason why
     // the size of inputs is 1 is that the segment was filtered out by zone map or others.
     return std::make_unique<VMergeIterator>(std::move(inputs), sequence_id_idx, is_unique,
-                                            is_reverse, merged_rows);
+                                            is_reverse, merged_rows, output_schema);
 }
 
 RowwiseIteratorUPtr new_union_iterator(std::vector<RowwiseIteratorUPtr>&& inputs) {

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -149,12 +149,15 @@ Status VMergeIteratorContext::copy_rows(Block* block, bool advanced) {
     if (_cur_batch_num == 0) {
         return Status::OK();
     }
+    size_t output_cols = _output_schema->num_column_ids();
+    DCHECK_EQ(src.columns(), output_cols);
+    DCHECK_EQ(dst.columns(), output_cols);
 
     // copy a row to dst block column by column
     size_t start = _index_in_block - _cur_batch_num + 1 - advanced;
 
     RETURN_IF_CATCH_EXCEPTION({
-        for (size_t i = 0; i < _num_columns; ++i) {
+        for (size_t i = 0; i < output_cols; ++i) {
             auto& s_col = src.get_by_position(i);
             auto& d_col = dst.get_by_position(i);
 

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -150,8 +150,8 @@ Status VMergeIteratorContext::copy_rows(Block* block, bool advanced) {
         return Status::OK();
     }
     size_t output_cols = _output_schema->num_column_ids();
-    // src block may contain extra columns (e.g. delete-predicate columns) because 
-    // SegmentIterator reads with input_schema = return_columns + delete columns 
+    // src block may contain extra columns (e.g. delete-predicate columns) because
+    // SegmentIterator reads with input_schema = return_columns + delete columns
     // to evaluate row filtering. We should only copy the requested output columns.
     DCHECK_GE(src.columns(), output_cols);
     DCHECK_EQ(dst.columns(), output_cols);

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -377,8 +377,8 @@ public:
     // Iterators' ownership it transferred to this class.
     // This class will delete all iterators when destructs
     // Client should not use iterators anymore.
-    VUnionIterator(std::vector<RowwiseIteratorUPtr>&& v, const Schema* output_schema)
-            : _schema(output_schema), _origin_iters(std::move(v)) {}
+    VUnionIterator(std::vector<RowwiseIteratorUPtr>&& v, SchemaSPtr output_schema)
+            : _schema(std::move(output_schema)), _origin_iters(std::move(v)) {}
 
     ~VUnionIterator() override = default;
 
@@ -397,7 +397,7 @@ public:
     }
 
 private:
-    const Schema* _schema = nullptr; // output schema
+    SchemaSPtr _schema; // output schema
     RowwiseIteratorUPtr _cur_iter = nullptr;
     StorageReadOptions _read_options;
     std::vector<RowwiseIteratorUPtr> _origin_iters;
@@ -448,20 +448,20 @@ Status VUnionIterator::current_block_row_locations(std::vector<RowLocation>* loc
 
 RowwiseIteratorUPtr new_merge_iterator(std::vector<RowwiseIteratorUPtr>&& inputs,
                                        int sequence_id_idx, bool is_unique, bool is_reverse,
-                                       uint64_t* merged_rows, const Schema* output_schema) {
+                                       uint64_t* merged_rows, SchemaSPtr output_schema) {
     // when the size of inputs is 1, we also need to use VMergeIterator, because the
     // next_block_view function only be implemented in VMergeIterator. The reason why
     // the size of inputs is 1 is that the segment was filtered out by zone map or others.
     return std::make_unique<VMergeIterator>(std::move(inputs), sequence_id_idx, is_unique,
-                                            is_reverse, merged_rows, output_schema);
+                                            is_reverse, merged_rows, std::move(output_schema));
 }
 
 RowwiseIteratorUPtr new_union_iterator(std::vector<RowwiseIteratorUPtr>&& inputs,
-                                       const Schema* output_schema) {
+                                       SchemaSPtr output_schema) {
     if (inputs.size() == 1) {
         return std::move(inputs[0]);
     }
-    return std::make_unique<VUnionIterator>(std::move(inputs), output_schema);
+    return std::make_unique<VUnionIterator>(std::move(inputs), std::move(output_schema));
 }
 
 RowwiseIterator* new_vstatistics_iterator(std::shared_ptr<Segment> segment, const Schema& schema) {

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -98,12 +98,20 @@ Status VStatisticsIterator::next_batch(Block* block) {
     return Status::EndOfFile("End of VStatisticsIterator");
 }
 
+// Build the block using the output schema, which contains only the columns
+// the caller requested (return_columns). Delete predicate columns are excluded
+// because SegmentIterator handles them independently:
+//   - _init_current_block() skips predicate columns (including delete predicates)
+//     via the _is_pred_column[cid] check, so it never accesses the block by those positions.
+//   - _output_non_pred_columns() checks loc < block->columns() before filling any column,
+//     so delete predicate columns (whose loc exceeds block->columns()) are simply skipped.
+//   - Delete predicate evaluation happens entirely through _current_return_columns and
+//     _evaluate_short_circuit_predicate(), which are independent of the block structure.
 Status VMergeIteratorContext::block_reset(const std::shared_ptr<Block>& block) {
     if (!block->columns()) {
-        const Schema& schema = _iter->schema();
-        const auto& column_ids = schema.column_ids();
-        for (size_t i = 0; i < schema.num_column_ids(); ++i) {
-            auto column_desc = schema.column(column_ids[i]);
+        const auto& column_ids = _output_schema->column_ids();
+        for (size_t i = 0; i < _output_schema->num_column_ids(); ++i) {
+            auto column_desc = _output_schema->column(column_ids[i]);
             auto data_type = Schema::get_data_type_ptr(*column_desc);
             if (data_type == nullptr) {
                 return Status::RuntimeError("invalid data type");
@@ -143,24 +151,24 @@ bool VMergeIteratorContext::compare(const VMergeIteratorContext& rhs) const {
     return result;
 }
 
+// Copy rows from the internal _block to the destination block.
+// Both blocks are built with the output schema (return_columns only), so they
+// have the same number of columns. We iterate over _output_schema->num_column_ids()
+// columns to copy from src to dst.
 Status VMergeIteratorContext::copy_rows(Block* block, bool advanced) {
     Block& src = *_block;
     Block& dst = *block;
+    DCHECK_EQ(src.columns(), _output_schema->num_column_ids());
+    DCHECK_EQ(dst.columns(), _output_schema->num_column_ids());
     if (_cur_batch_num == 0) {
         return Status::OK();
     }
-    size_t output_cols = _output_schema->num_column_ids();
-    // src block may contain extra columns (e.g. delete-predicate columns) because
-    // SegmentIterator reads with input_schema = return_columns + delete columns
-    // to evaluate row filtering. We should only copy the requested output columns.
-    DCHECK_GE(src.columns(), output_cols);
-    DCHECK_EQ(dst.columns(), output_cols);
 
     // copy a row to dst block column by column
     size_t start = _index_in_block - _cur_batch_num + 1 - advanced;
 
     RETURN_IF_CATCH_EXCEPTION({
-        for (size_t i = 0; i < output_cols; ++i) {
+        for (size_t i = 0; i < _output_schema->num_column_ids(); ++i) {
             auto& s_col = src.get_by_position(i);
             auto& d_col = dst.get_by_position(i);
 
@@ -350,13 +358,12 @@ Status VMergeIterator::init(const StorageReadOptions& opts) {
     if (_origin_iters.empty()) {
         return Status::OK();
     }
-    DCHECK(_schema != nullptr);
     _record_rowids = opts.record_rowids;
 
     for (auto& iter : _origin_iters) {
-        auto ctx = std::make_shared<VMergeIteratorContext>(std::move(iter), _sequence_id_idx,
-                                                           _is_unique, _is_reverse,
-                                                           opts.read_orderby_key_columns, _schema);
+        auto ctx = std::make_shared<VMergeIteratorContext>(
+                std::move(iter), _sequence_id_idx, _is_unique, _is_reverse,
+                opts.read_orderby_key_columns, _output_schema);
         RETURN_IF_ERROR(ctx->init(opts));
         if (!ctx->valid()) {
             continue;
@@ -372,13 +379,18 @@ Status VMergeIterator::init(const StorageReadOptions& opts) {
 }
 
 // VUnionIterator will read data from input iterator one by one.
+// Unlike VMergeIterator, VUnionIterator does NOT have its own internal block or copy_rows().
+// It passes the caller's block directly to the underlying SegmentIterator via next_batch(),
+// so there is no input-schema vs output-schema mismatch issue here.
+// The output_schema parameter is accepted only so that schema() can return the output schema
+// consistently with VMergeIterator.
 class VUnionIterator : public RowwiseIterator {
 public:
     // Iterators' ownership it transferred to this class.
     // This class will delete all iterators when destructs
     // Client should not use iterators anymore.
     VUnionIterator(std::vector<RowwiseIteratorUPtr>&& v, SchemaSPtr output_schema)
-            : _schema(std::move(output_schema)), _origin_iters(std::move(v)) {}
+            : _output_schema(std::move(output_schema)), _origin_iters(std::move(v)) {}
 
     ~VUnionIterator() override = default;
 
@@ -386,7 +398,7 @@ public:
 
     Status next_batch(Block* block) override;
 
-    const Schema& schema() const override { return *_schema; }
+    const Schema& schema() const override { return *_output_schema; }
 
     Status current_block_row_locations(std::vector<RowLocation>* locations) override;
 
@@ -397,7 +409,7 @@ public:
     }
 
 private:
-    SchemaSPtr _schema; // output schema
+    const SchemaSPtr _output_schema;
     RowwiseIteratorUPtr _cur_iter = nullptr;
     StorageReadOptions _read_options;
     std::vector<RowwiseIteratorUPtr> _origin_iters;
@@ -407,8 +419,6 @@ Status VUnionIterator::init(const StorageReadOptions& opts) {
     if (_origin_iters.empty()) {
         return Status::OK();
     }
-    DCHECK(_schema != nullptr);
-
     // we use back() and pop_back() of std::vector to handle each iterator,
     // so reverse the vector here to keep result block of next_batch to be
     // in the same order as the original segments.

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -334,7 +334,8 @@ RowwiseIteratorUPtr new_merge_iterator(std::vector<RowwiseIteratorUPtr>&& inputs
 // input iterators one by one.
 //
 // Inputs iterators' ownership is taken by created union iterator.
-RowwiseIteratorUPtr new_union_iterator(std::vector<RowwiseIteratorUPtr>&& inputs);
+RowwiseIteratorUPtr new_union_iterator(std::vector<RowwiseIteratorUPtr>&& inputs,
+                                       const Schema* output_schema);
 
 // Create an auto increment iterator which returns num_rows data in format of schema.
 // This class aims to be used in unit test.

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -87,12 +87,13 @@ private:
 class VMergeIteratorContext {
 public:
     VMergeIteratorContext(RowwiseIteratorUPtr&& iter, int sequence_id_idx, bool is_unique,
-                          bool is_reverse, std::vector<uint32_t>* read_orderby_key_columns)
+                          bool is_reverse, std::vector<uint32_t>* read_orderby_key_columns,
+                          const Schema* output_schema)
             : _iter(std::move(iter)),
               _sequence_id_idx(sequence_id_idx),
               _is_unique(is_unique),
               _is_reverse(is_reverse),
-              _num_columns(cast_set<int>(_iter->schema().num_column_ids())),
+              _num_columns(cast_set<int>(output_schema->num_column_ids())),
               _num_key_columns(cast_set<int>(_iter->schema().num_key_columns())),
               _compare_columns(read_orderby_key_columns) {}
 
@@ -193,8 +194,9 @@ class VMergeIterator : public RowwiseIterator {
 public:
     // VMergeIterator takes the ownership of input iterators
     VMergeIterator(std::vector<RowwiseIteratorUPtr>&& iters, int sequence_id_idx, bool is_unique,
-                   bool is_reverse, uint64_t* merged_rows)
+                   bool is_reverse, uint64_t* merged_rows, const Schema* output_schema)
             : _origin_iters(std::move(iters)),
+              _schema(output_schema),
               _sequence_id_idx(sequence_id_idx),
               _is_unique(is_unique),
               _is_reverse(is_reverse),
@@ -294,7 +296,7 @@ private:
     // It will be released after '_merge_heap' has been built.
     std::vector<RowwiseIteratorUPtr> _origin_iters;
 
-    const Schema* _schema = nullptr;
+    const Schema* _schema = nullptr; // output schema
 
     struct VMergeContextComparator {
         bool operator()(const std::shared_ptr<VMergeIteratorContext>& lhs,
@@ -326,7 +328,7 @@ private:
 // should delete returned iterator after usage.
 RowwiseIteratorUPtr new_merge_iterator(std::vector<RowwiseIteratorUPtr>&& inputs,
                                        int sequence_id_idx, bool is_unique, bool is_reverse,
-                                       uint64_t* merged_rows);
+                                       uint64_t* merged_rows, const Schema* output_schema);
 
 // Create a union iterator for input iterators. Union iterator will read
 // input iterators one by one.

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -93,7 +93,7 @@ public:
               _sequence_id_idx(sequence_id_idx),
               _is_unique(is_unique),
               _is_reverse(is_reverse),
-              _num_columns(cast_set<int>(output_schema->num_column_ids())),
+              _output_schema(output_schema),
               _num_key_columns(cast_set<int>(_iter->schema().num_key_columns())),
               _compare_columns(read_orderby_key_columns) {}
 
@@ -176,7 +176,7 @@ private:
     size_t _index_in_block = -1;
     // 4096 minus 16 + 16 bytes padding that in padding pod array
     int _block_row_max = 4064;
-    int _num_columns;
+    const Schema* _output_schema = nullptr;
     int _num_key_columns;
     std::vector<uint32_t>* _compare_columns;
     std::vector<RowLocation> _block_row_locations;

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -94,7 +94,7 @@ public:
               _is_unique(is_unique),
               _is_reverse(is_reverse),
               _output_schema(std::move(output_schema)),
-              _num_key_columns(cast_set<int>(_iter->schema().num_key_columns())),
+              _num_key_columns(cast_set<int>(_output_schema->num_key_columns())),
               _compare_columns(read_orderby_key_columns) {}
 
     VMergeIteratorContext(const VMergeIteratorContext&) = delete;
@@ -104,6 +104,22 @@ public:
 
     ~VMergeIteratorContext() = default;
 
+    // Reset (or initialize) the internal _block using the output schema.
+    //
+    // The output schema contains only the columns the caller requested (return_columns),
+    // excluding delete predicate columns. For example, if the query reads columns {c1, c2}
+    // but there is a delete predicate on column c3 (e.g., "DELETE FROM t WHERE c3 = 'foo'"):
+    //   - input schema  (iter->schema) = {c1, c2, c3}   (3 columns)
+    //   - output schema                = {c1, c2}       (2 columns)
+    //
+    // It is safe to build the block with only the output schema because SegmentIterator
+    // handles delete predicate columns independently of the block structure:
+    //   - _init_current_block() skips predicate columns (including delete predicates)
+    //     via the _is_pred_column[cid] check, never accessing the block for them.
+    //   - _output_non_pred_columns() checks loc < block->columns() before filling any
+    //     column, so delete predicate columns are simply skipped when the block is smaller.
+    //   - Delete predicate evaluation uses _current_return_columns and
+    //     _evaluate_short_circuit_predicate(), independent of the block.
     Status block_reset(const std::shared_ptr<Block>& block);
 
     // Initialize this context and will prepare data for current_row()
@@ -111,6 +127,10 @@ public:
 
     bool compare(const VMergeIteratorContext& rhs) const;
 
+    // Copy rows from internal _block to the destination block.
+    // Both blocks have _output_schema columns (return_columns only).
+    // Only _output_schema->num_column_ids() columns are copied.
+    //
     // `advanced = false` when current block finished
     // when input argument type is block, we do not process same_bit,
     // this case we only need merge and return ordered data (VCollectIterator::_topn_next), data mode is dup/mow can guarantee all rows are different
@@ -176,7 +196,14 @@ private:
     size_t _index_in_block = -1;
     // 4096 minus 16 + 16 bytes padding that in padding pod array
     int _block_row_max = 4064;
-    SchemaSPtr _output_schema;
+    // The output schema defines which columns are in _block and in the caller's dst block.
+    // It contains only the requested return_columns, excluding delete predicate columns.
+    // For example:
+    //   - _iter->schema() (input)  = {c1, c2, c3}  — c3 for "DELETE WHERE c3='foo'"
+    //   - _output_schema           = {c1, c2}      — only the requested columns
+    // block_reset() uses _output_schema to build _block, and copy_rows() iterates over
+    // _output_schema->num_column_ids() columns to copy from _block to the destination.
+    const SchemaSPtr _output_schema;
     int _num_key_columns;
     std::vector<uint32_t>* _compare_columns;
     std::vector<RowLocation> _block_row_locations;
@@ -196,7 +223,7 @@ public:
     VMergeIterator(std::vector<RowwiseIteratorUPtr>&& iters, int sequence_id_idx, bool is_unique,
                    bool is_reverse, uint64_t* merged_rows, SchemaSPtr output_schema)
             : _origin_iters(std::move(iters)),
-              _schema(std::move(output_schema)),
+              _output_schema(std::move(output_schema)),
               _sequence_id_idx(sequence_id_idx),
               _is_unique(is_unique),
               _is_reverse(is_reverse),
@@ -212,7 +239,7 @@ public:
     }
     Status next_batch(BlockView* block_view) override { return _next_batch(block_view); }
 
-    const Schema& schema() const override { return *_schema; }
+    const Schema& schema() const override { return *_output_schema; }
 
     Status current_block_row_locations(std::vector<RowLocation>* block_row_locations) override {
         DCHECK(_record_rowids);
@@ -296,7 +323,9 @@ private:
     // It will be released after '_merge_heap' has been built.
     std::vector<RowwiseIteratorUPtr> _origin_iters;
 
-    SchemaSPtr _schema; // output schema
+    // The output schema (excludes delete predicate columns). Passed down to each
+    // VMergeIteratorContext to control how many columns copy_rows() copies.
+    const SchemaSPtr _output_schema;
 
     struct VMergeContextComparator {
         bool operator()(const std::shared_ptr<VMergeIteratorContext>& lhs,

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -88,12 +88,12 @@ class VMergeIteratorContext {
 public:
     VMergeIteratorContext(RowwiseIteratorUPtr&& iter, int sequence_id_idx, bool is_unique,
                           bool is_reverse, std::vector<uint32_t>* read_orderby_key_columns,
-                          const Schema* output_schema)
+                          SchemaSPtr output_schema)
             : _iter(std::move(iter)),
               _sequence_id_idx(sequence_id_idx),
               _is_unique(is_unique),
               _is_reverse(is_reverse),
-              _output_schema(output_schema),
+              _output_schema(std::move(output_schema)),
               _num_key_columns(cast_set<int>(_iter->schema().num_key_columns())),
               _compare_columns(read_orderby_key_columns) {}
 
@@ -176,7 +176,7 @@ private:
     size_t _index_in_block = -1;
     // 4096 minus 16 + 16 bytes padding that in padding pod array
     int _block_row_max = 4064;
-    const Schema* _output_schema = nullptr;
+    SchemaSPtr _output_schema;
     int _num_key_columns;
     std::vector<uint32_t>* _compare_columns;
     std::vector<RowLocation> _block_row_locations;
@@ -194,9 +194,9 @@ class VMergeIterator : public RowwiseIterator {
 public:
     // VMergeIterator takes the ownership of input iterators
     VMergeIterator(std::vector<RowwiseIteratorUPtr>&& iters, int sequence_id_idx, bool is_unique,
-                   bool is_reverse, uint64_t* merged_rows, const Schema* output_schema)
+                   bool is_reverse, uint64_t* merged_rows, SchemaSPtr output_schema)
             : _origin_iters(std::move(iters)),
-              _schema(output_schema),
+              _schema(std::move(output_schema)),
               _sequence_id_idx(sequence_id_idx),
               _is_unique(is_unique),
               _is_reverse(is_reverse),
@@ -296,7 +296,7 @@ private:
     // It will be released after '_merge_heap' has been built.
     std::vector<RowwiseIteratorUPtr> _origin_iters;
 
-    const Schema* _schema = nullptr; // output schema
+    SchemaSPtr _schema; // output schema
 
     struct VMergeContextComparator {
         bool operator()(const std::shared_ptr<VMergeIteratorContext>& lhs,
@@ -328,14 +328,14 @@ private:
 // should delete returned iterator after usage.
 RowwiseIteratorUPtr new_merge_iterator(std::vector<RowwiseIteratorUPtr>&& inputs,
                                        int sequence_id_idx, bool is_unique, bool is_reverse,
-                                       uint64_t* merged_rows, const Schema* output_schema);
+                                       uint64_t* merged_rows, SchemaSPtr output_schema);
 
 // Create a union iterator for input iterators. Union iterator will read
 // input iterators one by one.
 //
 // Inputs iterators' ownership is taken by created union iterator.
 RowwiseIteratorUPtr new_union_iterator(std::vector<RowwiseIteratorUPtr>&& inputs,
-                                       const Schema* output_schema);
+                                       SchemaSPtr output_schema);
 
 // Create an auto increment iterator which returns num_rows data in format of schema.
 // This class aims to be used in unit test.

--- a/be/test/vec/exec/vgeneric_iterators_test.cpp
+++ b/be/test/vec/exec/vgeneric_iterators_test.cpp
@@ -20,6 +20,7 @@
 #include <gtest/gtest-message.h>
 #include <gtest/gtest-test-part.h>
 
+#include <memory>
 #include <vector>
 
 #include "gtest/gtest_pred_impl.h"
@@ -104,13 +105,14 @@ TEST(VGenericIteratorsTest, AutoIncrement) {
 
 TEST(VGenericIteratorsTest, Union) {
     auto schema = create_schema();
+    auto output_schema = std::make_shared<Schema>(schema);
     std::vector<RowwiseIteratorUPtr> inputs;
 
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 100));
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 200));
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 300));
 
-    auto iter = vectorized::new_union_iterator(std::move(inputs));
+    auto iter = vectorized::new_union_iterator(std::move(inputs), output_schema);
     StorageReadOptions opts;
     auto st = iter->init(opts);
     EXPECT_TRUE(st.ok());
@@ -148,13 +150,15 @@ TEST(VGenericIteratorsTest, Union) {
 TEST(VGenericIteratorsTest, MergeAgg) {
     EXPECT_TRUE(1);
     auto schema = create_schema();
+    auto output_schema = std::make_shared<Schema>(schema);
     std::vector<RowwiseIteratorUPtr> inputs;
 
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 100));
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 200));
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 300));
 
-    auto iter = vectorized::new_merge_iterator(std::move(inputs), -1, false, false, nullptr);
+    auto iter = vectorized::new_merge_iterator(std::move(inputs), -1, false, false, nullptr,
+                                               output_schema);
     StorageReadOptions opts;
     auto st = iter->init(opts);
     EXPECT_TRUE(st.ok());
@@ -197,13 +201,15 @@ TEST(VGenericIteratorsTest, MergeAgg) {
 TEST(VGenericIteratorsTest, MergeUnique) {
     EXPECT_TRUE(1);
     auto schema = create_schema();
+    auto output_schema = std::make_shared<Schema>(schema);
     std::vector<RowwiseIteratorUPtr> inputs;
 
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 100));
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 200));
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 300));
 
-    auto iter = vectorized::new_merge_iterator(std::move(inputs), -1, true, false, nullptr);
+    auto iter = vectorized::new_merge_iterator(std::move(inputs), -1, true, false, nullptr,
+                                               output_schema);
     StorageReadOptions opts;
     auto st = iter->init(opts);
     EXPECT_TRUE(st.ok());
@@ -310,6 +316,7 @@ public:
 TEST(VGenericIteratorsTest, MergeWithSeqColumn) {
     EXPECT_TRUE(1);
     auto schema = create_schema();
+    auto output_schema = std::make_shared<Schema>(schema);
     std::vector<RowwiseIteratorUPtr> inputs;
 
     int seq_column_id = 2;
@@ -325,8 +332,8 @@ TEST(VGenericIteratorsTest, MergeWithSeqColumn) {
                 schema, num_rows, rows_begin, seq_column_id, seq_id_in_every_file));
     }
 
-    auto iter =
-            vectorized::new_merge_iterator(std::move(inputs), seq_column_id, true, false, nullptr);
+    auto iter = vectorized::new_merge_iterator(std::move(inputs), seq_column_id, true, false,
+                                               nullptr, output_schema);
     StorageReadOptions opts;
     auto st = iter->init(opts);
     EXPECT_TRUE(st.ok());


### PR DESCRIPTION
This PR ensures merge/union iterators use an explicit output schema projection and copy only the requested columns, preventing column count mismatches when delete-predicate columns are read in addition to return columns. 

BetaRowsetReader now builds an `output_schema` from return_columns and passes it to merge/union iterators, VMergeIteratorContext copies using the output schema (not the incorrect _iter->schema())

Consider the following table:

```sql
CREATE TABLE tbl (
  k INT NOT NULL,
  v1 INT NOT NULL,
  v2 INT NOT NULL
) DUPLICATE KEY(k) ...;
```

And a delete predicate applied to a non-key column:

```sql
DELETE FROM tbl WHERE v1 = 1;
```

When executing ORDER BY k LIMIT n, Doris has a Top-N optimization. Even though the query is SELECT *, the engine initially avoids scanning all columns. It constructs a minimal intermediate schema containing only the sort keys (k) and the internal `__DORIS_ROWID_COL__` to perform the merge and sorting efficiently. (_col_ids = {0, 3}, ==> _num_columns = 2). However, because a delete predicate exists on column v1, the BetaRowsetReader add v1 to this intermediate schema to evaluate and filter out deleted rows during the scan. (_col_ids = {0, 3, 1}, note that column v1 (index=1) is appended to this schema ==> _num_columns = 3)

The previous implementation of VMergeIteratorContext::copy_rows used the incorrect _num_columns value, resulting in an array out-of-bounds access and causing BE coredumped.

Detailed reproduction steps are follows:

1. modify conf/be.conf

```
write_buffer_size = 8
```

2. execute the following sql

```sql
CREATE TABLE tbl1
(
    k INT NOT NULL,
    v1 INT NOT NULL,
    v2 INT NOT NULL
)
DUPLICATE KEY(k)
DISTRIBUTED BY HASH(k) BUCKETS 5
PROPERTIES(
    "replication_num" = "1"

);
CREATE TABLE tbl2
(
    k INT NOT NULL,
    v1 INT NOT NULL,
    v2 INT NOT NULL
)
DUPLICATE KEY(k)
DISTRIBUTED BY HASH(k) BUCKETS 1
PROPERTIES(
    "replication_num" = "1"
);

INSERT INTO tbl1 VALUES (1, 1, 1),(2, 2, 2),(3, 3, 3),(4, 4, 4),(5, 5, 5);
INSERT INTO tbl2 SELECT * FROM tbl1;
SELECT * FROM tbl2 ORDER BY k limit 100; -- ok

DELETE FROM tbl2 WHERE v1 = 100;
SELECT * FROM tbl2 ORDER BY k limit 100; -- coredump
```

Co-authored-by: yiguolei <guolei@selectdb.com>

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

