### PR TITLE
[fix](search) Fix MATCH_ALL_DOCS query failing in multi-field search mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SearchDslParser.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SearchDslParser.java
@@ -453,6 +453,11 @@ public class SearchDslParser {
 
             // Extract field bindings from expanded AST
             Set<String> fieldNames = collectFieldNames(expandedRoot);
+            // If no fields were collected (e.g., MATCH_ALL_DOCS query that matches all docs
+            // regardless of field), use the original fields list to ensure proper push-down
+            if (fieldNames.isEmpty()) {
+                fieldNames = new LinkedHashSet<>(fields);
+            }
             List<QsFieldBinding> bindings = new ArrayList<>();
             int slotIndex = 0;
             for (String fieldName : fieldNames) {
@@ -533,6 +538,11 @@ public class SearchDslParser {
 
             // Extract field bindings from expanded AST
             Set<String> fieldNames = collectFieldNames(expandedRoot);
+            // If no fields were collected (e.g., MATCH_ALL_DOCS query that matches all docs
+            // regardless of field), use the original fields list to ensure proper push-down
+            if (fieldNames.isEmpty()) {
+                fieldNames = new LinkedHashSet<>(fields);
+            }
             List<QsFieldBinding> bindings = new ArrayList<>();
             int slotIndex = 0;
             for (String fieldName : fieldNames) {

--- a/regression-test/data/search/test_search_multi_field.out
+++ b/regression-test/data/search/test_search_multi_field.out
@@ -122,3 +122,15 @@
 1	machine learning basics
 9	machine guide
 
+-- !multi_field_match_all_best_fields --
+9
+
+-- !multi_field_match_all_cross_fields --
+9
+
+-- !match_all_single_field --
+9
+
+-- !multi_field_match_all_standard --
+9
+

--- a/regression-test/suites/search/test_search_multi_field.groovy
+++ b/regression-test/suites/search/test_search_multi_field.groovy
@@ -294,6 +294,36 @@ suite("test_search_multi_field") {
         ORDER BY id
     """
 
+    // ============ Test 23: MATCH_ALL_DOCS (*) with best_fields + lucene mode ============
+    // Regression test for DORIS-24536: search('*', ...) with multi-field should not error
+    // "*" is a match-all query that should return all rows
+    qt_multi_field_match_all_best_fields """
+        SELECT /*+SET_VAR(enable_common_expr_pushdown=true) */ count(*)
+        FROM ${tableName}
+        WHERE search('*', '{"fields":["title","content"],"type":"best_fields","default_operator":"AND","mode":"lucene","minimum_should_match":0}')
+    """
+
+    // ============ Test 24: MATCH_ALL_DOCS (*) with cross_fields + lucene mode ============
+    qt_multi_field_match_all_cross_fields """
+        SELECT /*+SET_VAR(enable_common_expr_pushdown=true) */ count(*)
+        FROM ${tableName}
+        WHERE search('*', '{"fields":["title","content"],"type":"cross_fields","default_operator":"AND","mode":"lucene","minimum_should_match":0}')
+    """
+
+    // ============ Test 25: MATCH_ALL_DOCS (*) with single default_field + lucene mode ============
+    qt_match_all_single_field """
+        SELECT /*+SET_VAR(enable_common_expr_pushdown=true) */ count(*)
+        FROM ${tableName}
+        WHERE search('*', '{"default_field":"title","default_operator":"AND","mode":"lucene","minimum_should_match":0}')
+    """
+
+    // ============ Test 26: MATCH_ALL_DOCS (*) with best_fields standard mode (no lucene) ============
+    qt_multi_field_match_all_standard """
+        SELECT /*+SET_VAR(enable_common_expr_pushdown=true) */ count(*)
+        FROM ${tableName}
+        WHERE search('*', '{"fields":["title","content"],"type":"best_fields","default_operator":"AND"}')
+    """
+
     // Cleanup
     sql "DROP TABLE IF EXISTS ${tableName}"
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close 

Problem Summary:

When using `search('*', ...)` with multi-field options (`fields` parameter), the query fails with:
```
only inverted index queries are supported
```

The root cause is in `SearchDslParser.java`: the multi-field parsing methods (`parseDslMultiFieldMode` and `parseDslMultiFieldLuceneMode`) collect field bindings by calling `collectFieldNames()` on the expanded AST. When the query is `*` (match all), the AST node is `MATCH_ALL_DOCS` which has no field set — by design it matches all documents regardless of field. This caused `collectFieldNames` to return an empty set, resulting in no field bindings. Without field bindings, `RewriteSearchToSlots` couldn't create slot references, so the search expression was never pushed down to the inverted index path, and BE fell back to `execute_impl()` which returns the error.

**Fix**: After `collectFieldNames()`, if the result is empty, fall back to using the original `fields` list as field bindings. This ensures the push-down mechanism works for `MATCH_ALL_DOCS` queries.

**Reproducing queries** (from bug report):
```sql
select count(*) from wikipedia where search('*', '{"fields":["title", "content"], "type": "best_fields", "default_operator":"AND","mode":"lucene", "minimum_should_match": 0}');

select count(*) from wikipedia where search('*', '{"default_field": "title", "default_operator":"AND","mode":"lucene", "minimum_should_match": 0}');
```

### Release note

Fix search('*', ...) with multi-field mode failing with "only inverted index queries are supported" error.

### Check List (For Author)

- Test
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] Yes. `search('*', ...)` with `fields` parameter now correctly matches all documents instead of erroring.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label