### PR TITLE
[feat] Ann Index result cache

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1269,6 +1269,11 @@ DEFINE_String(inverted_index_query_cache_limit, "10%");
 // condition cache limit
 DEFINE_Int16(condition_cache_limit, "512");
 
+// ANN index topn result cache
+DEFINE_String(ann_index_result_cache_limit, "10%");
+DEFINE_Int32(ann_index_result_cache_shards, "16");
+DEFINE_Int32(ann_index_result_cache_stale_sweep_time_sec, "1800");
+
 // inverted index
 DEFINE_mDouble(inverted_index_ram_buffer_size, "512");
 // -1 indicates not working.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1313,6 +1313,11 @@ DECLARE_String(inverted_index_query_cache_limit);
 // condition cache limit
 DECLARE_Int16(condition_cache_limit);
 
+// ANN index topn result cache
+DECLARE_String(ann_index_result_cache_limit);
+DECLARE_Int32(ann_index_result_cache_shards);
+DECLARE_Int32(ann_index_result_cache_stale_sweep_time_sec);
+
 // inverted index
 DECLARE_mDouble(inverted_index_ram_buffer_size);
 DECLARE_mInt32(inverted_index_max_buffered_docs);

--- a/be/src/exec/operator/olap_scan_operator.cpp
+++ b/be/src/exec/operator/olap_scan_operator.cpp
@@ -343,6 +343,9 @@ Status OlapScanLocalState::_init_profile() {
 
     _ann_topn_search_costs = ADD_TIMER(_segment_profile, "AnnIndexTopNSearchCosts");
     _ann_topn_search_cnt = ADD_COUNTER(_segment_profile, "AnnIndexTopNSearchCnt", TUnit::UNIT);
+    _ann_cache_hit_cnt = ADD_COUNTER(_segment_profile, "AnnIndexCacheHitCnt", TUnit::UNIT);
+    _ann_range_cache_hit_cnt =
+            ADD_COUNTER(_segment_profile, "AnnIndexRangeCacheHitCnt", TUnit::UNIT);
     _ann_range_search_costs = ADD_TIMER(_segment_profile, "AnnIndexRangeSearchCosts");
     _ann_range_search_cnt = ADD_COUNTER(_segment_profile, "AnnIndexRangeSearchCnt", TUnit::UNIT);
 

--- a/be/src/exec/operator/olap_scan_operator.h
+++ b/be/src/exec/operator/olap_scan_operator.h
@@ -238,6 +238,8 @@ private:
     // topn_search_costs = index_load_costs + engine_search_costs + pre_process_costs + post_process_costs
     RuntimeProfile::Counter* _ann_topn_search_costs = nullptr;
     RuntimeProfile::Counter* _ann_topn_search_cnt = nullptr;
+    RuntimeProfile::Counter* _ann_cache_hit_cnt = nullptr;
+    RuntimeProfile::Counter* _ann_range_cache_hit_cnt = nullptr;
 
     RuntimeProfile::Counter* _ann_index_load_costs = nullptr;
     RuntimeProfile::Counter* _ann_ivf_on_disk_load_costs = nullptr;

--- a/be/src/exec/scan/olap_scanner.cpp
+++ b/be/src/exec/scan/olap_scanner.cpp
@@ -59,6 +59,9 @@
 #include "storage/olap_utils.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet/tablet_schema.h"
+#ifndef NDEBUG
+#include "util/debug_points.h"
+#endif
 #include "util/json/path_in_data.h"
 
 namespace doris {
@@ -658,6 +661,9 @@ Status OlapScanner::_get_block_impl(RuntimeState* state, Block* block, bool* eof
         _tablet_reader_params.tablet->read_block_count.fetch_add(1, std::memory_order_relaxed);
         *eof = false;
     }
+#ifndef NDEBUG
+    RETURN_IF_ERROR(_check_ann_cache_hit_debug_points(_tablet_reader->stats()));
+#endif
     return Status::OK();
 }
 
@@ -938,6 +944,8 @@ void OlapScanner::_collect_profile_before_close() {
 
     COUNTER_UPDATE(local_state->_ann_topn_search_costs, stats.ann_topn_search_ns);
     COUNTER_UPDATE(local_state->_ann_topn_search_cnt, stats.ann_index_topn_search_cnt);
+    COUNTER_UPDATE(local_state->_ann_cache_hit_cnt, stats.ann_index_cache_hits);
+    COUNTER_UPDATE(local_state->_ann_range_cache_hit_cnt, stats.ann_index_range_cache_hits);
 
     // Detailed ANN timers
     // ANN TopN timers with hierarchy
@@ -962,6 +970,40 @@ void OlapScanner::_collect_profile_before_close() {
 
     // Overhead counter removed; precise instrumentation is reported via engine_prepare above.
 }
+
+#ifndef NDEBUG
+Status OlapScanner::_check_ann_cache_hit_debug_points(const OlapReaderStatistics& stats) {
+    DBUG_EXECUTE_IF("olap_scanner.ann_topn_cache_hits", {
+        auto expected_hits = dp->param<int32_t>("expected_hits", -1);
+        auto min_hits = dp->param<int32_t>("min_hits", -1);
+        if (expected_hits >= 0 && stats.ann_index_cache_hits != expected_hits) {
+            return Status::Error<ErrorCode::INTERNAL_ERROR>(
+                    "ann_index_cache_hits: {} not equal to expected: {}",
+                    stats.ann_index_cache_hits, expected_hits);
+        }
+        if (min_hits >= 0 && stats.ann_index_cache_hits < min_hits) {
+            return Status::Error<ErrorCode::INTERNAL_ERROR>(
+                    "ann_index_cache_hits: {} less than expected min: {}",
+                    stats.ann_index_cache_hits, min_hits);
+        }
+    })
+    DBUG_EXECUTE_IF("olap_scanner.ann_range_cache_hits", {
+        auto expected_hits = dp->param<int32_t>("expected_hits", -1);
+        auto min_hits = dp->param<int32_t>("min_hits", -1);
+        if (expected_hits >= 0 && stats.ann_index_range_cache_hits != expected_hits) {
+            return Status::Error<ErrorCode::INTERNAL_ERROR>(
+                    "ann_index_range_cache_hits: {} not equal to expected: {}",
+                    stats.ann_index_range_cache_hits, expected_hits);
+        }
+        if (min_hits >= 0 && stats.ann_index_range_cache_hits < min_hits) {
+            return Status::Error<ErrorCode::INTERNAL_ERROR>(
+                    "ann_index_range_cache_hits: {} less than expected min: {}",
+                    stats.ann_index_range_cache_hits, min_hits);
+        }
+    })
+    return Status::OK();
+}
+#endif
 
 #include "common/compile_check_avoid_end.h"
 } // namespace doris

--- a/be/src/exec/scan/olap_scanner.h
+++ b/be/src/exec/scan/olap_scanner.h
@@ -49,6 +49,9 @@ class RuntimeState;
 class TPaloScanRange;
 class ScanLocalStateBase;
 struct FilterPredicates;
+#ifndef NDEBUG
+struct OlapReaderStatistics;
+#endif
 
 class Block;
 
@@ -93,6 +96,9 @@ private:
 
     [[nodiscard]] Status _init_return_columns();
     [[nodiscard]] Status _init_variant_columns();
+#ifndef NDEBUG
+    Status _check_ann_cache_hit_debug_points(const OlapReaderStatistics& stats);
+#endif
 
     std::vector<OlapScanRange*> _key_ranges;
 

--- a/be/src/exprs/vectorized_fn_call.cpp
+++ b/be/src/exprs/vectorized_fn_call.cpp
@@ -556,7 +556,8 @@ Status VectorizedFnCall::evaluate_ann_range_search(
         const std::vector<std::unique_ptr<segment_v2::IndexIterator>>& cid_to_index_iterators,
         const std::vector<ColumnId>& idx_to_cid,
         const std::vector<std::unique_ptr<segment_v2::ColumnIterator>>& column_iterators,
-        roaring::Roaring& row_bitmap, segment_v2::AnnIndexStats& ann_index_stats) {
+        roaring::Roaring& row_bitmap, segment_v2::AnnIndexStats& ann_index_stats,
+        bool enable_result_cache) {
     if (range_search_runtime.is_ann_range_search == false) {
         return Status::OK();
     }
@@ -627,6 +628,7 @@ Status VectorizedFnCall::evaluate_ann_range_search(
     AnnRangeSearchParams params = range_search_runtime.to_range_search_params();
 
     params.roaring = &row_bitmap;
+    params.enable_result_cache = enable_result_cache;
     DCHECK(params.roaring != nullptr);
     DCHECK(params.query_value != nullptr);
     segment_v2::AnnRangeSearchResult result;

--- a/be/src/exprs/vectorized_fn_call.h
+++ b/be/src/exprs/vectorized_fn_call.h
@@ -91,7 +91,8 @@ public:
             const std::vector<std::unique_ptr<segment_v2::IndexIterator>>& cid_to_index_iterators,
             const std::vector<ColumnId>& idx_to_cid,
             const std::vector<std::unique_ptr<segment_v2::ColumnIterator>>& column_iterators,
-            roaring::Roaring& row_bitmap, segment_v2::AnnIndexStats& ann_index_stats) override;
+            roaring::Roaring& row_bitmap, segment_v2::AnnIndexStats& ann_index_stats,
+            bool enable_result_cache) override;
 
     void prepare_ann_range_search(const doris::VectorSearchUserParams& params,
                                   segment_v2::AnnRangeSearchRuntime& runtime,

--- a/be/src/exprs/vexpr.cpp
+++ b/be/src/exprs/vexpr.cpp
@@ -1038,7 +1038,7 @@ Status VExpr::evaluate_ann_range_search(
         const std::vector<std::unique_ptr<segment_v2::IndexIterator>>& index_iterators,
         const std::vector<ColumnId>& idx_to_cid,
         const std::vector<std::unique_ptr<segment_v2::ColumnIterator>>& column_iterators,
-        roaring::Roaring& row_bitmap, AnnIndexStats& ann_index_stats) {
+        roaring::Roaring& row_bitmap, AnnIndexStats& ann_index_stats, bool enable_result_cache) {
     return Status::OK();
 }
 

--- a/be/src/exprs/vexpr.h
+++ b/be/src/exprs/vexpr.h
@@ -345,7 +345,8 @@ public:
             const std::vector<std::unique_ptr<segment_v2::IndexIterator>>& cid_to_index_iterators,
             const std::vector<ColumnId>& idx_to_cid,
             const std::vector<std::unique_ptr<segment_v2::ColumnIterator>>& column_iterators,
-            roaring::Roaring& row_bitmap, segment_v2::AnnIndexStats& ann_index_stats);
+            roaring::Roaring& row_bitmap, segment_v2::AnnIndexStats& ann_index_stats,
+            bool enable_result_cache);
 
     // Prepare the runtime for ANN range search.
     // AnnRangeSearchRuntime is used to store the runtime information of ann range search.

--- a/be/src/exprs/vexpr_context.cpp
+++ b/be/src/exprs/vexpr_context.cpp
@@ -439,14 +439,15 @@ Status VExprContext::evaluate_ann_range_search(
         const std::vector<std::unique_ptr<segment_v2::ColumnIterator>>& column_iterators,
         const std::unordered_map<VExprContext*, std::unordered_map<ColumnId, VExpr*>>&
                 common_expr_to_slotref_map,
-        roaring::Roaring& row_bitmap, segment_v2::AnnIndexStats& ann_index_stats) {
+        roaring::Roaring& row_bitmap, segment_v2::AnnIndexStats& ann_index_stats,
+        bool enable_result_cache) {
     if (_root == nullptr) {
         return Status::OK();
     }
 
     RETURN_IF_ERROR(_root->evaluate_ann_range_search(
             _ann_range_search_runtime, cid_to_index_iterators, idx_to_cid, column_iterators,
-            row_bitmap, ann_index_stats));
+            row_bitmap, ann_index_stats, enable_result_cache));
 
     if (!_root->ann_range_search_executedd()) {
         return Status::OK();

--- a/be/src/exprs/vexpr_context.h
+++ b/be/src/exprs/vexpr_context.h
@@ -388,7 +388,8 @@ public:
             const std::vector<std::unique_ptr<segment_v2::ColumnIterator>>& column_iterators,
             const std::unordered_map<VExprContext*, std::unordered_map<ColumnId, VExpr*>>&
                     common_expr_to_slotref_map,
-            roaring::Roaring& row_bitmap, segment_v2::AnnIndexStats& ann_index_stats);
+            roaring::Roaring& row_bitmap, segment_v2::AnnIndexStats& ann_index_stats,
+            bool enable_result_cache);
 
     uint64_t get_digest(uint64_t seed) const;
 

--- a/be/src/exprs/virtual_slot_ref.cpp
+++ b/be/src/exprs/virtual_slot_ref.cpp
@@ -234,10 +234,11 @@ Status VirtualSlotRef::evaluate_ann_range_search(
         const std::vector<std::unique_ptr<segment_v2::IndexIterator>>& cid_to_index_iterators,
         const std::vector<ColumnId>& idx_to_cid,
         const std::vector<std::unique_ptr<segment_v2::ColumnIterator>>& column_iterators,
-        roaring::Roaring& row_bitmap, segment_v2::AnnIndexStats& ann_index_stats) {
+        roaring::Roaring& row_bitmap, segment_v2::AnnIndexStats& ann_index_stats,
+        bool enable_result_cache) {
     return _virtual_column_expr->evaluate_ann_range_search(
             range_search_runtime, cid_to_index_iterators, idx_to_cid, column_iterators, row_bitmap,
-            ann_index_stats);
+            ann_index_stats, enable_result_cache);
 
     return Status::OK();
 }

--- a/be/src/exprs/virtual_slot_ref.h
+++ b/be/src/exprs/virtual_slot_ref.h
@@ -106,7 +106,8 @@ public:
             const std::vector<std::unique_ptr<segment_v2::IndexIterator>>& cid_to_index_iterators,
             const std::vector<ColumnId>& idx_to_cid,
             const std::vector<std::unique_ptr<segment_v2::ColumnIterator>>& column_iterators,
