### PR TITLE
[fix](cache) Fix null pointer dereference in prefetch dryrun fallback path

### DIFF
--- a/be/src/io/cache/cached_remote_file_reader.cpp
+++ b/be/src/io/cache/cached_remote_file_reader.cpp
@@ -546,18 +546,23 @@ Status CachedRemoteFileReader::read_at_impl(size_t offset, Slice result, size_t*
                 }
             }
             if (!st || block_state != FileBlock::State::DOWNLOADED) {
-                LOG(WARNING) << "Read data failed from file cache downloaded by others. err="
-                             << st.msg() << ", block state=" << block_state;
-                size_t nest_bytes_read {0};
-                stats.hit_cache = false;
-                stats.from_peer_cache = false;
-                s3_read_counter << 1;
-                SCOPED_RAW_TIMER(&stats.remote_read_timer);
-                RETURN_IF_ERROR(_remote_file_reader->read_at(
-                        current_offset, Slice(result.data + (current_offset - offset), read_size),
-                        &nest_bytes_read));
-                indirect_read_bytes += read_size;
-                DCHECK(nest_bytes_read == read_size);
+                if (is_dryrun) [[unlikely]] {
+                    // dryrun mode uses a null buffer, skip actual remote IO
+                } else {
+                    LOG(WARNING) << "Read data failed from file cache downloaded by others. err="
+                                 << st.msg() << ", block state=" << block_state;
+                    size_t nest_bytes_read {0};
+                    stats.hit_cache = false;
+                    stats.from_peer_cache = false;
+                    s3_read_counter << 1;
+                    SCOPED_RAW_TIMER(&stats.remote_read_timer);
+                    RETURN_IF_ERROR(_remote_file_reader->read_at(
+                            current_offset,
+                            Slice(result.data + (current_offset - offset), read_size),
+                            &nest_bytes_read));
+                    indirect_read_bytes += read_size;
+                    DCHECK(nest_bytes_read == read_size);
+                }
             }
         }
         *bytes_read += read_size;


### PR DESCRIPTION
### What problem does this PR solve?

fix the bug of https://github.com/apache/doris/pull/59482

Null pointer of buffer should not be triggered by s3 io
```
23:58:57   26# doris::io::S3FileReader::read_at_impl(unsigned long, doris::Slice, unsigned long*, doris::io::IOContext const*) at /root/doris/be/build_ASAN/../src/io/fs/s3_file_reader.cpp:166
23:58:57   27# doris::io::FileReader::read_at(unsigned long, doris::Slice, unsigned long*, doris::io::IOContext const*) at /root/doris/be/build_ASAN/../src/io/fs/file_reader.cpp:34
23:58:57   28# doris::io::CachedRemoteFileReader::read_at_impl(unsigned long, doris::Slice, unsigned long*, doris::io::IOContext const*) at /root/doris/be/build_ASAN/../src/io/cache/cached_remote_file_reader.cpp:556
23:58:57   29# std::_Function_handler<void (), doris::io::CachedRemoteFileReader::prefetch_range(unsigned long, unsigned long, doris::io::IOContext const*)::$_0>::_M_invoke(std::_Any_data const&) at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:292
```

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

