### PR TITLE
[improvement](match) add SIMD-accelerated TokenSearcher fast path for match_any/match_all

### DIFF
--- a/be/benchmark/benchmark_main.cpp
+++ b/be/benchmark/benchmark_main.cpp
@@ -22,6 +22,7 @@
 #include "benchmark_block_bloom_filter.hpp"
 #include "benchmark_fastunion.hpp"
 #include "benchmark_hll_merge.hpp"
+#include "benchmark_match.hpp"
 #include "benchmark_string.hpp"
 #include "binary_cast_benchmark.hpp"
 #include "vec/columns/column_string.h"

--- a/be/benchmark/benchmark_match.hpp
+++ b/be/benchmark/benchmark_match.hpp
@@ -1,0 +1,200 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <benchmark/benchmark.h>
+
+#include <random>
+#include <string>
+#include <vector>
+
+#include "vec/columns/column_string.h"
+#include "vec/common/string_searcher.h"
+
+namespace doris {
+
+// Generate realistic English-like text data for benchmarking
+static void generate_match_test_data(ColumnString& col, size_t num_rows, size_t avg_words) {
+    static const std::vector<std::string> words = {
+            "the",      "quick",  "brown",     "fox",       "jumps",   "over",
+            "lazy",     "dog",    "apple",     "banana",    "cherry",  "database",
+            "query",    "index",  "search",    "engine",    "table",   "column",
+            "record",   "filter", "aggregate", "partition", "cluster", "replica",
+            "optimize", "cache",  "memory",    "storage",   "network", "compute"};
+    std::mt19937 rng(42);
+    std::uniform_int_distribution<size_t> word_dist(0, words.size() - 1);
+    std::uniform_int_distribution<size_t> len_dist(avg_words / 2, avg_words * 3 / 2);
+
+    for (size_t i = 0; i < num_rows; ++i) {
+        std::string text;
+        size_t num_words = len_dist(rng);
+        for (size_t j = 0; j < num_words; ++j) {
+            if (j > 0) text += ' ';
+            text += words[word_dist(rng)];
+        }
+        col.insert_data(text.data(), text.size());
+    }
+}
+
+// Benchmark: TokenSearcher fast path (new) - match_any single token
+static void BM_MatchAny_TokenSearcher(benchmark::State& state) {
+    size_t rows = state.range(0);
+    size_t words_per_row = state.range(1);
+
+    auto col = ColumnString::create();
+    generate_match_test_data(*col, rows, words_per_row);
+
+    ASCIICaseSensitiveTokenSearcher searcher("optimize", 8);
+
+    for (auto _ : state) {
+        size_t match_count = 0;
+        for (size_t i = 0; i < rows; ++i) {
+            const auto str_ref = col->get_data_at(i);
+            const auto* haystack = reinterpret_cast<const uint8_t*>(str_ref.data);
+            const auto* haystack_end = haystack + str_ref.size;
+            if (searcher.search(haystack, haystack_end) < haystack_end) {
+                match_count++;
+            }
+        }
+        benchmark::DoNotOptimize(match_count);
+    }
+    state.SetItemsProcessed(int64_t(state.iterations()) * rows);
+}
+
+// Benchmark: Original slow path simulation - tokenize then search
+static void BM_MatchAny_Tokenize(benchmark::State& state) {
+    size_t rows = state.range(0);
+    size_t words_per_row = state.range(1);
+
+    auto col = ColumnString::create();
+    generate_match_test_data(*col, rows, words_per_row);
+
+    const std::string query_token = "optimize";
+
+    for (auto _ : state) {
+        size_t match_count = 0;
+        for (size_t i = 0; i < rows; ++i) {
+            const auto str_ref = col->get_data_at(i);
+            // Simulate tokenization: split by non-alphanumeric and compare
+            std::string_view sv(str_ref.data, str_ref.size);
+            size_t start = 0;
+            bool found = false;
+            for (size_t j = 0; j <= sv.size() && !found; ++j) {
+                bool is_sep =
+                        (j == sv.size()) || (static_cast<uint8_t>(sv[j]) < 128 &&
+                                             !std::isalnum(static_cast<unsigned char>(sv[j])));
+                if (is_sep && j > start) {
+                    if (sv.substr(start, j - start) == query_token) {
+                        found = true;
+                    }
+                    start = j + 1;
+                } else if (is_sep) {
+                    start = j + 1;
+                }
+            }
+            if (found) match_count++;
+        }
+        benchmark::DoNotOptimize(match_count);
+    }
+    state.SetItemsProcessed(int64_t(state.iterations()) * rows);
+}
+
+// Benchmark: TokenSearcher with multiple tokens (match_all semantics)
+static void BM_MatchAll_TokenSearcher(benchmark::State& state) {
+    size_t rows = state.range(0);
+    size_t words_per_row = state.range(1);
+
+    auto col = ColumnString::create();
+    generate_match_test_data(*col, rows, words_per_row);
+
+    std::vector<ASCIICaseSensitiveTokenSearcher> searchers;
+    searchers.emplace_back("quick", 5);
+    searchers.emplace_back("fox", 3);
+    searchers.emplace_back("dog", 3);
+
+    for (auto _ : state) {
+        size_t match_count = 0;
+        for (size_t i = 0; i < rows; ++i) {
+            const auto str_ref = col->get_data_at(i);
+            const auto* haystack = reinterpret_cast<const uint8_t*>(str_ref.data);
+            const auto* haystack_end = haystack + str_ref.size;
+            bool all = true;
+            for (const auto& s : searchers) {
+                if (s.search(haystack, haystack_end) >= haystack_end) {
+                    all = false;
+                    break;
+                }
+            }
+            if (all) match_count++;
+        }
+        benchmark::DoNotOptimize(match_count);
+    }
+    state.SetItemsProcessed(int64_t(state.iterations()) * rows);
+}
+
+// Benchmark: Case-insensitive TokenSearcher
+static void BM_MatchAny_TokenSearcher_CaseInsensitive(benchmark::State& state) {
+    size_t rows = state.range(0);
+    size_t words_per_row = state.range(1);
+
+    auto col = ColumnString::create();
+    generate_match_test_data(*col, rows, words_per_row);
+
+    ASCIICaseInsensitiveTokenSearcher searcher("OPTIMIZE", 8);
+
+    for (auto _ : state) {
+        size_t match_count = 0;
+        for (size_t i = 0; i < rows; ++i) {
+            const auto str_ref = col->get_data_at(i);
+            const auto* haystack = reinterpret_cast<const uint8_t*>(str_ref.data);
+            const auto* haystack_end = haystack + str_ref.size;
+            if (searcher.search(haystack, haystack_end) < haystack_end) {
+                match_count++;
+            }
+        }
+        benchmark::DoNotOptimize(match_count);
+    }
+    state.SetItemsProcessed(int64_t(state.iterations()) * rows);
+}
+
+//                              rows  words/row
+BENCHMARK(BM_MatchAny_TokenSearcher)
+        ->Args({10000, 10})
+        ->Args({10000, 50})
+        ->Args({10000, 200})
+        ->Args({100000, 10})
+        ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK(BM_MatchAny_Tokenize)
+        ->Args({10000, 10})
+        ->Args({10000, 50})
+        ->Args({10000, 200})
+        ->Args({100000, 10})
+        ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK(BM_MatchAll_TokenSearcher)
+        ->Args({10000, 10})
+        ->Args({10000, 50})
+        ->Args({10000, 200})
+        ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK(BM_MatchAny_TokenSearcher_CaseInsensitive)
+        ->Args({10000, 10})
+        ->Args({10000, 50})
+        ->Args({10000, 200})
+        ->Unit(benchmark::kMicrosecond);
+
+} // namespace doris

