### PR TITLE
[opt](build) enable maven cache and check maven version

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -65,6 +65,26 @@ under the License.
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.6.2</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>[3.9.0,)</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
                 <version>1.2.5</version>
@@ -211,6 +231,11 @@ under the License.
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
                 <version>1.7.0</version>
+            </extension>
+            <extension>
+                <groupId>org.apache.maven.extensions</groupId>
+                <artifactId>maven-build-cache-extension</artifactId>
+                <version>1.2.2</version>
             </extension>
         </extensions>
     </build>

--- a/fs_brokers/cdc_client/build.sh
+++ b/fs_brokers/cdc_client/build.sh
@@ -27,7 +27,7 @@ export CDC_CLIENT_HOME="${ROOT}"
 
 "${DORIS_HOME}"/generated-source.sh noclean
 cd "${DORIS_HOME}/fe"
-"${MVN_CMD}" install -pl fe-common -Dskip.doc=true -DskipTests
+"${MVN_CMD}" install -pl fe-common -Dskip.doc=true -DskipTests -Dmaven.build.cache.enabled=false
 
 echo "Install cdc client..."
 cd "${CDC_CLIENT_HOME}"


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

This pull request updates the Maven build configuration to enforce a minimum Maven version and improve build performance through caching. The most important changes are:

Build requirements and enforcement:

* Added the `maven-enforcer-plugin` (version 3.6.2) to the `fe/pom.xml` build plugins, enforcing that Maven version 3.9.0 or higher is required to build the project.

Build performance improvements:

* Added the `maven-build-cache-extension` (version 1.2.2) to the `fe/pom.xml` build extensions, enabling build caching to speed up repeated builds.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [x] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

