### PR TITLE
[bugfix](topn) add schema to merge iterator

### DIFF
--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -152,6 +152,10 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
     // create segment iterators
     VLOG_NOTICE << "read columns size: " << read_columns.size();
     _input_schema = std::make_shared<Schema>(_read_context->tablet_schema->columns(), read_columns);
+    // output_schema only contains return_columns (excludes extra columns like delete-predicate columns).
+    // It is used by merge/union iterators to determine how many columns to copy to the output block.
+    _output_schema = std::make_shared<Schema>(_read_context->tablet_schema->columns(),
+                                              *(_read_context->return_columns));
     if (_read_context->predicates != nullptr) {
         _read_options.column_predicates.insert(_read_options.column_predicates.end(),
                                                _read_context->predicates->begin(),
@@ -330,13 +334,14 @@ Status BetaRowsetReader::_init_iterator() {
         }
         _iterator = vectorized::new_merge_iterator(
                 std::move(iterators), sequence_loc, _read_context->is_unique,
-                _read_context->read_orderby_key_reverse, _read_context->merged_rows);
+                _read_context->read_orderby_key_reverse, _read_context->merged_rows,
+                _output_schema);
     } else {
         if (_read_context->read_orderby_key_reverse) {
             // reverse iterators to read backward for ORDER BY key DESC
             std::reverse(iterators.begin(), iterators.end());
         }
-        _iterator = vectorized::new_union_iterator(std::move(iterators));
+        _iterator = vectorized::new_union_iterator(std::move(iterators), _output_schema);
     }
 
     auto s = _iterator->init(_read_options);

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -332,10 +332,10 @@ Status BetaRowsetReader::_init_iterator() {
                 }
             }
         }