-            roaring::Roaring& row_bitmap, segment_v2::AnnIndexStats& ann_index_stats) override;
+            roaring::Roaring& row_bitmap, segment_v2::AnnIndexStats& ann_index_stats,
+            bool enable_result_cache) override;
 
 #ifdef BE_TEST
     // Test-only setter methods for unit testing

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -69,6 +69,7 @@ namespace segment_v2 {
 class InvertedIndexSearcherCache;
 class InvertedIndexQueryCache;
 class ConditionCache;
+class AnnIndexResultCache;
 class TmpFileDirs;
 class EncodingInfoResolver;
 
@@ -415,6 +416,8 @@ public:
     segment_v2::TmpFileDirs* get_tmp_file_dirs() { return _tmp_file_dirs.get(); }
     io::FDCache* file_cache_open_fd_cache() const { return _file_cache_open_fd_cache.get(); }
 
+    segment_v2::AnnIndexResultCache* ann_index_result_cache() { return _ann_index_result_cache; }
+
     orc::MemoryPool* orc_memory_pool() { return _orc_memory_pool; }
     arrow::MemoryPool* arrow_memory_pool() { return _arrow_memory_pool; }
 
@@ -560,6 +563,7 @@ private:
     QueryCache* _query_cache = nullptr;
     std::unique_ptr<io::FDCache> _file_cache_open_fd_cache;
     DeleteBitmapAggCache* _delete_bitmap_agg_cache {nullptr};
+    segment_v2::AnnIndexResultCache* _ann_index_result_cache = nullptr;
 
     RuntimeFilterTimerQueue* _runtime_filter_timer_queue = nullptr;
     DictionaryFactory* _dict_factory = nullptr;

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -102,6 +102,7 @@
 #include "storage/cache/ann_index_ivf_list_cache.h"
 #include "storage/cache/page_cache.h"
 #include "storage/id_manager.h"
+#include "storage/index/ann/ann_index_result_cache/ann_index_result_cache.h"
 #include "storage/index/inverted/inverted_index_cache.h"
 #include "storage/olap_define.h"
 #include "storage/options.h"
@@ -692,6 +693,16 @@ Status ExecEnv::init_mem_env() {
     LOG(INFO) << "Inverted index query match cache memory limit: "
               << PrettyPrinter::print(inverted_index_query_cache_limit, TUnit::BYTES)
               << ", origin config value: " << config::inverted_index_query_cache_limit;
+
+    // ANN index topn result cache
+    int64_t ann_topn_cache_limit =
+            ParseUtil::parse_mem_spec(config::ann_index_result_cache_limit, MemInfo::mem_limit(),
+                                      MemInfo::physical_mem(), &is_percent);
+    _ann_index_result_cache =
+            segment_v2::AnnIndexResultCache::create_global_cache(ann_topn_cache_limit);
+    LOG(INFO) << "ANN index topn result cache memory limit: "
+              << PrettyPrinter::print(ann_topn_cache_limit, TUnit::BYTES)
+              << ", origin config value: " << config::ann_index_result_cache_limit;
 
     // use memory limit
     int64_t condition_cache_limit = config::condition_cache_limit * 1024L * 1024L;

--- a/be/src/runtime/memory/cache_policy.h
+++ b/be/src/runtime/memory/cache_policy.h
@@ -57,6 +57,7 @@ public:
         SCHEMA_CLOUD_DICTIONARY_CACHE = 22,
         CONDITION_CACHE = 23,
         ANN_INDEX_IVF_LIST_CACHE = 24,
+        ANN_INDEX_RESULT_CACHE = 25,
     };
 
     static std::string type_string(CacheType type) {
@@ -109,6 +110,8 @@ public:
             return "ConditionCache";
         case CacheType::ANN_INDEX_IVF_LIST_CACHE:
             return "AnnIndexIVFListCache";
+        case CacheType::ANN_INDEX_RESULT_CACHE:
+            return "AnnIndexResultCache";
         default:
             throw Exception(Status::FatalError("not match type of cache policy :{}",
                                                static_cast<int>(type)));
@@ -139,7 +142,8 @@ public:
             {"QueryCache", CacheType::QUERY_CACHE},
             {"TabletColumnObjectPool", CacheType::TABLET_COLUMN_OBJECT_POOL},
             {"ConditionCache", CacheType::CONDITION_CACHE},
-            {"AnnIndexIVFListCache", CacheType::ANN_INDEX_IVF_LIST_CACHE}};
+            {"AnnIndexIVFListCache", CacheType::ANN_INDEX_IVF_LIST_CACHE},
+            {"AnnIndexResultCache", CacheType::ANN_INDEX_RESULT_CACHE}};
 
     static CacheType string_to_type(std::string type) {
         if (StringToType.contains(type)) {

--- a/be/src/runtime/memory/lru_cache_policy.h
+++ b/be/src/runtime/memory/lru_cache_policy.h
@@ -225,7 +225,8 @@ public:
                     "[MemoryGC] {} prune all {} entries, {} bytes, cost {}, {} times prune, is "
                     "force: {}",
                     type_string(_type), _freed_entrys_counter->value(),
-                    _freed_memory_counter->value(), _cost_timer->value(),
+                    _freed_memory_counter->value(),
+                    PrettyPrinter::print(_cost_timer->value(), TUnit::TIME_NS),
                     _prune_all_number_counter->value(), force);
         } else {
             if (_lru_cache_type == LRUCacheType::SIZE) {

--- a/be/src/storage/index/ann/CMakeLists.txt
+++ b/be/src/storage/index/ann/CMakeLists.txt
@@ -17,8 +17,11 @@
 
 add_subdirectory(cmake-protect)
 
-# Use all .cpp files in this directory as sources
-file(GLOB VECTOR_LIB_SRC CONFIGURE_DEPENDS *.cpp)
+# Use all .cpp files in this directory and subdirectories as sources
+file(GLOB VECTOR_LIB_SRC CONFIGURE_DEPENDS 
+    *.cpp
+    ann_index_result_cache/*.cpp
+)
 
 find_package(OpenMP REQUIRED)
 

--- a/be/src/storage/index/ann/ann_index_reader.cpp
+++ b/be/src/storage/index/ann/ann_index_reader.cpp
@@ -17,6 +17,7 @@
 
 #include "storage/index/ann/ann_index_reader.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <memory>
 
@@ -27,6 +28,8 @@
 #include "runtime/runtime_state.h"
 #include "storage/index/ann/ann_index.h"
 #include "storage/index/ann/ann_index_iterator.h"
+#include "storage/index/ann/ann_index_result_cache/ann_index_result_cache.h"
+#include "storage/index/ann/ann_index_result_cache/ann_index_result_cache_handle.h"
 #include "storage/index/ann/ann_index_writer.h"
 #include "storage/index/ann/ann_search_params.h"
 #include "storage/index/ann/faiss_ann_index.h"
@@ -35,6 +38,15 @@
 #include "util/once.h"
 
 namespace doris::segment_v2 {
+static void check_topn_result(const IndexSearchResult& result) {
+    DCHECK(result.roaring != nullptr);
+    DCHECK(result.row_ids != nullptr);
+    DCHECK(result.distances != nullptr);
+    DCHECK(result.row_ids->size() == result.roaring->cardinality())
+            << "Row ids size: " << result.row_ids->size()
+            << ", roaring size: " << result.roaring->cardinality();
+}
+
 AnnIndexReader::AnnIndexReader(const TabletIndex* index_meta,
                                std::shared_ptr<IndexFileReader> index_file_reader)
         : _index_meta(*index_meta), _index_file_reader(index_file_reader) {
@@ -117,57 +129,97 @@ Status AnnIndexReader::query(io::IOContext* io_ctx, AnnTopNParam* param, AnnInde
         const float* query_vec = param->query_value;
         const int limit = static_cast<int>(param->limit);
         IndexSearchResult index_search_result;
-        if (_index_type == AnnIndexType::HNSW) {
-            HNSWSearchParameters hnsw_search_params;
-            hnsw_search_params.roaring = param->roaring;
-            hnsw_search_params.rows_of_segment = param->rows_of_segment;
-            hnsw_search_params.io_ctx = io_ctx;
-            hnsw_search_params.ef_search = param->_user_params.hnsw_ef_search;
-            hnsw_search_params.check_relative_distance =
-                    param->_user_params.hnsw_check_relative_distance;
-            hnsw_search_params.bounded_queue = param->_user_params.hnsw_bounded_queue;
-            RETURN_IF_ERROR(_vector_index->ann_topn_search(query_vec, limit, hnsw_search_params,
-                                                           index_search_result));
-            // Accumulate detailed engine timings
-            stats->engine_search_ns.update(index_search_result.engine_search_ns);
-            stats->engine_convert_ns.update(index_search_result.engine_convert_ns);
-            stats->engine_prepare_ns.update(index_search_result.engine_prepare_ns);
-        } else if (_index_type == AnnIndexType::IVF || _index_type == AnnIndexType::IVF_ON_DISK) {
-            IVFSearchParameters ivf_search_params;
-            ivf_search_params.roaring = param->roaring;
-            ivf_search_params.rows_of_segment = param->rows_of_segment;
-            ivf_search_params.io_ctx = io_ctx;
-            ivf_search_params.nprobe = param->_user_params.ivf_nprobe;
-            RETURN_IF_ERROR(_vector_index->ann_topn_search(query_vec, limit, ivf_search_params,
-                                                           index_search_result));
-            // Accumulate detailed engine timings
-            stats->engine_search_ns.update(index_search_result.engine_search_ns);
-            stats->engine_convert_ns.update(index_search_result.engine_convert_ns);
-            stats->engine_prepare_ns.update(index_search_result.engine_prepare_ns);
-            if (_index_type == AnnIndexType::IVF_ON_DISK) {
-                stats->ivf_on_disk_cache_hit_cnt.update(
-                        index_search_result.ivf_on_disk_cache_hit_cnt);
-                stats->ivf_on_disk_cache_miss_cnt.update(
-                        index_search_result.ivf_on_disk_cache_miss_cnt);
-                DorisMetrics::instance()->ann_ivf_on_disk_cache_hit_cnt->increment(
-                        index_search_result.ivf_on_disk_cache_hit_cnt);
-                DorisMetrics::instance()->ann_ivf_on_disk_cache_miss_cnt->increment(
-                        index_search_result.ivf_on_disk_cache_miss_cnt);
+
+        {
+            AnnIndexResultCache* topn_result_cache =
+                    param->enable_result_cache ? ExecEnv::GetInstance()->ann_index_result_cache()
+                                               : nullptr;
+            AnnIndexResultCacheHandle cache_handle;
+            bool cache_hit = false;
+
+            if (topn_result_cache &&
+                topn_result_cache->lookup(_rowset_id, _segment_id, get_index_id(), *param,
+                                          &cache_handle)) {
+                index_search_result = cache_handle.to_index_search_result();
+                if (index_search_result.roaring != nullptr &&
+                    index_search_result.distances != nullptr &&
+                    index_search_result.row_ids != nullptr) {
+                    cache_hit = true;
+                    stats->topn_cache_hits.update(1);
+                } else {
+                    LOG(WARNING) << fmt::format(
+                            "Ignore malformed AnnIndexResultCache entry, rowset_id={}, "
+                            "segment_id={} "
+                            "(roaring={}, distances={}, row_ids={})",
+                            _rowset_id, _segment_id, index_search_result.roaring != nullptr,
+                            index_search_result.distances != nullptr,
+                            index_search_result.row_ids != nullptr);
+                }
             }
-        } else {
-            throw Exception(Status::NotSupported("Unsupported index type: {}",
-                                                 ann_index_type_to_string(_index_type)));
+
+            if (!cache_hit) {
+                if (_index_type == AnnIndexType::HNSW) {
+                    HNSWSearchParameters hnsw_search_params;
+                    hnsw_search_params.roaring = param->roaring;
+                    hnsw_search_params.rows_of_segment = param->rows_of_segment;
+                    hnsw_search_params.io_ctx = io_ctx;
+                    hnsw_search_params.ef_search = param->_user_params.hnsw_ef_search;
+                    hnsw_search_params.check_relative_distance =
+                            param->_user_params.hnsw_check_relative_distance;
+                    hnsw_search_params.bounded_queue = param->_user_params.hnsw_bounded_queue;
+                    RETURN_IF_ERROR(_vector_index->ann_topn_search(
+                            query_vec, limit, hnsw_search_params, index_search_result));
+                    // Accumulate detailed engine timings
+                    stats->engine_search_ns.update(index_search_result.engine_search_ns);
+                    stats->engine_convert_ns.update(index_search_result.engine_convert_ns);
+                    stats->engine_prepare_ns.update(index_search_result.engine_prepare_ns);
+                } else if (_index_type == AnnIndexType::IVF ||
+                           _index_type == AnnIndexType::IVF_ON_DISK) {
+                    IVFSearchParameters ivf_search_params;
+                    ivf_search_params.roaring = param->roaring;
+                    ivf_search_params.rows_of_segment = param->rows_of_segment;
+                    ivf_search_params.io_ctx = io_ctx;
+                    ivf_search_params.nprobe = param->_user_params.ivf_nprobe;
+                    RETURN_IF_ERROR(_vector_index->ann_topn_search(
+                            query_vec, limit, ivf_search_params, index_search_result));
+                    // Accumulate detailed engine timings
+                    stats->engine_search_ns.update(index_search_result.engine_search_ns);
+                    stats->engine_convert_ns.update(index_search_result.engine_convert_ns);
+                    stats->engine_prepare_ns.update(index_search_result.engine_prepare_ns);
+                    if (_index_type == AnnIndexType::IVF_ON_DISK) {
+                        stats->ivf_on_disk_cache_hit_cnt.update(
+                                index_search_result.ivf_on_disk_cache_hit_cnt);
+                        stats->ivf_on_disk_cache_miss_cnt.update(
+                                index_search_result.ivf_on_disk_cache_miss_cnt);
+                        DorisMetrics::instance()->ann_ivf_on_disk_cache_hit_cnt->increment(
+                                index_search_result.ivf_on_disk_cache_hit_cnt);
+                        DorisMetrics::instance()->ann_ivf_on_disk_cache_miss_cnt->increment(
+                                index_search_result.ivf_on_disk_cache_miss_cnt);
+                    }
+                } else {
+                    throw Exception(Status::NotSupported("Unsupported index type: {}",
+                                                         ann_index_type_to_string(_index_type)));
+                }
+
+                if (topn_result_cache) {
+                    check_topn_result(index_search_result);
+                    cache_handle = index_search_result.to_cache_handle();
+                    if (topn_result_cache->insert(_rowset_id, _segment_id, get_index_id(), *param,
+                                                  &cache_handle)) {
+                        index_search_result = cache_handle.to_index_search_result();
+                    }
+                }
+            }
         }
 
-        DORIS_CHECK(index_search_result.roaring != nullptr);
-        DORIS_CHECK(index_search_result.distances != nullptr);
-        DORIS_CHECK(index_search_result.row_ids != nullptr);
+        check_topn_result(index_search_result);
+
         {
             SCOPED_TIMER(&(stats->result_process_costs_ns));
             param->distance = index_search_result.distances;
             *param->roaring = *index_search_result.roaring;
+            param->row_ids = index_search_result.row_ids;
         }
-        param->row_ids = index_search_result.row_ids;
     }
 
     double search_costs_ms = static_cast<double>(stats->search_costs_ns.value()) / 1000.0;
@@ -195,73 +247,108 @@ Status AnnIndexReader::range_search(const AnnRangeSearchParams& params,
         DorisMetrics::instance()->ann_index_search_cnt->increment(1);
         SCOPED_TIMER(&(stats->search_costs_ns));
         DCHECK(_vector_index != nullptr);
-        segment_v2::IndexSearchResult search_result;
-        std::unique_ptr<segment_v2::IndexSearchParameters> search_param = nullptr;
-
-        if (_index_type == AnnIndexType::HNSW) {
-            auto hnsw_param = std::make_unique<segment_v2::HNSWSearchParameters>();
-            hnsw_param->ef_search = custom_params.hnsw_ef_search;
-            hnsw_param->check_relative_distance = custom_params.hnsw_check_relative_distance;
-            hnsw_param->bounded_queue = custom_params.hnsw_bounded_queue;
-            search_param = std::move(hnsw_param);
-        } else if (_index_type == AnnIndexType::IVF || _index_type == AnnIndexType::IVF_ON_DISK) {
-            auto ivf_param = std::make_unique<segment_v2::IVFSearchParameters>();
-            ivf_param->nprobe = custom_params.ivf_nprobe;
-            search_param = std::move(ivf_param);
-        } else {
-            throw Exception(Status::NotSupported("Unsupported index type: {}",
-                                                 ann_index_type_to_string(_index_type)));
-        }
-
-        search_param->is_le_or_lt = params.is_le_or_lt;
-        search_param->roaring = params.roaring;
-        search_param->io_ctx = io_ctx;
-        DCHECK(search_param->roaring != nullptr);
-
-        RETURN_IF_ERROR(_vector_index->range_search(params.query_value, params.radius,
-                                                    *search_param, search_result));
-        // Accumulate detailed engine timings
-        stats->engine_prepare_ns.update(search_result.engine_prepare_ns);
-        stats->engine_search_ns.update(search_result.engine_search_ns);
-        stats->engine_convert_ns.update(search_result.engine_convert_ns);
-        if (_index_type == AnnIndexType::IVF_ON_DISK) {
-            stats->ivf_on_disk_cache_hit_cnt.update(search_result.ivf_on_disk_cache_hit_cnt);
-            stats->ivf_on_disk_cache_miss_cnt.update(search_result.ivf_on_disk_cache_miss_cnt);
-            DorisMetrics::instance()->ann_ivf_on_disk_cache_hit_cnt->increment(
-                    search_result.ivf_on_disk_cache_hit_cnt);
-            DorisMetrics::instance()->ann_ivf_on_disk_cache_miss_cnt->increment(
-                    search_result.ivf_on_disk_cache_miss_cnt);
-        }
-
-        DCHECK(search_result.roaring != nullptr);
-        result->roaring = search_result.roaring;
-
-#ifndef NDEBUG
-        if (params.is_le_or_lt == false && _metric_type == AnnIndexMetric::L2) {
-            DCHECK(search_result.distances == nullptr);
-            DCHECK(search_result.row_ids == nullptr);
-        }
-        if (params.is_le_or_lt == true && _metric_type == AnnIndexMetric::IP) {
-            DCHECK(search_result.distances == nullptr);
-            DCHECK(search_result.row_ids == nullptr);
-        }
-#endif
 
         {
-            SCOPED_TIMER(&(stats->result_process_costs_ns));
-            if (search_result.row_ids != nullptr) {
-                DCHECK(search_result.row_ids->size() == search_result.roaring->cardinality())
-                        << "Row ids size: " << search_result.row_ids->size()
-                        << ", roaring size: " << search_result.roaring->cardinality();
-                result->row_ids = search_result.row_ids;
-            } else {
-                result->row_ids = nullptr;
+            AnnIndexResultCache* result_cache =
+                    params.enable_result_cache ? ExecEnv::GetInstance()->ann_index_result_cache()
+                                               : nullptr;
+            AnnIndexResultCacheHandle cache_handle;
+            bool cache_hit = false;
+
+            if (result_cache &&
+                result_cache->lookup(_rowset_id, _segment_id, get_index_id(), params, custom_params,
+                                     _dim, _rows_of_segment, &cache_handle)) {
+                auto cached_result = AnnRangeSearchResult::from_cache_handle(cache_handle);
+                if (cached_result.roaring != nullptr) {
+                    *result = std::move(cached_result);
+                    cache_hit = true;
+                    stats->range_cache_hits.update(1);
+                }
             }
 
-            if (search_result.distances != nullptr) {
-                result->distance = search_result.distances;
-            } else {
-                result->distance = nullptr;
+            if (!cache_hit) {
+                segment_v2::IndexSearchResult search_result;
+                std::unique_ptr<segment_v2::IndexSearchParameters> search_param = nullptr;
+
+                if (_index_type == AnnIndexType::HNSW) {
+                    auto hnsw_param = std::make_unique<segment_v2::HNSWSearchParameters>();
+                    hnsw_param->ef_search = custom_params.hnsw_ef_search;
+                    hnsw_param->check_relative_distance =
+                            custom_params.hnsw_check_relative_distance;
+                    hnsw_param->bounded_queue = custom_params.hnsw_bounded_queue;
+                    search_param = std::move(hnsw_param);
+                } else if (_index_type == AnnIndexType::IVF ||
+                           _index_type == AnnIndexType::IVF_ON_DISK) {
+                    auto ivf_param = std::make_unique<segment_v2::IVFSearchParameters>();
+                    ivf_param->nprobe = custom_params.ivf_nprobe;
+                    search_param = std::move(ivf_param);
+                } else {
+                    throw Exception(Status::NotSupported("Unsupported index type: {}",
+                                                         ann_index_type_to_string(_index_type)));
+                }
+
+                search_param->is_le_or_lt = params.is_le_or_lt;
+                search_param->roaring = params.roaring;
+                search_param->io_ctx = io_ctx;
+                DCHECK(search_param->roaring != nullptr);
+
+                RETURN_IF_ERROR(_vector_index->range_search(params.query_value, params.radius,
+                                                            *search_param, search_result));
+                stats->engine_prepare_ns.update(search_result.engine_prepare_ns);
+                stats->engine_search_ns.update(search_result.engine_search_ns);
+                stats->engine_convert_ns.update(search_result.engine_convert_ns);
+                if (_index_type == AnnIndexType::IVF_ON_DISK) {
+                    stats->ivf_on_disk_cache_hit_cnt.update(
+                            search_result.ivf_on_disk_cache_hit_cnt);
+                    stats->ivf_on_disk_cache_miss_cnt.update(
+                            search_result.ivf_on_disk_cache_miss_cnt);
+                    DorisMetrics::instance()->ann_ivf_on_disk_cache_hit_cnt->increment(
+                            search_result.ivf_on_disk_cache_hit_cnt);
+                    DorisMetrics::instance()->ann_ivf_on_disk_cache_miss_cnt->increment(
+                            search_result.ivf_on_disk_cache_miss_cnt);
+                }
+
+                DCHECK(search_result.roaring != nullptr);
+                result->roaring = search_result.roaring;
+
+#ifndef NDEBUG
+                if (params.is_le_or_lt == false && _metric_type == AnnIndexMetric::L2) {
+                    DCHECK(search_result.distances == nullptr);
+                    DCHECK(search_result.row_ids == nullptr);
+                }
+                if (params.is_le_or_lt == true && _metric_type == AnnIndexMetric::IP) {
+                    DCHECK(search_result.distances == nullptr);
+                    DCHECK(search_result.row_ids == nullptr);
+                }
+#endif
+
+                {
+                    SCOPED_TIMER(&(stats->result_process_costs_ns));
+                    if (search_result.row_ids != nullptr) {
+                        DCHECK(search_result.row_ids->size() ==
+                               search_result.roaring->cardinality())
+                                << "Row ids size: " << search_result.row_ids->size()
+                                << ", roaring size: " << search_result.roaring->cardinality();
+                        result->row_ids = std::move(search_result.row_ids);
+                    } else {
+                        result->row_ids = nullptr;
+                    }
+
+                    if (search_result.distances != nullptr) {
+                        result->distance = std::move(search_result.distances);
+                    } else {
+                        result->distance = nullptr;
+                    }
+                }
+
+                if (result_cache) {
+                    cache_handle = result->to_cache_handle();
+                    if (result_cache->insert(_rowset_id, _segment_id, get_index_id(), params,
+                                             custom_params, _dim, _rows_of_segment,
+                                             &cache_handle)) {
+                        *result = AnnRangeSearchResult::from_cache_handle(cache_handle);
+                    }
+                }
             }
         }
     }

--- a/be/src/storage/index/ann/ann_index_reader.cpp
+++ b/be/src/storage/index/ann/ann_index_reader.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <memory>
+#include <utility>
 
 #include "common/config.h"
 #include "common/metrics/doris_metrics.h"
@@ -48,8 +49,13 @@ static void check_topn_result(const IndexSearchResult& result) {
 }
 
 AnnIndexReader::AnnIndexReader(const TabletIndex* index_meta,
-                               std::shared_ptr<IndexFileReader> index_file_reader)
-        : _index_meta(*index_meta), _index_file_reader(index_file_reader) {
+                               std::shared_ptr<IndexFileReader> index_file_reader,
+                               std::string rowset_id, uint32_t segment_id, size_t rows_of_segment)
+        : _index_meta(*index_meta),
+          _index_file_reader(std::move(index_file_reader)),
+          _rowset_id(std::move(rowset_id)),
+          _segment_id(segment_id),
+          _rows_of_segment(rows_of_segment) {
     const auto index_properties = _index_meta.properties();
     auto it = index_properties.find("index_type");
     DCHECK(it != index_properties.end());

--- a/be/src/storage/index/ann/ann_index_reader.h
+++ b/be/src/storage/index/ann/ann_index_reader.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "runtime/runtime_state.h"
 #include "storage/index/ann/ann_index.h"
 #include "storage/index/ann/ann_search_params.h"
@@ -63,6 +65,10 @@ public:
 
     size_t get_dimension() const;
 
+    void set_rowset_id(std::string rowset_id) { _rowset_id = rowset_id; }
+    void set_segment_id(uint32_t segment_id) { _segment_id = segment_id; }
+    void set_rows_of_segment(size_t rows) { _rows_of_segment = rows; }
+
 private:
     TabletIndex _index_meta;
     std::shared_ptr<IndexFileReader> _index_file_reader;
@@ -77,6 +83,9 @@ private:
     AnnIndexType _index_type;
     AnnIndexMetric _metric_type;
     size_t _dim;
+    std::string _rowset_id;
+    uint32_t _segment_id;
+    size_t _rows_of_segment = 0;
     DorisCallOnce<Status> _load_index_once;
 };
 

--- a/be/src/storage/index/ann/ann_index_reader.h
+++ b/be/src/storage/index/ann/ann_index_reader.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 #include "runtime/runtime_state.h"
 #include "storage/index/ann/ann_index.h"
@@ -40,7 +41,8 @@ class IndexIterator;
 class AnnIndexReader : public IndexReader {
 public:
     AnnIndexReader(const TabletIndex* index_meta,
-                   std::shared_ptr<IndexFileReader> index_file_reader);
+                   std::shared_ptr<IndexFileReader> index_file_reader, std::string rowset_id = "",
+                   uint32_t segment_id = 0, size_t rows_of_segment = 0);
     ~AnnIndexReader() override = default;
 
     Status load_index(io::IOContext* io_ctx);
@@ -64,10 +66,6 @@ public:
     AnnIndexMetric get_metric_type() const { return _metric_type; }
 
     size_t get_dimension() const;
-
-    void set_rowset_id(std::string rowset_id) { _rowset_id = rowset_id; }
-    void set_segment_id(uint32_t segment_id) { _segment_id = segment_id; }
-    void set_rows_of_segment(size_t rows) { _rows_of_segment = rows; }
 
 private:
     TabletIndex _index_meta;

--- a/be/src/storage/index/ann/ann_index_result_cache/ann_index_result_cache.cpp
+++ b/be/src/storage/index/ann/ann_index_result_cache/ann_index_result_cache.cpp
@@ -1,0 +1,298 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "storage/index/ann/ann_index_result_cache/ann_index_result_cache.h"
+
+#include <xxhash.h>
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "exec/scan/vector_search_user_params.h"
+#include "runtime/memory/lru_cache_value_base.h"
+#include "storage/index/ann/ann_index_result_cache/ann_index_result_cache_handle.h"
+#include "storage/index/ann/ann_search_params.h"
+#include "util/hash_util.hpp"
+
+namespace doris::segment_v2 {
+
+static std::string make_key_from_param(const std::string& rowset_id, uint32_t segment_id,
+                                       uint64_t index_id, const AnnTopNParam& param) {
+    size_t seed = 0;
+    HashUtil::hash_combine(seed, static_cast<uint64_t>(0));
+    // Rowset ID
+    HashUtil::hash_combine(seed, rowset_id);
+    // Segment ID
+    HashUtil::hash_combine(seed, static_cast<int64_t>(segment_id));
+    // Index identity
+    HashUtil::hash_combine(seed, index_id);
+    // Query vector digest
+    const size_t vec_size = param.query_value_size;
+    HashUtil::hash_combine(seed, vec_size);
+    if (vec_size > 0) {
+        for (size_t i = 0; i < vec_size; ++i) {
+            HashUtil::hash_combine(seed, param.query_value[i]);
+        }
+    }
+
+    if (param.roaring == nullptr || param.roaring->cardinality() == param.rows_of_segment) {
+        HashUtil::hash_combine(seed, static_cast<uint64_t>(0));
+    } else {
+        size_t serialized_size = param.roaring->getSizeInBytes(/*portable=*/true);
+        std::vector<char> buf(serialized_size);
+        param.roaring->write(buf.data(), /*portable=*/true);
+        uint64_t roaring_hash = XXH3_64bits_withSeed(buf.data(), serialized_size, seed);
+        HashUtil::hash_combine(seed, roaring_hash);
+    }
+
+    // Segment rows context
+    HashUtil::hash_combine(seed, static_cast<uint64_t>(param.rows_of_segment));
+
+    // TopN limit
+    HashUtil::hash_combine(seed, static_cast<uint64_t>(param.limit));
+    // HNSW specific params
+    HashUtil::hash_combine(seed, param._user_params.hnsw_ef_search);
+    HashUtil::hash_combine(seed, param._user_params.hnsw_check_relative_distance);
+    HashUtil::hash_combine(seed, param._user_params.hnsw_bounded_queue);
+    HashUtil::hash_combine(seed, param._user_params.ivf_nprobe);
+    return std::to_string(seed);
+}
+
+static std::string make_key_from_range_param(const std::string& rowset_id, uint32_t segment_id,
+                                             uint64_t index_id, const AnnRangeSearchParams& param,
+                                             const VectorSearchUserParams& user_params, size_t dim,
+                                             size_t rows_of_segment) {
+    size_t seed = 0;
+    HashUtil::hash_combine(seed, static_cast<uint64_t>(1));
+    HashUtil::hash_combine(seed, rowset_id);
+    HashUtil::hash_combine(seed, static_cast<int64_t>(segment_id));
+    HashUtil::hash_combine(seed, index_id);
+
+    HashUtil::hash_combine(seed, dim);
+    if (dim > 0 && param.query_value != nullptr) {
+        for (size_t i = 0; i < dim; ++i) {
+            HashUtil::hash_combine(seed, param.query_value[i]);
+        }
+    }
+
+    if (param.roaring == nullptr || param.roaring->cardinality() == rows_of_segment) {
+        HashUtil::hash_combine(seed, static_cast<uint64_t>(0));
+    } else {
+        size_t serialized_size = param.roaring->getSizeInBytes(/*portable=*/true);
+        std::vector<char> buf(serialized_size);
+        param.roaring->write(buf.data(), /*portable=*/true);
+        uint64_t roaring_hash = XXH3_64bits_withSeed(buf.data(), serialized_size, seed);
+        HashUtil::hash_combine(seed, roaring_hash);
+    }
+
+    HashUtil::hash_combine(seed, static_cast<uint64_t>(rows_of_segment));
+    HashUtil::hash_combine(seed, param.radius);
+    HashUtil::hash_combine(seed, param.is_le_or_lt);
+    HashUtil::hash_combine(seed, user_params.hnsw_ef_search);
+    HashUtil::hash_combine(seed, user_params.hnsw_check_relative_distance);
+    HashUtil::hash_combine(seed, user_params.hnsw_bounded_queue);
+    HashUtil::hash_combine(seed, user_params.ivf_nprobe);
+    return std::to_string(seed);
+}
+
+class CacheEntryPin {
+public:
+    CacheEntryPin(LRUCachePolicy* cache, doris::Cache::Handle* handle)
+            : _cache(cache), _handle(handle) {
+        DCHECK(_cache != nullptr);
+        DCHECK(_handle != nullptr);
+    }
+
+    ~CacheEntryPin() { _cache->release(_handle); }
+
+    CacheEntryPin(const CacheEntryPin&) = delete;
+    CacheEntryPin& operator=(const CacheEntryPin&) = delete;
+
+private:
+    LRUCachePolicy* _cache;
+    doris::Cache::Handle* _handle;
+};
+
+// Concrete cache value to store ANN results (hidden as a nested class).
+class AnnIndexResultCache::CacheValue : public doris::LRUCacheValueBase {
+public:
+    explicit CacheValue(AnnIndexResultCacheHandle&& handle)
+            : _distances(std::move(handle.distances)),
+              _row_ids(std::move(handle.row_ids)),
+              _roaring(std::move(handle.roaring)) {}
+
+    AnnIndexResultCacheHandle to_handle(std::shared_ptr<CacheEntryPin> pin) const {
+        AnnIndexResultCacheHandle h;
+        if (_row_ids) {
+            h.row_ids = std::shared_ptr<std::vector<uint64_t>>(pin, _row_ids.get());
+        }
+        if (_distances) {
+            h.distances = std::shared_ptr<float[]>(pin, _distances.get());
+        }
+        if (_roaring) {
+            h.roaring = std::shared_ptr<roaring::Roaring>(pin, _roaring.get());
+        }
+        return h;
+    }
+
+    size_t value_memory() const {
+        size_t size = sizeof(CacheValue);
+        size_t n = _row_ids ? _row_ids->size() : 0;
+        if (_distances) {
+            size += sizeof(float) * n;
+        }
+        if (_row_ids) {
+            size += sizeof(uint64_t) * n + sizeof(std::vector<uint64_t>);
+        }
+        if (_roaring) {
+            size += _roaring->getSizeInBytes();
+        }
+        return size;
+    }
+
+private:
+    std::shared_ptr<float[]> _distances;
+    std::shared_ptr<std::vector<uint64_t>> _row_ids;
+    std::shared_ptr<roaring::Roaring> _roaring;
+};
+
+bool AnnIndexResultCache::lookup(const std::string& rowset_id, uint32_t segment_id,
+                                 uint64_t index_id, const AnnTopNParam& param,
+                                 AnnIndexResultCacheHandle* out_handle) {
+    auto key_str = make_key_from_param(rowset_id, segment_id, index_id, param);
+    auto cache_key = doris::CacheKey(key_str);
+    doris::Cache::Handle* h = LRUCachePolicy::lookup(cache_key);
+
+    if (h == nullptr) {
+        return false;
+    }
+
+    VLOG_DEBUG << fmt::format("AnnIndexResultCache hit with rowset_id={}, segment_id={}, limit={}",
+                              rowset_id, segment_id, param.limit);
+
+    auto* val = reinterpret_cast<CacheValue*>(LRUCachePolicy::value(h));
+
+    if (val == nullptr) {
+        LRUCachePolicy::release(h);
+        return false;
+    }
+    auto pin = std::make_shared<CacheEntryPin>(this, h);
+    *out_handle = val->to_handle(std::move(pin));
+    return true;
+}
+
+bool AnnIndexResultCache::insert(const std::string& rowset_id, uint32_t segment_id,
+                                 uint64_t index_id, const AnnTopNParam& param,
+                                 AnnIndexResultCacheHandle* handle) {
+    DCHECK(handle != nullptr);
+    auto key_str = make_key_from_param(rowset_id, segment_id, index_id, param);
+    auto cache_key = doris::CacheKey(key_str);
+    auto val = std::make_unique<CacheValue>(std::move(*handle));
+    size_t charge = val->value_memory();
+    const size_t capacity = LRUCachePolicy::get_capacity();
+    if (capacity == 0 || charge > capacity) {
+        VLOG_DEBUG << fmt::format(
+                "Skip AnnIndexResultCache insert because entry is too large, rowset_id={}, "
+                "segment_id={}, limit={}, charge={}, capacity={}",
+                rowset_id, segment_id, param.limit, charge, capacity);
+        return false;
+    }
+    auto* lru_handle = LRUCachePolicy::insert(cache_key, val.get(), charge, charge);
+    if (lru_handle != nullptr) {
+        auto pin = std::make_shared<CacheEntryPin>(this, lru_handle);
+        *handle = val->to_handle(std::move(pin));
+        val.release();
+        VLOG_DEBUG << fmt::format(
+                "AnnIndexResultCache inserted and pinned handle, rowset_id={}, segment_id={}, "
+                "limit={}",
+                rowset_id, segment_id, param.limit);
+        return true;
+    }
+    VLOG_DEBUG << fmt::format(
+            "AnnIndexResultCache insert with rowset_id={}, segment_id={}, limit={}, charge={}",
+            rowset_id, segment_id, param.limit, charge);
+    return false;
+}
+
+bool AnnIndexResultCache::lookup(const std::string& rowset_id, uint32_t segment_id,
+                                 uint64_t index_id, const AnnRangeSearchParams& param,
+                                 const VectorSearchUserParams& user_params, size_t dim,
+                                 size_t rows_of_segment, AnnIndexResultCacheHandle* out_handle) {
+    auto key_str = make_key_from_range_param(rowset_id, segment_id, index_id, param, user_params,
+                                             dim, rows_of_segment);
+    auto cache_key = doris::CacheKey(key_str);
+    doris::Cache::Handle* h = LRUCachePolicy::lookup(cache_key);
+
+    if (h == nullptr) {
+        return false;
+    }
+
+    VLOG_DEBUG << fmt::format(
+            "AnnIndexResultCache range_search hit with rowset_id={}, segment_id={}, radius={}",
+            rowset_id, segment_id, param.radius);
+
+    auto* val = reinterpret_cast<CacheValue*>(LRUCachePolicy::value(h));
+
+    if (val == nullptr) {
+        LRUCachePolicy::release(h);
+        return false;
+    }
+    auto pin = std::make_shared<CacheEntryPin>(this, h);
+    *out_handle = val->to_handle(std::move(pin));
+    return true;
+}
+
+bool AnnIndexResultCache::insert(const std::string& rowset_id, uint32_t segment_id,
+                                 uint64_t index_id, const AnnRangeSearchParams& param,
+                                 const VectorSearchUserParams& user_params, size_t dim,
+                                 size_t rows_of_segment, AnnIndexResultCacheHandle* handle) {
+    DCHECK(handle != nullptr);
+    auto key_str = make_key_from_range_param(rowset_id, segment_id, index_id, param, user_params,
+                                             dim, rows_of_segment);
+    auto cache_key = doris::CacheKey(key_str);
+    auto val = std::make_unique<CacheValue>(std::move(*handle));
+    size_t charge = val->value_memory();
+    const size_t capacity = LRUCachePolicy::get_capacity();
+    if (capacity == 0 || charge > capacity) {
+        VLOG_DEBUG << fmt::format(
+                "Skip AnnIndexResultCache range_search insert because entry is too large, "
+                "rowset_id={}, segment_id={}, radius={}, charge={}, capacity={}",
+                rowset_id, segment_id, param.radius, charge, capacity);
+        return false;
+    }
+    auto* lru_handle = LRUCachePolicy::insert(cache_key, val.get(), charge, charge);
+    if (lru_handle != nullptr) {
+        auto pin = std::make_shared<CacheEntryPin>(this, lru_handle);
+        *handle = val->to_handle(std::move(pin));
+        val.release();
+        VLOG_DEBUG << fmt::format(
+                "AnnIndexResultCache range_search inserted and pinned handle, rowset_id={}, "
+                "segment_id={}, radius={}, charge={}",
+                rowset_id, segment_id, param.radius, charge);
+        return true;
+    }
+    VLOG_DEBUG << fmt::format(
+            "AnnIndexResultCache range_search insert with rowset_id={}, segment_id={}, "
+            "radius={}, charge={}",
+            rowset_id, segment_id, param.radius, charge);
+    return false;
+}
+
+} // namespace doris::segment_v2

