### PR TITLE
[refactor](recursive-cte) Replace in-place PFC reset with full recreation between recursion rounds

### DIFF
--- a/be/src/pipeline/exec/partitioned_hash_join_sink_operator.cpp
+++ b/be/src/pipeline/exec/partitioned_hash_join_sink_operator.cpp
@@ -565,6 +565,8 @@ Status PartitionedHashJoinSinkLocalState::_setup_internal_operator(RuntimeState*
     /// Set these two values after all the work is ready.
     _shared_state->inner_shared_state = std::move(inner_shared_state);
     _shared_state->inner_runtime_state = std::move(inner_runtime_state);
+    state->merge_register_runtime_filter(
+            _shared_state->inner_runtime_state->get_deregister_runtime_filter());
     return Status::OK();
 }
 

--- a/be/src/pipeline/exec/rec_cte_source_operator.h
+++ b/be/src/pipeline/exec/rec_cte_source_operator.h
@@ -146,7 +146,8 @@ private:
     Status _recursive_process(RuntimeState* state, size_t last_round_offset) const {
         RETURN_IF_ERROR(_send_rerun_fragments(state, PRerunFragmentParams::wait_for_destroy));
         RETURN_IF_ERROR(_send_reset_global_rf(state));
-        RETURN_IF_ERROR(_send_rerun_fragments(state, PRerunFragmentParams::recreate_and_submit));
+        RETURN_IF_ERROR(_send_rerun_fragments(state, PRerunFragmentParams::rebuild));
+        RETURN_IF_ERROR(_send_rerun_fragments(state, PRerunFragmentParams::submit));
         RETURN_IF_ERROR(get_local_state(state)._shared_state->send_data_to_targets(
                 state, last_round_offset));
         return Status::OK();

--- a/be/src/pipeline/exec/rec_cte_source_operator.h
+++ b/be/src/pipeline/exec/rec_cte_source_operator.h
@@ -138,17 +138,15 @@ private:
                                               "RecursiveRound", TUnit::UNIT);
             round_counter->set(int64_t(get_local_state(state)._shared_state->current_round));
 
