### PR TITLE
[feat](search) Add searcher cache reuse and DSL result cache for search() function

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1243,6 +1243,9 @@ DEFINE_Int32(inverted_index_query_cache_shards, "256");
 // inverted index match bitmap cache size
 DEFINE_String(inverted_index_query_cache_limit, "10%");
 
+// search() function DSL result cache size
+DEFINE_String(search_function_query_cache_limit, "10%");
+
 // condition cache limit
 DEFINE_Int16(condition_cache_limit, "512");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1273,6 +1273,9 @@ DECLARE_Int32(inverted_index_query_cache_shards);
 // inverted index match bitmap cache size
 DECLARE_String(inverted_index_query_cache_limit);
 
+// search() function DSL result cache size
+DECLARE_String(search_function_query_cache_limit);
+
 // condition cache limit
 DECLARE_Int16(condition_cache_limit);
 

--- a/be/src/olap/rowset/segment_v2/index_file_reader.h
+++ b/be/src/olap/rowset/segment_v2/index_file_reader.h
@@ -66,6 +66,7 @@ public:
     void debug_file_entries();
     std::string get_index_file_cache_key(const TabletIndex* index_meta) const;
     std::string get_index_file_path(const TabletIndex* index_meta) const;
+    const std::string& get_index_path_prefix() const { return _index_path_prefix; }
     Status index_file_exist(const TabletIndex* index_meta, bool* res) const;
     Status has_null(const TabletIndex* index_meta, bool* res) const;
     Result<InvertedIndexDirectoryMap> get_all_directories();

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
@@ -141,4 +141,35 @@ void InvertedIndexQueryCache::insert(const CacheKey& key, std::shared_ptr<roarin
     *handle = InvertedIndexQueryCacheHandle(this, lru_handle);
 }
 
+bool SearchFunctionQueryCache::lookup(const CacheKey& key, InvertedIndexQueryCacheHandle* handle) {
+    auto encoded = key.encode();
+    if (encoded.empty()) {
+        return false;
+    }
+    auto* lru_handle = LRUCachePolicy::lookup(encoded);
+    if (lru_handle == nullptr) {
+        return false;
+    }
+    *handle = InvertedIndexQueryCacheHandle(this, lru_handle);
+    return true;
+}
+
+void SearchFunctionQueryCache::insert(const CacheKey& key,
+                                      std::shared_ptr<roaring::Roaring> result_bitmap,
+                                      std::shared_ptr<roaring::Roaring> null_bitmap,
+                                      InvertedIndexQueryCacheHandle* handle) {
+    auto encoded = key.encode();
+    if (encoded.empty()) {
+        return;
+    }
+    auto cache_value = std::make_unique<SearchFunctionQueryCache::CacheValue>();
+    cache_value->result_bitmap = std::move(result_bitmap);
+    cache_value->null_bitmap = std::move(null_bitmap);
+    size_t mem_size = cache_value->result_bitmap->getSizeInBytes() +
+                      cache_value->null_bitmap->getSizeInBytes();
+    auto* lru_handle = LRUCachePolicy::insert(encoded, cache_value.release(), mem_size, mem_size,
+                                              CachePriority::NORMAL);
+    *handle = InvertedIndexQueryCacheHandle(this, lru_handle);
+}
+
 } // namespace doris::segment_v2

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
@@ -165,8 +165,9 @@ void SearchFunctionQueryCache::insert(const CacheKey& key,
     auto cache_value = std::make_unique<SearchFunctionQueryCache::CacheValue>();
     cache_value->result_bitmap = std::move(result_bitmap);
     cache_value->null_bitmap = std::move(null_bitmap);
-    size_t mem_size = cache_value->result_bitmap->getSizeInBytes() +
-                      cache_value->null_bitmap->getSizeInBytes();
+    size_t mem_size =
+            (cache_value->result_bitmap ? cache_value->result_bitmap->getSizeInBytes() : 0) +
+            (cache_value->null_bitmap ? cache_value->null_bitmap->getSizeInBytes() : 0);
     auto* lru_handle = LRUCachePolicy::insert(encoded, cache_value.release(), mem_size, mem_size,
                                               CachePriority::NORMAL);
     *handle = InvertedIndexQueryCacheHandle(this, lru_handle);

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.h
@@ -274,12 +274,63 @@ public:
         return ((InvertedIndexQueryCache::CacheValue*)_cache->value(_handle))->bitmap;
     }
 
+    void* get_value() const {
+        if (!_cache || !_handle) {
+            return nullptr;
+        }
+        return _cache->value(_handle);
+    }
+
 private:
     LRUCachePolicy* _cache = nullptr;
     Cache::Handle* _handle = nullptr;
 
     // Don't allow copy and assign
     DISALLOW_COPY_AND_ASSIGN(InvertedIndexQueryCacheHandle);
