### PR TITLE
[fix](search) support minus/plus prefix modifiers in search DSL

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/search/SearchLexer.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/search/SearchLexer.g4
@@ -45,6 +45,8 @@ AND : 'AND' ;
 OR  : 'OR' ;
 NOT : 'NOT' | '!' ;
 
+PLUS     : '+' ;
+MINUS    : '-' ;
 LPAREN   : '(' ;
 RPAREN   : ')' ;
 COLON    : ':' ;

--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/search/SearchParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/search/SearchParser.g4
@@ -24,7 +24,7 @@ clause     : orClause ;
 orClause   : andClause (OR andClause)* ;
 // AND is optional - space-separated terms use default_operator
 andClause  : notClause (AND? notClause)* ;
-notClause  : NOT atomClause | atomClause ;
+notClause  : NOT atomClause | MINUS atomClause | PLUS atomClause | atomClause ;
 // Note: fieldGroupQuery is listed before fieldQuery so ANTLR prioritizes field:(group) over field:value.
 // fieldQuery is listed before bareQuery so ANTLR prioritizes field:value over bare value.
 // This ensures "field:term" is parsed as fieldQuery, not bareQuery with "field" as term.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SearchDslParser.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SearchDslParser.java
@@ -1517,7 +1517,14 @@ public class SearchDslParser {
         private static QsNode expandNodeCrossFields(QsNode node, List<String> fields, boolean luceneMode) {
             // MATCH_ALL_DOCS matches all documents regardless of field - don't expand
             if (node.getType() == QsClauseType.MATCH_ALL_DOCS) {
-                return new QsNode(QsClauseType.MATCH_ALL_DOCS, (List<QsNode>) null);
+                QsNode result = new QsNode(QsClauseType.MATCH_ALL_DOCS, (List<QsNode>) null);
+                // Preserve occur attribute (e.g., SHOULD from "X OR *" queries)
+                // Without this, occur defaults to null which BE interprets as MUST,
+                // changing "X OR *" from matching all docs to matching only X.
+                if (node.getOccur() != null) {
+                    result.setOccur(node.getOccur());
+                }
+                return result;
             }
 
             // Check if this is a leaf node (no children)
@@ -1598,7 +1605,11 @@ public class SearchDslParser {
         private static QsNode deepCopyWithField(QsNode node, String field, List<String> fields) {
             // MATCH_ALL_DOCS matches all documents regardless of field - don't set field
             if (node.getType() == QsClauseType.MATCH_ALL_DOCS) {
-                return new QsNode(QsClauseType.MATCH_ALL_DOCS, (List<QsNode>) null);
+                QsNode result = new QsNode(QsClauseType.MATCH_ALL_DOCS, (List<QsNode>) null);
+                if (node.getOccur() != null) {
+                    result.setOccur(node.getOccur());
+                }
+                return result;
             }
             if (isLeafNode(node)) {
                 // If the user explicitly wrote "field:term" syntax, preserve original field
@@ -1645,7 +1656,11 @@ public class SearchDslParser {
         private static QsNode setFieldOnLeaves(QsNode node, String field, List<String> fields) {
             // MATCH_ALL_DOCS matches all documents regardless of field - don't set field
             if (node.getType() == QsClauseType.MATCH_ALL_DOCS) {
-                return new QsNode(QsClauseType.MATCH_ALL_DOCS, (List<QsNode>) null);
+                QsNode result = new QsNode(QsClauseType.MATCH_ALL_DOCS, (List<QsNode>) null);
+                if (node.getOccur() != null) {
+                    result.setOccur(node.getOccur());
+                }
+                return result;
             }
             if (isLeafNode(node)) {
                 // If the user explicitly wrote "field:term" syntax, preserve original field

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SearchDslParser.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SearchDslParser.java
@@ -765,7 +765,8 @@ public class SearchDslParser {
 
         @Override
         public QsNode visitNotClause(SearchParser.NotClauseContext ctx) {
-            if (ctx.NOT() != null) {
+            if (ctx.NOT() != null || ctx.MINUS() != null) {
+                // NOT or - prefix: negate the operand
                 QsNode child = visit(ctx.atomClause());
                 if (child == null) {
                     throw new RuntimeException("Invalid NOT clause: missing operand");
@@ -2208,7 +2209,8 @@ public class SearchDslParser {
 
         private void collectTermsFromNotClause(SearchParser.NotClauseContext ctx, List<TermWithOccur> terms,
                 QsOccur defaultOccur, boolean introducedByOr, boolean introducedByAnd) {
-            boolean isNegated = ctx.NOT() != null;
+            boolean isNegated = ctx.NOT() != null || ctx.MINUS() != null;
+            boolean isRequired = ctx.PLUS() != null;
             SearchParser.AtomClauseContext atomCtx = ctx.atomClause();
 
             QsNode node;
@@ -2238,6 +2240,7 @@ public class SearchDslParser {
             term.introducedByOr = introducedByOr;
             term.introducedByAnd = introducedByAnd;
             term.isNegated = isNegated;
+            term.isRequired = isRequired;
             terms.add(term);
         }
 
@@ -2264,8 +2267,17 @@ public class SearchDslParser {
             for (int i = 0; i < terms.size(); i++) {
                 TermWithOccur current = terms.get(i);
 
-                if (current.isNegated) {
-                    // NOT modifier - mark as MUST_NOT
+                if (current.isRequired) {
+                    // + prefix: force MUST regardless of context
+                    current.occur = QsOccur.MUST;
+                    if (current.introducedByOr && i > 0 && useAnd) {
+                        TermWithOccur prev = terms.get(i - 1);
+                        if (prev.occur != QsOccur.MUST_NOT) {
+                            prev.occur = QsOccur.SHOULD;
+                        }
+                    }
+                } else if (current.isNegated) {
+                    // NOT or - prefix: mark as MUST_NOT
                     current.occur = QsOccur.MUST_NOT;
 
                     if (current.introducedByAnd && i > 0) {
@@ -2350,7 +2362,8 @@ public class SearchDslParser {
 
         @Override
         public QsNode visitNotClause(SearchParser.NotClauseContext ctx) {
-            if (ctx.NOT() != null) {
+            if (ctx.NOT() != null || ctx.MINUS() != null) {
+                // NOT or - prefix: negate the operand
                 QsNode child = visit(ctx.atomClause());
                 if (child == null) {
                     throw new RuntimeException("Invalid NOT clause: missing operand");
@@ -2605,6 +2618,7 @@ public class SearchDslParser {
         boolean introducedByOr = false;
         boolean introducedByAnd = false;
         boolean isNegated = false;
+        boolean isRequired = false;
 
         TermWithOccur(QsNode node, QsOccur occur) {
             this.node = node;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SearchDslParserTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SearchDslParserTest.java
@@ -782,6 +782,59 @@ public class SearchDslParserTest {
     }
 
     @Test
+    public void testLuceneModeMinusPrefixNot() {
+        // Test: "-a" should be treated as NOT a (MUST_NOT with MATCH_ALL_DOCS injection)
+        String dsl = "-field:a";
+        String options = "{\"mode\":\"lucene\"}";
+        QsPlan plan = SearchDslParser.parseDsl(dsl, options);
+
+        Assertions.assertNotNull(plan);
+        Assertions.assertEquals(QsClauseType.OCCUR_BOOLEAN, plan.getRoot().getType());
+        Assertions.assertEquals(2, plan.getRoot().getChildren().size());
+        Assertions.assertEquals(QsClauseType.MATCH_ALL_DOCS, plan.getRoot().getChildren().get(0).getType());
+        Assertions.assertEquals(QsOccur.MUST_NOT, plan.getRoot().getChildren().get(1).getOccur());
+    }
+
+    @Test
+    public void testLuceneModeMinusPrefixMultiple() {
+        // Test: "-a -b" with default_operator=and
+        String dsl = "-field:a -field:b";
+        String options = "{\"mode\":\"lucene\",\"default_operator\":\"and\"}";
+        QsPlan plan = SearchDslParser.parseDsl(dsl, options);
+
+        Assertions.assertNotNull(plan);
+        Assertions.assertEquals(QsClauseType.OCCUR_BOOLEAN, plan.getRoot().getType());
+        // Both are MUST_NOT
+        long mustNotCount = plan.getRoot().getChildren().stream()
+                .filter(c -> c.getOccur() == QsOccur.MUST_NOT).count();
+        Assertions.assertTrue(mustNotCount >= 2, "Should have at least 2 MUST_NOT children");
+    }
+
+    @Test
+    public void testLuceneModePlusPrefixRequired() {
+        // Test: "+a b" - plus prefix forces MUST
+        String dsl = "+field:a field:b";
+        String options = "{\"mode\":\"lucene\"}";
+        QsPlan plan = SearchDslParser.parseDsl(dsl, options);
+
+        Assertions.assertNotNull(plan);
+        Assertions.assertEquals(QsClauseType.OCCUR_BOOLEAN, plan.getRoot().getType());
+        Assertions.assertEquals(2, plan.getRoot().getChildren().size());
+        Assertions.assertEquals(QsOccur.MUST, plan.getRoot().getChildren().get(0).getOccur());
+    }
+
+    @Test
+    public void testStandardModeMinusPrefix() {
+        // Test: "-a" in standard mode should parse as NOT
+        String dsl = "-field:a";
+        QsPlan plan = SearchDslParser.parseDsl(dsl);
+
+        Assertions.assertNotNull(plan);
+        // Standard mode: NOT wrapping
+        Assertions.assertEquals(QsClauseType.NOT, plan.getRoot().getType());
+    }
+
+    @Test
     public void testLuceneModeMinimumShouldMatchExplicit() {
         // Test: explicit minimum_should_match=1 keeps SHOULD clauses
         String dsl = "field:a AND field:b OR field:c";


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #60814

Problem Summary:
The search() function's DSL parser does not support `-` (minus/prohibited)
and `+` (plus/required) prefix modifiers, which are standard Lucene
query_string syntax supported by ES. Queries like `-apple` or `+apple fox`
fail to parse or produce incorrect results.

Fix: Add PLUS and MINUS lexer tokens and parser grammar alternatives.
Handle `-` as NOT/MUST_NOT and `+` as MUST in both standard and lucene
mode visitors.

Examples:
- `-apple` → MUST_NOT(apple) (same as `NOT apple`)
- `+apple fox` → MUST(apple) SHOULD(fox)
- `-apple -fox` → MUST_NOT(apple) MUST_NOT(fox) + MATCH_ALL_DOCS injection

### Release note

Support `-` (prohibited) and `+` (required) prefix modifiers in search() DSL, matching ES query_string syntax.

### Check List (For Author)

- Test
    - [x] Unit Test
    - [ ] Regression test
    - [ ] Manual test
    - [ ] No need to test

- Behavior changed:
    - [x] Yes. `-term` now parsed as NOT/MUST_NOT; `+term` parsed as required/MUST.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label