### PR TITLE
[Test](regression) Normalize labels for external table suites

### DIFF
--- a/regression-test/pipeline/external/conf/regression-conf.groovy
+++ b/regression-test/pipeline/external/conf/regression-conf.groovy
@@ -75,6 +75,7 @@ excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as th
     "test_profile," +
     "test_refresh_mtmv," +
     "test_spark_load," +
+    "test_paimon_gcs," +
     "test_broker_load_func," +
     "test_stream_stub_fault_injection," +
     "test_iceberg_overwrite_with_wrong_partition," +

--- a/regression-test/pipeline/external/conf/regression-conf.groovy
+++ b/regression-test/pipeline/external/conf/regression-conf.groovy
@@ -57,7 +57,7 @@ trinoPluginsPath = "/tmp/trino_connector"
 
 // will test <group>/<suite>.groovy
 // empty group will test all group
-testGroups = ""
+testGroups = "external"
 // empty suite will test all suite
 testSuites = ""
 // empty directories will test all directories

--- a/regression-test/suites/external_table_p0/broker_load/test_broker_load_func.groovy
+++ b/regression-test/suites/external_table_p0/broker_load/test_broker_load_func.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_broker_load_func", "p0,external,hive,external_docker,external_docker_hive,external_docker_broker") {
+suite("test_broker_load_func", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/cache/test_file_cache_features.groovy
+++ b/regression-test/suites/external_table_p0/cache/test_file_cache_features.groovy
@@ -30,7 +30,7 @@ final String INITIAL_VALUES_NOT_ZERO_CHECK_FAILED_MSG = FILE_CACHE_FEATURES_CHEC
 final String DISK_RESOURCE_LIMIT_MODE_TEST_FAILED_MSG = "Disk resource limit mode test failed"
 final String NEED_EVICT_CACHE_IN_ADVANCE_TEST_FAILED_MSG = "Need evict cache in advance test failed"
 
-suite("test_file_cache_features", "external_docker,hive,external_docker_hive,p0,external,nonConcurrent") {
+suite("test_file_cache_features", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/cache/test_file_cache_query_limit.groovy
+++ b/regression-test/suites/external_table_p0/cache/test_file_cache_query_limit.groovy
@@ -43,7 +43,7 @@ final String NORMAL_QUEUE_CURR_SIZE_NOT_GREATER_THAN_ZERO_MSG = FILE_CACHE_FEATU
 final String NORMAL_QUEUE_CURR_ELEMENTS_NOT_GREATER_THAN_ZERO_MSG = FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "normal_queue_curr_elements is not greater than 0 after cache operation"
 final String NORMAL_QUEUE_CURR_SIZE_GREATER_THAN_QUERY_CACHE_CAPACITY_MSG = FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "normal_queue_curr_size is greater than query cache capacity"
 
-suite("test_file_cache_query_limit", "external_docker,hive,external_docker_hive,p0,external,nonConcurrent") {
+suite("test_file_cache_query_limit", "p0,external") {
     String enableHiveTest = context.config.otherConfigs.get("enableHiveTest")
     if (enableHiveTest == null || !enableHiveTest.equalsIgnoreCase("true")) {
         logger.info("disable hive test.")

--- a/regression-test/suites/external_table_p0/cache/test_file_cache_query_limit_config.groovy
+++ b/regression-test/suites/external_table_p0/cache/test_file_cache_query_limit_config.groovy
@@ -23,7 +23,7 @@ import org.awaitility.Awaitility;
 final String ERROR_SQL_SUCCEED_MSG = "SQL should have failed but succeeded"
 final String SET_SESSION_VARIABLE_FAILED_MSG = "SQL set session variable failed"
 
-suite("test_file_cache_query_limit_config", "external_docker,hive,external_docker_hive,p0,external,nonConcurrent") {
+suite("test_file_cache_query_limit_config", "p0,external") {
 
     sql """set file_cache_query_limit_percent = 1"""
     def fileCacheQueryLimitPercentResult = sql """show variables like 'file_cache_query_limit_percent';"""

--- a/regression-test/suites/external_table_p0/cache/test_file_cache_statistics.groovy
+++ b/regression-test/suites/external_table_p0/cache/test_file_cache_statistics.groovy
@@ -41,7 +41,7 @@ final String INITIAL_TOTAL_READ_COUNTS_NOT_GREATER_THAN_0_MSG = HIT_AND_READ_COU
 final String TOTAL_HIT_COUNTS_DID_NOT_INCREASE_MSG = HIT_AND_READ_COUNTS_CHECK_FAILED_PREFIX + "total_hit_counts did not increase after cache operation"
 final String TOTAL_READ_COUNTS_DID_NOT_INCREASE_MSG = HIT_AND_READ_COUNTS_CHECK_FAILED_PREFIX + "total_read_counts did not increase after cache operation"
 
-suite("test_file_cache_statistics", "external_docker,hive,external_docker_hive,p0,external,nonConcurrent") {
+suite("test_file_cache_statistics", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/cache/test_hive_warmup_select.groovy
+++ b/regression-test/suites/external_table_p0/cache/test_hive_warmup_select.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_warmup_select", "p0,external,hive,external_docker,external_docker_hive,nonConcurrent") {
+suite("test_hive_warmup_select", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable Hive test.")

--- a/regression-test/suites/external_table_p0/dialect_compatible/sql/test_hive_view_rewrite.groovy
+++ b/regression-test/suites/external_table_p0/dialect_compatible/sql/test_hive_view_rewrite.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_view_rewrite", "external_docker,hive,external_docker_hive,p0,external") {
+suite("test_hive_view_rewrite", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/es/test_es_catalog_http_open_api.groovy
+++ b/regression-test/suites/external_table_p0/es/test_es_catalog_http_open_api.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_es_catalog_http_open_api", "p0,external,es,external_docker,external_docker_es") {
+suite("test_es_catalog_http_open_api", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableEsTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/es/test_es_flatten_type.groovy
+++ b/regression-test/suites/external_table_p0/es/test_es_flatten_type.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_es_flatten_type", "p0,external,es,external_docker,external_docker_es") {
+suite("test_es_flatten_type", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableEsTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/es/test_es_query.groovy
+++ b/regression-test/suites/external_table_p0/es/test_es_query.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_es_query", "p0,external,es,external_docker,external_docker_es") {
+suite("test_es_query", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableEsTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/es/test_es_query_nereids.groovy
+++ b/regression-test/suites/external_table_p0/es/test_es_query_nereids.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_es_query_nereids", "p0,external,es,external_docker,external_docker_es") {
+suite("test_es_query_nereids", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableEsTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/es/test_es_query_no_http_url.groovy
+++ b/regression-test/suites/external_table_p0/es/test_es_query_no_http_url.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_es_query_no_http_url", "p0,external,es,external_docker,external_docker_es") {
+suite("test_es_query_no_http_url", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableEsTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/export/hive_read/orc/test_hive_read_orc.groovy
+++ b/regression-test/suites/external_table_p0/export/hive_read/orc/test_hive_read_orc.groovy
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
 
-suite("test_hive_read_orc", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_read_orc", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/export/hive_read/orc/test_hive_read_orc_complex_type.groovy
+++ b/regression-test/suites/external_table_p0/export/hive_read/orc/test_hive_read_orc_complex_type.groovy
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
 
-suite("test_hive_read_orc_complex_type", "external,hive,external_docker") {
+suite("test_hive_read_orc_complex_type", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/export/hive_read/parquet/test_hive_read_parquet.groovy
+++ b/regression-test/suites/external_table_p0/export/hive_read/parquet/test_hive_read_parquet.groovy
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
 
-suite("test_hive_read_parquet", "external,hive,external_docker") {
+suite("test_hive_read_parquet", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/export/hive_read/parquet/test_hive_read_parquet_comlex_type.groovy
+++ b/regression-test/suites/external_table_p0/export/hive_read/parquet/test_hive_read_parquet_comlex_type.groovy
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
 
-suite("test_hive_read_parquet_complex_type", "external,hive,external_docker") {
+suite("test_hive_read_parquet_complex_type", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/export/test_export_external_table.groovy
+++ b/regression-test/suites/external_table_p0/export/test_export_external_table.groovy
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
 
-suite("test_export_external_table", "p0,external,mysql,external_docker,external_docker_mysql") {
+suite("test_export_external_table", "p0,external") {
     // open nereids
     sql """ set enable_nereids_planner=true """
     sql """ set enable_fallback_to_original_planner=false """

--- a/regression-test/suites/external_table_p0/export/test_hive_export_varbinary.groovy
+++ b/regression-test/suites/external_table_p0/export/test_hive_export_varbinary.groovy
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
 
-suite("test_hive_export_varbinary", "external,hive,external_docker") {
+suite("test_hive_export_varbinary", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_ctas.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_ctas.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_ctas", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_ctas", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_ddl.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_ddl.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_ddl", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_ddl", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         def file_formats = ["parquet", "orc"]

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_ddl_text_format.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_ddl_text_format.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_ddl_text_format", "p0,external,hive,external_docker,external_docker_hive,nonConcurrent") {
+suite("test_hive_ddl_text_format", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_drop_db.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_drop_db.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_drop_db", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_drop_db", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_show_create_table.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_show_create_table.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_show_create_table", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_show_create_table", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_truncate_table.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_truncate_table.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_truncate_table", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_truncate_table", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_write_type.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_write_type.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_write_type", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_write_type", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/hive_config_test.groovy
+++ b/regression-test/suites/external_table_p0/hive/hive_config_test.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("hive_config_test", "p0,external,hive,external_docker,external_docker_hive") {
+suite("hive_config_test", "p0,external") {
     String db_name = "regression_test_external_table_p0_hive"
     String internal_table = "hive_config_test"
     String catalog_name = "docker_hive"

--- a/regression-test/suites/external_table_p0/hive/hive_json_basic_test.groovy
+++ b/regression-test/suites/external_table_p0/hive/hive_json_basic_test.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("hive_json_basic_test",  "p0,external,hive,external_docker,external_docker_hive") {
+suite("hive_json_basic_test", "p0,external") {
 
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")

--- a/regression-test/suites/external_table_p0/hive/hive_tpch_sf1_orc.groovy
+++ b/regression-test/suites/external_table_p0/hive/hive_tpch_sf1_orc.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_catalog_hive_orc", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_catalog_hive_orc", "p0,external") {
 
     String enable_file_cache = "false"
 

--- a/regression-test/suites/external_table_p0/hive/hive_tpch_sf1_parquet.groovy
+++ b/regression-test/suites/external_table_p0/hive/hive_tpch_sf1_parquet.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_catalog_hive_parquet", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_catalog_hive_parquet", "p0,external") {
 
     String enable_file_cache = "false"
 

--- a/regression-test/suites/external_table_p0/hive/test_autoinc_broker_load.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_autoinc_broker_load.groovy
@@ -16,7 +16,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_autoinc_broker_load", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_autoinc_broker_load", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/hive/test_complex_types.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_complex_types.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_complex_types", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_complex_types", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_different_column_orders.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_different_column_orders.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_different_column_orders", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_different_column_orders", "p0,external") {
     def q_parquet = {
         qt_q01 """
         select * from test_different_column_orders_parquet order by id;

--- a/regression-test/suites/external_table_p0/hive/test_different_parquet_types.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_different_parquet_types.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_different_parquet_types", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_different_parquet_types", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_drop_expired_table_stats.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_drop_expired_table_stats.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_drop_expired_table_stats", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_drop_expired_table_stats", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_external_catalog_hive.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_external_catalog_hive.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_external_catalog_hive", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_external_catalog_hive", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_external_catalog_hive_partition.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_external_catalog_hive_partition.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_external_catalog_hive_partition", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_external_catalog_hive_partition", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_external_credit_data.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_external_credit_data.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_external_credit_data", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_external_credit_data", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_external_sql_block_rule.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_external_sql_block_rule.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_external_sql_block_rule", "external_docker,hive,external_docker_hive,p0,external") {
+suite("test_external_sql_block_rule", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_file_meta_cache.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_file_meta_cache.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_file_meta_cache", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_file_meta_cache", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/hive/test_hive_analyze_db.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_analyze_db.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
- suite("test_hive_analyze_db", "p0,external,hive,external_docker,external_docker_hive") {
+ suite("test_hive_analyze_db", "p0,external") {
 
      def verify_column_stats_result = { column, result, count, ndv, nulls, size, avg_size, min, max ->
          def found = false;

--- a/regression-test/suites/external_table_p0/hive/test_hive_basic_type.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_basic_type.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_basic_type", "external_docker,hive,external_docker_hive,p0,external") {
+suite("test_hive_basic_type", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hive_broker_scan.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_broker_scan.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_broker_scan", "p0,external,hive,external_docker,external_docker_hive,external_docker_broker") {
+suite("test_hive_broker_scan", "p0,external") {
 
     def q01 = {
         qt_q01 """

--- a/regression-test/suites/external_table_p0/hive/test_hive_case_sensibility.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_case_sensibility.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_case_sensibility", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_hive_case_sensibility", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         return;

--- a/regression-test/suites/external_table_p0/hive/test_hive_compress_type.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_compress_type.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 
-suite("test_hive_compress_type", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_compress_type", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hive_default_partition.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_default_partition.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_default_partition", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_default_partition", "p0,external") {
     def one_partition1 = """select * from one_partition order by id;"""
     def one_partition2 = """select id, part1 from one_partition where part1 is null order by id;"""
     def one_partition3 = """select id from one_partition where part1 is not null order by id;"""

--- a/regression-test/suites/external_table_p0/hive/test_hive_get_schema_from_table.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_get_schema_from_table.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_get_schema_from_table", "external_docker,hive,external_docker_hive,p0,external") {
+suite("test_hive_get_schema_from_table", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hive_meta_cache.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_meta_cache.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_meta_cache", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_meta_cache", "p0,external") {
     String catalog_name = "test_hive_meta_cache"
     String catalog_name_no_cache = "test_hive_meta_no_cache"
 

--- a/regression-test/suites/external_table_p0/hive/test_hive_metadata_refresh_interval.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_metadata_refresh_interval.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_metadata_refresh_interval", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_metadata_refresh_interval", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/hive/test_hive_openx_json.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_openx_json.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_openx_json",  "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_openx_json", "p0,external") {
 
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")

--- a/regression-test/suites/external_table_p0/hive/test_hive_opt_fill_partition.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_opt_fill_partition.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 
-suite("test_hive_opt_fill_partition", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_opt_fill_partition", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String hivePrefix  ="hive3";

--- a/regression-test/suites/external_table_p0/hive/test_hive_orc.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_orc.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_orc", "all_types,p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_orc", "p0,external") {
     // Ensure that all types are parsed correctly
     def select_top50 = {
         qt_select_top50 """select * from orc_all_types order by int_col desc limit 50;"""

--- a/regression-test/suites/external_table_p0/hive/test_hive_orc_add_column.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_orc_add_column.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_orc_add_column", "all_types,p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_orc_add_column", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/hive/test_hive_orc_predicate.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_orc_predicate.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_orc_predicate", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_orc_predicate", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/hive/test_hive_other.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_other.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_other", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_other", "p0,external") {
 
     def q01 = {
         qt_q24 """ select name, count(1) as c from student group by name order by name desc;"""

--- a/regression-test/suites/external_table_p0/hive/test_hive_page_index.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_page_index.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_page_index", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_page_index", "p0,external") {
 
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")

--- a/regression-test/suites/external_table_p0/hive/test_hive_parquet.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_parquet.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_parquet", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_parquet", "p0,external") {
     def q01 = {
         qt_q01 """
         select * from partition_table order by l_orderkey, l_partkey, l_suppkey;

--- a/regression-test/suites/external_table_p0/hive/test_hive_parquet_add_column.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_parquet_add_column.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_parquet_add_column", "all_types,p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_parquet_add_column", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/hive/test_hive_parquet_alter_column.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_parquet_alter_column.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_parquet_alter_column", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_parquet_alter_column", "p0,external") {
     if (true) {
         //Turn off this test for now, I may delete this case or modify it later.
         return;

--- a/regression-test/suites/external_table_p0/hive/test_hive_parquet_skip_page.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_parquet_skip_page.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_parquet_skip_page", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_parquet_skip_page", "p0,external") {
     def q01 = {
         qt_q01 """
         select * from lineitem where l_orderkey  < 1000 order by l_orderkey,l_partkey limit 10;

--- a/regression-test/suites/external_table_p0/hive/test_hive_partition_column_analyze.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_partition_column_analyze.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_partition_column_analyze", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_partition_column_analyze", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hive_partition_location.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_partition_location.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_partition_location", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_partition_location", "p0,external") {
     def one_partition1 = """select * from partition_location_1 order by id;"""
     def one_partition2 = """select * from partition_location_1 where part='part1';"""
     def one_partition3 = """select * from partition_location_1 where part='part2';"""

--- a/regression-test/suites/external_table_p0/hive/test_hive_partition_values_tvf.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_partition_values_tvf.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_partition_values_tvf", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_partition_values_tvf", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hive_partitions.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_partitions.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_partitions", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_partitions", "p0,external") {
     def q01 = {
         qt_q01 """
         select id, data from table_with_pars where dt_par = '2023-02-01' order by id;

--- a/regression-test/suites/external_table_p0/hive/test_hive_query_cache.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_query_cache.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_query_cache", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_query_cache", "p0,external") {
     withGlobalLock("cache_last_version_interval_second") {
         def assertHasCache = { String sqlStr ->
             explain {

--- a/regression-test/suites/external_table_p0/hive/test_hive_remove_partition.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_remove_partition.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_remove_partition", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_remove_partition", "p0,external") {
     def case1 = """select * from partition_manual_remove order by id;"""
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")

--- a/regression-test/suites/external_table_p0/hive/test_hive_rename_column_orc_parquet.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_rename_column_orc_parquet.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 
-suite("test_hive_rename_column_orc_parquet", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_rename_column_orc_parquet", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String hivePrefix  ="hive3";

--- a/regression-test/suites/external_table_p0/hive/test_hive_runtime_filter_partition_pruning.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_runtime_filter_partition_pruning.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_runtime_filter_partition_pruning", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_runtime_filter_partition_pruning", "p0,external") {
     def test_runtime_filter_partition_pruning = {
         qt_runtime_filter_partition_pruning_decimal1 """
             select count(*) from decimal_partition_table where partition_col =

--- a/regression-test/suites/external_table_p0/hive/test_hive_same_db_table_name.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_same_db_table_name.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_same_db_table_name", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_same_db_table_name", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hive_schema_change.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_schema_change.groovy
@@ -89,7 +89,7 @@ alter table type_change_parquet change column fd_double fd_double double;
 alter table type_change_parquet change column date_timestamp date_timestamp timestamp;
 alter table type_change_parquet change column timestamp_date timestamp_date date;
 */
-suite("test_hive_schema_change", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_schema_change", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         for (String hivePrefix : ["hive2", "hive3"]) {

--- a/regression-test/suites/external_table_p0/hive/test_hive_schema_change_orc.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_schema_change_orc.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_schema_change_orc", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_schema_change_orc", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         for (String hivePrefix : ["hive3"]) {

--- a/regression-test/suites/external_table_p0/hive/test_hive_schema_change_parquet.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_schema_change_parquet.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_schema_change_parquet", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_schema_change_parquet", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         for (String hivePrefix : ["hive3"]) {

--- a/regression-test/suites/external_table_p0/hive/test_hive_schema_evolution.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_schema_evolution.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_schema_evolution", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_schema_evolution", "p0,external") {
     def q_text = {
         qt_q01 """
         select * from schema_evo_test_text order by id;

--- a/regression-test/suites/external_table_p0/hive/test_hive_serde_prop.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_serde_prop.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_serde_prop", "external_docker,hive,external_docker_hive,p0,external") {
+suite("test_hive_serde_prop", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hive_special_char_partition.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_special_char_partition.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_special_char_partition", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_special_char_partition", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hive_star_qualifier.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_star_qualifier.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_star_qualifier", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_star_qualifier", "p0,external") {
     String catalog_name = "test_hive_star_qualifier"
 
     def test1 = """select * from ${catalog_name}.multi_catalog.one_partition order by id;"""

--- a/regression-test/suites/external_table_p0/hive/test_hive_statistic.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_statistic.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_statistic", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_statistic", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hive_statistic_auto.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_statistic_auto.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_statistic_auto", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_statistic_auto", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hive_statistic_clean.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_statistic_clean.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_statistic_clean", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_statistic_clean", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hive_statistic_timeout.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_statistic_timeout.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_statistic_timeout", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_statistic_timeout", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hive_statistics_all_type_p0.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_statistics_all_type_p0.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_statistics_all_type_p0", "all_types,p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_statistics_all_type_p0", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hive_statistics_p0.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_statistics_p0.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_statistics_p0", "all_types,p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_statistics_p0", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hive_struct_add_column.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_struct_add_column.groovy
@@ -17,7 +17,7 @@
 
 
 
-suite("test_hive_struct_add_column", "all_types,p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_struct_add_column", "p0,external") {
 
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")

--- a/regression-test/suites/external_table_p0/hive/test_hive_tablesample_p0.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_tablesample_p0.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_tablesample_p0", "all_types,p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_tablesample_p0", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/hive/test_hive_text_complex_type.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_text_complex_type.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_text_complex_type", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_text_complex_type", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (!"true".equalsIgnoreCase(enabled)) {
         return;

--- a/regression-test/suites/external_table_p0/hive/test_hive_to_array.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_to_array.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_to_array", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_to_array", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hive_to_date.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_to_date.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_to_date", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_to_date", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hive_topn_lazy_mat.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_topn_lazy_mat.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_topn_lazy_mat", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_topn_lazy_mat", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hive_topn_rf_null.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_topn_rf_null.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_topn_rf_null", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_topn_rf_null", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hive_use_meta_cache_false.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_use_meta_cache_false.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_use_meta_cache_false", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_use_meta_cache_false", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/hive/test_hive_use_meta_cache_true.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_use_meta_cache_true.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_use_meta_cache_true", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_use_meta_cache_true", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/hive/test_hive_varbinary_type.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_varbinary_type.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 
-suite("test_hive_varbinary_type","p0,external,tvf,hive,external_docker,external_docker_hive") {
+suite("test_hive_varbinary_type", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hive_view.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_view.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_view", "external_docker,hive,external_docker_hive,p0,external") {
+suite("test_hive_view", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hms_event_notification.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hms_event_notification.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hms_event_notification", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hms_event_notification", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_hms_event_notification_multi_catalog.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hms_event_notification_multi_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hms_event_notification_multi_catalog", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hms_event_notification_multi_catalog", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_information_schema_external.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_information_schema_external.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_information_schema_external", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_information_schema_external", "p0,external") {
     // test  schemata 、columns、files、metadata_name_ids、partitions、tables、views
     //files  partitions no imp 
 

--- a/regression-test/suites/external_table_p0/hive/test_mixed_par_locations.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_mixed_par_locations.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_mixed_par_locations", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_mixed_par_locations", "p0,external") {
 
     def formats = ["_parquet", "_orc"]
     def q1 = """select * from test_mixed_par_locationsSUFFIX order by id;"""

--- a/regression-test/suites/external_table_p0/hive/test_multi_delimit_serde.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_multi_delimit_serde.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_multi_delimit_serde", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_multi_delimit_serde", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_multi_langs.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_multi_langs.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_multi_langs", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_multi_langs", "p0,external") {
 
     def formats = ["_parquet", "_orc", "_text"]
     def q1 = """select * from test_chineseSUFFIX where col1='是' order by id"""

--- a/regression-test/suites/external_table_p0/hive/test_open_csv_serde.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_open_csv_serde.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 
-suite("test_open_csv_serde","p0,external,tvf,hive,external_docker,external_docker_hive") {
+suite("test_open_csv_serde", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_orc_lazy_mat_profile.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_orc_lazy_mat_profile.groovy
@@ -17,7 +17,7 @@
 
 import groovy.json.JsonSlurper
 
-suite("test_orc_lazy_mat_profile", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_orc_lazy_mat_profile", "p0,external") {
     def getProfileList = {
         def dst = 'http://' + context.config.feHttpAddress
         def conn = new URL(dst + "/rest/v1/query_profile").openConnection()

--- a/regression-test/suites/external_table_p0/hive/test_orc_nested_types.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_orc_nested_types.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_orc_nested_types", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_orc_nested_types", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_orc_tiny_stripes.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_orc_tiny_stripes.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_orc_tiny_stripes", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_orc_tiny_stripes", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/hive/test_parquet_bloom_filter.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_parquet_bloom_filter.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_parquet_bloom_filter", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_parquet_bloom_filter", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (!"true".equalsIgnoreCase(enabled)) {
         return;

--- a/regression-test/suites/external_table_p0/hive/test_parquet_join_runtime_filter.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_parquet_join_runtime_filter.groovy
@@ -17,7 +17,7 @@
 
 import groovy.json.JsonSlurper
 
-suite("test_parquet_join_runtime_filter", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_parquet_join_runtime_filter", "p0,external") {
 
     def getProfileList = {
         def dst = 'http://' + context.config.feHttpAddress

--- a/regression-test/suites/external_table_p0/hive/test_parquet_lazy_mat_profile.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_parquet_lazy_mat_profile.groovy
@@ -18,7 +18,7 @@
 import java.util.regex.Pattern
 import groovy.json.JsonSlurper
 
-suite("test_parquet_lazy_mat_profile", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_parquet_lazy_mat_profile", "p0,external") {
 
 
     def getProfileList = {

--- a/regression-test/suites/external_table_p0/hive/test_parquet_nested_types.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_parquet_nested_types.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_parquet_nested_types", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_parquet_nested_types", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_partial_update_broker_load.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_partial_update_broker_load.groovy
@@ -16,7 +16,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_primary_key_partial_update_broker_load", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_primary_key_partial_update_broker_load", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/hive/test_prepare_hive_data_in_case.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_prepare_hive_data_in_case.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_prepare_hive_data_in_case", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_prepare_hive_data_in_case", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/hive/test_special_orc_formats.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_special_orc_formats.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_special_orc_formats", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_special_orc_formats", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_string_dict_filter.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_string_dict_filter.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_string_dict_filter", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_string_dict_filter", "p0,external") {
     def q_parquet = {
         qt_q01 """
         select * from test_string_dict_filter_parquet where o_orderstatus = 'F';

--- a/regression-test/suites/external_table_p0/hive/test_text_garbled_file.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_text_garbled_file.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_text_garbled_file", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_text_garbled_file", "p0,external") {
     //test hive garbled files  , prevent be hanged
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")

--- a/regression-test/suites/external_table_p0/hive/test_text_skip_header.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_text_skip_header.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 
-suite("test_hive_text_skip_header","p0,external,tvf,hive,external_docker,external_docker_hive") {
+suite("test_hive_text_skip_header", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_transactional_hive.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_transactional_hive.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_transactional_hive", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_transactional_hive", "p0,external") {
     String skip_checking_acid_version_file = "false"
 
     def q01 = {

--- a/regression-test/suites/external_table_p0/hive/test_truncate_char_or_varchar_columns.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_truncate_char_or_varchar_columns.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_truncate_char_or_varchar_columns", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_truncate_char_or_varchar_columns", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_upper_case_column_name.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_upper_case_column_name.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_upper_case_column_name", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_upper_case_column_name", "p0,external") {
     def hiveParquet1 = """select * from hive_upper_case_parquet;"""
     def hiveParquet2 = """select * from hive_upper_case_parquet where id=1;"""
     def hiveParquet3 = """select * from hive_upper_case_parquet where id>1;"""

--- a/regression-test/suites/external_table_p0/hive/test_utf8_check.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_utf8_check.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 
-suite("test_utf8_check","p0,external,tvf,hive,external_docker,external_docker_hive") {
+suite("test_utf8_check", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable Hive test.")

--- a/regression-test/suites/external_table_p0/hive/test_wide_table.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_wide_table.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_wide_table", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_wide_table", "p0,external") {
 
     def formats = ["_orc"]
     def decimal_test1 = """select col1, col70, col71, col81, col100, col534 from wide_table1SUFFIX where col1 is not null order by col1 limit 1;"""

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_ctas_to_doris.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_ctas_to_doris.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_ctas_to_doris", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_ctas_to_doris", "p0,external") {
 
     for (String hivePrefix : ["hive2"]) {
 

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_insert_overwrite_with_empty_table.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_insert_overwrite_with_empty_table.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_insert_overwrite_with_empty_table", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_insert_overwrite_with_empty_table", "p0,external") {
 
     for (String hivePrefix : ["hive2"]) {
 

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_staging_dir.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_staging_dir.groovy
@@ -20,7 +20,7 @@ import org.apache.hadoop.fs.Path
 
 import java.net.URI
 
-suite("test_hive_staging_dir", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_staging_dir", "p0,external") {
     def getHiveTableLocation = { String db, String tbl ->
         def rows = hive_docker """describe formatted `${db}`.`${tbl}`"""
         for (def row : rows) {

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_text_write_insert.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_text_write_insert.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_text_write_insert", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_text_write_insert", "p0,external") {
     def q01 = { String format_compression, String catalog_name ->
         logger.info("hive sql: " + """ truncate table all_types_text; """)
         hive_docker """ truncate table all_types_text; """

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_write_different_path.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_write_different_path.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_write_different_path", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_write_different_path", "p0,external") {
 
     for (String hivePrefix : ["hive2", "hive3"]) {
 

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_write_insert.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_write_insert.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_write_insert", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_write_insert", "p0,external") {
     def format_compressions = ["parquet_snappy", "orc_zlib"]
 
     def q01 = { String format_compression, String catalog_name ->

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_write_partitions.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_write_partitions.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_write_partitions", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_hive_write_partitions", "p0,external") {
     def format_compressions = ["parquet_snappy", "orc_zlib"]
 
     def q01 = { String format_compression, String catalog_name ->

--- a/regression-test/suites/external_table_p0/iceberg/action/test_iceberg_execute_actions.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/action/test_iceberg_execute_actions.groovy
@@ -21,7 +21,7 @@ import java.time.temporal.ChronoField
 import java.time.LocalDateTime
 import java.time.ZoneId
 
-suite("test_iceberg_optimize_actions_ddl", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_optimize_actions_ddl", "p0,external") {
     DateTimeFormatter unifiedFormatter = new DateTimeFormatterBuilder()
             .appendPattern("yyyy-MM-dd")
             .optionalStart()

--- a/regression-test/suites/external_table_p0/iceberg/action/test_iceberg_expire_snapshots.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/action/test_iceberg_expire_snapshots.groovy
@@ -22,7 +22,7 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import groovy.json.JsonSlurper
 
-suite("test_iceberg_expire_snapshots", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_expire_snapshots", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/action/test_iceberg_rewrite_data_files.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/action/test_iceberg_rewrite_data_files.groovy
@@ -21,7 +21,7 @@ import java.time.temporal.ChronoField
 import java.time.LocalDateTime
 import java.time.ZoneId
 
-suite("test_iceberg_rewrite_data_files", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_rewrite_data_files", "p0,external") {
     DateTimeFormatter unifiedFormatter = new DateTimeFormatterBuilder()
             .appendPattern("yyyy-MM-dd")
             .optionalStart()

--- a/regression-test/suites/external_table_p0/iceberg/action/test_iceberg_rewrite_data_files_expression_conversion.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/action/test_iceberg_rewrite_data_files_expression_conversion.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_rewrite_data_files_expression_conversion", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_rewrite_data_files_expression_conversion", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/action/test_iceberg_rewrite_data_files_parallelism.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/action/test_iceberg_rewrite_data_files_parallelism.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_rewrite_data_files_parallelism", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_rewrite_data_files_parallelism", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/action/test_iceberg_rewrite_data_files_where_conditions.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/action/test_iceberg_rewrite_data_files_where_conditions.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_rewrite_data_files_where_conditions", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_rewrite_data_files_where_conditions", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/action/test_iceberg_rewrite_manifests.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/action/test_iceberg_rewrite_manifests.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_rewrite_manifests", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_rewrite_manifests", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/branch_tag/iceberg_branch_complex_queries.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/branch_tag/iceberg_branch_complex_queries.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_branch_complex_queries", "p0,external,doris,external_docker,external_docker_doris,branch_tag") {
+suite("iceberg_branch_complex_queries", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/branch_tag/iceberg_branch_cross_operations.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/branch_tag/iceberg_branch_cross_operations.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_branch_cross_operations", "p0,external,doris,external_docker,external_docker_doris,branch_tag") {
+suite("iceberg_branch_cross_operations", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/branch_tag/iceberg_branch_partition_operations.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/branch_tag/iceberg_branch_partition_operations.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_branch_partition_operations", "p0,external,doris,external_docker,external_docker_doris,branch_tag") {
+suite("iceberg_branch_partition_operations", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/branch_tag/iceberg_branch_retention_and_snapshot.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/branch_tag/iceberg_branch_retention_and_snapshot.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_branch_retention_and_snapshot", "p0,external,doris,external_docker,external_docker_doris,branch_tag") {
+suite("iceberg_branch_retention_and_snapshot", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/branch_tag/iceberg_branch_tag_auth.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/branch_tag/iceberg_branch_tag_auth.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_branch_tag_auth", "p0,external_docker,external,branch_tag") {
+suite("iceberg_branch_tag_auth", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/branch_tag/iceberg_branch_tag_edge_cases.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/branch_tag/iceberg_branch_tag_edge_cases.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_branch_tag_edge_cases", "p0,external,doris,external_docker,external_docker_doris,branch_tag") {
+suite("iceberg_branch_tag_edge_cases", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/branch_tag/iceberg_branch_tag_parallel_op.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/branch_tag/iceberg_branch_tag_parallel_op.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_branch_tag_parallel_op", "p2,external,branch_tag") {
+suite("iceberg_branch_tag_parallel_op", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/branch_tag/iceberg_branch_tag_schema_change_extended.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/branch_tag/iceberg_branch_tag_schema_change_extended.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_branch_tag_schema_change_extended", "p0,external,doris,external_docker,external_docker_doris,branch_tag") {
+suite("iceberg_branch_tag_schema_change_extended", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/branch_tag/iceberg_branch_tag_system_tables.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/branch_tag/iceberg_branch_tag_system_tables.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_branch_tag_system_tables", "p0,external,doris,external_docker,external_docker_doris,branch_tag") {
+suite("iceberg_branch_tag_system_tables", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/branch_tag/iceberg_tag_retention_and_consistency.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/branch_tag/iceberg_tag_retention_and_consistency.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_tag_retention_and_consistency", "p0,external,doris,external_docker,external_docker_doris,branch_tag") {
+suite("iceberg_tag_retention_and_consistency", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/iceberg_and_internal_nested_namespace.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/iceberg_and_internal_nested_namespace.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_and_internal_nested_namespace", "p0,external,doris,external_docker,external_docker_doris") {
+suite("iceberg_and_internal_nested_namespace", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/iceberg_branch_insert_data.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/iceberg_branch_insert_data.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_branch_insert_data", "p0,external,doris,external_docker,external_docker_doris") {
+suite("iceberg_branch_insert_data", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/iceberg_branch_tag_operate.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/iceberg_branch_tag_operate.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_branch_tag_operate", "p0,external,doris,external_docker,external_docker_doris,branch_tag") {
+suite("iceberg_branch_tag_operate", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/iceberg_complex_type.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/iceberg_complex_type.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_complex_type", "p0,external,doris,external_docker,external_docker_doris") {
+suite("iceberg_complex_type", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/iceberg_drop_rest_table.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/iceberg_drop_rest_table.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_drop_rest_table", "p0,external,doris,external_docker,external_docker_doris") {
+suite("iceberg_drop_rest_table", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/iceberg_partition_upper_case_nereids.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/iceberg_partition_upper_case_nereids.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_partition_upper_case_nereids", "p0,external,doris,external_docker,external_docker_doris") {
+suite("iceberg_partition_upper_case_nereids", "p0,external") {
     def orc_upper1 = """select * from iceberg_partition_upper_case_orc order by k1;"""
     def orc_upper2 = """select k1, city from iceberg_partition_upper_case_orc order by k1;"""
     def orc_upper3 = """select k1, k2 from iceberg_partition_upper_case_orc order by k1;"""

--- a/regression-test/suites/external_table_p0/iceberg/iceberg_query_tag_branch.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/iceberg_query_tag_branch.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_query_tag_branch", "p0,external,doris,external_docker,external_docker_doris,branch_tag") {
+suite("iceberg_query_tag_branch", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/iceberg_read_unitycatalog_table.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/iceberg_read_unitycatalog_table.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_read_unitycatalog_table", "p0,external,doris,external_docker,external_docker_doris") {
+suite("iceberg_read_unitycatalog_table", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/iceberg_schema_change.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/iceberg_schema_change.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_schema_change", "p0,external,doris,external_docker,external_docker_doris") {
+suite("iceberg_schema_change", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/iceberg_schema_change2.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/iceberg_schema_change2.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_schema_change2", "p0,external,doris,external_docker,external_docker_doris") {
+suite("iceberg_schema_change2", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/iceberg_schema_change_ddl.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/iceberg_schema_change_ddl.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_schema_change_ddl", "p0,external,doris,external_docker,external_docker_doris") {
+suite("iceberg_schema_change_ddl", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/iceberg_schema_change_ddl_with_branch.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/iceberg_schema_change_ddl_with_branch.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_schema_change_ddl_with_branch", "p0,external,doris,external_docker,external_docker_doris") {
+suite("iceberg_schema_change_ddl_with_branch", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/test_external_catalog_iceberg_common.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_external_catalog_iceberg_common.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_external_catalog_iceberg_common", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_external_catalog_iceberg_common", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/test_external_catalog_iceberg_partition.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_external_catalog_iceberg_partition.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_external_catalog_iceberg_partition", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_external_catalog_iceberg_partition", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/test_gen_iceberg_by_api.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_gen_iceberg_by_api.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_gen_iceberg_by_api", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_gen_iceberg_by_api", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_deletion_vector.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_deletion_vector.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_deletion_vector", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_deletion_vector", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_drop_db.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_drop_db.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_drop_db", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_drop_db", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_equality_delete.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_equality_delete.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_equality_delete", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_equality_delete", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_export_timestamp_tz.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_export_timestamp_tz.groovy
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
 
-suite("test_iceberg_export_timestamp_tz", "external,hive,external_docker") {
+suite("test_iceberg_export_timestamp_tz", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_filter.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_filter.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_filter", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_filter", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         try {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_full_schema_change.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_full_schema_change.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_full_schema_change", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_full_schema_change", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_hadoop_case_sensibility.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_hadoop_case_sensibility.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_hadoop_case_sensibility", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_hadoop_case_sensibility", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         return;

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_hms_case_sensibility.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_hms_case_sensibility.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_hms_case_sensibility", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_hms_case_sensibility", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         return;

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_invaild_avro_name.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_invaild_avro_name.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_invaild_avro_name", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_invaild_avro_name", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_jdbc_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_jdbc_catalog", "p0,external,iceberg,external_docker,external_docker_iceberg") {
+suite("test_iceberg_jdbc_catalog", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("Iceberg test is not enabled, skip this test")

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_manifest_cache.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_manifest_cache.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_manifest_cache", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_manifest_cache", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String restPort = context.config.otherConfigs.get("iceberg_rest_uri_port")

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_optimize_count.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_optimize_count.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_optimize_count", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_optimize_count", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         return

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_partition_evolution.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_partition_evolution.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_partition_evolution", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_partition_evolution", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_partition_evolution_ddl.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_partition_evolution_ddl.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_partition_evolution_ddl", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_partition_evolution_ddl", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_partition_evolution_query_write.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_partition_evolution_query_write.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_partition_evolution_query_write", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_partition_evolution_query_write", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_position_delete.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_position_delete.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_position_delete", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_position_delete", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_predicate_conversion.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_predicate_conversion.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_predicate_conversion", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_predicate_conversion", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("diable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_read_with_posdelete.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_read_with_posdelete.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_read_with_delete", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_read_with_delete", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         try {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_rest_case_sensibility.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_rest_case_sensibility.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_rest_case_sensibility", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_rest_case_sensibility", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         return;

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_runtime_filter_partition_pruning.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_runtime_filter_partition_pruning.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_runtime_filter_partition_pruning", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_runtime_filter_partition_pruning", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_runtime_filter_partition_pruning_transform.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_runtime_filter_partition_pruning_transform.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_runtime_filter_partition_pruning_transform", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_runtime_filter_partition_pruning_transform", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_schema_change_with_branch_tag.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_schema_change_with_branch_tag.groovy
@@ -17,7 +17,7 @@
 
 
 
-suite("iceberg_schema_change_with_branch_tag", "p0,external,doris,external_docker,external_docker_doris") {
+suite("iceberg_schema_change_with_branch_tag", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_schema_change_with_timetravel.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_schema_change_with_timetravel.groovy
@@ -17,7 +17,7 @@
 
 
 
-suite("iceberg_schema_change_with_timetravel", "p0,external,doris,external_docker,external_docker_doris") {
+suite("iceberg_schema_change_with_timetravel", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_show_create.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_show_create.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_show_create", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_show_create", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_sql_block_rule.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_sql_block_rule.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_sql_block_rule", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_sql_block_rule", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_statistics.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_statistics.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_statistics", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_statistics", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         try {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_struct_schema_evolution.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_struct_schema_evolution.groovy
@@ -27,7 +27,7 @@
 // Prerequisites: 
 // - Tables created by run24.sql in docker iceberg scripts
 
-suite("test_iceberg_struct_schema_evolution", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_struct_schema_evolution", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_sys_table.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_sys_table.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_sys_table", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_sys_table", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_sys_table_auth.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_sys_table_auth.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_sys_table_auth", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_sys_table_auth", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_table_cache.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_table_cache.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_table_cache", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_table_cache", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_table_meta_cache.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_table_meta_cache.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_table_meta_cache", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_table_meta_cache", "p0,external") {
     String catalog_name = "test_iceberg_meta_cache"
     String catalog_name_no_cache = "test_iceberg_meta_no_cache"
 

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_table_stats.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_table_stats.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_table_stats", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_table_stats", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         try {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_time_travel.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_time_travel.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_time_travel", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_time_travel", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_timestamp_tz.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_timestamp_tz.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_timestamp_tz", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_timestamp_tz", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_transform_partitions.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_transform_partitions.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_transform_partitions", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_transform_partitions", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_upper_case_column_name.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_upper_case_column_name.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_upper_case_column_name", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_upper_case_column_name", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_varbinary.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_varbinary.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_varbinary", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_varbinary", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_view_query_p0.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_view_query_p0.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_view_query_p0", "p0,external,iceberg,external_docker,external_docker_iceberg") {
+suite("test_iceberg_view_query_p0", "p0,external") {
 
     String enableIcebergTest = context.config.otherConfigs.get("enableIcebergTest")
     // if (enableIcebergTest == null || !enableIcebergTest.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_create_table.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_create_table.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_create_table", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_create_table", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_insert_overwrite.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_insert_overwrite.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_insert_overwrite", "p0,external,iceberg,external_docker,external_docker_iceberg") {
+suite("test_iceberg_insert_overwrite", "p0,external") {
     def format_compressions = ["parquet_zstd", "orc_zlib"]
 
     def q01 = { String format_compression, String catalog_name ->

--- a/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_insert_overwrite_with_empty_table.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_insert_overwrite_with_empty_table.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_insert_overwrite_with_empty_table", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_insert_overwrite_with_empty_table", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_overwrite_with_wrong_partition.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_overwrite_with_wrong_partition.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_overwrite_with_wrong_partition", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_iceberg_overwrite_with_wrong_partition", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_static_partition_overwrite.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_static_partition_overwrite.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_static_partition_overwrite", "p0,external,iceberg,external_docker,external_docker_iceberg") {
+suite("test_iceberg_static_partition_overwrite", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_support_char_varchar.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_support_char_varchar.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_support_char_varchar", "p0,external,iceberg,external_docker,external_docker_iceberg") {
+suite("test_iceberg_support_char_varchar", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable hive test.")

--- a/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_write_insert.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_write_insert.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_write_insert", "p0,external,iceberg,external_docker,external_docker_iceberg") {
+suite("test_iceberg_write_insert", "p0,external") {
     def format_compressions = ["parquet_zstd", "orc_zlib"]
 
     def q01 = { String format_compression, String catalog_name ->

--- a/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_write_partitions.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_write_partitions.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_write_partitions", "p0,external,iceberg,external_docker,external_docker_iceberg") {
+suite("test_iceberg_write_partitions", "p0,external") {
     def format_compressions = ["parquet_snappy", "orc_zlib"]
 
     def q01 = { String format_compression, String catalog_name, String hive_catalog_name ->

--- a/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_write_stats2.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_write_stats2.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_write_stats2", "p0,external,iceberg,external_docker,external_docker_iceberg") {
+suite("test_iceberg_write_stats2", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_write_timestamp_ntz.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_write_timestamp_ntz.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_write_timestamp_ntz", "p0,external,iceberg,external_docker,external_docker_iceberg") { 
+suite("test_iceberg_write_timestamp_ntz", "p0,external") { 
     
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_write_transform_partitions.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/write/test_iceberg_write_transform_partitions.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_write_transform_partitions", "p0,external,iceberg,external_docker,external_docker_iceberg") {
+suite("test_iceberg_write_transform_partitions", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable iceberg test.")

--- a/regression-test/suites/external_table_p0/info_schema_db/backend_tablets.groovy
+++ b/regression-test/suites/external_table_p0/info_schema_db/backend_tablets.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("backend_tablets", "p0, external_table,information_schema,backend_tablets") {
+suite("backend_tablets", "p0,external") {
     if (!isCloudMode()) {
         def dbName = "test_backend_tablets_db"
         def tbName1 = "test_backend_tablets_1"

--- a/regression-test/suites/external_table_p0/info_schema_db/backend_tablets.groovy
+++ b/regression-test/suites/external_table_p0/info_schema_db/backend_tablets.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("backend_tablets", "p0,external") {
+suite("backend_tablets", "p0") {
     if (!isCloudMode()) {
         def dbName = "test_backend_tablets_db"
         def tbName1 = "test_backend_tablets_1"

--- a/regression-test/suites/external_table_p0/info_schema_db/test_backend_configuration.groovy
+++ b/regression-test/suites/external_table_p0/info_schema_db/test_backend_configuration.groovy
@@ -16,7 +16,7 @@
 // under the License.
 import org.apache.doris.regression.suite.ClusterOptions
 
-suite("test_backend_configuration", "docker, p0, external_table,information_schema,backend_configuration") {
+suite("test_backend_configuration", "p0,external") {
     def options = new ClusterOptions()
     options.setFeNum(1)
     options.setBeNum(3)

--- a/regression-test/suites/external_table_p0/info_schema_db/test_backend_configuration.groovy
+++ b/regression-test/suites/external_table_p0/info_schema_db/test_backend_configuration.groovy
@@ -16,7 +16,7 @@
 // under the License.
 import org.apache.doris.regression.suite.ClusterOptions
 
-suite("test_backend_configuration", "p0,external") {
+suite("test_backend_configuration", "p0") {
     def options = new ClusterOptions()
     options.setFeNum(1)
     options.setBeNum(3)

--- a/regression-test/suites/external_table_p0/info_schema_db/test_info_schema_db.groovy
+++ b/regression-test/suites/external_table_p0/info_schema_db/test_info_schema_db.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_info_schema_db", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_info_schema_db", "p0,external") {
 
     String catalog_name = "hive_test_infodb";
     String innerdb = "innerdb";

--- a/regression-test/suites/external_table_p0/info_schema_db/test_information_schema_timezone.groovy
+++ b/regression-test/suites/external_table_p0/info_schema_db/test_information_schema_timezone.groovy
@@ -18,7 +18,7 @@
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
-suite("test_information_schema_timezone", "p0,external,hive,kerberos,external_docker,external_docker_kerberos") {
+suite("test_information_schema_timezone", "p0,external") {
     /* 
      * In this test case, we compare the intervals between two time zones. 
      *      List<List<Object>> routines_res_1 = sql """ select CREATED,LAST_ALTERED from information_schema.routines where ROUTINE_NAME="TEST_INFORMATION_SCHEMA_TIMEZONE1" """

--- a/regression-test/suites/external_table_p0/jdbc/test_clickhouse_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_clickhouse_jdbc_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_clickhouse_jdbc_catalog", "p0,external,clickhouse,external_docker,external_docker_clickhouse") {
+suite("test_clickhouse_jdbc_catalog", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String catalog_name = "clickhouse_catalog";

--- a/regression-test/suites/external_table_p0/jdbc/test_db2_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_db2_jdbc_catalog.groovy
@@ -20,7 +20,7 @@ import java.sql.Connection
 import java.sql.DriverManager
 import java.net.URL
 
-suite("test_db2_jdbc_catalog", "p0,external,db2,external_docker,external_docker_db2") {
+suite("test_db2_jdbc_catalog", "p0,external") {
     qt_sql """select current_catalog()"""
 
     String enabled = context.config.otherConfigs.get("enableJdbcTest")

--- a/regression-test/suites/external_table_p0/jdbc/test_doris_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_doris_jdbc_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_doris_jdbc_catalog", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_doris_jdbc_catalog", "p0,external") {
     qt_sql """select current_catalog()"""
 
     String jdbcUrl = context.config.jdbcUrl + "&sessionVariables=return_object_data_as_binary=true"

--- a/regression-test/suites/external_table_p0/jdbc/test_doris_jdbc_catalog_query_bitmap.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_doris_jdbc_catalog_query_bitmap.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_doris_jdbc_catalog_query_bitmap", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_doris_jdbc_catalog_query_bitmap", "p0,external") {
     qt_sql """select current_catalog()"""
 
     String jdbcUrl = context.config.jdbcUrl + "&sessionVariables=return_object_data_as_binary=true"

--- a/regression-test/suites/external_table_p0/jdbc/test_gbase_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_gbase_jdbc_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_gbase_jdbc_catalog", "p0,external,gbase,external_docker,external_docker_gbase") {
+suite("test_gbase_jdbc_catalog", "p0,external") {
     // Because there is no Gbase Dcoker test environment, the test case will not be executed for the time being.
     // Gbase ddl
     // CREATE TABLE gbase_test (

--- a/regression-test/suites/external_table_p0/jdbc/test_jdbc_call.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_jdbc_call.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_jdbc_call", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_jdbc_call", "p0,external") {
     String jdbcUrl = context.config.jdbcUrl + "&sessionVariables=return_object_data_as_binary=true"
     String jdbcUser = context.config.jdbcUser
     String jdbcPassword = context.config.jdbcPassword

--- a/regression-test/suites/external_table_p0/jdbc/test_jdbc_catalog_ddl.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_jdbc_catalog_ddl.groovy
@@ -18,7 +18,7 @@
 import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 
-suite("test_jdbc_catalog_ddl", "p0,external,mysql,external_docker,external_docker_mysql") {
+suite("test_jdbc_catalog_ddl", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/jdbc/test_jdbc_catalog_push_cast.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_jdbc_catalog_push_cast.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_jdbc_catalog_push_cast", "p0,external,mysql,external_docker,external_docker_mysql") {
+suite("test_jdbc_catalog_push_cast", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/jdbc/test_jdbc_catalog_refresh_update_time.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_jdbc_catalog_refresh_update_time.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_jdbc_catalog_refresh_update_time", "p0,external,mysql,external_docker,external_docker_mysql") {
+suite("test_jdbc_catalog_refresh_update_time", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/jdbc/test_jdbc_query_mysql.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_jdbc_query_mysql.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_jdbc_query_mysql", "p0,external,mysql,external_docker,external_docker_mysql") {
+suite("test_jdbc_query_mysql", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/jdbc/test_jdbc_query_pg.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_jdbc_query_pg.groovy
@@ -17,7 +17,7 @@
 
 import java.nio.charset.Charset;
 
-suite("test_jdbc_query_pg", "p0,external,pg,external_docker,external_docker_pg") {
+suite("test_jdbc_query_pg", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/jdbc/test_jdbc_query_tvf.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_jdbc_query_tvf.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_jdbc_query_tvf", "p0,external,external_docker") {
+suite("test_jdbc_query_tvf", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/jdbc/test_jdbc_row_count.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_jdbc_row_count.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_jdbc_row_count", "p0,external,mysql,external_docker,external_docker_mysql") {
+suite("test_jdbc_row_count", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     logger.info("enabled " + enabled)
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/jdbc/test_jni_complex_type.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_jni_complex_type.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_jni_complex_type", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_jni_complex_type", "p0,external") {
     qt_sql """select current_catalog()"""
 
     String jdbcUrl = context.config.jdbcUrl + "&sessionVariables=return_object_data_as_binary=true"

--- a/regression-test/suites/external_table_p0/jdbc/test_mariadb_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_mariadb_jdbc_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_mariadb_jdbc_catalog", "p0,external,mariadb,external_docker,external_docker_mariadb") {
+suite("test_mariadb_jdbc_catalog", "p0,external") {
     qt_sql """select current_catalog()"""
 
     String enabled = context.config.otherConfigs.get("enableJdbcTest")

--- a/regression-test/suites/external_table_p0/jdbc/test_mysql_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_mysql_jdbc_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_mysql_jdbc_catalog", "p0,external,mysql,external_docker,external_docker_mysql") {
+suite("test_mysql_jdbc_catalog", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/jdbc/test_mysql_jdbc_catalog_nereids.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_mysql_jdbc_catalog_nereids.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_mysql_jdbc_catalog_nereids", "p0,external,mysql,external_docker,external_docker_mysql") {
+suite("test_mysql_jdbc_catalog_nereids", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/jdbc/test_mysql_jdbc_catalog_table_comment.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_mysql_jdbc_catalog_table_comment.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_jdbc_mysql_catalog_table_comment", "p0,external") {
+suite("test_jdbc_mysql_catalog_table_comment", "p0") {
     String ex_table_name = "test_table_comment";
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/jdbc/test_mysql_jdbc_catalog_table_comment.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_mysql_jdbc_catalog_table_comment.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_jdbc_mysql_catalog_table_comment") {
+suite("test_jdbc_mysql_catalog_table_comment", "p0,external") {
     String ex_table_name = "test_table_comment";
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/jdbc/test_mysql_jdbc_statistics.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_mysql_jdbc_statistics.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_mysql_jdbc_statistics", "p0,external,mysql,external_docker,external_docker_mysql") {
+suite("test_mysql_jdbc_statistics", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     logger.info("enabled " + enabled)
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/jdbc/test_oceanbase_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_oceanbase_jdbc_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_oceanbase_jdbc_catalog", "p0,external,oceanbase,external_docker,external_docker_oceanbase") {
+suite("test_oceanbase_jdbc_catalog", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest");
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/jdbc/test_oracle_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_oracle_jdbc_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_oracle_jdbc_catalog", "p0,external,oracle,external_docker,external_docker_oracle") {
+suite("test_oracle_jdbc_catalog", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest");
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/jdbc/test_pg_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_pg_jdbc_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_pg_jdbc_catalog", "p0,external,pg,external_docker,external_docker_pg") {
+suite("test_pg_jdbc_catalog", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/jdbc/test_query_tvf_cross_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_query_tvf_cross_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_query_tvf_cross_catalog", "p0,external,mysql,external_docker,external_docker_mysql") {
+suite("test_query_tvf_cross_catalog", "p0,external") {
     String jdbcUrl = context.config.jdbcUrl + "&jdbcCompliantTruncation=false&sessionVariables=return_object_data_as_binary=true"
     String jdbcUser = context.config.jdbcUser
     String jdbcPassword = context.config.jdbcPassword

--- a/regression-test/suites/external_table_p0/jdbc/test_sqlserver_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_sqlserver_jdbc_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_sqlserver_jdbc_catalog", "p0,external,sqlserver,external_docker,external_docker_sqlserver") {
+suite("test_sqlserver_jdbc_catalog", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest");
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/jdbc/test_switch_catalog_and_delete_internal.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_switch_catalog_and_delete_internal.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_switch_catalog_and_delete_internal", "p0,external,external_docker") {
+suite("test_switch_catalog_and_delete_internal", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String mysql_port = context.config.otherConfigs.get("mysql_57_port");

--- a/regression-test/suites/external_table_p0/jdbc/type_test/ctas/test_mysql_all_types_ctas.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/type_test/ctas/test_mysql_all_types_ctas.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_mysql_all_types_ctas", "p0,external,mysql,external_docker,external_docker_mysql") {
+suite("test_mysql_all_types_ctas", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/jdbc/type_test/select/test_clickhouse_all_types_select.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/type_test/select/test_clickhouse_all_types_select.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_clickhouse_all_types_select", "p0,external,clickhouse,external_docker,external_docker_clickhouse") {
+suite("test_clickhouse_all_types_select", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/jdbc/type_test/select/test_doris_all_types_select.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/type_test/select/test_doris_all_types_select.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_doris_all_types_select", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_doris_all_types_select", "p0,external") {
     String jdbcUrl = context.config.jdbcUrl + "&jdbcCompliantTruncation=false&sessionVariables=return_object_data_as_binary=true"
     String jdbcUser = context.config.jdbcUser
     String jdbcPassword = context.config.jdbcPassword

--- a/regression-test/suites/external_table_p0/jdbc/type_test/select/test_mysql_all_types_select.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/type_test/select/test_mysql_all_types_select.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_mysql_all_types_select", "p0,external,mysql,external_docker,external_docker_mysql") {
+suite("test_mysql_all_types_select", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/jdbc/type_test/select/test_mysql_varbinary_with_udf.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/type_test/select/test_mysql_varbinary_with_udf.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_mysql_varbinary_with_udf", "p0,external,mysql,external_docker,external_docker_mysql") {
+suite("test_mysql_varbinary_with_udf", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/jdbc/type_test/select/test_oracle_all_types_select.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/type_test/select/test_oracle_all_types_select.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_oracle_all_types_select", "p0,external,oracle,external_docker,external_docker_oracle") {
+suite("test_oracle_all_types_select", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/jdbc/type_test/select/test_pg_all_types_select.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/type_test/select/test_pg_all_types_select.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_pg_all_types_select", "p0,external,pg,external_docker,external_docker_pg") {
+suite("test_pg_all_types_select", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/jdbc/type_test/select/test_sqlserver_all_types_select.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/type_test/select/test_sqlserver_all_types_select.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_sqlserver_all_types_select", "p0,external,sqlserver,external_docker,external_docker_sqlserver") {
+suite("test_sqlserver_all_types_select", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/jdbc/type_test/tvf/test_mysql_all_types_tvf.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/type_test/tvf/test_mysql_all_types_tvf.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_mysql_all_types_tvf", "p0,external,mysql,external_docker,external_docker_mysql") {
+suite("test_mysql_all_types_tvf", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/kerberos/test_iceberg_hadoop_catalog_kerberos.groovy
+++ b/regression-test/suites/external_table_p0/kerberos/test_iceberg_hadoop_catalog_kerberos.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_hadoop_catalog_kerberos", "p0,external,kerberos,external_docker,external_docker_kerberos") {
+suite("test_iceberg_hadoop_catalog_kerberos", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableKerberosTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         return

--- a/regression-test/suites/external_table_p0/kerberos/test_non_catalog_kerberos.groovy
+++ b/regression-test/suites/external_table_p0/kerberos/test_non_catalog_kerberos.groovy
@@ -18,7 +18,7 @@
 import org.awaitility.Awaitility;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-suite("test_non_catalog_kerberos", "p0,external,kerberos,external_docker,external_docker_kerberos") {
+suite("test_non_catalog_kerberos", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableNonCatalogKerberosTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         return

--- a/regression-test/suites/external_table_p0/kerberos/test_single_hive_kerberos.groovy
+++ b/regression-test/suites/external_table_p0/kerberos/test_single_hive_kerberos.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_single_hive_kerberos", "p0,external,kerberos,external_docker,external_docker_kerberos") {
+suite("test_single_hive_kerberos", "p0,external") {
     def command = "sudo docker ps"
     def process = command.execute()
     process.waitFor()

--- a/regression-test/suites/external_table_p0/kerberos/test_two_hive_kerberos.groovy
+++ b/regression-test/suites/external_table_p0/kerberos/test_two_hive_kerberos.groovy
@@ -20,7 +20,7 @@ import groovyjarjarantlr4.v4.codegen.model.ExceptionClause
 import org.junit.Assert;
 import java.util.concurrent.*
 
-suite("test_two_hive_kerberos", "p0,external,kerberos,external_docker,external_docker_kerberos") {
+suite("test_two_hive_kerberos", "p0,external") {
     def command = "sudo docker ps"
     def process = command.execute() 
     process.waitFor()               

--- a/regression-test/suites/external_table_p0/lower_case/test_conflict_name.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/test_conflict_name.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_conflict_name", "p0,external,doris,meta_names_mapping,external_docker") {
+suite("test_conflict_name", "p0,external") {
 
     String jdbcUrl = context.config.jdbcUrl
     String jdbcUser = "test_conflict_name_user"

--- a/regression-test/suites/external_table_p0/lower_case/test_lower_case_meta_include.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/test_lower_case_meta_include.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_lower_case_meta_include", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_lower_case_meta_include", "p0,external") {
 
     String jdbcUrl = context.config.jdbcUrl
     String jdbcUser = "test_lower_include_user"

--- a/regression-test/suites/external_table_p0/lower_case/test_lower_case_meta_show_and_select.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/test_lower_case_meta_show_and_select.groovy
@@ -19,7 +19,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import org.awaitility.Awaitility
 
-suite("test_lower_case_meta_show_and_select", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_lower_case_meta_show_and_select", "p0,external") {
 
     String jdbcUrl = context.config.jdbcUrl
     String jdbcUser = "test_lower_without_conf_user"

--- a/regression-test/suites/external_table_p0/lower_case/test_lower_case_meta_with_lower_table_conf_grant.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/test_lower_case_meta_with_lower_table_conf_grant.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_lower_case_meta_with_lower_table_conf_auth", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_lower_case_meta_with_lower_table_conf_auth", "p0,external") {
 
     String jdbcUrl = context.config.jdbcUrl
     String jdbcUser = context.config.jdbcUser

--- a/regression-test/suites/external_table_p0/lower_case/test_lower_case_meta_with_lower_table_conf_show_and_select.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/test_lower_case_meta_with_lower_table_conf_show_and_select.groovy
@@ -19,7 +19,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import org.awaitility.Awaitility
 
-suite("test_lower_case_meta_with_lower_table_conf_show_and_select", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_lower_case_meta_with_lower_table_conf_show_and_select", "p0,external") {
 
     String jdbcUrl = context.config.jdbcUrl
     String jdbcUser = "test_lower_with_conf"

--- a/regression-test/suites/external_table_p0/lower_case/test_lower_case_mtmv.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/test_lower_case_mtmv.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_lower_case_mtmv", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_lower_case_mtmv", "p0,external") {
 
     String jdbcUrl = context.config.jdbcUrl
     String jdbcUser = "test_lower_case_mtmv_user"

--- a/regression-test/suites/external_table_p0/lower_case/test_meta_cache_select_without_refresh.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/test_meta_cache_select_without_refresh.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_meta_cache_select_without_refresh", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_meta_cache_select_without_refresh", "p0,external") {
 
     String jdbcUrl = context.config.jdbcUrl
     String jdbcUser = "test_meta_cache_select_without_refresh_user"

--- a/regression-test/suites/external_table_p0/lower_case/test_meta_names_mapping.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/test_meta_names_mapping.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_meta_names_mapping", "p0,external,doris,meta_names_mapping,external_docker") {
+suite("test_meta_names_mapping", "p0,external") {
 
     String jdbcUrl = context.config.jdbcUrl
     String jdbcUser = "test_meta_names_mapping_user"

--- a/regression-test/suites/external_table_p0/lower_case/test_timing_refresh_catalog.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/test_timing_refresh_catalog.groovy
@@ -19,7 +19,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import org.awaitility.Awaitility
 
-suite("test_timing_refresh_catalog", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_timing_refresh_catalog", "p0,external") {
 
     String jdbcUrl = context.config.jdbcUrl
     String jdbcUser = "test_timing_refresh_catalog_user"

--- a/regression-test/suites/external_table_p0/lower_case/upgrade/load.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/upgrade/load.groovy
@@ -19,7 +19,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import org.awaitility.Awaitility
 
-suite("test_upgrade_lower_case_catalog_prepare", "p0,external,doris,external_docker,external_docker_doris,restart_fe") {
+suite("test_upgrade_lower_case_catalog_prepare", "p0,external") {
 
     String jdbcUrl = context.config.jdbcUrl
     String jdbcUser = "test_upgrade_lower_case_catalog_user"

--- a/regression-test/suites/external_table_p0/lower_case/upgrade/test_upgrade_lower_case_catalog.groovy
+++ b/regression-test/suites/external_table_p0/lower_case/upgrade/test_upgrade_lower_case_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_upgrade_lower_case_catalog", "p0,external,doris,external_docker,external_docker_doris,restart_fe") {
+suite("test_upgrade_lower_case_catalog", "p0,external") {
 
     test {
         sql """show databases from test_upgrade_lower_case_catalog"""

--- a/regression-test/suites/external_table_p0/nereids_commands/test_nereids_refresh_catalog.groovy
+++ b/regression-test/suites/external_table_p0/nereids_commands/test_nereids_refresh_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_nereids_refresh_catalog", "p0,external,mysql,external_docker,external_docker_mysql") {
+suite("test_nereids_refresh_catalog", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/nereids_commands/test_nereids_refresh_ldap.groovy
+++ b/regression-test/suites/external_table_p0/nereids_commands/test_nereids_refresh_ldap.groovy
@@ -16,7 +16,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_nereids_refresh_ldap") {
+suite("test_nereids_refresh_ldap", "p0,external") {
     String user = 'test_nereids_refresh_ldap_user'
 
     try_sql("DROP USER ${user}")

--- a/regression-test/suites/external_table_p0/nereids_commands/test_nereids_refresh_ldap.groovy
+++ b/regression-test/suites/external_table_p0/nereids_commands/test_nereids_refresh_ldap.groovy
@@ -16,7 +16,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_nereids_refresh_ldap", "p0,external") {
+suite("test_nereids_refresh_ldap", "p0") {
     String user = 'test_nereids_refresh_ldap_user'
 
     try_sql("DROP USER ${user}")

--- a/regression-test/suites/external_table_p0/nereids_commands/test_use_database_stmt.groovy
+++ b/regression-test/suites/external_table_p0/nereids_commands/test_use_database_stmt.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_use_database_stmt", "p0,external,mysql,external_docker,external_docker_mysql") {
+suite("test_use_database_stmt", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/paimon/paimon_base_filesystem.groovy
+++ b/regression-test/suites/external_table_p0/paimon/paimon_base_filesystem.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("paimon_base_filesystem", "p0,external,doris,external_docker,external_docker_doris,new_catalog_property") {
+suite("paimon_base_filesystem", "p0,external") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
 
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/paimon/paimon_data_system_table.groovy
+++ b/regression-test/suites/external_table_p0/paimon/paimon_data_system_table.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("paimon_data_system_table", "p0,external,doris,external_docker,external_docker_doris") {
+suite("paimon_data_system_table", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/paimon/paimon_incr_read.groovy
+++ b/regression-test/suites/external_table_p0/paimon/paimon_incr_read.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_incr_read", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_paimon_incr_read", "p0,external") {
     logger.info("start paimon test")
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/paimon/paimon_system_table.groovy
+++ b/regression-test/suites/external_table_p0/paimon/paimon_system_table.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("paimon_system_table", "p0,external,doris,external_docker,external_docker_doris") {
+suite("paimon_system_table", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/paimon/paimon_tb_mix_format.groovy
+++ b/regression-test/suites/external_table_p0/paimon/paimon_tb_mix_format.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("paimon_tb_mix_format", "p0,external,doris,external_docker,external_docker_doris") {
+suite("paimon_tb_mix_format", "p0,external") {
 
     logger.info("start paimon test")
     String enabled = context.config.otherConfigs.get("enablePaimonTest")

--- a/regression-test/suites/external_table_p0/paimon/paimon_time_travel.groovy
+++ b/regression-test/suites/external_table_p0/paimon/paimon_time_travel.groovy
@@ -23,7 +23,7 @@ import java.time.ZoneId
 
 
 
-suite("paimon_time_travel", "p0,external,doris,external_docker,external_docker_doris") {
+suite("paimon_time_travel", "p0,external") {
     logger.info("start paimon test")
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/paimon/paimon_timestamp_types.groovy
+++ b/regression-test/suites/external_table_p0/paimon/paimon_timestamp_types.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("paimon_timestamp_types", "p0,external,doris,external_docker,external_docker_doris") {
+suite("paimon_timestamp_types", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_catalog.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_catalog", "p0,external,doris,external_docker,external_docker_doris,new_catalog_property") {
+suite("test_paimon_catalog", "p0,external") {
 
     String file_ctl_name = "paimon_file_catalog";
     String hms_ctl_name = "paimon_hms_catalog";

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_catalog_timestamp_tz.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_catalog_timestamp_tz.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_catalog_timestamp_tz", "p0,external,doris,external_docker,external_docker_doris,new_catalog_property") {
+suite("test_paimon_catalog_timestamp_tz", "p0,external") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_catalog_varbinary.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_catalog_varbinary.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_catalog_varbinary", "p0,external,doris,external_docker,external_docker_doris,new_catalog_property") {
+suite("test_paimon_catalog_varbinary", "p0,external") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_char_varchar_type.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_char_varchar_type.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_char_varchar_type", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_paimon_char_varchar_type", "p0,external") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
         if (enabled != null && enabled.equalsIgnoreCase("true")) {
             String minio_port = context.config.otherConfigs.get("iceberg_minio_port")

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_count.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_count.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_count", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_paimon_count", "p0,external") {
 
     logger.info("start paimon test")
     String enabled = context.config.otherConfigs.get("enablePaimonTest")

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_deletion_vector.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_deletion_vector.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_deletion_vector", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_paimon_deletion_vector", "p0,external") {
 
     logger.info("start paimon test")
     String enabled = context.config.otherConfigs.get("enablePaimonTest")

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_deletion_vector_oss.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_deletion_vector_oss.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_deletion_vector_oss", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_paimon_deletion_vector_oss", "p0,external") {
 
     logger.info("start paimon test")
     String enabled = context.config.otherConfigs.get("enablePaimonTest")

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_full_schema_change.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_full_schema_change.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_full_schema_change", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_paimon_full_schema_change", "p0,external") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String minio_port = context.config.otherConfigs.get("iceberg_minio_port")

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_gcs.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_gcs.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_gcs", "p0,external,doris,new_catalog_property") {
+suite("test_paimon_gcs", "p0,external") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String gcs_warehouse = "s3://selectdb-qa-datalake-test/paimon_warehouse"

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_minio.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_minio.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_minio", "p0,external,doris,external_docker,external_docker_doris,new_catalog_property") {
+suite("test_paimon_minio", "p0,external") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String minio_port = context.config.otherConfigs.get("iceberg_minio_port")

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_partition_table.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_partition_table.groovy
@@ -17,7 +17,7 @@ import com.google.common.collect.Lists
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_partition_table", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_paimon_partition_table", "p0,external") {
     logger.info("start paimon test")
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_predict.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_predict.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_predict", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_paimon_predict", "p0,external") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable paimon test")

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_runtime_filter_partition_pruning.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_runtime_filter_partition_pruning.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_runtime_filter_partition_pruning", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_paimon_runtime_filter_partition_pruning", "p0,external") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String minio_port = context.config.otherConfigs.get("iceberg_minio_port")

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_s3.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_s3.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_s3", "p0,external,doris,external_docker,external_docker_doris,new_catalog_property") {
+suite("test_paimon_s3", "p0,external") {
     def testQuery = { String catalogProperties, String prefix, String dbName ->
         def catalog_name = "test_paimon_on_fs_${prefix}_catalog"
         sql """

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_schema_change.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_schema_change.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_schema_change", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_paimon_schema_change", "p0,external") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String minio_port = context.config.otherConfigs.get("iceberg_minio_port")

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_sql_block_rule.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_sql_block_rule.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_sql_block_rule", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_paimon_sql_block_rule", "p0,external") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable paimon test.")

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_statistics.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_statistics.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_statistics", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_paimon_statistics", "p0,external") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         try {

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_system_table_auth.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_system_table_auth.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_system_table_auth", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_paimon_system_table_auth", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_table.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_table.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_create_paimon_table", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_create_paimon_table", "p0,external") {
     String catalog_name = "paimon_hms_catalog_test01"
 
     String enabled = context.config.otherConfigs.get("enablePaimonTest")

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_table_meta_cache.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_table_meta_cache.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_table_meta_cache", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_paimon_table_meta_cache", "p0,external") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable paimon test.")

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_table_properties.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_table_properties.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_table_properties", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_paimon_table_properties", "p0,external") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String minio_port = context.config.otherConfigs.get("iceberg_minio_port")

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_table_stats.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_table_stats.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_table_stats", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_paimon_table_stats", "p0,external") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         try {

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_timestamp_with_time_zone.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_timestamp_with_time_zone.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_timestamp_with_time_zone", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_paimon_timestamp_with_time_zone", "p0,external") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String minio_port = context.config.otherConfigs.get("iceberg_minio_port")

--- a/regression-test/suites/external_table_p0/polaris/test_iceberg_insert_refresh.groovy
+++ b/regression-test/suites/external_table_p0/polaris/test_iceberg_insert_refresh.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_insert_refresh", "p0,external,iceberg,polaris,external_docker,external_docker_polaris") {
+suite("test_iceberg_insert_refresh", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/polaris/test_polaris.groovy
+++ b/regression-test/suites/external_table_p0/polaris/test_polaris.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_polaris", "p0,external,iceberg,polaris,external_docker,external_docker_polaris,new_catalog_property") {
+suite("test_polaris", "p0,external") {
 
     def testQueryAndInsert = { String catalogProperties, String prefix ->
 

--- a/regression-test/suites/external_table_p0/refactor_storage_param/backup_restore_object_storage.groovy
+++ b/regression-test/suites/external_table_p0/refactor_storage_param/backup_restore_object_storage.groovy
@@ -18,7 +18,7 @@ import org.awaitility.Awaitility;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static groovy.test.GroovyAssert.shouldFail
 
-suite("refactor_storage_backup_restore_object_storage", "p0,external,external_docker") {
+suite("refactor_storage_backup_restore_object_storage", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableRefactorParamsTest")
     if (enabled == null || enabled.equalsIgnoreCase("false")) {
         return

--- a/regression-test/suites/external_table_p0/refactor_storage_param/hdfs_all_test.groovy
+++ b/regression-test/suites/external_table_p0/refactor_storage_param/hdfs_all_test.groovy
@@ -18,7 +18,7 @@ import org.awaitility.Awaitility;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static groovy.test.GroovyAssert.shouldFail
 
-suite("refactor_params_hdfs_all_test", "p0,external,kerberos,external_docker,external_docker_kerberos") {
+suite("refactor_params_hdfs_all_test", "p0,external") {
     String enabled = context.config.otherConfigs.get("refactor_params_hdfs_kerberos_test")
     if (enabled == null || enabled.equalsIgnoreCase("false")) {
         return

--- a/regression-test/suites/external_table_p0/refactor_storage_param/hdfs_load_default_file_format.groovy
+++ b/regression-test/suites/external_table_p0/refactor_storage_param/hdfs_load_default_file_format.groovy
@@ -18,7 +18,7 @@ import org.awaitility.Awaitility;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static groovy.test.GroovyAssert.shouldFail
 
-suite("hdfs_load_default_file_format", "external_docker,hive,external_docker_hive,p0,external") {
+suite("hdfs_load_default_file_format", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable Hive test.")

--- a/regression-test/suites/external_table_p0/refactor_storage_param/iceberg_rest_on_hdfs.groovy
+++ b/regression-test/suites/external_table_p0/refactor_storage_param/iceberg_rest_on_hdfs.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_rest_on_hdfs", "external,iceberg,external_docker,external_docker_iceberg_rest,new_catalog_property") {
+suite("iceberg_rest_on_hdfs", "p0,external") {
 
     def testQueryAndInsert = { String catalogProperties, String prefix ->
 

--- a/regression-test/suites/external_table_p0/refactor_storage_param/s3_load.groovy
+++ b/regression-test/suites/external_table_p0/refactor_storage_param/s3_load.groovy
@@ -19,7 +19,7 @@ import org.awaitility.Awaitility
 import static groovy.test.GroovyAssert.shouldFail;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-suite("refactor_storage_param_s3_load", "p0,external,external_docker") {
+suite("refactor_storage_param_s3_load", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableRefactorParamsTest")
     if (enabled == null || enabled.equalsIgnoreCase("false")) {
         return

--- a/regression-test/suites/external_table_p0/refactor_storage_param/test_outfile_s3_storage.groovy
+++ b/regression-test/suites/external_table_p0/refactor_storage_param/test_outfile_s3_storage.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_outfile_s3_storage", "p0,external,external_docker") {
+suite("test_outfile_s3_storage", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableRefactorParamsTest")
     if (enabled == null || enabled.equalsIgnoreCase("false")) {
         return

--- a/regression-test/suites/external_table_p0/refactor_storage_param/test_s3_tvf_s3_storage.groovy
+++ b/regression-test/suites/external_table_p0/refactor_storage_param/test_s3_tvf_s3_storage.groovy
@@ -16,7 +16,7 @@
 // under the License.
 import static groovy.test.GroovyAssert.shouldFail
 
-suite("test_s3_tvf_s3_storage", "p0,external,external_docker") {
+suite("test_s3_tvf_s3_storage", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableRefactorParamsTest")
     if (enabled == null || enabled.equalsIgnoreCase("false")) {
         return

--- a/regression-test/suites/external_table_p0/remote_doris/test_query_remote_doris_as_olap_table_select.groovy
+++ b/regression-test/suites/external_table_p0/remote_doris/test_query_remote_doris_as_olap_table_select.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_query_remote_doris_as_olap_table_select", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_query_remote_doris_as_olap_table_select", "p0,external") {
     String remote_doris_host = context.config.otherConfigs.get("extArrowFlightSqlHost")
     String remote_doris_arrow_port = context.config.otherConfigs.get("extArrowFlightSqlPort")
     String remote_doris_http_port = context.config.otherConfigs.get("extArrowFlightHttpPort")

--- a/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_agg_table_select.groovy
+++ b/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_agg_table_select.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_remote_doris_agg_table_select", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_remote_doris_agg_table_select", "p0,external") {
     String remote_doris_host = context.config.otherConfigs.get("extArrowFlightSqlHost")
     String remote_doris_arrow_port = context.config.otherConfigs.get("extArrowFlightSqlPort")
     String remote_doris_http_port = context.config.otherConfigs.get("extArrowFlightHttpPort")

--- a/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_all_types_select.groovy
+++ b/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_all_types_select.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_remote_doris_all_types_select", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_remote_doris_all_types_select", "p0,external") {
     String remote_doris_host = context.config.otherConfigs.get("extArrowFlightSqlHost")
     String remote_doris_arrow_port = context.config.otherConfigs.get("extArrowFlightSqlPort")
     String remote_doris_http_port = context.config.otherConfigs.get("extArrowFlightHttpPort")

--- a/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_all_types_show.groovy
+++ b/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_all_types_show.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_remote_doris_all_types_show", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_remote_doris_all_types_show", "p0,external") {
     String remote_doris_host = context.config.otherConfigs.get("extArrowFlightSqlHost")
     String remote_doris_arrow_port = context.config.otherConfigs.get("extArrowFlightSqlPort")
     String remote_doris_http_port = context.config.otherConfigs.get("extArrowFlightHttpPort")

--- a/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_catalog.groovy
+++ b/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_remote_doris_catalog", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_remote_doris_catalog", "p0,external") {
     String remote_doris_host = context.config.otherConfigs.get("extArrowFlightSqlHost")
     String remote_doris_arrow_port = context.config.otherConfigs.get("extArrowFlightSqlPort")
     String remote_doris_http_port = context.config.otherConfigs.get("extArrowFlightHttpPort")

--- a/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_predict.groovy
+++ b/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_predict.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_remote_doris_predict", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_remote_doris_predict", "p0,external") {
     String remote_doris_host = context.config.otherConfigs.get("extArrowFlightSqlHost")
     String remote_doris_arrow_port = context.config.otherConfigs.get("extArrowFlightSqlPort")
     String remote_doris_http_port = context.config.otherConfigs.get("extArrowFlightHttpPort")

--- a/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_refresh.groovy
+++ b/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_refresh.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_remote_doris_refresh", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_remote_doris_refresh", "p0,external") {
     String remote_doris_host = context.config.otherConfigs.get("extArrowFlightSqlHost")
     String remote_doris_arrow_port = context.config.otherConfigs.get("extArrowFlightSqlPort")
     String remote_doris_http_port = context.config.otherConfigs.get("extArrowFlightHttpPort")

--- a/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_statistics.groovy
+++ b/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_statistics.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_remote_doris_statistics", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_remote_doris_statistics", "p0,external") {
     String remote_doris_host = context.config.otherConfigs.get("extArrowFlightSqlHost")
     String remote_doris_arrow_port = context.config.otherConfigs.get("extArrowFlightSqlPort")
     String remote_doris_http_port = context.config.otherConfigs.get("extArrowFlightHttpPort")

--- a/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_table_stats.groovy
+++ b/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_table_stats.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_remote_doris_table_stats", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_remote_doris_table_stats", "p0,external") {
     String remote_doris_host = context.config.otherConfigs.get("extArrowFlightSqlHost")
     String remote_doris_arrow_port = context.config.otherConfigs.get("extArrowFlightSqlPort")
     String remote_doris_http_port = context.config.otherConfigs.get("extArrowFlightHttpPort")

--- a/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_unique_table_select.groovy
+++ b/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_unique_table_select.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_remote_doris_unique_table_select", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_remote_doris_unique_table_select", "p0,external") {
     String remote_doris_host = context.config.otherConfigs.get("extArrowFlightSqlHost")
     String remote_doris_arrow_port = context.config.otherConfigs.get("extArrowFlightSqlPort")
     String remote_doris_http_port = context.config.otherConfigs.get("extArrowFlightHttpPort")

--- a/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_variant_select.groovy
+++ b/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_variant_select.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_remote_doris_variant_select", "p0,external,doris,external_docker,external_docker_doris") {
+suite("test_remote_doris_variant_select", "p0,external") {
     String remote_doris_host = context.config.otherConfigs.get("extArrowFlightSqlHost")
     String remote_doris_arrow_port = context.config.otherConfigs.get("extArrowFlightSqlPort")
     String remote_doris_http_port = context.config.otherConfigs.get("extArrowFlightHttpPort")

--- a/regression-test/suites/external_table_p0/test_catalog_ddl.groovy
+++ b/regression-test/suites/external_table_p0/test_catalog_ddl.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_catalog_ddl", "p0,external,external_docker") {
+suite("test_catalog_ddl", "p0,external") {
         String catalog1 = "test_ddl_ctr1";
         // This is only for testing catalog ddl syntax
         sql """drop catalog if exists ${catalog1};"""

--- a/regression-test/suites/external_table_p0/test_connection/test_iceberg_rest_minio_connectivity.groovy
+++ b/regression-test/suites/external_table_p0/test_connection/test_iceberg_rest_minio_connectivity.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_rest_minio_connectivity", "p0,external,iceberg,external_docker,external_docker_polaris") {
+suite("test_iceberg_rest_minio_connectivity", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/test_external_and_internal_describe.groovy
+++ b/regression-test/suites/external_table_p0/test_external_and_internal_describe.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_external_and_internal_describe", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_external_and_internal_describe", "p0,external") {
     String catalog_name = "test_test_external_describe"
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")

--- a/regression-test/suites/external_table_p0/test_external_table_update_time.groovy
+++ b/regression-test/suites/external_table_p0/test_external_table_update_time.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_external_table_update_time", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_external_table_update_time", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable Hive test.")

--- a/regression-test/suites/external_table_p0/test_show_catalogs_error_msg.groovy
+++ b/regression-test/suites/external_table_p0/test_show_catalogs_error_msg.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_show_catalogs_error_msg", "p0,external,iceberg,external_docker,external_docker_iceberg") { 
+suite("test_show_catalogs_error_msg", "p0,external") { 
     
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_different_parquet_types.groovy
+++ b/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_different_parquet_types.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_trino_different_parquet_types", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_trino_different_parquet_types", "p0,external") {
 
     String hms_port = context.config.otherConfigs.get("hive2HmsPort")
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")

--- a/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_hive_orc.groovy
+++ b/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_hive_orc.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_trino_hive_orc", "all_types,external,hive,external_docker,external_docker_hive") {
+suite("test_trino_hive_orc", "p0,external") {
 
     // Ensure that all types are parsed correctly
     def select_top50 = {

--- a/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_hive_other.groovy
+++ b/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_hive_other.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_trino_hive_other", "external,hive,external_docker,external_docker_hive") {
+suite("test_trino_hive_other", "p0,external") {
 
     def q01 = {
         qt_q24 """ select name, count(1) as c from student group by name order by name desc;"""

--- a/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_hive_parquet.groovy
+++ b/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_hive_parquet.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_trino_hive_parquet", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_trino_hive_parquet", "p0,external") {
 
     def q01 = {
         qt_q01 """

--- a/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_hive_schema_evolution.groovy
+++ b/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_hive_schema_evolution.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_trino_hive_schema_evolution", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_trino_hive_schema_evolution", "p0,external") {
 
     def q_text = {
         qt_q01 """

--- a/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_hive_serde_prop.groovy
+++ b/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_hive_serde_prop.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_trino_hive_serde_prop", "external_docker,hive,external_docker_hive,p0,external") {
+suite("test_trino_hive_serde_prop", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_hive_tablesample_p0.groovy
+++ b/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_hive_tablesample_p0.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_trino_hive_tablesample_p0", "all_types,p0,external,hive,external_docker,external_docker_hive") {
+suite("test_trino_hive_tablesample_p0", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {

--- a/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_prepare_hive_data_in_case.groovy
+++ b/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_prepare_hive_data_in_case.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_trino_prepare_hive_data_in_case", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_trino_prepare_hive_data_in_case", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     def catalog_name = "test_trino_prepare_hive_data_in_case"

--- a/regression-test/suites/external_table_p0/trino_connector/jdbc/test_trino_clickhouse.groovy
+++ b/regression-test/suites/external_table_p0/trino_connector/jdbc/test_trino_clickhouse.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_trino_clickhouse", "p0,external,clickhouse,external_docker,external_docker_clickhouse") {
+suite("test_trino_clickhouse", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String enabled_trino_connector = context.config.otherConfigs.get("enableTrinoConnectorTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/trino_connector/jdbc/test_trino_mysql.groovy
+++ b/regression-test/suites/external_table_p0/trino_connector/jdbc/test_trino_mysql.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_trino_mysql", "p0,external,mysql,external_docker,external_docker_mysql") {
+suite("test_trino_mysql", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String enabled_trino_connector = context.config.otherConfigs.get("enableTrinoConnectorTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/trino_connector/jdbc/test_trino_oracle.groovy
+++ b/regression-test/suites/external_table_p0/trino_connector/jdbc/test_trino_oracle.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_trino_oracle", "p0,external,oracle,external_docker,external_docker_oracle") {
+suite("test_trino_oracle", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String enabled_trino_connector = context.config.otherConfigs.get("enableTrinoConnectorTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/trino_connector/jdbc/test_trino_pg.groovy
+++ b/regression-test/suites/external_table_p0/trino_connector/jdbc/test_trino_pg.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_trino_pg", "p0,external,pg,external_docker,external_docker_pg") {
+suite("test_trino_pg", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String enabled_trino_connector = context.config.otherConfigs.get("enableTrinoConnectorTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/trino_connector/jdbc/test_trino_sqlserver.groovy
+++ b/regression-test/suites/external_table_p0/trino_connector/jdbc/test_trino_sqlserver.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_trino_sqlserver", "p0,external,sqlserver,external_docker,external_docker_sqlserver") {
+suite("test_trino_sqlserver", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     String enabled_trino_connector = context.config.otherConfigs.get("enableTrinoConnectorTest")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/trino_connector/kafka/test_trino_kafka_base.groovy
+++ b/regression-test/suites/external_table_p0/trino_connector/kafka/test_trino_kafka_base.groovy
@@ -20,7 +20,7 @@ import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.ProducerConfig
 
-suite("test_trino_kafka_base", "external,kafka,external_docker,external_docker_kafka") {
+suite("test_trino_kafka_base", "p0,external") {
 
     // Ensure that all types are parsed correctly
     def select_top50 = {

--- a/regression-test/suites/external_table_p0/trino_connector/test_plugins_download.groovy
+++ b/regression-test/suites/external_table_p0/trino_connector/test_plugins_download.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_plugins_download", "external,hive,external_docker,external_docker_hive") {
+suite("test_plugins_download", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableTrinoConnectorTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         def host_ips = new ArrayList()

--- a/regression-test/suites/external_table_p0/trino_connector/test_trinoconnector_information_schema.groovy
+++ b/regression-test/suites/external_table_p0/trino_connector/test_trinoconnector_information_schema.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_trinoconnector_information_schema", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_trinoconnector_information_schema", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         def host_ips = new ArrayList()

--- a/regression-test/suites/external_table_p0/tvf/insert/test_insert_into_hdfs_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/insert/test_insert_into_hdfs_tvf.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_insert_into_hdfs_tvf", "external,hive,tvf,external_docker") {
+suite("test_insert_into_hdfs_tvf", "p0,external") {
 
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/tvf/insert/test_insert_into_local_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/insert/test_insert_into_local_tvf.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_insert_into_local_tvf", "tvf,external,external_docker") {
+suite("test_insert_into_local_tvf", "p0,external") {
 
     List<List<Object>> backends = sql """ show backends """
     assertTrue(backends.size() > 0)

--- a/regression-test/suites/external_table_p0/tvf/insert/test_insert_into_s3_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/insert/test_insert_into_s3_tvf.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_insert_into_s3_tvf", "external,external_docker") {
+suite("test_insert_into_s3_tvf", "p0,external") {
 
     String ak = getS3AK()
     String sk = getS3SK()

--- a/regression-test/suites/external_table_p0/tvf/orc_format/test_orc_exception_files.groovy
+++ b/regression-test/suites/external_table_p0/tvf/orc_format/test_orc_exception_files.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_orc_exception_files","external,hive,tvf,external_docker") {
+suite("test_orc_exception_files", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/orc_tvf/test_hdfs_orc_group0_orc_files.groovy
+++ b/regression-test/suites/external_table_p0/tvf/orc_tvf/test_hdfs_orc_group0_orc_files.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hdfs_orc_group0_orc_files","external,hive,tvf,external_docker") {
+suite("test_hdfs_orc_group0_orc_files", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/orc_tvf/test_hdfs_orc_group1_orc_files.groovy
+++ b/regression-test/suites/external_table_p0/tvf/orc_tvf/test_hdfs_orc_group1_orc_files.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hdfs_orc_group1_orc_files","external,hive,tvf,external_docker") {
+suite("test_hdfs_orc_group1_orc_files", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/orc_tvf/test_hdfs_orc_group2_orc_files.groovy
+++ b/regression-test/suites/external_table_p0/tvf/orc_tvf/test_hdfs_orc_group2_orc_files.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hdfs_orc_group2_orc_files","external,hive,tvf,external_docker") {
+suite("test_hdfs_orc_group2_orc_files", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/orc_tvf/test_hdfs_orc_group3_orc_files.groovy
+++ b/regression-test/suites/external_table_p0/tvf/orc_tvf/test_hdfs_orc_group3_orc_files.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hdfs_orc_group3_orc_files","external,hive,tvf,external_docker") {
+suite("test_hdfs_orc_group3_orc_files", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/orc_tvf/test_hdfs_orc_group4_orc_files.groovy
+++ b/regression-test/suites/external_table_p0/tvf/orc_tvf/test_hdfs_orc_group4_orc_files.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hdfs_orc_group4_orc_files","external,hive,tvf,external_docker") {
+suite("test_hdfs_orc_group4_orc_files", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/orc_tvf/test_hdfs_orc_group5_orc_files.groovy
+++ b/regression-test/suites/external_table_p0/tvf/orc_tvf/test_hdfs_orc_group5_orc_files.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hdfs_orc_group5_orc_files","external,hive,tvf,external_docker") {
+suite("test_hdfs_orc_group5_orc_files", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/orc_tvf/test_hdfs_orc_group6_orc_files.groovy
+++ b/regression-test/suites/external_table_p0/tvf/orc_tvf/test_hdfs_orc_group6_orc_files.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hdfs_orc_group6_orc_files","external,hive,tvf,external_docker") {
+suite("test_hdfs_orc_group6_orc_files", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/orc_tvf/test_hdfs_orc_group7_orc_files.groovy
+++ b/regression-test/suites/external_table_p0/tvf/orc_tvf/test_hdfs_orc_group7_orc_files.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hdfs_orc_group7_orc_files","external,hive,tvf,external_docker") {
+suite("test_hdfs_orc_group7_orc_files", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/queries/test_queries_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/queries/test_queries_tvf.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_queries_tvf","p0,external,tvf,external_docker") {
+suite("test_queries_tvf", "p0,external") {
     def table_name = "test_queries_tvf"
     sql """ DROP TABLE IF EXISTS ${table_name} """
     sql """

--- a/regression-test/suites/external_table_p0/tvf/test_backends_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_backends_tvf.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 // This suit test the `backends` tvf
-suite("test_backends_tvf","p0,external,tvf,external_docker") {
+suite("test_backends_tvf", "p0,external") {
     List<List<Object>> table =  sql """ select * from backends(); """
     assertTrue(table.size() > 0)
     assertEquals(29, table[0].size())

--- a/regression-test/suites/external_table_p0/tvf/test_catalogs_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_catalogs_tvf.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_catalogs_tvf","p0,external,tvf,external_docker") {
+suite("test_catalogs_tvf", "p0,external") {
     List<List<Object>> table =  sql """ select * from catalogs(); """
     assertTrue(table.size() > 0)
     assertEquals(5, table[0].size())

--- a/regression-test/suites/external_table_p0/tvf/test_create_view_from_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_create_view_from_tvf.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
- suite("test_create_view_from_tvf","p0,external,tvf,external_docker") {
+ suite("test_create_view_from_tvf", "p0,external") {
     String testViewName = "test_view_from_number"
 
     def create_view = {createViewSql -> 

--- a/regression-test/suites/external_table_p0/tvf/test_ctas_with_hdfs.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_ctas_with_hdfs.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_ctas_with_hdfs","external,hive,tvf,external_docker") {
+suite("test_ctas_with_hdfs", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/test_file_tvf_hdfs.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_file_tvf_hdfs.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_file_tvf_hdfs","external,hive,tvf,external_docker") {
+suite("test_file_tvf_hdfs", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/test_file_tvf_local.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_file_tvf_local.groovy
@@ -17,7 +17,7 @@ import org.junit.Assert
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_file_tvf_local", "p0,tvf,external,external_docker") {
+suite("test_file_tvf_local", "p0,external") {
     List<List<Object>> backends =  sql """ show backends """
     assertTrue(backends.size() > 0)
     def be_id = backends[0][0]

--- a/regression-test/suites/external_table_p0/tvf/test_file_tvf_s3.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_file_tvf_s3.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_file_tvf_s3", "p0") {
+suite("test_file_tvf_s3", "p0,external") {
 
     def export_table_name = "test_file_tvf_s3"
 

--- a/regression-test/suites/external_table_p0/tvf/test_file_tvf_s3.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_file_tvf_s3.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_file_tvf_s3", "p0,external") {
+suite("test_file_tvf_s3", "p0") {
 
     def export_table_name = "test_file_tvf_s3"
 

--- a/regression-test/suites/external_table_p0/tvf/test_frontends_disks_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_frontends_disks_tvf.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 // This suit test the `frontends_disks` tvf
-suite("test_frontends_disks_tvf", "p0,external,external_docker") {
+suite("test_frontends_disks_tvf", "p0,external") {
     List<List<Object>> table =  sql """ select * from `frontends_disks`(); """
     assertTrue(table.size() > 0)
     assertTrue(table[0].size() == 10)

--- a/regression-test/suites/external_table_p0/tvf/test_frontends_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_frontends_tvf.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 // This suit test the `frontends` tvf
-suite("test_frontends_tvf","p0,external,tvf,external_docker") {
+suite("test_frontends_tvf", "p0,external") {
     List<List<Object>> table =  sql """ select * from `frontends`(); """
     logger.info("${table}")
     assertTrue(table.size() > 0)

--- a/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group0.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group0.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hdfs_parquet_group0","external,hive,tvf,external_docker") {
+suite("test_hdfs_parquet_group0", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group1.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group1.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hdfs_parquet_group1","external,hive,tvf,external_docker") {
+suite("test_hdfs_parquet_group1", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group2.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group2.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hdfs_parquet_group2","external,hive,tvf,external_docker") {
+suite("test_hdfs_parquet_group2", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group3.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group3.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hdfs_parquet_group3","external,hive,tvf,external_docker") {
+suite("test_hdfs_parquet_group3", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group4.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group4.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hdfs_parquet_group4","external,hive,tvf,external_docker") {
+suite("test_hdfs_parquet_group4", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group5.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group5.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hdfs_parquet_group5","external,hive,tvf,external_docker") {
+suite("test_hdfs_parquet_group5", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group6.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hdfs_parquet_group6.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hdfs_parquet_group6","external,hive,tvf,external_docker") {
+suite("test_hdfs_parquet_group6", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/test_hdfs_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hdfs_tvf.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hdfs_tvf","external,hive,tvf,external_docker") {
+suite("test_hdfs_tvf", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/test_hdfs_tvf_compression.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hdfs_tvf_compression.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hdfs_tvf_compression", "p0,external,tvf,external_docker,hive") {
+suite("test_hdfs_tvf_compression", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String nameNodeHost = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/tvf/test_hdfs_tvf_csv.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hdfs_tvf_csv.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hdfs_tvf_csv","external,hive,tvf,external_docker") {
+suite("test_hdfs_tvf_csv", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/test_hdfs_tvf_error_uri.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hdfs_tvf_error_uri.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hdfs_tvf_error_uri","external,hive,tvf,external_docker") {
+suite("test_hdfs_tvf_error_uri", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/test_hdfs_tvf_float16.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hdfs_tvf_float16.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hdfs_tvf_float16","external,hive,tvf,external_docker") {
+suite("test_hdfs_tvf_float16", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/test_hms_partitions_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hms_partitions_tvf.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hms_partitions_tvf","p0,external,tvf,external_docker") {
+suite("test_hms_partitions_tvf", "p0,external") {
     String suiteName = "test_hms_partitions_tvf"
     String tableName = "mtmv_base1"
     String dbName = "default"

--- a/regression-test/suites/external_table_p0/tvf/test_http_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_http_tvf.groovy
@@ -23,7 +23,7 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.net.InetSocketAddress
 
-suite("test_http_tvf", "p2") {
+suite("test_http_tvf", "p0,external") {
     // csv
     qt_sql01 """
         SELECT *

--- a/regression-test/suites/external_table_p0/tvf/test_http_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_http_tvf.groovy
@@ -23,7 +23,7 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.net.InetSocketAddress
 
-suite("test_http_tvf", "p0,external") {
+suite("test_http_tvf", "p0") {
     // csv
     qt_sql01 """
         SELECT *

--- a/regression-test/suites/external_table_p0/tvf/test_http_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_http_tvf.groovy
@@ -189,21 +189,23 @@ suite("test_http_tvf", "p0") {
     """
 
     // hf
-    qt_sql15 """
+    def hfCountOneFile = sql """
         select count(*) from
         http(
             "uri" = "hf://datasets/fka/awesome-chatgpt-prompts/blob/main/prompts.csv",
             "format" = "csv"
         );
     """
+    assertTrue(Long.parseLong(hfCountOneFile[0][0].toString()) > 0)
 
-    qt_sql16 """
+    def hfCountWildcard = sql """
         select count(*) from
         http(
             "uri" = "hf://datasets/fka/awesome-chatgpt-prompts/blob/main/*.csv",
             "format" = "csv"
         );
     """
+    assertTrue(Long.parseLong(hfCountWildcard[0][0].toString()) > 0)
     
     qt_sql17 """
         desc function
@@ -255,4 +257,3 @@ suite("test_http_tvf", "p0") {
         ) order by text limit 1;
     """
 }
-

--- a/regression-test/suites/external_table_p0/tvf/test_insert_from_tvf_with_common_user.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_insert_from_tvf_with_common_user.groovy
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
 
-suite("test_insert_from_tvf_with_common_user", "p0,external,external_docker") {
+suite("test_insert_from_tvf_with_common_user", "p0,external") {
     String ak = getS3AK()
     String sk = getS3SK()
     String s3_endpoint = getS3Endpoint()

--- a/regression-test/suites/external_table_p0/tvf/test_local_tvf_compression.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_local_tvf_compression.groovy
@@ -17,7 +17,7 @@ import org.junit.Assert
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_local_tvf_compression", "p0,tvf,external,external_docker") {
+suite("test_local_tvf_compression", "p0,external") {
     List<List<Object>> backends =  sql """ show backends """
     assertTrue(backends.size() > 0)
     def be_id = backends[0][0]

--- a/regression-test/suites/external_table_p0/tvf/test_local_tvf_enclose.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_local_tvf_enclose.groovy
@@ -17,7 +17,7 @@ import org.junit.Assert
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_local_tvf_enclose", "p0,tvf,external,external_docker") {
+suite("test_local_tvf_enclose", "p0,external") {
     List<List<Object>> backends =  sql """ show backends """
     assertTrue(backends.size() > 0)
     def be_id = backends[0][0]

--- a/regression-test/suites/external_table_p0/tvf/test_local_tvf_lzo.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_local_tvf_lzo.groovy
@@ -18,7 +18,7 @@ import org.junit.Assert
 // under the License.
 
 // This suit test the `backends` tvf
-suite("test_local_tvf_lzo", "p0,external,external_docker") {
+suite("test_local_tvf_lzo", "p0,external") {
     List<List<Object>> backends =  sql """ show backends """
     def dataFilePath = context.config.dataPath + "/external_table_p0/tvf/lzo"
 

--- a/regression-test/suites/external_table_p0/tvf/test_local_tvf_parquet_unsigned_integers.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_local_tvf_parquet_unsigned_integers.groovy
@@ -18,7 +18,7 @@ import org.junit.Assert
 // under the License.
 
 // This suit test the `backends` tvf
-suite("test_local_tvf_parquet_unsigned_integers", "p0,external,external_docker") {
+suite("test_local_tvf_parquet_unsigned_integers", "p0,external") {
     List<List<Object>> backends =  sql """ show backends """
     def dataFilePath = context.config.dataPath + "/external_table_p0/tvf/"
 

--- a/regression-test/suites/external_table_p0/tvf/test_local_tvf_with_complex_type.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_local_tvf_with_complex_type.groovy
@@ -18,7 +18,7 @@ import org.junit.Assert
 // under the License.
 
 // This suit test the `backends` tvf
-suite("test_local_tvf_with_complex_type", "p0,external,external_docker") {
+suite("test_local_tvf_with_complex_type", "p0,external") {
     List<List<Object>> backends =  sql """ show backends """
     def dataFilePath = context.config.dataPath + "/external_table_p0/tvf/"
 

--- a/regression-test/suites/external_table_p0/tvf/test_local_tvf_with_complex_type_element_at.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_local_tvf_with_complex_type_element_at.groovy
@@ -18,7 +18,7 @@ import org.junit.Assert
 // under the License.
 
 // This suit test the `backends` tvf
-suite("test_local_tvf_with_complex_type_element_at", "p0,external,external_docker") {
+suite("test_local_tvf_with_complex_type_element_at", "p0,external") {
     List<List<Object>> backends =  sql """ show backends """
     assertTrue(backends.size() > 0)
     def be_id = backends[0][0]

--- a/regression-test/suites/external_table_p0/tvf/test_local_tvf_with_complex_type_insertinto_doris.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_local_tvf_with_complex_type_insertinto_doris.groovy
@@ -18,7 +18,7 @@ import org.junit.Assert
 // under the License.
 
 // This suit test the `backends` tvf
-suite("test_local_tvf_with_complex_type_insertinto_doris", "p0,external,external_docker") {
+suite("test_local_tvf_with_complex_type_insertinto_doris", "p0,external") {
     List<List<Object>> backends =  sql """ select * from backends(); """
     assertTrue(backends.size() > 0)
     def be_id = backends[0][0]

--- a/regression-test/suites/external_table_p0/tvf/test_numbers.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_numbers.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 
- suite("test_numbers","p0,external,external_docker") {
+ suite("test_numbers", "p0,external") {
     // Test basic features
     order_qt_basic1 """ select * from numbers("number" = "1"); """
     order_qt_basic2 """ select * from numbers("number" = "10"); """

--- a/regression-test/suites/external_table_p0/tvf/test_parquet_meta_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_parquet_meta_tvf.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_parquet_meta_tvf", "p0,external,external_docker,tvf") {
+suite("test_parquet_meta_tvf", "p0,external") {
     // use nereids planner
     sql """ set enable_nereids_planner=true """
     sql """ set enable_fallback_to_original_planner=false """

--- a/regression-test/suites/external_table_p0/tvf/test_partitions_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_partitions_tvf.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_partitions_tvf","p0,external,tvf,external_docker") {
+suite("test_partitions_tvf", "p0,external") {
     String suiteName = "test_partitions_tvf"
     String tableName = "${suiteName}_table"
     sql """drop table if exists `${tableName}`"""

--- a/regression-test/suites/external_table_p0/tvf/test_path_partition_keys.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_path_partition_keys.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_path_partition_keys", "p0,external,tvf,external_docker,hive") {
+suite("test_path_partition_keys", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String nameNodeHost = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/tvf/test_read_csv_empty_line_as_null.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_read_csv_empty_line_as_null.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_read_csv_empty_line_as_null", "p0,external,external_docker") {
+suite("test_read_csv_empty_line_as_null", "p0,external") {
     // open nereids
     sql """ set enable_nereids_planner=true """
     sql """ set enable_fallback_to_original_planner=false """

--- a/regression-test/suites/external_table_p0/tvf/test_s3_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_s3_tvf.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_s3_tvf", "p0,external,external_docker") {
+suite("test_s3_tvf", "p0,external") {
     // open nereids
     sql """ set enable_nereids_planner=true """
     sql """ set enable_fallback_to_original_planner=false """

--- a/regression-test/suites/external_table_p0/tvf/test_s3_tvf_compression.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_s3_tvf_compression.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_s3_tvf_compression", "p0,external,external_docker") {
+suite("test_s3_tvf_compression", "p0,external") {
     
     String ak = getS3AK()
     String sk = getS3SK()

--- a/regression-test/suites/external_table_p0/tvf/test_s3_tvf_parquet_compress.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_s3_tvf_parquet_compress.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_s3_tvf_parquet_compress", "p0,external,external_docker") {
+suite("test_s3_tvf_parquet_compress", "p0,external") {
 //parquet data page v2 test 
 
 

--- a/regression-test/suites/external_table_p0/tvf/test_s3_tvf_with_resource.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_s3_tvf_with_resource.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_s3_tvf_with_resource", "p0,external,external_docker") {
+suite("test_s3_tvf_with_resource", "p0,external") {
     // open nereids
     sql """ set enable_nereids_planner=true """
     sql """ set enable_fallback_to_original_planner=false """

--- a/regression-test/suites/external_table_p0/tvf/test_tvf_avro.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_tvf_avro.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_tvf_avro", "external,hive,tvf,avro,external_docker") {
+suite("test_tvf_avro", "p0,external") {
 
     // def all_type_file = "all_type.avro";
     // def format = "avro"

--- a/regression-test/suites/external_table_p0/tvf/test_tvf_csv_line_end.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_tvf_csv_line_end.groovy
@@ -17,7 +17,7 @@ import org.junit.Assert
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_tvf_csv_line_end", "p0,tvf,external,external_docker") {
+suite("test_tvf_csv_line_end", "p0,external") {
     List<List<Object>> backends =  sql """ show backends """
     assertTrue(backends.size() > 0)
     def be_id = backends[0][0]

--- a/regression-test/suites/external_table_p0/tvf/test_tvf_p0.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_tvf_p0.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_tvf_p0", "p0,external,tvf,external_docker,hive") {
+suite("test_tvf_p0", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String nameNodeHost = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/tvf/test_tvf_topn_lazy_mat.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_tvf_topn_lazy_mat.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_tvf_topn_lazy_mat","external,hive,tvf,external_docker") {
+suite("test_tvf_topn_lazy_mat", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/test_tvf_view.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_tvf_view.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_tvf_view", "p0,external,tvf,external_docker,hive") {
+suite("test_tvf_view", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String nameNodeHost = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/tvf/test_user_empty_lzo.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_user_empty_lzo.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_user_empty_lzo","external,hive,tvf,external_docker") {
+suite("test_user_empty_lzo", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/upgrade/load.groovy
+++ b/regression-test/suites/external_table_p0/tvf/upgrade/load.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_tvf_upgrade_load", "p0,external,hive,external_docker,external_docker_hive,restart_fe,upgrade_case") {
+suite("test_tvf_upgrade_load", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/tvf/upgrade/test.groovy
+++ b/regression-test/suites/external_table_p0/tvf/upgrade/test.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_tvf_upgrade_test", "p0,external,hive,external_docker,external_docker_hive,restart_fe,upgrade_case") {
+suite("test_tvf_upgrade_test", "p0,external") {
     String hdfs_port = context.config.otherConfigs.get("hive2HdfsPort")
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p0/upgrade/load.groovy
+++ b/regression-test/suites/external_table_p0/upgrade/load.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_catalog_upgrade_load", "p0,external,hive,external_docker,external_docker_hive,restart_fe,upgrade_case") {
+suite("test_catalog_upgrade_load", "p0,external") {
 
     // Hive
     String enabled = context.config.otherConfigs.get("enableHiveTest")

--- a/regression-test/suites/external_table_p0/upgrade/test.groovy
+++ b/regression-test/suites/external_table_p0/upgrade/test.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_catalog_upgrade_test", "p0,external,hive,external_docker,external_docker_hive,restart_fe,upgrade_case") {
+suite("test_catalog_upgrade_test", "p0,external") {
 
     // Hive
     String enabled = context.config.otherConfigs.get("enableHiveTest")

--- a/regression-test/suites/external_table_p2/hive/test_cloud_accessible_obs.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_cloud_accessible_obs.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_cloud_accessible_obs", "p2,external,hive,external_remote,external_remote_hive") {
+suite("test_cloud_accessible_obs", "p2,external") {
 
     Boolean ignoreP2 = true;
     if (ignoreP2) {

--- a/regression-test/suites/external_table_p2/hive/test_cloud_accessible_oss.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_cloud_accessible_oss.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_cloud_accessible_oss", "p2,external,hive,external_remote,external_remote_hive") {
+suite("test_cloud_accessible_oss", "p2,external") {
 
     Boolean ignoreP2 = true;
     if (ignoreP2) {

--- a/regression-test/suites/external_table_p2/hive/test_external_brown.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_external_brown.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_external_brown", "p2,external,hive,external_remote,external_remote_hive") {
+suite("test_external_brown", "p2,external") {
     Boolean ignoreP2 = true;
     if (ignoreP2) {
         logger.info("disable p2 test");

--- a/regression-test/suites/external_table_p2/hive/test_external_catalog_glue_table.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_external_catalog_glue_table.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_external_catalog_glue_table", "p2,external,hive,external_remote,external_remote_hive") {
+suite("test_external_catalog_glue_table", "p2,external") {
 
     Boolean ignoreP2 = true;
     if (ignoreP2) {

--- a/regression-test/suites/external_table_p2/hive/test_external_github.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_external_github.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_external_github", "p2,external,hive,external_remote,external_remote_hive") {
+suite("test_external_github", "p2,external") {
     Boolean ignoreP2 = true;
     if (ignoreP2) {
         logger.info("disable p2 test");

--- a/regression-test/suites/external_table_p2/hive/test_external_yandex_nereids.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_external_yandex_nereids.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_external_yandex_nereids", "p2,external,hive,external_remote,external_remote_hive") {
+suite("test_external_yandex_nereids", "p2,external") {
     Boolean ignoreP2 = true;
     if (ignoreP2) {
         logger.info("disable p2 test");

--- a/regression-test/suites/external_table_p2/hive/test_hive_hudi.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_hive_hudi.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_hudi", "p2,external,hive,hudi") {
+suite("test_hive_hudi", "p2,external") {
 
     Boolean ignoreP2 = true;
     if (ignoreP2) {

--- a/regression-test/suites/external_table_p2/hive/test_hive_hudi_statistics.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_hive_hudi_statistics.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_hudi_statistics", "p2,external,hive,hudi") {
+suite("test_hive_hudi_statistics", "p2,external") {
 
     Boolean ignoreP2 = true;
     if (ignoreP2) {

--- a/regression-test/suites/external_table_p2/hive/test_hive_partition_statistic.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_hive_partition_statistic.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_partition_statistic", "p2,external,hive,external_remote,external_remote_hive") {
+suite("test_hive_partition_statistic", "p2,external") {
     Boolean ignoreP2 = true;
     if (ignoreP2) {
         logger.info("disable p2 test");

--- a/regression-test/suites/external_table_p2/hive/test_hive_statistic_cache.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_hive_statistic_cache.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_statistic_cache", "p2,external,hive,external_remote,external_remote_hive") {
+suite("test_hive_statistic_cache", "p2,external") {
 
     Boolean ignoreP2 = true;
     if (ignoreP2) {

--- a/regression-test/suites/external_table_p2/hive/test_hive_statistic_sample.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_hive_statistic_sample.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_statistic_sample", "p2,external,hive,external_remote,external_remote_hive") {
+suite("test_hive_statistic_sample", "p2,external") {
     Boolean ignoreP2 = true;
     if (ignoreP2) {
         logger.info("disable p2 test");

--- a/regression-test/suites/external_table_p2/hive/test_hive_translation_insert_only.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_hive_translation_insert_only.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_translation_insert_only", "p2,external,hive,external_remote,external_remote_hive") {
+suite("test_hive_translation_insert_only", "p2,external") {
 
     String enabled = context.config.otherConfigs.get("enableExternalHudiTest")
     //hudi hive use same catalog in p2.

--- a/regression-test/suites/external_table_p2/hive/test_hive_write_insert_s3.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_hive_write_insert_s3.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_write_insert_s3", "p2,external,hive,external_remote,external_remote_hive") {
+suite("test_hive_write_insert_s3", "p2,external") {
 
     Boolean ignoreP2 = true;
     if (ignoreP2) {

--- a/regression-test/suites/external_table_p2/hive/test_orc_merge_io_input_streams.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_orc_merge_io_input_streams.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_orc_merge_io_input_streams", "p2,external,hive,external_remote,external_remote_hive") {
+suite("test_orc_merge_io_input_streams", "p2,external") {
 
     String enabled = context.config.otherConfigs.get("enableExternalHudiTest")
     //hudi hive use same catalog in p2.

--- a/regression-test/suites/external_table_p2/hive/test_parquet_complex_cross_page.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_parquet_complex_cross_page.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_parquet_complex_cross_page", "p2,external,hive,external_remote,external_remote_hive") {
+suite("test_parquet_complex_cross_page", "p2,external") {
 
     String enabled = context.config.otherConfigs.get("enableExternalHudiTest")
     //hudi hive use same catalog in p2.

--- a/regression-test/suites/external_table_p2/hive/test_select_count_optimize.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_select_count_optimize.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_select_count_optimize", "p2,external,hive,external_remote,external_remote_hive") {
+suite("test_select_count_optimize", "p2,external") {
 
     Boolean ignoreP2 = true;
     if (ignoreP2) {

--- a/regression-test/suites/external_table_p2/hive/test_upper_case_column_name.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_upper_case_column_name.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("upper_case_column_name", "p2,external,hive,external_remote,external_remote_hive") {
+suite("upper_case_column_name", "p2,external") {
 
     Boolean ignoreP2 = true;
     if (ignoreP2) {

--- a/regression-test/suites/external_table_p2/hive/test_viewfs_hive.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_viewfs_hive.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_viewfs_hive", "p2,external,hive,external_remote,external_remote_hive") {
+suite("test_viewfs_hive", "p2,external") {
     Boolean ignoreP2 = true;
     if (ignoreP2) {
         logger.info("disable p2 test");

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_catalog.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hudi_catalog", "p2,external,hudi") {
+suite("test_hudi_catalog", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableHudiTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable hudi test")

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_full_schema_change.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_full_schema_change.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hudi_full_schema_change", "p2,external,hudi") {
+suite("test_hudi_full_schema_change", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableHudiTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable hudi test")

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_incremental.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_incremental.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hudi_incremental", "p2,external,hudi") {
+suite("test_hudi_incremental", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableHudiTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable hudi test")

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_meta.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_meta.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hudi_meta", "p2,external,hudi") {
+suite("test_hudi_meta", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableHudiTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable hudi test")

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_mtmv.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_mtmv.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hudi_mtmv", "p2,external,hudi") {
+suite("test_hudi_mtmv", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableHudiTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable hudi test")

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_olap_rewrite_mtmv.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_olap_rewrite_mtmv.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hudi_olap_rewrite_mtmv", "p2,external,hudi") {
+suite("test_hudi_olap_rewrite_mtmv", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableHudiTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable hudi test")

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_orc_tables.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_orc_tables.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hudi_orc_tables", "p2,external,hudi") {
+suite("test_hudi_orc_tables", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableHudiTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable hudi test")

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_partition_prune.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_partition_prune.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hudi_partition_prune", "p2,external,hudi") {
+suite("test_hudi_partition_prune", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableHudiTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable hudi test")

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_rewrite_mtmv.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_rewrite_mtmv.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hudi_rewrite_mtmv", "p2,external,hudi") {
+suite("test_hudi_rewrite_mtmv", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableHudiTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable hudi test")

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_runtime_filter_partition_pruning.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_runtime_filter_partition_pruning.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hudi_runtime_filter_partition_pruning", "p2,external,hudi") {
+suite("test_hudi_runtime_filter_partition_pruning", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableHudiTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable hudi test")

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_schema_change.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_schema_change.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hudi_schema_change", "p2,external,hudi") {
+suite("test_hudi_schema_change", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableHudiTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable hudi test")

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_schema_evolution.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_schema_evolution.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hudi_schema_evolution", "p2,external,hudi") {
+suite("test_hudi_schema_evolution", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableHudiTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable hudi test")

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_snapshot.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_snapshot.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hudi_snapshot", "p2,external,hudi") {
+suite("test_hudi_snapshot", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableHudiTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable hudi test")

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_timestamp.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_timestamp.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hudi_timestamp", "p2,external,hudi") {
+suite("test_hudi_timestamp", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableHudiTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable hudi test")

--- a/regression-test/suites/external_table_p2/hudi/test_hudi_timetravel.groovy
+++ b/regression-test/suites/external_table_p2/hudi/test_hudi_timetravel.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hudi_timetravel", "p2,external,hudi") {
+suite("test_hudi_timetravel", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableHudiTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable hudi test")

--- a/regression-test/suites/external_table_p2/iceberg/test_iceberg_dlf_catalog.groovy
+++ b/regression-test/suites/external_table_p2/iceberg/test_iceberg_dlf_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_dlf_catalog", "p2,external,iceberg,external_remote,external_remote_iceberg") {
+suite("test_iceberg_dlf_catalog", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         return

--- a/regression-test/suites/external_table_p2/iceberg/test_iceberg_equal_delete.groovy
+++ b/regression-test/suites/external_table_p2/iceberg/test_iceberg_equal_delete.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_equal_delete", "p2,external,iceberg,external_remote,external_remote_iceberg") {
+suite("test_iceberg_equal_delete", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableIcebergTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         return

--- a/regression-test/suites/external_table_p2/iceberg/test_s3tables_glue_insert.groovy
+++ b/regression-test/suites/external_table_p2/iceberg/test_s3tables_glue_insert.groovy
@@ -17,7 +17,7 @@
 
 import java.util.concurrent.ThreadLocalRandom
 
-suite("test_s3tables_glue_insert", "p2,external,iceberg,external_remote,external_remote_iceberg") {
+suite("test_s3tables_glue_insert", "p2,external") {
     def format_compressions = ["parquet_zstd", "orc_zlib"]
 
     def q01 = { String format_compression, String catalog_name ->

--- a/regression-test/suites/external_table_p2/iceberg/test_s3tables_glue_insert_overwrite.groovy
+++ b/regression-test/suites/external_table_p2/iceberg/test_s3tables_glue_insert_overwrite.groovy
@@ -17,7 +17,7 @@
 
 import java.util.concurrent.ThreadLocalRandom
 
-suite("test_s3tables_glue_insert_overwrite", "p0,external,iceberg,external_docker,external_docker_iceberg") {
+suite("test_s3tables_glue_insert_overwrite", "p2,external") {
     def format_compressions = ["parquet_zstd", "orc_zlib"]
 
     def q01 = { String format_compression, String catalog_name ->

--- a/regression-test/suites/external_table_p2/iceberg/test_s3tables_glue_insert_partitions.groovy
+++ b/regression-test/suites/external_table_p2/iceberg/test_s3tables_glue_insert_partitions.groovy
@@ -17,7 +17,7 @@
 
 import java.util.concurrent.ThreadLocalRandom
 
-suite("test_s3tables_glue_insert_partitions", "p0,external,iceberg,external_docker,external_docker_iceberg") {
+suite("test_s3tables_glue_insert_partitions", "p2,external") {
     def format_compressions = ["parquet_snappy", "orc_zlib"]
 
     def test_s3_columns_out_of_order = {  String format_compression, String catalog_name ->

--- a/regression-test/suites/external_table_p2/iceberg/test_s3tables_insert_overwrite.groovy
+++ b/regression-test/suites/external_table_p2/iceberg/test_s3tables_insert_overwrite.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 import java.util.concurrent.ThreadLocalRandom
-suite("test_s3tables_insert_overwrite", "p0,external,iceberg,external_docker,external_docker_iceberg") {
+suite("test_s3tables_insert_overwrite", "p2,external") {
     // disable this test by default, glue + s3table is recommended
     def run_test = false;
     if (!run_test) {

--- a/regression-test/suites/external_table_p2/iceberg/test_s3tables_write_insert.groovy
+++ b/regression-test/suites/external_table_p2/iceberg/test_s3tables_write_insert.groovy
@@ -17,7 +17,7 @@ import java.util.concurrent.ThreadLocalRandom
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_s3tables_write_insert", "p2,external,iceberg,external_remote,external_remote_iceberg") {
+suite("test_s3tables_write_insert", "p2,external") {
     // disable this test by default, glue + s3table is recommended
     def run_test = false;
     if (!run_test) {

--- a/regression-test/suites/external_table_p2/iceberg/test_s3tables_write_partitions.groovy
+++ b/regression-test/suites/external_table_p2/iceberg/test_s3tables_write_partitions.groovy
@@ -17,7 +17,7 @@ import java.util.concurrent.ThreadLocalRandom
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_s3tables_write_partitions", "p0,external,iceberg,external_docker,external_docker_iceberg") {
+suite("test_s3tables_write_partitions", "p2,external") {
     // disable this test by default, glue + s3table is recommended
     def run_test = false;
     if (!run_test) {

--- a/regression-test/suites/external_table_p2/maxcompute/test_external_catalog_maxcompute.groovy
+++ b/regression-test/suites/external_table_p2/maxcompute/test_external_catalog_maxcompute.groovy
@@ -326,7 +326,7 @@
   INSERT INTO TABLE `mc_parts2`  PARTITION (`ds`='2027-01-09', `audit_flag`='Y') values ('3');
   INSERT INTO TABLE `mc_parts2`  PARTITION (`ds`='2024-01-01', `audit_flag`='N') values ('4');
  */
-suite("test_external_catalog_maxcompute", "p2,external,maxcompute,external_remote,external_remote_maxcompute") {
+suite("test_external_catalog_maxcompute", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableMaxComputeTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String ak = context.config.otherConfigs.get("ak")

--- a/regression-test/suites/external_table_p2/maxcompute/test_max_compute_all_type.groovy
+++ b/regression-test/suites/external_table_p2/maxcompute/test_max_compute_all_type.groovy
@@ -312,7 +312,7 @@ ALTER TABLE mc_all_types MERGE SMALLFILES;
 
 select * from mc_all_types;
  */
-suite("test_max_compute_all_type", "p2,external,maxcompute,external_remote,external_remote_maxcompute") {
+suite("test_max_compute_all_type", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableMaxComputeTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String ak = context.config.otherConfigs.get("ak")

--- a/regression-test/suites/external_table_p2/maxcompute/test_max_compute_complex_type.groovy
+++ b/regression-test/suites/external_table_p2/maxcompute/test_max_compute_complex_type.groovy
@@ -157,7 +157,7 @@
         )
     );
  */
-suite("test_max_compute_complex_type", "p2,external,maxcompute,external_remote,external_remote_maxcompute") {
+suite("test_max_compute_complex_type", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableMaxComputeTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String ak = context.config.otherConfigs.get("ak")

--- a/regression-test/suites/external_table_p2/maxcompute/test_max_compute_create_table.groovy
+++ b/regression-test/suites/external_table_p2/maxcompute/test_max_compute_create_table.groovy
@@ -28,7 +28,7 @@
  * Note: Tables are NOT deleted after creation to allow inspection after tests run
  */
 
-suite("test_max_compute_create_table", "p2,external,maxcompute,external_remote,external_remote_maxcompute") {
+suite("test_max_compute_create_table", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableMaxComputeTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String ak = context.config.otherConfigs.get("ak")

--- a/regression-test/suites/external_table_p2/maxcompute/test_max_compute_partition_prune.groovy
+++ b/regression-test/suites/external_table_p2/maxcompute/test_max_compute_partition_prune.groovy
@@ -71,7 +71,7 @@ show partitions two_partition_tb;
 show partitions three_partition_tb;
 */
 
-suite("test_max_compute_partition_prune", "p2,external,maxcompute,external_remote,external_remote_maxcompute") {
+suite("test_max_compute_partition_prune", "p2,external") {
 
 
     def one_partition_1_1 = """SELECT * FROM one_partition_tb WHERE part1 = 2024 ORDER BY id;"""

--- a/regression-test/suites/external_table_p2/maxcompute/test_max_compute_schema.groovy
+++ b/regression-test/suites/external_table_p2/maxcompute/test_max_compute_schema.groovy
@@ -87,7 +87,7 @@ INSERT INTO employee_salary VALUES
 (3, 'Mike', 'HR', 9800.00, CAST('2024-06-20' AS DATE)),
 (4, 'Lucy', 'IT', 13500.00, CAST('2022-11-05' AS DATE));
  */
-suite("test_max_compute_schema", "p2,external,maxcompute,external_remote,external_remote_maxcompute") {
+suite("test_max_compute_schema", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableMaxComputeTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String ak = context.config.otherConfigs.get("ak")

--- a/regression-test/suites/external_table_p2/maxcompute/test_max_compute_timestamp.groovy
+++ b/regression-test/suites/external_table_p2/maxcompute/test_max_compute_timestamp.groovy
@@ -83,7 +83,7 @@ INSERT INTO TABLE timestamp_tb4 VALUES
     (timestamp '9999-12-31 23:59:59.999999876', timestamp_ntz '9999-12-31 23:59:59.999999876');
 */
 
-suite("test_max_compute_timestamp", "p2,external,maxcompute,external_remote,external_remote_maxcompute") {
+suite("test_max_compute_timestamp", "p2,external") {
 
 
     String enabled = context.config.otherConfigs.get("enableMaxComputeTest")

--- a/regression-test/suites/external_table_p2/maxcompute/write/test_mc_write_ctas.groovy
+++ b/regression-test/suites/external_table_p2/maxcompute/write/test_mc_write_ctas.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_mc_write_ctas", "p2,external,maxcompute,external_remote,external_remote_maxcompute") {
+suite("test_mc_write_ctas", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableMaxComputeTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable MaxCompute test.")

--- a/regression-test/suites/external_table_p2/maxcompute/write/test_mc_write_insert.groovy
+++ b/regression-test/suites/external_table_p2/maxcompute/write/test_mc_write_insert.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_mc_write_insert", "p2,external,maxcompute,external_remote,external_remote_maxcompute") {
+suite("test_mc_write_insert", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableMaxComputeTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable MaxCompute test.")

--- a/regression-test/suites/external_table_p2/maxcompute/write/test_mc_write_large_data.groovy
+++ b/regression-test/suites/external_table_p2/maxcompute/write/test_mc_write_large_data.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_mc_write_large_data", "p2,external,maxcompute,external_remote,external_remote_maxcompute") {
+suite("test_mc_write_large_data", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableMaxComputeTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable MaxCompute test.")

--- a/regression-test/suites/external_table_p2/maxcompute/write/test_mc_write_partitions.groovy
+++ b/regression-test/suites/external_table_p2/maxcompute/write/test_mc_write_partitions.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_mc_write_partitions", "p2,external,maxcompute,external_remote,external_remote_maxcompute") {
+suite("test_mc_write_partitions", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableMaxComputeTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable MaxCompute test.")

--- a/regression-test/suites/external_table_p2/maxcompute/write/test_mc_write_static_partitions.groovy
+++ b/regression-test/suites/external_table_p2/maxcompute/write/test_mc_write_static_partitions.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_mc_write_static_partitions", "p2,external,maxcompute,external_remote,external_remote_maxcompute") {
+suite("test_mc_write_static_partitions", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableMaxComputeTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable MaxCompute test.")

--- a/regression-test/suites/external_table_p2/maxcompute/write/test_mc_write_types.groovy
+++ b/regression-test/suites/external_table_p2/maxcompute/write/test_mc_write_types.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_mc_write_types", "p2,external,maxcompute,external_remote,external_remote_maxcompute") {
+suite("test_mc_write_types", "p2,external") {
     String enabled = context.config.otherConfigs.get("enableMaxComputeTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable MaxCompute test.")

--- a/regression-test/suites/external_table_p2/mysql/test_external_catalog_mysql.groovy
+++ b/regression-test/suites/external_table_p2/mysql/test_external_catalog_mysql.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 //import com.mysql.cj.jdbc.Driver
-suite("test_external_catalog_mysql", "p2,external,mysql,external_remote,external_remote_mysql") {
+suite("test_external_catalog_mysql", "p2,external") {
 
     Boolean ignoreP2 = true;
     if (ignoreP2) {

--- a/regression-test/suites/external_table_p2/mysql/test_external_resource_mysql.groovy
+++ b/regression-test/suites/external_table_p2/mysql/test_external_resource_mysql.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 //import com.mysql.cj.jdbc.Driver
-suite("test_external_resource_mysql", "p2,external,mysql,external_remote,external_remote_mysql") {
+suite("test_external_resource_mysql", "p2,external") {
 
     Boolean ignoreP2 = true;
     if (ignoreP2) {

--- a/regression-test/suites/external_table_p2/paimon/test_paimon_dlf_catalog.groovy
+++ b/regression-test/suites/external_table_p2/paimon/test_paimon_dlf_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_dlf_catalog", "p2,external,paimon,external_remote,external_remote_paimon,new_catalog_property") {
+suite("test_paimon_dlf_catalog", "p2,external") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         return

--- a/regression-test/suites/external_table_p2/paimon/test_paimon_dlf_catalog_miss_dlf_param.groovy
+++ b/regression-test/suites/external_table_p2/paimon/test_paimon_dlf_catalog_miss_dlf_param.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_dlf_catalog_miss_dlf_param", "p2,external,paimon,external_remote,external_remote_paimon,new_catalog_property") {
+suite("test_paimon_dlf_catalog_miss_dlf_param", "p2,external") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         return

--- a/regression-test/suites/external_table_p2/paimon/test_paimon_dlf_catalog_new_param.groovy
+++ b/regression-test/suites/external_table_p2/paimon/test_paimon_dlf_catalog_new_param.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_dlf_catalog_new_param", "p2,external,paimon,external_remote,external_remote_paimon,new_catalog_property") {
+suite("test_paimon_dlf_catalog_new_param", "p2,external") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         return

--- a/regression-test/suites/external_table_p2/paimon/test_paimon_dlf_rest_catalog.groovy
+++ b/regression-test/suites/external_table_p2/paimon/test_paimon_dlf_rest_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_dlf_rest_catalog", "p2,external,paimon,external_remote,external_remote_paimon,new_catalog_property") {
+suite("test_paimon_dlf_rest_catalog", "p2,external") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         return

--- a/regression-test/suites/external_table_p2/paimon/test_paimon_hms_catalog.groovy
+++ b/regression-test/suites/external_table_p2/paimon/test_paimon_hms_catalog.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_paimon_hms_catalog", "p2,external,paimon,new_catalog_property") {
+suite("test_paimon_hms_catalog", "p2,external") {
 
     def testQuery = { String catalogProperties, String prefix, String dbName ->
         def catalog_name = "test_paimon_on_hms_${prefix}_catalog"

--- a/regression-test/suites/external_table_p2/pg/test_external_pg_nereids.groovy
+++ b/regression-test/suites/external_table_p2/pg/test_external_pg_nereids.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 //import org.postgresql.Driver
-suite("test_external_pg_nereids", "p2,external,pg,external_remote,external_remote_pg") {
+suite("test_external_pg_nereids", "p2,external") {
 
     Boolean ignoreP2 = true;
     if (ignoreP2) {

--- a/regression-test/suites/external_table_p2/refactor_catalog_param/azure_blob_all_test.groovy
+++ b/regression-test/suites/external_table_p2/refactor_catalog_param/azure_blob_all_test.groovy
@@ -17,7 +17,7 @@
 import static groovy.test.GroovyAssert.shouldFail;
 import java.util.concurrent.ThreadLocalRandom
 
-suite("azure_blob_all_test", "p2,external,new_catalog_property") {
+suite("azure_blob_all_test", "p2,external") {
 
 
     String abfsAzureAccountName = context.config.otherConfigs.get("abfsAccountName")

--- a/regression-test/suites/external_table_p2/refactor_catalog_param/azure_non_catalog_all_test.groovy
+++ b/regression-test/suites/external_table_p2/refactor_catalog_param/azure_non_catalog_all_test.groovy
@@ -18,7 +18,7 @@ import org.awaitility.Awaitility;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static groovy.test.GroovyAssert.shouldFail
 
-suite("azure_non_catalog_all_test", "p2,external,new_catalog_property") {
+suite("azure_non_catalog_all_test", "p2,external") {
 
     // create internal table
     def createDBAndTbl = { String dbName , String table->

--- a/regression-test/suites/external_table_p2/refactor_catalog_param/backup_restore_azure.groovy
+++ b/regression-test/suites/external_table_p2/refactor_catalog_param/backup_restore_azure.groovy
@@ -18,7 +18,7 @@ import org.awaitility.Awaitility;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static groovy.test.GroovyAssert.shouldFail
 
-suite("refactor_storage_backup_restore_azure", "p2,external,new_catalog_property") {
+suite("refactor_storage_backup_restore_azure", "p2,external") {
     
 
 

--- a/regression-test/suites/external_table_p2/refactor_catalog_param/hive_on_hms_and_dlf.groovy
+++ b/regression-test/suites/external_table_p2/refactor_catalog_param/hive_on_hms_and_dlf.groovy
@@ -17,7 +17,7 @@
 import static groovy.test.GroovyAssert.shouldFail;
 import java.util.concurrent.ThreadLocalRandom
 
-suite("hive_on_hms_and_dlf", "p2,external,new_catalog_property") {
+suite("hive_on_hms_and_dlf", "p2,external") {
 
 
     def testQueryAndInsert = { String catalogProperties, String prefix, String dbLocation ->

--- a/regression-test/suites/external_table_p2/refactor_catalog_param/iceberg_and_hive_on_glue.groovy
+++ b/regression-test/suites/external_table_p2/refactor_catalog_param/iceberg_and_hive_on_glue.groovy
@@ -16,7 +16,7 @@
 // under the License.
 import static groovy.test.GroovyAssert.shouldFail;
 
-suite("iceberg_and_hive_on_glue", "p2,external,hive,new_catalog_property") {
+suite("iceberg_and_hive_on_glue", "p2,external") {
 
 
     def testQueryAndInsert = { String catalogProperties, String prefix, String dbLocation ->

--- a/regression-test/suites/external_table_p2/refactor_catalog_param/iceberg_on_hms_and_filesystem_and_dlf.groovy
+++ b/regression-test/suites/external_table_p2/refactor_catalog_param/iceberg_on_hms_and_filesystem_and_dlf.groovy
@@ -18,7 +18,7 @@
 import java.util.concurrent.ThreadLocalRandom
 
 import static groovy.test.GroovyAssert.shouldFail;
-suite("iceberg_on_hms_and_filesystem_and_dlf", "p2,external,new_catalog_property") {
+suite("iceberg_on_hms_and_filesystem_and_dlf", "p2,external") {
     
     def hmsTestQueryAndInsert = { String catalogProperties, String prefix ->
 

--- a/regression-test/suites/external_table_p2/refactor_catalog_param/iceberg_rest_s3_storage_vended_test.groovy
+++ b/regression-test/suites/external_table_p2/refactor_catalog_param/iceberg_rest_s3_storage_vended_test.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_rest_s3_storage_vended_test", "p2,external,iceberg,external_docker,external_docker_iceberg_rest,new_catalog_property") {
+suite("iceberg_rest_s3_storage_vended_test", "p2,external") {
     // Since the vended credential test environment of oss/cos/s3 is currently unavailable, the test is temporarily closed
     // After the environment is ready, start the test
     // Minio-based vended credential test reference test_polaris.groovy

--- a/regression-test/suites/external_table_p2/refactor_catalog_param/iceberg_rest_storage_test.groovy
+++ b/regression-test/suites/external_table_p2/refactor_catalog_param/iceberg_rest_storage_test.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_rest_storage_test", "p2,external,iceberg,external_docker,external_docker_iceberg_rest,new_catalog_property") {
+suite("iceberg_rest_storage_test", "p2,external") {
 
     def testQueryAndInsert = { String catalogProperties, String prefix ->
 

--- a/regression-test/suites/external_table_p2/refactor_catalog_param/oss_hdfs_catalog_test.groovy
+++ b/regression-test/suites/external_table_p2/refactor_catalog_param/oss_hdfs_catalog_test.groovy
@@ -17,7 +17,7 @@
 import static groovy.test.GroovyAssert.shouldFail;
 import java.util.concurrent.ThreadLocalRandom
 
-suite("oss_hdfs_catalog_test", "p2,external,new_catalog_property") {
+suite("oss_hdfs_catalog_test", "p2,external") {
     def testQueryAndInsert = { String catalogProperties, String prefix, String dbLocation ->
 
         def catalog_name = "${prefix}_catalog"

--- a/regression-test/suites/external_table_p2/test_connection/test_connectivity.groovy
+++ b/regression-test/suites/external_table_p2/test_connection/test_connectivity.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_connectivity", "p2,external,hive,iceberg,external_docker,external_docker_hive,new_catalog_property") {
+suite("test_connectivity", "p2,external") {
 
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 

--- a/regression-test/suites/external_table_p2/trino_connector/hive/test_trino_hive_tpch_sf1_orc.groovy
+++ b/regression-test/suites/external_table_p2/trino_connector/hive/test_trino_hive_tpch_sf1_orc.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_trino_hive_tpch_sf1_orc", "p2,external,hive,external_docker,external_docker_hive") {
+suite("test_trino_hive_tpch_sf1_orc", "p2,external") {
 
     String enable_file_cache = "false"
     def q01 = { 

--- a/regression-test/suites/external_table_p2/trino_connector/hive/test_trino_hive_tpch_sf1_parquet.groovy
+++ b/regression-test/suites/external_table_p2/trino_connector/hive/test_trino_hive_tpch_sf1_parquet.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_trino_hive_tpch_sf1_parquet", "p0,external,hive,external_docker,external_docker_hive") {
+suite("test_trino_hive_tpch_sf1_parquet", "p2,external") {
 
     String enable_file_cache = "false"
     def q01 = { 

--- a/regression-test/suites/external_table_p2/tvf/test_iceberg_meta.groovy
+++ b/regression-test/suites/external_table_p2/tvf/test_iceberg_meta.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_iceberg_meta", "p2,external,iceberg,external_remote,external_remote_iceberg") {
+suite("test_iceberg_meta", "p2,external") {
     String suiteName = "test_iceberg_meta"
     Boolean ignoreP2 = true;
     if (ignoreP2) {


### PR DESCRIPTION
## Summary
- normalize all suite labels under `regression-test/suites/external_table_p0` to `p0,external`
- normalize all suite labels under `regression-test/suites/external_table_p2` to `p2,external`

## Scope
- only modifies suite label strings in external table regression cases
- total updated files: 470