### PR TITLE
[fix](local shuffle) fix bucket shuffle + set operation + local shuffle compute wrong result

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -2391,13 +2391,14 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
             setOperationNode.setColocate(true);
         }
 
-        for (Plan child : setOperation.children()) {
-            PhysicalPlan childPhysicalPlan = (PhysicalPlan) child;
-            if (JoinUtils.isStorageBucketed(childPhysicalPlan.getPhysicalProperties())) {
-                setOperationNode.setDistributionMode(DistributionMode.BUCKET_SHUFFLE);
-                break;
-            }
-        }
+        // TODO: open comment when support `enable_local_shuffle_planner`
+        // for (Plan child : setOperation.children()) {
+        //     PhysicalPlan childPhysicalPlan = (PhysicalPlan) child;
+        //     if (JoinUtils.isStorageBucketed(childPhysicalPlan.getPhysicalProperties())) {
+        //         setOperationNode.setDistributionMode(DistributionMode.BUCKET_SHUFFLE);
+        //         break;
+        //     }
+        // }
 
         return setOperationFragment;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriver.java
@@ -30,7 +30,6 @@ import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.functions.table.TableValuedFunction;
 import org.apache.doris.nereids.trees.plans.Plan;
-import org.apache.doris.nereids.trees.plans.algebra.Union;
 import org.apache.doris.nereids.trees.plans.physical.AbstractPhysicalSort;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalAssertNumRows;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalCTEAnchor;
@@ -74,11 +73,9 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -459,52 +456,53 @@ public class ChildOutputPropertyDeriver extends PlanVisitor<PhysicalProperties, 
             return PhysicalProperties.GATHER;
         }
 