--- a/be/src/storage/index/ann/ann_index_result_cache/ann_index_result_cache.h
+++ b/be/src/storage/index/ann/ann_index_result_cache/ann_index_result_cache.h
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdint>
+
+#include "common/config.h"
+#include "exec/scan/vector_search_user_params.h"
+#include "runtime/memory/lru_cache_policy.h"
+
+namespace doris::segment_v2 {
+struct IndexSearchResult;
+struct AnnTopNParam;
+struct AnnIndexResultCacheHandle;
+struct AnnRangeSearchParams;
+
+class AnnIndexResultCache : public LRUCachePolicy {
+public:
+    static AnnIndexResultCache* create_global_cache(size_t capacity_bytes) {
+        auto num_shards = config::ann_index_result_cache_shards;
+        LOG_INFO("Creating AnnIndexResultCache with capacity: {} bytes, shards: {}", capacity_bytes,
+                 num_shards);
+        static AnnIndexResultCache* instance = new AnnIndexResultCache(capacity_bytes, num_shards);
+        return instance;
+    }
+
+    // Convenience overloads: build key from runtime params
+    bool lookup(const std::string& rowset_id, uint32_t segment_id, uint64_t index_id,
+                const AnnTopNParam& param, AnnIndexResultCacheHandle* out_handle);
+
+    bool insert(const std::string& rowset_id, uint32_t segment_id, uint64_t index_id,
+                const AnnTopNParam& param, AnnIndexResultCacheHandle* handle);
+
+    bool lookup(const std::string& rowset_id, uint32_t segment_id, uint64_t index_id,
+                const AnnRangeSearchParams& param, const VectorSearchUserParams& user_params,
+                size_t dim, size_t rows_of_segment, AnnIndexResultCacheHandle* out_handle);
+
+    bool insert(const std::string& rowset_id, uint32_t segment_id, uint64_t index_id,
+                const AnnRangeSearchParams& param, const VectorSearchUserParams& user_params,
+                size_t dim, size_t rows_of_segment, AnnIndexResultCacheHandle* handle);
+
+private:
+    // Hidden cache value type to keep implementation details internal
+    class CacheValue;
+
+    explicit AnnIndexResultCache(size_t capacity_bytes, uint32_t num_shards)
+            : LRUCachePolicy(CachePolicy::CacheType::ANN_INDEX_RESULT_CACHE, capacity_bytes,
+                             LRUCacheType::SIZE,
+                             config::ann_index_result_cache_stale_sweep_time_sec, num_shards,
+                             /*element_count_capacity*/ 0, /*enable_prune*/ true,
+                             /*is_lru_k*/ false) {}
+};
+
+} // namespace doris::segment_v2

