### PR TITLE
[fix](iceberg) Invalidate related-table cache on external table refresh

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
@@ -29,6 +29,7 @@ import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.datasource.hive.HMSExternalCatalog;
 import org.apache.doris.datasource.hive.HMSExternalTable;
 import org.apache.doris.datasource.hive.HiveMetaStoreCache;
+import org.apache.doris.datasource.iceberg.IcebergExternalTable;
 import org.apache.doris.persist.OperationType;
 
 import com.google.common.base.Strings;
@@ -232,6 +233,11 @@ public class RefreshManager {
 
     public void refreshTableInternal(ExternalDatabase db, ExternalTable table, long updateTime) {
         table.unsetObjectCreated();
+        // Iceberg partition evolution can change partition specs across FEs.
+        // Clear related-table validation cache to avoid stale partitioned/unpartitioned judgment.
+        if (table instanceof IcebergExternalTable) {
+            ((IcebergExternalTable) table).setIsValidRelatedTableCached(false);
+        }
         if (updateTime > 0) {
             table.setUpdateTime(updateTime);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
@@ -859,8 +859,6 @@ public class IcebergMetadataOps implements ExternalMetadataOps {
                     + ", error message is: " + ExceptionUtils.getRootCauseMessage(e), e);
         }
         refreshTable(dorisTable, updateTime);
-        // Reset cached isValidRelatedTable flag after partition evolution
-        ((IcebergExternalTable) dorisTable).setIsValidRelatedTableCached(false);
     }
 
     /**
@@ -888,8 +886,6 @@ public class IcebergMetadataOps implements ExternalMetadataOps {
                     + ", error message is: " + ExceptionUtils.getRootCauseMessage(e), e);
         }
         refreshTable(dorisTable, updateTime);
-        // Reset cached isValidRelatedTable flag after partition evolution
-        ((IcebergExternalTable) dorisTable).setIsValidRelatedTableCached(false);
     }
 
     /**
@@ -931,8 +927,6 @@ public class IcebergMetadataOps implements ExternalMetadataOps {
                     + ", error message is: " + ExceptionUtils.getRootCauseMessage(e), e);
         }
         refreshTable(dorisTable, updateTime);
-        // Reset cached isValidRelatedTable flag after partition evolution
-        ((IcebergExternalTable) dorisTable).setIsValidRelatedTableCached(false);
     }
 
     @Override
@@ -1052,5 +1046,4 @@ public class IcebergMetadataOps implements ExternalMetadataOps {
         return builder.build();
     }
 }
-
 


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: N/A

Related PR: #57972 

Problem Summary:

In multi-FE deployments, Iceberg partition evolution (ADD/REPLACE/DROP PARTITION KEY) can leave some FEs with a stale
`IcebergExternalTable.isValidRelatedTableCached` value. This stale cache may cause incorrect partitioned/unpartitioned
judgment and query failures until the table is refreshed.

This PR:
- Clears the related-table validation cache during `OP_REFRESH_EXTERNAL_TABLE` replay
  (`RefreshManager.refreshTableInternal()`).
- Removes the redundant per-operation manual cache clearing in `IcebergMetadataOps`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] Previous test can cover this change.
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
