### PR TITLE
[opt](in list) remove redundant condition in camp_field

### DIFF
--- a/be/src/olap/in_list_predicate.h
+++ b/be/src/olap/in_list_predicate.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <roaring/roaring.hh>
 
+#include "common/compiler_util.h"
 #include "common/exception.h"
 #include "decimal12.h"
 #include "exprs/hybrid_set.h"
@@ -259,10 +260,8 @@ public:
 
     bool camp_field(const vectorized::Field& min_field, const vectorized::Field& max_field) const {
         if constexpr (PT == PredicateType::IN_LIST) {
-            return (Compare::less_equal(min_field.template get<Type>(), _max_value) &&
-                    Compare::greater_equal(max_field.template get<Type>(), _min_value)) ||
-                   (Compare::greater_equal(max_field.template get<Type>(), _min_value) &&
-                    Compare::less_equal(min_field.template get<Type>(), _max_value));
+            return Compare::less_equal(min_field.template get<Type>(), _max_value) &&
+                   Compare::greater_equal(max_field.template get<Type>(), _min_value);
         } else {
             return true;
         }
@@ -271,18 +270,19 @@ public:
     bool evaluate_and(vectorized::ParquetPredicate::ColumnStat* statistic) const override {
         bool result = true;
         if ((*statistic->get_stat_func)(statistic, column_id())) {
-            vectorized::Field min_field;
-            vectorized::Field max_field;
             if (statistic->is_all_null) {
                 result = false;
-            } else if (!vectorized::ParquetPredicate::parse_min_max_value(
-                                statistic->col_schema, statistic->encoded_min_value,
-                                statistic->encoded_max_value, *statistic->ctz, &min_field,
-                                &max_field)
-                                .ok()) [[unlikely]] {
-                result = true;
             } else {
-                result = camp_field(min_field, max_field);
+                vectorized::Field min_field;
+                vectorized::Field max_field;
+                auto st = vectorized::ParquetPredicate::parse_min_max_value(
+                        statistic->col_schema, statistic->encoded_min_value,
+                        statistic->encoded_max_value, *statistic->ctz, &min_field, &max_field);
+                if (LIKELY(st.ok())) {
+                    result = camp_field(min_field, max_field);
+                } else { // status is not ok, return true directly
+                    result = true;
+                }
             }
         }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

in camp_field function, this or condition is same, (A && B) or (B and A)

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

