### PR TITLE
[chore](type) optimize code of AggStateType

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -5088,7 +5088,8 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
                 // TODO use function binder to check function exists
                 throw new ParseException("Can not found function '" + functionName + "'", ctx);
             }
-            return new AggStateType(functionName, dataTypes, nullables);
+            return new AggStateType(functionName, dataTypes, nullables,
+                    BuiltinAggregateFunctions.INSTANCE.aggFuncNameNullableMap.get(functionName));
         });
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/AggCombinerFunctionBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/AggCombinerFunctionBuilder.java
@@ -28,6 +28,7 @@ import org.apache.doris.nereids.trees.expressions.functions.combinator.UnionComb
 import org.apache.doris.nereids.types.AggStateType;
 import org.apache.doris.nereids.types.ArrayType;
 import org.apache.doris.nereids.types.DataType;
+import org.apache.doris.nereids.types.DataTypeUtils;
 
 import java.util.List;
 import java.util.Objects;
@@ -75,7 +76,7 @@ public class AggCombinerFunctionBuilder extends FunctionBuilder {
                 return false;
             }
 
-            return nestedBuilder.canApply(((AggStateType) argument.getDataType()).getMockedExpressions());
+            return nestedBuilder.canApply(DataTypeUtils.getMockedExpressions((AggStateType) argument.getDataType()));
         }
     }
 
@@ -121,7 +122,7 @@ public class AggCombinerFunctionBuilder extends FunctionBuilder {
         if (arg instanceof StateCombinator) {
             nestedArguments = arg.children();
         } else {
-            nestedArguments = ((AggStateType) arg.getDataType()).getMockedExpressions();
+            nestedArguments = DataTypeUtils.getMockedExpressions((AggStateType) arg.getDataType());
         }
 
         return (AggregateFunction) nestedBuilder.build(nestedName, nestedArguments).first;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/combinator/StateCombinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/combinator/StateCombinator.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.trees.expressions.functions.combinator;
 
+import org.apache.doris.catalog.BuiltinAggregateFunctions;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.FunctionRegistry;
 import org.apache.doris.catalog.FunctionSignature;
@@ -28,6 +29,7 @@ import org.apache.doris.nereids.trees.expressions.functions.AggCombinerFunctionB
 import org.apache.doris.nereids.trees.expressions.functions.AlwaysNotNullable;
 import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
+import org.apache.doris.nereids.trees.expressions.functions.ExpressionTrait;
 import org.apache.doris.nereids.trees.expressions.functions.Function;
 import org.apache.doris.nereids.trees.expressions.functions.FunctionBuilder;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
@@ -66,11 +68,10 @@ public class StateCombinator extends ScalarFunction
         }
 
         this.nested = Objects.requireNonNull(nested, "nested can not be null");
-        this.returnType = new AggStateType(nested.getName(), arguments.stream().map(arg -> {
-            return arg.getDataType();
-        }).collect(ImmutableList.toImmutableList()), arguments.stream().map(arg -> {
-            return arg.nullable();
-        }).collect(ImmutableList.toImmutableList()));
+        this.returnType = new AggStateType(nested.getName(),
+                arguments.stream().map(ExpressionTrait::getDataType).collect(ImmutableList.toImmutableList()),
+                arguments.stream().map(ExpressionTrait::nullable).collect(ImmutableList.toImmutableList()),
+                BuiltinAggregateFunctions.INSTANCE.aggFuncNameNullableMap.get(nested.getName()));
     }
 
     private StateCombinator(ScalarFunctionParams functionParams, AggregateFunction nested) {
@@ -83,11 +84,12 @@ public class StateCombinator extends ScalarFunction
         }
 
         this.nested = Objects.requireNonNull(nested, "nested can not be null");
-        this.returnType = new AggStateType(nested.getName(), functionParams.arguments.stream().map(arg -> {
-            return arg.getDataType();
-        }).collect(ImmutableList.toImmutableList()), functionParams.arguments.stream().map(arg -> {
-            return arg.nullable();
-        }).collect(ImmutableList.toImmutableList()));
+        this.returnType = new AggStateType(nested.getName(),
+                functionParams.arguments.stream()
+                        .map(ExpressionTrait::getDataType).collect(ImmutableList.toImmutableList()),
+                functionParams.arguments.stream()
+                        .map(ExpressionTrait::nullable).collect(ImmutableList.toImmutableList()),
+                BuiltinAggregateFunctions.INSTANCE.aggFuncNameNullableMap.get(nested.getName()));
     }
 
     public static StateCombinator create(AggregateFunction nested) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
