### PR TITLE
[fix](search) fix MATCH_ALL_DOCS losing occur attribute in multi-field expansion

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SearchDslParser.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SearchDslParser.java
@@ -1517,7 +1517,14 @@ public class SearchDslParser {
         private static QsNode expandNodeCrossFields(QsNode node, List<String> fields, boolean luceneMode) {
             // MATCH_ALL_DOCS matches all documents regardless of field - don't expand
             if (node.getType() == QsClauseType.MATCH_ALL_DOCS) {
-                return new QsNode(QsClauseType.MATCH_ALL_DOCS, (List<QsNode>) null);
+                QsNode result = new QsNode(QsClauseType.MATCH_ALL_DOCS, (List<QsNode>) null);
+                // Preserve occur attribute (e.g., SHOULD from "X OR *" queries)
+                // Without this, occur defaults to null which BE interprets as MUST,
+                // changing "X OR *" from matching all docs to matching only X.
+                if (node.getOccur() != null) {
+                    result.setOccur(node.getOccur());
+                }
+                return result;
             }
 
             // Check if this is a leaf node (no children)
@@ -1598,7 +1605,11 @@ public class SearchDslParser {
         private static QsNode deepCopyWithField(QsNode node, String field, List<String> fields) {
             // MATCH_ALL_DOCS matches all documents regardless of field - don't set field
             if (node.getType() == QsClauseType.MATCH_ALL_DOCS) {
-                return new QsNode(QsClauseType.MATCH_ALL_DOCS, (List<QsNode>) null);
+                QsNode result = new QsNode(QsClauseType.MATCH_ALL_DOCS, (List<QsNode>) null);
+                if (node.getOccur() != null) {
+                    result.setOccur(node.getOccur());
+                }
+                return result;
             }
             if (isLeafNode(node)) {
                 // If the user explicitly wrote "field:term" syntax, preserve original field
@@ -1645,7 +1656,11 @@ public class SearchDslParser {
         private static QsNode setFieldOnLeaves(QsNode node, String field, List<String> fields) {
             // MATCH_ALL_DOCS matches all documents regardless of field - don't set field
             if (node.getType() == QsClauseType.MATCH_ALL_DOCS) {
-                return new QsNode(QsClauseType.MATCH_ALL_DOCS, (List<QsNode>) null);
+                QsNode result = new QsNode(QsClauseType.MATCH_ALL_DOCS, (List<QsNode>) null);
+                if (node.getOccur() != null) {
+                    result.setOccur(node.getOccur());
+                }
+                return result;
             }
             if (isLeafNode(node)) {
                 // If the user explicitly wrote "field:term" syntax, preserve original field


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #DORIS-24561

Problem Summary:

In lucene mode with multi-field queries (e.g., `best_fields` with `fields: ["title", "content"]`), the query `"Lauren Boebert" OR *` returns results inconsistent with Elasticsearch.

**Root cause:** During multi-field expansion (`expandNodeCrossFields`, `deepCopyWithField`, `setFieldOnLeaves`), `MATCH_ALL_DOCS` nodes are recreated without preserving the `occur` attribute (e.g., `SHOULD`). The BE defaults `occur=null` to `MUST`, changing the query semantics:

- **Expected (ES behavior):** `SHOULD(phrase) OR SHOULD(match_all)` = all documents
- **Actual (bug):** `SHOULD(phrase) AND MUST(match_all)` = only phrase-matching documents

**ES explain** for `"Lauren Boebert" OR *`:
```
(title:"lauren boebert" | content:"lauren boebert") (ConstantScore(FieldExistsQuery [field=content]) | ConstantScore(FieldExistsQuery [field=title]))
```
Returns 1,000,000 docs (all). Doris was returning only phrase-matching docs.

**Fix:** Preserve the `occur` attribute when creating new `MATCH_ALL_DOCS` nodes in all three multi-field expansion methods.

### Release note

Fix search() function returning incorrect results for lucene mode queries containing standalone wildcard `*` with multi-field expansion (e.g., `"phrase" OR *` with `best_fields`).

### Check List (For Author)

- Test
    - [x] Unit Test
    - [ ] Regression test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] Yes. Multi-field lucene mode queries with standalone `*` (MATCH_ALL_DOCS) now correctly preserve the `occur` attribute during cross-field expansion, matching ES behavior.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label