-        int distributeToChildIndex
-                = setOperation.<Integer>getMutableState(PhysicalSetOperation.DISTRIBUTE_TO_CHILD_INDEX).orElse(-1);
-        if (distributeToChildIndex >= 0
-                && childrenDistribution.get(distributeToChildIndex) instanceof DistributionSpecHash) {
-            DistributionSpecHash childDistribution
-                    = (DistributionSpecHash) childrenDistribution.get(distributeToChildIndex);
-            List<SlotReference> childToIndex = setOperation.getRegularChildrenOutputs().get(distributeToChildIndex);
-            Map<ExprId, Integer> idToOutputIndex = new LinkedHashMap<>();
-            for (int j = 0; j < childToIndex.size(); j++) {
-                idToOutputIndex.put(childToIndex.get(j).getExprId(), j);
-            }
-
-            List<ExprId> orderedShuffledColumns = childDistribution.getOrderedShuffledColumns();
-            List<ExprId> setOperationDistributeColumnIds = new ArrayList<>();
-            for (ExprId tableDistributeColumnId : orderedShuffledColumns) {
-                Integer index = idToOutputIndex.get(tableDistributeColumnId);
-                if (index == null) {
-                    break;
-                }
-                setOperationDistributeColumnIds.add(setOperation.getOutput().get(index).getExprId());
-            }
-            // check whether the set operation output all distribution columns of the child
-            if (setOperationDistributeColumnIds.size() == orderedShuffledColumns.size()) {
-                boolean isUnion = setOperation instanceof Union;
-                boolean shuffleToRight = distributeToChildIndex > 0;
-                if (!isUnion && shuffleToRight) {
-                    return new PhysicalProperties(
-                            new DistributionSpecHash(
-                                    setOperationDistributeColumnIds,
-                                    ShuffleType.EXECUTION_BUCKETED
-                            )
-                    );
-                } else {
-                    // keep the distribution as the child
-                    return new PhysicalProperties(
-                            new DistributionSpecHash(
-                                    setOperationDistributeColumnIds,
-                                    childDistribution.getShuffleType(),
-                                    childDistribution.getTableId(),
-                                    childDistribution.getSelectedIndexId(),
-                                    childDistribution.getPartitionIds()
-                            )
-                    );
-                }
-            }
-        }
+        // TODO: open comment when support `enable_local_shuffle_planner`
+        // int distributeToChildIndex
+        //         = setOperation.<Integer>getMutableState(PhysicalSetOperation.DISTRIBUTE_TO_CHILD_INDEX).orElse(-1);
+        // if (distributeToChildIndex >= 0
+        //         && childrenDistribution.get(distributeToChildIndex) instanceof DistributionSpecHash) {
+        //     DistributionSpecHash childDistribution
+        //             = (DistributionSpecHash) childrenDistribution.get(distributeToChildIndex);
+        //     List<SlotReference> childToIndex = setOperation.getRegularChildrenOutputs().get(distributeToChildIndex);
+        //     Map<ExprId, Integer> idToOutputIndex = new LinkedHashMap<>();
+        //     for (int j = 0; j < childToIndex.size(); j++) {
+        //         idToOutputIndex.put(childToIndex.get(j).getExprId(), j);
+        //     }
+        //
+        //     List<ExprId> orderedShuffledColumns = childDistribution.getOrderedShuffledColumns();
+        //     List<ExprId> setOperationDistributeColumnIds = new ArrayList<>();
+        //     for (ExprId tableDistributeColumnId : orderedShuffledColumns) {
+        //         Integer index = idToOutputIndex.get(tableDistributeColumnId);
+        //         if (index == null) {
+        //             break;
+        //         }
+        //         setOperationDistributeColumnIds.add(setOperation.getOutput().get(index).getExprId());
+        //     }
+        //     // check whether the set operation output all distribution columns of the child
+        //     if (setOperationDistributeColumnIds.size() == orderedShuffledColumns.size()) {
+        //         boolean isUnion = setOperation instanceof Union;
+        //         boolean shuffleToRight = distributeToChildIndex > 0;
+        //         if (!isUnion && shuffleToRight) {
+        //             return new PhysicalProperties(
+        //                     new DistributionSpecHash(
+        //                             setOperationDistributeColumnIds,
+        //                             ShuffleType.EXECUTION_BUCKETED
+        //                     )
+        //             );
+        //         } else {
+        //             // keep the distribution as the child
+        //             return new PhysicalProperties(
+        //                     new DistributionSpecHash(
+        //                             setOperationDistributeColumnIds,
+        //                             childDistribution.getShuffleType(),
+        //                             childDistribution.getTableId(),
+        //                             childDistribution.getSelectedIndexId(),
+        //                             childDistribution.getPartitionIds()
+        //                     )
+        //             );
+        //         }
+        //     }
+        // }
 
         for (int i = 0; i < childrenDistribution.size(); i++) {
             DistributionSpec childDistribution = childrenDistribution.get(i);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
@@ -295,13 +295,14 @@ public class RequestPropertyDeriver extends PlanVisitor<Void, PlanContext> {
             // shuffle all column
             // TODO: for wide table, may be we should add a upper limit of shuffle columns
 
+            // TODO: open comment when support `enable_local_shuffle_planner` and change to REQUIRE
             // intersect/except always need hash distribution, we use REQUIRE to auto select
             // bucket shuffle or execution shuffle
             addRequestPropertyToChildren(setOperation.getRegularChildrenOutputs().stream()
                     .map(childOutputs -> childOutputs.stream()
                             .map(SlotReference::getExprId)
                             .collect(ImmutableList.toImmutableList()))
-                    .map(l -> PhysicalProperties.createHash(l, ShuffleType.REQUIRE))
+                    .map(l -> PhysicalProperties.createHash(l, ShuffleType.EXECUTION_BUCKETED))
                     .collect(Collectors.toList()));
         }
         return null;

--- a/regression-test/data/nereids_rules_p0/infer_set_operator_distinct/infer_set_operator_distinct.out
+++ b/regression-test/data/nereids_rules_p0/infer_set_operator_distinct/infer_set_operator_distinct.out
@@ -42,8 +42,9 @@ PhysicalResultSink
 -- !except_distinct --
 PhysicalResultSink
 --PhysicalDistribute[DistributionSpecGather]
-----PhysicalExcept[bucketShuffle]
-------PhysicalOlapScan[t1]
+----PhysicalExcept
+------PhysicalDistribute[DistributionSpecHash]
+--------PhysicalOlapScan[t1]
 ------PhysicalDistribute[DistributionSpecHash]
 --------PhysicalOlapScan[t2]
 
@@ -58,8 +59,9 @@ PhysicalResultSink
 -- !intersect_distinct --
 PhysicalResultSink
 --PhysicalDistribute[DistributionSpecGather]
-----PhysicalIntersect[bucketShuffle]
-------PhysicalOlapScan[t1]
+----PhysicalIntersect
+------PhysicalDistribute[DistributionSpecHash]
+--------PhysicalOlapScan[t1]
 ------PhysicalDistribute[DistributionSpecHash]
 --------PhysicalOlapScan[t2]
 
@@ -84,20 +86,20 @@ PhysicalResultSink
 -- !mixed_set_operators --
 PhysicalResultSink
 --PhysicalDistribute[DistributionSpecGather]
-----PhysicalIntersect[bucketShuffle]
-------PhysicalDistribute[DistributionSpecHash]
---------PhysicalExcept[bucketShuffle]
+----PhysicalIntersect
+------PhysicalExcept
+--------hashAgg[GLOBAL]
 ----------PhysicalDistribute[DistributionSpecHash]
-------------hashAgg[GLOBAL]
---------------PhysicalDistribute[DistributionSpecHash]
-----------------hashAgg[LOCAL]
-------------------PhysicalUnion
---------------------PhysicalDistribute[DistributionSpecExecutionAny]
-----------------------PhysicalOlapScan[t1]
---------------------PhysicalDistribute[DistributionSpecExecutionAny]
-----------------------PhysicalOlapScan[t2]
+------------hashAgg[LOCAL]
+--------------PhysicalUnion
+----------------PhysicalDistribute[DistributionSpecExecutionAny]
+------------------PhysicalOlapScan[t1]
+----------------PhysicalDistribute[DistributionSpecExecutionAny]
+------------------PhysicalOlapScan[t2]
+--------PhysicalDistribute[DistributionSpecHash]
 ----------PhysicalOlapScan[t3]
-------PhysicalOlapScan[t4]
+------PhysicalDistribute[DistributionSpecHash]
+--------PhysicalOlapScan[t4]
 
 -- !join_with_union --
 PhysicalResultSink
@@ -241,8 +243,9 @@ PhysicalResultSink
 -- !except_with_subquery --
 PhysicalResultSink
 --PhysicalDistribute[DistributionSpecGather]
-----PhysicalExcept[bucketShuffle]
-------PhysicalOlapScan[t1]
+----PhysicalExcept
+------PhysicalDistribute[DistributionSpecHash]
+--------PhysicalOlapScan[t1]
 ------PhysicalDistribute[DistributionSpecHash]
 --------filter((t2.score > 10))
 ----------PhysicalOlapScan[t2]
@@ -292,9 +295,10 @@ PhysicalResultSink
 -- !except_complex_subquery --
 PhysicalResultSink
 --PhysicalDistribute[DistributionSpecGather]
-----PhysicalExcept[bucketShuffle]
-------PhysicalProject
---------PhysicalOlapScan[t1]
+----PhysicalExcept
+------PhysicalDistribute[DistributionSpecHash]
+--------PhysicalProject
+----------PhysicalOlapScan[t1]
 ------PhysicalDistribute[DistributionSpecHash]
 --------PhysicalProject
 ----------filter((t2.score > 20))
@@ -385,9 +389,10 @@ SyntaxError:
 -- !with_hint_except_distinct --
 PhysicalResultSink
 --PhysicalDistribute[DistributionSpecGather]
-----PhysicalExcept[bucketShuffle]
-------hashAgg[GLOBAL]
---------PhysicalOlapScan[t1]
+----PhysicalExcept
+------PhysicalDistribute[DistributionSpecHash]
+--------hashAgg[GLOBAL]
+----------PhysicalOlapScan[t1]
 ------PhysicalDistribute[DistributionSpecHash]
 --------hashAgg[GLOBAL]
 ----------PhysicalOlapScan[t2]
@@ -413,9 +418,10 @@ SyntaxError:
 -- !with_hint_intersect_distinct --
 PhysicalResultSink
 --PhysicalDistribute[DistributionSpecGather]
-----PhysicalIntersect[bucketShuffle]
-------hashAgg[GLOBAL]
---------PhysicalOlapScan[t1]
+----PhysicalIntersect
+------PhysicalDistribute[DistributionSpecHash]
+--------hashAgg[GLOBAL]
+----------PhysicalOlapScan[t1]
 ------PhysicalDistribute[DistributionSpecHash]
 --------hashAgg[GLOBAL]
 ----------PhysicalOlapScan[t2]
@@ -451,25 +457,25 @@ SyntaxError:
 -- !with_hint_mixed_set_operators --
 PhysicalResultSink
 --PhysicalDistribute[DistributionSpecGather]
-----PhysicalIntersect[bucketShuffle]
-------PhysicalDistribute[DistributionSpecHash]
---------hashAgg[GLOBAL]
-----------PhysicalExcept[bucketShuffle]
+----PhysicalIntersect
+------hashAgg[GLOBAL]
+--------PhysicalExcept
+----------hashAgg[GLOBAL]
 ------------PhysicalDistribute[DistributionSpecHash]
---------------hashAgg[GLOBAL]
-----------------PhysicalDistribute[DistributionSpecHash]
-------------------hashAgg[LOCAL]
---------------------PhysicalUnion
-----------------------PhysicalDistribute[DistributionSpecExecutionAny]
-------------------------hashAgg[GLOBAL]
---------------------------PhysicalOlapScan[t1]
-----------------------PhysicalDistribute[DistributionSpecExecutionAny]
-------------------------hashAgg[GLOBAL]
---------------------------PhysicalOlapScan[t2]
+--------------hashAgg[LOCAL]
+----------------PhysicalUnion
+------------------PhysicalDistribute[DistributionSpecExecutionAny]
+--------------------hashAgg[GLOBAL]
+----------------------PhysicalOlapScan[t1]
+------------------PhysicalDistribute[DistributionSpecExecutionAny]
+--------------------hashAgg[GLOBAL]
+----------------------PhysicalOlapScan[t2]
+----------PhysicalDistribute[DistributionSpecHash]
 ------------hashAgg[GLOBAL]
 --------------PhysicalOlapScan[t3]
-------hashAgg[GLOBAL]
---------PhysicalOlapScan[t4]
+------PhysicalDistribute[DistributionSpecHash]
+--------hashAgg[GLOBAL]
+----------PhysicalOlapScan[t4]
 
 Hint log:
 Used: use_INFER_SET_OPERATOR_DISTINCT
@@ -687,9 +693,10 @@ SyntaxError:
 -- !with_hint_except_with_subquery --
 PhysicalResultSink
 --PhysicalDistribute[DistributionSpecGather]
-----PhysicalExcept[bucketShuffle]
-------hashAgg[GLOBAL]
---------PhysicalOlapScan[t1]
+----PhysicalExcept
+------PhysicalDistribute[DistributionSpecHash]
+--------hashAgg[GLOBAL]
+----------PhysicalOlapScan[t1]
 ------PhysicalDistribute[DistributionSpecHash]
 --------hashAgg[GLOBAL]
 ----------filter((t2.score > 10))
@@ -764,10 +771,11 @@ SyntaxError:
 -- !with_hint_except_complex_subquery --
 PhysicalResultSink
 --PhysicalDistribute[DistributionSpecGather]
-----PhysicalExcept[bucketShuffle]
-------hashAgg[GLOBAL]
---------PhysicalProject
-----------PhysicalOlapScan[t1]
+----PhysicalExcept
+------PhysicalDistribute[DistributionSpecHash]
+--------hashAgg[GLOBAL]
+----------PhysicalProject
+------------PhysicalOlapScan[t1]
 ------PhysicalDistribute[DistributionSpecHash]
 --------hashAgg[GLOBAL]
 ----------PhysicalProject
@@ -860,8 +868,9 @@ SyntaxError:
 -- !with_hint_no_except_distinct --
 PhysicalResultSink
 --PhysicalDistribute[DistributionSpecGather]
-----PhysicalExcept[bucketShuffle]
-------PhysicalOlapScan[t1]
+----PhysicalExcept
+------PhysicalDistribute[DistributionSpecHash]
+--------PhysicalOlapScan[t1]
 ------PhysicalDistribute[DistributionSpecHash]
 --------PhysicalOlapScan[t2]
 
@@ -886,8 +895,9 @@ SyntaxError:
 -- !with_hint_no_intersect_distinct --
 PhysicalResultSink
 --PhysicalDistribute[DistributionSpecGather]
-----PhysicalIntersect[bucketShuffle]
-------PhysicalOlapScan[t1]
+----PhysicalIntersect
+------PhysicalDistribute[DistributionSpecHash]
+--------PhysicalOlapScan[t1]
 ------PhysicalDistribute[DistributionSpecHash]
 --------PhysicalOlapScan[t2]
 
@@ -922,20 +932,20 @@ SyntaxError:
 -- !with_hint_no_mixed_set_operators --
 PhysicalResultSink
 --PhysicalDistribute[DistributionSpecGather]
-----PhysicalIntersect[bucketShuffle]
-------PhysicalDistribute[DistributionSpecHash]
---------PhysicalExcept[bucketShuffle]
+----PhysicalIntersect
+------PhysicalExcept
+--------hashAgg[GLOBAL]
 ----------PhysicalDistribute[DistributionSpecHash]
-------------hashAgg[GLOBAL]
---------------PhysicalDistribute[DistributionSpecHash]
-----------------hashAgg[LOCAL]
-------------------PhysicalUnion
---------------------PhysicalDistribute[DistributionSpecExecutionAny]
-----------------------PhysicalOlapScan[t1]
---------------------PhysicalDistribute[DistributionSpecExecutionAny]
-----------------------PhysicalOlapScan[t2]
+------------hashAgg[LOCAL]
+--------------PhysicalUnion
+----------------PhysicalDistribute[DistributionSpecExecutionAny]
+------------------PhysicalOlapScan[t1]
+----------------PhysicalDistribute[DistributionSpecExecutionAny]
+------------------PhysicalOlapScan[t2]
+--------PhysicalDistribute[DistributionSpecHash]
 ----------PhysicalOlapScan[t3]
-------PhysicalOlapScan[t4]
+------PhysicalDistribute[DistributionSpecHash]
+--------PhysicalOlapScan[t4]
 
 Hint log:
 Used:
@@ -1129,8 +1139,9 @@ SyntaxError:
 -- !with_hint_no_except_with_subquery --
 PhysicalResultSink
 --PhysicalDistribute[DistributionSpecGather]
-----PhysicalExcept[bucketShuffle]
-------PhysicalOlapScan[t1]
+----PhysicalExcept
+------PhysicalDistribute[DistributionSpecHash]
+--------PhysicalOlapScan[t1]
 ------PhysicalDistribute[DistributionSpecHash]
 --------filter((t2.score > 10))
 ----------PhysicalOlapScan[t2]
@@ -1200,9 +1211,10 @@ SyntaxError:
 -- !with_hint_no_except_complex_subquery --
 PhysicalResultSink
 --PhysicalDistribute[DistributionSpecGather]
-----PhysicalExcept[bucketShuffle]
-------PhysicalProject
---------PhysicalOlapScan[t1]
+----PhysicalExcept
+------PhysicalDistribute[DistributionSpecHash]
+--------PhysicalProject
+----------PhysicalOlapScan[t1]
 ------PhysicalDistribute[DistributionSpecHash]
 --------PhysicalProject
 ----------filter((t2.score > 20))

--- a/regression-test/data/shape_check/tpch_sf1000/runtime_filter/test_pushdown_setop.out
+++ b/regression-test/data/shape_check/tpch_sf1000/runtime_filter/test_pushdown_setop.out
@@ -6,16 +6,16 @@ PhysicalResultSink
 ------hashAgg[LOCAL]
 --------PhysicalProject
 ----------hashJoin[INNER_JOIN broadcast] hashCondition=((T.l_linenumber = expr_cast(r_regionkey as BIGINT))) otherCondition=() build RFs:RF0 expr_cast(r_regionkey as BIGINT)->[cast(l_linenumber as BIGINT),o_orderkey]
-------------PhysicalExcept[bucketShuffle] RFV2: RF1[l_linenumber->o_orderkey]
+------------PhysicalExcept RFV2: RF1[l_linenumber->o_orderkey]
+--------------hashAgg[GLOBAL]
+----------------PhysicalDistribute[DistributionSpecHash]
+------------------hashAgg[LOCAL]
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[lineitem] apply RFs: RF0
 --------------PhysicalDistribute[DistributionSpecHash]
 ----------------hashAgg[GLOBAL]
-------------------PhysicalDistribute[DistributionSpecHash]
---------------------hashAgg[LOCAL]
-----------------------PhysicalProject
-------------------------PhysicalOlapScan[lineitem] apply RFs: RF0
---------------hashAgg[GLOBAL]
-----------------PhysicalProject
-------------------PhysicalOlapScan[orders] apply RFs: RF0 RFV2: RF1
+------------------PhysicalProject
+--------------------PhysicalOlapScan[orders] apply RFs: RF0 RFV2: RF1
 ------------PhysicalProject
 --------------PhysicalOlapScan[region]
 
@@ -27,16 +27,16 @@ PhysicalResultSink
 --------PhysicalProject
 ----------hashJoin[INNER_JOIN broadcast] hashCondition=((expr_abs(l_linenumber) = expr_cast(r_regionkey as LARGEINT))) otherCondition=() build RFs:RF0 expr_cast(r_regionkey as LARGEINT)->[abs(cast(l_linenumber as BIGINT)),abs(o_orderkey)]
 ------------PhysicalProject
---------------PhysicalExcept[bucketShuffle] RFV2: RF1[l_linenumber->o_orderkey]
+--------------PhysicalExcept RFV2: RF1[l_linenumber->o_orderkey]
+----------------hashAgg[GLOBAL]
+------------------PhysicalDistribute[DistributionSpecHash]
+--------------------hashAgg[LOCAL]
+----------------------PhysicalProject
+------------------------PhysicalOlapScan[lineitem] apply RFs: RF0
 ----------------PhysicalDistribute[DistributionSpecHash]
 ------------------hashAgg[GLOBAL]
---------------------PhysicalDistribute[DistributionSpecHash]
-----------------------hashAgg[LOCAL]
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[lineitem] apply RFs: RF0
-----------------hashAgg[GLOBAL]
-------------------PhysicalProject
---------------------PhysicalOlapScan[orders] apply RFs: RF0 RFV2: RF1
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[orders] apply RFs: RF0 RFV2: RF1
 ------------PhysicalProject
 --------------PhysicalOlapScan[region]
 

--- a/regression-test/suites/query_p0/set_operations/bucket_shuffle_set_operation.groovy
+++ b/regression-test/suites/query_p0/set_operations/bucket_shuffle_set_operation.groovy
@@ -16,6 +16,9 @@
 // under the License.
 
 suite("bucket_shuffle_set_operation") {
+    // TODO: open comment when support `enable_local_shuffle_planner` and change to REQUIRE
+    return
+
     multi_sql """
         drop table if exists bucket_shuffle_set_operation1;
         create table bucket_shuffle_set_operation1(id int, value int) distributed by hash(id) buckets 10 properties('replication_num'='1');


### PR DESCRIPTION
### What problem does this PR solve?

fix bucket shuffle + set operation + local shuffle compute wrong result, because backend can not plan the correct local shuffle type, introduced by #59006.
so we should disable bucket shuffle for set operation  now, after support plan local shuffle in frontend, we can support this feature.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