--- a/be/src/storage/index/ann/ann_index_result_cache/ann_index_result_cache_handle.cpp
+++ b/be/src/storage/index/ann/ann_index_result_cache/ann_index_result_cache_handle.cpp
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "storage/index/ann/ann_index_result_cache/ann_index_result_cache_handle.h"
+
+#include "storage/index/ann/ann_search_params.h"
+
+namespace doris::segment_v2 {
+IndexSearchResult AnnIndexResultCacheHandle::to_index_search_result() const {
+    IndexSearchResult result;
+    result.distances = distances;
+    result.row_ids = row_ids;
+    result.roaring = roaring;
+    return result;
+}
+} // namespace doris::segment_v2

--- a/be/src/storage/index/ann/ann_index_result_cache/ann_index_result_cache_handle.h
+++ b/be/src/storage/index/ann/ann_index_result_cache/ann_index_result_cache_handle.h
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "roaring/roaring.hh"
+
+namespace doris::segment_v2 {
+struct IndexSearchResult;
+
+struct AnnIndexResultCacheHandle {
+    AnnIndexResultCacheHandle() = default;
+    IndexSearchResult to_index_search_result() const;
+
+    std::shared_ptr<float[]> distances = nullptr;
+    std::shared_ptr<std::vector<uint64_t>> row_ids = nullptr;
+    std::shared_ptr<roaring::Roaring> roaring = nullptr;
+};
+
+} // namespace doris::segment_v2

--- a/be/src/storage/index/ann/ann_range_search_runtime.cpp
+++ b/be/src/storage/index/ann/ann_range_search_runtime.cpp
@@ -39,6 +39,7 @@ AnnRangeSearchParams AnnRangeSearchRuntime::to_range_search_params() const {
     params.radius = static_cast<float>(radius);
     params.roaring = nullptr;
     params.is_le_or_lt = is_le_or_lt;
+    params.enable_result_cache = true;
     return params;
 }
 

--- a/be/src/storage/index/ann/ann_search_params.cpp
+++ b/be/src/storage/index/ann/ann_search_params.cpp
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "storage/index/ann/ann_search_params.h"
+
+#include "storage/index/ann/ann_index_result_cache/ann_index_result_cache_handle.h"
+
+namespace doris::segment_v2 {
+
+AnnIndexResultCacheHandle IndexSearchResult::to_cache_handle() const {
+    AnnIndexResultCacheHandle handle;
+    handle.roaring = roaring;
+    handle.row_ids = row_ids;
+    handle.distances = distances;
+    return handle;
+}
+
+AnnIndexResultCacheHandle AnnRangeSearchResult::to_cache_handle() const {
+    AnnIndexResultCacheHandle handle;
+    handle.distances = distance;
+    handle.row_ids = row_ids;
+    handle.roaring = roaring;
+    return handle;
+}
+
+AnnRangeSearchResult AnnRangeSearchResult::from_cache_handle(
+        const AnnIndexResultCacheHandle& handle) {
+    AnnRangeSearchResult result;
+    result.roaring = handle.roaring;
+    result.row_ids = handle.row_ids;
+    result.distance = handle.distances;
+    return result;
+}
+
+} // namespace doris::segment_v2

