### PR TITLE
[fix](cache) invalidate sorted partition cache after replacing temp partition in cloud mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -6755,6 +6755,13 @@ public class Env {
         if (Config.isNotCloudMode()) {
             version = olapTable.getNextVersion();
             olapTable.updateVisibleVersionAndTime(version, versionTime);
+        } else {
+            // Invalidate sorted partition cache for this table to avoid stale cache after partition replacement.
+            // In non-cloud mode, the version update above would also trigger cache invalidation on next query,
+            // but in cloud mode, getVisibleVersion() fetches version from meta service via RPC,
+            // so the local version update may not be reflected. Explicit invalidation is needed.
+            Env.getCurrentEnv().getSortedPartitionsCacheManager()
+                    .invalidateTable(db.getCatalog().getName(), db.getFullName(), olapTable.getName());
         }
         // Here, we only wait for the EventProcessor to finish processing the event,
         // but regardless of the success or failure of the result,
@@ -6797,6 +6804,13 @@ public class Env {
             if (Config.isNotCloudMode()) {
                 olapTable.updateVisibleVersionAndTime(replaceTempPartitionLog.getVersion(),
                         replaceTempPartitionLog.getVersionTime());
+            } else {
+                // Invalidate sorted partition cache for this table to avoid stale cache after partition replacement.
+                // In non-cloud mode, the version update above would also trigger cache invalidation on next query,
+                // but in cloud mode, getVisibleVersion() fetches version from meta service via RPC,
+                // so the local version update may not be reflected. Explicit invalidation is needed.
+                Env.getCurrentEnv().getSortedPartitionsCacheManager()
+                        .invalidateTable(db.getCatalog().getName(), db.getFullName(), olapTable.getName());
             }
         } catch (DdlException e) {
             throw new MetaNotFoundException(e);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/cache/NereidsSortedPartitionsCacheManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/cache/NereidsSortedPartitionsCacheManager.java
@@ -66,6 +66,11 @@ public class NereidsSortedPartitionsCacheManager {
         this.partitionCaches.invalidateAll();
     }
 
+    public void invalidateTable(String catalog, String db, String table) {
+        TableIdentifier key = new TableIdentifier(catalog, db, table);
+        partitionCaches.invalidate(key);
+    }
+
     public Optional<SortedPartitionRanges<?>> get(
             SupportBinarySearchFilteringPartitions table, CatalogRelation scan) {
         ConnectContext connectContext = ConnectContext.get();

--- a/regression-test/suites/query_p0/cache/clear_sorted_partition_cache.groovy
+++ b/regression-test/suites/query_p0/cache/clear_sorted_partition_cache.groovy
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("clear_sorted_partition_cache") {
+    multi_sql """
+        set enable_sql_cache=false;
+        set enable_binary_search_filtering_partitions=true;
+        drop table if exists t_part_cache;
+        create table t_part_cache(
+            id int,
+            dt int
+        )
+        partition by range(dt) (
+            partition p20250101 values [(20250101), (20250102))
+        )
+        distributed by hash(id)
+        properties("replication_num" = "1");
+        alter table t_part_cache add temporary partition tp20250101 values [(20250101), (20250102));
+        insert into t_part_cache temporary partition (tp20250101) select 1, 20250101;
+        """
+    // wait cache valid
+    sleep(10000)
+    // query the original empty partition to populate the sorted partition cache
+    test {
+        sql """
+        select *
+        from t_part_cache
+        where dt = '20250101'
+        """
+        rowNum 0
+    }
+    sql "alter table t_part_cache replace partition p20250101 WITH TEMPORARY PARTITION tp20250101;"
+    test {
+        sql """
+        select *
+        from t_part_cache
+        where dt = '20250101'
+        """
+        rowNum 1
+    }
+}


### PR DESCRIPTION
## Summary
After executing `ALTER TABLE ... REPLACE PARTITION ... WITH TEMPORARY PARTITION`,
queries on the replaced partition may return empty results due to stale sorted
partition cache (used by binary search partition pruning).

## Root Cause
`Env.replaceTempPartition()` internally calls `OlapTable.replaceTempPartitions()`,
which drops the old partitions and promotes temp partitions to formal ones. However,
the sorted partition cache (`NereidsSortedPartitionsCacheManager`) is not invalidated
after this operation, causing subsequent queries to use stale cached partition IDs
that no longer exist.

### Non-cloud mode
The table version update was conditionally skipped with an incorrect comment claiming
"the internal partition deletion logic will update the table version in cloud mode".
In reality, tracing the call chain:

  replaceTempPartitions() → dropPartition() → dropPartitionCommon() → recyclePartition()

None of these methods update the table version. Without a version bump,
the cache version comparison in `NereidsSortedPartitionsCacheManager.get()` matches
the old cached version, so the stale sorted partition ranges are returned.

### Cloud mode
Even with the table version update fix, cloud mode fetches the table version from
meta service via RPC (`getVisibleVersion()` → `VersionHelper.getVersionFromMeta()`),
not from local `tableAttributes`. Since `replaceTempPartition` does not notify the
meta service (the old partition only enters the recycle bin via `recyclePartition()`,
and meta service is only notified when the recycle bin later erases the partition via
`CloudInternalCatalog.dropCloudPartition()`), the meta service version remains
unchanged, and the cache still hits.

## Fix
1. Always update the table version in `replaceTempPartition()` and
   `replayReplaceTempPartition()` (removes the incorrect `isNotCloudMode()` guard).
2. Explicitly invalidate the sorted partition cache for the specific table after
   partition replacement, via a new `invalidateTable()` method on
   `NereidsSortedPartitionsCacheManager`. This ensures cache correctness in both
   cloud and non-cloud modes.

## How to Reproduce
1. Create a range-partitioned table
2. Add a temporary partition with the same range
3. Insert data into the temporary partition
4. Wait for sorted partition cache to populate (~10s, controlled by
   `cache_sorted_partition_interval_second`)
5. Query the table (returns 0 rows from the empty original partition, populating cache)
6. Replace the partition with the temporary partition
7. Query again — returns 0 rows (stale cache) instead of the expected 1 row
