### PR TITLE
[fix](insert-overwrite) skip deleted partitions before replace to avoid DdlException

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/insertoverwrite/InsertOverwriteUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/insertoverwrite/InsertOverwriteUtil.java
@@ -89,10 +89,21 @@ public class InsertOverwriteUtil {
                 if (!olapTable.writeLockIfExist()) {
                     return;
                 }
+                // Filter out partitions that were deleted between the snapshot time and now.
+                // The write lock is held here, so this check and the subsequent replace are atomic.
+                // The temp partition list is kept as-is so all written data remains visible.
+                List<String> validPartitionNames = new ArrayList<>();
+                for (int i = 0; i < partitionNames.size(); i++) {
+                    if (((OlapTable) olapTable).checkPartitionNameExist(partitionNames.get(i), false)) {
+                        validPartitionNames.add(partitionNames.get(i));
+                    } else {
+                        LOG.warn("partition [{}] has been deleted before replace, skipping", partitionNames.get(i));
+                    }
+                }
                 Map<String, String> properties = Maps.newHashMap();
                 properties.put(PropertyAnalyzer.PROPERTIES_USE_TEMP_PARTITION_NAME, "false");
                 ReplacePartitionOp replacePartitionOp = new ReplacePartitionOp(
-                        new PartitionNamesInfo(false, partitionNames),
+                        new PartitionNamesInfo(false, validPartitionNames),
                         new PartitionNamesInfo(true, tempPartitionNames), isForce, properties);
                 if (replacePartitionOp.getTempPartitionNames().isEmpty()) {
                     return;


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

When performing insert overwrite on a whole table, partition names are snapshotted at planning time without holding the table lock. A concurrent DROP PARTITION between the snapshot and the replace step causes Env.replaceTempPartition() to throw DdlException because the original partition no longer exists.

Fix: after acquiring the table write lock in InsertOverwriteUtil.replacePartition(), filter out any original partitions that have been deleted before constructing ReplacePartitionOp. The temp partition list is kept intact so all written data remains visible.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

