### PR TITLE
[fix](search) Validate mode parameter in search() DSL options

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SearchDslParser.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SearchDslParser.java
@@ -1834,12 +1834,21 @@ public class SearchDslParser {
         /**
          * Validate the options after deserialization.
          * Checks for:
+         * - mode is "standard" or "lucene"
          * - Mutual exclusion between fields and default_field
          * - minimum_should_match is non-negative if specified
          *
          * @throws IllegalArgumentException if validation fails
          */
         public void validate() {
+            // Validation: mode must be "standard" or "lucene"
+            if (mode != null) {
+                String normalizedMode = mode.trim().toLowerCase();
+                if (!"standard".equals(normalizedMode) && !"lucene".equals(normalizedMode)) {
+                    throw new IllegalArgumentException(
+                            "'mode' must be 'standard' or 'lucene', got: " + mode);
+                }
+            }
             // Validation: fields and default_field are mutually exclusive
             if (fields != null && !fields.isEmpty()
                     && defaultField != null && !defaultField.isEmpty()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SearchDslParser.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SearchDslParser.java
@@ -1848,6 +1848,7 @@ public class SearchDslParser {
                     throw new IllegalArgumentException(
                             "'mode' must be 'standard' or 'lucene', got: " + mode);
                 }
+                this.mode = normalizedMode;
             }
             // Validation: fields and default_field are mutually exclusive
             if (fields != null && !fields.isEmpty()

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SearchDslParserTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SearchDslParserTest.java
@@ -1618,6 +1618,18 @@ public class SearchDslParserTest {
     }
 
     @Test
+    public void testInvalidMode() {
+        // Test: invalid mode value should throw exception
+        String dsl = "hello";
+        String options = "{\"default_field\":\"title\",\"mode\":\"lucenedfafa\"}";
+
+        IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            SearchDslParser.parseDsl(dsl, options);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("'mode' must be 'standard' or 'lucene'"));
+    }
+
+    @Test
     public void testMultiFieldSingleTermSameResultForBothTypes() {
         // Test: single term should have same structure for both types
         // since there's only one term, no difference between best_fields and cross_fields


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #DORIS-24352

Problem Summary:
When using `search()` with an invalid `mode` value in the options JSON (e.g., `"mode":"lucenedfafa"`), the query silently falls back to standard mode instead of reporting an error. This makes it difficult for users to detect typos or misconfiguration.

This PR adds validation in `SearchOptions.validate()` to reject any mode value other than `"standard"` or `"lucene"`, throwing a clear error message.

### Release note

Fix search() DSL to report an error when an invalid mode value is specified instead of silently falling back to standard mode.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] Yes. Previously, invalid mode values were silently accepted and treated as "standard" mode. Now they throw an `IllegalArgumentException` with a descriptive message.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label