### PR TITLE
[Fix](Cloud)decouple min pipeline executor size from ConnectContext

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/system/CloudSystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/system/CloudSystemInfoService.java
@@ -760,16 +760,8 @@ public class CloudSystemInfoService extends SystemInfoService {
     }
 
     @Override
-    public int getMinPipelineExecutorSize() {
-        String clusterName = "";
-        try {
-            clusterName = ConnectContext.get().getCloudCluster(false);
-        } catch (ComputeGroupException e) {
-            LOG.warn("failed to get cluster name", e);
-            return 1;
-        }
-        if (ConnectContext.get() != null
-                && Strings.isNullOrEmpty(clusterName)) {
+    public int getMinPipelineExecutorSize(String clusterName) {
+        if (Strings.isNullOrEmpty(clusterName)) {
             return 1;
         }
         List<Backend> currentBackends = getBackendsByClusterName(clusterName);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -650,6 +650,9 @@ public class ConnectContext {
 
     public void setCurrentUserIdentity(UserIdentity currentUserIdentity) {
         this.currentUserIdentity = currentUserIdentity;
+        if (sessionVariable != null) {
+            sessionVariable.setQualifiedUser(getQualifiedUser());
+        }
     }
 
     public SessionVariable getSessionVariable() {
@@ -658,6 +661,9 @@ public class ConnectContext {
 
     public void setSessionVariable(SessionVariable sessionVariable) {
         this.sessionVariable = sessionVariable;
+        if (this.sessionVariable != null) {
+            this.sessionVariable.setQualifiedUser(getQualifiedUser());
+        }
     }
 
     public ConnectScheduler getConnectScheduler() {
@@ -1426,6 +1432,7 @@ public class ConnectContext {
                 LOG.debug("finally set context compute group name {} for user {} with chose way '{}'",
                         cloudCluster, getCurrentUserIdentity(), choseWay);
             }
+            getSessionVariable().setCloudCluster(cloudCluster);
             return cloudCluster;
         }
 
@@ -1438,6 +1445,7 @@ public class ConnectContext {
                         getCurrentUserIdentity(), choseWay);
             }
             this.cloudCluster = userPropCluster;
+            getSessionVariable().setCloudCluster(userPropCluster);
             return userPropCluster;
         }
 
@@ -1463,6 +1471,7 @@ public class ConnectContext {
             throw exception;
         }
         this.cloudCluster = policyCluster;
+        getSessionVariable().setCloudCluster(policyCluster);
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("finally set context compute group name {} for user {} with chose way '{}'", this.cloudCluster,

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1312,6 +1312,10 @@ public class SessionVariable implements Serializable, Writable {
                         setter = "setPipelineTaskNum")
     public int parallelPipelineTaskNum = 0;
 
+    // Used by per-session auth-based overrides (for example user-level parallel instance setting).
+    // Keep it out of serialized session variables.
+    private transient String qualifiedUser;
+
 
     public enum IgnoreSplitType {
         NONE,
@@ -4176,21 +4180,41 @@ public class SessionVariable implements Serializable, Writable {
     }
 
     public int getParallelExecInstanceNum() {
-        ConnectContext connectContext = ConnectContext.get();
-        if (connectContext != null && connectContext.getEnv() != null && connectContext.getEnv().getAuth() != null) {
-            int userParallelExecInstanceNum = connectContext.getEnv().getAuth()
-                    .getParallelFragmentExecInstanceNum(connectContext.getQualifiedUser());
+        Env currentEnv = Env.getCurrentEnv();
+        if (!Strings.isNullOrEmpty(qualifiedUser)
+                && currentEnv != null
+                && currentEnv.getAuth() != null) {
+            int userParallelExecInstanceNum = currentEnv.getAuth()
+                    .getParallelFragmentExecInstanceNum(qualifiedUser);
             if (userParallelExecInstanceNum > 0) {
                 return userParallelExecInstanceNum;
             }
         }
         if (parallelPipelineTaskNum == 0) {
-            int size = Env.getCurrentSystemInfo().getMinPipelineExecutorSize();
+            int size = Env.getCurrentSystemInfo().getMinPipelineExecutorSize(resolveCloudClusterForAutoParallel());
             int autoInstance = (size + 1) / 2;
             return Math.min(autoInstance, maxInstanceNum);
         } else {
             return parallelPipelineTaskNum;
         }
+    }
+
+    public void setQualifiedUser(String qualifiedUser) {
+        this.qualifiedUser = qualifiedUser;
+    }
+
+    private String resolveCloudClusterForAutoParallel() {
+        if (!Config.isCloudMode()) {
+            return "";
+        }
+        if (!Strings.isNullOrEmpty(cloudCluster)) {
+            return cloudCluster;
+        }
+        Env currentEnv = Env.getCurrentEnv();
+        if (currentEnv == null || currentEnv.getAuth() == null || Strings.isNullOrEmpty(qualifiedUser)) {
+            return "";
+        }
+        return Strings.nullToEmpty(currentEnv.getAuth().getDefaultCloudCluster(qualifiedUser));
     }
 
     public boolean getEnablePreferCachedRowset() {

--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -1079,7 +1079,7 @@ public class SystemInfoService {
         return idToBackendRef;
     }
 
-    public int getMinPipelineExecutorSize() {
+    public int getMinPipelineExecutorSize(String clusterName) {
         List<Backend> currentBackends = null;
         try {
             currentBackends = getAllBackendsByAllCluster().values().asList();

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/system/CloudSystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/system/CloudSystemInfoServiceTest.java
@@ -369,7 +369,7 @@ public class CloudSystemInfoServiceTest {
 
         try {
             // Since there are no backends in the cluster, should return 1
-            int result = infoService.getMinPipelineExecutorSize();
+            int result = getMinPipelineExecutorSizeByContext(infoService);
             Assert.assertEquals(1, result);
         } finally {
             ConnectContext.remove();
@@ -403,7 +403,7 @@ public class CloudSystemInfoServiceTest {
 
         try {
             // Should return the pipeline executor size of the single backend
-            int result = infoService.getMinPipelineExecutorSize();
+            int result = getMinPipelineExecutorSizeByContext(infoService);
             Assert.assertEquals(8, result);
         } finally {
             ConnectContext.remove();
@@ -454,7 +454,7 @@ public class CloudSystemInfoServiceTest {
 
         try {
             // Should return the minimum pipeline executor size (6)
-            int result = infoService.getMinPipelineExecutorSize();
+            int result = getMinPipelineExecutorSizeByContext(infoService);
             Assert.assertEquals(6, result);
         } finally {
             ConnectContext.remove();
@@ -505,7 +505,7 @@ public class CloudSystemInfoServiceTest {
 
         try {
             // Should return the minimum positive pipeline executor size (4)
-            int result = infoService.getMinPipelineExecutorSize();
+            int result = getMinPipelineExecutorSizeByContext(infoService);
             Assert.assertEquals(4, result);
         } finally {
             ConnectContext.remove();
@@ -549,7 +549,7 @@ public class CloudSystemInfoServiceTest {
         try {
             // Should return 1 when no valid pipeline executor sizes are
             // found
-            int result = infoService.getMinPipelineExecutorSize();
+            int result = getMinPipelineExecutorSizeByContext(infoService);
             Assert.assertEquals(1, result);
         } finally {
             ConnectContext.remove();
@@ -565,11 +565,44 @@ public class CloudSystemInfoServiceTest {
         createTestConnectContext(null);
         try {
             // Should return 1 when no cluster is set in ConnectContext
-            int result = infoService.getMinPipelineExecutorSize();
+            int result = getMinPipelineExecutorSizeByContext(infoService);
             Assert.assertEquals(1, result);
         } finally {
             ConnectContext.remove();
         }
+    }
+
+    @Test
+    public void testGetMinPipelineExecutorSizeWithExplicitClusterNameWithoutContext() {
+        infoService = new CloudSystemInfoService();
+        String clusterName = "explicit_cluster";
+        String clusterId = "explicit_cluster_id";
+
+        ComputeGroup cg = new ComputeGroup(clusterId, clusterName, ComputeGroup.ComputeTypeEnum.COMPUTE);
+        infoService.addComputeGroup(clusterId, cg);
+
+        List<Backend> toAdd = new ArrayList<>();
+        Backend backend1 = new Backend(Env.getCurrentEnv().getNextId(), "127.0.1.1", 9050);
+        Map<String, String> tagMap1 = Tag.DEFAULT_BACKEND_TAG.toMap();
+        tagMap1.put(Tag.CLOUD_CLUSTER_NAME, clusterName);
+        tagMap1.put(Tag.CLOUD_CLUSTER_ID, clusterId);
+        backend1.setTagMap(tagMap1);
+        backend1.setPipelineExecutorSize(10);
+        toAdd.add(backend1);
+
+        Backend backend2 = new Backend(Env.getCurrentEnv().getNextId(), "127.0.1.2", 9050);
+        Map<String, String> tagMap2 = Tag.DEFAULT_BACKEND_TAG.toMap();
+        tagMap2.put(Tag.CLOUD_CLUSTER_NAME, clusterName);
+        tagMap2.put(Tag.CLOUD_CLUSTER_ID, clusterId);
+        backend2.setTagMap(tagMap2);
+        backend2.setPipelineExecutorSize(6);
+        toAdd.add(backend2);
+
+        infoService.updateCloudClusterMapNoLock(toAdd, new ArrayList<>());
+        ConnectContext.remove();
+
+        int result = infoService.getMinPipelineExecutorSize(clusterName);
+        Assert.assertEquals(6, result);
     }
 
     @Test
@@ -628,7 +661,7 @@ public class CloudSystemInfoServiceTest {
 
         try {
             // Should return 8 (minimum valid size)
-            int result = infoService.getMinPipelineExecutorSize();
+            int result = getMinPipelineExecutorSizeByContext(infoService);
             Assert.assertEquals(8, result);
         } finally {
             ConnectContext.remove();
@@ -679,7 +712,7 @@ public class CloudSystemInfoServiceTest {
 
         try {
             // Should return 512 (minimum among large values)
-            int result = infoService.getMinPipelineExecutorSize();
+            int result = getMinPipelineExecutorSizeByContext(infoService);
             Assert.assertEquals(512, result);
         } finally {
             ConnectContext.remove();
@@ -715,7 +748,7 @@ public class CloudSystemInfoServiceTest {
 
         try {
             // Should return 32 (consistent across all backends)
-            int result = infoService.getMinPipelineExecutorSize();
+            int result = getMinPipelineExecutorSizeByContext(infoService);
             Assert.assertEquals(32, result);
         } finally {
             ConnectContext.remove();
@@ -786,7 +819,7 @@ public class CloudSystemInfoServiceTest {
 
         try {
             // Should return 8 (minimum from current cluster2), not 2 (global minimum from cluster1)
-            int result = infoService.getMinPipelineExecutorSize();
+            int result = getMinPipelineExecutorSizeByContext(infoService);
             Assert.assertEquals(8, result);
         } finally {
             ConnectContext.remove();
@@ -860,14 +893,14 @@ public class CloudSystemInfoServiceTest {
         try {
             // Should return 32 (minimum from virtual cluster's physical cluster), not 8
             // (from other cluster)
-            int result = infoService.getMinPipelineExecutorSize();
+            int result = getMinPipelineExecutorSizeByContext(infoService);
             Assert.assertEquals(32, result);
 
             // Switch to other cluster
             ctx.setCloudCluster(otherClusterName);
 
             // Should return 8 (from other cluster)
-            result = infoService.getMinPipelineExecutorSize();
+            result = getMinPipelineExecutorSizeByContext(infoService);
             Assert.assertEquals(8, result);
 
         } finally {
@@ -885,13 +918,20 @@ public class CloudSystemInfoServiceTest {
 
         try {
             // Should return 1 because no cluster is set (will catch AnalysisException)
-            int result = infoService.getMinPipelineExecutorSize();
+            int result = getMinPipelineExecutorSizeByContext(infoService);
             Assert.assertEquals(1, result);
 
         } finally {
             // Clean up ConnectContext
             ConnectContext.remove();
         }
+    }
+
+    @Test
+    public void testGetMinPipelineExecutorSizeWithoutConnectContext() {
+        infoService = new CloudSystemInfoService();
+        ConnectContext.remove();
+        Assert.assertEquals(1, getMinPipelineExecutorSizeByContext(infoService));
     }
 
     // Test using real ConnectContext to select compute group
@@ -958,19 +998,37 @@ public class CloudSystemInfoServiceTest {
 
         try {
             // Should return 2 (minimum from cluster1), not 16 (minimum from cluster2)
-            int result = infoService.getMinPipelineExecutorSize();
+            int result = getMinPipelineExecutorSizeByContext(infoService);
             Assert.assertEquals(2, result);
 
             // Now switch to cluster2
             ctx.setCloudCluster(cluster2Name);
 
             // Should return 16 (minimum from cluster2), not 2 (minimum from cluster1)
-            result = infoService.getMinPipelineExecutorSize();
+            result = getMinPipelineExecutorSizeByContext(infoService);
             Assert.assertEquals(16, result);
         } finally {
             // Clean up ConnectContext
             ConnectContext.remove();
         }
+    }
+
+    /**
+     * Resolve min pipeline executor size by current ConnectContext-selected cluster.
+     * Keep test intent unchanged after removing no-arg getMinPipelineExecutorSize().
+     */
+    private int getMinPipelineExecutorSizeByContext(CloudSystemInfoService infoService) {
+        ConnectContext context = ConnectContext.get();
+        if (context == null) {
+            return infoService.getMinPipelineExecutorSize("");
+        }
+        String clusterName = "";
+        try {
+            clusterName = context.getCloudCluster(false);
+        } catch (Exception e) {
+            return 1;
+        }
+        return infoService.getMinPipelineExecutorSize(clusterName);
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/system/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/system/SystemInfoServiceTest.java
@@ -447,7 +447,7 @@ public class SystemInfoServiceTest {
     @Test
     public void testGetMinPipelineExecutorSize() {
         // Test case 1: No backends
-        int result = infoService.getMinPipelineExecutorSize();
+        int result = infoService.getMinPipelineExecutorSize("");
         Assert.assertEquals(1, result);
 
         // Test case 2: Single backend with pipeline executor size = 8
@@ -456,7 +456,7 @@ public class SystemInfoServiceTest {
         be1.setPipelineExecutorSize(8);
         be1.setAlive(true);
 
-        result = infoService.getMinPipelineExecutorSize();
+        result = infoService.getMinPipelineExecutorSize("");
         Assert.assertEquals(8, result);
 
         // Test case 3: Multiple backends with different pipeline executor sizes
@@ -470,7 +470,7 @@ public class SystemInfoServiceTest {
         be3.setPipelineExecutorSize(12);
         be3.setAlive(true);
 
-        result = infoService.getMinPipelineExecutorSize();
+        result = infoService.getMinPipelineExecutorSize("");
         Assert.assertEquals(4, result);
 
         // Test case 4: Backends with zero and negative pipeline executor sizes (should
@@ -485,7 +485,7 @@ public class SystemInfoServiceTest {
         be5.setPipelineExecutorSize(-1); // Should be ignored
         be5.setAlive(true);
 
-        result = infoService.getMinPipelineExecutorSize();
+        result = infoService.getMinPipelineExecutorSize("");
         Assert.assertEquals(4, result); // Still should be 4 from be2
 
         // Test case 5: All backends have zero or negative pipeline executor sizes
@@ -493,7 +493,7 @@ public class SystemInfoServiceTest {
         be2.setPipelineExecutorSize(-5);
         be3.setPipelineExecutorSize(0);
 
-        result = infoService.getMinPipelineExecutorSize();
+        result = infoService.getMinPipelineExecutorSize("");
         Assert.assertEquals(1, result); // Should return default value 1
 
         // Test case 6: Mix of positive and non-positive values
@@ -501,7 +501,7 @@ public class SystemInfoServiceTest {
         be2.setPipelineExecutorSize(0); // ignored
         be3.setPipelineExecutorSize(6); // This should be the minimum
 
-        result = infoService.getMinPipelineExecutorSize();
+        result = infoService.getMinPipelineExecutorSize("");
         Assert.assertEquals(6, result);
     }
 


### PR DESCRIPTION
 ## Background

#60648

  getMinPipelineExecutorSize in cloud paths implicitly depended on ConnectContext, which caused two issues:

  1. Unstable behavior when no thread-local context is available (e.g. internal/async paths).
  2. Unclear API semantics since callers could not explicitly specify the target cluster.

  This PR makes the API explicit by requiring clusterName.

  ## What Changed

  1. Removed the no-arg getMinPipelineExecutorSize() API and kept only: getMinPipelineExecutorSize(String clusterName).
  2. Unified SystemInfoService and CloudSystemInfoService implementations to the string-arg API.
  3. Updated SessionVariable#getParallelExecInstanceNum() to call the string-arg API, with cluster resolved from session/auth information (instead of directly depending on ConnectContext).
  4. Added synchronization in ConnectContext:

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