-        _iterator = vectorized::new_merge_iterator(
-                std::move(iterators), sequence_loc, _read_context->is_unique,
-                _read_context->read_orderby_key_reverse, _read_context->merged_rows,
-                _output_schema);
+        _iterator = vectorized::new_merge_iterator(std::move(iterators), sequence_loc,
+                                                   _read_context->is_unique,
+                                                   _read_context->read_orderby_key_reverse,
+                                                   _read_context->merged_rows, _output_schema);
     } else {
         if (_read_context->read_orderby_key_reverse) {
             // reverse iterators to read backward for ORDER BY key DESC

--- a/be/src/olap/rowset/beta_rowset_reader.h
+++ b/be/src/olap/rowset/beta_rowset_reader.h
@@ -147,6 +147,7 @@ private:
     std::vector<RowRanges> _segment_row_ranges;
 
     SchemaSPtr _input_schema;
+    SchemaSPtr _output_schema;
     RowsetReaderContext* _read_context = nullptr;
     BetaRowsetSharedPtr _rowset;
 

--- a/be/src/olap/rowset/beta_rowset_reader.h
+++ b/be/src/olap/rowset/beta_rowset_reader.h
@@ -147,15 +147,14 @@ private:
     std::vector<RowRanges> _segment_row_ranges;
 
     // _input_schema: includes return_columns + delete_predicate_columns.
-    // Used by SegmentIterator internally (block_reset creates blocks with this schema),
-    // because SegmentIterator::_init_current_block and _output_non_pred_columns both
-    // index into the block assuming input_schema column count.
+    // Used by SegmentIterator internally (iter->schema() returns this). SegmentIterator
+    // handles the extra delete predicate columns through _current_return_columns and
+    // _evaluate_short_circuit_predicate(), independent of the block structure.
     // e.g. return_columns={c1, c2}, delete_pred on c3 => input_schema={c1, c2, c3}
     SchemaSPtr _input_schema;
     // _output_schema: includes only return_columns (a subset of input_schema).
-    // Passed to VMergeIterator/VUnionIterator so that copy_rows only copies the columns
-    // the caller actually needs, avoiding OOB access on the destination block which is
-    // sized according to return_columns only.
+    // Passed to VMergeIterator/VUnionIterator. block_reset() builds the internal block
+    // with this schema, and copy_rows() copies exactly these columns to the destination.
     // e.g. return_columns={c1, c2} => output_schema={c1, c2}
     SchemaSPtr _output_schema;
     RowsetReaderContext* _read_context = nullptr;

--- a/be/src/olap/rowset/beta_rowset_reader.h
+++ b/be/src/olap/rowset/beta_rowset_reader.h
@@ -150,13 +150,13 @@ private:
     // Used by SegmentIterator internally (block_reset creates blocks with this schema),
     // because SegmentIterator::_init_current_block and _output_non_pred_columns both
     // index into the block assuming input_schema column count.
-    // e.g. return_columns={k, __ROWID__}, delete_pred on v1 => input_schema={k, __ROWID__, v1}
+    // e.g. return_columns={c1, c2}, delete_pred on c3 => input_schema={c1, c2, c3}
     SchemaSPtr _input_schema;
     // _output_schema: includes only return_columns (a subset of input_schema).
     // Passed to VMergeIterator/VUnionIterator so that copy_rows only copies the columns
     // the caller actually needs, avoiding OOB access on the destination block which is
     // sized according to return_columns only.
-    // e.g. return_columns={k, __ROWID__} => output_schema={k, __ROWID__}
+    // e.g. return_columns={c1, c2} => output_schema={c1, c2}
     SchemaSPtr _output_schema;
     RowsetReaderContext* _read_context = nullptr;
     BetaRowsetSharedPtr _rowset;

--- a/be/src/olap/rowset/beta_rowset_reader.h
+++ b/be/src/olap/rowset/beta_rowset_reader.h
@@ -146,7 +146,17 @@ private:
     std::pair<int64_t, int64_t> _segment_offsets;
     std::vector<RowRanges> _segment_row_ranges;
 
+    // _input_schema: includes return_columns + delete_predicate_columns.
+    // Used by SegmentIterator internally (block_reset creates blocks with this schema),
+    // because SegmentIterator::_init_current_block and _output_non_pred_columns both
+    // index into the block assuming input_schema column count.
+    // e.g. return_columns={k, __ROWID__}, delete_pred on v1 => input_schema={k, __ROWID__, v1}
     SchemaSPtr _input_schema;
+    // _output_schema: includes only return_columns (a subset of input_schema).
+    // Passed to VMergeIterator/VUnionIterator so that copy_rows only copies the columns
+    // the caller actually needs, avoiding OOB access on the destination block which is
+    // sized according to return_columns only.
+    // e.g. return_columns={k, __ROWID__} => output_schema={k, __ROWID__}
     SchemaSPtr _output_schema;
     RowsetReaderContext* _read_context = nullptr;
     BetaRowsetSharedPtr _rowset;

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -2083,8 +2083,20 @@ Status SegmentIterator::_output_non_pred_columns(vectorized::Block* block) {
     RETURN_IF_ERROR(_convert_to_expected_type(_non_predicate_columns));
     for (auto cid : _non_predicate_columns) {
         auto loc = _schema_block_id_map[cid];
-        // if loc > block->columns() means the column is delete column and should
-        // not output by block, so just skip the column.
+        // Whether a delete predicate column gets output depends on how the caller builds
+        // the block passed to next_batch(). Two calling paths exist:
+        //
+        // 1) VMergeIterator path: block_reset() builds _block using the full input schema
+        //    (return_columns + delete_pred_columns), e.g. block has 3 columns {c1, c2, c3}.
+        //    Here loc=2 for c3, block->columns()=3, so loc < block->columns() is true,
+        //    and c3 is filled into the block. The extra column is later excluded by
+        //    VMergeIteratorContext::copy_rows(), which only copies output_schema columns
+        //    (e.g. 2 columns {c1, c2}) to the destination block.
+        //
+        // 2) VUnionIterator path: the caller's block is built with only return_columns
+        //    (output schema), e.g. block has 2 columns {c1, c2}.
+        //    Here loc=2 for c3, block->columns()=2, so loc < block->columns() is false,
+        //    and c3 is skipped — effectively trimmed at the SegmentIterator level.
         if (loc < block->columns()) {
             bool column_in_block_is_nothing =
                     vectorized::check_and_get_column<const vectorized::ColumnNothing>(

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -2084,19 +2084,18 @@ Status SegmentIterator::_output_non_pred_columns(vectorized::Block* block) {
     for (auto cid : _non_predicate_columns) {
         auto loc = _schema_block_id_map[cid];
         // Whether a delete predicate column gets output depends on how the caller builds
-        // the block passed to next_batch(). Two calling paths exist:
+        // the block passed to next_batch(). Both calling paths now build the block with
+        // only the output schema (return_columns), so delete predicate columns are skipped:
         //
-        // 1) VMergeIterator path: block_reset() builds _block using the full input schema
-        //    (return_columns + delete_pred_columns), e.g. block has 3 columns {c1, c2, c3}.
-        //    Here loc=2 for c3, block->columns()=3, so loc < block->columns() is true,
-        //    and c3 is filled into the block. The extra column is later excluded by
-        //    VMergeIteratorContext::copy_rows(), which only copies output_schema columns
-        //    (e.g. 2 columns {c1, c2}) to the destination block.
+        // 1) VMergeIterator path: block_reset() builds _block using the output schema
+        //    (return_columns only), e.g. block has 2 columns {c1, c2}.
+        //    Here loc=2 for delete predicate c3, block->columns()=2, so loc < block->columns()
+        //    is false, and c3 is skipped.
         //
         // 2) VUnionIterator path: the caller's block is built with only return_columns
         //    (output schema), e.g. block has 2 columns {c1, c2}.
         //    Here loc=2 for c3, block->columns()=2, so loc < block->columns() is false,
-        //    and c3 is skipped — effectively trimmed at the SegmentIterator level.
+        //    and c3 is skipped — same behavior as the VMergeIterator path.
         if (loc < block->columns()) {
             bool column_in_block_is_nothing =
                     vectorized::check_and_get_column<const vectorized::ColumnNothing>(

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -572,7 +572,14 @@ Status VSchemaChangeDirectly::_inner_process(RowsetReaderSharedPtr rowset_reader
     bool eof = false;
     do {
         auto new_block = vectorized::Block::create_unique(new_tablet_schema->create_block());
-        auto ref_block = vectorized::Block::create_unique(base_tablet_schema->create_block(false));
+        // create_block() skips dropped columns (from light-weight schema change).
+        // Dropped columns are only needed for delete predicate evaluation, which
+        // SegmentIterator handles internally — it creates temporary columns for
+        // predicate columns not present in the block (via `i >= block->columns()`
+        // guard in _init_current_block). If dropped columns were included here,
+        // the block would have more columns than VMergeIterator's output_schema
+        // expects, causing DCHECK failures in copy_rows.
+        auto ref_block = vectorized::Block::create_unique(base_tablet_schema->create_block());
 
         Status st = next_batch(rowset_reader, ref_block.get(), _row_same_bit);
         if (!st) {
@@ -641,7 +648,14 @@ Status VBaseSchemaChangeWithSorting::_inner_process(RowsetReaderSharedPtr rowset
 
     bool eof = false;
     do {
-        auto ref_block = vectorized::Block::create_unique(base_tablet_schema->create_block(false));
+        // create_block() skips dropped columns (from light-weight schema change).
+        // Dropped columns are only needed for delete predicate evaluation, which
+        // SegmentIterator handles internally — it creates temporary columns for
+        // predicate columns not present in the block (via `i >= block->columns()`
+        // guard in _init_current_block). If dropped columns were included here,
+        // the block would have more columns than VMergeIterator's output_schema
+        // expects, causing DCHECK failures in copy_rows.
+        auto ref_block = vectorized::Block::create_unique(base_tablet_schema->create_block());
         Status st = next_batch(rowset_reader, ref_block.get(), _row_same_bit);
         if (!st) {
             if (st.is<ErrorCode::END_OF_FILE>()) {

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -935,6 +935,27 @@ Status SchemaChangeJob::_do_process_alter_tablet(const TAlterTabletReqV2& reques
     // dropped column during light weight schema change.
     // But the tablet schema in base tablet maybe not the latest from FE, so that if fe pass through
     // a tablet schema, then use request schema.
+    //
+    // return_columns does NOT include dropped columns. It is computed here BEFORE
+    // merge_dropped_columns() appends dropped columns to _base_tablet_schema below.
+    // This means return_columns only covers the original (non-dropped) columns.
+    //
+    // This is important because:
+    // - BetaRowsetReader builds _output_schema from return_columns, which determines the
+    //   number of columns in ref_block (via create_block() which also skips dropped cols).
+    // - VMergeIterator's copy_rows iterates over _output_schema columns, so ref_block
+    //   must match _output_schema exactly.
+    // - Dropped columns are only needed for delete predicate evaluation, and SegmentIterator
+    //   handles them internally (creates temporary columns for predicate columns not present
+    //   in the block via `i >= block->columns()` guard in _init_current_block).
+    //
+    // Example: table has columns [k1, v1, v2], then DROP COLUMN v1, then
+    //   DELETE FROM t WHERE v1 = 'x' was issued before the drop.
+    //   - _base_tablet_schema after merge_dropped_columns: [k1, v2, v1(DROPPED)]
+    //   - return_columns (computed before merge): [0, 1] → [k1, v2]
+    //   - _output_schema / ref_block columns: [k1, v2] (2 columns)
+    //   - SegmentIterator reads v1 internally for delete predicate, but does not
+    //     output it to ref_block. copy_rows only iterates 2 columns — no OOB access.
     size_t num_cols =
             request.columns.empty() ? _base_tablet_schema->num_columns() : request.columns.size();
     return_columns.resize(num_cols);

--- a/be/src/olap/tablet_schema.cpp
+++ b/be/src/olap/tablet_schema.cpp
@@ -1862,10 +1862,10 @@ vectorized::Block TabletSchema::create_block(
     return block;
 }
 
-vectorized::Block TabletSchema::create_block(bool ignore_dropped_col) const {
+vectorized::Block TabletSchema::create_block() const {
     vectorized::Block block;
     for (const auto& col : _cols) {
-        if (ignore_dropped_col && is_dropped_column(*col)) {
+        if (is_dropped_column(*col)) {
             continue;
         }
 

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -578,7 +578,7 @@ public:
     vectorized::Block create_block(
             const std::vector<uint32_t>& return_columns,
             const std::unordered_set<uint32_t>* tablet_columns_need_convert_null = nullptr) const;
-    vectorized::Block create_block(bool ignore_dropped_col = true) const;
+    vectorized::Block create_block() const;
     void set_schema_version(int32_t version) { _schema_version = version; }
     void set_auto_increment_column(const std::string& auto_increment_column) {
         _auto_increment_column = auto_increment_column;

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -100,9 +100,9 @@ Status VStatisticsIterator::next_batch(Block* block) {
 
 // Use _iter->schema() (input schema) to build the block, NOT the output schema.
 // The input schema includes all columns the SegmentIterator needs to fill, which may be
-// a superset of the output schema. For example, with a delete predicate "DELETE WHERE v1='foo'":
-//   - input schema  = {k, __ROWID__, v1}  — v1 is needed for delete predicate evaluation
-//   - output schema = {k, __ROWID__}      — v1 is not returned to the caller
+// a superset of the output schema. For example, with a delete predicate "DELETE WHERE c3='foo'":
+//   - input schema  = {c1, c2, c3}  — c3 is needed for delete predicate evaluation
+//   - output schema = {c1, c2}      — c3 is not returned to the caller
 // SegmentIterator::_init_current_block() indexes into the block by input schema positions,
 // and _output_non_pred_columns() checks block->columns() to decide whether to output
 // the delete predicate column. So the block must match the input schema.
@@ -152,11 +152,11 @@ bool VMergeIteratorContext::compare(const VMergeIteratorContext& rhs) const {
 }
 
 // Copy rows from the internal _block (built with input schema) to the destination block
-// (built with output schema). Only copy the first _num_columns columns, which corresponds
-// to the output schema. The source _block may have more columns than the destination when
-// delete predicates add extra columns. For example:
-//   - src (_block):  {k, __ROWID__, v1}  — 3 columns (input schema, v1 for delete predicate)
-//   - dst (block):   {k, __ROWID__}      — 2 columns (output schema)
+// (built with output schema). Only copy the first _output_schema->num_column_ids() columns,
+// which corresponds to the output schema. The source _block may have more columns than the
+// destination when delete predicates add extra columns. For example:
+//   - src (_block):  {c1, c2, c3}  — 3 columns (input schema, c3 for delete predicate)
+//   - dst (block):   {c1, c2}      — 2 columns (output schema)
 // We must NOT iterate over all src columns, otherwise we'd access dst out of bounds.
 Status VMergeIteratorContext::copy_rows(Block* block, bool advanced) {
     Block& src = *_block;
@@ -169,7 +169,7 @@ Status VMergeIteratorContext::copy_rows(Block* block, bool advanced) {
     size_t start = _index_in_block - _cur_batch_num + 1 - advanced;
 
     RETURN_IF_CATCH_EXCEPTION({
-        for (size_t i = 0; i < _num_columns; ++i) {
+        for (size_t i = 0; i < _output_schema->num_column_ids(); ++i) {
             auto& s_col = src.get_by_position(i);
             auto& d_col = dst.get_by_position(i);
 
@@ -295,10 +295,6 @@ Status VAutoIncrementIterator::init(const StorageReadOptions& opts) {
 Status VMergeIteratorContext::init(const StorageReadOptions& opts) {
     _block_row_max = opts.block_row_max;
     _record_rowids = opts.record_rowids;
-    // _num_columns is the number of columns to copy in copy_rows().
-    // output_schema only contains return_columns (excludes delete predicate columns),
-    // so copy_rows will only copy the columns the caller actually needs.
-    _num_columns = cast_set<int>(_output_schema->num_column_ids());
     RETURN_IF_ERROR(_load_next_block());
     if (valid()) {
         RETURN_IF_ERROR(advance());
@@ -363,9 +359,6 @@ Status VMergeIterator::init(const StorageReadOptions& opts) {
     if (_origin_iters.empty()) {
         return Status::OK();
     }
-    // Use output_schema to set the schema for this iterator.
-    // The output schema excludes delete predicate columns.
-    _schema = _output_schema.get();
     _record_rowids = opts.record_rowids;
 
     for (auto& iter : _origin_iters) {
@@ -407,7 +400,7 @@ public:
 
     Status next_batch(Block* block) override;
 
-    const Schema& schema() const override { return *_schema; }
+    const Schema& schema() const override { return *_output_schema; }
 
     Status current_block_row_locations(std::vector<RowLocation>* locations) override;
 
@@ -418,8 +411,7 @@ public:
     }
 
 private:
-    const Schema* _schema = nullptr;
-    SchemaSPtr _output_schema;
+    const SchemaSPtr _output_schema;
     RowwiseIteratorUPtr _cur_iter = nullptr;
     StorageReadOptions _read_options;
     std::vector<RowwiseIteratorUPtr> _origin_iters;
@@ -438,8 +430,6 @@ Status VUnionIterator::init(const StorageReadOptions& opts) {
     _read_options = opts;
     _cur_iter = std::move(_origin_iters.back());
     RETURN_IF_ERROR(_cur_iter->init(_read_options));
-    // Use output_schema to set the schema for this iterator.
-    _schema = _output_schema.get();
     return Status::OK();
 }
 

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -98,6 +98,14 @@ Status VStatisticsIterator::next_batch(Block* block) {
     return Status::EndOfFile("End of VStatisticsIterator");
 }
 
+// Use _iter->schema() (input schema) to build the block, NOT the output schema.
+// The input schema includes all columns the SegmentIterator needs to fill, which may be
+// a superset of the output schema. For example, with a delete predicate "DELETE WHERE v1='foo'":
+//   - input schema  = {k, __ROWID__, v1}  — v1 is needed for delete predicate evaluation
+//   - output schema = {k, __ROWID__}      — v1 is not returned to the caller
+// SegmentIterator::_init_current_block() indexes into the block by input schema positions,
+// and _output_non_pred_columns() checks block->columns() to decide whether to output
+// the delete predicate column. So the block must match the input schema.
 Status VMergeIteratorContext::block_reset(const std::shared_ptr<Block>& block) {
     if (!block->columns()) {
         const Schema& schema = _iter->schema();
@@ -143,6 +151,13 @@ bool VMergeIteratorContext::compare(const VMergeIteratorContext& rhs) const {
     return result;
 }
 
+// Copy rows from the internal _block (built with input schema) to the destination block
+// (built with output schema). Only copy the first _num_columns columns, which corresponds
+// to the output schema. The source _block may have more columns than the destination when
+// delete predicates add extra columns. For example:
+//   - src (_block):  {k, __ROWID__, v1}  — 3 columns (input schema, v1 for delete predicate)
+//   - dst (block):   {k, __ROWID__}      — 2 columns (output schema)
+// We must NOT iterate over all src columns, otherwise we'd access dst out of bounds.
 Status VMergeIteratorContext::copy_rows(Block* block, bool advanced) {
     Block& src = *_block;
     Block& dst = *block;
@@ -280,6 +295,11 @@ Status VAutoIncrementIterator::init(const StorageReadOptions& opts) {
 Status VMergeIteratorContext::init(const StorageReadOptions& opts) {
     _block_row_max = opts.block_row_max;
     _record_rowids = opts.record_rowids;
+    // _num_columns is the number of columns to copy in copy_rows().
+    // When output_schema is provided (merge path with possible delete predicates),
+    // use it; otherwise fall back to the full input schema (no extra columns).
+    _num_columns = _output_schema ? cast_set<int>(_output_schema->num_column_ids())
+                                  : cast_set<int>(_iter->schema().num_column_ids());
     RETURN_IF_ERROR(_load_next_block());
     if (valid()) {
         RETURN_IF_ERROR(advance());
@@ -344,13 +364,16 @@ Status VMergeIterator::init(const StorageReadOptions& opts) {
     if (_origin_iters.empty()) {
         return Status::OK();
     }
-    _schema = &(_origin_iters[0]->schema());
+    // Use output_schema if provided; otherwise fall back to the underlying iterator's schema
+    // (input schema). The output schema excludes delete predicate columns.
+    _schema = _output_schema ? _output_schema.get() : &(_origin_iters[0]->schema());
     _record_rowids = opts.record_rowids;
 
     for (auto& iter : _origin_iters) {
         auto ctx = std::make_shared<VMergeIteratorContext>(std::move(iter), _sequence_id_idx,
                                                            _is_unique, _is_reverse,
-                                                           opts.read_orderby_key_columns);
+                                                           opts.read_orderby_key_columns,
+                                                           _output_schema);
         RETURN_IF_ERROR(ctx->init(opts));
         if (!ctx->valid()) {
             continue;
@@ -366,12 +389,18 @@ Status VMergeIterator::init(const StorageReadOptions& opts) {
 }
 
 // VUnionIterator will read data from input iterator one by one.
+// Unlike VMergeIterator, VUnionIterator does NOT have its own internal block or copy_rows().
+// It passes the caller's block directly to the underlying SegmentIterator via next_batch(),
+// so there is no input-schema vs output-schema mismatch issue here.
+// The output_schema parameter is accepted only so that schema() can return the output schema
+// consistently with VMergeIterator.
 class VUnionIterator : public RowwiseIterator {
 public:
     // Iterators' ownership it transferred to this class.
     // This class will delete all iterators when destructs
     // Client should not use iterators anymore.
-    VUnionIterator(std::vector<RowwiseIteratorUPtr>&& v) : _origin_iters(std::move(v)) {}
+    VUnionIterator(std::vector<RowwiseIteratorUPtr>&& v, SchemaSPtr output_schema)
+            : _origin_iters(std::move(v)), _output_schema(std::move(output_schema)) {}
 
     ~VUnionIterator() override = default;
 
@@ -391,6 +420,7 @@ public:
 
 private:
     const Schema* _schema = nullptr;
+    SchemaSPtr _output_schema;
     RowwiseIteratorUPtr _cur_iter = nullptr;
     StorageReadOptions _read_options;
     std::vector<RowwiseIteratorUPtr> _origin_iters;
@@ -409,7 +439,8 @@ Status VUnionIterator::init(const StorageReadOptions& opts) {
     _read_options = opts;
     _cur_iter = std::move(_origin_iters.back());
     RETURN_IF_ERROR(_cur_iter->init(_read_options));
-    _schema = &_cur_iter->schema();
+    // Use output_schema if provided; otherwise fall back to the underlying iterator's schema.
+    _schema = _output_schema ? _output_schema.get() : &_cur_iter->schema();
     return Status::OK();
 }
 
@@ -441,19 +472,20 @@ Status VUnionIterator::current_block_row_locations(std::vector<RowLocation>* loc
 
 RowwiseIteratorUPtr new_merge_iterator(std::vector<RowwiseIteratorUPtr>&& inputs,
                                        int sequence_id_idx, bool is_unique, bool is_reverse,
-                                       uint64_t* merged_rows) {
+                                       uint64_t* merged_rows, SchemaSPtr output_schema) {
     // when the size of inputs is 1, we also need to use VMergeIterator, because the
     // next_block_view function only be implemented in VMergeIterator. The reason why
     // the size of inputs is 1 is that the segment was filtered out by zone map or others.
     return std::make_unique<VMergeIterator>(std::move(inputs), sequence_id_idx, is_unique,
-                                            is_reverse, merged_rows);
+                                            is_reverse, merged_rows, std::move(output_schema));
 }
 
-RowwiseIteratorUPtr new_union_iterator(std::vector<RowwiseIteratorUPtr>&& inputs) {
+RowwiseIteratorUPtr new_union_iterator(std::vector<RowwiseIteratorUPtr>&& inputs,
+                                       SchemaSPtr output_schema) {
     if (inputs.size() == 1) {
         return std::move(inputs[0]);
     }
-    return std::make_unique<VUnionIterator>(std::move(inputs));
+    return std::make_unique<VUnionIterator>(std::move(inputs), std::move(output_schema));
 }
 
 RowwiseIterator* new_vstatistics_iterator(std::shared_ptr<Segment> segment, const Schema& schema) {

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -161,6 +161,11 @@ bool VMergeIteratorContext::compare(const VMergeIteratorContext& rhs) const {
 Status VMergeIteratorContext::copy_rows(Block* block, bool advanced) {
     Block& src = *_block;
     Block& dst = *block;
+    // src (_block) is built by block_reset() using the input schema, which may include
+    // delete predicate columns beyond the output schema. e.g. input={c1,c2,c3}, output={c1,c2}.
+    DCHECK_GE(src.columns(), _output_schema->num_column_ids());
+    // dst is built by the caller using the output schema (return_columns only).
+    DCHECK_EQ(dst.columns(), _output_schema->num_column_ids());
     if (_cur_batch_num == 0) {
         return Status::OK();
     }

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -396,7 +396,7 @@ public:
     // This class will delete all iterators when destructs
     // Client should not use iterators anymore.
     VUnionIterator(std::vector<RowwiseIteratorUPtr>&& v, SchemaSPtr output_schema)
-            : _origin_iters(std::move(v)), _output_schema(std::move(output_schema)) {}
+            : _output_schema(std::move(output_schema)), _origin_iters(std::move(v)) {}
 
     ~VUnionIterator() override = default;
 

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -98,20 +98,20 @@ Status VStatisticsIterator::next_batch(Block* block) {
     return Status::EndOfFile("End of VStatisticsIterator");
 }
 
-// Use _iter->schema() (input schema) to build the block, NOT the output schema.
-// The input schema includes all columns the SegmentIterator needs to fill, which may be
-// a superset of the output schema. For example, with a delete predicate "DELETE WHERE c3='foo'":
-//   - input schema  = {c1, c2, c3}  — c3 is needed for delete predicate evaluation
-//   - output schema = {c1, c2}      — c3 is not returned to the caller
-// SegmentIterator::_init_current_block() indexes into the block by input schema positions,
-// and _output_non_pred_columns() checks block->columns() to decide whether to output
-// the delete predicate column. So the block must match the input schema.
+// Build the block using the output schema, which contains only the columns
+// the caller requested (return_columns). Delete predicate columns are excluded
+// because SegmentIterator handles them independently:
+//   - _init_current_block() skips predicate columns (including delete predicates)
+//     via the _is_pred_column[cid] check, so it never accesses the block by those positions.
+//   - _output_non_pred_columns() checks loc < block->columns() before filling any column,
+//     so delete predicate columns (whose loc exceeds block->columns()) are simply skipped.
+//   - Delete predicate evaluation happens entirely through _current_return_columns and
+//     _evaluate_short_circuit_predicate(), which are independent of the block structure.
 Status VMergeIteratorContext::block_reset(const std::shared_ptr<Block>& block) {
     if (!block->columns()) {
-        const Schema& schema = _iter->schema();
-        const auto& column_ids = schema.column_ids();
-        for (size_t i = 0; i < schema.num_column_ids(); ++i) {
-            auto column_desc = schema.column(column_ids[i]);
+        const auto& column_ids = _output_schema->column_ids();
+        for (size_t i = 0; i < _output_schema->num_column_ids(); ++i) {
+            auto column_desc = _output_schema->column(column_ids[i]);
             auto data_type = Schema::get_data_type_ptr(*column_desc);
             if (data_type == nullptr) {
                 return Status::RuntimeError("invalid data type");
@@ -151,20 +151,14 @@ bool VMergeIteratorContext::compare(const VMergeIteratorContext& rhs) const {
     return result;
 }
 
-// Copy rows from the internal _block (built with input schema) to the destination block
-// (built with output schema). Only copy the first _output_schema->num_column_ids() columns,
-// which corresponds to the output schema. The source _block may have more columns than the
-// destination when delete predicates add extra columns. For example:
-//   - src (_block):  {c1, c2, c3}  — 3 columns (input schema, c3 for delete predicate)
-//   - dst (block):   {c1, c2}      — 2 columns (output schema)
-// We must NOT iterate over all src columns, otherwise we'd access dst out of bounds.
+// Copy rows from the internal _block to the destination block.
+// Both blocks are built with the output schema (return_columns only), so they
+// have the same number of columns. We iterate over _output_schema->num_column_ids()
+// columns to copy from src to dst.
 Status VMergeIteratorContext::copy_rows(Block* block, bool advanced) {
     Block& src = *_block;
     Block& dst = *block;
-    // src (_block) is built by block_reset() using the input schema, which may include
-    // delete predicate columns beyond the output schema. e.g. input={c1,c2,c3}, output={c1,c2}.
-    DCHECK_GE(src.columns(), _output_schema->num_column_ids());
-    // dst is built by the caller using the output schema (return_columns only).
+    DCHECK_EQ(src.columns(), _output_schema->num_column_ids());
     DCHECK_EQ(dst.columns(), _output_schema->num_column_ids());
     if (_cur_batch_num == 0) {
         return Status::OK();

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -296,10 +296,9 @@ Status VMergeIteratorContext::init(const StorageReadOptions& opts) {
     _block_row_max = opts.block_row_max;
     _record_rowids = opts.record_rowids;
     // _num_columns is the number of columns to copy in copy_rows().
-    // When output_schema is provided (merge path with possible delete predicates),
-    // use it; otherwise fall back to the full input schema (no extra columns).
-    _num_columns = _output_schema ? cast_set<int>(_output_schema->num_column_ids())
-                                  : cast_set<int>(_iter->schema().num_column_ids());
+    // output_schema only contains return_columns (excludes delete predicate columns),
+    // so copy_rows will only copy the columns the caller actually needs.
+    _num_columns = cast_set<int>(_output_schema->num_column_ids());
     RETURN_IF_ERROR(_load_next_block());
     if (valid()) {
         RETURN_IF_ERROR(advance());
@@ -364,9 +363,9 @@ Status VMergeIterator::init(const StorageReadOptions& opts) {
     if (_origin_iters.empty()) {
         return Status::OK();
     }
-    // Use output_schema if provided; otherwise fall back to the underlying iterator's schema
-    // (input schema). The output schema excludes delete predicate columns.
-    _schema = _output_schema ? _output_schema.get() : &(_origin_iters[0]->schema());
+    // Use output_schema to set the schema for this iterator.
+    // The output schema excludes delete predicate columns.
+    _schema = _output_schema.get();
     _record_rowids = opts.record_rowids;
 
     for (auto& iter : _origin_iters) {
@@ -439,8 +438,8 @@ Status VUnionIterator::init(const StorageReadOptions& opts) {
     _read_options = opts;
     _cur_iter = std::move(_origin_iters.back());
     RETURN_IF_ERROR(_cur_iter->init(_read_options));
-    // Use output_schema if provided; otherwise fall back to the underlying iterator's schema.
-    _schema = _output_schema ? _output_schema.get() : &_cur_iter->schema();
+    // Use output_schema to set the schema for this iterator.
+    _schema = _output_schema.get();
     return Status::OK();
 }
 

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -362,10 +362,9 @@ Status VMergeIterator::init(const StorageReadOptions& opts) {
     _record_rowids = opts.record_rowids;
 
     for (auto& iter : _origin_iters) {
-        auto ctx = std::make_shared<VMergeIteratorContext>(std::move(iter), _sequence_id_idx,
-                                                           _is_unique, _is_reverse,
-                                                           opts.read_orderby_key_columns,
-                                                           _output_schema);
+        auto ctx = std::make_shared<VMergeIteratorContext>(
+                std::move(iter), _sequence_id_idx, _is_unique, _is_reverse,
+                opts.read_orderby_key_columns, _output_schema);
         RETURN_IF_ERROR(ctx->init(opts));
         if (!ctx->valid()) {
             continue;

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -222,11 +222,11 @@ public:
     VMergeIterator(std::vector<RowwiseIteratorUPtr>&& iters, int sequence_id_idx, bool is_unique,
                    bool is_reverse, uint64_t* merged_rows, SchemaSPtr output_schema)
             : _origin_iters(std::move(iters)),
+              _output_schema(std::move(output_schema)),
               _sequence_id_idx(sequence_id_idx),
               _is_unique(is_unique),
               _is_reverse(is_reverse),
-              _merged_rows(merged_rows),
-              _output_schema(std::move(output_schema)) {}
+              _merged_rows(merged_rows) {}
 
     ~VMergeIterator() override = default;
 

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -363,7 +363,7 @@ RowwiseIteratorUPtr new_merge_iterator(std::vector<RowwiseIteratorUPtr>&& inputs
 //
 // Inputs iterators' ownership is taken by created union iterator.
 RowwiseIteratorUPtr new_union_iterator(std::vector<RowwiseIteratorUPtr>&& inputs,
-                                      SchemaSPtr output_schema);
+                                       SchemaSPtr output_schema);
 
 // Create an auto increment iterator which returns num_rows data in format of schema.
 // This class aims to be used in unit test.

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -94,7 +94,7 @@ public:
               _is_unique(is_unique),
               _is_reverse(is_reverse),
               _output_schema(std::move(output_schema)),
-              _num_key_columns(cast_set<int>(_iter->schema().num_key_columns())),
+              _num_key_columns(cast_set<int>(_output_schema->num_key_columns())),
               _compare_columns(read_orderby_key_columns) {}
 
     VMergeIteratorContext(const VMergeIteratorContext&) = delete;

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -128,7 +128,8 @@ public:
     bool compare(const VMergeIteratorContext& rhs) const;
 
     // Copy rows from internal _block to the destination block.
-    // Both blocks have the same columns (output schema = return_columns only).
+    // Both blocks have _output_schema columns (return_columns only).
+    // Only _output_schema->num_column_ids() columns are copied.
     //
     // `advanced = false` when current block finished
     // when input argument type is block, we do not process same_bit,

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -104,20 +104,22 @@ public:
 
     ~VMergeIteratorContext() = default;
 
-    // Reset (or initialize) the internal _block using the *input* schema from the underlying
-    // SegmentIterator (_iter->schema()), NOT the output schema.
+    // Reset (or initialize) the internal _block using the output schema.
     //
-    // The input schema may contain extra columns that are not in the output schema, such as
-    // delete predicate columns. For example, if the query reads columns {c1, c2} but
-    // there is a delete predicate on column c3 (e.g., "DELETE FROM t WHERE c3 = 'foo'"), then:
+    // The output schema contains only the columns the caller requested (return_columns),
+    // excluding delete predicate columns. For example, if the query reads columns {c1, c2}
+    // but there is a delete predicate on column c3 (e.g., "DELETE FROM t WHERE c3 = 'foo'"):
     //   - input schema  (iter->schema) = {c1, c2, c3}   (3 columns)
     //   - output schema                = {c1, c2}       (2 columns)
     //
-    // SegmentIterator internally relies on the block having all input schema columns:
-    //   - _init_current_block() accesses block->get_by_position(i) for all columns in input schema
-    //   - _output_non_pred_columns() uses block->columns() to decide whether to fill delete
-    //     predicate columns
-    // Therefore block_reset must create the block with the full input schema.
+    // It is safe to build the block with only the output schema because SegmentIterator
+    // handles delete predicate columns independently of the block structure:
+    //   - _init_current_block() skips predicate columns (including delete predicates)
+    //     via the _is_pred_column[cid] check, never accessing the block for them.
+    //   - _output_non_pred_columns() checks loc < block->columns() before filling any
+    //     column, so delete predicate columns are simply skipped when the block is smaller.
+    //   - Delete predicate evaluation uses _current_return_columns and
+    //     _evaluate_short_circuit_predicate(), independent of the block.
     Status block_reset(const std::shared_ptr<Block>& block);
 
     // Initialize this context and will prepare data for current_row()
@@ -125,10 +127,8 @@ public:
 
     bool compare(const VMergeIteratorContext& rhs) const;
 
-    // Copy rows from internal _block (which has input schema columns) to the destination block
-    // (which has output schema columns). Only the first _output_schema->num_column_ids() columns
-    // are copied, skipping any extra columns (e.g., delete predicate columns) that exist in
-    // _block but not in the destination.
+    // Copy rows from internal _block to the destination block.
+    // Both blocks have the same columns (output schema = return_columns only).
     //
     // `advanced = false` when current block finished
     // when input argument type is block, we do not process same_bit,
@@ -195,13 +195,13 @@ private:
     size_t _index_in_block = -1;
     // 4096 minus 16 + 16 bytes padding that in padding pod array
     int _block_row_max = 4064;
-    // The output schema defines which columns to copy to the caller's dst block.
-    // It may have fewer columns than _iter->schema() (the input schema) when delete
-    // predicates add extra columns. For example:
+    // The output schema defines which columns are in _block and in the caller's dst block.
+    // It contains only the requested return_columns, excluding delete predicate columns.
+    // For example:
     //   - _iter->schema() (input)  = {c1, c2, c3}  — c3 for "DELETE WHERE c3='foo'"
     //   - _output_schema           = {c1, c2}      — only the requested columns
-    // block_reset() uses _iter->schema() to build _block (SegmentIterator needs all columns),
-    // while copy_rows() uses _output_schema->num_column_ids() to copy only the output columns.
+    // block_reset() uses _output_schema to build _block, and copy_rows() iterates over
+    // _output_schema->num_column_ids() columns to copy from _block to the destination.
     const SchemaSPtr _output_schema;
     int _num_key_columns;
     std::vector<uint32_t>* _compare_columns;

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -87,12 +87,13 @@ private:
 class VMergeIteratorContext {
 public:
     VMergeIteratorContext(RowwiseIteratorUPtr&& iter, int sequence_id_idx, bool is_unique,
-                          bool is_reverse, std::vector<uint32_t>* read_orderby_key_columns)
+                          bool is_reverse, std::vector<uint32_t>* read_orderby_key_columns,
+                          SchemaSPtr output_schema)
             : _iter(std::move(iter)),
               _sequence_id_idx(sequence_id_idx),
               _is_unique(is_unique),
               _is_reverse(is_reverse),
-              _num_columns(cast_set<int>(_iter->schema().num_column_ids())),
+              _output_schema(std::move(output_schema)),
               _num_key_columns(cast_set<int>(_iter->schema().num_key_columns())),
               _compare_columns(read_orderby_key_columns) {}
 
@@ -103,6 +104,20 @@ public:
 
     ~VMergeIteratorContext() = default;
 
+    // Reset (or initialize) the internal _block using the *input* schema from the underlying
+    // SegmentIterator (_iter->schema()), NOT the output schema.
+    //
+    // The input schema may contain extra columns that are not in the output schema, such as
+    // delete predicate columns. For example, if the query reads columns {k, __ROWID__} but
+    // there is a delete predicate on column v1 (e.g., "DELETE FROM t WHERE v1 = 'foo'"), then:
+    //   - input schema  (iter->schema) = {k, __ROWID__, v1}   (3 columns)
+    //   - output schema                = {k, __ROWID__}       (2 columns)
+    //
+    // SegmentIterator internally relies on the block having all input schema columns:
+    //   - _init_current_block() accesses block->get_by_position(i) for all columns in input schema
+    //   - _output_non_pred_columns() uses block->columns() to decide whether to fill delete
+    //     predicate columns
+    // Therefore block_reset must create the block with the full input schema.
     Status block_reset(const std::shared_ptr<Block>& block);
 
     // Initialize this context and will prepare data for current_row()
@@ -110,6 +125,11 @@ public:
 
     bool compare(const VMergeIteratorContext& rhs) const;
 
+    // Copy rows from internal _block (which has input schema columns) to the destination block
+    // (which has output schema columns). Only the first _output_schema->num_column_ids() columns
+    // are copied, skipping any extra columns (e.g., delete predicate columns) that exist in
+    // _block but not in the destination.
+    //
     // `advanced = false` when current block finished
     // when input argument type is block, we do not process same_bit,
     // this case we only need merge and return ordered data (VCollectIterator::_topn_next), data mode is dup/mow can guarantee all rows are different
@@ -175,6 +195,16 @@ private:
     size_t _index_in_block = -1;
     // 4096 minus 16 + 16 bytes padding that in padding pod array
     int _block_row_max = 4064;
+    // The output schema defines which columns to copy to the caller's dst block.
+    // It may have fewer columns than _iter->schema() (the input schema) when delete
+    // predicates add extra columns. For example:
+    //   - _iter->schema() (input)  = {k, __ROWID__, v1}  — v1 for "DELETE WHERE v1='foo'"
+    //   - _output_schema           = {k, __ROWID__}      — only the requested columns
+    // block_reset() uses _iter->schema() to build _block (SegmentIterator needs all columns),
+    // while copy_rows() uses _num_columns (from _output_schema) to copy only the output columns.
+    SchemaSPtr _output_schema;
+    // Number of columns in the output schema. Used as the loop bound in copy_rows() to avoid
+    // accessing columns in the dst block that don't exist (when input schema > output schema).
     int _num_columns;
     int _num_key_columns;
     std::vector<uint32_t>* _compare_columns;
@@ -193,12 +223,13 @@ class VMergeIterator : public RowwiseIterator {
 public:
     // VMergeIterator takes the ownership of input iterators
     VMergeIterator(std::vector<RowwiseIteratorUPtr>&& iters, int sequence_id_idx, bool is_unique,
-                   bool is_reverse, uint64_t* merged_rows)
+                   bool is_reverse, uint64_t* merged_rows, SchemaSPtr output_schema)
             : _origin_iters(std::move(iters)),
               _sequence_id_idx(sequence_id_idx),
               _is_unique(is_unique),
               _is_reverse(is_reverse),
-              _merged_rows(merged_rows) {}
+              _merged_rows(merged_rows),
+              _output_schema(std::move(output_schema)) {}
 
     ~VMergeIterator() override = default;
 
@@ -295,6 +326,9 @@ private:
     std::vector<RowwiseIteratorUPtr> _origin_iters;
 
     const Schema* _schema = nullptr;
+    // The output schema (excludes delete predicate columns). Passed down to each
+    // VMergeIteratorContext to control how many columns copy_rows() copies.
+    SchemaSPtr _output_schema;
 
     struct VMergeContextComparator {
         bool operator()(const std::shared_ptr<VMergeIteratorContext>& lhs,
@@ -326,13 +360,14 @@ private:
 // should delete returned iterator after usage.
 RowwiseIteratorUPtr new_merge_iterator(std::vector<RowwiseIteratorUPtr>&& inputs,
                                        int sequence_id_idx, bool is_unique, bool is_reverse,
-                                       uint64_t* merged_rows);
+                                       uint64_t* merged_rows, SchemaSPtr output_schema);
 
 // Create a union iterator for input iterators. Union iterator will read
 // input iterators one by one.
 //
 // Inputs iterators' ownership is taken by created union iterator.
-RowwiseIteratorUPtr new_union_iterator(std::vector<RowwiseIteratorUPtr>&& inputs);
+RowwiseIteratorUPtr new_union_iterator(std::vector<RowwiseIteratorUPtr>&& inputs,
+                                      SchemaSPtr output_schema);
 
 // Create an auto increment iterator which returns num_rows data in format of schema.
 // This class aims to be used in unit test.

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -108,10 +108,10 @@ public:
     // SegmentIterator (_iter->schema()), NOT the output schema.
     //
     // The input schema may contain extra columns that are not in the output schema, such as
-    // delete predicate columns. For example, if the query reads columns {k, __ROWID__} but
-    // there is a delete predicate on column v1 (e.g., "DELETE FROM t WHERE v1 = 'foo'"), then:
-    //   - input schema  (iter->schema) = {k, __ROWID__, v1}   (3 columns)
-    //   - output schema                = {k, __ROWID__}       (2 columns)
+    // delete predicate columns. For example, if the query reads columns {c1, c2} but
+    // there is a delete predicate on column c3 (e.g., "DELETE FROM t WHERE c3 = 'foo'"), then:
+    //   - input schema  (iter->schema) = {c1, c2, c3}   (3 columns)
+    //   - output schema                = {c1, c2}       (2 columns)
     //
     // SegmentIterator internally relies on the block having all input schema columns:
     //   - _init_current_block() accesses block->get_by_position(i) for all columns in input schema
@@ -198,14 +198,11 @@ private:
     // The output schema defines which columns to copy to the caller's dst block.
     // It may have fewer columns than _iter->schema() (the input schema) when delete
     // predicates add extra columns. For example:
-    //   - _iter->schema() (input)  = {k, __ROWID__, v1}  — v1 for "DELETE WHERE v1='foo'"
-    //   - _output_schema           = {k, __ROWID__}      — only the requested columns
+    //   - _iter->schema() (input)  = {c1, c2, c3}  — c3 for "DELETE WHERE c3='foo'"
+    //   - _output_schema           = {c1, c2}      — only the requested columns
     // block_reset() uses _iter->schema() to build _block (SegmentIterator needs all columns),
-    // while copy_rows() uses _num_columns (from _output_schema) to copy only the output columns.
-    SchemaSPtr _output_schema;
-    // Number of columns in the output schema. Used as the loop bound in copy_rows() to avoid
-    // accessing columns in the dst block that don't exist (when input schema > output schema).
-    int _num_columns;
+    // while copy_rows() uses _output_schema->num_column_ids() to copy only the output columns.
+    const SchemaSPtr _output_schema;
     int _num_key_columns;
     std::vector<uint32_t>* _compare_columns;
     std::vector<RowLocation> _block_row_locations;
@@ -241,7 +238,7 @@ public:
     }
     Status next_batch(BlockView* block_view) override { return _next_batch(block_view); }
 
-    const Schema& schema() const override { return *_schema; }
+    const Schema& schema() const override { return *_output_schema; }
 
     Status current_block_row_locations(std::vector<RowLocation>* block_row_locations) override {
         DCHECK(_record_rowids);
@@ -325,10 +322,9 @@ private:
     // It will be released after '_merge_heap' has been built.
     std::vector<RowwiseIteratorUPtr> _origin_iters;
 
-    const Schema* _schema = nullptr;
     // The output schema (excludes delete predicate columns). Passed down to each
     // VMergeIteratorContext to control how many columns copy_rows() copies.
-    SchemaSPtr _output_schema;
+    const SchemaSPtr _output_schema;
 
     struct VMergeContextComparator {
         bool operator()(const std::shared_ptr<VMergeIteratorContext>& lhs,

--- a/be/test/vec/exec/vgeneric_iterators_test.cpp
+++ b/be/test/vec/exec/vgeneric_iterators_test.cpp
@@ -110,7 +110,7 @@ TEST(VGenericIteratorsTest, Union) {
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 200));
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 300));
 
-    auto iter = vectorized::new_union_iterator(std::move(inputs));
+    auto iter = vectorized::new_union_iterator(std::move(inputs), nullptr);
     StorageReadOptions opts;
     auto st = iter->init(opts);
     EXPECT_TRUE(st.ok());
@@ -154,7 +154,8 @@ TEST(VGenericIteratorsTest, MergeAgg) {
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 200));
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 300));
 
-    auto iter = vectorized::new_merge_iterator(std::move(inputs), -1, false, false, nullptr);
+    auto iter = vectorized::new_merge_iterator(std::move(inputs), -1, false, false, nullptr,
+                                                nullptr);
     StorageReadOptions opts;
     auto st = iter->init(opts);
     EXPECT_TRUE(st.ok());
@@ -203,7 +204,8 @@ TEST(VGenericIteratorsTest, MergeUnique) {
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 200));
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 300));
 
-    auto iter = vectorized::new_merge_iterator(std::move(inputs), -1, true, false, nullptr);
+    auto iter = vectorized::new_merge_iterator(std::move(inputs), -1, true, false, nullptr,
+                                                nullptr);
     StorageReadOptions opts;
     auto st = iter->init(opts);
     EXPECT_TRUE(st.ok());
@@ -325,8 +327,8 @@ TEST(VGenericIteratorsTest, MergeWithSeqColumn) {
                 schema, num_rows, rows_begin, seq_column_id, seq_id_in_every_file));
     }
 
-    auto iter =
-            vectorized::new_merge_iterator(std::move(inputs), seq_column_id, true, false, nullptr);
+    auto iter = vectorized::new_merge_iterator(std::move(inputs), seq_column_id, true, false,
+                                                nullptr, nullptr);
     StorageReadOptions opts;
     auto st = iter->init(opts);
     EXPECT_TRUE(st.ok());

--- a/be/test/vec/exec/vgeneric_iterators_test.cpp
+++ b/be/test/vec/exec/vgeneric_iterators_test.cpp
@@ -157,7 +157,7 @@ TEST(VGenericIteratorsTest, MergeAgg) {
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 300));
 
     auto iter = vectorized::new_merge_iterator(std::move(inputs), -1, false, false, nullptr,
-                                                schema_ptr);
+                                               schema_ptr);
     StorageReadOptions opts;
     auto st = iter->init(opts);
     EXPECT_TRUE(st.ok());
@@ -207,8 +207,8 @@ TEST(VGenericIteratorsTest, MergeUnique) {
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 200));
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 300));
 
-    auto iter = vectorized::new_merge_iterator(std::move(inputs), -1, true, false, nullptr,
-                                                schema_ptr);
+    auto iter =
+            vectorized::new_merge_iterator(std::move(inputs), -1, true, false, nullptr, schema_ptr);
     StorageReadOptions opts;
     auto st = iter->init(opts);
     EXPECT_TRUE(st.ok());
@@ -332,7 +332,7 @@ TEST(VGenericIteratorsTest, MergeWithSeqColumn) {
     }
 
     auto iter = vectorized::new_merge_iterator(std::move(inputs), seq_column_id, true, false,
-                                                nullptr, schema_ptr);
+                                               nullptr, schema_ptr);
     StorageReadOptions opts;
     auto st = iter->init(opts);
     EXPECT_TRUE(st.ok());

--- a/be/test/vec/exec/vgeneric_iterators_test.cpp
+++ b/be/test/vec/exec/vgeneric_iterators_test.cpp
@@ -104,13 +104,14 @@ TEST(VGenericIteratorsTest, AutoIncrement) {
 
 TEST(VGenericIteratorsTest, Union) {
     auto schema = create_schema();
+    auto schema_ptr = std::make_shared<Schema>(schema);
     std::vector<RowwiseIteratorUPtr> inputs;
 
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 100));
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 200));
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 300));
 
-    auto iter = vectorized::new_union_iterator(std::move(inputs), nullptr);
+    auto iter = vectorized::new_union_iterator(std::move(inputs), schema_ptr);
     StorageReadOptions opts;
     auto st = iter->init(opts);
     EXPECT_TRUE(st.ok());
@@ -148,6 +149,7 @@ TEST(VGenericIteratorsTest, Union) {
 TEST(VGenericIteratorsTest, MergeAgg) {
     EXPECT_TRUE(1);
     auto schema = create_schema();
+    auto schema_ptr = std::make_shared<Schema>(schema);
     std::vector<RowwiseIteratorUPtr> inputs;
 
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 100));
@@ -155,7 +157,7 @@ TEST(VGenericIteratorsTest, MergeAgg) {
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 300));
 
     auto iter = vectorized::new_merge_iterator(std::move(inputs), -1, false, false, nullptr,
-                                                nullptr);
+                                                schema_ptr);
     StorageReadOptions opts;
     auto st = iter->init(opts);
     EXPECT_TRUE(st.ok());
@@ -198,6 +200,7 @@ TEST(VGenericIteratorsTest, MergeAgg) {
 TEST(VGenericIteratorsTest, MergeUnique) {
     EXPECT_TRUE(1);
     auto schema = create_schema();
+    auto schema_ptr = std::make_shared<Schema>(schema);
     std::vector<RowwiseIteratorUPtr> inputs;
 
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 100));
@@ -205,7 +208,7 @@ TEST(VGenericIteratorsTest, MergeUnique) {
     inputs.push_back(vectorized::new_auto_increment_iterator(schema, 300));
 
     auto iter = vectorized::new_merge_iterator(std::move(inputs), -1, true, false, nullptr,
-                                                nullptr);
+                                                schema_ptr);
     StorageReadOptions opts;
     auto st = iter->init(opts);
     EXPECT_TRUE(st.ok());
@@ -312,6 +315,7 @@ public:
 TEST(VGenericIteratorsTest, MergeWithSeqColumn) {
     EXPECT_TRUE(1);
     auto schema = create_schema();
+    auto schema_ptr = std::make_shared<Schema>(schema);
     std::vector<RowwiseIteratorUPtr> inputs;
 
     int seq_column_id = 2;
@@ -328,7 +332,7 @@ TEST(VGenericIteratorsTest, MergeWithSeqColumn) {
     }
 
     auto iter = vectorized::new_merge_iterator(std::move(inputs), seq_column_id, true, false,
-                                                nullptr, nullptr);
+                                                nullptr, schema_ptr);
     StorageReadOptions opts;
     auto st = iter->init(opts);
     EXPECT_TRUE(st.ok());


### PR DESCRIPTION
### What problem does this PR solve?

https://github.com/apache/doris/pull/60772 This PR want to fix topn bug, In merge iterator, should always use input schema to generate block.  But schema change process will generate a ref block contains delete predicate in https://github.com/apache/doris/pull/57191. So the code is very complex, So that in this PR, I simplify all the logic:
1. add a input schema to merge iterator.
2. using input schema in all merge iterator and union iterator.
3. change schema change logic not use delete predicate column.

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

