### PR TITLE
[fix](search) inject MATCH_ALL_DOCS for multi-MUST_NOT queries in lucene mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SearchDslParser.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SearchDslParser.java
@@ -2097,6 +2097,23 @@ public class SearchDslParser {
             // Apply Lucene boolean logic
             applyLuceneBooleanLogic(terms);
 
+            // Check if ALL terms are MUST_NOT (pure negation query).
+            // In Lucene, a BooleanQuery with only MUST_NOT clauses matches nothing,
+            // so we inject a MATCH_ALL_DOCS(SHOULD) node to ensure proper semantics:
+            // match all docs EXCEPT those matching any MUST_NOT term.
+            boolean allMustNot = terms.stream().allMatch(t -> t.occur == QsOccur.MUST_NOT);
+            if (allMustNot) {
+                QsNode matchAllNode = new QsNode(QsClauseType.MATCH_ALL_DOCS, (List<QsNode>) null);
+                matchAllNode.setOccur(QsOccur.SHOULD);
+                List<QsNode> children = new ArrayList<>();
+                children.add(matchAllNode);
+                for (TermWithOccur term : terms) {
+                    term.node.setOccur(term.occur);
+                    children.add(term.node);
+                }
+                return new QsNode(QsClauseType.OCCUR_BOOLEAN, children, 1);
+            }
+
             // Determine minimum_should_match
             // Only use explicit option at top level; nested clauses use default logic
             Integer minShouldMatch = (nestingLevel == 0) ? options.getMinimumShouldMatch() : null;


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #60814

Problem Summary:
In search() lucene mode, when all terms in a boolean query are MUST_NOT
(e.g., `NOT a AND NOT b` or `NOT a NOT b` with default_operator=AND),
the query incorrectly returns all documents instead of returning all
documents EXCEPT those matching the negated terms.

Root cause: Lucene's BooleanQuery with only MUST_NOT clauses matches
nothing (by design). ES handles this by injecting a MatchAllDocsQuery
with SHOULD occur. Doris only handled the single-term MUST_NOT case
but not multi-term all-MUST_NOT queries.

Fix: After `applyLuceneBooleanLogic()`, detect if ALL terms are MUST_NOT
and inject `MATCH_ALL_DOCS(SHOULD)` with `minimum_should_match=1`.

### Release note

Fix search() lucene mode returning incorrect results for multi-MUST_NOT queries like "NOT a AND NOT b".

### Check List (For Author)

- Test
    - [x] Unit Test
    - [ ] Regression test
    - [ ] Manual test
    - [ ] No need to test

- Behavior changed:
    - [x] Yes. Pure multi-MUST_NOT queries now correctly exclude matching docs instead of returning all.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label