### PR TITLE
[Fix](func) Fixing microsecond_from_unixtime decimal arg type to DECIMAL(18, 6)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/MicrosecondFromUnixtime.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/MicrosecondFromUnixtime.java
@@ -63,6 +63,14 @@ public class MicrosecondFromUnixtime extends ScalarFunction
     }
 
     @Override
+    public FunctionSignature computeSignature(FunctionSignature signature) {
+        // skip super.computeSignature() to avoid changing the decimal precision
+        // manually set decimal argument's type to always decimal(18, 6), same with FROM_UNIXTIME
+        return FunctionSignature.ret(IntegerType.INSTANCE)
+                .args(DecimalV3Type.createDecimalV3Type(18, 6));
+    }
+
+    @Override
     public List<FunctionSignature> getSignatures() {
         return SIGNATURES;
     }

--- a/regression-test/suites/datatype_p0/date/test_from_unixtime.groovy
+++ b/regression-test/suites/datatype_p0/date/test_from_unixtime.groovy
@@ -18,6 +18,7 @@
 
 suite("test_from_unixtime") {
     sql "set enable_fold_constant_by_be=true"
+    sql "set enable_query_cache=false"
 
     sql "set time_zone='+08:00'"
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: https://github.com/apache/doris/pull/57941

Problem Summary:

```sql
mysql> SELECT MICROSECOND_FROM_UNIXTIME(1145.14);
+------------------------------------+
| MICROSECOND_FROM_UNIXTIME(1145.14) |
+------------------------------------+
|                             140000 |
+------------------------------------+
1 row in set (0.02 sec)

mysql> select @@debug_skip_fold_constant;
+----------------------------+
| @@debug_skip_fold_constant |
+----------------------------+
|                          0 |
+----------------------------+
1 row in set (0.01 sec)

mysql> set debug_skip_fold_constant=true;
Query OK, 0 rows affected (0.02 sec)

mysql> SELECT MICROSECOND_FROM_UNIXTIME(1145.14);
ERROR 1105 (HY000): RpcException, msg: send fragments failed. io.grpc.StatusRuntimeException: UNAVAILABLE: Keepalive failed. The connection is likely gone, host: 10.16.10.3
```
```text
F20260225 00:04:40.698660 618581 status.h:467] Bad cast from type:doris::vectorized::ColumnDecimal<(doris::PrimitiveType)28>* to doris::vectorized::ColumnDecimal<(doris::PrimitiveType)29> const*
*** Check failure stack trace: ***
    @     0x55dbc5c4dc4f  google::LogMessage::SendToLog()
    @     0x55dbc5c44260  google::LogMessage::Flush()
    @     0x55dbc5c47959  google::LogMessageFatal::~LogMessageFatal()
    @     0x55db8f09709b  doris::Status::FatalError<>()
    @     0x55dbb7936b66  _ZZ11assert_castIPKN5doris10vectorized13ColumnDecimalILNS0_13PrimitiveTypeE29EEEL18TypeCheckOnRelease1EPKNS1_7IColumnEET_OT1_ENKUlOSB_E_clISA_EES6_SE_
    @     0x55dbb7935f74  assert_cast<>()
    @     0x55dbbcbf2f1f  doris::vectorized::FunctionTimeFieldFromUnixtime<>::execute_impl()
    @     0x55dbbcbf3762  doris::vectorized::FunctionTimeFieldFromUnixtime<>::execute_impl()
    @     0x55dbba5ca2d8  doris::vectorized::PreparedFunctionImpl::_execute_skipped_constant_deal()
    @     0x55dbba5ad094  doris::vectorized::PreparedFunctionImpl::default_implementation_for_constant_arguments()
    @     0x55dbba5af1fd  doris::vectorized::PreparedFunctionImpl::default_execute()
    @     0x55dbba5af624  doris::vectorized::PreparedFunctionImpl::execute()
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