+};
+
+// Cache for search() function DSL query results per segment.
+// Caches the final roaring::Roaring bitmap so repeated identical DSL queries
+// against the same segment skip Lucene execution entirely.
+class SearchFunctionQueryCache : public LRUCachePolicy {
+public:
+    using LRUCachePolicy::insert;
+
+    struct CacheKey {
+        std::string segment_prefix; // index_path_prefix, identifies the segment
+        std::string dsl_signature;  // encode(original_dsl, field_bindings)
+
+        std::string encode() const { return segment_prefix + "#" + dsl_signature; }
+    };
+
+    class CacheValue : public LRUCacheValueBase {
+    public:
+        std::shared_ptr<roaring::Roaring> result_bitmap;
+        std::shared_ptr<roaring::Roaring> null_bitmap;
+    };
+
+    static SearchFunctionQueryCache* create_global_cache(size_t capacity,
+                                                         uint32_t num_shards = 16) {
+        return new SearchFunctionQueryCache(capacity, num_shards);
+    }
+
+    static SearchFunctionQueryCache* instance() {
+        return ExecEnv::GetInstance()->get_search_function_query_cache();
+    }
+
+    SearchFunctionQueryCache() = delete;
+
+    SearchFunctionQueryCache(size_t capacity, uint32_t num_shards)
+            : LRUCachePolicy(CachePolicy::CacheType::SEARCH_FUNCTION_QUERY_CACHE, capacity,
+                             LRUCacheType::SIZE, config::inverted_index_cache_stale_sweep_time_sec,
+                             num_shards, /*element_count_capacity*/ 0, /*enable_prune*/ true,
+                             /*is_lru_k*/ true) {}
+
+    bool lookup(const CacheKey& key, InvertedIndexQueryCacheHandle* handle);
+
+    void insert(const CacheKey& key, std::shared_ptr<roaring::Roaring> result_bitmap,
+                std::shared_ptr<roaring::Roaring> null_bitmap,
+                InvertedIndexQueryCacheHandle* handle);
 };
 
 } // namespace segment_v2

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -69,6 +69,7 @@ class PackedFileManager;
 namespace segment_v2 {
 class InvertedIndexSearcherCache;
 class InvertedIndexQueryCache;
+class SearchFunctionQueryCache;
 class ConditionCache;
 class TmpFileDirs;
 class EncodingInfoResolver;
@@ -386,6 +387,9 @@ public:
     segment_v2::InvertedIndexQueryCache* get_inverted_index_query_cache() {
         return _inverted_index_query_cache;
     }
+    segment_v2::SearchFunctionQueryCache* get_search_function_query_cache() {
+        return _search_function_query_cache;
+    }
     segment_v2::ConditionCache* get_condition_cache() { return _condition_cache; }
     segment_v2::EncodingInfoResolver* get_encoding_info_resolver() {
         return _encoding_info_resolver;
@@ -545,6 +549,7 @@ private:
     HeapProfiler* _heap_profiler = nullptr;
     segment_v2::InvertedIndexSearcherCache* _inverted_index_searcher_cache = nullptr;
     segment_v2::InvertedIndexQueryCache* _inverted_index_query_cache = nullptr;
+    segment_v2::SearchFunctionQueryCache* _search_function_query_cache = nullptr;
     segment_v2::ConditionCache* _condition_cache = nullptr;
     segment_v2::EncodingInfoResolver* _encoding_info_resolver = nullptr;
     QueryCache* _query_cache = nullptr;

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -640,8 +640,21 @@ Status ExecEnv::init_mem_env() {
     _inverted_index_query_cache = InvertedIndexQueryCache::create_global_cache(
             inverted_index_query_cache_limit, config::inverted_index_query_cache_shards);
     LOG(INFO) << "Inverted index query match cache memory limit: "
-              << PrettyPrinter::print(inverted_index_cache_limit, TUnit::BYTES)
+              << PrettyPrinter::print(inverted_index_query_cache_limit, TUnit::BYTES)
               << ", origin config value: " << config::inverted_index_query_cache_limit;
+
+    // use memory limit
+    int64_t search_function_query_cache_limit =
+            ParseUtil::parse_mem_spec(config::search_function_query_cache_limit,
+                                      MemInfo::mem_limit(), MemInfo::physical_mem(), &is_percent);
+    while (!is_percent && search_function_query_cache_limit > MemInfo::mem_limit() / 2) {
+        search_function_query_cache_limit = search_function_query_cache_limit / 2;
+    }
+    _search_function_query_cache =
+            SearchFunctionQueryCache::create_global_cache(search_function_query_cache_limit, 256);
+    LOG(INFO) << "Search function query cache memory limit: "
+              << PrettyPrinter::print(search_function_query_cache_limit, TUnit::BYTES)
+              << ", origin config value: " << config::search_function_query_cache_limit;
 
     // use memory limit
     int64_t condition_cache_limit = config::condition_cache_limit * 1024L * 1024L;
@@ -839,6 +852,7 @@ void ExecEnv::destroy() {
 
     SAFE_DELETE(_load_channel_mgr);
 
+    SAFE_DELETE(_search_function_query_cache);
     SAFE_DELETE(_inverted_index_query_cache);
     SAFE_DELETE(_inverted_index_searcher_cache);
     SAFE_DELETE(_condition_cache);

--- a/be/src/runtime/memory/cache_policy.h
+++ b/be/src/runtime/memory/cache_policy.h
@@ -57,6 +57,7 @@ public:
         TABLET_COLUMN_OBJECT_POOL = 21,
         SCHEMA_CLOUD_DICTIONARY_CACHE = 22,
         CONDITION_CACHE = 23,
+        SEARCH_FUNCTION_QUERY_CACHE = 24,
     };
 
     static std::string type_string(CacheType type) {
@@ -107,6 +108,8 @@ public:
             return "SchemaCloudDictionaryCache";
         case CacheType::CONDITION_CACHE:
             return "ConditionCache";
+        case CacheType::SEARCH_FUNCTION_QUERY_CACHE:
+            return "SearchFunctionQueryCache";
         default:
             throw Exception(Status::FatalError("not match type of cache policy :{}",
                                                static_cast<int>(type)));
@@ -136,6 +139,7 @@ public:
             {"ForUTCacheNumber", CacheType::FOR_UT_CACHE_NUMBER},
             {"QueryCache", CacheType::QUERY_CACHE},
             {"TabletColumnObjectPool", CacheType::TABLET_COLUMN_OBJECT_POOL},
+            {"SearchFunctionQueryCache", CacheType::SEARCH_FUNCTION_QUERY_CACHE},
     };
 
     static CacheType string_to_type(std::string type) {

--- a/be/src/vec/functions/function_search.cpp
+++ b/be/src/vec/functions/function_search.cpp
@@ -49,6 +49,7 @@
 #include "olap/rowset/segment_v2/inverted_index/util/string_helper.h"
 #include "olap/rowset/segment_v2/inverted_index_iterator.h"
 #include "olap/rowset/segment_v2/inverted_index_reader.h"
+#include "olap/rowset/segment_v2/inverted_index_searcher.h"
 #include "util/string_util.h"
 #include "vec/columns/column_const.h"
 #include "vec/core/columns_with_type_and_name.h"
@@ -56,6 +57,58 @@
 #include "vec/functions/simple_function_factory.h"
 
 namespace doris::vectorized {
+
+// Build canonical DSL signature for SearchFunctionQueryCache key.
+// Includes original DSL + sorted field bindings with index metadata.
+static std::string build_dsl_signature(const TSearchParam& param) {
+    std::string sig = param.original_dsl;
+    sig += '#';
+    // Sort field bindings by field_name for canonical ordering
+    std::vector<const TSearchFieldBinding*> sorted_bindings;
+    sorted_bindings.reserve(param.field_bindings.size());
+    for (const auto& fb : param.field_bindings) {
+        sorted_bindings.push_back(&fb);
+    }
+    std::sort(sorted_bindings.begin(), sorted_bindings.end(),
+              [](const TSearchFieldBinding* a, const TSearchFieldBinding* b) {
+                  return a->field_name < b->field_name;
+              });
+    for (const auto* fb : sorted_bindings) {
+        sig += fb->field_name;
+        sig += '=';
+        if (fb->__isset.index_properties) {
+            auto it = fb->index_properties.find("index_id");
+            if (it != fb->index_properties.end()) {
+                sig += it->second;
+            }
+        }
+        sig += ';';
+    }
+    return sig;
+}
+
+// Extract segment path prefix from the first available inverted index iterator.
+// All fields in the same segment share the same path prefix.
+static std::string extract_segment_prefix(
+        const std::unordered_map<std::string, IndexIterator*>& iterators) {
+    for (const auto& [field_name, iter] : iterators) {
+        auto* inv_iter = dynamic_cast<InvertedIndexIterator*>(iter);
+        if (!inv_iter) continue;
+        // Try fulltext reader first, then string type
+        for (auto type :
+             {InvertedIndexReaderType::FULLTEXT, InvertedIndexReaderType::STRING_TYPE}) {
+            IndexReaderType reader_type = type;
+            auto reader = inv_iter->get_reader(reader_type);
+            if (!reader) continue;
+            auto inv_reader = std::dynamic_pointer_cast<InvertedIndexReader>(reader);
+            if (!inv_reader) continue;
+            auto file_reader = inv_reader->get_index_file_reader();
+            if (!file_reader) continue;
+            return file_reader->get_index_path_prefix();
+        }
+    }
+    return "";
+}
 
 Status FieldReaderResolver::resolve(const std::string& field_name,
                                     InvertedIndexQueryType query_type,
@@ -149,33 +202,58 @@ Status FieldReaderResolver::resolve(const std::string& field_name,
                 "index file reader is null for field '{}'", field_name);
     }
 
-    RETURN_IF_ERROR(
-            index_file_reader->init(config::inverted_index_read_buffer_size, _context->io_ctx));
+    // Use InvertedIndexSearcherCache to avoid re-opening index files repeatedly
+    auto index_file_key =
+            index_file_reader->get_index_file_cache_key(&inverted_reader->get_index_meta());
+    InvertedIndexSearcherCache::CacheKey searcher_cache_key(index_file_key);
+    InvertedIndexCacheHandle searcher_cache_handle;
+    bool cache_hit = InvertedIndexSearcherCache::instance()->lookup(searcher_cache_key,
+                                                                    &searcher_cache_handle);
 
-    auto directory = DORIS_TRY(
-            index_file_reader->open(&inverted_reader->get_index_meta(), _context->io_ctx));
-
-    lucene::index::IndexReader* raw_reader = nullptr;
-    try {
-        raw_reader = lucene::index::IndexReader::open(
-                directory.get(), config::inverted_index_read_buffer_size, false);
-    } catch (const CLuceneError& e) {
-        return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
-                "failed to open IndexReader for field '{}': {}", field_name, e.what());
+    std::shared_ptr<lucene::index::IndexReader> reader_holder;
+    if (cache_hit) {
+        auto searcher_variant = searcher_cache_handle.get_index_searcher();
+        auto* searcher_ptr = std::get_if<FulltextIndexSearcherPtr>(&searcher_variant);
+        if (searcher_ptr != nullptr && *searcher_ptr != nullptr) {
+            reader_holder = std::shared_ptr<lucene::index::IndexReader>(
+                    (*searcher_ptr)->getReader(),
+                    [](lucene::index::IndexReader*) { /* lifetime managed by searcher cache */ });
+        }
     }
 
-    if (raw_reader == nullptr) {
-        return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
-                "IndexReader is null for field '{}'", field_name);
+    if (!reader_holder) {
+        // Cache miss: open directory, build IndexSearcher, insert into cache
+        RETURN_IF_ERROR(
+                index_file_reader->init(config::inverted_index_read_buffer_size, _context->io_ctx));
+        auto directory = DORIS_TRY(
+                index_file_reader->open(&inverted_reader->get_index_meta(), _context->io_ctx));
+
+        auto index_searcher_builder = DORIS_TRY(
+                IndexSearcherBuilder::create_index_searcher_builder(inverted_reader->type()));
+        auto searcher_result =
+                DORIS_TRY(index_searcher_builder->get_index_searcher(directory.get()));
+        auto reader_size = index_searcher_builder->get_reader_size();
+
+        auto* cache_value = new InvertedIndexSearcherCache::CacheValue(std::move(searcher_result),
+                                                                       reader_size, UnixMillis());
+        InvertedIndexSearcherCache::instance()->insert(searcher_cache_key, cache_value,
+                                                       &searcher_cache_handle);
+
+        auto new_variant = searcher_cache_handle.get_index_searcher();
+        auto* new_ptr = std::get_if<FulltextIndexSearcherPtr>(&new_variant);
+        if (new_ptr != nullptr && *new_ptr != nullptr) {
+            reader_holder = std::shared_ptr<lucene::index::IndexReader>(
+                    (*new_ptr)->getReader(),
+                    [](lucene::index::IndexReader*) { /* lifetime managed by searcher cache */ });
+        }
+
+        if (!reader_holder) {
+            return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
+                    "failed to build IndexSearcher for field '{}'", field_name);
+        }
     }
 
-    auto reader_holder = std::shared_ptr<lucene::index::IndexReader>(
-            raw_reader, [](lucene::index::IndexReader* reader) {
-                if (reader != nullptr) {
-                    reader->close();
-                    _CLDELETE(reader);
-                }
-            });
+    _searcher_cache_handles.push_back(std::move(searcher_cache_handle));
 
     FieldReaderBinding resolved;
     resolved.logical_field_name = field_name;
@@ -233,6 +311,20 @@ Status FunctionSearch::evaluate_inverted_index_with_search_param(
         bitmap_result = InvertedIndexResultBitmap(std::make_shared<roaring::Roaring>(),
                                                   std::make_shared<roaring::Roaring>());
         return Status::OK();
+    }
+
+    // DSL result cache: try to return cached bitmap for this (segment, DSL) pair
+    auto* dsl_cache = SearchFunctionQueryCache::instance();
+    std::string seg_prefix = extract_segment_prefix(iterators);
+    std::string dsl_sig = build_dsl_signature(search_param);
+    SearchFunctionQueryCache::CacheKey dsl_cache_key {seg_prefix, dsl_sig};
+    InvertedIndexQueryCacheHandle dsl_cache_handle;
+    if (dsl_cache && !seg_prefix.empty() && dsl_cache->lookup(dsl_cache_key, &dsl_cache_handle)) {
+        auto* cv = static_cast<SearchFunctionQueryCache::CacheValue*>(dsl_cache_handle.get_value());
+        if (cv != nullptr) {
+            bitmap_result = InvertedIndexResultBitmap(cv->result_bitmap, cv->null_bitmap);
+            return Status::OK();
+        }
     }
 
     auto context = std::make_shared<IndexQueryContext>();
@@ -351,6 +443,13 @@ Status FunctionSearch::evaluate_inverted_index_with_search_param(
 
     VLOG_TRACE << "search: After mask - result_bitmap="
                << bitmap_result.get_data_bitmap()->cardinality();
+
+    // Insert result into DSL cache for future reuse
+    if (dsl_cache && !seg_prefix.empty()) {
+        InvertedIndexQueryCacheHandle insert_handle;
+        dsl_cache->insert(dsl_cache_key, bitmap_result.get_data_bitmap(),
+                          bitmap_result.get_null_bitmap(), &insert_handle);
+    }
 
     return Status::OK();
 }

--- a/be/src/vec/functions/function_search.cpp
+++ b/be/src/vec/functions/function_search.cpp
@@ -51,6 +51,7 @@
 #include "olap/rowset/segment_v2/inverted_index_reader.h"
 #include "olap/rowset/segment_v2/inverted_index_searcher.h"
 #include "util/string_util.h"
+#include "util/thrift_util.h"
 #include "vec/columns/column_const.h"
 #include "vec/core/columns_with_type_and_name.h"
 #include "vec/data_types/data_type_string.h"
@@ -59,30 +60,17 @@
 namespace doris::vectorized {
 
 // Build canonical DSL signature for SearchFunctionQueryCache key.
-// Includes original DSL + sorted field bindings with index metadata.
+// Serializes the entire TSearchParam via Thrift binary protocol so that
+// every field (DSL, AST root, field bindings, default_operator,
+// minimum_should_match, etc.) is included automatically.
 std::string FunctionSearch::build_dsl_signature(const TSearchParam& param) {
-    std::string sig = param.original_dsl;
-    sig += '#';
-    // Sort field bindings by field_name for canonical ordering
-    std::vector<const TSearchFieldBinding*> sorted_bindings;
-    sorted_bindings.reserve(param.field_bindings.size());
-    for (const auto& fb : param.field_bindings) {
-        sorted_bindings.push_back(&fb);
-    }
-    std::sort(sorted_bindings.begin(), sorted_bindings.end(),
-              [](const TSearchFieldBinding* a, const TSearchFieldBinding* b) {
-                  return a->field_name < b->field_name;
-              });
-    for (const auto* fb : sorted_bindings) {
-        sig += fb->field_name;
-        sig += '=';
-        if (fb->__isset.index_properties) {
-            auto it = fb->index_properties.find("index_id");
-            if (it != fb->index_properties.end()) {
-                sig += it->second;
-            }
-        }
-        sig += ';';
+    ThriftSerializer ser(false, 1024);
+    auto mutable_param = const_cast<TSearchParam&>(param);
+    std::string sig;
+    auto st = ser.serialize(&mutable_param, &sig);
+    if (UNLIKELY(!st.ok())) {
+        // Fallback: use original_dsl so caching is at least partially functional
+        return param.original_dsl;
     }
     return sig;
 }

--- a/be/src/vec/functions/function_search.cpp
+++ b/be/src/vec/functions/function_search.cpp
@@ -60,7 +60,7 @@ namespace doris::vectorized {
 
 // Build canonical DSL signature for SearchFunctionQueryCache key.
 // Includes original DSL + sorted field bindings with index metadata.
-static std::string build_dsl_signature(const TSearchParam& param) {
+std::string FunctionSearch::build_dsl_signature(const TSearchParam& param) {
     std::string sig = param.original_dsl;
     sig += '#';
     // Sort field bindings by field_name for canonical ordering

--- a/be/src/vec/functions/function_search.h
+++ b/be/src/vec/functions/function_search.h
@@ -201,6 +201,9 @@ public:
     Status collect_all_field_nulls(const TSearchClause& clause,
                                    const std::unordered_map<std::string, IndexIterator*>& iterators,
                                    std::shared_ptr<roaring::Roaring>& null_bitmap) const;
+
+    // Build canonical DSL signature for SearchFunctionQueryCache key.
+    static std::string build_dsl_signature(const TSearchParam& param);
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/functions/function_search.h
+++ b/be/src/vec/functions/function_search.h
@@ -28,6 +28,7 @@
 #include "gen_cpp/Exprs_types.h"
 #include "olap/rowset/segment_v2/index_query_context.h"
 #include "olap/rowset/segment_v2/inverted_index/query_v2/boolean_query/operator_boolean_query.h"
+#include "olap/rowset/segment_v2/inverted_index_cache.h"
 #include "vec/core/block.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
@@ -121,6 +122,9 @@ private:
     std::vector<std::shared_ptr<lucene::index::IndexReader>> _readers;
     std::unordered_map<std::string, std::shared_ptr<lucene::index::IndexReader>> _binding_readers;
     std::unordered_map<std::wstring, std::shared_ptr<lucene::index::IndexReader>> _field_readers;
+    // Keep searcher cache handles alive for the resolver's lifetime.
+    // This pins cached IndexSearcher entries so extracted IndexReaders remain valid.
+    std::vector<segment_v2::InvertedIndexCacheHandle> _searcher_cache_handles;
 };
 
 class FunctionSearch : public IFunction {

--- a/be/test/olap/rowset/segment_v2/search_function_query_cache_test.cpp
+++ b/be/test/olap/rowset/segment_v2/search_function_query_cache_test.cpp
@@ -1,0 +1,173 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <roaring/roaring.hh>
+#include <string>
+
+#include "olap/rowset/segment_v2/inverted_index_cache.h"
+
+namespace doris::segment_v2 {
+
+class SearchFunctionQueryCacheTest : public testing::Test {
+public:
+    static const int kCacheSize = 4096;
+
+    void SetUp() override { _cache = new SearchFunctionQueryCache(kCacheSize, 1); }
+
+    void TearDown() override { delete _cache; }
+
+protected:
+    SearchFunctionQueryCache* _cache = nullptr;
+};
+
+TEST_F(SearchFunctionQueryCacheTest, insert_and_lookup) {
+    auto result_bm = std::make_shared<roaring::Roaring>();
+    result_bm->add(1);
+    result_bm->add(3);
+    result_bm->add(5);
+
+    auto null_bm = std::make_shared<roaring::Roaring>();
+    null_bm->add(2);
+
+    SearchFunctionQueryCache::CacheKey key {"segment_0001", "title:hello#title=100;"};
+
+    InvertedIndexQueryCacheHandle handle;
+    _cache->insert(key, result_bm, null_bm, &handle);
+
+    // Lookup should succeed
+    InvertedIndexQueryCacheHandle lookup_handle;
+    EXPECT_TRUE(_cache->lookup(key, &lookup_handle));
+
+    auto* cv = static_cast<SearchFunctionQueryCache::CacheValue*>(lookup_handle.get_value());
+    ASSERT_NE(cv, nullptr);
+    EXPECT_TRUE(cv->result_bitmap->contains(1));
+    EXPECT_TRUE(cv->result_bitmap->contains(3));
+    EXPECT_TRUE(cv->result_bitmap->contains(5));
+    EXPECT_FALSE(cv->result_bitmap->contains(2));
+    EXPECT_EQ(cv->result_bitmap->cardinality(), 3);
+
+    EXPECT_TRUE(cv->null_bitmap->contains(2));
+    EXPECT_EQ(cv->null_bitmap->cardinality(), 1);
+}
+
+TEST_F(SearchFunctionQueryCacheTest, lookup_miss) {
+    SearchFunctionQueryCache::CacheKey key {"segment_0001", "title:hello#title=100;"};
+
+    InvertedIndexQueryCacheHandle handle;
+    EXPECT_FALSE(_cache->lookup(key, &handle));
+}
+
+TEST_F(SearchFunctionQueryCacheTest, different_keys_independent) {
+    auto bm1 = std::make_shared<roaring::Roaring>();
+    bm1->add(10);
+    auto bm2 = std::make_shared<roaring::Roaring>();
+    bm2->add(20);
+    auto null_bm = std::make_shared<roaring::Roaring>();
+
+    SearchFunctionQueryCache::CacheKey key1 {"seg_a", "dsl_1"};
+    SearchFunctionQueryCache::CacheKey key2 {"seg_a", "dsl_2"};
+
+    {
+        InvertedIndexQueryCacheHandle h;
+        _cache->insert(key1, bm1, null_bm, &h);
+    }
+    {
+        InvertedIndexQueryCacheHandle h;
+        _cache->insert(key2, bm2, null_bm, &h);
+    }
+
+    // Lookup key1
+    {
+        InvertedIndexQueryCacheHandle h;
+        EXPECT_TRUE(_cache->lookup(key1, &h));
+        auto* cv = static_cast<SearchFunctionQueryCache::CacheValue*>(h.get_value());
+        ASSERT_NE(cv, nullptr);
+        EXPECT_TRUE(cv->result_bitmap->contains(10));
+        EXPECT_FALSE(cv->result_bitmap->contains(20));
+    }
+
+    // Lookup key2
+    {
+        InvertedIndexQueryCacheHandle h;
+        EXPECT_TRUE(_cache->lookup(key2, &h));
+        auto* cv = static_cast<SearchFunctionQueryCache::CacheValue*>(h.get_value());
+        ASSERT_NE(cv, nullptr);
+        EXPECT_TRUE(cv->result_bitmap->contains(20));
+        EXPECT_FALSE(cv->result_bitmap->contains(10));
+    }
+}
+
+TEST_F(SearchFunctionQueryCacheTest, null_bitmap_handling) {
+    auto result_bm = std::make_shared<roaring::Roaring>();
+    result_bm->add(1);
+
+    // Insert with nullptr null_bitmap
+    SearchFunctionQueryCache::CacheKey key {"seg_x", "dsl_null"};
+    InvertedIndexQueryCacheHandle handle;
+    _cache->insert(key, result_bm, nullptr, &handle);
+
+    InvertedIndexQueryCacheHandle lookup_handle;
+    EXPECT_TRUE(_cache->lookup(key, &lookup_handle));
+    auto* cv = static_cast<SearchFunctionQueryCache::CacheValue*>(lookup_handle.get_value());
+    ASSERT_NE(cv, nullptr);
+    EXPECT_TRUE(cv->result_bitmap->contains(1));
+    EXPECT_EQ(cv->null_bitmap, nullptr);
+}
+
+TEST_F(SearchFunctionQueryCacheTest, cache_key_encode) {
+    SearchFunctionQueryCache::CacheKey key {"segment_prefix", "dsl_sig"};
+    EXPECT_EQ(key.encode(), "segment_prefix#dsl_sig");
+
+    SearchFunctionQueryCache::CacheKey key2 {"", "dsl"};
+    EXPECT_EQ(key2.encode(), "#dsl");
+
+    SearchFunctionQueryCache::CacheKey key3 {"seg", ""};
+    EXPECT_EQ(key3.encode(), "seg#");
+}
+
+TEST_F(SearchFunctionQueryCacheTest, overwrite_same_key) {
+    auto bm1 = std::make_shared<roaring::Roaring>();
+    bm1->add(1);
+    auto bm2 = std::make_shared<roaring::Roaring>();
+    bm2->add(99);
+    auto null_bm = std::make_shared<roaring::Roaring>();
+
+    SearchFunctionQueryCache::CacheKey key {"seg", "dsl"};
+
+    {
+        InvertedIndexQueryCacheHandle h;
+        _cache->insert(key, bm1, null_bm, &h);
+    }
+
+    // Insert again with different bitmap
+    {
+        InvertedIndexQueryCacheHandle h;
+        _cache->insert(key, bm2, null_bm, &h);
+    }
+
+    // Lookup should return the latest value
+    InvertedIndexQueryCacheHandle h;
+    EXPECT_TRUE(_cache->lookup(key, &h));
+    auto* cv = static_cast<SearchFunctionQueryCache::CacheValue*>(h.get_value());
+    ASSERT_NE(cv, nullptr);
+    EXPECT_TRUE(cv->result_bitmap->contains(99));
+}
+
+} // namespace doris::segment_v2

--- a/be/test/vec/function/function_search_test.cpp
+++ b/be/test/vec/function/function_search_test.cpp
@@ -2201,4 +2201,80 @@ TEST_F(FunctionSearchTest, TestEvaluateInvertedIndexWithOccurBoolean) {
     EXPECT_TRUE(status.is<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>());
 }
 
+TEST_F(FunctionSearchTest, TestBuildDslSignatureBasic) {
+    TSearchParam param;
+    param.original_dsl = "title:hello";
+
+    TSearchFieldBinding fb1;
+    fb1.field_name = "title";
+    fb1.slot_index = 0;
+    fb1.index_properties = {{"index_id", "100"}, {"parser", "english"}};
+    fb1.__isset.index_properties = true;
+    param.field_bindings = {fb1};
+
+    auto sig = FunctionSearch::build_dsl_signature(param);
+    EXPECT_EQ(sig, "title:hello#title=100;");
+}
+
+TEST_F(FunctionSearchTest, TestBuildDslSignatureSortOrder) {
+    TSearchParam param;
+    param.original_dsl = "title:hello OR content:world";
+
+    TSearchFieldBinding fb_content;
+    fb_content.field_name = "content";
+    fb_content.slot_index = 1;
+    fb_content.index_properties = {{"index_id", "200"}};
+    fb_content.__isset.index_properties = true;
+
+    TSearchFieldBinding fb_title;
+    fb_title.field_name = "title";
+    fb_title.slot_index = 0;
+    fb_title.index_properties = {{"index_id", "100"}};
+    fb_title.__isset.index_properties = true;
+
+    // Insert in reverse order - should still produce canonical signature
+    param.field_bindings = {fb_content, fb_title};
+
+    auto sig = FunctionSearch::build_dsl_signature(param);
+    // Fields sorted alphabetically: content before title
+    EXPECT_EQ(sig, "title:hello OR content:world#content=200;title=100;");
+}
+
+TEST_F(FunctionSearchTest, TestBuildDslSignatureNoIndexId) {
+    TSearchParam param;
+    param.original_dsl = "test";
+
+    TSearchFieldBinding fb;
+    fb.field_name = "field_a";
+    fb.slot_index = 0;
+    // No index_properties set
+    param.field_bindings = {fb};
+
+    auto sig = FunctionSearch::build_dsl_signature(param);
+    EXPECT_EQ(sig, "test#field_a=;");
+}
+
+TEST_F(FunctionSearchTest, TestBuildDslSignatureEmpty) {
+    TSearchParam param;
+    param.original_dsl = "";
+
+    auto sig = FunctionSearch::build_dsl_signature(param);
+    EXPECT_EQ(sig, "#");
+}
+
+TEST_F(FunctionSearchTest, TestSearcherCacheHandlesLifetime) {
+    // Verify FieldReaderResolver keeps _searcher_cache_handles alive
+    std::unordered_map<std::string, vectorized::IndexFieldNameAndTypePair> data_types;
+    std::unordered_map<std::string, IndexIterator*> iterators;
+    auto context = std::make_shared<IndexQueryContext>();
+
+    FieldReaderResolver resolver(data_types, iterators, context);
+
+    // The resolver should have an empty cache handles vector initially
+    // (We can't directly access _searcher_cache_handles, but we can verify
+    // that binding_cache is empty)
+    EXPECT_TRUE(resolver.binding_cache().empty());
+    EXPECT_TRUE(resolver.readers().empty());
+}
+
 } // namespace doris::vectorized

--- a/be/test/vec/function/function_search_test.cpp
+++ b/be/test/vec/function/function_search_test.cpp
@@ -2201,9 +2201,14 @@ TEST_F(FunctionSearchTest, TestEvaluateInvertedIndexWithOccurBoolean) {
     EXPECT_TRUE(status.is<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>());
 }
 
-TEST_F(FunctionSearchTest, TestBuildDslSignatureBasic) {
+TEST_F(FunctionSearchTest, TestBuildDslSignatureDeterministic) {
     TSearchParam param;
     param.original_dsl = "title:hello";
+    param.root.clause_type = "TERM";
+    param.root.field_name = "title";
+    param.root.__isset.field_name = true;
+    param.root.value = "hello";
+    param.root.__isset.value = true;
 
     TSearchFieldBinding fb1;
     fb1.field_name = "title";
@@ -2212,54 +2217,77 @@ TEST_F(FunctionSearchTest, TestBuildDslSignatureBasic) {
     fb1.__isset.index_properties = true;
     param.field_bindings = {fb1};
 
-    auto sig = FunctionSearch::build_dsl_signature(param);
-    EXPECT_EQ(sig, "title:hello#title=100;");
+    auto sig1 = FunctionSearch::build_dsl_signature(param);
+    auto sig2 = FunctionSearch::build_dsl_signature(param);
+    // Same param must produce identical signature
+    EXPECT_EQ(sig1, sig2);
+    EXPECT_FALSE(sig1.empty());
 }
 
-TEST_F(FunctionSearchTest, TestBuildDslSignatureSortOrder) {
-    TSearchParam param;
-    param.original_dsl = "title:hello OR content:world";
-
-    TSearchFieldBinding fb_content;
-    fb_content.field_name = "content";
-    fb_content.slot_index = 1;
-    fb_content.index_properties = {{"index_id", "200"}};
-    fb_content.__isset.index_properties = true;
-
-    TSearchFieldBinding fb_title;
-    fb_title.field_name = "title";
-    fb_title.slot_index = 0;
-    fb_title.index_properties = {{"index_id", "100"}};
-    fb_title.__isset.index_properties = true;
-
-    // Insert in reverse order - should still produce canonical signature
-    param.field_bindings = {fb_content, fb_title};
-
-    auto sig = FunctionSearch::build_dsl_signature(param);
-    // Fields sorted alphabetically: content before title
-    EXPECT_EQ(sig, "title:hello OR content:world#content=200;title=100;");
-}
-
-TEST_F(FunctionSearchTest, TestBuildDslSignatureNoIndexId) {
-    TSearchParam param;
-    param.original_dsl = "test";
+TEST_F(FunctionSearchTest, TestBuildDslSignatureDifferentDsl) {
+    TSearchParam param1;
+    param1.original_dsl = "title:hello";
+    param1.root.clause_type = "TERM";
 
     TSearchFieldBinding fb;
-    fb.field_name = "field_a";
+    fb.field_name = "title";
     fb.slot_index = 0;
-    // No index_properties set
-    param.field_bindings = {fb};
+    param1.field_bindings = {fb};
 
-    auto sig = FunctionSearch::build_dsl_signature(param);
-    EXPECT_EQ(sig, "test#field_a=;");
+    TSearchParam param2 = param1;
+    param2.original_dsl = "title:world";
+
+    EXPECT_NE(FunctionSearch::build_dsl_signature(param1),
+              FunctionSearch::build_dsl_signature(param2));
+}
+
+TEST_F(FunctionSearchTest, TestBuildDslSignatureDifferentOperator) {
+    TSearchParam param_and;
+    param_and.original_dsl = "hello world";
+    param_and.root.clause_type = "TERM";
+
+    TSearchFieldBinding fb;
+    fb.field_name = "title";
+    fb.slot_index = 0;
+    param_and.field_bindings = {fb};
+    param_and.default_operator = "and";
+    param_and.__isset.default_operator = true;
+
+    TSearchParam param_or = param_and;
+    param_or.default_operator = "or";
+
+    // Different default_operator must produce different signatures
+    EXPECT_NE(FunctionSearch::build_dsl_signature(param_and),
+              FunctionSearch::build_dsl_signature(param_or));
+}
+
+TEST_F(FunctionSearchTest, TestBuildDslSignatureDifferentMinShouldMatch) {
+    TSearchParam param_msm0;
+    param_msm0.original_dsl = "apple banana cherry";
+    param_msm0.root.clause_type = "TERM";
+
+    TSearchFieldBinding fb;
+    fb.field_name = "title";
+    fb.slot_index = 0;
+    param_msm0.field_bindings = {fb};
+    // No minimum_should_match set
+
+    TSearchParam param_msm1 = param_msm0;
+    param_msm1.minimum_should_match = 1;
+    param_msm1.__isset.minimum_should_match = true;
+
+    // Different minimum_should_match must produce different signatures
+    EXPECT_NE(FunctionSearch::build_dsl_signature(param_msm0),
+              FunctionSearch::build_dsl_signature(param_msm1));
 }
 
 TEST_F(FunctionSearchTest, TestBuildDslSignatureEmpty) {
     TSearchParam param;
     param.original_dsl = "";
+    param.root.clause_type = "TERM";
 
     auto sig = FunctionSearch::build_dsl_signature(param);
-    EXPECT_EQ(sig, "#");
+    EXPECT_FALSE(sig.empty());
 }
 
 TEST_F(FunctionSearchTest, TestSearcherCacheHandlesLifetime) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -810,6 +810,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String ENABLE_FALLBACK_ON_MISSING_INVERTED_INDEX = "enable_fallback_on_missing_inverted_index";
     public static final String ENABLE_INVERTED_INDEX_SEARCHER_CACHE = "enable_inverted_index_searcher_cache";
     public static final String ENABLE_INVERTED_INDEX_QUERY_CACHE = "enable_inverted_index_query_cache";
+    public static final String ENABLE_SEARCH_FUNCTION_QUERY_CACHE = "enable_search_function_query_cache";
 
     public static final String IN_LIST_VALUE_COUNT_THRESHOLD = "in_list_value_count_threshold";
 
@@ -3185,6 +3186,12 @@ public class SessionVariable implements Serializable, Writable {
     })
     public boolean enableInvertedIndexQueryCache = true;
 
+    @VariableMgr.VarAttr(name = ENABLE_SEARCH_FUNCTION_QUERY_CACHE, description = {
+        "开启后会缓存 search() 函数 DSL 查询结果",
+        "Enabling this will cache the results of search() function DSL queries."
+    })
+    public boolean enableSearchFunctionQueryCache = true;
+
     @VariableMgr.VarAttr(name = IN_LIST_VALUE_COUNT_THRESHOLD, description = {
         "in 条件 value 数量大于这个 threshold 后将不会走 fast_execute",
         "When the number of values in the IN condition exceeds this threshold,"
@@ -5239,6 +5246,7 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setEnableFallbackOnMissingInvertedIndex(enableFallbackOnMissingInvertedIndex);
         tResult.setEnableInvertedIndexSearcherCache(enableInvertedIndexSearcherCache);
         tResult.setEnableInvertedIndexQueryCache(enableInvertedIndexQueryCache);
+        tResult.setEnableSearchFunctionQueryCache(enableSearchFunctionQueryCache);
         tResult.setHiveOrcUseColumnNames(hiveOrcUseColumnNames);
         tResult.setHiveParquetUseColumnNames(hiveParquetUseColumnNames);
         tResult.setQuerySlotCount(wgQuerySlotCount);

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -438,6 +438,8 @@ struct TQueryOptions {
 
   200: optional bool enable_adjust_conjunct_order_by_cost;
 
+  201: optional bool enable_search_function_query_cache = true;
+
   // For cloud, to control if the content would be written into file cache
   // In write path, to control if the content would be written into file cache.
   // In read path, read from file cache or remote storage when execute query.

--- a/regression-test/suites/search/test_search_boundary_cases.groovy
+++ b/regression-test/suites/search/test_search_boundary_cases.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_search_boundary_cases") {
+suite("test_search_boundary_cases", "p0") {
     def tableName = "search_boundary_test"
 
     sql "DROP TABLE IF EXISTS ${tableName}"

--- a/regression-test/suites/search/test_search_cache.groovy
+++ b/regression-test/suites/search/test_search_cache.groovy
@@ -1,0 +1,137 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_search_cache", "p0") {
+    def tableName = "search_cache_test"
+
+    sql "DROP TABLE IF EXISTS ${tableName}"
+    sql """
+        CREATE TABLE ${tableName} (
+            id INT,
+            title VARCHAR(200),
+            content VARCHAR(500),
+            INDEX idx_title(title) USING INVERTED PROPERTIES("parser" = "english"),
+            INDEX idx_content(content) USING INVERTED PROPERTIES("parser" = "english")
+        ) ENGINE=OLAP
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES ("replication_num" = "1")
+    """
+
+    sql """INSERT INTO ${tableName} VALUES
+        (1, 'apple banana cherry', 'red fruit sweet'),
+        (2, 'banana grape mango', 'yellow fruit tropical'),
+        (3, 'cherry plum peach', 'stone fruit summer'),
+        (4, 'apple grape kiwi', 'green fruit fresh'),
+        (5, 'mango pineapple coconut', 'tropical fruit exotic'),
+        (6, 'apple cherry plum', 'mixed fruit salad'),
+        (7, 'banana coconut papaya', 'smoothie blend tropical'),
+        (8, 'grape cherry apple', 'wine fruit tart')
+    """
+    sql """sync"""
+
+    // Wait for index building
+    Thread.sleep(10000)
+
+    // Test 1: Cache consistency - same query returns same results with cache enabled
+    def result1 = sql """
+        SELECT /*+SET_VAR(enable_common_expr_pushdown=true,enable_search_function_query_cache=true) */
+        id FROM ${tableName}
+        WHERE search('title:apple')
+        ORDER BY id
+    """
+
+    // Run same query again (should hit cache)
+    def result2 = sql """
+        SELECT /*+SET_VAR(enable_common_expr_pushdown=true,enable_search_function_query_cache=true) */
+        id FROM ${tableName}
+        WHERE search('title:apple')
+        ORDER BY id
+    """
+
+    // Results must be identical (cache hit returns same data)
+    assertEquals(result1, result2)
+
+    // Test 2: Cache disabled returns same results as cache enabled
+    def result_no_cache = sql """
+        SELECT /*+SET_VAR(enable_common_expr_pushdown=true,enable_search_function_query_cache=false) */
+        id FROM ${tableName}
+        WHERE search('title:apple')
+        ORDER BY id
+    """
+    assertEquals(result1, result_no_cache)
+
+    // Test 3: Multi-field query cache consistency
+    def mf_result1 = sql """
+        SELECT /*+SET_VAR(enable_common_expr_pushdown=true,enable_search_function_query_cache=true) */
+        id FROM ${tableName}
+        WHERE search('title:cherry OR content:tropical')
+        ORDER BY id
+    """
+
+    def mf_result2 = sql """
+        SELECT /*+SET_VAR(enable_common_expr_pushdown=true,enable_search_function_query_cache=true) */
+        id FROM ${tableName}
+        WHERE search('title:cherry OR content:tropical')
+        ORDER BY id
+    """
+    assertEquals(mf_result1, mf_result2)
+
+    // Test 4: Different queries produce different cache entries
+    def diff_result = sql """
+        SELECT /*+SET_VAR(enable_common_expr_pushdown=true,enable_search_function_query_cache=true) */
+        id FROM ${tableName}
+        WHERE search('title:banana')
+        ORDER BY id
+    """
+    // banana result should differ from apple result
+    assertNotEquals(result1, diff_result)
+
+    // Test 5: AND query - cache vs no-cache consistency
+    def and_cached = sql """
+        SELECT /*+SET_VAR(enable_common_expr_pushdown=true,enable_search_function_query_cache=true) */
+        id, title FROM ${tableName}
+        WHERE search('title:apple AND title:cherry')
+        ORDER BY id
+    """
+
+    def and_uncached = sql """
+        SELECT /*+SET_VAR(enable_common_expr_pushdown=true,enable_search_function_query_cache=false) */
+        id, title FROM ${tableName}
+        WHERE search('title:apple AND title:cherry')
+        ORDER BY id
+    """
+    assertEquals(and_cached, and_uncached)
+
+    // Test 6: Complex boolean query - cache vs no-cache consistency
+    def complex_cached = sql """
+        SELECT /*+SET_VAR(enable_common_expr_pushdown=true,enable_search_function_query_cache=true) */
+        id, title FROM ${tableName}
+        WHERE search('(title:apple OR title:banana) AND content:fruit')
+        ORDER BY id
+    """
+
+    def complex_uncached = sql """
+        SELECT /*+SET_VAR(enable_common_expr_pushdown=true,enable_search_function_query_cache=false) */
+        id, title FROM ${tableName}
+        WHERE search('(title:apple OR title:banana) AND content:fruit')
+        ORDER BY id
+    """
+    assertEquals(complex_cached, complex_uncached)
+
+    sql "DROP TABLE IF EXISTS ${tableName}"
+}

--- a/regression-test/suites/search/test_search_default_field_operator.groovy
+++ b/regression-test/suites/search/test_search_default_field_operator.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_search_default_field_operator") {
+suite("test_search_default_field_operator", "p0") {
     def tableName = "search_enhanced_test"
 
     sql "DROP TABLE IF EXISTS ${tableName}"

--- a/regression-test/suites/search/test_search_dsl_operators.groovy
+++ b/regression-test/suites/search/test_search_dsl_operators.groovy
@@ -35,7 +35,7 @@
  * - NOT marks current term as MUST_NOT (-)
  * - With minimum_should_match=0 and MUST clauses present, SHOULD clauses are discarded
  */
-suite("test_search_dsl_operators") {
+suite("test_search_dsl_operators", "p0") {
     def tableName = "search_dsl_operators_test"
 
     sql "DROP TABLE IF EXISTS ${tableName}"

--- a/regression-test/suites/search/test_search_dsl_syntax.groovy
+++ b/regression-test/suites/search/test_search_dsl_syntax.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_search_dsl_syntax") {
+suite("test_search_dsl_syntax", "p0") {
     def tableName = "search_dsl_test_table"
     
     sql "DROP TABLE IF EXISTS ${tableName}"

--- a/regression-test/suites/search/test_search_escape.groovy
+++ b/regression-test/suites/search/test_search_escape.groovy
@@ -29,7 +29,7 @@
  * - Groovy string: \\\\ -> SQL string: \\ -> DSL: \ (escape char)
  * - Groovy string: \\\\\\\\ -> SQL string: \\\\ -> DSL: \\ -> literal: \
  */
-suite("test_search_escape") {
+suite("test_search_escape", "p0") {
     def tableName = "search_escape_test"
 
     sql "DROP TABLE IF EXISTS ${tableName}"

--- a/regression-test/suites/search/test_search_exact_basic.groovy
+++ b/regression-test/suites/search/test_search_exact_basic.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_search_exact_basic") {
+suite("test_search_exact_basic", "p0") {
     def tableName = "exact_basic_test"
 
     sql "DROP TABLE IF EXISTS ${tableName}"

--- a/regression-test/suites/search/test_search_exact_lowercase.groovy
+++ b/regression-test/suites/search/test_search_exact_lowercase.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_search_exact_lowercase") {
+suite("test_search_exact_lowercase", "p0") {
     def tableName = "exact_lowercase_test"
 
     sql "DROP TABLE IF EXISTS ${tableName}"

--- a/regression-test/suites/search/test_search_exact_match.groovy
+++ b/regression-test/suites/search/test_search_exact_match.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_search_exact_match") {
+suite("test_search_exact_match", "p0") {
     def tableName = "search_exact_test_table"
 
     sql "DROP TABLE IF EXISTS ${tableName}"

--- a/regression-test/suites/search/test_search_exact_multi_index.groovy
+++ b/regression-test/suites/search/test_search_exact_multi_index.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_search_exact_multi_index") {
+suite("test_search_exact_multi_index", "p0") {
     def tableName = "exact_multi_index_test"
 
     sql "DROP TABLE IF EXISTS ${tableName}"

--- a/regression-test/suites/search/test_search_function.groovy
+++ b/regression-test/suites/search/test_search_function.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_search_function") {
+suite("test_search_function", "p0") {
     def tableName = "search_test_table"
     def indexTableName = "search_test_index_table"
     

--- a/regression-test/suites/search/test_search_inverted_index.groovy
+++ b/regression-test/suites/search/test_search_inverted_index.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_search_inverted_index") {
+suite("test_search_inverted_index", "p0") {
     def tableWithIndex = "search_index_test_table"
     def tableWithoutIndex = "search_no_index_test_table"
 

--- a/regression-test/suites/search/test_search_lucene_mode.groovy
+++ b/regression-test/suites/search/test_search_lucene_mode.groovy
@@ -30,7 +30,7 @@
  * Enable Lucene mode with options parameter (JSON format):
  *   search(dsl, '{"default_field":"title","default_operator":"and","mode":"lucene"}')
  */
-suite("test_search_lucene_mode") {
+suite("test_search_lucene_mode", "p0") {
     def tableName = "search_lucene_mode_test"
 
     sql "DROP TABLE IF EXISTS ${tableName}"

--- a/regression-test/suites/search/test_search_mow_support.groovy
+++ b/regression-test/suites/search/test_search_mow_support.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_search_mow_support") {
+suite("test_search_mow_support", "p0") {
     def tableName = "search_mow_support_tbl"
     sql "DROP TABLE IF EXISTS ${tableName}"
 

--- a/regression-test/suites/search/test_search_multi_field.groovy
+++ b/regression-test/suites/search/test_search_multi_field.groovy
@@ -30,7 +30,7 @@
  *
  * Multi-field search can also be combined with Lucene mode for MUST/SHOULD/MUST_NOT semantics.
  */
-suite("test_search_multi_field") {
+suite("test_search_multi_field", "p0") {
     def tableName = "search_multi_field_test"
 
     sql "DROP TABLE IF EXISTS ${tableName}"

--- a/regression-test/suites/search/test_search_null_regression.groovy
+++ b/regression-test/suites/search/test_search_null_regression.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_search_null_regression") {
+suite("test_search_null_regression", "p0") {
     def tableName = "search_null_regression_test"
 
     sql "DROP TABLE IF EXISTS ${tableName}"

--- a/regression-test/suites/search/test_search_null_semantics.groovy
+++ b/regression-test/suites/search/test_search_null_semantics.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_search_null_semantics") {
+suite("test_search_null_semantics", "p0") {
     def tableName = "search_null_test"
 
     sql "DROP TABLE IF EXISTS ${tableName}"

--- a/regression-test/suites/search/test_search_regexp_lowercase.groovy
+++ b/regression-test/suites/search/test_search_regexp_lowercase.groovy
@@ -19,7 +19,7 @@
 // Regex patterns are NOT lowercased (matching ES query_string behavior).
 // Wildcard patterns ARE lowercased (matching ES query_string normalizer behavior).
 
-suite("test_search_regexp_lowercase") {
+suite("test_search_regexp_lowercase", "p0") {
     def tableName = "search_regexp_lowercase_test"
 
     sql "DROP TABLE IF EXISTS ${tableName}"

--- a/regression-test/suites/search/test_search_usage_restrictions.groovy
+++ b/regression-test/suites/search/test_search_usage_restrictions.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_search_usage_restrictions") {
+suite("test_search_usage_restrictions", "p0") {
     def tableName = "search_usage_test_table"
     def tableName2 = "search_usage_test_table2"
 

--- a/regression-test/suites/search/test_search_variant_dual_index_reader.groovy
+++ b/regression-test/suites/search/test_search_variant_dual_index_reader.groovy
@@ -33,7 +33,7 @@
  * Before fix: search() returns empty (wrong reader selected)
  * After fix:  search() returns matching rows (correct FULLTEXT reader selected)
  */
-suite("test_search_variant_dual_index_reader") {
+suite("test_search_variant_dual_index_reader", "p0") {
     def tableName = "test_variant_dual_index_reader"
 
     sql """ set enable_match_without_inverted_index = false """

--- a/regression-test/suites/search/test_search_variant_subcolumn_analyzer.groovy
+++ b/regression-test/suites/search/test_search_variant_subcolumn_analyzer.groovy
@@ -28,7 +28,7 @@
  * Fix: FE now looks up the Index for each field in SearchExpression and passes
  * the index_properties via TSearchFieldBinding to BE.
  */
-suite("test_search_variant_subcolumn_analyzer") {
+suite("test_search_variant_subcolumn_analyzer", "p0") {
     def tableName = "test_variant_subcolumn_analyzer"
 
     sql """ set enable_match_without_inverted_index = false """

--- a/regression-test/suites/search/test_search_vs_match_consistency.groovy
+++ b/regression-test/suites/search/test_search_vs_match_consistency.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_search_vs_match_consistency") {
+suite("test_search_vs_match_consistency", "p0") {
     def tableName = "search_match_consistency_test"
 
     sql "DROP TABLE IF EXISTS ${tableName}"


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
The `search()` function bypasses `InvertedIndexSearcherCache`, opening Lucene IndexReader directly per field per segment. This causes redundant file I/O and misses cache benefits that other index readers enjoy. Additionally, identical DSL queries against the same segment re-execute Lucene matching from scratch.

This PR adds two caching layers:

**Phase 1 - Searcher Cache Reuse**: `FieldReaderResolver::resolve()` now looks up `InvertedIndexSearcherCache` before opening index files. On cache hit, it extracts `IndexReader*` from the cached `IndexSearcher` via `getReader()`. On miss, it builds the searcher, inserts into cache, then extracts the reader. Cache handles are held in `_searcher_cache_handles` vector to keep entries pinned during query execution.

**Phase 2 - DSL Result Cache**: A new `SearchFunctionQueryCache` (LRU, keyed by `segment_prefix + "#" + dsl_signature`) caches the final `roaring::Roaring` bitmap result. Repeated identical DSL queries against the same segment skip Lucene execution entirely. Controlled by:
- `enable_search_function_query_cache` session variable (default: `true`)
- `search_function_query_cache_limit` BE config (default: `"10%"`)

### Release note

Add searcher cache reuse and DSL-level result cache for the search() function to reduce redundant Lucene I/O and improve query performance.

### Check List (For Author)

- Test
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. search() function now caches IndexSearcher handles and DSL query results. Cache can be disabled via `set enable_search_function_query_cache = false`.

- Does this need documentation?
    - [ ] No.
    - [x] Yes. New session variable `enable_search_function_query_cache` and BE config `search_function_query_cache_limit`.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label