@@ -443,7 +443,8 @@ public abstract class DataType {
                 org.apache.doris.catalog.AggStateType catalogType = ((org.apache.doris.catalog.AggStateType) type);
                 List<DataType> types = catalogType.getSubTypes().stream().map(DataType::fromCatalogType)
                         .collect(Collectors.toList());
-                return new AggStateType(catalogType.getFunctionName(), types, catalogType.getSubTypeNullables());
+                return new AggStateType(catalogType.getFunctionName(), types,
+                        catalogType.getSubTypeNullables(), catalogType.getResultIsNullable());
             }
             case DECIMALV2: {
                 ScalarType scalarType = (ScalarType) type;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataTypeUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataTypeUtils.java
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.types;
+
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * utils for data type of nereids.
+ */
+public class DataTypeUtils {
+
+    /**
+     * getMockedExpressions.
+     */
+    public static List<Expression> getMockedExpressions(AggStateType aggStateType) {
+        List<Expression> result = new ArrayList<>();
+        for (int i = 0; i < aggStateType.getSubTypes().size(); i++) {
+            result.add(new SlotReference("mocked", aggStateType.getSubTypes().get(i),
+                    aggStateType.getSubTypeNullables().get(i)));
+        }
+        return result;
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionMatrixTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionMatrixTest.java
@@ -96,7 +96,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(NullType.INSTANCE, HllType.INSTANCE, HllType.INSTANCE);
         testProcessComparisonPredicate(NullType.INSTANCE, BitmapType.INSTANCE, BitmapType.INSTANCE);
         testProcessComparisonPredicate(NullType.INSTANCE, QuantileStateType.INSTANCE, QuantileStateType.INSTANCE);
-        testProcessComparisonPredicate(NullType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)));
+        testProcessComparisonPredicate(NullType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true));
     }
 
     @Test