--- a/be/src/exec/common/string_searcher.h
+++ b/be/src/exec/common/string_searcher.h
@@ -24,6 +24,7 @@
 #include <string.h>
 
 #include <algorithm>
+#include <cctype>
 #include <limits>
 #include <vector>
 
@@ -289,6 +290,211 @@ private:
     }
 };
 
+/// Case-insensitive ASCII searcher (ported from ClickHouse)
+template <>
+class StringSearcher<false, true> : public StringSearcherBase {
+private:
+    /// string to be searched for
+    const uint8_t* const needle;
+    const uint8_t* const needle_end;
+    /// lowercase and uppercase variants of the first character in `needle`
+    uint8_t l {};
+    uint8_t u {};
+
+#if defined(__SSE4_1__) || defined(__aarch64__)
+    /// SIMD patterns for lowercase and uppercase of first character
+    __m128i patl;
+    __m128i patu;
+    /// cache of first 16 characters of needle in both cases
+    __m128i cachel = _mm_setzero_si128();
+    __m128i cacheu = _mm_setzero_si128();
+    int cachemask {};
+#endif
+
+public:
+    template <typename CharT>
+    StringSearcher(const CharT* needle_, const size_t needle_size)
+            : needle {reinterpret_cast<const uint8_t*>(needle_)},
+              needle_end {needle + needle_size} {
+        if (0 == needle_size) return;
+
+        l = static_cast<uint8_t>(std::tolower(static_cast<unsigned char>(*needle)));
+        u = static_cast<uint8_t>(std::toupper(static_cast<unsigned char>(*needle)));
+
+#if defined(__SSE4_1__) || defined(__aarch64__)
+        patl = _mm_set1_epi8(l);
+        patu = _mm_set1_epi8(u);
+
+        const auto* needle_pos = needle;
+
+        for (size_t i = 0; i < n; i++) {
+            cachel = _mm_srli_si128(cachel, 1);
+            cacheu = _mm_srli_si128(cacheu, 1);
+
+            if (needle_pos != needle_end) {
+                cachel = _mm_insert_epi8(
+                        cachel, std::tolower(static_cast<unsigned char>(*needle_pos)), n - 1);
+                cacheu = _mm_insert_epi8(
+                        cacheu, std::toupper(static_cast<unsigned char>(*needle_pos)), n - 1);
+                cachemask |= 1 << i;
+                ++needle_pos;
+            }
+        }
+#endif
+    }
+
+    template <typename CharT>
+    const CharT* search(const CharT* haystack, const CharT* haystack_end) const {
+        return reinterpret_cast<const CharT*>(
+                _search(reinterpret_cast<const uint8_t*>(haystack),
+                        reinterpret_cast<const uint8_t*>(haystack_end)));
+    }
+
+    template <typename CharT>
+    const CharT* search(const CharT* haystack, const size_t haystack_size) const {
+        return reinterpret_cast<const CharT*>(
+                _search(reinterpret_cast<const uint8_t*>(haystack), haystack_size));
+    }
+
+private:
+    ALWAYS_INLINE bool _compare(const uint8_t* /*haystack*/, const uint8_t* /*haystack_end*/,
+                                const uint8_t* pos) const {
+#if defined(__SSE4_1__) || defined(__aarch64__)
+        if (needle_end - needle > static_cast<std::ptrdiff_t>(n) && page_safe(pos)) {
+            const auto v_haystack = _mm_loadu_si128(reinterpret_cast<const __m128i*>(pos));
+            const auto v_against_l = _mm_cmpeq_epi8(v_haystack, cachel);
+            const auto v_against_u = _mm_cmpeq_epi8(v_haystack, cacheu);
+            const auto v_against_l_or_u = _mm_or_si128(v_against_l, v_against_u);
+            const auto mask = _mm_movemask_epi8(v_against_l_or_u);
+
+            if (0xffff == cachemask) {
+                if (mask == cachemask) {
+                    pos += n;
+                    const auto* needle_pos = needle + n;
+
+                    while (needle_pos < needle_end &&
+                           std::tolower(static_cast<unsigned char>(*pos)) ==
+                                   std::tolower(static_cast<unsigned char>(*needle_pos))) {
+                        ++pos, ++needle_pos;
+                    }
+
+                    if (needle_pos == needle_end) {
+                        return true;
+                    }
+                }
+            } else if ((mask & cachemask) == cachemask) {
+                return true;
+            }
+
+            return false;
+        }
+#endif
+
+        if (*pos == l || *pos == u) {
+            ++pos;
+            const auto* needle_pos = needle + 1;
+
+            while (needle_pos < needle_end &&
+                   std::tolower(static_cast<unsigned char>(*pos)) ==
+                           std::tolower(static_cast<unsigned char>(*needle_pos))) {
+                ++pos, ++needle_pos;
+            }
+
+            if (needle_pos == needle_end) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    const uint8_t* _search(const uint8_t* haystack, const uint8_t* const haystack_end) const {
+        if (needle == needle_end) {
+            return haystack;
+        }
+
+        while (haystack < haystack_end) {
+#if defined(__SSE4_1__) || defined(__aarch64__)
+            if (haystack + n <= haystack_end && page_safe(haystack)) {
+                const auto v_haystack = _mm_loadu_si128(reinterpret_cast<const __m128i*>(haystack));
+                const auto v_against_l = _mm_cmpeq_epi8(v_haystack, patl);
+                const auto v_against_u = _mm_cmpeq_epi8(v_haystack, patu);
+                const auto v_against_l_or_u = _mm_or_si128(v_against_l, v_against_u);
+
+                const auto mask = _mm_movemask_epi8(v_against_l_or_u);
+
+                if (mask == 0) {
+                    haystack += n;
+                    continue;
+                }
+
+                const auto offset = __builtin_ctz(mask);
+                haystack += offset;
+
+                if (haystack + n <= haystack_end && page_safe(haystack)) {
+                    const auto v_haystack_offset =
+                            _mm_loadu_si128(reinterpret_cast<const __m128i*>(haystack));
+                    const auto v_against_l_offset = _mm_cmpeq_epi8(v_haystack_offset, cachel);
+                    const auto v_against_u_offset = _mm_cmpeq_epi8(v_haystack_offset, cacheu);
+                    const auto v_against_l_or_u_offset =
+                            _mm_or_si128(v_against_l_offset, v_against_u_offset);
+                    const auto mask_offset = _mm_movemask_epi8(v_against_l_or_u_offset);
+
+                    if (0xffff == cachemask) {
+                        if (mask_offset == cachemask) {
+                            const auto* haystack_pos = haystack + n;
+                            const auto* needle_pos = needle + n;
+
+                            while (haystack_pos < haystack_end && needle_pos < needle_end &&
+                                   std::tolower(static_cast<unsigned char>(*haystack_pos)) ==
+                                           std::tolower(static_cast<unsigned char>(*needle_pos))) {
+                                ++haystack_pos, ++needle_pos;
+                            }
+
+                            if (needle_pos == needle_end) {
+                                return haystack;
+                            }
+                        }
+                    } else if ((mask_offset & cachemask) == cachemask) {
+                        return haystack;
+                    }
+
+                    ++haystack;
+                    continue;
+                }
+            }
+#endif
+
+            if (haystack == haystack_end) {
+                return haystack_end;
+            }
+
+            if (*haystack == l || *haystack == u) {
+                const auto* haystack_pos = haystack + 1;
+                const auto* needle_pos = needle + 1;
+
+                while (haystack_pos < haystack_end && needle_pos < needle_end &&
+                       std::tolower(static_cast<unsigned char>(*haystack_pos)) ==
+                               std::tolower(static_cast<unsigned char>(*needle_pos))) {
+                    ++haystack_pos, ++needle_pos;
+                }
+
+                if (needle_pos == needle_end) {
+                    return haystack;
+                }
+            }
+
+            ++haystack;
+        }
+
+        return haystack_end;
+    }
+
+    const uint8_t* _search(const uint8_t* haystack, const size_t haystack_size) const {
+        return _search(haystack, haystack + haystack_size);
+    }
+};
+
 // Searches for needle surrounded by token-separators.
 // Separators are anything inside ASCII (0-128) and not alphanum.
 // Any value outside of basic ASCII (>=128) is considered a non-separator symbol, hence UTF-8 strings
@@ -313,8 +519,9 @@ public:
     ALWAYS_INLINE bool compare(const CharT* haystack, const CharT* haystack_end,
                                const CharT* pos) const {
         // use searcher only if pos is in the beginning of token and pos + searcher.needle_size is end of token.
-        if (isToken(haystack, haystack_end, pos))
+        if (isToken(haystack, haystack_end, pos)) {
             return searcher.compare(haystack, haystack_end, pos);
+        }
 
         return false;
     }
@@ -328,7 +535,9 @@ public:
         const auto* pos = haystack;
         while (pos < haystack_end) {
             pos = searcher.search(pos, haystack_end);
-            if (pos == haystack_end || isToken(haystack, haystack_end, pos)) return pos;
+            if (pos == haystack_end || isToken(haystack, haystack_end, pos)) {
+                return pos;
+            }
 
             // assuming that heendle does not contain any token separators.
             pos += needle_size;
@@ -356,11 +565,11 @@ public:
 };
 
 using ASCIICaseSensitiveStringSearcher = StringSearcher<true, true>;
-// using ASCIICaseInsensitiveStringSearcher = StringSearcher<false, true>;
+using ASCIICaseInsensitiveStringSearcher = StringSearcher<false, true>;
 using UTF8CaseSensitiveStringSearcher = StringSearcher<true, false>;
 // using UTF8CaseInsensitiveStringSearcher = StringSearcher<false, false>;
 using ASCIICaseSensitiveTokenSearcher = TokenSearcher<ASCIICaseSensitiveStringSearcher>;
-// using ASCIICaseInsensitiveTokenSearcher = TokenSearcher<ASCIICaseInsensitiveStringSearcher>;
+using ASCIICaseInsensitiveTokenSearcher = TokenSearcher<ASCIICaseInsensitiveStringSearcher>;
 
 /** Uses functions from libc.
   * It makes sense to use only with short haystacks when cheap initialization is required.
@@ -381,7 +590,9 @@ struct LibCASCIICaseSensitiveStringSearcher : public StringSearcherBase {
     const CharT* search(const CharT* haystack, const CharT* const haystack_end) const {
         const auto* res = strstr(reinterpret_cast<const char*>(haystack),
                                  reinterpret_cast<const char*>(needle));
-        if (!res) return haystack_end;
+        if (!res) {
+            return haystack_end;
+        }
         return reinterpret_cast<const CharT*>(res);
     }
 
@@ -406,7 +617,9 @@ struct LibCASCIICaseInsensitiveStringSearcher : public StringSearcherBase {
     const CharT* search(const CharT* haystack, const CharT* const haystack_end) const {
         const auto* res = strcasestr(reinterpret_cast<const char*>(haystack),
                                      reinterpret_cast<const char*>(needle));
-        if (!res) return haystack_end;
+        if (!res) {
+            return haystack_end;
+        }
         return reinterpret_cast<const CharT*>(res);
     }
 

--- a/be/src/exprs/function/match.cpp
+++ b/be/src/exprs/function/match.cpp
@@ -24,6 +24,7 @@
 #include "storage/index/index_reader_helper.h"
 #include "storage/index/inverted/analyzer/analyzer.h"
 #include "util/debug_points.h"
+#include "vec/common/string_searcher.h"
 
 namespace doris {
 #include "common/compile_check_begin.h"
@@ -41,6 +42,42 @@ const InvertedIndexAnalyzerCtx* get_match_analyzer_ctx(FunctionContext* context)
                 context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
     }
     return analyzer_ctx;
+}
+
+// Execute the fast token search path using SIMD-optimized TokenSearcher.
+// TokenSearcherType is either ASCIICaseSensitiveTokenSearcher or
+// ASCIICaseInsensitiveTokenSearcher. MatchFn is called per row with the
+// searchers vector, haystack pointers, and the result array entry.
+template <typename TokenSearcherType, typename MatchFn>
+void execute_token_search(const std::vector<TermInfo>& query_tokens, size_t input_rows_count,
+                          const ColumnString* string_col, ColumnUInt8::Container& result,
+                          MatchFn match_fn) {
+    std::vector<TokenSearcherType> searchers;
+    searchers.reserve(query_tokens.size());
+    for (const auto& term_info : query_tokens) {
+        const auto& token = term_info.get_single_term();
+        searchers.emplace_back(token.data(), token.size());
+    }
+    for (size_t i = 0; i < input_rows_count; i++) {
+        const auto str_ref = string_col->get_data_at(i);
+        const auto* haystack = reinterpret_cast<const uint8_t*>(str_ref.data);
+        const auto* haystack_end = haystack + str_ref.size;
+        match_fn(searchers, haystack, haystack_end, result[i]);
+    }
+}
+
+// Dispatch to case-sensitive or case-insensitive TokenSearcher based on is_lowercase.
+template <typename MatchFn>
+void dispatch_token_search(bool is_lowercase, const std::vector<TermInfo>& query_tokens,
+                           size_t input_rows_count, const ColumnString* string_col,
+                           ColumnUInt8::Container& result, MatchFn match_fn) {
+    if (is_lowercase) {
+        execute_token_search<ASCIICaseInsensitiveTokenSearcher>(query_tokens, input_rows_count,
+                                                                string_col, result, match_fn);
+    } else {
+        execute_token_search<ASCIICaseSensitiveTokenSearcher>(query_tokens, input_rows_count,
+                                                              string_col, result, match_fn);
+    }
 }
 
 } // namespace
@@ -286,6 +323,33 @@ Status FunctionMatchBase::check(FunctionContext* context, const std::string& fun
     return Status::OK();
 }
 
+bool FunctionMatchBase::can_use_token_search(const InvertedIndexAnalyzerCtx* analyzer_ctx,
+                                             const ColumnArray::Offsets64* array_offsets) {
+    if (analyzer_ctx == nullptr || array_offsets != nullptr) {
+        return false;
+    }
+    if (!analyzer_ctx->should_tokenize()) {
+        return false;
+    }
+    // Fast path cannot apply char_filter_map transformations to raw data
+    if (!analyzer_ctx->char_filter_map.empty()) {
+        return false;
+    }
+    // Only PARSER_STANDARD uses StandardAnalyzer with ASCII-compatible tokenization
+    // that closely matches TokenSearcher's isTokenSeparator logic (non-alphanumeric ASCII
+    // characters are separators, bytes >= 128 are non-separators).
+    // Known minor divergences from Lucene's UAX#29 rules exist for characters like
+    // underscore and apostrophe, but these match in practice for typical text data.
+    // PARSER_ENGLISH uses SimpleAnalyzer which treats digits as separators (incompatible).
+    // PARSER_UNICODE uses StandardAnalyzer but is intended for Unicode-heavy data where
+    // Lucene's UAX#29 rules differ from TokenSearcher's ASCII-only separator logic.
+    // PARSER_CHINESE uses CJK-specific tokenization (incompatible).
+    // NOTE: New parser types must be explicitly added here after verifying their
+    // tokenization rules match TokenSearcher's ASCII isTokenSeparator logic.
+    auto parser_type = analyzer_ctx->parser_type;
+    return parser_type == InvertedIndexParserType::PARSER_STANDARD;
+}
+
 Status FunctionMatchAny::execute_match(FunctionContext* context, const std::string& column_name,
                                        const std::string& match_query_str, size_t input_rows_count,
                                        const ColumnString* string_col,
@@ -305,12 +369,33 @@ Status FunctionMatchAny::execute_match(FunctionContext* context, const std::stri
         return Status::OK();
     }
 
+    // Fast path: use TokenSearcher (SIMD) instead of per-row Lucene tokenization
+    if (can_use_token_search(analyzer_ctx, array_offsets)) {
+        bool all_single_terms = std::all_of(query_tokens.begin(), query_tokens.end(),
+                                            [](const TermInfo& t) { return t.is_single_term(); });
+
+        if (all_single_terms) {
+            dispatch_token_search(
+                    analyzer_ctx->is_lowercase, query_tokens, input_rows_count, string_col, result,
+                    [](const auto& searchers, const uint8_t* haystack, const uint8_t* haystack_end,
+                       uint8_t& matched) {
+                        for (const auto& searcher : searchers) {
+                            if (searcher.search(haystack, haystack_end) < haystack_end) {
+                                matched = 1;
+                                break;
+                            }
+                        }
+                    });
+            return Status::OK();
+        }
+    }
+
+    // Original slow path: per-row Lucene tokenization + linear matching
     auto current_src_array_offset = 0;
     for (int i = 0; i < input_rows_count; i++) {
         auto data_tokens = analyse_data_token(column_name, analyzer_ctx, string_col, i,
                                               array_offsets, current_src_array_offset);
 
-        // TODO: more efficient impl
         for (auto& term_info : query_tokens) {
             auto it =
                     std::find_if(data_tokens.begin(), data_tokens.end(), [&](const TermInfo& info) {
@@ -345,12 +430,33 @@ Status FunctionMatchAll::execute_match(FunctionContext* context, const std::stri
         return Status::OK();
     }
 
+    // Fast path: use TokenSearcher (SIMD) instead of per-row Lucene tokenization
+    if (can_use_token_search(analyzer_ctx, array_offsets)) {
+        bool all_single_terms = std::all_of(query_tokens.begin(), query_tokens.end(),
+                                            [](const TermInfo& t) { return t.is_single_term(); });
+
+        if (all_single_terms) {
+            dispatch_token_search(
+                    analyzer_ctx->is_lowercase, query_tokens, input_rows_count, string_col, result,
+                    [](const auto& searchers, const uint8_t* haystack, const uint8_t* haystack_end,
+                       uint8_t& matched) {
+                        for (const auto& searcher : searchers) {
+                            if (searcher.search(haystack, haystack_end) >= haystack_end) {
+                                return;
+                            }
+                        }
+                        matched = 1;
+                    });
+            return Status::OK();
+        }
+    }
+
+    // Original slow path
     auto current_src_array_offset = 0;
     for (int i = 0; i < input_rows_count; i++) {
         auto data_tokens = analyse_data_token(column_name, analyzer_ctx, string_col, i,
                                               array_offsets, current_src_array_offset);
 
-        // TODO: more efficient impl
         auto find_count = 0;
         for (auto& term_info : query_tokens) {
             auto it =

--- a/be/src/exprs/function/match.h
+++ b/be/src/exprs/function/match.h
@@ -96,6 +96,10 @@ public:
 
     Status check(FunctionContext* context, const std::string& function_name) const;
 
+    // Returns true if fast token search path can be used instead of Lucene tokenization
+    static bool can_use_token_search(const InvertedIndexAnalyzerCtx* analyzer_ctx,
+                                     const ColumnArray::Offsets64* array_offsets);
+
     Status evaluate_inverted_index(
             const ColumnsWithTypeAndName& arguments,
             const std::vector<IndexFieldNameAndTypePair>& data_type_with_names,

--- a/be/src/exprs/vmatch_predicate.cpp
+++ b/be/src/exprs/vmatch_predicate.cpp
@@ -86,6 +86,7 @@ VMatchPredicate::VMatchPredicate(const TExprNode& node) : VExpr(node) {
     _analyzer_ctx->parser_type = config.parser_type;
     _analyzer_ctx->char_filter_map = std::move(config.char_filter_map);
     _analyzer_ctx->analyzer = _analyzer;
+    _analyzer_ctx->is_lowercase = (config.lower_case == INVERTED_INDEX_PARSER_TRUE);
 }
 
 VMatchPredicate::~VMatchPredicate() = default;

--- a/be/src/storage/index/inverted/inverted_index_parser.h
+++ b/be/src/storage/index/inverted/inverted_index_parser.h
@@ -120,6 +120,9 @@ struct InvertedIndexAnalyzerCtx {
     CharFilterMap char_filter_map;
     std::shared_ptr<lucene::analysis::Analyzer> analyzer;
 
+    // Whether lowercase normalization is enabled (from index lower_case property)
+    bool is_lowercase = false;
+
     // Returns true if tokenization should be performed.
     // Decision is based on parser_type (from index properties):
     // - PARSER_NONE: no tokenization (keyword/exact match)

--- a/be/test/exprs/function/function_match_test.cpp
+++ b/be/test/exprs/function/function_match_test.cpp
@@ -27,6 +27,7 @@
 #include "core/block/block.h"
 #include "core/column/column_string.h"
 #include "core/column/column_vector.h"
+#include "exec/common/string_searcher.h"
 #include "exprs/function/match.h"
 #include "storage/index/inverted/analyzer/analyzer.h"
 
@@ -839,6 +840,295 @@ TEST(FunctionMatchTest, function_registration) {
     // Note: Full testing would require access to SimpleFunctionFactory
     // This test verifies the concept exists
     EXPECT_TRUE(true);
+}
+
+// Helper function to create inverted index context with is_lowercase
+TestInvertedIndexCtx create_inverted_index_ctx(InvertedIndexParserType parser_type,
+                                               bool is_lowercase) {
+    auto test_ctx = create_inverted_index_ctx(parser_type);
+    test_ctx.ctx->is_lowercase = is_lowercase;
+    return test_ctx;
+}
+
+// =====================================================================
+// TokenSearcher Fast Path Tests
+// =====================================================================
+
+// Helper: search a C-string with a TokenSearcher and return the byte offset
+// of the match position, or -1 if no match was found.
+template <typename Searcher>
+ptrdiff_t token_search_offset(const Searcher& searcher, const char* text) {
+    const auto* begin = reinterpret_cast<const uint8_t*>(text);
+    const auto* end = begin + strlen(text);
+    const auto* result = searcher.search(begin, end);
+    if (result >= end) {
+        return -1;
+    }
+    return result - begin;
+}
+
+TEST(FunctionMatchTest, token_searcher_case_sensitive_basic) {
+    using doris::ASCIICaseSensitiveTokenSearcher;
+
+    // Match "brown" as a whole token in "The quick brown fox"
+    {
+        ASCIICaseSensitiveTokenSearcher searcher("brown", 5);
+        EXPECT_EQ(token_search_offset(searcher, "The quick brown fox"), 10);
+    }
+
+    // Should NOT match partial token: "brown" in "brownie"
+    {
+        ASCIICaseSensitiveTokenSearcher searcher("brown", 5);
+        EXPECT_EQ(token_search_offset(searcher, "brownie recipe"), -1);
+    }
+
+    // Token at start of string
+    {
+        ASCIICaseSensitiveTokenSearcher searcher("hello", 5);
+        EXPECT_EQ(token_search_offset(searcher, "hello world"), 0);
+    }
+
+    // Token at end of string
+    {
+        ASCIICaseSensitiveTokenSearcher searcher("world", 5);
+        EXPECT_EQ(token_search_offset(searcher, "hello world"), 6);
+    }
+
+    // No match
+    {
+        ASCIICaseSensitiveTokenSearcher searcher("missing", 7);
+        EXPECT_EQ(token_search_offset(searcher, "hello world"), -1);
+    }
+
+    // Case-sensitive: "Brown" should not match "brown"
+    {
+        ASCIICaseSensitiveTokenSearcher searcher("Brown", 5);
+        EXPECT_EQ(token_search_offset(searcher, "the quick brown fox"), -1);
+    }
+
+    // Token separated by non-alphanumeric characters
+    {
+        ASCIICaseSensitiveTokenSearcher searcher("test", 4);
+        EXPECT_EQ(token_search_offset(searcher, "foo.test.bar"), 4);
+    }
+
+    // Single character token
+    {
+        ASCIICaseSensitiveTokenSearcher searcher("a", 1);
+        EXPECT_GE(token_search_offset(searcher, "this is a test"), 0);
+    }
+
+    // Empty haystack
+    {
+        ASCIICaseSensitiveTokenSearcher searcher("test", 4);
+        EXPECT_EQ(token_search_offset(searcher, ""), -1);
+    }
+}
+
+TEST(FunctionMatchTest, token_searcher_case_insensitive) {
+    using doris::ASCIICaseInsensitiveTokenSearcher;
+
+    // "brown" should match "BROWN" case-insensitively
+    {
+        ASCIICaseInsensitiveTokenSearcher searcher("brown", 5);
+        EXPECT_GE(token_search_offset(searcher, "The Quick BROWN Fox"), 0);
+    }
+
+    // Mixed case should match
+    {
+        ASCIICaseInsensitiveTokenSearcher searcher("Hello", 5);
+        EXPECT_GE(token_search_offset(searcher, "say hElLo world"), 0);
+    }
+
+    // Should NOT match partial token even case-insensitively
+    {
+        ASCIICaseInsensitiveTokenSearcher searcher("brown", 5);
+        EXPECT_EQ(token_search_offset(searcher, "BROWNIE recipe"), -1);
+    }
+
+    // Token at end of string, case-insensitive
+    {
+        ASCIICaseInsensitiveTokenSearcher searcher("WORLD", 5);
+        EXPECT_EQ(token_search_offset(searcher, "hello world"), 6);
+    }
+
+    // Case-insensitive with special separators
+    {
+        ASCIICaseInsensitiveTokenSearcher searcher("TEST", 4);
+        EXPECT_EQ(token_search_offset(searcher, "foo.test.bar"), 4);
+    }
+}
+
+// Test is_lowercase field propagation
+TEST(FunctionMatchTest, is_lowercase_field) {
+    {
+        auto ctx = create_inverted_index_ctx(InvertedIndexParserType::PARSER_ENGLISH, true);
+        EXPECT_TRUE(ctx.ctx->is_lowercase);
+    }
+    {
+        auto ctx = create_inverted_index_ctx(InvertedIndexParserType::PARSER_ENGLISH, false);
+        EXPECT_FALSE(ctx.ctx->is_lowercase);
+    }
+    {
+        auto ctx = create_inverted_index_ctx(InvertedIndexParserType::PARSER_STANDARD, true);
+        EXPECT_TRUE(ctx.ctx->is_lowercase);
+    }
+}
+
+// Test can_use_token_search conditions
+TEST(FunctionMatchTest, can_use_token_search) {
+    // nullptr analyzer_ctx -> false
+    EXPECT_FALSE(FunctionMatchBase::can_use_token_search(nullptr, nullptr));
+
+    // PARSER_NONE -> false (no tokenization)
+    {
+        auto ctx = create_inverted_index_ctx(InvertedIndexParserType::PARSER_NONE);
+        EXPECT_FALSE(FunctionMatchBase::can_use_token_search(ctx.ctx.get(), nullptr));
+    }
+
+    // PARSER_ENGLISH -> false (SimpleAnalyzer treats digits as separators, incompatible)
+    {
+        auto ctx = create_inverted_index_ctx(InvertedIndexParserType::PARSER_ENGLISH);
+        EXPECT_FALSE(FunctionMatchBase::can_use_token_search(ctx.ctx.get(), nullptr));
+    }
+
+    // PARSER_STANDARD -> true
+    {
+        auto ctx = create_inverted_index_ctx(InvertedIndexParserType::PARSER_STANDARD);
+        EXPECT_TRUE(FunctionMatchBase::can_use_token_search(ctx.ctx.get(), nullptr));
+    }
+
+    // PARSER_UNICODE -> false (CJK tokenization incompatible with ASCII-only TokenSearcher)
+    {
+        auto ctx = create_inverted_index_ctx(InvertedIndexParserType::PARSER_UNICODE);
+        EXPECT_FALSE(FunctionMatchBase::can_use_token_search(ctx.ctx.get(), nullptr));
+    }
+
+    // PARSER_CHINESE -> false
+    {
+        auto ctx = create_inverted_index_ctx(InvertedIndexParserType::PARSER_CHINESE);
+        EXPECT_FALSE(FunctionMatchBase::can_use_token_search(ctx.ctx.get(), nullptr));
+    }
+
+    // With array_offsets -> false
+    {
+        auto ctx = create_inverted_index_ctx(InvertedIndexParserType::PARSER_STANDARD);
+        ColumnArray::Offsets64 offsets = {2, 4};
+        EXPECT_FALSE(FunctionMatchBase::can_use_token_search(ctx.ctx.get(), &offsets));
+    }
+
+    // With non-empty char_filter_map -> false
+    {
+        auto ctx = create_inverted_index_ctx(InvertedIndexParserType::PARSER_STANDARD);
+        ctx.ctx->char_filter_map["_"] = " ";
+        EXPECT_FALSE(FunctionMatchBase::can_use_token_search(ctx.ctx.get(), nullptr));
+    }
+}
+
+// Test TokenSearcher with digit-containing tokens (PARSER_STANDARD specific behavior)
+TEST(FunctionMatchTest, token_searcher_digit_tokens) {
+    // Digits should be part of tokens, not separators
+    {
+        ASCIICaseSensitiveTokenSearcher searcher("test123", 7);
+        EXPECT_GE(token_search_offset(searcher, "foo test123 bar"), 0);
+        // Should not match partial: "test1234" is a different token
+        EXPECT_EQ(token_search_offset(searcher, "foo test1234 bar"), -1);
+        // Should not match partial: "test12" is shorter
+        EXPECT_EQ(token_search_offset(searcher, "foo test12 bar"), -1);
+    }
+    // Pure numeric token
+    {
+        ASCIICaseSensitiveTokenSearcher searcher("42", 2);
+        EXPECT_GE(token_search_offset(searcher, "answer is 42 indeed"), 0);
+        EXPECT_EQ(token_search_offset(searcher, "answer is 421 indeed"), -1);
+    }
+}
+
+// Test TokenSearcher with separator-only input and edge cases
+TEST(FunctionMatchTest, token_searcher_edge_cases) {
+    // Separator-only haystack - no tokens can match
+    {
+        ASCIICaseSensitiveTokenSearcher searcher("hello", 5);
+        EXPECT_EQ(token_search_offset(searcher, "... --- !!!"), -1);
+        EXPECT_EQ(token_search_offset(searcher, ""), -1);
+        EXPECT_EQ(token_search_offset(searcher, "   "), -1);
+    }
+    // Single character token
+    {
+        ASCIICaseSensitiveTokenSearcher searcher("x", 1);
+        EXPECT_GE(token_search_offset(searcher, "a x b"), 0);
+        EXPECT_EQ(token_search_offset(searcher, "axb"), -1); // not a token boundary
+        EXPECT_GE(token_search_offset(searcher, "x"), 0);    // exact match
+    }
+    // Token at various positions
+    {
+        ASCIICaseSensitiveTokenSearcher searcher("mid", 3);
+        EXPECT_GE(token_search_offset(searcher, "mid end"), 0);       // start
+        EXPECT_GE(token_search_offset(searcher, "start mid"), 0);     // end
+        EXPECT_GE(token_search_offset(searcher, "start mid end"), 0); // middle
+    }
+}
+
+// Test multi-token search patterns (match_any/match_all semantics)
+TEST(FunctionMatchTest, token_searcher_multi_token_patterns) {
+    const char* text = "the quick brown fox jumps over the lazy dog";
+    auto text_begin = reinterpret_cast<const uint8_t*>(text);
+    auto text_end = text_begin + strlen(text);
+
+    // match_any pattern: any token found -> match
+    {
+        ASCIICaseSensitiveTokenSearcher s1("quick", 5);
+        ASCIICaseSensitiveTokenSearcher s2("missing", 7);
+        // "quick" is found, "missing" is not -- match_any should succeed
+        bool any_found = false;
+        for (const auto& s : {s1, s2}) {
+            if (s.search(text_begin, text_end) < text_end) {
+                any_found = true;
+                break;
+            }
+        }
+        EXPECT_TRUE(any_found);
+    }
+    // match_any pattern: no tokens found -> no match
+    {
+        ASCIICaseSensitiveTokenSearcher s1("missing", 7);
+        ASCIICaseSensitiveTokenSearcher s2("absent", 6);
+        bool any_found = false;
+        for (const auto& s : {s1, s2}) {
+            if (s.search(text_begin, text_end) < text_end) {
+                any_found = true;
+                break;
+            }
+        }
+        EXPECT_FALSE(any_found);
+    }
+
+    // match_all pattern: all tokens found -> match
+    {
+        ASCIICaseSensitiveTokenSearcher s1("quick", 5);
+        ASCIICaseSensitiveTokenSearcher s2("fox", 3);
+        bool all_found = true;
+        for (const auto& s : {s1, s2}) {
+            if (s.search(text_begin, text_end) >= text_end) {
+                all_found = false;
+                break;
+            }
+        }
+        EXPECT_TRUE(all_found);
+    }
+    // match_all pattern: not all tokens found -> no match
+    {
+        ASCIICaseSensitiveTokenSearcher s1("quick", 5);
+        ASCIICaseSensitiveTokenSearcher s2("missing", 7);
+        bool all_found = true;
+        for (const auto& s : {s1, s2}) {
+            if (s.search(text_begin, text_end) >= text_end) {
+                all_found = false;
+                break;
+            }
+        }
+        EXPECT_FALSE(all_found);
+    }
 }
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
When `enable_match_without_inverted_index=true`, `match_any` and `match_all` functions fall back to per-row Lucene tokenization which is expensive. This PR adds a SIMD-accelerated fast path using TokenSearcher (ported from ClickHouse's `hasToken` pattern) that eliminates per-row tokenization overhead for PARSER_STANDARD columns.

The fast path uses SSE4.1 SIMD instructions for substring search combined with token boundary verification. It activates only for PARSER_STANDARD with no char_filter_map and single-term query tokens, falling back to the original Lucene path otherwise.

Key changes:
- Port case-insensitive ASCII StringSearcher from ClickHouse with SSE4.1 SIMD acceleration
- Add `is_lowercase` field to `InvertedIndexAnalyzerCtx` for case-sensitivity dispatch
- Add `can_use_token_search` guard with strict conditions (PARSER_STANDARD only, no char_filter_map, no array offsets)
- Implement fast path for both `match_any` (OR semantics) and `match_all` (AND semantics)
- Add comprehensive unit tests (36 tests) and Google Benchmark

### Release note

Improve match_any/match_all performance for no-index queries on PARSER_STANDARD columns using SIMD-accelerated token search.

### Check List (For Author)

- Test
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. match_any/match_all without inverted index now uses a faster code path for PARSER_STANDARD columns. Results are semantically equivalent.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label