-            RETURN_IF_ERROR(_send_rerun_fragments(state, PRerunFragmentParams::close));
+            RETURN_IF_ERROR(_send_rerun_fragments(state, PRerunFragmentParams::final_close));
         }
         return Status::OK();
     }
 
     Status _recursive_process(RuntimeState* state, size_t last_round_offset) const {
-        RETURN_IF_ERROR(_send_rerun_fragments(state, PRerunFragmentParams::wait));
+        RETURN_IF_ERROR(_send_rerun_fragments(state, PRerunFragmentParams::wait_for_destroy));
         RETURN_IF_ERROR(_send_reset_global_rf(state));
-        RETURN_IF_ERROR(_send_rerun_fragments(state, PRerunFragmentParams::release));
-        RETURN_IF_ERROR(_send_rerun_fragments(state, PRerunFragmentParams::rebuild));
-        RETURN_IF_ERROR(_send_rerun_fragments(state, PRerunFragmentParams::submit));
+        RETURN_IF_ERROR(_send_rerun_fragments(state, PRerunFragmentParams::recreate_and_submit));
         RETURN_IF_ERROR(get_local_state(state)._shared_state->send_data_to_targets(
                 state, last_round_offset));
         return Status::OK();

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -179,9 +179,16 @@ void PipelineFragmentContext::cancel(const Status reason) {
     {
         std::lock_guard<std::mutex> l(_task_mutex);
         if (_closed_tasks >= _total_tasks) {
+            if (_need_notify_close) {
+                // if fragment cancelled and waiting for notify to close, need to remove from fragment mgr
+                _exec_env->fragment_mgr()->remove_pipeline_context({_query_id, _fragment_id});
+                _need_notify_close = false;
+            }
             // All tasks in this PipelineXFragmentContext already closed.
             return;
         }
+        // make fragment release by self after cancel
+        _need_notify_close = false;
     }
     // Timeout is a special error code, we need print current stack to debug timeout issue.
     if (reason.is<ErrorCode::TIMEOUT>()) {
@@ -417,10 +424,6 @@ Status PipelineFragmentContext::_build_pipeline_tasks_for_instance(
 
                 task_runtime_state->set_task_execution_context(shared_from_this());
                 task_runtime_state->set_be_number(local_params.backend_num);
-                if (_need_notify_close) {
-                    // rec cte require child rf to wait infinitely to make sure all rpc done
-                    task_runtime_state->set_force_make_rf_wait_infinite();
-                }
 
                 if (_params.__isset.backend_id) {
                     task_runtime_state->set_backend_id(_params.backend_id);
@@ -1802,14 +1805,11 @@ void PipelineFragmentContext::_close_fragment_instance() {
     if (_is_fragment_instance_closed) {
         return;
     }
-    Defer defer_op {[&]() {
-        _is_fragment_instance_closed = true;
-        _notify_cv.notify_all();
-    }};
+    Defer defer_op {[&]() { _is_fragment_instance_closed = true; }};
     _fragment_level_profile->total_time_counter()->update(_fragment_watcher.elapsed_time());
     if (!_need_notify_close) {
         auto st = send_report(true);
-        if (!st) {
+        if (!st && !st.is<ErrorCode::NEED_SEND_AGAIN>()) {
             LOG(WARNING) << fmt::format("Failed to send report for query {}, fragment {}: {}",
                                         print_id(_query_id), _fragment_id, st.to_string());
         }
@@ -1990,9 +1990,8 @@ std::string PipelineFragmentContext::debug_string() {
     fmt::memory_buffer debug_string_buffer;
     fmt::format_to(debug_string_buffer,
                    "PipelineFragmentContext Info: _closed_tasks={}, _total_tasks={}, "
-                   "need_notify_close={}, has_task_execution_ctx_ref_count={}\n",
-                   _closed_tasks, _total_tasks, _need_notify_close,
-                   _has_task_execution_ctx_ref_count);
+                   "need_notify_close={}, fragment_id={}\n",
+                   _closed_tasks, _total_tasks, _need_notify_close, _fragment_id);
     for (size_t j = 0; j < _tasks.size(); j++) {
         fmt::format_to(debug_string_buffer, "Tasks in instance {}:\n", j);
         for (size_t i = 0; i < _tasks[j].size(); i++) {
@@ -2067,54 +2066,19 @@ PipelineFragmentContext::collect_realtime_load_channel_profile() const {
     return load_channel_profile;
 }
 
-Status PipelineFragmentContext::wait_close(bool close) {
-    if (_exec_env->new_load_stream_mgr()->get(_query_id) != nullptr) {
-        return Status::InternalError("stream load do not support reset");
-    }
-    if (!_need_notify_close) {
-        return Status::InternalError("_need_notify_close is false, do not support reset");
-    }
-
-    {
-        std::unique_lock<std::mutex> lock(_task_mutex);
-        while (!(_is_fragment_instance_closed.load() && !_has_task_execution_ctx_ref_count)) {
-            if (_query_ctx->is_cancelled()) {
-                return Status::Cancelled("Query has been cancelled");
-            }
-            _notify_cv.wait_for(lock, std::chrono::seconds(1));
+std::set<int> PipelineFragmentContext::get_deregister_runtime_filter() const {
+    std::set<int> result;
+    for (const auto& _task : _tasks) {
+        for (const auto& task : _task) {
+            auto set = task.first->runtime_state()->get_deregister_runtime_filter();
+            result.merge(set);
         }
     }
-
-    if (close) {
-        auto st = send_report(true);
-        if (!st) {
-            LOG(WARNING) << fmt::format("Failed to send report for query {}, fragment {}: {}",
-                                        print_id(_query_id), _fragment_id, st.to_string());
-        }
-        _exec_env->fragment_mgr()->remove_pipeline_context({_query_id, _fragment_id});
+    if (_runtime_state) {
+        auto set = _runtime_state->get_deregister_runtime_filter();
+        result.merge(set);
     }
-    return Status::OK();
-}
-
-Status PipelineFragmentContext::set_to_rerun() {
-    {
-        std::lock_guard<std::mutex> l(_task_mutex);
-        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_query_ctx->query_mem_tracker());
-        for (auto& tasks : _tasks) {
-            for (const auto& task : tasks) {
-                task.first->runtime_state()->reset_to_rerun();
-            }
-        }
-    }
-    _release_resource();
-    _runtime_state->reset_to_rerun();
-    return Status::OK();
-}
-
-Status PipelineFragmentContext::rebuild(ThreadPool* thread_pool) {
-    _submitted = false;
-    _is_fragment_instance_closed = false;
-    return _build_and_prepare_full_pipeline(thread_pool);
+    return result;
 }
 
 void PipelineFragmentContext::_release_resource() {

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -1809,7 +1809,7 @@ void PipelineFragmentContext::_close_fragment_instance() {
     _fragment_level_profile->total_time_counter()->update(_fragment_watcher.elapsed_time());
     if (!_need_notify_close) {
         auto st = send_report(true);
-        if (!st && !st.is<ErrorCode::NEED_SEND_AGAIN>()) {
+        if (!st) {
             LOG(WARNING) << fmt::format("Failed to send report for query {}, fragment {}: {}",
                                         print_id(_query_id), _fragment_id, st.to_string());
         }
@@ -1914,6 +1914,10 @@ Status PipelineFragmentContext::send_report(bool done) {
     // When limit is reached the fragment is also cancelled, but _is_report_on_cancel will
     // be set to false, to avoid sending fault report to FE.
     if (!_is_report_success && !_is_report_on_cancel) {
+        if (done) {
+            // if done is true, which means the query is finished successfully, we can safely close the fragment instance without sending report to FE, and just return OK status here.
+            return Status::OK();
+        }
         return Status::NeedSendAgain("");
     }
 

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -1904,7 +1904,7 @@ Status PipelineFragmentContext::send_report(bool done) {
     // Load will set _is_report_success to true because load wants to know
     // the process.
     if (!_is_report_success && done && exec_status.ok()) {
-        return Status::NeedSendAgain("");
+        return Status::OK();
     }
 
     // If both _is_report_success and _is_report_on_cancel are false,

--- a/be/src/pipeline/pipeline_fragment_context.h
+++ b/be/src/pipeline/pipeline_fragment_context.h
@@ -128,8 +128,6 @@ public:
     std::string get_load_error_url();
     std::string get_first_error_msg();
 
-    bool need_notify_close() const { return _need_notify_close; }
-
     std::set<int> get_deregister_runtime_filter() const;
 
     Status listen_wait_close(const std::shared_ptr<brpc::ClosureGuard>& guard,
@@ -137,10 +135,14 @@ public:
         if (_wait_close_guard) {
             return Status::InternalError("Already listening wait close");
         }
-        _wait_close_guard = guard;
+        if (!_need_notify_close) {
+            return Status::InternalError("Not need to listen wait close");
+        }
         if (need_send_report_on_destruction) {
-            _need_notify_close = true;
+            _need_notify_close = false;
             return send_report(true);
+        } else {
+            _wait_close_guard = guard;
         }
         return Status::OK();
     }

--- a/be/src/pipeline/pipeline_fragment_context.h
+++ b/be/src/pipeline/pipeline_fragment_context.h
@@ -128,11 +128,22 @@ public:
     std::string get_load_error_url();
     std::string get_first_error_msg();
 
-    Status wait_close(bool close);
-    Status rebuild(ThreadPool* thread_pool);
-    Status set_to_rerun();
-
     bool need_notify_close() const { return _need_notify_close; }
+
+    std::set<int> get_deregister_runtime_filter() const;
+
+    Status listen_wait_close(const std::shared_ptr<brpc::ClosureGuard>& guard,
+                             bool need_send_report_on_destruction) {
+        if (_wait_close_guard) {
+            return Status::InternalError("Already listening wait close");
+        }
+        _wait_close_guard = guard;
+        if (need_send_report_on_destruction) {
+            _need_notify_close = true;
+            return send_report(true);
+        }
+        return Status::OK();
+    }
 
 private:
     void _release_resource();
@@ -342,6 +353,7 @@ private:
     int32_t _parallel_instances = 0;
 
     bool _need_notify_close = false;
+    std::shared_ptr<brpc::ClosureGuard> _wait_close_guard = nullptr;
 };
 } // namespace pipeline
 } // namespace doris

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -1541,7 +1541,7 @@ Status FragmentMgr::rerun_fragment(const std::shared_ptr<brpc::ClosureGuard>& gu
                 fragment_ctx->listen_wait_close(guard, stage == PRerunFragmentParams::final_close));
         remove_pipeline_context({query_id, fragment});
         return Status::OK();
-    } else if (stage == PRerunFragmentParams::recreate_and_submit) {
+    } else if (stage == PRerunFragmentParams::rebuild) {
         auto q_ctx = get_query_ctx(query_id);
         if (!q_ctx) {
             return Status::NotFound(
@@ -1554,9 +1554,8 @@ Status FragmentMgr::rerun_fragment(const std::shared_ptr<brpc::ClosureGuard>& gu
             std::lock_guard<std::mutex> lk(_rerunnable_params_lock);
             auto it = _rerunnable_params_map.find({query_id, fragment});
             if (it == _rerunnable_params_map.end()) {
-                return Status::NotFound(
-                        "recreate_and_submit (query-id: {}, fragment-id: {}) not found",
-                        print_id(query_id), fragment);
+                return Status::NotFound("rebuild (query-id: {}, fragment-id: {}) not found",
+                                        print_id(query_id), fragment);
             }
             it->second.stage++;
             RETURN_IF_ERROR(q_ctx->update_filters_stage(it->second.stage,
@@ -1583,10 +1582,15 @@ Status FragmentMgr::rerun_fragment(const std::shared_ptr<brpc::ClosureGuard>& gu
 
         // Update QueryContext mapping (must support overwrite)
         q_ctx->set_pipeline_context(info.params.fragment_id, context);
-
-        RETURN_IF_ERROR(context->submit());
         return Status::OK();
 
+    } else if (stage == PRerunFragmentParams::submit) {
+        auto fragment_ctx = _pipeline_map.find({query_id, fragment});
+        if (!fragment_ctx) {
+            return Status::NotFound("Fragment context (query-id: {}, fragment-id: {}) not found",
+                                    print_id(query_id), fragment);
+        }
+        return fragment_ctx->submit();
     } else {
         return Status::InvalidArgument("Unknown rerun fragment opcode: {}", stage);
     }

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -345,6 +345,10 @@ void FragmentMgr::stop() {
     // destructred and remove it from _query_ctx_map_delay_delete which is destructring. it's UB.
     _query_ctx_map_delay_delete.clear();
     _pipeline_map.clear();
+    {
+        std::lock_guard<std::mutex> lk(_rerunnable_params_lock);
+        _rerunnable_params_map.clear();
+    }
 }
 
 std::string FragmentMgr::to_http_path(const std::string& file_name) {
@@ -687,6 +691,18 @@ void FragmentMgr::remove_pipeline_context(std::pair<TUniqueId, int> key) {
 }
 
 void FragmentMgr::remove_query_context(const TUniqueId& key) {
+    // Clean up any saved rerunnable params for this query to avoid memory leaks.
+    // This covers both cancel and normal destruction paths.
+    {
+        std::lock_guard<std::mutex> lk(_rerunnable_params_lock);
+        for (auto it = _rerunnable_params_map.begin(); it != _rerunnable_params_map.end();) {
+            if (it->first.first == key) {
+                it = _rerunnable_params_map.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
     _query_ctx_map_delay_delete.erase(key);
 #ifndef BE_TEST
     _query_ctx_map.erase(key);
@@ -918,6 +934,17 @@ Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params,
                     print_id(params.query_id), params.fragment_id);
         }
         _pipeline_map.insert({params.query_id, params.fragment_id}, context);
+    }
+
+    // Save params for recursive CTE child fragments so we can recreate the PFC later.
+    if (params.__isset.need_notify_close && params.need_notify_close) {
+        std::lock_guard<std::mutex> lk(_rerunnable_params_lock);
+        _rerunnable_params_map[{params.query_id, params.fragment_id}] = {
+                .deregister_runtime_filter_ids = {},
+                .params = params,
+                .parent = parent,
+                .finish_callback = cb,
+                .query_ctx = query_ctx};
     }
 
     if (!params.__isset.need_wait_execution_trigger || !params.need_wait_execution_trigger) {
@@ -1327,6 +1354,10 @@ Status FragmentMgr::apply_filterv2(const PPublishFilterRequestV2* request,
     query_id.__set_lo(queryid.lo);
     if (auto q_ctx = get_query_ctx(query_id)) {
         SCOPED_ATTACH_TASK(q_ctx.get());
+        // just discard low stage request
+        if (q_ctx->get_stage(request->filter_id()) != request->stage()) {
+            return Status::OK();
+        }
         RuntimeFilterMgr* runtime_filter_mgr = q_ctx->runtime_filter_mgr();
         DCHECK(runtime_filter_mgr != nullptr);
 
@@ -1355,6 +1386,10 @@ Status FragmentMgr::send_filter_size(const PSendFilterSizeRequest* request) {
     }
 
     if (auto q_ctx = get_query_ctx(query_id)) {
+        // just discard low stage request
+        if (q_ctx->get_stage(request->filter_id()) != request->stage()) {
+            return Status::OK();
+        }
         return q_ctx->get_merge_controller_handler()->send_filter_size(q_ctx, request);
     } else {
         return Status::EndOfFile(
@@ -1370,6 +1405,10 @@ Status FragmentMgr::sync_filter_size(const PSyncFilterSizeRequest* request) {
     query_id.__set_hi(queryid.hi);
     query_id.__set_lo(queryid.lo);
     if (auto q_ctx = get_query_ctx(query_id)) {
+        // just discard low stage request
+        if (q_ctx->get_stage(request->filter_id()) != request->stage()) {
+            return Status::OK();
+        }
         try {
             return q_ctx->runtime_filter_mgr()->sync_filter_size(request);
         } catch (const Exception& e) {
@@ -1393,6 +1432,10 @@ Status FragmentMgr::merge_filter(const PMergeFilterRequest* request,
     query_id.__set_lo(queryid.lo);
     if (auto q_ctx = get_query_ctx(query_id)) {
         SCOPED_ATTACH_TASK(q_ctx.get());
+        // just discard low stage request
+        if (q_ctx->get_stage(request->filter_id()) != request->stage()) {
+            return Status::OK();
+        }
         if (!q_ctx->get_merge_controller_handler()) {
             return Status::InternalError("Merge filter failed: Merge controller handler is null");
         }
@@ -1461,35 +1504,92 @@ Status FragmentMgr::transmit_rec_cte_block(
     }
 }
 
-Status FragmentMgr::rerun_fragment(const TUniqueId& query_id, int fragment,
+Status FragmentMgr::rerun_fragment(const std::shared_ptr<brpc::ClosureGuard>& guard,
+                                   const TUniqueId& query_id, int fragment,
                                    PRerunFragmentParams_Opcode stage) {
-    if (auto q_ctx = get_query_ctx(query_id)) {
-        SCOPED_ATTACH_TASK(q_ctx.get());
+    if (stage == PRerunFragmentParams::wait_for_destroy ||
+        stage == PRerunFragmentParams::final_close) {
         auto fragment_ctx = _pipeline_map.find({query_id, fragment});
         if (!fragment_ctx) {
             return Status::NotFound("Fragment context (query-id: {}, fragment-id: {}) not found",
                                     print_id(query_id), fragment);
         }
 
-        if (stage == PRerunFragmentParams::wait) {
-            return fragment_ctx->wait_close(false);
-        } else if (stage == PRerunFragmentParams::release) {
-            return fragment_ctx->set_to_rerun();
-        } else if (stage == PRerunFragmentParams::rebuild) {
-            return fragment_ctx->rebuild(_thread_pool.get());
-        } else if (stage == PRerunFragmentParams::submit) {
-            return fragment_ctx->submit();
-        } else if (stage == PRerunFragmentParams::close) {
-            return fragment_ctx->wait_close(true);
-        } else {
-            return Status::InvalidArgument("Unknown rerun fragment opcode: {}", stage);
+        if (stage == PRerunFragmentParams::wait_for_destroy) {
+            std::lock_guard<std::mutex> lk(_rerunnable_params_lock);
+            auto it = _rerunnable_params_map.find({query_id, fragment});
+            if (it == _rerunnable_params_map.end()) {
+                auto st = fragment_ctx->listen_wait_close(guard, true);
+                if (!st.ok()) {
+                    LOG(WARNING) << fmt::format(
+                            "wait_for_destroy fragment context (query-id: {}, fragment-id: "
+                            "{}) failed: {}",
+                            print_id(query_id), fragment, st.to_string());
+                }
+                return Status::NotFound(
+                        "Rerunnable params (query-id: {}, fragment-id: {}) not found",
+                        print_id(query_id), fragment);
+            }
+
+            it->second.deregister_runtime_filter_ids.merge(
+                    fragment_ctx->get_deregister_runtime_filter());
         }
+
+        auto* query_ctx = fragment_ctx->get_query_ctx();
+        SCOPED_ATTACH_TASK(query_ctx);
+        RETURN_IF_ERROR(
+                fragment_ctx->listen_wait_close(guard, stage == PRerunFragmentParams::final_close));
+        remove_pipeline_context({query_id, fragment});
+        return Status::OK();
+    } else if (stage == PRerunFragmentParams::recreate_and_submit) {
+        auto q_ctx = get_query_ctx(query_id);
+        if (!q_ctx) {
+            return Status::NotFound(
+                    "rerun_fragment: Query context (query-id: {}) not found, maybe finished",
+                    print_id(query_id));
+        }
+        SCOPED_ATTACH_TASK(q_ctx.get());
+        RerunableFragmentInfo info;
+        {
+            std::lock_guard<std::mutex> lk(_rerunnable_params_lock);
+            auto it = _rerunnable_params_map.find({query_id, fragment});
+            if (it == _rerunnable_params_map.end()) {
+                return Status::NotFound(
+                        "recreate_and_submit (query-id: {}, fragment-id: {}) not found",
+                        print_id(query_id), fragment);
+            }
+            it->second.stage++;
+            RETURN_IF_ERROR(q_ctx->update_filters_stage(it->second.stage,
+                                                        it->second.deregister_runtime_filter_ids));
+            info = it->second;
+        }
+
+        auto context = std::make_shared<pipeline::PipelineFragmentContext>(
+                q_ctx->query_id(), info.params, q_ctx, _exec_env, info.finish_callback,
+                [this](const ReportStatusRequest& req, auto&& ctx) {
+                    return this->trigger_pipeline_context_report(req, std::move(ctx));
+                });
+
+        Status prepare_st = Status::OK();
+        ASSIGN_STATUS_IF_CATCH_EXCEPTION(prepare_st = context->prepare(_thread_pool.get()),
+                                         prepare_st);
+        if (!prepare_st.ok()) {
+            q_ctx->cancel(prepare_st, info.params.fragment_id);
+            return prepare_st;
+        }
+
+        // Insert new PFC into _pipeline_map (old one was removed)
+        _pipeline_map.insert({info.params.query_id, info.params.fragment_id}, context);
+
+        // Update QueryContext mapping (must support overwrite)
+        q_ctx->set_pipeline_context(info.params.fragment_id, context);
+
+        RETURN_IF_ERROR(context->submit());
+        return Status::OK();
+
     } else {
-        return Status::NotFound(
-                "reset_fragment: Query context (query-id: {}) not found, maybe finished",
-                print_id(query_id));
+        return Status::InvalidArgument("Unknown rerun fragment opcode: {}", stage);
     }
-    return Status::OK();
 }
 
 Status FragmentMgr::reset_global_rf(const TUniqueId& query_id,

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <brpc/closure_guard.h>
 #include <gen_cpp/FrontendService_types.h>
 #include <gen_cpp/QueryPlanExtra_types.h>
 #include <gen_cpp/Types_types.h>
@@ -25,6 +26,7 @@
 #include <cstdint>
 #include <functional>
 #include <iosfwd>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -191,7 +193,8 @@ public:
                                   const google::protobuf::RepeatedPtrField<PBlock>& pblocks,
                                   bool eos);
 
-    Status rerun_fragment(const TUniqueId& query_id, int fragment,
+    Status rerun_fragment(const std::shared_ptr<brpc::ClosureGuard>& guard,
+                          const TUniqueId& query_id, int fragment,
                           PRerunFragmentParams_Opcode stage);
 
     Status reset_global_rf(const TUniqueId& query_id,
@@ -232,6 +235,19 @@ private:
                          std::shared_ptr<pipeline::PipelineFragmentContext>,
                          pipeline::PipelineFragmentContext>
             _pipeline_map;
+
+    // Saved params and callback for rerunnable (recursive CTE) fragments.
+    // Only populated when need_notify_close == true during exec_plan_fragment.
+    struct RerunableFragmentInfo {
+        std::set<int> deregister_runtime_filter_ids;
+        TPipelineFragmentParams params;
+        TPipelineFragmentParamsList parent;
+        FinishCallback finish_callback;
+        std::shared_ptr<QueryContext> query_ctx; // avoid query_ctx release
+        uint32_t stage = 0;
+    };
+    std::mutex _rerunnable_params_lock;
+    std::map<std::pair<TUniqueId, int>, RerunableFragmentInfo> _rerunnable_params_map;
 
     // query id -> QueryContext
     ConcurrentContextMap<TUniqueId, std::weak_ptr<QueryContext>, QueryContext> _query_ctx_map;

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -389,7 +389,9 @@ std::string QueryContext::print_all_pipeline_context() {
 void QueryContext::set_pipeline_context(
         const int fragment_id, std::shared_ptr<pipeline::PipelineFragmentContext> pip_ctx) {
     std::lock_guard<std::mutex> lock(_pipeline_map_write_lock);
-    _fragment_id_to_pipeline_ctx.insert({fragment_id, pip_ctx});
+    // Use insert_or_assign instead of insert to support overwriting old entries
+    // when recursive CTE recreates PipelineFragmentContext between rounds.
+    _fragment_id_to_pipeline_ctx.insert_or_assign(fragment_id, pip_ctx);
 }
 
 doris::pipeline::TaskScheduler* QueryContext::get_pipe_exec_scheduler() {

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -475,10 +475,6 @@ QueryContext::_collect_realtime_query_profile() {
                 continue;
             }
 
-            if (fragment_ctx->need_notify_close()) {
-                continue;
-            }
-
             auto profile = fragment_ctx->collect_realtime_profile();
 
             if (profile.empty()) {

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -394,6 +394,10 @@ private:
     std::map<std::pair<TUniqueId, int>, pipeline::RecCTEScanLocalState*> _cte_scan;
     std::mutex _cte_scan_lock;
 
+    // for represent the rf's fragment execution round number of recursive cte
+    std::unordered_map<int, uint32_t> _filter_id_to_stage; // filter id -> stage number
+    std::mutex __filter_id_to_stage_mtx;
+
 public:
     // when fragment of pipeline is closed, it will register its profile to this map by using add_fragment_profile
     void add_fragment_profile(
@@ -410,7 +414,32 @@ public:
     timespec get_query_arrival_timestamp() const { return this->_query_arrival_timestamp; }
     QuerySource get_query_source() const { return this->_query_source; }
 
-    const TQueryOptions get_query_options() const { return _query_options; }
+    TQueryOptions get_query_options() const { return _query_options; }
+
+    uint32_t get_stage(int filter_id) {
+        std::lock_guard<std::mutex> lock(__filter_id_to_stage_mtx);
+        auto it = _filter_id_to_stage.find(filter_id);
+        if (it != _filter_id_to_stage.end()) {
+            return it->second;
+        }
+        return 0;
+    }
+
+    Status update_filters_stage(uint32_t stage, const std::set<int32_t>& filter_ids) {
+        std::lock_guard<std::mutex> lock(__filter_id_to_stage_mtx);
+        for (int32_t filter_id : filter_ids) {
+            if (_filter_id_to_stage[filter_id] > stage) {
+                return Status::InternalError(
+                        "The stage of runtime filter {} is {}, cannot be updated to {}", filter_id,
+                        _filter_id_to_stage[filter_id], stage);
+            } else if (_filter_id_to_stage[filter_id] == stage) {
+                continue;
+            }
+            runtime_filter_mgr()->remove_filter(filter_id);
+            _filter_id_to_stage[filter_id] = stage;
+        }
+        return Status::OK();
+    }
 };
 
 } // namespace doris

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -418,11 +418,7 @@ public:
 
     uint32_t get_stage(int filter_id) {
         std::lock_guard<std::mutex> lock(__filter_id_to_stage_mtx);
-        auto it = _filter_id_to_stage.find(filter_id);
-        if (it != _filter_id_to_stage.end()) {
-            return it->second;
-        }
-        return 0;
+        return _filter_id_to_stage[filter_id];
     }
 
     Status update_filters_stage(uint32_t stage, const std::set<int32_t>& filter_ids) {

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -191,6 +191,10 @@ const std::set<int>& RuntimeState::get_deregister_runtime_filter() const {
     return _registered_runtime_filter_ids;
 }
 
+void RuntimeState::merge_register_runtime_filter(const std::set<int>& runtime_filter_ids) {
+    _registered_runtime_filter_ids.insert(runtime_filter_ids.begin(), runtime_filter_ids.end());
+}
+
 Status RuntimeState::init(const TUniqueId& fragment_instance_id, const TQueryOptions& query_options,
                           const TQueryGlobals& query_globals, ExecEnv* exec_env) {
     _fragment_instance_id = fragment_instance_id;

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -184,8 +184,11 @@ RuntimeState::~RuntimeState() {
     if (_error_log_file != nullptr && _error_log_file->is_open()) {
         _error_log_file->close();
     }
-
     _obj_pool->clear();
+}
+
+const std::set<int>& RuntimeState::get_deregister_runtime_filter() const {
+    return _registered_runtime_filter_ids;
 }
 
 Status RuntimeState::init(const TUniqueId& fragment_instance_id, const TQueryOptions& query_options,
@@ -494,16 +497,6 @@ bool RuntimeState::is_nereids() const {
 std::vector<std::shared_ptr<RuntimeProfile>> RuntimeState::pipeline_id_to_profile() {
     std::shared_lock lc(_pipeline_profile_lock);
     return _pipeline_id_to_profile;
-}
-
-void RuntimeState::reset_to_rerun() {
-    if (local_runtime_filter_mgr()) {
-        local_runtime_filter_mgr()->remove_filters(_registered_runtime_filter_ids);
-        global_runtime_filter_mgr()->remove_filters(_registered_runtime_filter_ids);
-        _registered_runtime_filter_ids.clear();
-    }
-    std::unique_lock lc(_pipeline_profile_lock);
-    _pipeline_id_to_profile.clear();
 }
 
 std::vector<std::shared_ptr<RuntimeProfile>> RuntimeState::build_pipeline_profile(

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -769,6 +769,8 @@ public:
 
     const std::set<int>& get_deregister_runtime_filter() const;
 
+    void merge_register_runtime_filter(const std::set<int>& runtime_filter_ids);
+
 private:
     Status create_error_log_file();
 

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -762,16 +762,12 @@ public:
                                       _query_options.hnsw_bounded_queue, _query_options.ivf_nprobe);
     }
 
-    void reset_to_rerun();
-
-    void set_force_make_rf_wait_infinite() {
-        _query_options.__set_runtime_filter_wait_infinitely(true);
-    }
-
     bool runtime_filter_wait_infinitely() const {
         return _query_options.__isset.runtime_filter_wait_infinitely &&
                _query_options.runtime_filter_wait_infinitely;
     }
+
+    const std::set<int>& get_deregister_runtime_filter() const;
 
 private:
     Status create_error_log_file();

--- a/be/src/runtime/task_execution_context.cpp
+++ b/be/src/runtime/task_execution_context.cpp
@@ -19,22 +19,14 @@
 
 #include <glog/logging.h>
 
-#include <condition_variable>
-
 namespace doris {
-void TaskExecutionContext::ref_task_execution_ctx() {
-    ++_has_task_execution_ctx_ref_count;
-}
 
-void TaskExecutionContext::unref_task_execution_ctx() {
-    --_has_task_execution_ctx_ref_count;
-    if (_has_task_execution_ctx_ref_count == 0) {
-        _notify_cv.notify_all();
-    }
-}
+TaskExecutionContext ::TaskExecutionContext() = default;
+TaskExecutionContext ::~TaskExecutionContext() = default;
 
 HasTaskExecutionCtx::HasTaskExecutionCtx(RuntimeState* state)
         : task_exec_ctx_(state->get_task_execution_context()) {}
 
 HasTaskExecutionCtx::~HasTaskExecutionCtx() = default;
+
 } // namespace doris

--- a/be/src/runtime/task_execution_context.h
+++ b/be/src/runtime/task_execution_context.h
@@ -17,8 +17,6 @@
 
 #pragma once
 
-#include <atomic>
-#include <condition_variable>
 #include <memory>
 
 #include "runtime/runtime_state.h"
@@ -27,22 +25,14 @@ namespace doris {
 
 class RuntimeState;
 
-// This class act as a super class of all context like things such as
-// plan fragment executor or pipelinefragmentcontext or pipelinexfragmentcontext
+// Base class for execution contexts (e.g. PipelineFragmentContext).
+//
+// For recursive CTE, the PFC (which inherits from this class) is held by external threads
+// (scanner threads, brpc callbacks, etc.) via weak_ptr<TaskExecutionContext>.
 class TaskExecutionContext : public std::enable_shared_from_this<TaskExecutionContext> {
 public:
-    TaskExecutionContext() = default;
-    virtual ~TaskExecutionContext() = default;
-
-    void ref_task_execution_ctx();
-
-    void unref_task_execution_ctx();
-
-    int has_task_execution_ctx_ref_count() const { return _has_task_execution_ctx_ref_count; }
-
-protected:
-    std::atomic<int> _has_task_execution_ctx_ref_count = 0;
-    std::condition_variable _notify_cv;
+    TaskExecutionContext();
+    virtual ~TaskExecutionContext();
 };
 
 using TaskExecutionContextSPtr = std::shared_ptr<TaskExecutionContext>;

--- a/be/src/runtime_filter/runtime_filter.cpp
+++ b/be/src/runtime_filter/runtime_filter.cpp
@@ -35,6 +35,7 @@ Status RuntimeFilter::_push_to_remote(RuntimeState* state, const TNetworkAddress
     }
 
     auto merge_filter_request = std::make_shared<PMergeFilterRequest>();
+    merge_filter_request->set_stage(state->get_query_ctx()->get_stage(_wrapper->filter_id()));
     auto merge_filter_callback = DummyBrpcCallback<PMergeFilterResponse>::create_shared();
     auto merge_filter_closure =
             AutoReleaseClosure<PMergeFilterRequest, DummyBrpcCallback<PMergeFilterResponse>>::

--- a/be/src/runtime_filter/runtime_filter_mgr.cpp
+++ b/be/src/runtime_filter/runtime_filter_mgr.cpp
@@ -25,6 +25,7 @@
 #include <gen_cpp/internal_service.pb.h>
 #include <gen_cpp/types.pb.h>
 
+#include <mutex>
 #include <ostream>
 #include <string>
 #include <utility>
@@ -236,6 +237,10 @@ Status RuntimeFilterMergeControllerEntity::send_filter_size(std::shared_ptr<Quer
     }
     auto& cnt_val = iter->second;
     std::unique_lock<std::mutex> l(iter->second.mtx);
+    // discard low stage rf
+    if (request->stage() != iter->second.stage) {
+        return Status::OK();
+    }
     cnt_val.source_addrs.push_back(request->source_addr());
 
     Status st = Status::OK();
@@ -253,9 +258,12 @@ Status RuntimeFilterMergeControllerEntity::send_filter_size(std::shared_ptr<Quer
                 continue;
             }
 
+            auto sync_request = std::make_shared<PSyncFilterSizeRequest>();
+            sync_request->set_stage(query_ctx->get_stage(request->filter_id()));
+
             auto closure = AutoReleaseClosure<PSyncFilterSizeRequest,
                                               DummyBrpcCallback<PSyncFilterSizeResponse>>::
-                    create_unique(std::make_shared<PSyncFilterSizeRequest>(),
+                    create_unique(sync_request,
                                   DummyBrpcCallback<PSyncFilterSizeResponse>::create_shared(), ctx);
 
             auto* pquery_id = closure->request_->mutable_query_id();
@@ -326,6 +334,14 @@ Status RuntimeFilterMergeControllerEntity::merge(std::shared_ptr<QueryContext> q
     bool is_ready = false;
     {
         std::lock_guard<std::mutex> l(iter->second.mtx);
+        // discard low stage rf
+        if (request->stage() != iter->second.stage) {
+            return Status::OK();
+        }
+        if (cnt_val.merger == nullptr) {
+            return Status::InternalError("Merger is null for filter id {}",
+                                         std::to_string(request->filter_id()));
+        }
         // Skip the other broadcast join runtime filter
         if (cnt_val.arrive_id.size() == 1 && cnt_val.runtime_filter_desc.is_broadcast_join) {
             return Status::OK();
@@ -372,6 +388,12 @@ Status RuntimeFilterMergeControllerEntity::_send_rf_to_target(GlobalMergeContext
     butil::IOBuf request_attachment;
 
     PPublishFilterRequestV2 apply_request;
+    if (auto q_ctx = ctx.lock(); q_ctx) {
+        apply_request.set_stage(q_ctx->get_stage(cnt_val.runtime_filter_desc.filter_id));
+    } else {
+        return Status::EndOfFile("Merge filter failed: Query context already finished");
+    }
+
     // serialize filter
     void* data = nullptr;
     int len = 0;
@@ -441,12 +463,14 @@ Status RuntimeFilterMergeControllerEntity::_send_rf_to_target(GlobalMergeContext
 }
 
 Status GlobalMergeContext::reset(QueryContext* query_ctx) {
+    std::unique_lock<std::mutex> lock(mtx);
     int producer_size = merger->get_expected_producer_num();
     RETURN_IF_ERROR(RuntimeFilterMerger::create(query_ctx, &runtime_filter_desc, &merger));
     merger->set_expected_producer_num(producer_size);
     arrive_id.clear();
     source_addrs.clear();
     done = false;
+    stage++;
     return Status::OK();
 }
 

--- a/be/src/runtime_filter/runtime_filter_mgr.h
+++ b/be/src/runtime_filter/runtime_filter_mgr.h
@@ -72,6 +72,10 @@ struct GlobalMergeContext {
     std::vector<PNetworkAddress> source_addrs;
     std::atomic<bool> done = false;
 
+    // for represent the round number of recursive cte
+    // if lower stage rf input to higher stage, we just discard the rf
+    uint32_t stage = 0;
+
     Status reset(QueryContext* query_ctx);
 };
 
@@ -104,13 +108,11 @@ public:
 
     std::string debug_string();
 
-    void remove_filters(const std::set<int32_t>& filter_ids) {
+    void remove_filter(int32_t filter_id) {
         std::lock_guard<std::mutex> l(_lock);
-        for (const auto& id : filter_ids) {
-            _consumer_map.erase(id);
-            _local_merge_map.erase(id);
-            _producer_id_set.erase(id);
-        }
+        _consumer_map.erase(filter_id);
+        _local_merge_map.erase(filter_id);
+        _producer_id_set.erase(filter_id);
     }
 
 private:

--- a/be/src/runtime_filter/runtime_filter_producer.cpp
+++ b/be/src/runtime_filter/runtime_filter_producer.cpp
@@ -199,6 +199,8 @@ Status RuntimeFilterProducer::send_size(RuntimeState* state, uint64_t local_filt
     }
 
     auto request = std::make_shared<PSendFilterSizeRequest>();
+    request->set_stage(state->get_query_ctx()->get_stage(_wrapper->filter_id()));
+
     auto callback = DummyBrpcCallback<PSendFilterSizeResponse>::create_shared();
     // RuntimeFilter maybe deconstructed before the rpc finished, so that could not use
     // a raw pointer in closure. Has to use the context's shared ptr.

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1645,10 +1645,11 @@ void PInternalService::rerun_fragment(google::protobuf::RpcController* controlle
                                       PRerunFragmentResult* response,
                                       google::protobuf::Closure* done) {
     bool ret = _light_work_pool.try_offer([this, request, response, done]() {
-        brpc::ClosureGuard closure_guard(done);
-        auto st =
-                _exec_env->fragment_mgr()->rerun_fragment(UniqueId(request->query_id()).to_thrift(),
-                                                          request->fragment_id(), request->stage());
+        std::shared_ptr<brpc::ClosureGuard> closure_guard =
+                std::make_shared<brpc::ClosureGuard>(done);
+        auto st = _exec_env->fragment_mgr()->rerun_fragment(
+                closure_guard, UniqueId(request->query_id()).to_thrift(), request->fragment_id(),
+                request->stage());
         st.to_protobuf(response->mutable_status());
     });
     if (!ret) {

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -98,9 +98,6 @@ ScannerContext::ScannerContext(
     }
     _dependency = dependency;
     DorisMetrics::instance()->scanner_ctx_cnt->increment(1);
-    if (auto ctx = task_exec_ctx(); ctx) {
-        ctx->ref_task_execution_ctx();
-    }
 }
 
 // After init function call, should not access _parent
@@ -194,9 +191,6 @@ ScannerContext::~ScannerContext() {
             static_cast<void>(task_executor_scheduler->task_executor()->remove_task(_task_handle));
         }
         _task_handle = nullptr;
-    }
-    if (auto ctx = task_exec_ctx(); ctx) {
-        ctx->unref_task_execution_ctx();
     }
 }
 

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -75,11 +75,9 @@ message PTransmitRecCTEBlockResult {
 
 message PRerunFragmentParams {
     enum Opcode {
-    wait = 1;    // wait fragment execute done
-    release = 2; // release current round's resource
-    rebuild = 3; // rebuild next round pipeline tasks
-    submit = 4;  // submit tasks to execute
-    close = 5;   // close fragment
+    wait_for_destroy = 1;     // deregister RF, destroy old PFC, async wait for tasks to close via brpc closure
+    recreate_and_submit = 2;  // recreate a new PFC from saved params and submit it for execution
+    final_close = 3;          // async wait for tasks to close, send report, and clean up (last round)
     }
     optional PUniqueId query_id = 1;
     optional int32 fragment_id = 2;
@@ -610,6 +608,7 @@ message PSendFilterSizeRequest {
     required PUniqueId query_id = 2;
     required PNetworkAddress source_addr = 3;
     required uint64 filter_size = 4;
+    optional uint32 stage = 5;
 };
 
 message PSendFilterSizeResponse {
@@ -620,6 +619,7 @@ message PSyncFilterSizeRequest {
     required int32 filter_id = 1;
     required PUniqueId query_id = 2;
     required uint64 filter_size = 3;
+    optional uint32 stage = 5;
 };
 
 message PSyncFilterSizeResponse {
@@ -641,6 +641,7 @@ message PMergeFilterRequest {
     optional bool ignored = 12;
     optional uint64 local_merge_time = 13;
     optional bool disabled = 14;
+    optional uint32 stage = 15;
 };
 
 message PMergeFilterResponse {
@@ -662,6 +663,7 @@ message PPublishFilterRequestV2 {
     repeated int32 fragment_ids = 12; // deprecated
     optional uint64 local_merge_time = 13;
     optional bool disabled = 14;
+    optional uint32 stage = 15;
 };
 
 message PPublishFilterResponse {

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -76,8 +76,9 @@ message PTransmitRecCTEBlockResult {
 message PRerunFragmentParams {
     enum Opcode {
     wait_for_destroy = 1;     // deregister RF, destroy old PFC, async wait for tasks to close via brpc closure
-    recreate_and_submit = 2;  // recreate a new PFC from saved params and submit it for execution
-    final_close = 3;          // async wait for tasks to close, send report, and clean up (last round)
+    rebuild = 2;              // rebuild next round pipeline tasks
+    submit = 3;               // submit tasks to execute
+    final_close = 4;          // async wait for tasks to close, send report, and clean up (last round)
     }
     optional PUniqueId query_id = 1;
     optional int32 fragment_id = 2;


### PR DESCRIPTION
This pull request introduces significant improvements to the management and rerunning of recursive CTE (Common Table Expression) fragments in the pipeline execution engine. The changes focus on robust lifecycle management, memory leak prevention, and enhanced handling of runtime filters and rerunnable fragments. Key updates include refactoring the rerun logic for fragments, improving resource cleanup, and adding safeguards to prevent race conditions and memory leaks.

**Recursive CTE and Fragment Lifecycle Management:**

- Refactored the rerun logic for recursive CTE fragments, introducing new opcodes (`wait_for_destroy`, `final_close`) and a more robust mechanism for fragment rerunning and destruction. This includes saving rerunnable parameters and properly recreating fragment contexts as needed. (`be/src/runtime/fragment_mgr.cpp` [[1]](diffhunk://#diff-3be0bcdb0c3c5fe6415556cf49c7270d4fc2e2f071c0240145ce175a32a484e2L1464-L1492) [[2]](diffhunk://#diff-3be0bcdb0c3c5fe6415556cf49c7270d4fc2e2f071c0240145ce175a32a484e2R939-R949) [[3]](diffhunk://#diff-3be0bcdb0c3c5fe6415556cf49c7270d4fc2e2f071c0240145ce175a32a484e2R694-R705) [[4]](diffhunk://#diff-3be0bcdb0c3c5fe6415556cf49c7270d4fc2e2f071c0240145ce175a32a484e2R348-R351) [[5]](diffhunk://#diff-9f558888989dd08ae617466466716e106c8480524f9f1d86d7b0b650115058a1R20) [[6]](diffhunk://#diff-9f558888989dd08ae617466466716e106c8480524f9f1d86d7b0b650115058a1R29)
- Improved the management of the `need_notify_close` flag and added a `_wait_close_guard` to ensure that fragment closure notifications are handled safely and only once. (`be/src/pipeline/pipeline_fragment_context.h` [[1]](diffhunk://#diff-c606eba62cda49d906e1cdd2566a8c8f6c6344c2503a75cc4cd3213e69796ab2L131-R148) [[2]](diffhunk://#diff-c606eba62cda49d906e1cdd2566a8c8f6c6344c2503a75cc4cd3213e69796ab2R358) `be/src/pipeline/pipeline_fragment_context.cpp` [[3]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617R182-R191) [[4]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617L1805-R1808) [[5]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617L1993-R1998) [[6]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617R1917-R1920) [[7]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617L1907-R1907) [[8]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617L2070-R2085)
- Enhanced resource cleanup by ensuring that rerunnable parameters are cleared on both normal and cancel paths, preventing memory leaks. (`be/src/runtime/fragment_mgr.cpp` [[1]](diffhunk://#diff-3be0bcdb0c3c5fe6415556cf49c7270d4fc2e2f071c0240145ce175a32a484e2R694-R705) [[2]](diffhunk://#diff-3be0bcdb0c3c5fe6415556cf49c7270d4fc2e2f071c0240145ce175a32a484e2R348-R351)

**Runtime Filter and Stage Handling:**

- Added logic to discard runtime filter requests that arrive at an incorrect stage, preventing stale or duplicate filter updates from being processed. (`be/src/runtime/fragment_mgr.cpp` [[1]](diffhunk://#diff-3be0bcdb0c3c5fe6415556cf49c7270d4fc2e2f071c0240145ce175a32a484e2R1357-R1360) [[2]](diffhunk://#diff-3be0bcdb0c3c5fe6415556cf49c7270d4fc2e2f071c0240145ce175a32a484e2R1389-R1392) [[3]](diffhunk://#diff-3be0bcdb0c3c5fe6415556cf49c7270d4fc2e2f071c0240145ce175a32a484e2R1408-R1411) [[4]](diffhunk://#diff-3be0bcdb0c3c5fe6415556cf49c7270d4fc2e2f071c0240145ce175a32a484e2R1435-R1438)
- Improved propagation and deregistration of runtime filters during fragment rerun and closure, ensuring correct filter state across fragment lifecycles. (`be/src/pipeline/exec/partitioned_hash_join_sink_operator.cpp` [[1]](diffhunk://#diff-0d26f173a45e4b0d4a51e9e8bc14d8725fd218b183be900ebd8210443a9d8299R568-R569) `be/src/pipeline/pipeline_fragment_context.cpp` [[2]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617L2070-R2085)

**Other Notable Improvements:**

- Updated debug logging to provide clearer information about fragment context state, aiding in troubleshooting and diagnostics. (`be/src/pipeline/pipeline_fragment_context.cpp` [be/src/pipeline/pipeline_fragment_context.cppL1993-R1998](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617L1993-R1998))
- Adjusted status handling for fragment reporting to avoid unnecessary retries and to ensure that fragments can be closed safely when execution completes successfully. (`be/src/pipeline/pipeline_fragment_context.cpp` [[1]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617L1907-R1907) [[2]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617R1917-R1920)

These changes collectively make the recursive CTE execution more robust, improve resource management, and enhance the reliability of runtime filter handling.

**References:**  
- Recursive CTE and Fragment Lifecycle Management: [[1]](diffhunk://#diff-3be0bcdb0c3c5fe6415556cf49c7270d4fc2e2f071c0240145ce175a32a484e2L1464-L1492) [[2]](diffhunk://#diff-3be0bcdb0c3c5fe6415556cf49c7270d4fc2e2f071c0240145ce175a32a484e2R939-R949) [[3]](diffhunk://#diff-3be0bcdb0c3c5fe6415556cf49c7270d4fc2e2f071c0240145ce175a32a484e2R694-R705) [[4]](diffhunk://#diff-3be0bcdb0c3c5fe6415556cf49c7270d4fc2e2f071c0240145ce175a32a484e2R348-R351) [[5]](diffhunk://#diff-9f558888989dd08ae617466466716e106c8480524f9f1d86d7b0b650115058a1R20) [[6]](diffhunk://#diff-9f558888989dd08ae617466466716e106c8480524f9f1d86d7b0b650115058a1R29) [[7]](diffhunk://#diff-c606eba62cda49d906e1cdd2566a8c8f6c6344c2503a75cc4cd3213e69796ab2L131-R148) [[8]](diffhunk://#diff-c606eba62cda49d906e1cdd2566a8c8f6c6344c2503a75cc4cd3213e69796ab2R358) [[9]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617R182-R191) [[10]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617L1805-R1808) [[11]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617L1993-R1998) [[12]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617R1917-R1920) [[13]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617L1907-R1907) [[14]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617L2070-R2085)
- Runtime Filter and Stage Handling: [[1]](diffhunk://#diff-3be0bcdb0c3c5fe6415556cf49c7270d4fc2e2f071c0240145ce175a32a484e2R1357-R1360) [[2]](diffhunk://#diff-3be0bcdb0c3c5fe6415556cf49c7270d4fc2e2f071c0240145ce175a32a484e2R1389-R1392) [[3]](diffhunk://#diff-3be0bcdb0c3c5fe6415556cf49c7270d4fc2e2f071c0240145ce175a32a484e2R1408-R1411) [[4]](diffhunk://#diff-3be0bcdb0c3c5fe6415556cf49c7270d4fc2e2f071c0240145ce175a32a484e2R1435-R1438) [[5]](diffhunk://#diff-0d26f173a45e4b0d4a51e9e8bc14d8725fd218b183be900ebd8210443a9d8299R568-R569) [[6]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617L2070-R2085)
- Other Notable Improvements: [[1]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617L1993-R1998) [[2]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617L1907-R1907) [[3]](diffhunk://#diff-83005c47a16e1f9dca3a3d2ae1dc171affb74cdff7545390d52e1f2deb4cd617R1917-R1920)