@@ -134,7 +134,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(BooleanType.INSTANCE, HllType.INSTANCE, null);
         testProcessComparisonPredicate(BooleanType.INSTANCE, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(BooleanType.INSTANCE, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(BooleanType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(BooleanType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -180,7 +180,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(TinyIntType.INSTANCE, HllType.INSTANCE, null);
         testProcessComparisonPredicate(TinyIntType.INSTANCE, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(TinyIntType.INSTANCE, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(TinyIntType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(TinyIntType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -226,7 +226,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(SmallIntType.INSTANCE, HllType.INSTANCE, null);
         testProcessComparisonPredicate(SmallIntType.INSTANCE, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(SmallIntType.INSTANCE, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(SmallIntType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(SmallIntType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -272,7 +272,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(IntegerType.INSTANCE, HllType.INSTANCE, null);
         testProcessComparisonPredicate(IntegerType.INSTANCE, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(IntegerType.INSTANCE, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(IntegerType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(IntegerType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -318,7 +318,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(BigIntType.INSTANCE, HllType.INSTANCE, null);
         testProcessComparisonPredicate(BigIntType.INSTANCE, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(BigIntType.INSTANCE, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(BigIntType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(BigIntType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -364,7 +364,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(LargeIntType.INSTANCE, HllType.INSTANCE, null);
         testProcessComparisonPredicate(LargeIntType.INSTANCE, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(LargeIntType.INSTANCE, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(LargeIntType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(LargeIntType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -413,7 +413,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(DecimalV2Type.SYSTEM_DEFAULT, HllType.INSTANCE, null);
         testProcessComparisonPredicate(DecimalV2Type.SYSTEM_DEFAULT, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(DecimalV2Type.SYSTEM_DEFAULT, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(DecimalV2Type.SYSTEM_DEFAULT, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(DecimalV2Type.SYSTEM_DEFAULT, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -462,7 +462,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(DecimalV3Type.createDecimalV3Type(30, 15), HllType.INSTANCE, null);
         testProcessComparisonPredicate(DecimalV3Type.createDecimalV3Type(30, 15), BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(DecimalV3Type.createDecimalV3Type(30, 15), QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(DecimalV3Type.createDecimalV3Type(30, 15), new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(DecimalV3Type.createDecimalV3Type(30, 15), new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -502,7 +502,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(FloatType.INSTANCE, HllType.INSTANCE, null);
         testProcessComparisonPredicate(FloatType.INSTANCE, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(FloatType.INSTANCE, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(FloatType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(FloatType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -542,7 +542,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(DoubleType.INSTANCE, HllType.INSTANCE, null);
         testProcessComparisonPredicate(DoubleType.INSTANCE, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(DoubleType.INSTANCE, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(DoubleType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(DoubleType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -582,7 +582,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(DateType.INSTANCE, HllType.INSTANCE, null);
         testProcessComparisonPredicate(DateType.INSTANCE, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(DateType.INSTANCE, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(DateType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(DateType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -622,7 +622,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(DateV2Type.INSTANCE, HllType.INSTANCE, null);
         testProcessComparisonPredicate(DateV2Type.INSTANCE, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(DateV2Type.INSTANCE, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(DateV2Type.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(DateV2Type.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -662,7 +662,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(DateTimeType.INSTANCE, HllType.INSTANCE, null);
         testProcessComparisonPredicate(DateTimeType.INSTANCE, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(DateTimeType.INSTANCE, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(DateTimeType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(DateTimeType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -702,7 +702,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(DateTimeV2Type.of(4), HllType.INSTANCE, null);
         testProcessComparisonPredicate(DateTimeV2Type.of(4), BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(DateTimeV2Type.of(4), QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(DateTimeV2Type.of(4), new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(DateTimeV2Type.of(4), new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -742,7 +742,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(TimeV2Type.of(4), HllType.INSTANCE, null);
         testProcessComparisonPredicate(TimeV2Type.of(4), BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(TimeV2Type.of(4), QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(TimeV2Type.of(4), new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(TimeV2Type.of(4), new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -778,7 +778,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(IPv4Type.INSTANCE, HllType.INSTANCE, null);
         testProcessComparisonPredicate(IPv4Type.INSTANCE, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(IPv4Type.INSTANCE, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(IPv4Type.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(IPv4Type.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -814,7 +814,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(IPv6Type.INSTANCE, HllType.INSTANCE, null);
         testProcessComparisonPredicate(IPv6Type.INSTANCE, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(IPv6Type.INSTANCE, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(IPv6Type.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(IPv6Type.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -850,7 +850,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(JsonType.INSTANCE, HllType.INSTANCE, null);
         testProcessComparisonPredicate(JsonType.INSTANCE, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(JsonType.INSTANCE, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(JsonType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(JsonType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -892,7 +892,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(CharType.createCharType(3), HllType.INSTANCE, null);
         testProcessComparisonPredicate(CharType.createCharType(3), BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(CharType.createCharType(3), QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(CharType.createCharType(3), new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(CharType.createCharType(3), new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -934,7 +934,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(VarcharType.createVarcharType(3), HllType.INSTANCE, null);
         testProcessComparisonPredicate(VarcharType.createVarcharType(3), BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(VarcharType.createVarcharType(3), QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(VarcharType.createVarcharType(3), new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(VarcharType.createVarcharType(3), new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -975,7 +975,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(StringType.INSTANCE, HllType.INSTANCE, null);
         testProcessComparisonPredicate(StringType.INSTANCE, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(StringType.INSTANCE, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(StringType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(StringType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -1013,7 +1013,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(arrayType, HllType.INSTANCE, null);
         testProcessComparisonPredicate(arrayType, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(arrayType, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(arrayType, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(arrayType, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -1051,7 +1051,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(mapType, HllType.INSTANCE, null);
         testProcessComparisonPredicate(mapType, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(mapType, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(mapType, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(mapType, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -1090,7 +1090,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(structType, HllType.INSTANCE, null);
         testProcessComparisonPredicate(structType, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(structType, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(structType, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(structType, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -1131,7 +1131,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(HllType.INSTANCE, HllType.INSTANCE, HllType.INSTANCE);
         testProcessComparisonPredicate(HllType.INSTANCE, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(HllType.INSTANCE, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(HllType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(HllType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -1172,7 +1172,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(BitmapType.INSTANCE, HllType.INSTANCE, null);
         testProcessComparisonPredicate(BitmapType.INSTANCE, BitmapType.INSTANCE, BitmapType.INSTANCE);
         testProcessComparisonPredicate(BitmapType.INSTANCE, QuantileStateType.INSTANCE, null);
-        testProcessComparisonPredicate(BitmapType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(BitmapType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
@@ -1213,12 +1213,12 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(QuantileStateType.INSTANCE, HllType.INSTANCE, null);
         testProcessComparisonPredicate(QuantileStateType.INSTANCE, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(QuantileStateType.INSTANCE, QuantileStateType.INSTANCE, QuantileStateType.INSTANCE);
-        testProcessComparisonPredicate(QuantileStateType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(QuantileStateType.INSTANCE, new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     @Test
     public void testProcessComparisonPredicateForAggStateType() {
-        AggStateType aggStateType = new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true));
+        AggStateType aggStateType = new AggStateType("sum", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true);
         testProcessComparisonPredicate(aggStateType, NullType.INSTANCE, aggStateType);
         testProcessComparisonPredicate(aggStateType, BooleanType.INSTANCE, null);
         testProcessComparisonPredicate(aggStateType, TinyIntType.INSTANCE, null);
@@ -1256,7 +1256,7 @@ public class TypeCoercionMatrixTest {
         testProcessComparisonPredicate(aggStateType, BitmapType.INSTANCE, null);
         testProcessComparisonPredicate(aggStateType, QuantileStateType.INSTANCE, null);
         testProcessComparisonPredicate(aggStateType, aggStateType, aggStateType);
-        testProcessComparisonPredicate(aggStateType, new AggStateType("avg", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true)), null);
+        testProcessComparisonPredicate(aggStateType, new AggStateType("avg", ImmutableList.of(IntegerType.INSTANCE), ImmutableList.of(true), true), null);
     }
 
     private void testProcessComparisonPredicate(DataType leftType, DataType rightType, DataType commonType) {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

This pull request refactors and enhances the handling of aggregate state types (`AggStateType`) in the codebase, improving how nullability is tracked and simplifying related logic. The most important changes include adding explicit support for the return nullability of aggregate functions, refactoring the construction and conversion of `AggStateType`, and extracting utility logic for mocked expressions.

Enhancements to `AggStateType` and nullability tracking:

* Added a `returnNullable` field to `AggStateType`, ensuring that the nullability of aggregate function results is explicitly tracked and propagated throughout the codebase. All constructors and usages of `AggStateType` have been updated to include this field. [[1]](diffhunk://#diff-bf1978d57acdd865d169ed2b9c0b67c932698cf9313e5947078f11fb8d151335R62-R85) [[2]](diffhunk://#diff-8ef1d9bfc0b70b41ae4beb552ff49886a734d9f76a8fdd917e2659e9f5bbf4e9L5091-R5092) [[3]](diffhunk://#diff-3689e25f9f4e37beae29567d8ec2d8c220f3fd725076a992f29f515bd9fa4604L69-R74) [[4]](diffhunk://#diff-3689e25f9f4e37beae29567d8ec2d8c220f3fd725076a992f29f515bd9fa4604L86-R92) [[5]](diffhunk://#diff-89f6ec1889e94e1bb1e8a50f5a5cb5b019564172e75e9e67979b2b3355062f2fL446-R447)
* Updated conversion and catalog methods in `AggStateType` to use the new `returnNullable` field, ensuring correct type conversion and catalog representation.

Refactoring and code simplification:

* Extracted the logic for generating mocked expressions from `AggStateType` into a new utility class, `DataTypeUtils`, making the code more modular and reusable. All relevant usages have been updated to use this new utility. [[1]](diffhunk://#diff-2cd3e85294abe0336744f457d090888bcc3e0a864e484c9c9b59ae729e16be67L78-R79) [[2]](diffhunk://#diff-2cd3e85294abe0336744f457d090888bcc3e0a864e484c9c9b59ae729e16be67L124-R125) [[3]](diffhunk://#diff-6cd78459d3dd1bf19727fe12f4a5b14d5319991a7fe1bf45d5dbb9e4a3e16e80R1-R39)
* Updated test cases to use the new `AggStateType` constructor with the `returnNullable` parameter, ensuring tests reflect the new nullability tracking. [[1]](diffhunk://#diff-4126c768e4468f1da30a7300e2749a23f8f1e4c46bd49359c1b237a7e77410a2L99-R99) [[2]](diffhunk://#diff-4126c768e4468f1da30a7300e2749a23f8f1e4c46bd49359c1b237a7e77410a2L137-R137) [[3]](diffhunk://#diff-4126c768e4468f1da30a7300e2749a23f8f1e4c46bd49359c1b237a7e77410a2L183-R183) [[4]](diffhunk://#diff-4126c768e4468f1da30a7300e2749a23f8f1e4c46bd49359c1b237a7e77410a2L229-R229) [[5]](diffhunk://#diff-4126c768e4468f1da30a7300e2749a23f8f1e4c46bd49359c1b237a7e77410a2L275-R275) [[6]](diffhunk://#diff-4126c768e4468f1da30a7300e2749a23f8f1e4c46bd49359c1b237a7e77410a2L321-R321) [[7]](diffhunk://#diff-4126c768e4468f1da30a7300e2749a23f8f1e4c46bd49359c1b237a7e77410a2L367-R367) [[8]](diffhunk://#diff-4126c768e4468f1da30a7300e2749a23f8f1e4c46bd49359c1b237a7e77410a2L416-R416) [[9]](diffhunk://#diff-4126c768e4468f1da30a7300e2749a23f8f1e4c46bd49359c1b237a7e77410a2L465-R465)

Dependency and import updates:

* Added necessary imports for new utility classes and traits to maintain consistency and support the refactored logic. [[1]](diffhunk://#diff-2cd3e85294abe0336744f457d090888bcc3e0a864e484c9c9b59ae729e16be67R31) [[2]](diffhunk://#diff-3689e25f9f4e37beae29567d8ec2d8c220f3fd725076a992f29f515bd9fa4604R20) [[3]](diffhunk://#diff-3689e25f9f4e37beae29567d8ec2d8c220f3fd725076a992f29f515bd9fa4604R32)

These changes collectively improve the robustness and clarity of aggregate state type handling, particularly around nullability, and make the codebase easier to maintain and extend.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