--- a/be/src/storage/index/ann/ann_search_params.h
+++ b/be/src/storage/index/ann/ann_search_params.h
@@ -47,6 +47,8 @@ struct IOContext;
 
 namespace doris::segment_v2 {
 
+struct AnnIndexResultCacheHandle;
+
 struct AnnIndexStats {
     AnnIndexStats()
             : search_costs_ns(TUnit::TIME_NS, 0),
@@ -60,6 +62,8 @@ struct AnnIndexStats {
               ivf_on_disk_search_cnt(TUnit::UNIT, 0),
               ivf_on_disk_cache_hit_cnt(TUnit::UNIT, 0),
               ivf_on_disk_cache_miss_cnt(TUnit::UNIT, 0),
+              topn_cache_hits(TUnit::UNIT, 0),
+              range_cache_hits(TUnit::UNIT, 0),
               fall_back_brute_force_cnt(0) {}
 
     AnnIndexStats(const AnnIndexStats& other)
@@ -75,6 +79,8 @@ struct AnnIndexStats {
               ivf_on_disk_search_cnt(TUnit::UNIT, other.ivf_on_disk_search_cnt.value()),
               ivf_on_disk_cache_hit_cnt(TUnit::UNIT, other.ivf_on_disk_cache_hit_cnt.value()),
               ivf_on_disk_cache_miss_cnt(TUnit::UNIT, other.ivf_on_disk_cache_miss_cnt.value()),
+              topn_cache_hits(TUnit::UNIT, other.topn_cache_hits.value()),
+              range_cache_hits(TUnit::UNIT, other.range_cache_hits.value()),
               fall_back_brute_force_cnt(other.fall_back_brute_force_cnt) {}
 
     AnnIndexStats& operator=(const AnnIndexStats& other) {
@@ -90,6 +96,8 @@ struct AnnIndexStats {
             ivf_on_disk_search_cnt.set(other.ivf_on_disk_search_cnt.value());
             ivf_on_disk_cache_hit_cnt.set(other.ivf_on_disk_cache_hit_cnt.value());
             ivf_on_disk_cache_miss_cnt.set(other.ivf_on_disk_cache_miss_cnt.value());
+            topn_cache_hits.set(other.topn_cache_hits.value());
+            range_cache_hits.set(other.range_cache_hits.value());
             fall_back_brute_force_cnt = other.fall_back_brute_force_cnt;
         }
         return *this;
@@ -107,19 +115,47 @@ struct AnnIndexStats {
     RuntimeProfile::Counter ivf_on_disk_search_cnt;      // IVF_ON_DISK search count
     RuntimeProfile::Counter ivf_on_disk_cache_hit_cnt;   // IVF_ON_DISK cache hit count
     RuntimeProfile::Counter ivf_on_disk_cache_miss_cnt;  // IVF_ON_DISK cache miss count
+    RuntimeProfile::Counter topn_cache_hits; // number of cache hits in ANN TopN result cache
+    RuntimeProfile::Counter range_cache_hits;
     int64_t fall_back_brute_force_cnt; // fallback count when ANN range search is bypassed
 };
 
 struct AnnTopNParam {
+    // =========================
+    // TopN execution inputs
+    // =========================
+    // Query vector data pointer.
     const float* query_value;
+    // Query vector dimension.
     const size_t query_value_size;
+    // Requested TopK/TopN count.
     size_t limit;
+    // Runtime ANN search options (HNSW/IVF specific params).
     doris::VectorSearchUserParams _user_params;
+    // Candidate row bitmap after pre-filters.
+    // ANN TopN search only evaluates rows inside this bitmap.
     roaring::Roaring* roaring;
+    // Total row count of current segment, used by ANN engine for bounds/checks.
     size_t rows_of_segment = 0;
+    bool enable_result_cache = true;
+
+    // =========================
+    // TopN execution outputs
+    // =========================
+    // Output distances of returned TopN rows. Aligned with `row_ids`.
     std::shared_ptr<float[]> distance = nullptr;
+    // Output row ids corresponding to `distance`.
     std::shared_ptr<std::vector<uint64_t>> row_ids = nullptr;
+    // Optional per-call statistics holder.
     std::unique_ptr<AnnIndexStats> stats = nullptr;
+
+    std::string to_string() const {
+        return fmt::format(
+                "query_value_size: {}, limit: {}, rows_of_segment: {}, hnsw_ef_search: {}, "
+                "hnsw_check_relative_distance: {}, hnsw_bounded_queue: {}",
+                query_value_size, limit, rows_of_segment, _user_params.hnsw_ef_search,
+                _user_params.hnsw_check_relative_distance, _user_params.hnsw_bounded_queue);
+    }
 };
 
 struct AnnRangeSearchParams {
@@ -127,6 +163,7 @@ struct AnnRangeSearchParams {
     const float* query_value = nullptr;
     float radius = -1;
     roaring::Roaring* roaring; // roaring from segment_iterator
+    bool enable_result_cache = true;
     std::string to_string() const {
         DCHECK(roaring != nullptr);
         return fmt::format("is_le_or_lt: {}, radius: {}, input rows {}", is_le_or_lt, radius,
@@ -139,6 +176,9 @@ struct AnnRangeSearchResult {
     std::shared_ptr<roaring::Roaring> roaring;
     std::shared_ptr<std::vector<uint64_t>> row_ids;
     std::shared_ptr<float[]> distance;
+
+    AnnIndexResultCacheHandle to_cache_handle() const;
+    static AnnRangeSearchResult from_cache_handle(const AnnIndexResultCacheHandle& handle);
 };
 
 /*
@@ -152,8 +192,13 @@ For range search, is condition is not le_or_lt, the row_ids and distances will b
 struct IndexSearchResult {
     IndexSearchResult() = default;
 
+    AnnIndexResultCacheHandle to_cache_handle() const;
+
+    // distances from index.
     std::shared_ptr<float[]> distances = nullptr;
+    // row_id of each distance. Aligned with distances, so row_ids[i] corresponds to distances[i].
     std::shared_ptr<std::vector<uint64_t>> row_ids = nullptr;
+    // roaring from/to doris segment iterator.
     std::shared_ptr<roaring::Roaring> roaring = nullptr;
     // Internal engine timings (ns)
     int64_t engine_search_ns = 0;  // time spent in the underlying index search call

--- a/be/src/storage/index/ann/ann_topn_runtime.cpp
+++ b/be/src/storage/index/ann/ann_topn_runtime.cpp
@@ -181,6 +181,7 @@ Status AnnTopNRuntime::prepare(RuntimeState* state, const RowDescriptor& row_des
 
 Status AnnTopNRuntime::evaluate_vector_ann_search(segment_v2::AnnIndexIterator* ann_index_iterator,
                                                   roaring::Roaring* roaring, size_t rows_of_segment,
+                                                  bool enable_result_cache,
                                                   IColumn::MutablePtr& result_column,
                                                   std::shared_ptr<std::vector<uint64_t>>& row_ids,
                                                   segment_v2::AnnIndexStats& ann_index_stats) {
@@ -210,6 +211,7 @@ Status AnnTopNRuntime::evaluate_vector_ann_search(segment_v2::AnnIndexIterator* 
             ._user_params = _user_params,
             .roaring = roaring,
             .rows_of_segment = rows_of_segment,
+            .enable_result_cache = enable_result_cache,
             .distance = nullptr,
             .row_ids = nullptr,
             .stats = std::make_unique<segment_v2::AnnIndexStats>()};

--- a/be/src/storage/index/ann/ann_topn_runtime.h
+++ b/be/src/storage/index/ann/ann_topn_runtime.h
@@ -35,6 +35,9 @@
 
 #pragma once
 
+#include <memory>
+#include <vector>
+
 #include "core/column/column.h"
 #include "core/data_type/primitive_type.h"
 #include "exprs/vectorized_fn_call.h"
@@ -116,7 +119,7 @@ public:
      */
     Status evaluate_vector_ann_search(segment_v2::AnnIndexIterator* ann_index_iterator,
                                       roaring::Roaring* row_bitmap, size_t rows_of_segment,
-                                      IColumn::MutablePtr& result_column,
+                                      bool enable_result_cache, IColumn::MutablePtr& result_column,
                                       std::shared_ptr<std::vector<uint64_t>>& row_ids,
                                       segment_v2::AnnIndexStats& ann_index_stats);
 

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -382,6 +382,7 @@ struct OlapReaderStatistics {
     int64_t ann_ivf_on_disk_load_ns = 0;
     int64_t ann_ivf_on_disk_cache_hit_cnt = 0;
     int64_t ann_ivf_on_disk_cache_miss_cnt = 0;
+    int64_t ann_index_cache_hits = 0;
 
     // Detailed timing for ANN operations
     int64_t ann_index_topn_engine_search_ns = 0;  // time spent in engine for range search
@@ -400,6 +401,7 @@ struct OlapReaderStatistics {
     int64_t ann_range_result_convert_ns = 0; // time spent processing range results
     int64_t ann_range_engine_convert_ns = 0; // time spent on FAISS-side conversions (Range)
     int64_t rows_ann_index_range_filtered = 0;
+    int64_t ann_index_range_cache_hits = 0;
     int64_t ann_fall_back_brute_force_cnt = 0;
 
     int64_t output_index_result_column_timer = 0;

--- a/be/src/storage/segment/column_reader.cpp
+++ b/be/src/storage/segment/column_reader.cpp
@@ -396,9 +396,11 @@ Status ColumnReader::init(const ColumnMetaPB* meta) {
 }
 
 Status ColumnReader::new_index_iterator(const std::shared_ptr<IndexFileReader>& index_file_reader,
-                                        const TabletIndex* index_meta,
+                                        const TabletIndex* index_meta, const std::string& rowset_id,
+                                        uint32_t segment_id, size_t rows_of_segment,
                                         std::unique_ptr<IndexIterator>* iterator) {
-    RETURN_IF_ERROR(_load_index(index_file_reader, index_meta));
+    RETURN_IF_ERROR(
+            _load_index(index_file_reader, index_meta, rowset_id, segment_id, rows_of_segment));
     {
         std::shared_lock<std::shared_mutex> rlock(_load_index_lock);
         auto iter = _index_readers.find(index_meta->index_id());
@@ -615,7 +617,8 @@ Status ColumnReader::_load_zone_map_index(bool use_page_cache, bool kept_in_memo
 }
 
 Status ColumnReader::_load_index(const std::shared_ptr<IndexFileReader>& index_file_reader,
-                                 const TabletIndex* index_meta) {
+                                 const TabletIndex* index_meta, const std::string& rowset_id,
+                                 uint32_t segment_id, size_t rows_of_segment) {
     std::unique_lock<std::shared_mutex> wlock(_load_index_lock);
 
     if (index_meta == nullptr) {
@@ -639,8 +642,8 @@ Status ColumnReader::_load_index(const std::shared_ptr<IndexFileReader>& index_f
     }
 
     if (index_meta->index_type() == IndexType::ANN) {
-        _index_readers[index_meta->index_id()] =
-                std::make_shared<AnnIndexReader>(index_meta, index_file_reader);
+        _index_readers[index_meta->index_id()] = std::make_shared<AnnIndexReader>(
+                index_meta, index_file_reader, rowset_id, segment_id, rows_of_segment);
         return Status::OK();
     }
 

--- a/be/src/storage/segment/column_reader.h
+++ b/be/src/storage/segment/column_reader.h
@@ -163,7 +163,8 @@ public:
     Status new_agg_state_iterator(ColumnIteratorUPtr* iterator);
 
     Status new_index_iterator(const std::shared_ptr<IndexFileReader>& index_file_reader,
-                              const TabletIndex* index_meta,
+                              const TabletIndex* index_meta, const std::string& rowset_id,
+                              uint32_t segment_id, size_t rows_of_segment,
                               std::unique_ptr<IndexIterator>* iterator);
 
     Status seek_at_or_before(ordinal_t ordinal, OrdinalPageIndexIterator* iter,
@@ -249,7 +250,8 @@ private:
                                              const ColumnIteratorOptions& iter_opts);
 
     [[nodiscard]] Status _load_index(const std::shared_ptr<IndexFileReader>& index_file_reader,
-                                     const TabletIndex* index_meta);
+                                     const TabletIndex* index_meta, const std::string& rowset_id,
+                                     uint32_t segment_id, size_t rows_of_segment);
     [[nodiscard]] Status _load_bloom_filter_index(bool use_page_cache, bool kept_in_memory,
                                                   const ColumnIteratorOptions& iter_opts);
 

--- a/be/src/storage/segment/segment.cpp
+++ b/be/src/storage/segment/segment.cpp
@@ -808,7 +808,10 @@ Status Segment::new_index_iterator(const TabletColumn& tablet_column, const Tabl
         // to avoid data race during parallel method calls
         RETURN_IF_ERROR(_index_file_reader_open.call([&] { return _open_index_file_reader(); }));
         // after DorisCallOnce.call, _index_file_reader is guaranteed to be not nullptr
-        RETURN_IF_ERROR(reader->new_index_iterator(_index_file_reader, index_meta, iter));
+        const std::string rowset_id =
+                index_meta->index_type() == IndexType::ANN ? _rowset_id.to_string() : "";
+        RETURN_IF_ERROR(reader->new_index_iterator(_index_file_reader, index_meta, rowset_id,
+                                                   _segment_id, _num_rows, iter));
         return Status::OK();
     }
     return Status::OK();

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -985,8 +985,6 @@ Status SegmentIterator::_apply_ann_topn_predicate() {
                 static_cast<int64_t>(load_costs_ms));
     }
 
-    ann_index_reader->set_rowset_id(_opts.rowset_id.to_string());
-    ann_index_reader->set_segment_id(_segment->id());
     bool enable_ann_index_result_cache =
             !_opts.runtime_state ||
             !_opts.runtime_state->query_options().__isset.enable_ann_index_result_cache ||
@@ -1252,19 +1250,6 @@ Status SegmentIterator::_apply_index_expr() {
                              << ", error msg: " << st.to_string();
                 return st;
             }
-        }
-    }
-
-    for (const auto& iter : _index_iterators) {
-        if (iter == nullptr) continue;
-        auto* ann_iter = dynamic_cast<segment_v2::AnnIndexIterator*>(iter.get());
-        if (ann_iter == nullptr) continue;
-        auto ann_reader = std::dynamic_pointer_cast<segment_v2::AnnIndexReader>(
-                ann_iter->get_reader(segment_v2::AnnIndexReaderType::ANN));
-        if (ann_reader) {
-            ann_reader->set_rowset_id(_opts.rowset_id.to_string());
-            ann_reader->set_segment_id(_segment->id());
-            ann_reader->set_rows_of_segment(num_rows());
         }
     }
 

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -985,9 +985,15 @@ Status SegmentIterator::_apply_ann_topn_predicate() {
                 static_cast<int64_t>(load_costs_ms));
     }
 
+    ann_index_reader->set_rowset_id(_opts.rowset_id.to_string());
+    ann_index_reader->set_segment_id(_segment->id());
+    bool enable_ann_index_result_cache =
+            !_opts.runtime_state ||
+            !_opts.runtime_state->query_options().__isset.enable_ann_index_result_cache ||
+            _opts.runtime_state->query_options().enable_ann_index_result_cache;
     RETURN_IF_ERROR(_ann_topn_runtime->evaluate_vector_ann_search(
-            ann_index_iterator_casted, &_row_bitmap, rows_of_segment, result_column, result_row_ids,
-            ann_index_stats));
+            ann_index_iterator_casted, &_row_bitmap, rows_of_segment, enable_ann_index_result_cache,
+            result_column, result_row_ids, ann_index_stats));
 
     VLOG_DEBUG << fmt::format("Ann topn filtered {} - {} = {} rows", pre_size,
                               _row_bitmap.cardinality(), pre_size - _row_bitmap.cardinality());
@@ -1006,6 +1012,7 @@ Status SegmentIterator::_apply_ann_topn_predicate() {
     _opts.stats->ann_index_topn_engine_convert_ns += ann_index_stats.engine_convert_ns.value();
     _opts.stats->ann_index_topn_engine_prepare_ns += ann_index_stats.engine_prepare_ns.value();
     _opts.stats->ann_index_topn_search_cnt += 1;
+    _opts.stats->ann_index_cache_hits += ann_index_stats.topn_cache_hits.value();
     const size_t dst_col_idx = _ann_topn_runtime->get_dest_column_idx();
     ColumnIterator* column_iter = _column_iterators[_schema->column_id(dst_col_idx)].get();
     DCHECK(column_iter != nullptr);
@@ -1210,6 +1217,11 @@ bool SegmentIterator::_check_apply_by_inverted_index(std::shared_ptr<ColumnPredi
 
 // TODO: optimization when all expr can not evaluate by inverted/ann index,
 Status SegmentIterator::_apply_index_expr() {
+    bool enable_ann_index_result_cache =
+            !_opts.runtime_state ||
+            !_opts.runtime_state->query_options().__isset.enable_ann_index_result_cache ||
+            _opts.runtime_state->query_options().enable_ann_index_result_cache;
+
     for (const auto& expr_ctx : _common_expr_ctxs_push_down) {
         if (Status st = expr_ctx->evaluate_inverted_index(num_rows()); !st.ok()) {
             if (_downgrade_without_index(st) || st.code() == ErrorCode::NOT_IMPLEMENTED_ERROR) {
@@ -1243,13 +1255,27 @@ Status SegmentIterator::_apply_index_expr() {
         }
     }
 
+    for (const auto& iter : _index_iterators) {
+        if (iter == nullptr) continue;
+        auto* ann_iter = dynamic_cast<segment_v2::AnnIndexIterator*>(iter.get());
+        if (ann_iter == nullptr) continue;
+        auto ann_reader = std::dynamic_pointer_cast<segment_v2::AnnIndexReader>(
+                ann_iter->get_reader(segment_v2::AnnIndexReaderType::ANN));
+        if (ann_reader) {
+            ann_reader->set_rowset_id(_opts.rowset_id.to_string());
+            ann_reader->set_segment_id(_segment->id());
+            ann_reader->set_rows_of_segment(num_rows());
+        }
+    }
+
     // Apply ann range search
     for (const auto& expr_ctx : _common_expr_ctxs_push_down) {
         segment_v2::AnnIndexStats ann_index_stats;
         size_t origin_rows = _row_bitmap.cardinality();
         RETURN_IF_ERROR(expr_ctx->evaluate_ann_range_search(
                 _index_iterators, _schema->column_ids(), _column_iterators,
-                _common_expr_to_slotref_map, _row_bitmap, ann_index_stats));
+                _common_expr_to_slotref_map, _row_bitmap, ann_index_stats,
+                enable_ann_index_result_cache));
         _opts.stats->rows_ann_index_range_filtered += (origin_rows - _row_bitmap.cardinality());
         _opts.stats->ann_index_load_ns += ann_index_stats.load_index_costs_ns.value();
         _opts.stats->ann_index_range_search_ns += ann_index_stats.search_costs_ns.value();
@@ -1263,6 +1289,7 @@ Status SegmentIterator::_apply_index_expr() {
         _opts.stats->ann_range_engine_convert_ns += ann_index_stats.engine_convert_ns.value();
         _opts.stats->ann_range_pre_process_ns += ann_index_stats.engine_prepare_ns.value();
         _opts.stats->ann_fall_back_brute_force_cnt += ann_index_stats.fall_back_brute_force_cnt;
+        _opts.stats->ann_index_range_cache_hits += ann_index_stats.range_cache_hits.value();
     }
 
     for (auto it = _common_expr_ctxs_push_down.begin(); it != _common_expr_ctxs_push_down.end();) {
@@ -3418,8 +3445,9 @@ void SegmentIterator::_prepare_score_column_materialization() {
     const size_t dst_col_idx = _score_runtime->get_dest_column_idx();
     auto* column_iter = _column_iterators[_schema->column_id(dst_col_idx)].get();
     auto* virtual_column_iter = dynamic_cast<VirtualColumnIterator*>(column_iter);
-    virtual_column_iter->prepare_materialization(std::move(result_column),
-                                                 std::move(result_row_ids));
+    virtual_column_iter->prepare_materialization(
+            std::move(result_column),
+            std::shared_ptr<std::vector<uint64_t>>(std::move(result_row_ids)));
 }
 
 } // namespace segment_v2

--- a/be/src/storage/segment/virtual_column_iterator.h
+++ b/be/src/storage/segment/virtual_column_iterator.h
@@ -20,7 +20,9 @@
 #include <sys/types.h>
 
 #include <cstdint>
+#include <memory>
 #include <unordered_map>
+#include <vector>
 
 #include "common/be_mock_util.h"
 #include "core/column/column.h"

--- a/be/test/storage/index/ann/ann_index_result_cache_test.cpp
+++ b/be/test/storage/index/ann/ann_index_result_cache_test.cpp
@@ -1,0 +1,769 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "storage/index/ann/ann_index_result_cache/ann_index_result_cache.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <roaring/roaring.hh>
+#include <vector>
+
+#include "storage/index/ann/ann_index_result_cache/ann_index_result_cache_handle.h"
+#include "storage/index/ann/ann_search_params.h"
+#include "storage/index/ann/vector_search_utils.h"
+
+namespace doris::segment_v2 {
+
+// ============================================================================
+// Helper to build AnnTopNParam for cache key tests
+// ============================================================================
+static AnnTopNParam make_topn_param(const std::vector<float>& vec, size_t limit,
+                                    roaring::Roaring* bitmap, size_t rows_of_segment,
+                                    VectorSearchUserParams user_params = {}) {
+    AnnTopNParam p {
+            .query_value = vec.data(),
+            .query_value_size = vec.size(),
+            .limit = limit,
+            ._user_params = user_params,
+            .roaring = bitmap,
+            .rows_of_segment = rows_of_segment,
+    };
+    return p;
+}
+
+// ============================================================================
+// TopN Cache Key Tests
+// ============================================================================
+class TopnCacheKeyTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        cache_ = std::make_unique<AnnIndexResultCache>(/*capacity=*/64 * 1024 * 1024,
+                                                       /*shards=*/1);
+        vec_ = {1.0f, 2.0f, 3.0f, 4.0f};
+    }
+    std::unique_ptr<AnnIndexResultCache> cache_;
+    std::vector<float> vec_;
+};
+
+TEST_F(TopnCacheKeyTest, SameParamsSameKey) {
+    auto p1 = make_topn_param(vec_, 10, nullptr, 1000);
+    auto p2 = make_topn_param(vec_, 10, nullptr, 1000);
+
+    AnnIndexResultCacheHandle h;
+    do {
+        AnnIndexResultCacheHandle h;
+        cache_->insert("rs1", 0, 1, p1, &h);
+    } while (false);
+    EXPECT_TRUE(cache_->lookup("rs1", 0, 1, p2, &h));
+}
+
+TEST_F(TopnCacheKeyTest, DifferentQueryVectorMisses) {
+    auto p1 = make_topn_param(vec_, 10, nullptr, 1000);
+    do {
+        AnnIndexResultCacheHandle h;
+        cache_->insert("rs1", 0, 1, p1, &h);
+    } while (false);
+
+    std::vector<float> vec2 = {5.0f, 6.0f, 7.0f, 8.0f};
+    auto p2 = make_topn_param(vec2, 10, nullptr, 1000);
+    AnnIndexResultCacheHandle h;
+    EXPECT_FALSE(cache_->lookup("rs1", 0, 1, p2, &h));
+}
+
+TEST_F(TopnCacheKeyTest, DifferentRowsetMisses) {
+    auto p = make_topn_param(vec_, 10, nullptr, 1000);
+    do {
+        AnnIndexResultCacheHandle h;
+        cache_->insert("rs1", 0, 1, p, &h);
+    } while (false);
+
+    AnnIndexResultCacheHandle h;
+    EXPECT_FALSE(cache_->lookup("rs2", 0, 1, p, &h));
+}
+
+TEST_F(TopnCacheKeyTest, DifferentSegmentMisses) {
+    auto p = make_topn_param(vec_, 10, nullptr, 1000);
+    do {
+        AnnIndexResultCacheHandle h;
+        cache_->insert("rs1", 0, 1, p, &h);
+    } while (false);
+
+    AnnIndexResultCacheHandle h;
+    EXPECT_FALSE(cache_->lookup("rs1", 1, 1, p, &h));
+}
+
+TEST_F(TopnCacheKeyTest, DifferentLimitMisses) {
+    auto p1 = make_topn_param(vec_, 10, nullptr, 1000);
+    do {
+        AnnIndexResultCacheHandle h;
+        cache_->insert("rs1", 0, 1, p1, &h);
+    } while (false);
+
+    auto p2 = make_topn_param(vec_, 20, nullptr, 1000);
+    AnnIndexResultCacheHandle h;
+    EXPECT_FALSE(cache_->lookup("rs1", 0, 1, p2, &h));
+}
+
+TEST_F(TopnCacheKeyTest, NullBitmapAndFullBitmapSameKey) {
+    // null bitmap
+    auto p1 = make_topn_param(vec_, 10, nullptr, 1000);
+    do {
+        AnnIndexResultCacheHandle h;
+        cache_->insert("rs1", 0, 1, p1, &h);
+    } while (false);
+
+    // full bitmap (cardinality == rows_of_segment)
+    roaring::Roaring full;
+    full.addRange(0, 1000);
+    ASSERT_EQ(full.cardinality(), 1000u);
+    auto p2 = make_topn_param(vec_, 10, &full, 1000);
+    AnnIndexResultCacheHandle h;
+    EXPECT_TRUE(cache_->lookup("rs1", 0, 1, p2, &h));
+}
+
+TEST_F(TopnCacheKeyTest, PartialBitmapDiffersFromNull) {
+    auto p1 = make_topn_param(vec_, 10, nullptr, 1000);
+    do {
+        AnnIndexResultCacheHandle h;
+        cache_->insert("rs1", 0, 1, p1, &h);
+    } while (false);
+
+    roaring::Roaring partial;
+    partial.addRange(0, 500);
+    auto p2 = make_topn_param(vec_, 10, &partial, 1000);
+    AnnIndexResultCacheHandle h;
+    EXPECT_FALSE(cache_->lookup("rs1", 0, 1, p2, &h));
+}
+
+TEST_F(TopnCacheKeyTest, DifferentPartialBitmapsMiss) {
+    roaring::Roaring bm1;
+    bm1.addRange(0, 500);
+    auto p1 = make_topn_param(vec_, 10, &bm1, 1000);
+    do {
+        AnnIndexResultCacheHandle h;
+        cache_->insert("rs1", 0, 1, p1, &h);
+    } while (false);
+
+    roaring::Roaring bm2;
+    bm2.addRange(200, 700);
+    auto p2 = make_topn_param(vec_, 10, &bm2, 1000);
+    AnnIndexResultCacheHandle h;
+    EXPECT_FALSE(cache_->lookup("rs1", 0, 1, p2, &h));
+}
+
+TEST_F(TopnCacheKeyTest, SamePartialBitmapHits) {
+    roaring::Roaring bm1;
+    bm1.addRange(0, 500);
+    auto p1 = make_topn_param(vec_, 10, &bm1, 1000);
+    do {
+        AnnIndexResultCacheHandle h;
+        cache_->insert("rs1", 0, 1, p1, &h);
+    } while (false);
+
+    roaring::Roaring bm2;
+    bm2.addRange(0, 500);
+    auto p2 = make_topn_param(vec_, 10, &bm2, 1000);
+    AnnIndexResultCacheHandle h;
+    EXPECT_TRUE(cache_->lookup("rs1", 0, 1, p2, &h));
+}
+
+TEST_F(TopnCacheKeyTest, DifferentHnswEfSearchMisses) {
+    VectorSearchUserParams up1;
+    up1.hnsw_ef_search = 32;
+    auto p1 = make_topn_param(vec_, 10, nullptr, 1000, up1);
+    do {
+        AnnIndexResultCacheHandle h;
+        cache_->insert("rs1", 0, 1, p1, &h);
+    } while (false);
+
+    VectorSearchUserParams up2;
+    up2.hnsw_ef_search = 64;
+    auto p2 = make_topn_param(vec_, 10, nullptr, 1000, up2);
+    AnnIndexResultCacheHandle h;
+    EXPECT_FALSE(cache_->lookup("rs1", 0, 1, p2, &h));
+}
+
+TEST_F(TopnCacheKeyTest, DifferentIndexIdMisses) {
+    auto p = make_topn_param(vec_, 10, nullptr, 1000);
+    do {
+        AnnIndexResultCacheHandle h;
+        cache_->insert("rs1", 0, 1, p, &h);
+    } while (false);
+
+    AnnIndexResultCacheHandle h;
+    EXPECT_FALSE(cache_->lookup("rs1", 0, 2, p, &h));
+}
+
+// ============================================================================
+// Range Cache Key Tests
+// ============================================================================
+class RangeCacheKeyTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        cache_ = std::make_unique<AnnIndexResultCache>(64 * 1024 * 1024, 1);
+        vec_ = {1.0f, 2.0f, 3.0f, 4.0f};
+    }
+    std::unique_ptr<AnnIndexResultCache> cache_;
+    std::vector<float> vec_;
+    VectorSearchUserParams user_params_;
+};
+
+TEST_F(RangeCacheKeyTest, SameParamsHit) {
+    AnnRangeSearchParams p;
+    p.query_value = vec_.data();
+    p.radius = 5.0f;
+    p.is_le_or_lt = true;
+    p.roaring = nullptr;
+
+    do {
+        AnnIndexResultCacheHandle h;
+        cache_->insert("rs1", 0, 1, p, user_params_, 4, 1000, &h);
+    } while (false);
+    AnnIndexResultCacheHandle h;
+    EXPECT_TRUE(cache_->lookup("rs1", 0, 1, p, user_params_, 4, 1000, &h));
+}
+
+TEST_F(RangeCacheKeyTest, DifferentRadiusMisses) {
+    AnnRangeSearchParams p;
+    p.query_value = vec_.data();
+    p.radius = 5.0f;
+    p.is_le_or_lt = true;
+    p.roaring = nullptr;
+    do {
+        AnnIndexResultCacheHandle h;
+        cache_->insert("rs1", 0, 1, p, user_params_, 4, 1000, &h);
+    } while (false);
+
+    AnnRangeSearchParams p2;
+    p2.query_value = vec_.data();
+    p2.radius = 10.0f;
+    p2.is_le_or_lt = true;
+    p2.roaring = nullptr;
+    AnnIndexResultCacheHandle h;
+    EXPECT_FALSE(cache_->lookup("rs1", 0, 1, p2, user_params_, 4, 1000, &h));
+}
+
+TEST_F(RangeCacheKeyTest, DifferentIsLeOrLtMisses) {
+    AnnRangeSearchParams p;
+    p.query_value = vec_.data();
+    p.radius = 5.0f;
+    p.is_le_or_lt = true;
+    p.roaring = nullptr;
+    do {
+        AnnIndexResultCacheHandle h;
+        cache_->insert("rs1", 0, 1, p, user_params_, 4, 1000, &h);
+    } while (false);
+
+    AnnRangeSearchParams p2;
+    p2.query_value = vec_.data();
+    p2.radius = 5.0f;
+    p2.is_le_or_lt = false;
+    p2.roaring = nullptr;
+    AnnIndexResultCacheHandle h;
+    EXPECT_FALSE(cache_->lookup("rs1", 0, 1, p2, user_params_, 4, 1000, &h));
+}
+
+TEST_F(RangeCacheKeyTest, NullAndFullBitmapSameKey) {
+    AnnRangeSearchParams p1;
+    p1.query_value = vec_.data();
+    p1.radius = 5.0f;
+    p1.is_le_or_lt = true;
+    p1.roaring = nullptr;
+    do {
+        AnnIndexResultCacheHandle h;
+        cache_->insert("rs1", 0, 1, p1, user_params_, 4, 1000, &h);
+    } while (false);
+
+    roaring::Roaring full;
+    full.addRange(0, 1000);
+    AnnRangeSearchParams p2;
+    p2.query_value = vec_.data();
+    p2.radius = 5.0f;
+    p2.is_le_or_lt = true;
+    p2.roaring = &full;
+    AnnIndexResultCacheHandle h;
+    EXPECT_TRUE(cache_->lookup("rs1", 0, 1, p2, user_params_, 4, 1000, &h));
+}
+
+TEST_F(RangeCacheKeyTest, DifferentIndexIdMisses) {
+    AnnRangeSearchParams p;
+    p.query_value = vec_.data();
+    p.radius = 5.0f;
+    p.is_le_or_lt = true;
+    p.roaring = nullptr;
+    do {
+        AnnIndexResultCacheHandle h;
+        cache_->insert("rs1", 0, 1, p, user_params_, 4, 1000, &h);
+    } while (false);
+
+    AnnIndexResultCacheHandle h;
+    EXPECT_FALSE(cache_->lookup("rs1", 0, 2, p, user_params_, 4, 1000, &h));
+}
+
+TEST_F(RangeCacheKeyTest, TopnAndRangeKeysDontCollide) {
+    // Insert a topn entry
+    auto topn_p = make_topn_param(vec_, 10, nullptr, 1000);
+    do {
+        AnnIndexResultCacheHandle h;
+        cache_->insert("rs1", 0, 1, topn_p, &h);
+    } while (false);
+
+    // Lookup range with same vec should miss (type=1 vs type=0)
+    AnnRangeSearchParams rp;
+    rp.query_value = vec_.data();
+    rp.radius = 10.0f;
+    rp.is_le_or_lt = true;
+    rp.roaring = nullptr;
+    AnnIndexResultCacheHandle h;
+    EXPECT_FALSE(cache_->lookup("rs1", 0, 1, rp, user_params_, 4, 1000, &h));
+}
+
+// ============================================================================
+// Cache Lifecycle Tests
+// ============================================================================
+class CacheLifecycleTest : public ::testing::Test {
+protected:
+    void SetUp() override { cache_ = std::make_unique<AnnIndexResultCache>(64 * 1024 * 1024, 1); }
+    std::unique_ptr<AnnIndexResultCache> cache_;
+};
+
+TEST_F(CacheLifecycleTest, LookupWithoutInsertMisses) {
+    std::vector<float> vec = {1.0f, 2.0f};
+    auto p = make_topn_param(vec, 5, nullptr, 100);
+    AnnIndexResultCacheHandle h;
+    EXPECT_FALSE(cache_->lookup("rs1", 0, 1, p, &h));
+}
+
+TEST_F(CacheLifecycleTest, InsertThenLookupReturnsData) {
+    std::vector<float> vec = {1.0f, 2.0f};
+    auto p = make_topn_param(vec, 5, nullptr, 100);
+
+    AnnIndexResultCacheHandle insert_h;
+    insert_h.row_ids = std::make_shared<std::vector<uint64_t>>(std::vector<uint64_t> {10, 20, 30});
+    insert_h.distances = std::shared_ptr<float[]>(new float[3] {0.1f, 0.2f, 0.3f});
+    auto bm = std::make_shared<roaring::Roaring>();
+    bm->add(10);
+    bm->add(20);
+    bm->add(30);
+    insert_h.roaring = bm;
+
+    ASSERT_TRUE(cache_->insert("rs1", 0, 1, p, &insert_h));
+
+    AnnIndexResultCacheHandle out;
+    ASSERT_TRUE(cache_->lookup("rs1", 0, 1, p, &out));
+    ASSERT_NE(out.row_ids, nullptr);
+    EXPECT_EQ(out.row_ids->size(), 3u);
+    EXPECT_EQ((*out.row_ids)[0], 10u);
+    EXPECT_EQ((*out.row_ids)[1], 20u);
+    EXPECT_EQ((*out.row_ids)[2], 30u);
+    ASSERT_NE(out.distances, nullptr);
+    EXPECT_FLOAT_EQ(out.distances[0], 0.1f);
+    EXPECT_FLOAT_EQ(out.distances[1], 0.2f);
+    EXPECT_FLOAT_EQ(out.distances[2], 0.3f);
+    ASSERT_NE(out.roaring, nullptr);
+    EXPECT_TRUE(out.roaring->contains(10));
+    EXPECT_TRUE(out.roaring->contains(20));
+    EXPECT_TRUE(out.roaring->contains(30));
+}
+
+// ============================================================================
+// IndexSearchResult::to_cache_handle() Tests
+// ============================================================================
+class IndexSearchResultToCacheHandleTest : public ::testing::Test {};
+
+TEST_F(IndexSearchResultToCacheHandleTest, AllFieldsSet) {
+    IndexSearchResult r;
+    r.row_ids = std::make_shared<std::vector<uint64_t>>(std::vector<uint64_t> {1, 2, 3});
+    r.distances = std::shared_ptr<float[]>(new float[3]);
+    r.distances[0] = 0.1f;
+    r.distances[1] = 0.2f;
+    r.distances[2] = 0.3f;
+    r.roaring = std::make_shared<roaring::Roaring>();
+    r.roaring->add(1);
+    r.roaring->add(2);
+    r.roaring->add(3);
+
+    auto h = r.to_cache_handle();
+    ASSERT_NE(h.row_ids, nullptr);
+    EXPECT_EQ(h.row_ids->size(), 3u);
+    ASSERT_NE(h.distances, nullptr);
+    EXPECT_FLOAT_EQ(h.distances[0], 0.1f);
+    ASSERT_NE(h.roaring, nullptr);
+    EXPECT_EQ(h.roaring->cardinality(), 3u);
+}
+
+TEST_F(IndexSearchResultToCacheHandleTest, OnlyRowIdsSet) {
+    IndexSearchResult r;
+    r.row_ids = std::make_shared<std::vector<uint64_t>>(std::vector<uint64_t> {5, 10});
+
+    auto h = r.to_cache_handle();
+    ASSERT_NE(h.row_ids, nullptr);
+    EXPECT_EQ(h.row_ids->size(), 2u);
+    EXPECT_EQ(h.distances, nullptr);
+    EXPECT_EQ(h.roaring, nullptr);
+}
+
+TEST_F(IndexSearchResultToCacheHandleTest, OnlyRoaringSet) {
+    IndexSearchResult r;
+    r.roaring = std::make_shared<roaring::Roaring>();
+    r.roaring->add(42);
+
+    auto h = r.to_cache_handle();
+    EXPECT_EQ(h.row_ids, nullptr);
+    EXPECT_EQ(h.distances, nullptr);
+    ASSERT_NE(h.roaring, nullptr);
+    EXPECT_TRUE(h.roaring->contains(42));
+}
+
+TEST_F(IndexSearchResultToCacheHandleTest, EmptyResult) {
+    IndexSearchResult r;
+    auto h = r.to_cache_handle();
+    EXPECT_EQ(h.row_ids, nullptr);
+    EXPECT_EQ(h.distances, nullptr);
+    EXPECT_EQ(h.roaring, nullptr);
+}
+
+TEST_F(IndexSearchResultToCacheHandleTest, DistancesWithZeroRows) {
+    IndexSearchResult r;
+    r.distances = std::shared_ptr<float[]>(new float[0]);
+
+    auto h = r.to_cache_handle();
+    // distances are shared even when row_ids is null
+    ASSERT_NE(h.distances, nullptr);
+}
+
+// ============================================================================
+// AnnIndexResultCacheHandle::to_index_search_result() Tests
+// ============================================================================
+class CacheHandleToIndexSearchResultTest : public ::testing::Test {};
+
+TEST_F(CacheHandleToIndexSearchResultTest, AllFieldsSet) {
+    AnnIndexResultCacheHandle h;
+    h.row_ids = std::make_shared<std::vector<uint64_t>>(std::vector<uint64_t> {1, 2});
+    h.distances = std::shared_ptr<float[]>(new float[2] {0.5f, 1.5f});
+    h.roaring = std::make_shared<roaring::Roaring>();
+    h.roaring->add(1);
+    h.roaring->add(2);
+
+    auto r = h.to_index_search_result();
+    ASSERT_NE(r.row_ids, nullptr);
+    EXPECT_EQ(r.row_ids->size(), 2u);
+    ASSERT_NE(r.distances, nullptr);
+    EXPECT_FLOAT_EQ(r.distances[0], 0.5f);
+    EXPECT_FLOAT_EQ(r.distances[1], 1.5f);
+    ASSERT_NE(r.roaring, nullptr);
+    EXPECT_EQ(r.roaring->cardinality(), 2u);
+}
+
+TEST_F(CacheHandleToIndexSearchResultTest, DistancesNull) {
+    AnnIndexResultCacheHandle h;
+    h.row_ids = std::make_shared<std::vector<uint64_t>>(std::vector<uint64_t> {1});
+
+    auto r = h.to_index_search_result();
+    EXPECT_EQ(r.distances, nullptr);
+    ASSERT_NE(r.row_ids, nullptr);
+    EXPECT_EQ(r.row_ids->size(), 1u);
+}
+
+TEST_F(CacheHandleToIndexSearchResultTest, RowIdsNull) {
+    AnnIndexResultCacheHandle h;
+    h.distances = std::shared_ptr<float[]>(new float[1] {1.0f});
+
+    auto r = h.to_index_search_result();
+    EXPECT_EQ(r.row_ids, nullptr);
+    ASSERT_NE(r.distances, nullptr);
+}
+
+TEST_F(CacheHandleToIndexSearchResultTest, AllNull) {
+    AnnIndexResultCacheHandle h;
+    auto r = h.to_index_search_result();
+    EXPECT_EQ(r.distances, nullptr);
+    EXPECT_EQ(r.row_ids, nullptr);
+    EXPECT_EQ(r.roaring, nullptr);
+}
+
+TEST_F(CacheHandleToIndexSearchResultTest, RoaringShared) {
+    AnnIndexResultCacheHandle h;
+    h.roaring = std::make_shared<roaring::Roaring>();
+    h.roaring->add(99);
+
+    auto r = h.to_index_search_result();
+    ASSERT_NE(r.roaring, nullptr);
+    // roaring is shared, not deep-copied
+    EXPECT_EQ(r.roaring.get(), h.roaring.get());
+}
+
+// ============================================================================
+// AnnRangeSearchResult::to_cache_handle() Tests
+// ============================================================================
+class RangeResultToCacheHandleTest : public ::testing::Test {};
+
+TEST_F(RangeResultToCacheHandleTest, AllFieldsSet) {
+    AnnRangeSearchResult r;
+    r.roaring = std::make_shared<roaring::Roaring>();
+    r.roaring->add(1);
+    r.roaring->add(2);
+    r.row_ids = std::make_shared<std::vector<uint64_t>>(std::vector<uint64_t> {1, 2});
+    r.distance = std::shared_ptr<float[]>(new float[2]);
+    r.distance[0] = 0.1f;
+    r.distance[1] = 0.2f;
+
+    auto h = r.to_cache_handle();
+    ASSERT_NE(h.roaring, nullptr);
+    EXPECT_EQ(h.roaring->cardinality(), 2u);
+    // Shared pointer: no deep copy
+    EXPECT_EQ(h.roaring.get(), r.roaring.get());
+    ASSERT_NE(h.row_ids, nullptr);
+    EXPECT_EQ(h.row_ids->size(), 2u);
+    ASSERT_NE(h.distances, nullptr);
+    EXPECT_FLOAT_EQ(h.distances[0], 0.1f);
+}
+
+TEST_F(RangeResultToCacheHandleTest, OnlyRoaringSet) {
+    AnnRangeSearchResult r;
+    r.roaring = std::make_shared<roaring::Roaring>();
+    r.roaring->add(42);
+
+    auto h = r.to_cache_handle();
+    ASSERT_NE(h.roaring, nullptr);
+    EXPECT_TRUE(h.roaring->contains(42));
+    EXPECT_EQ(h.row_ids, nullptr);
+    EXPECT_EQ(h.distances, nullptr);
+}
+
+TEST_F(RangeResultToCacheHandleTest, EmptyResult) {
+    AnnRangeSearchResult r;
+    auto h = r.to_cache_handle();
+    EXPECT_EQ(h.roaring, nullptr);
+    EXPECT_EQ(h.row_ids, nullptr);
+    EXPECT_EQ(h.distances, nullptr);
+}
+
+// ============================================================================
+// AnnRangeSearchResult::from_cache_handle() Tests
+// ============================================================================
+class RangeResultFromCacheHandleTest : public ::testing::Test {};
+
+TEST_F(RangeResultFromCacheHandleTest, RoundtripFidelity) {
+    AnnRangeSearchResult orig;
+    orig.roaring = std::make_shared<roaring::Roaring>();
+    orig.roaring->add(3);
+    orig.roaring->add(7);
+    orig.row_ids = std::make_shared<std::vector<uint64_t>>(std::vector<uint64_t> {3, 7});
+    orig.distance = std::shared_ptr<float[]>(new float[2]);
+    orig.distance[0] = 1.1f;
+    orig.distance[1] = 2.2f;
+
+    auto h = orig.to_cache_handle();
+    auto restored = AnnRangeSearchResult::from_cache_handle(h);
+
+    ASSERT_NE(restored.roaring, nullptr);
+    EXPECT_TRUE(restored.roaring->contains(3));
+    EXPECT_TRUE(restored.roaring->contains(7));
+    EXPECT_EQ(restored.roaring->cardinality(), 2u);
+    ASSERT_NE(restored.row_ids, nullptr);
+    EXPECT_EQ(restored.row_ids->size(), 2u);
+    EXPECT_EQ((*restored.row_ids)[0], 3u);
+    EXPECT_EQ((*restored.row_ids)[1], 7u);
+    ASSERT_NE(restored.distance, nullptr);
+    EXPECT_FLOAT_EQ(restored.distance[0], 1.1f);
+    EXPECT_FLOAT_EQ(restored.distance[1], 2.2f);
+    EXPECT_EQ(restored.roaring.get(), orig.roaring.get());
+    EXPECT_EQ(restored.row_ids.get(), orig.row_ids.get());
+    EXPECT_EQ(restored.distance.get(), orig.distance.get());
+}
+
+TEST_F(RangeResultFromCacheHandleTest, AllNullFields) {
+    AnnIndexResultCacheHandle h;
+    auto r = AnnRangeSearchResult::from_cache_handle(h);
+    EXPECT_EQ(r.roaring, nullptr);
+    EXPECT_EQ(r.row_ids, nullptr);
+    EXPECT_EQ(r.distance, nullptr);
+}
+
+TEST_F(RangeResultFromCacheHandleTest, OnlyRowIdsInHandle) {
+    AnnIndexResultCacheHandle h;
+    h.row_ids = std::make_shared<std::vector<uint64_t>>(std::vector<uint64_t> {5});
+
+    auto r = AnnRangeSearchResult::from_cache_handle(h);
+    ASSERT_NE(r.row_ids, nullptr);
+    EXPECT_EQ(r.row_ids->size(), 1u);
+    EXPECT_EQ(r.roaring, nullptr);
+    EXPECT_EQ(r.distance, nullptr);
+}
+
+// ============================================================================
+// normalize_topn_result() Tests
+//
+// normalize_topn_result is a static function in ann_index_reader.cpp.
+// We replicate its logic here for unit testing since it's not publicly
+// accessible. These tests verify all 6 if-branch conditions.
+// ============================================================================
+
+static void normalize_topn_result(IndexSearchResult& result) {
+    if (result.roaring == nullptr && result.row_ids != nullptr) {
+        auto rebuilt = std::make_shared<roaring::Roaring>();
+        for (auto row_id : *result.row_ids) {
+            rebuilt->add(static_cast<uint32_t>(row_id));
+        }
+        result.roaring = std::move(rebuilt);
+    }
+
+    if (result.roaring == nullptr) {
+        result.roaring = std::make_shared<roaring::Roaring>();
+    }
+
+    if (result.row_ids == nullptr) {
+        result.row_ids = std::make_shared<std::vector<uint64_t>>();
+    }
+
+    size_t rows = std::min<size_t>(result.row_ids->size(), result.roaring->cardinality());
+
+    if (result.row_ids->size() != rows) {
+        result.row_ids->resize(rows);
+    }
+
+    if (result.distances == nullptr) {
+        result.distances = std::shared_ptr<float[]>(new float[rows]);
+        for (size_t i = 0; i < rows; ++i) {
+            result.distances[i] = 0.0f;
+        }
+    }
+
+    if (result.roaring->cardinality() != rows) {
+        auto rebuilt = std::make_shared<roaring::Roaring>();
+        for (size_t i = 0; i < rows; ++i) {
+            rebuilt->add(static_cast<uint32_t>((*result.row_ids)[i]));
+        }
+        result.roaring = std::move(rebuilt);
+    }
+}
+
+class NormalizeTopnResultTest : public ::testing::Test {};
+
+// Branch 1: roaring null + row_ids present → roaring rebuilt from row_ids
+TEST_F(NormalizeTopnResultTest, RoaringNullRowIdsPresent) {
+    IndexSearchResult r;
+    r.row_ids = std::make_shared<std::vector<uint64_t>>(std::vector<uint64_t> {5, 10, 15});
+    r.distances = std::shared_ptr<float[]>(new float[3]);
+    r.distances[0] = 1.0f;
+    r.distances[1] = 2.0f;
+    r.distances[2] = 3.0f;
+
+    normalize_topn_result(r);
+
+    ASSERT_NE(r.roaring, nullptr);
+    EXPECT_EQ(r.roaring->cardinality(), 3u);
+    EXPECT_TRUE(r.roaring->contains(5));
+    EXPECT_TRUE(r.roaring->contains(10));
+    EXPECT_TRUE(r.roaring->contains(15));
+}
+
+// Branch 2: roaring null + row_ids null → both set to empty
+TEST_F(NormalizeTopnResultTest, BothNull) {
+    IndexSearchResult r;
+
+    normalize_topn_result(r);
+
+    ASSERT_NE(r.roaring, nullptr);
+    EXPECT_EQ(r.roaring->cardinality(), 0u);
+    ASSERT_NE(r.row_ids, nullptr);
+    EXPECT_EQ(r.row_ids->size(), 0u);
+    ASSERT_NE(r.distances, nullptr);
+}
+
+// Branch 3: distances null → filled with 0.0f
+TEST_F(NormalizeTopnResultTest, DistancesNull) {
+    IndexSearchResult r;
+    r.row_ids = std::make_shared<std::vector<uint64_t>>(std::vector<uint64_t> {1, 2});
+    r.roaring = std::make_shared<roaring::Roaring>();
+    r.roaring->add(1);
+    r.roaring->add(2);
+
+    normalize_topn_result(r);
+
+    ASSERT_NE(r.distances, nullptr);
+    EXPECT_FLOAT_EQ(r.distances[0], 0.0f);
+    EXPECT_FLOAT_EQ(r.distances[1], 0.0f);
+}
+
+// Branch 4: row_ids larger than roaring cardinality → truncated to min
+TEST_F(NormalizeTopnResultTest, RowIdsLargerThanRoaring) {
+    IndexSearchResult r;
+    r.row_ids = std::make_shared<std::vector<uint64_t>>(std::vector<uint64_t> {1, 2, 3, 4, 5});
+    r.distances = std::shared_ptr<float[]>(new float[5]);
+    for (int i = 0; i < 5; ++i) r.distances[i] = static_cast<float>(i);
+    r.roaring = std::make_shared<roaring::Roaring>();
+    r.roaring->add(1);
+    r.roaring->add(2);
+
+    normalize_topn_result(r);
+
+    // rows = min(5, 2) = 2
+    EXPECT_EQ(r.row_ids->size(), 2u);
+    // roaring rebuilt from truncated row_ids
+    EXPECT_EQ(r.roaring->cardinality(), 2u);
+    EXPECT_TRUE(r.roaring->contains(1));
+    EXPECT_TRUE(r.roaring->contains(2));
+}
+
+// Branch 5: roaring cardinality larger than row_ids → roaring rebuilt
+TEST_F(NormalizeTopnResultTest, RoaringLargerThanRowIds) {
+    IndexSearchResult r;
+    r.row_ids = std::make_shared<std::vector<uint64_t>>(std::vector<uint64_t> {1});
+    r.distances = std::shared_ptr<float[]>(new float[1]);
+    r.distances[0] = 0.5f;
+    r.roaring = std::make_shared<roaring::Roaring>();
+    r.roaring->add(1);
+    r.roaring->add(2);
+    r.roaring->add(3);
+
+    normalize_topn_result(r);
+
+    // rows = min(1, 3) = 1, row_ids stays size 1, roaring rebuilt with just {1}
+    EXPECT_EQ(r.row_ids->size(), 1u);
+    EXPECT_EQ(r.roaring->cardinality(), 1u);
+    EXPECT_TRUE(r.roaring->contains(1));
+}
+
+// Branch 6: all fields consistent → no changes
+TEST_F(NormalizeTopnResultTest, AllConsistent) {
+    IndexSearchResult r;
+    r.row_ids = std::make_shared<std::vector<uint64_t>>(std::vector<uint64_t> {10, 20});
+    r.distances = std::shared_ptr<float[]>(new float[2]);
+    r.distances[0] = 1.0f;
+    r.distances[1] = 2.0f;
+    r.roaring = std::make_shared<roaring::Roaring>();
+    r.roaring->add(10);
+    r.roaring->add(20);
+
+    auto* orig_row_ids = r.row_ids.get();
+    auto* orig_distances = r.distances.get();
+    auto orig_roaring = r.roaring;
+
+    normalize_topn_result(r);
+
+    EXPECT_EQ(r.row_ids.get(), orig_row_ids);
+    EXPECT_EQ(r.distances.get(), orig_distances);
+    // roaring not rebuilt when cardinality matches
+    EXPECT_EQ(r.roaring.get(), orig_roaring.get());
+    EXPECT_EQ(r.row_ids->size(), 2u);
+    EXPECT_EQ(r.roaring->cardinality(), 2u);
+}
+
+} // namespace doris::segment_v2

--- a/be/test/storage/index/ann/ann_range_search_test.cpp
+++ b/be/test/storage/index/ann/ann_range_search_test.cpp
@@ -169,7 +169,7 @@ TEST_F(VectorSearchTest, TestEvaluateAnnRangeSearch) {
     ASSERT_TRUE(range_search_ctx
                         ->evaluate_ann_range_search(cid_to_index_iterators, idx_to_cid,
                                                     column_iterators, common_expr_to_slotref_map,
-                                                    row_bitmap, stats)
+                                                    row_bitmap, stats, false)
                         .ok());
 
     doris::segment_v2::VirtualColumnIterator* virtual_column_iter =
@@ -266,7 +266,7 @@ TEST_F(VectorSearchTest, TestEvaluateAnnRangeSearch2) {
     ASSERT_TRUE(range_search_ctx
                         ->evaluate_ann_range_search(cid_to_index_iterators, idx_to_cid,
                                                     column_iterators, common_expr_to_slotref_map,
-                                                    row_bitmap, stats)
+                                                    row_bitmap, stats, false)
                         .ok());
 
     doris::segment_v2::VirtualColumnIterator* virtual_column_iter =
@@ -664,7 +664,7 @@ TEST_F(VectorSearchTest, TestEvaluateAnnRangeSearch_DimensionMismatch) {
 
     auto st = range_search_ctx->evaluate_ann_range_search(
             cid_to_index_iterators, idx_to_cid, column_iterators, common_expr_to_slotref_map,
-            row_bitmap, stats);
+            row_bitmap, stats, false);
     EXPECT_FALSE(st.ok());
     EXPECT_TRUE(st.is<doris::ErrorCode::INVALID_ARGUMENT>());
 }

--- a/be/test/storage/index/ann/ann_topn_descriptor_test.cpp
+++ b/be/test/storage/index/ann/ann_topn_descriptor_test.cpp
@@ -174,7 +174,7 @@ TEST_F(VectorSearchTest, AnnTopNRuntimeEvaluateTopN) {
     // rows_of_segment is mocked as 10 to align with mocked iterator outputs
     size_t rows_of_segment = 10;
     st = predicate->evaluate_vector_ann_search(_ann_index_iterator.get(), &roaring, rows_of_segment,
-                                               _result_column, row_ids, ann_index_stats);
+                                               false, _result_column, row_ids, ann_index_stats);
     ColumnFloat32* result_column_float = assert_cast<ColumnFloat32*>(_result_column.get());
     for (size_t i = 0; i < query_vector->size(); ++i) {
         EXPECT_EQ(result_column_float->get_data()[i], (*query_vector)[i]);

--- a/be/test/storage/index/ann/ann_topn_runtime_negative_test.cpp
+++ b/be/test/storage/index/ann/ann_topn_runtime_negative_test.cpp
@@ -136,7 +136,7 @@ TEST_F(VectorSearchTest, AnnTopNRuntimeEvaluate_DimensionMismatch) {
     IColumn::MutablePtr result_col = ColumnFloat32::create(0);
     std::shared_ptr<std::vector<uint64_t>> row_ids;
     doris::segment_v2::AnnIndexStats stats;
-    Status st = runtime->evaluate_vector_ann_search(_ann_index_iterator.get(), &bitmap, 10,
+    Status st = runtime->evaluate_vector_ann_search(_ann_index_iterator.get(), &bitmap, 10, false,
                                                     result_col, row_ids, stats);
     ASSERT_FALSE(st.ok());
     EXPECT_THAT(st.to_string(), HasSubstr("dimension"));

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -842,6 +842,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String ENABLE_FALLBACK_ON_MISSING_INVERTED_INDEX = "enable_fallback_on_missing_inverted_index";
     public static final String ENABLE_INVERTED_INDEX_SEARCHER_CACHE = "enable_inverted_index_searcher_cache";
     public static final String ENABLE_INVERTED_INDEX_QUERY_CACHE = "enable_inverted_index_query_cache";
+    public static final String ENABLE_ANN_INDEX_RESULT_CACHE = "enable_ann_index_result_cache";
 
     public static final String IN_LIST_VALUE_COUNT_THRESHOLD = "in_list_value_count_threshold";
 
@@ -3408,6 +3409,12 @@ public class SessionVariable implements Serializable, Writable {
     })
     public boolean enableInvertedIndexQueryCache = true;
 
+    @VarAttrDef.VarAttr(name = ENABLE_ANN_INDEX_RESULT_CACHE, needForward = true, description = {
+        "开启后会缓存 ANN 索引查询结果",
+        "Enabling this will cache the results of ANN index queries."
+    })
+    public boolean enableAnnIndexResultCache = true;
+
     @VarAttrDef.VarAttr(name = IN_LIST_VALUE_COUNT_THRESHOLD, description = {
         "in 条件 value 数量大于这个 threshold 后将不会走 fast_execute",
         "When the number of values in the IN condition exceeds this threshold,"
@@ -5600,6 +5607,7 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setEnableFallbackOnMissingInvertedIndex(enableFallbackOnMissingInvertedIndex);
         tResult.setEnableInvertedIndexSearcherCache(enableInvertedIndexSearcherCache);
         tResult.setEnableInvertedIndexQueryCache(enableInvertedIndexQueryCache);
+        tResult.setEnableAnnIndexResultCache(enableAnnIndexResultCache);
         tResult.setHiveOrcUseColumnNames(hiveOrcUseColumnNames);
         tResult.setHiveParquetUseColumnNames(hiveParquetUseColumnNames);
         tResult.setQuerySlotCount(wgQuerySlotCount);

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -492,6 +492,7 @@ struct TQueryOptions {
   // Push LIMIT into SegmentIterator when safe.
   219: optional bool enable_segment_limit_pushdown = true
 
+  220: optional bool enable_ann_index_result_cache = true
   // For cloud, to control if the content would be written into file cache
   // In write path, to control if the content would be written into file cache.
   // In read path, read from file cache or remote storage when execute query.

--- a/regression-test/suites/ann_index_p0/ann_index_cache_additional.groovy
+++ b/regression-test/suites/ann_index_p0/ann_index_cache_additional.groovy
@@ -1,0 +1,248 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("ann_index_cache_additional", "nonConcurrent") {
+    sql "unset variable all;"
+    sql "set enable_common_expr_pushdown=true;"
+    sql "set parallel_pipeline_task_num=1;"
+    sql "set enable_sql_cache=false;"
+
+    String[][] backends = sql """ show backends """
+    def backendIdToBackendIP = [:]
+    def backendIdToBackendHttpPort = [:]
+    for (String[] backend in backends) {
+        if (backend[9].equalsIgnoreCase("true")) {
+            backendIdToBackendIP.put(backend[0], backend[1])
+            backendIdToBackendHttpPort.put(backend[0], backend[4])
+        }
+    }
+    assertTrue(backendIdToBackendIP.size() > 0)
+
+    def clearAnnResultCache = {
+        for (def backendId : backendIdToBackendIP.keySet()) {
+            def url = backendIdToBackendIP.get(backendId) + ":" +
+                    backendIdToBackendHttpPort.get(backendId) + "/api/clear_cache/AnnIndexResultCache"
+            httpTest {
+                endpoint ""
+                uri url
+                op "get"
+                body ""
+                check { respCode, body ->
+                    assertEquals("${respCode}".toString(), "200")
+                    assertTrue("${body}".toString().contains("prune win"))
+                }
+            }
+        }
+    }
+
+    def checkAnnCacheHit = { String debugPoint, Map debugParams, String query ->
+        def params = debugParams + [execute: 1]
+        GetDebugPoint().enableDebugPointForAllBEs(debugPoint, params)
+        sql query
+    }
+
+    def checkTopnCacheHit = { Map debugParams, String query ->
+        checkAnnCacheHit("olap_scanner.ann_topn_cache_hits", debugParams, query)
+    }
+
+    def checkRangeCacheHit = { Map debugParams, String query ->
+        checkAnnCacheHit("olap_scanner.ann_range_cache_hits", debugParams, query)
+    }
+
+    sql "drop table if exists ann_index_cache_ip"
+    sql """
+        CREATE TABLE ann_index_cache_ip (
+            id INT NOT NULL,
+            embedding ARRAY<FLOAT> NOT NULL,
+            INDEX idx_emb (`embedding`) USING ANN PROPERTIES(
+                "index_type"="hnsw",
+                "metric_type"="inner_product",
+                "dim"="4"
+            )
+        ) ENGINE=OLAP
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES ("replication_num" = "1");
+    """
+    sql """
+        INSERT INTO ann_index_cache_ip VALUES
+        (1, [0.1, 0.2, 0.3, 0.4]),
+        (2, [0.5, 0.6, 0.7, 0.8]),
+        (3, [1.0, 1.0, 1.0, 1.0]),
+        (4, [0.0, 0.1, 0.0, 0.1]);
+    """
+
+    clearAnnResultCache()
+
+    sql """
+        select id
+        from ann_index_cache_ip
+        order by inner_product_approximate(embedding, [0.1,0.2,0.3,0.4]) desc
+        limit 2;
+    """
+    checkTopnCacheHit([min_hits: 1], """
+        select id
+        from ann_index_cache_ip
+        order by inner_product_approximate(embedding, [0.1,0.2,0.3,0.4]) desc
+        limit 2;
+    """)
+
+    clearAnnResultCache()
+
+    sql """
+        select id
+        from ann_index_cache_ip
+        order by inner_product_approximate(embedding, [0.1,0.2,0.3,0.4]) asc
+        limit 2;
+    """
+    checkTopnCacheHit([expected_hits: 0], """
+        select id
+        from ann_index_cache_ip
+        order by inner_product_approximate(embedding, [0.1,0.2,0.3,0.4]) asc
+        limit 2;
+    """)
+
+    sql "drop table if exists ann_index_cache_metric_mismatch"
+    sql """
+        CREATE TABLE ann_index_cache_metric_mismatch (
+            id INT NOT NULL,
+            embedding ARRAY<FLOAT> NOT NULL,
+            INDEX idx_emb (`embedding`) USING ANN PROPERTIES(
+                "index_type"="hnsw",
+                "metric_type"="l2_distance",
+                "dim"="4"
+            )
+        ) ENGINE=OLAP
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES ("replication_num" = "1");
+    """
+    sql "insert into ann_index_cache_metric_mismatch select * from ann_index_cache_ip"
+
+    clearAnnResultCache()
+
+    sql """
+        select id
+        from ann_index_cache_metric_mismatch
+        order by inner_product_approximate(embedding, [0.1,0.2,0.3,0.4]) desc
+        limit 2;
+    """
+    checkTopnCacheHit([expected_hits: 0], """
+        select id
+        from ann_index_cache_metric_mismatch
+        order by inner_product_approximate(embedding, [0.1,0.2,0.3,0.4]) desc
+        limit 2;
+    """)
+
+    clearAnnResultCache()
+
+    sql """
+        select id
+        from ann_index_cache_metric_mismatch
+        order by l2_distance_approximate(embedding, [0.1,0.2,0.3,0.4]) desc
+        limit 2;
+    """
+    checkTopnCacheHit([expected_hits: 0], """
+        select id
+        from ann_index_cache_metric_mismatch
+        order by l2_distance_approximate(embedding, [0.1,0.2,0.3,0.4]) desc
+        limit 2;
+    """)
+
+    clearAnnResultCache()
+
+    sql """
+        select id
+        from ann_index_cache_ip
+        where inner_product_approximate(embedding, [0.1,0.2,0.3,0.4]) >= 0.6
+        order by id;
+    """
+    checkRangeCacheHit([min_hits: 1], """
+        select id
+        from ann_index_cache_ip
+        where inner_product_approximate(embedding, [0.1,0.2,0.3,0.4]) >= 0.6
+        order by id;
+    """)
+
+    clearAnnResultCache()
+
+    sql """
+        select id
+        from ann_index_cache_metric_mismatch
+        where inner_product_approximate(embedding, [0.1,0.2,0.3,0.4]) >= 0.6
+        order by id;
+    """
+    checkRangeCacheHit([expected_hits: 0], """
+        select id
+        from ann_index_cache_metric_mismatch
+        where inner_product_approximate(embedding, [0.1,0.2,0.3,0.4]) >= 0.6
+        order by id;
+    """)
+
+    sql "drop table if exists ann_index_cache_two_ann_cols"
+    sql """
+        CREATE TABLE ann_index_cache_two_ann_cols (
+            id INT NOT NULL,
+            emb_a ARRAY<FLOAT> NOT NULL,
+            emb_b ARRAY<FLOAT> NOT NULL,
+            INDEX idx_emb_a (`emb_a`) USING ANN PROPERTIES(
+                "index_type"="hnsw",
+                "metric_type"="l2_distance",
+                "dim"="3"
+            ),
+            INDEX idx_emb_b (`emb_b`) USING ANN PROPERTIES(
+                "index_type"="hnsw",
+                "metric_type"="l2_distance",
+                "dim"="3"
+            )
+        ) ENGINE=OLAP
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES ("replication_num" = "1");
+    """
+    sql """
+        INSERT INTO ann_index_cache_two_ann_cols VALUES
+        (1, [1.0, 2.0, 3.0], [9.0, 9.0, 9.0]),
+        (2, [1.1, 2.1, 3.1], [8.0, 8.0, 8.0]),
+        (3, [8.0, 8.0, 8.0], [1.0, 2.0, 3.0]),
+        (4, [9.0, 9.0, 9.0], [1.1, 2.1, 3.1]);
+    """
+
+    clearAnnResultCache()
+
+    checkTopnCacheHit([expected_hits: 0], """
+        select id
+        from ann_index_cache_two_ann_cols
+        order by l2_distance_approximate(emb_a, [1.0,2.0,3.0])
+        limit 2;
+    """)
+
+    checkTopnCacheHit([expected_hits: 0], """
+        select id
+        from ann_index_cache_two_ann_cols
+        order by l2_distance_approximate(emb_b, [1.0,2.0,3.0])
+        limit 2;
+    """)
+
+    checkTopnCacheHit([min_hits: 1], """
+        select id
+        from ann_index_cache_two_ann_cols
+        order by l2_distance_approximate(emb_b, [1.0,2.0,3.0])
+        limit 2;
+    """)
+    GetDebugPoint().clearDebugPointsForAllBEs()
+}

--- a/regression-test/suites/ann_index_p0/ann_index_result_cache.groovy
+++ b/regression-test/suites/ann_index_p0/ann_index_result_cache.groovy
@@ -1,0 +1,236 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("ann_index_result_cache", "nonConcurrent") {
+    sql "unset variable all;"
+    sql "set enable_common_expr_pushdown=true;"
+    sql "set parallel_pipeline_task_num=1;"
+    sql "set enable_sql_cache=false;"
+
+    String[][] backends = sql """ show backends """
+    def backendIdToBackendIP = [:]
+    def backendIdToBackendHttpPort = [:]
+    for (String[] backend in backends) {
+        if (backend[9].equalsIgnoreCase("true")) {
+            backendIdToBackendIP.put(backend[0], backend[1])
+            backendIdToBackendHttpPort.put(backend[0], backend[4])
+        }
+    }
+    assertTrue(backendIdToBackendIP.size() > 0)
+
+    def clearAnnTopnResultCache = {
+        for (def backendId : backendIdToBackendIP.keySet()) {
+            def url = backendIdToBackendIP.get(backendId) + ":" +
+                    backendIdToBackendHttpPort.get(backendId) + "/api/clear_cache/AnnIndexResultCache"
+            httpTest {
+                endpoint ""
+                uri url
+                op "get"
+                body ""
+                check { respCode, body ->
+                    assertEquals("${respCode}".toString(), "200")
+                    assertTrue("${body}".toString().contains("prune win"))
+                }
+            }
+        }
+    }
+
+    def checkAnnCacheHit = { String debugPoint, Map debugParams, String query ->
+        def params = debugParams + [execute: 1]
+        GetDebugPoint().enableDebugPointForAllBEs(debugPoint, params)
+        sql query
+    }
+
+    def checkTopnCacheHit = { Map debugParams, String query ->
+        checkAnnCacheHit("olap_scanner.ann_topn_cache_hits", debugParams, query)
+    }
+
+    def checkRangeCacheHit = { Map debugParams, String query ->
+        checkAnnCacheHit("olap_scanner.ann_range_cache_hits", debugParams, query)
+    }
+
+    def timeout = 60000
+    def deltaTime = 1000
+    def wait_for_latest_op_on_table_finish = { tableName, opTimeout ->
+        int useTime = 0
+        for (int t = deltaTime; t <= opTimeout; t += deltaTime) {
+            def alterRes = sql """SHOW ALTER TABLE COLUMN WHERE TableName = "${tableName}" ORDER BY CreateTime DESC LIMIT 1;"""
+            def alterResStr = alterRes.toString()
+            if (alterResStr.contains("FINISHED")) {
+                sleep(3000)
+                break
+            }
+            useTime = t
+            sleep(deltaTime)
+        }
+        assertTrue(useTime <= opTimeout, "wait_for_latest_op_on_table_finish timeout")
+    }
+
+    // ======================== Setup ========================
+    sql "drop table if exists ann_result_cache_test"
+    sql """
+        CREATE TABLE ann_result_cache_test (
+            id INT NOT NULL,
+            embedding ARRAY<FLOAT> NOT NULL,
+            INDEX idx_emb (`embedding`) USING ANN PROPERTIES(
+                "index_type"="hnsw",
+                "metric_type"="l2_distance",
+                "dim"="3"
+            )
+        ) ENGINE=OLAP
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES ("replication_num" = "1");
+    """
+
+    sql """
+        INSERT INTO ann_result_cache_test VALUES
+        (1, [1.0, 2.0, 3.0]),
+        (2, [1.1, 2.1, 3.1]),
+        (3, [1.2, 2.2, 3.2]),
+        (4, [1.3, 2.3, 3.3]),
+        (5, [1.4, 2.4, 3.4]),
+        (6, [1.5, 2.5, 3.5]),
+        (7, [5.0, 5.0, 5.0]),
+        (8, [8.0, 8.0, 8.0]),
+        (9, [9.0, 9.0, 9.0]);
+    """
+
+    clearAnnTopnResultCache()
+
+    // ======================== Test 1: TopN cache without prefilter ========================
+    sql """
+        select id
+        from ann_result_cache_test
+        order by l2_distance_approximate(embedding, [1.0,2.0,3.0])
+        limit 3;
+    """
+
+    checkTopnCacheHit([min_hits: 1], """
+        select id
+        from ann_result_cache_test
+        order by l2_distance_approximate(embedding, [1.0,2.0,3.0])
+        limit 3;
+    """)
+
+    // ======================== Test 2: TopN cache WITH prefilter (bitmap hashing) ========================
+    clearAnnTopnResultCache()
+
+    sql """
+        select id
+        from ann_result_cache_test
+        where id < 8
+        order by l2_distance_approximate(embedding, [1.0,2.0,3.0])
+        limit 3;
+    """
+
+    checkTopnCacheHit([min_hits: 1], """
+        select id
+        from ann_result_cache_test
+        where id < 8
+        order by l2_distance_approximate(embedding, [1.0,2.0,3.0])
+        limit 3;
+    """)
+
+    // ======================== Test 3: Different prefilter => cache miss ========================
+    checkTopnCacheHit([expected_hits: 0], """
+        select id
+        from ann_result_cache_test
+        where id < 6
+        order by l2_distance_approximate(embedding, [1.0,2.0,3.0])
+        limit 3;
+    """)
+
+    // ======================== Test 4: Range search cache without prefilter ========================
+    clearAnnTopnResultCache()
+
+    sql """
+        select id
+        from ann_result_cache_test
+        where l2_distance_approximate(embedding, [1.0,2.0,3.0]) < 1.0
+        order by id;
+    """
+
+    checkRangeCacheHit([min_hits: 1], """
+        select id
+        from ann_result_cache_test
+        where l2_distance_approximate(embedding, [1.0,2.0,3.0]) < 1.0
+        order by id;
+    """)
+
+    // ======================== Test 5: Range search cache with prefilter ========================
+    clearAnnTopnResultCache()
+
+    sql """
+        select id
+        from ann_result_cache_test
+        where id < 8 and l2_distance_approximate(embedding, [1.0,2.0,3.0]) < 1.0
+        order by id;
+    """
+
+    checkRangeCacheHit([min_hits: 1], """
+        select id
+        from ann_result_cache_test
+        where id < 8 and l2_distance_approximate(embedding, [1.0,2.0,3.0]) < 1.0
+        order by id;
+    """)
+
+    // ======================== Test 6: Range search different radius => cache miss ========================
+    checkRangeCacheHit([expected_hits: 0], """
+        select id
+        from ann_result_cache_test
+        where l2_distance_approximate(embedding, [1.0,2.0,3.0]) < 2.0
+        order by id;
+    """)
+
+    // ======================== Test 7: Cache clear API works for range search too ========================
+    clearAnnTopnResultCache()
+
+    checkRangeCacheHit([expected_hits: 0], """
+        select id
+        from ann_result_cache_test
+        where l2_distance_approximate(embedding, [1.0,2.0,3.0]) < 1.0
+        order by id;
+    """)
+
+    // ======================== Test 8: Drop index => fallback, cache stays 0 ========================
+    sql "drop index idx_emb on ann_result_cache_test"
+
+    wait_for_latest_op_on_table_finish("ann_result_cache_test", timeout)
+
+    sql """
+        select id
+        from ann_result_cache_test
+        order by l2_distance_approximate(embedding, [1.0,2.0,3.0])
+        limit 3;
+    """
+
+    checkTopnCacheHit([expected_hits: 0], """
+        select id
+        from ann_result_cache_test
+        order by l2_distance_approximate(embedding, [1.0,2.0,3.0])
+        limit 3;
+    """)
+
+    checkRangeCacheHit([expected_hits: 0], """
+        select id
+        from ann_result_cache_test
+        where l2_distance_approximate(embedding, [1.0,2.0,3.0]) < 1.0
+        order by id;
+    """)
+    GetDebugPoint().clearDebugPointsForAllBEs()
+}

--- a/regression-test/suites/ann_index_p0/ann_index_topn_cache.groovy
+++ b/regression-test/suites/ann_index_p0/ann_index_topn_cache.groovy
@@ -1,0 +1,185 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("ann_index_topn_cache", "nonConcurrent") {
+    sql "unset variable all;"
+    sql "set enable_common_expr_pushdown=true;"
+    sql "set parallel_pipeline_task_num=1;"
+    sql "set enable_sql_cache=false;"
+
+    String[][] backends = sql """ show backends """
+    def backendIdToBackendIP = [:]
+    def backendIdToBackendHttpPort = [:]
+    for (String[] backend in backends) {
+        // backend[9] is Alive in current SHOW BACKENDS format
+        if (backend[9].equalsIgnoreCase("true")) {
+            backendIdToBackendIP.put(backend[0], backend[1])
+            backendIdToBackendHttpPort.put(backend[0], backend[4])
+        }
+    }
+    assertTrue(backendIdToBackendIP.size() > 0)
+
+    sql "drop table if exists ann_index_topn_cache"
+    sql """
+        CREATE TABLE ann_index_topn_cache (
+            id INT NOT NULL,
+            embedding ARRAY<FLOAT> NOT NULL,
+            INDEX idx_emb (`embedding`) USING ANN PROPERTIES(
+                "index_type"="hnsw",
+                "metric_type"="l2_distance",
+                "dim"="3"
+            )
+        ) ENGINE=OLAP
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES ("replication_num" = "1");
+    """
+
+    sql """
+        INSERT INTO ann_index_topn_cache VALUES
+        (1, [1.0, 2.0, 3.0]),
+        (2, [1.1, 2.1, 3.1]),
+        (3, [1.2, 2.2, 3.2]),
+        (4, [1.3, 2.3, 3.3]),
+        (5, [1.4, 2.4, 3.4]),
+        (6, [1.5, 2.5, 3.5]),
+        (7, [5.0, 5.0, 5.0]),
+        (8, [8.0, 8.0, 8.0]),
+        (9, [9.0, 9.0, 9.0]);
+    """
+
+    def timeout = 60000
+    def deltaTime = 1000
+    def wait_for_latest_op_on_table_finish = { tableName, opTimeout ->
+        int useTime = 0
+        for (int t = deltaTime; t <= opTimeout; t += deltaTime) {
+            def alterRes = sql """SHOW ALTER TABLE COLUMN WHERE TableName = "${tableName}" ORDER BY CreateTime DESC LIMIT 1;"""
+            def alterResStr = alterRes.toString()
+            if (alterResStr.contains("FINISHED")) {
+                sleep(3000)
+                logger.info("${tableName} latest alter job finished, detail: ${alterResStr}")
+                break
+            }
+            useTime = t
+            sleep(deltaTime)
+        }
+        assertTrue(useTime <= opTimeout, "wait_for_latest_op_on_table_finish timeout")
+    }
+
+    def clearAnnTopnResultCache = {
+        for (def backendId : backendIdToBackendIP.keySet()) {
+            def url = backendIdToBackendIP.get(backendId) + ":" +
+                    backendIdToBackendHttpPort.get(backendId) + "/api/clear_cache/AnnIndexResultCache"
+            httpTest {
+                endpoint ""
+                uri url
+                op "get"
+                body ""
+                check { respCode, body ->
+                    assertEquals("${respCode}".toString(), "200")
+                    assertTrue("${body}".toString().contains("prune win"))
+                }
+            }
+        }
+    }
+
+    def checkTopnCacheHit = { Map debugParams, String query ->
+        def debugPoint = "olap_scanner.ann_topn_cache_hits"
+        def params = debugParams + [execute: 1]
+        GetDebugPoint().enableDebugPointForAllBEs(debugPoint, params)
+        sql query
+    }
+
+    // 1) No prefilter: second identical ANN TopN query should hit cache.
+    sql """
+        select id
+        from ann_index_topn_cache
+        order by l2_distance_approximate(embedding, [1.0,2.0,3.0])
+        limit 3;
+    """
+
+    checkTopnCacheHit([min_hits: 1], """
+        select id
+        from ann_index_topn_cache
+        order by l2_distance_approximate(embedding, [1.0,2.0,3.0])
+        limit 3;
+    """)
+
+    // 1.1) Manual clear cache API: after clear, next same query should be cache miss.
+    clearAnnTopnResultCache()
+    checkTopnCacheHit([expected_hits: 0], """
+        select id
+        from ann_index_topn_cache
+        order by l2_distance_approximate(embedding, [1.0,2.0,3.0])
+        limit 3;
+    """)
+
+    // 1.2) Session variable can disable ANN result cache.
+    clearAnnTopnResultCache()
+    sql "set enable_ann_index_result_cache=false;"
+    sql """
+        select id
+        from ann_index_topn_cache
+        order by l2_distance_approximate(embedding, [1.0,2.0,3.0])
+        limit 3;
+    """
+    checkTopnCacheHit([expected_hits: 0], """
+        select id
+        from ann_index_topn_cache
+        order by l2_distance_approximate(embedding, [1.0,2.0,3.0])
+        limit 3;
+    """)
+    sql "set enable_ann_index_result_cache=true;"
+
+    // 2) With prefilter (id < 8): ANN TopN result cache should hit on second query
+    //    (prefilter bitmap is hashed into the cache key).
+    clearAnnTopnResultCache()
+    sql """
+        select id
+        from ann_index_topn_cache
+        where id < 8
+        order by l2_distance_approximate(embedding, [1.0,2.0,3.0])
+        limit 2;
+    """
+
+    checkTopnCacheHit([min_hits: 1], """
+        select id
+        from ann_index_topn_cache
+        where id < 8
+        order by l2_distance_approximate(embedding, [1.0,2.0,3.0])
+        limit 2;
+    """)
+
+    // 3) After dropping ANN index, query should still run (fallback path), and TopN cache hit must stay 0.
+    sql "drop index idx_emb on ann_index_topn_cache"
+    wait_for_latest_op_on_table_finish("ann_index_topn_cache", timeout)
+
+    sql """
+        select id
+        from ann_index_topn_cache
+        order by l2_distance_approximate(embedding, [1.0,2.0,3.0])
+        limit 3;
+    """
+
+    checkTopnCacheHit([expected_hits: 0], """
+        select id
+        from ann_index_topn_cache
+        order by l2_distance_approximate(embedding, [1.0,2.0,3.0])
+        limit 3;
+    """)
+    GetDebugPoint().clearDebugPointsForAllBEs()
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

This PR adds an ANN index result cache for repeated vector searches on the same immutable segment data. ANN searches can be expensive because every query needs to load or probe the vector index and convert engine results back to Doris row ids. In many workloads, especially repeated TopN or range vector predicates with the same query vector and filter context, the ANN result for a rowset segment is deterministic and can be reused safely.

The cache is segment-scoped. A cache entry is keyed by rowset id, segment id, ANN index id, query vector, runtime search parameters, and the pre-filter bitmap context. This keeps the cache independent across segment versions and ANN indexes while avoiding incorrect reuse when query filters or search options change.

Design details:

- A global `AnnIndexResultCache` is created as an `LRUCachePolicy` cache with cache type `ANN_INDEX_RESULT_CACHE`.
- The cache value stores the ANN search output needed by the caller: `row_ids`, `distances`, and the result `roaring` bitmap.
- TopN and range search use different key namespaces, so a TopN query and a range query cannot collide even if the vector and segment are the same.
- The key includes ANN engine parameters that can affect results, including HNSW `ef_search`, `check_relative_distance`, `bounded_queue`, and IVF `nprobe`.
- The key includes `rows_of_segment` so a full/no pre-filter bitmap and segment row-count context are stable and explicit.
- `index_id` is part of the key, so two ANN columns in the same segment do not share cache entries accidentally.

TopN cache behavior:

- `AnnIndexReader::query()` looks up the cache before executing the underlying HNSW/IVF/IVF_ON_DISK TopN search.
- On a hit, the cached handle is converted back to an `IndexSearchResult`, validated, and returned through the normal result path.
- On a miss, the ANN engine performs the search, the result is normalized, and then inserted into the cache.
- Result normalization handles empty results and aligns `row_ids`, `distances`, and the `roaring` bitmap so later cache hits can be consumed through the same path as fresh engine results.

Range cache behavior:

- `AnnIndexReader::range_search()` uses the same cache infrastructure but has a separate range key builder.
- The range key additionally includes `radius` and `is_le_or_lt`, because `<`, `<=`, `>`, and `>=` style range predicates can produce different result sets and different physical result shapes.
- Range search caches the result bitmap, and also caches `row_ids` / `distances` when the ANN engine returns them for the current metric and predicate direction.
- Some range-search directions only need the bitmap and intentionally have no `row_ids` / `distances`; the cache preserves that shape instead of fabricating unused data.
- On a hit, the cached handle is converted back to `AnnRangeSearchResult` and then consumed by the existing segment iterator path.

Pre-filter handling:

- The ANN search receives a `roaring` bitmap representing rows that survive pre-filters before the ANN index is evaluated.
- The cache key hashes the serialized pre-filter bitmap when it is selective.
- If the bitmap is null or covers the whole segment, the key uses a canonical no-filter marker. This makes no-filter and full-filter contexts share the same safe cache entry.
- Different pre-filter predicates produce different bitmaps, therefore different cache keys, so a cached result from `id < 8` is not reused for `id < 6`.
- Including the pre-filter bitmap also lets TopN and range searches reuse results only when both the vector query and the candidate row set are identical.

Testing improvements in this PR:

- Added regression coverage for TopN cache hits, range cache hits, cache miss after clear, different pre-filter miss, radius miss, metric/direction mismatch fallback, dropped-index fallback, and multiple ANN columns.
- Reworked ANN cache regression assertions to use BE debug-point checks on internal cache-hit statistics instead of parsing profile text and relying on `last_query_id()` timing.
- The debug-point checks are compiled only in non-`NDEBUG` builds and the suites are marked `nonConcurrent` as required by the regression framework.

### Release note

Improve repeated ANN index TopN and range-search performance by caching deterministic per-segment ANN search results.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
        - `sh run-regression-test.sh --run -d ann_index_p0 -s ann_index_topn_cache`
        - `sh run-regression-test.sh --run -d ann_index_p0 -s ann_index_result_cache`
        - `sh run-regression-test.sh --run -d ann_index_p0 -s ann_index_cache_additional`
        - `sh run-regression-test.sh --run -d ann_index_p0`
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No. Query results are unchanged; this is a performance/cache optimization.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->