### PR TITLE
[Enhancement] (FE) Convert intra FE-to-FE calls to HTTPS when enabled

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -1592,7 +1592,8 @@ public class Env {
             }
 
             LOG.info("get fe node type {}, name {} from {}:{}:{}", role, nodeName,
-                    helperNode.getHost(), helperNode.getHost(), Config.http_port);
+                    helperNode.getHost(), helperNode.getPort(),
+                    Config.enable_https ? Config.https_port : Config.http_port);
             rightHelperNode = helperNode;
             break;
         }
@@ -1821,7 +1822,7 @@ public class Env {
 
             toMasterProgress = "log master info";
             this.masterInfo = new MasterInfo(Env.getCurrentEnv().getSelfNode().getHost(),
-                    Config.http_port,
+                    Config.enable_https ? Config.https_port : Config.http_port,
                     Config.rpc_port);
             editLog.logMasterInfo(masterInfo);
             LOG.info("logMasterInfo:{}", masterInfo);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -1593,7 +1593,7 @@ public class Env {
 
             LOG.info("get fe node type {}, name {} from {}:{}:{}", role, nodeName,
                     helperNode.getHost(), helperNode.getPort(),
-                    Config.enable_https ? Config.https_port : Config.http_port);
+                    HttpURLUtil.getHttpPort());
             rightHelperNode = helperNode;
             break;
         }
@@ -1822,7 +1822,7 @@ public class Env {
 
             toMasterProgress = "log master info";
             this.masterInfo = new MasterInfo(Env.getCurrentEnv().getSelfNode().getHost(),
-                    Config.enable_https ? Config.https_port : Config.http_port,
+                    HttpURLUtil.getHttpPort(),
                     Config.rpc_port);
             editLog.logMasterInfo(masterInfo);
             LOG.info("logMasterInfo:{}", masterInfo);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -1558,9 +1558,8 @@ public class Env {
             try {
                 // For upgrade compatibility, the host parameter name remains the same
                 // and the new hostname parameter is added
-                String url = "http://" + NetUtils.getHostPortInAccessibleFormat(helperNode.getHost(), Config.http_port)
-                        + "/role?host=" + selfNode.getHost()
-                        + "&port=" + selfNode.getPort();
+                String queryParams = "host=" + selfNode.getHost() + "&port=" + selfNode.getPort();
+                String url = HttpURLUtil.buildInternalFeUrl(helperNode.getHost(), "/role", queryParams);
                 HttpURLConnection conn = HttpURLUtil.getConnectionWithNodeIdent(url);
                 if (conn.getResponseCode() != 200) {
                     LOG.warn("failed to get fe node type from helper node: {}. response code: {}", helperNode,
@@ -2280,8 +2279,7 @@ public class Env {
 
     protected boolean getVersionFileFromHelper(HostInfo helperNode) throws IOException {
         try {
-            String url = "http://" + NetUtils.getHostPortInAccessibleFormat(helperNode.getHost(), Config.http_port)
-                    + "/version";
+            String url = HttpURLUtil.buildInternalFeUrl(helperNode.getHost(), "/version", null);
             File dir = new File(this.imageDir);
             MetaHelper.getRemoteFile(url, HTTP_TIMEOUT_SECOND * 1000,
                     MetaHelper.getFile(Storage.VERSION_FILE, dir));

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -1461,8 +1461,7 @@ public class Env {
                 getClusterIdFromStorage(storage);
                 token = storage.getToken();
                 try {
-                    String url = "http://" + NetUtils
-                            .getHostPortInAccessibleFormat(rightHelperNode.getHost(), Config.http_port) + "/check";
+                    String url = HttpURLUtil.buildInternalFeUrl(rightHelperNode.getHost(), "/check", null);
                     HttpURLConnection conn = HttpURLUtil.getConnectionWithNodeIdent(url);
                     conn.setConnectTimeout(2 * 1000);
                     conn.setReadTimeout(2 * 1000);
@@ -2298,8 +2297,7 @@ public class Env {
         localImageVersion = storage.getLatestImageSeq();
 
         try {
-            String hostPort = NetUtils.getHostPortInAccessibleFormat(helperNode.getHost(), Config.http_port);
-            String infoUrl = "http://" + hostPort + "/info";
+            String infoUrl = HttpURLUtil.buildInternalFeUrl(helperNode.getHost(), "/info", null);
             ResponseBody<StorageInfo> responseBody = MetaHelper
                     .doGet(infoUrl, HTTP_TIMEOUT_SECOND * 1000, StorageInfo.class);
             if (responseBody.getCode() != RestApiStatusCode.OK.code) {
@@ -2309,7 +2307,7 @@ public class Env {
             StorageInfo info = responseBody.getData();
             long version = info.getImageSeq();
             if (version > localImageVersion) {
-                String url = "http://" + hostPort + "/image?version=" + version;
+                String url = HttpURLUtil.buildInternalFeUrl(helperNode.getHost(), "/image", "version=" + version);
                 String filename = Storage.IMAGE + "." + version;
                 File dir = new File(this.imageDir);
                 MetaHelper.getRemoteFile(url, Config.sync_image_timeout_second * 1000,

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/HttpURLUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/HttpURLUtil.java
@@ -19,6 +19,7 @@ package org.apache.doris.common.util;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.cloud.security.SecurityChecker;
+import org.apache.doris.common.Config;
 import org.apache.doris.system.SystemInfoService.HostInfo;
 
 import com.google.common.collect.Maps;
@@ -34,9 +35,12 @@ public class HttpURLUtil {
         try {
             SecurityChecker.getInstance().startSSRFChecking(request);
             URL url = new URL(request);
+
+            if (url.getProtocol().equalsIgnoreCase("https") && Config.enable_https) {
+                InternalHttpsUtils.installTrustManagerForUrlConnection();
+            }
+
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            // Must use Env.getServingEnv() instead of getCurrentEnv(),
-            // because here we need to obtain selfNode through the official service catalog.
             HostInfo selfNode = Env.getServingEnv().getSelfNode();
             conn.setRequestProperty(Env.CLIENT_NODE_HOST_KEY, selfNode.getHost());
             conn.setRequestProperty(Env.CLIENT_NODE_PORT_KEY, selfNode.getPort() + "");
@@ -50,12 +54,22 @@ public class HttpURLUtil {
 
     public static Map<String, String> getNodeIdentHeaders() throws IOException {
         Map<String, String> headers = Maps.newHashMap();
-        // Must use Env.getServingEnv() instead of getCurrentEnv(),
-        // because here we need to obtain selfNode through the official service catalog.
         HostInfo selfNode = Env.getServingEnv().getSelfNode();
         headers.put(Env.CLIENT_NODE_HOST_KEY, selfNode.getHost());
         headers.put(Env.CLIENT_NODE_PORT_KEY, selfNode.getPort() + "");
         return headers;
+    }
+
+    public static String buildInternalFeUrl(String host, String path, String queryParams) {
+        String protocol = Config.enable_https ? "https" : "http";
+        int port = Config.enable_https ? Config.https_port : Config.http_port;
+
+        String url = protocol + "://" + NetUtils.getHostPortInAccessibleFormat(host, port) + path;
+        if (queryParams != null && !queryParams.isEmpty()) {
+            url += "?" + queryParams;
+        }
+
+        return url;
     }
 
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/HttpURLUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/HttpURLUtil.java
@@ -23,11 +23,13 @@ import org.apache.doris.common.Config;
 import org.apache.doris.system.SystemInfoService.HostInfo;
 
 import com.google.common.collect.Maps;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Map;
+import javax.net.ssl.HttpsURLConnection;
 
 public class HttpURLUtil {
 
@@ -35,12 +37,16 @@ public class HttpURLUtil {
         try {
             SecurityChecker.getInstance().startSSRFChecking(request);
             URL url = new URL(request);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
 
-            if (url.getProtocol().equalsIgnoreCase("https") && Config.enable_https) {
-                InternalHttpsUtils.installTrustManagerForUrlConnection();
+            if (conn instanceof HttpsURLConnection && Config.enable_https) {
+                HttpsURLConnection httpsConn = (HttpsURLConnection) conn;
+                httpsConn.setSSLSocketFactory(InternalHttpsUtils.getSslContext().getSocketFactory());
+                httpsConn.setHostnameVerifier(NoopHostnameVerifier.INSTANCE);
             }
 
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            // Must use Env.getServingEnv() instead of getCurrentEnv(),
+            // because here we need to obtain selfNode through the official service catalog.
             HostInfo selfNode = Env.getServingEnv().getSelfNode();
             conn.setRequestProperty(Env.CLIENT_NODE_HOST_KEY, selfNode.getHost());
             conn.setRequestProperty(Env.CLIENT_NODE_PORT_KEY, selfNode.getPort() + "");
@@ -54,6 +60,8 @@ public class HttpURLUtil {
 
     public static Map<String, String> getNodeIdentHeaders() throws IOException {
         Map<String, String> headers = Maps.newHashMap();
+        // Must use Env.getServingEnv() instead of getCurrentEnv(),
+        // because here we need to obtain selfNode through the official service catalog.
         HostInfo selfNode = Env.getServingEnv().getSelfNode();
         headers.put(Env.CLIENT_NODE_HOST_KEY, selfNode.getHost());
         headers.put(Env.CLIENT_NODE_PORT_KEY, selfNode.getPort() + "");

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/HttpURLUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/HttpURLUtil.java
@@ -68,9 +68,13 @@ public class HttpURLUtil {
         return headers;
     }
 
+    public static int getHttpPort() {
+        return Config.enable_https ? Config.https_port : Config.http_port;
+    }
+
     public static String buildInternalFeUrl(String host, String path, String queryParams) {
         String protocol = Config.enable_https ? "https" : "http";
-        int port = Config.enable_https ? Config.https_port : Config.http_port;
+        int port = getHttpPort();
 
         String url = protocol + "://" + NetUtils.getHostPortInAccessibleFormat(host, port) + path;
         if (queryParams != null && !queryParams.isEmpty()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/InternalHttpsUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/InternalHttpsUtils.java
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+import org.apache.doris.common.Config;
+
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.KeyStore;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * SSL-aware HTTP clients for internal FE communication using MySQL SSL truststore.
+ */
+public class InternalHttpsUtils {
+    private static final Logger LOG = LogManager.getLogger(InternalHttpsUtils.class);
+
+    public static CloseableHttpClient createValidatedHttpClient() {
+        try {
+            KeyStore trustStore = KeyStore.getInstance(Config.ssl_trust_store_type);
+            try (InputStream stream = Files.newInputStream(
+                    Paths.get(Config.mysql_ssl_default_ca_certificate))) {
+                trustStore.load(stream, Config.mysql_ssl_default_ca_certificate_password.toCharArray());
+            }
+
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance(
+                    TrustManagerFactory.getDefaultAlgorithm());
+            tmf.init(trustStore);
+
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, tmf.getTrustManagers(), null);
+
+            SSLConnectionSocketFactory sslFactory = new SSLConnectionSocketFactory(sslContext);
+
+            return HttpClients.custom()
+                    .setSSLSocketFactory(sslFactory)
+                    .build();
+        } catch (Exception e) {
+            LOG.error("Failed to create SSL-aware HTTP client using truststore: {}",
+                    Config.mysql_ssl_default_ca_certificate, e);
+            throw new RuntimeException("Failed to create SSL-aware HTTP client", e);
+        }
+    }
+
+    public static void installTrustManagerForUrlConnection() {
+        try {
+            KeyStore trustStore = KeyStore.getInstance(Config.ssl_trust_store_type);
+            try (InputStream stream = Files.newInputStream(
+                    Paths.get(Config.mysql_ssl_default_ca_certificate))) {
+                trustStore.load(stream, Config.mysql_ssl_default_ca_certificate_password.toCharArray());
+            }
+
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance(
+                    TrustManagerFactory.getDefaultAlgorithm());
+            tmf.init(trustStore);
+
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, tmf.getTrustManagers(), null);
+
+            javax.net.ssl.HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
+        } catch (Exception e) {
+            LOG.error("Failed to install trust manager for URLConnection using truststore: {}",
+                    Config.mysql_ssl_default_ca_certificate, e);
+            throw new RuntimeException("Failed to install trust manager for URLConnection", e);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/InternalHttpsUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/InternalHttpsUtils.java
@@ -19,6 +19,7 @@ package org.apache.doris.common.util;
 
 import org.apache.doris.common.Config;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -46,11 +47,32 @@ import javax.net.ssl.TrustManagerFactory;
  *
  * This approach is similar to other distributed systems (Kafka, Elasticsearch, Cassandra)
  * where inter-node SSL communication disables hostname verification for operational flexibility.
+ *
+ * The SSLContext is built once from the truststore and cached for the lifetime of the process.
+ * Certificate rotation requires a FE restart to take effect.
  */
 public class InternalHttpsUtils {
     private static final Logger LOG = LogManager.getLogger(InternalHttpsUtils.class);
 
-    public static CloseableHttpClient createValidatedHttpClient() {
+    @VisibleForTesting
+    static volatile SSLContext cachedSslContext = null;
+
+    /**
+     * Returns the cached SSLContext, building it from the configured truststore on first call.
+     * Thread-safe via double-checked locking on a volatile field.
+     */
+    public static SSLContext getSslContext() {
+        if (cachedSslContext == null) {
+            synchronized (InternalHttpsUtils.class) {
+                if (cachedSslContext == null) {
+                    cachedSslContext = buildSslContext();
+                }
+            }
+        }
+        return cachedSslContext;
+    }
+
+    private static SSLContext buildSslContext() {
         try {
             KeyStore trustStore = KeyStore.getInstance(Config.ssl_trust_store_type);
             try (InputStream stream = Files.newInputStream(
@@ -64,42 +86,21 @@ public class InternalHttpsUtils {
 
             SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(null, tmf.getTrustManagers(), null);
-
-            SSLConnectionSocketFactory sslFactory = new SSLConnectionSocketFactory(
-                    sslContext,
-                    NoopHostnameVerifier.INSTANCE);
-
-            return HttpClients.custom()
-                    .setSSLSocketFactory(sslFactory)
-                    .build();
+            return sslContext;
         } catch (Exception e) {
-            LOG.error("Failed to create SSL-aware HTTP client using truststore: {}",
+            LOG.error("Failed to build SSLContext from truststore: {}",
                     Config.mysql_ssl_default_ca_certificate, e);
-            throw new RuntimeException("Failed to create SSL-aware HTTP client", e);
+            throw new RuntimeException("Failed to build SSLContext from truststore", e);
         }
     }
 
-    public static void installTrustManagerForUrlConnection() {
-        try {
-            KeyStore trustStore = KeyStore.getInstance(Config.ssl_trust_store_type);
-            try (InputStream stream = Files.newInputStream(
-                    Paths.get(Config.mysql_ssl_default_ca_certificate))) {
-                trustStore.load(stream, Config.mysql_ssl_default_ca_certificate_password.toCharArray());
-            }
+    public static CloseableHttpClient createValidatedHttpClient() {
+        SSLConnectionSocketFactory sslFactory = new SSLConnectionSocketFactory(
+                getSslContext(),
+                NoopHostnameVerifier.INSTANCE);
 
-            TrustManagerFactory tmf = TrustManagerFactory.getInstance(
-                    TrustManagerFactory.getDefaultAlgorithm());
-            tmf.init(trustStore);
-
-            SSLContext sslContext = SSLContext.getInstance("TLS");
-            sslContext.init(null, tmf.getTrustManagers(), null);
-
-            javax.net.ssl.HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
-            javax.net.ssl.HttpsURLConnection.setDefaultHostnameVerifier((hostname, session) -> true);
-        } catch (Exception e) {
-            LOG.error("Failed to install trust manager for URLConnection using truststore: {}",
-                    Config.mysql_ssl_default_ca_certificate, e);
-            throw new RuntimeException("Failed to install trust manager for URLConnection", e);
-        }
+        return HttpClients.custom()
+                .setSSLSocketFactory(sslFactory)
+                .build();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/InternalHttpsUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/InternalHttpsUtils.java
@@ -19,6 +19,7 @@ package org.apache.doris.common.util;
 
 import org.apache.doris.common.Config;
 
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
@@ -34,6 +35,17 @@ import javax.net.ssl.TrustManagerFactory;
 
 /**
  * SSL-aware HTTP clients for internal FE communication using MySQL SSL truststore.
+ *
+ * Security Model:
+ * - Validates certificates against configured CA truststore (mysql_ssl_default_ca_certificate)
+ * - Hostname verification is DISABLED to support IP-based FE communication
+ * - This is safe for internal cluster communication because:
+ *   1. All endpoints enforce checkFromValidFe() - only registered FE nodes can connect
+ *   2. FE cluster is assumed to be on trusted network
+ *   3. Traffic is encrypted and authenticated via certificate validation
+ *
+ * This approach is similar to other distributed systems (Kafka, Elasticsearch, Cassandra)
+ * where inter-node SSL communication disables hostname verification for operational flexibility.
  */
 public class InternalHttpsUtils {
     private static final Logger LOG = LogManager.getLogger(InternalHttpsUtils.class);
@@ -53,7 +65,9 @@ public class InternalHttpsUtils {
             SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(null, tmf.getTrustManagers(), null);
 
-            SSLConnectionSocketFactory sslFactory = new SSLConnectionSocketFactory(sslContext);
+            SSLConnectionSocketFactory sslFactory = new SSLConnectionSocketFactory(
+                    sslContext,
+                    NoopHostnameVerifier.INSTANCE);
 
             return HttpClients.custom()
                     .setSSLSocketFactory(sslFactory)
@@ -81,6 +95,7 @@ public class InternalHttpsUtils {
             sslContext.init(null, tmf.getTrustManagers(), null);
 
             javax.net.ssl.HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
+            javax.net.ssl.HttpsURLConnection.setDefaultHostnameVerifier((hostname, session) -> true);
         } catch (Exception e) {
             LOG.error("Failed to install trust manager for URLConnection using truststore: {}",
                     Config.mysql_ssl_default_ca_certificate, e);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/InternalHttpsUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/InternalHttpsUtils.java
@@ -19,7 +19,6 @@ package org.apache.doris.common.util;
 
 import org.apache.doris.common.Config;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -35,31 +34,19 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 
 /**
- * SSL-aware HTTP clients for internal FE communication using MySQL SSL truststore.
+ * Utility for creating SSL-aware HTTP clients for internal FE-to-FE communication.
  *
- * Security Model:
- * - Validates certificates against configured CA truststore (mysql_ssl_default_ca_certificate)
- * - Hostname verification is DISABLED to support IP-based FE communication
- * - This is safe for internal cluster communication because:
- *   1. All endpoints enforce checkFromValidFe() - only registered FE nodes can connect
- *   2. FE cluster is assumed to be on trusted network
- *   3. Traffic is encrypted and authenticated via certificate validation
- *
- * This approach is similar to other distributed systems (Kafka, Elasticsearch, Cassandra)
- * where inter-node SSL communication disables hostname verification for operational flexibility.
- *
- * The SSLContext is built once from the truststore and cached for the lifetime of the process.
- * Certificate rotation requires a FE restart to take effect.
+ * <p>Builds an {@link SSLContext} from the configured CA truststore once and caches it.
+ * Hostname verification is disabled for IP-based intra-cluster connections.
+ * Certificate rotation requires a FE restart.
  */
 public class InternalHttpsUtils {
-    private static final Logger LOG = LogManager.getLogger(InternalHttpsUtils.class);
+    private static volatile SSLContext cachedSslContext = null;
 
-    @VisibleForTesting
-    static volatile SSLContext cachedSslContext = null;
+    private static final Logger LOG = LogManager.getLogger(InternalHttpsUtils.class);
 
     /**
      * Returns the cached SSLContext, building it from the configured truststore on first call.
-     * Thread-safe via double-checked locking on a volatile field.
      */
     public static SSLContext getSslContext() {
         if (cachedSslContext == null) {
@@ -90,10 +77,15 @@ public class InternalHttpsUtils {
         } catch (Exception e) {
             LOG.error("Failed to build SSLContext from truststore: {}",
                     Config.mysql_ssl_default_ca_certificate, e);
-            throw new RuntimeException("Failed to build SSLContext from truststore", e);
+            throw new RuntimeException(
+                    "Failed to build SSLContext from truststore: "
+                            + Config.mysql_ssl_default_ca_certificate, e);
         }
     }
 
+    /**
+     * Returns an HTTP client configured with the FE CA truststore and hostname verification disabled.
+     */
     public static CloseableHttpClient createValidatedHttpClient() {
         SSLConnectionSocketFactory sslFactory = new SSLConnectionSocketFactory(
                 getSslContext(),

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/InternalHttpsUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/InternalHttpsUtils.java
@@ -61,6 +61,8 @@ public class InternalHttpsUtils {
 
     private static SSLContext buildSslContext() {
         try {
+            // The same CA signs all Doris TLS certs (FE HTTPS + MySQL SSL), so mysql_ssl_default_ca_certificate
+            // is the correct trust anchor for FE-to-FE HTTPS. Hostname verification is skipped for IP-based comms.
             KeyStore trustStore = KeyStore.getInstance(Config.ssl_trust_store_type);
             try (InputStream stream = Files.newInputStream(
                     Paths.get(Config.mysql_ssl_default_ca_certificate))) {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebServerFactoryCustomizerConfig.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebServerFactoryCustomizerConfig.java
@@ -25,6 +25,7 @@ import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.ee10.websocket.server.config.JettyWebSocketServletContainerInitializer;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.ServerConnector;
 import org.springframework.boot.web.embedded.jetty.ConfigurableJettyWebServerFactory;
 import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory;
@@ -77,6 +78,10 @@ public class WebServerFactoryCustomizerConfig implements WebServerFactoryCustomi
 
             factory.addServerCustomizers(server -> {
                 if (server.getConnectors() != null && server.getConnectors().length > 0) {
+                    if (!(server.getConnectors()[0] instanceof ServerConnector)) {
+                        LOG.warn("First connector is not a ServerConnector, cannot configure SNI");
+                        return;
+                    }
                     ServerConnector existingConnector = (ServerConnector) server.getConnectors()[0];
                     HttpConnectionFactory httpFactory =
                             existingConnector.getConnectionFactory(HttpConnectionFactory.class);
@@ -84,6 +89,18 @@ public class WebServerFactoryCustomizerConfig implements WebServerFactoryCustomi
                         HttpConfiguration httpConfig = httpFactory.getHttpConfiguration();
                         httpConfig.setSecurePort(Config.https_port);
                         httpConfig.setSecureScheme("https");
+
+                        // Disable SNI host checking to allow IP-based connections
+                        // Safe because checkFromValidFe() validates only registered FE nodes can connect
+                        SecureRequestCustomizer secureCustomizer =
+                                httpConfig.getCustomizer(SecureRequestCustomizer.class);
+                        if (secureCustomizer == null) {
+                            secureCustomizer = new SecureRequestCustomizer();
+                            httpConfig.addCustomizer(secureCustomizer);
+                        }
+                        secureCustomizer.setSniHostCheck(false);
+                        secureCustomizer.setSniRequired(false);
+                        LOG.info("Disabled SNI host checking for IP-based HTTPS connections");
                     }
                 }
             });

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebServerFactoryCustomizerConfig.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebServerFactoryCustomizerConfig.java
@@ -72,7 +72,13 @@ public class WebServerFactoryCustomizerConfig implements WebServerFactoryCustomi
         });
 
         if (Config.enable_https) {
-            ((JettyServletWebServerFactory) factory).setConfigurations(
+            if (!(factory instanceof JettyServletWebServerFactory)) {
+                LOG.warn("Unexpected WebServerFactory type {}, skipping HTTPS configuration",
+                        factory.getClass().getName());
+                return;
+            }
+            JettyServletWebServerFactory jettyFactory = (JettyServletWebServerFactory) factory;
+            jettyFactory.setConfigurations(
                     Collections.singletonList(new HttpToHttpsJettyConfig())
             );
 

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebServerFactoryCustomizerConfig.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebServerFactoryCustomizerConfig.java
@@ -25,7 +25,6 @@ import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.ee10.websocket.server.config.JettyWebSocketServletContainerInitializer;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
-import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.ServerConnector;
 import org.springframework.boot.web.embedded.jetty.ConfigurableJettyWebServerFactory;
 import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory;
@@ -72,22 +71,12 @@ public class WebServerFactoryCustomizerConfig implements WebServerFactoryCustomi
         });
 
         if (Config.enable_https) {
-            if (!(factory instanceof JettyServletWebServerFactory)) {
-                LOG.warn("Unexpected WebServerFactory type {}, skipping HTTPS configuration",
-                        factory.getClass().getName());
-                return;
-            }
-            JettyServletWebServerFactory jettyFactory = (JettyServletWebServerFactory) factory;
-            jettyFactory.setConfigurations(
+            ((JettyServletWebServerFactory) factory).setConfigurations(
                     Collections.singletonList(new HttpToHttpsJettyConfig())
             );
 
             factory.addServerCustomizers(server -> {
                 if (server.getConnectors() != null && server.getConnectors().length > 0) {
-                    if (!(server.getConnectors()[0] instanceof ServerConnector)) {
-                        LOG.warn("First connector is not a ServerConnector, cannot configure SNI");
-                        return;
-                    }
                     ServerConnector existingConnector = (ServerConnector) server.getConnectors()[0];
                     HttpConnectionFactory httpFactory =
                             existingConnector.getConnectionFactory(HttpConnectionFactory.class);
@@ -95,18 +84,6 @@ public class WebServerFactoryCustomizerConfig implements WebServerFactoryCustomi
                         HttpConfiguration httpConfig = httpFactory.getHttpConfiguration();
                         httpConfig.setSecurePort(Config.https_port);
                         httpConfig.setSecureScheme("https");
-
-                        // Disable SNI host checking to allow IP-based connections
-                        // Safe because checkFromValidFe() validates only registered FE nodes can connect
-                        SecureRequestCustomizer secureCustomizer =
-                                httpConfig.getCustomizer(SecureRequestCustomizer.class);
-                        if (secureCustomizer == null) {
-                            secureCustomizer = new SecureRequestCustomizer();
-                            httpConfig.addCustomizer(secureCustomizer);
-                        }
-                        secureCustomizer.setSniHostCheck(false);
-                        secureCustomizer.setSniRequired(false);
-                        LOG.info("Disabled SNI host checking for IP-based HTTPS connections");
                     }
                 }
             });

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/SessionController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/SessionController.java
@@ -20,6 +20,7 @@ package org.apache.doris.httpv2.controller;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.SchemaTable;
 import org.apache.doris.catalog.Table;
+import org.apache.doris.common.util.HttpURLUtil;
 import org.apache.doris.httpv2.entity.ResponseBody;
 import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
 import org.apache.doris.httpv2.rest.RestBaseController;
@@ -118,8 +119,8 @@ public class SessionController extends RestBaseController {
                                                           Frontend frontend) throws IOException {
         Map<String, String> header = Maps.newHashMap();
         header.put(NodeAction.AUTHORIZATION, request.getHeader(NodeAction.AUTHORIZATION));
-        String res = HttpUtils.doGet(String.format("http://%s:%s/rest/v1/session",
-                frontend.getHost(), Env.getCurrentEnv().getMasterHttpPort()), header);
+        String res = HttpUtils.doGet(HttpURLUtil.buildInternalFeUrl(
+                frontend.getHost(), "/rest/v1/session", null), header);
         ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Object> jsonMap = objectMapper.readValue(res,
             new TypeReference<Map<String, Object>>() {});

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/meta/MetaService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/meta/MetaService.java
@@ -20,7 +20,7 @@ package org.apache.doris.httpv2.meta;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
-import org.apache.doris.common.util.NetUtils;
+import org.apache.doris.common.util.HttpURLUtil;
 import org.apache.doris.ha.FrontendNodeType;
 import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
 import org.apache.doris.httpv2.rest.RestBaseController;
@@ -163,8 +163,7 @@ public class MetaService extends RestBaseController {
                 clientHost, clientPort, machine, portStr);
 
         clientHost = Strings.isNullOrEmpty(clientHost) ? machine : clientHost;
-        String url = "http://" + NetUtils.getHostPortInAccessibleFormat(clientHost, Integer.valueOf(portStr))
-                + "/image?version=" + versionStr;
+        String url = HttpURLUtil.buildInternalFeUrl(clientHost, "/image", "version=" + versionStr);
 
         String filename = Storage.IMAGE + "." + versionStr;
         File dir = new File(Env.getCurrentEnv().getImageDir());

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/meta/MetaService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/meta/MetaService.java
@@ -20,7 +20,7 @@ package org.apache.doris.httpv2.meta;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
-import org.apache.doris.common.util.HttpURLUtil;
+import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.ha.FrontendNodeType;
 import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
 import org.apache.doris.httpv2.rest.RestBaseController;
@@ -163,7 +163,11 @@ public class MetaService extends RestBaseController {
                 clientHost, clientPort, machine, portStr);
 
         clientHost = Strings.isNullOrEmpty(clientHost) ? machine : clientHost;
-        String url = HttpURLUtil.buildInternalFeUrl(clientHost, "/image", "version=" + versionStr);
+        // Use the master-supplied port: Checkpoint sends getHttpPort() (https_port when
+        // enable_https=true), so scheme and port must stay consistent.
+        String scheme = Config.enable_https ? "https" : "http";
+        String url = scheme + "://" + NetUtils.getHostPortInAccessibleFormat(clientHost, port)
+                + "/image?version=" + versionStr;
 
         String filename = Storage.IMAGE + "." + versionStr;
         File dir = new File(Env.getCurrentEnv().getImageDir());

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
@@ -22,6 +22,8 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.HttpURLUtil;
+import org.apache.doris.common.util.InternalHttpsUtils;
 import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.httpv2.controller.BaseController;
 import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
@@ -36,6 +38,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jline.internal.Nullable;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.http.HttpEntity;
@@ -43,6 +46,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.view.RedirectView;
 
@@ -52,10 +56,12 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.stream.Collectors;
+import javax.net.ssl.HttpsURLConnection;
 
 public class RestBaseController extends BaseController {
 
@@ -271,8 +277,8 @@ public class RestBaseController extends BaseController {
                 redirectUrl =
                         getRedirectUrL(request, new TNetworkAddress(request.getServerName(), request.getServerPort()));
             } else {
-                redirectUrl = getRedirectUrL(request,
-                        new TNetworkAddress(env.getMasterHost(), env.getMasterHttpPort()));
+                redirectUrl = HttpURLUtil.buildInternalFeUrl(
+                        env.getMasterHost(), request.getRequestURI(), request.getQueryString());
             }
             String method = request.getMethod();
 
@@ -292,7 +298,25 @@ public class RestBaseController extends BaseController {
 
             HttpEntity<Object> entity = new HttpEntity<>(body, headers);
 
-            RestTemplate restTemplate = new RestTemplate();
+            RestTemplate restTemplate;
+            if (Config.enable_https) {
+                SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory() {
+                    @Override
+                    protected void prepareConnection(HttpURLConnection conn, String httpMethod)
+                            throws IOException {
+                        if (conn instanceof HttpsURLConnection) {
+                            HttpsURLConnection https = (HttpsURLConnection) conn;
+                            https.setSSLSocketFactory(
+                                    InternalHttpsUtils.getSslContext().getSocketFactory());
+                            https.setHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+                        }
+                        super.prepareConnection(conn, httpMethod);
+                    }
+                };
+                restTemplate = new RestTemplate(factory);
+            } else {
+                restTemplate = new RestTemplate();
+            }
 
             ResponseEntity<Object> responseEntity;
             switch (method) {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/ClusterAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/ClusterAction.java
@@ -71,7 +71,8 @@ public class ClusterAction extends RestBaseController {
         result.put("mysql", frontends.stream().map(ip -> NetUtils
                 .getHostPortInAccessibleFormat(ip, Config.query_port)).collect(Collectors.toList()));
         result.put("http", frontends.stream().map(ip -> NetUtils
-                .getHostPortInAccessibleFormat(ip, Config.http_port)).collect(Collectors.toList()));
+                .getHostPortInAccessibleFormat(ip,
+                        Config.enable_https ? Config.https_port : Config.http_port)).collect(Collectors.toList()));
         result.put("arrow flight sql server", frontends.stream().map(
                 ip -> NetUtils.getHostPortInAccessibleFormat(ip, Config.arrow_flight_sql_port))
                 .collect(Collectors.toList()));

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/ClusterAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/ClusterAction.java
@@ -20,6 +20,7 @@ package org.apache.doris.httpv2.rest.manager;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.util.HttpURLUtil;
 import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.httpv2.controller.BaseController.ActionAuthorizationInfo;
 import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
@@ -72,7 +73,7 @@ public class ClusterAction extends RestBaseController {
                 .getHostPortInAccessibleFormat(ip, Config.query_port)).collect(Collectors.toList()));
         result.put("http", frontends.stream().map(ip -> NetUtils
                 .getHostPortInAccessibleFormat(ip,
-                        Config.enable_https ? Config.https_port : Config.http_port)).collect(Collectors.toList()));
+                        HttpURLUtil.getHttpPort())).collect(Collectors.toList()));
         result.put("arrow flight sql server", frontends.stream().map(
                 ip -> NetUtils.getHostPortInAccessibleFormat(ip, Config.arrow_flight_sql_port))
                 .collect(Collectors.toList()));

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
@@ -20,7 +20,7 @@ package org.apache.doris.httpv2.rest.manager;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.Pair;
-import org.apache.doris.common.util.Util;
+import org.apache.doris.common.util.InternalHttpsUtils;
 import org.apache.doris.httpv2.entity.ResponseBody;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.system.Frontend;
@@ -130,7 +130,14 @@ public class HttpUtils {
     }
 
     private static String executeRequest(HttpRequestBase request) throws IOException {
-        CloseableHttpClient client = getHttpClient();
+        CloseableHttpClient client;
+
+        if (request.getURI().getScheme().equalsIgnoreCase("https") && Config.enable_https) {
+            client = InternalHttpsUtils.createValidatedHttpClient();
+        } else {
+            client = HttpClientBuilder.create().build();
+        }
+
         return client.execute(request, httpResponse -> EntityUtils.toString(httpResponse.getEntity()));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.InternalHttpsUtils;
+import org.apache.doris.common.util.Util;
 import org.apache.doris.httpv2.entity.ResponseBody;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.system.Frontend;

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
@@ -20,6 +20,7 @@ package org.apache.doris.httpv2.rest.manager;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.Pair;
+import org.apache.doris.common.util.HttpURLUtil;
 import org.apache.doris.common.util.InternalHttpsUtils;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.httpv2.entity.ResponseBody;
@@ -61,7 +62,7 @@ public class HttpUtils {
     static final int DEFAULT_TIME_OUT_MS = 2000;
 
     public static List<Pair<String, Integer>> getFeList() {
-        int port = Config.enable_https ? Config.https_port : Config.http_port;
+        int port = HttpURLUtil.getHttpPort();
         return Env.getCurrentEnv().getFrontends(null)
                 .stream().filter(Frontend::isAlive).map(fe -> Pair.of(fe.getHost(), port))
                 .collect(Collectors.toList());
@@ -70,7 +71,7 @@ public class HttpUtils {
     static boolean isCurrentFe(String ip, int port) {
         HostInfo hostInfo = Env.getCurrentEnv().getSelfNode();
         // Compare against the actual HTTP/HTTPS port, not the edit_log_port held by selfNode.
-        int selfPort = Config.enable_https ? Config.https_port : Config.http_port;
+        int selfPort = HttpURLUtil.getHttpPort();
         return hostInfo.getHost().equals(ip) && selfPort == port;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
@@ -52,7 +52,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 /*
- * used to forward http requests from manager to be.
+ * Used for internal HTTP(S) communication between FE nodes and from manager to BE.
  */
 public class HttpUtils {
     private static final Logger LOG = LogManager.getLogger(HttpUtils.class);
@@ -61,8 +61,9 @@ public class HttpUtils {
     static final int DEFAULT_TIME_OUT_MS = 2000;
 
     public static List<Pair<String, Integer>> getFeList() {
+        int port = Config.enable_https ? Config.https_port : Config.http_port;
         return Env.getCurrentEnv().getFrontends(null)
-                .stream().filter(Frontend::isAlive).map(fe -> Pair.of(fe.getHost(), Config.http_port))
+                .stream().filter(Frontend::isAlive).map(fe -> Pair.of(fe.getHost(), port))
                 .collect(Collectors.toList());
     }
 
@@ -72,7 +73,7 @@ public class HttpUtils {
     }
 
     public static String concatUrl(Pair<String, Integer> ipPort, String path, Map<String, String> arguments) {
-        StringBuilder url = new StringBuilder("http://")
+        StringBuilder url = new StringBuilder(Config.enable_https ? "https://" : "http://")
                 .append(ipPort.first).append(":").append(ipPort.second).append(path);
         boolean isFirst = true;
         for (Map.Entry<String, String> entry : arguments.entrySet()) {
@@ -131,15 +132,11 @@ public class HttpUtils {
     }
 
     private static String executeRequest(HttpRequestBase request) throws IOException {
-        CloseableHttpClient client;
-
-        if (request.getURI().getScheme().equalsIgnoreCase("https") && Config.enable_https) {
-            client = InternalHttpsUtils.createValidatedHttpClient();
-        } else {
-            client = HttpClientBuilder.create().build();
+        try (CloseableHttpClient client = Config.enable_https
+                ? InternalHttpsUtils.createValidatedHttpClient()
+                : HttpClientBuilder.create().build()) {
+            return client.execute(request, httpResponse -> EntityUtils.toString(httpResponse.getEntity()));
         }
-
-        return client.execute(request, httpResponse -> EntityUtils.toString(httpResponse.getEntity()));
     }
 
     static String parseResponse(String response) {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
@@ -69,7 +69,9 @@ public class HttpUtils {
 
     static boolean isCurrentFe(String ip, int port) {
         HostInfo hostInfo = Env.getCurrentEnv().getSelfNode();
-        return hostInfo.isSame(new HostInfo(ip, port));
+        // Compare against the actual HTTP/HTTPS port, not the edit_log_port held by selfNode.
+        int selfPort = Config.enable_https ? Config.https_port : Config.http_port;
+        return hostInfo.getHost().equals(ip) && selfPort == port;
     }
 
     public static String concatUrl(Pair<String, Integer> ipPort, String path, Map<String, String> arguments) {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
@@ -240,8 +240,9 @@ public class NodeAction extends RestBaseController {
     }
 
     private static List<String> getFeList() {
+        int port = Config.enable_https ? Config.https_port : Config.http_port;
         return Env.getCurrentEnv().getFrontends(null).stream()
-                .map(fe -> NetUtils.getHostPortInAccessibleFormat(fe.getHost(), Config.http_port))
+                .map(fe -> NetUtils.getHostPortInAccessibleFormat(fe.getHost(), port))
                 .collect(Collectors.toList());
     }
 
@@ -497,7 +498,8 @@ public class NodeAction extends RestBaseController {
         List<Map<String, String>> failedTotal = Lists.newArrayList();
         List<NodeConfigs> nodeConfigList = parseSetConfigNodes(requestBody, failedTotal);
         List<Pair<String, Integer>> aliveFe = Env.getCurrentEnv().getFrontends(null).stream().filter(Frontend::isAlive)
-                .map(fe -> Pair.of(fe.getHost(), Config.http_port)).collect(Collectors.toList());
+                .map(fe -> Pair.of(fe.getHost(),
+                        Config.enable_https ? Config.https_port : Config.http_port)).collect(Collectors.toList());
         checkNodeIsAlive(nodeConfigList, aliveFe, failedTotal);
 
         Map<String, String> header = Maps.newHashMap();
@@ -569,7 +571,8 @@ public class NodeAction extends RestBaseController {
     private String concatFeSetConfigUrl(NodeConfigs nodeConfigs, boolean isPersist) {
         StringBuilder sb = new StringBuilder();
         Pair<String, Integer> hostPort = nodeConfigs.getHostPort();
-        sb.append("http://").append(hostPort.first).append(":").append(hostPort.second).append("/api/_set_config");
+        sb.append(Config.enable_https ? "https://" : "http://")
+                .append(hostPort.first).append(":").append(hostPort.second).append("/api/_set_config");
         Map<String, String> configs = nodeConfigs.getConfigs(isPersist);
         boolean addAnd = false;
         for (Map.Entry<String, String> entry : configs.entrySet()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
@@ -374,7 +374,10 @@ public class NodeAction extends RestBaseController {
             Pair<String, Integer> hostPort = hostPorts.get(i);
             String address = NetUtils.getHostPortInAccessibleFormat(hostPort.first, hostPort.second);
             configRequestDoneSignal.addMark(address, -1);
-            String url = "http://" + address + questPath;
+            // FE nodes use HTTPS when enabled; BE nodes always use plain HTTP
+            // (BEs do not participate in the FE internal HTTPS scheme)
+            String scheme = (Config.enable_https && "FE".equals(nodeType)) ? "https://" : "http://";
+            String url = scheme + address + questPath;
             httpExecutor.submit(
                     new HttpConfigInfoTask(url, hostPort, authorization, nodeType, confNames, configRequestDoneSignal,
                             configInfoTotal.get(i)));

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
@@ -27,6 +27,7 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.common.proc.ProcResult;
 import org.apache.doris.common.proc.ProcService;
+import org.apache.doris.common.util.HttpURLUtil;
 import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.ha.FrontendNodeType;
@@ -240,7 +241,7 @@ public class NodeAction extends RestBaseController {
     }
 
     private static List<String> getFeList() {
-        int port = Config.enable_https ? Config.https_port : Config.http_port;
+        int port = HttpURLUtil.getHttpPort();
         return Env.getCurrentEnv().getFrontends(null).stream()
                 .map(fe -> NetUtils.getHostPortInAccessibleFormat(fe.getHost(), port))
                 .collect(Collectors.toList());
@@ -502,7 +503,7 @@ public class NodeAction extends RestBaseController {
         List<NodeConfigs> nodeConfigList = parseSetConfigNodes(requestBody, failedTotal);
         List<Pair<String, Integer>> aliveFe = Env.getCurrentEnv().getFrontends(null).stream().filter(Frontend::isAlive)
                 .map(fe -> Pair.of(fe.getHost(),
-                        Config.enable_https ? Config.https_port : Config.http_port)).collect(Collectors.toList());
+                        HttpURLUtil.getHttpPort())).collect(Collectors.toList());
         checkNodeIsAlive(nodeConfigList, aliveFe, failedTotal);
 
         Map<String, String> header = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
@@ -20,7 +20,6 @@ package org.apache.doris.httpv2.rest.manager;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.AuthenticationException;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.Status;
 import org.apache.doris.common.proc.CurrentQueryStatisticsProcDir;
@@ -28,6 +27,7 @@ import org.apache.doris.common.proc.ProcResult;
 import org.apache.doris.common.profile.ProfileManager;
 import org.apache.doris.common.profile.ProfileManager.ProfileElement;
 import org.apache.doris.common.profile.SummaryProfile;
+import org.apache.doris.common.util.HttpURLUtil;
 import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.httpv2.controller.BaseController.ActionAuthorizationInfo;
 import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
@@ -196,7 +196,7 @@ public class QueryProfileAction extends RestBaseController {
         // add node information
         for (List<String> query : queries) {
             query.set(1, NetUtils.getHostPortInAccessibleFormat(Env.getCurrentEnv().getSelfNode().getHost(),
-                    Config.enable_https ? Config.https_port : Config.http_port));
+                    HttpURLUtil.getHttpPort()));
         }
 
         if (!Strings.isNullOrEmpty(search)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
@@ -196,7 +196,7 @@ public class QueryProfileAction extends RestBaseController {
         // add node information
         for (List<String> query : queries) {
             query.set(1, NetUtils.getHostPortInAccessibleFormat(Env.getCurrentEnv().getSelfNode().getHost(),
-                    Config.http_port));
+                    Config.enable_https ? Config.https_port : Config.http_port));
         }
 
         if (!Strings.isNullOrEmpty(search)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
@@ -228,7 +228,7 @@ public class Checkpoint extends MasterDaemon {
                     // skip master itself
                     continue;
                 }
-                int port = Config.enable_https ? Config.https_port : Config.http_port;
+                int port = HttpURLUtil.getHttpPort();
 
                 String queryParams = "version=" + replayedJournalId + "&port=" + port;
                 String url = HttpURLUtil.buildInternalFeUrl(host, "/put", queryParams);
@@ -304,7 +304,7 @@ public class Checkpoint extends MasterDaemon {
                                 minOtherNodesJournalId = id;
                             }
                         } catch (Throwable e) {
-                            int port = Config.enable_https ? Config.https_port : Config.http_port;
+                            int port = HttpURLUtil.getHttpPort();
                             throw new CheckpointException(String.format("Exception when getting current replayed"
                                     + " journal id. host=%s, port=%d", host, port), e);
                         } finally {

--- a/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
@@ -229,10 +229,10 @@ public class Checkpoint extends MasterDaemon {
                     // skip master itself
                     continue;
                 }
-                int port = Config.http_port;
+                int port = Config.enable_https ? Config.https_port : Config.http_port;
 
-                String url = "http://" + NetUtils.getHostPortInAccessibleFormat(host, port) + "/put?version=" + replayedJournalId
-                        + "&port=" + port;
+                String queryParams = "version=" + replayedJournalId + "&port=" + port;
+                String url = HttpURLUtil.buildInternalFeUrl(host, "/put", queryParams);
                 LOG.info("Put image:{}", url);
 
                 try {
@@ -286,7 +286,6 @@ public class Checkpoint extends MasterDaemon {
                             // skip master itself
                             continue;
                         }
-                        int port = Config.http_port;
                         String idURL;
                         HttpURLConnection conn = null;
                         try {
@@ -296,7 +295,7 @@ public class Checkpoint extends MasterDaemon {
                              * any non-master node's current replayed journal id. otherwise,
                              * this lagging node can never get the deleted journal.
                              */
-                            idURL = "http://" + NetUtils.getHostPortInAccessibleFormat(host, port) + "/journal_id";
+                            idURL = HttpURLUtil.buildInternalFeUrl(host, "/journal_id", null);
                             conn = HttpURLUtil.getConnectionWithNodeIdent(idURL);
                             conn.setConnectTimeout(CONNECT_TIMEOUT_SECOND * 1000);
                             conn.setReadTimeout(READ_TIMEOUT_SECOND * 1000);
@@ -306,6 +305,7 @@ public class Checkpoint extends MasterDaemon {
                                 minOtherNodesJournalId = id;
                             }
                         } catch (Throwable e) {
+                            int port = Config.enable_https ? Config.https_port : Config.http_port;
                             throw new CheckpointException(String.format("Exception when getting current replayed"
                                     + " journal id. host=%s, port=%d", host, port), e);
                         } finally {

--- a/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
@@ -32,7 +32,6 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.util.HttpURLUtil;
 import org.apache.doris.common.util.MasterDaemon;
-import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.httpv2.entity.ResponseBody;
 import org.apache.doris.httpv2.rest.RestApiStatusCode;
 import org.apache.doris.metric.MetricRepo;

--- a/fe/fe-core/src/main/java/org/apache/doris/master/MetaHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/MetaHelper.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.util.Map;
 
 public class MetaHelper {
     public static final Logger LOG = LogManager.getLogger(MetaHelper.class);
@@ -147,7 +148,9 @@ public class MetaHelper {
     }
 
     public static <T> ResponseBody doGet(String url, int timeout, Class<T> clazz) throws IOException {
-        String response = HttpUtils.doGet(url, HttpURLUtil.getNodeIdentHeaders(), timeout);
+        Map<String, String> headers = HttpURLUtil.getNodeIdentHeaders();
+        LOG.debug("meta helper, url: {}, timeout: {}, headers: {}", url, timeout, headers);
+        String response = HttpUtils.doGet(url, headers, timeout);
         try {
             return parseResponse(response, clazz);
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/master/MetaHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/MetaHelper.java
@@ -148,10 +148,12 @@ public class MetaHelper {
     }
 
     public static <T> ResponseBody doGet(String url, int timeout, Class<T> clazz) throws IOException {
-        Map<String, String> headers = HttpURLUtil.getNodeIdentHeaders();
-        LOG.info("meta helper, url: {}, timeout{}, headers: {}", url, timeout, headers);
-        String response = HttpUtils.doGet(url, headers, timeout);
-        return parseResponse(response, clazz);
+        String response = HttpUtils.doGet(url, HttpURLUtil.getNodeIdentHeaders(), timeout);
+        try {
+            return parseResponse(response, clazz);
+        } catch (Exception e) {
+            throw new IOException("Failed to parse response from " + url + ". Response: " + response, e);
+        }
     }
 
     // download file from remote node

--- a/fe/fe-core/src/main/java/org/apache/doris/master/MetaHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/MetaHelper.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
-import java.util.Map;
 
 public class MetaHelper {
     public static final Logger LOG = LogManager.getLogger(MetaHelper.class);

--- a/fe/fe-core/src/main/java/org/apache/doris/master/MetaHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/MetaHelper.java
@@ -149,7 +149,7 @@ public class MetaHelper {
 
     public static <T> ResponseBody doGet(String url, int timeout, Class<T> clazz) throws IOException {
         Map<String, String> headers = HttpURLUtil.getNodeIdentHeaders();
-        LOG.debug("meta helper, url: {}, timeout: {}, headers: {}", url, timeout, headers);
+        LOG.info("meta helper, url: {}, timeout: {}, headers: {}", url, timeout, headers);
         String response = HttpUtils.doGet(url, headers, timeout);
         try {
             return parseResponse(response, clazz);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/minidump/MinidumpUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/minidump/MinidumpUtils.java
@@ -28,6 +28,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.proc.FrontendsProcNode;
 import org.apache.doris.common.util.DebugUtil;
+import org.apache.doris.common.util.HttpURLUtil;
 import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.glue.LogicalPlanAdapter;
@@ -106,7 +107,7 @@ public class MinidumpUtils {
     public static void saveMinidumpString(JSONObject minidump, String querId) {
         String dumpPath = MinidumpUtils.DUMP_PATH + File.separator + "_" + querId;
         String feAddress = FrontendsProcNode.getCurrentFrontendVersion(Env.getCurrentEnv()).getHost();
-        int feHttpPort = Config.enable_https ? Config.https_port : Config.http_port;
+        int feHttpPort = HttpURLUtil.getHttpPort();
         String scheme = Config.enable_https ? "https" : "http";
         MinidumpUtils.DUMP_FILE_FULL_PATH = dumpPath + ".json";
         MinidumpUtils.HTTP_GET_STRING = scheme + "://" + feAddress + ":" + feHttpPort

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/minidump/MinidumpUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/minidump/MinidumpUtils.java
@@ -106,9 +106,11 @@ public class MinidumpUtils {
     public static void saveMinidumpString(JSONObject minidump, String querId) {
         String dumpPath = MinidumpUtils.DUMP_PATH + File.separator + "_" + querId;
         String feAddress = FrontendsProcNode.getCurrentFrontendVersion(Env.getCurrentEnv()).getHost();
-        int feHttpPort = Config.http_port;
+        int feHttpPort = Config.enable_https ? Config.https_port : Config.http_port;
+        String scheme = Config.enable_https ? "https" : "http";
         MinidumpUtils.DUMP_FILE_FULL_PATH = dumpPath + ".json";
-        MinidumpUtils.HTTP_GET_STRING = "http://" + feAddress + ":" + feHttpPort + "/api/minidump?query_id=" + querId;
+        MinidumpUtils.HTTP_GET_STRING = scheme + "://" + feAddress + ":" + feHttpPort
+                + "/api/minidump?query_id=" + querId;
         String jsonMinidump = minidump.toString(4);
         try (FileWriter file = new FileWriter(MinidumpUtils.DUMP_FILE_FULL_PATH)) {
             file.write(jsonMinidump);

--- a/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -96,7 +96,7 @@ public class HeartbeatMgr extends MasterDaemon {
         TMasterInfo tMasterInfo = new TMasterInfo(
                 new TNetworkAddress(FrontendOptions.getLocalHostAddress(), Config.rpc_port), clusterId, epoch);
         tMasterInfo.setToken(token);
-        tMasterInfo.setHttpPort(Config.http_port);
+        tMasterInfo.setHttpPort(Config.enable_https ? Config.https_port : Config.http_port);
         long flags = heartbeatFlags.getHeartbeatFlags();
         tMasterInfo.setHeartbeatFlags(flags);
         if (Config.isCloudMode()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -97,6 +97,8 @@ public class HeartbeatMgr extends MasterDaemon {
         TMasterInfo tMasterInfo = new TMasterInfo(
                 new TNetworkAddress(FrontendOptions.getLocalHostAddress(), Config.rpc_port), clusterId, epoch);
         tMasterInfo.setToken(token);
+        // small_file_mgr at BE downloads from FE using this port,
+        // by trying http then fallback to https(for http_port=0 cases).
         tMasterInfo.setHttpPort(HttpURLUtil.getHttpPort());
         long flags = heartbeatFlags.getHeartbeatFlags();
         tMasterInfo.setHeartbeatFlags(flags);

--- a/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -26,6 +26,7 @@ import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.Version;
 import org.apache.doris.common.util.DebugPointUtil;
+import org.apache.doris.common.util.HttpURLUtil;
 import org.apache.doris.common.util.MasterDaemon;
 import org.apache.doris.persist.HbPackage;
 import org.apache.doris.resource.Tag;
@@ -96,7 +97,7 @@ public class HeartbeatMgr extends MasterDaemon {
         TMasterInfo tMasterInfo = new TMasterInfo(
                 new TNetworkAddress(FrontendOptions.getLocalHostAddress(), Config.rpc_port), clusterId, epoch);
         tMasterInfo.setToken(token);
-        tMasterInfo.setHttpPort(Config.enable_https ? Config.https_port : Config.http_port);
+        tMasterInfo.setHttpPort(HttpURLUtil.getHttpPort());
         long flags = heartbeatFlags.getHeartbeatFlags();
         tMasterInfo.setHeartbeatFlags(flags);
         if (Config.isCloudMode()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/HttpURLUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/HttpURLUtilTest.java
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+import org.apache.doris.common.Config;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HttpURLUtilTest {
+
+    @After
+    public void tearDown() {
+        Config.enable_https = false;
+        Config.http_port = 8030;
+        Config.https_port = 8050;
+    }
+
+    @Test
+    public void testBuildInternalFeUrlHttp() {
+        Config.enable_https = false;
+        Config.http_port = 8030;
+
+        String url = HttpURLUtil.buildInternalFeUrl("192.168.1.10", "/put", "version=123&port=8030");
+        Assert.assertEquals("http://192.168.1.10:8030/put?version=123&port=8030", url);
+    }
+
+    @Test
+    public void testBuildInternalFeUrlHttps() {
+        Config.enable_https = true;
+        Config.https_port = 8050;
+
+        String url = HttpURLUtil.buildInternalFeUrl("192.168.1.10", "/put", "version=123&port=8050");
+        Assert.assertEquals("https://192.168.1.10:8050/put?version=123&port=8050", url);
+    }
+
+    @Test
+    public void testBuildInternalFeUrlNoQueryParams() {
+        Config.enable_https = false;
+        Config.http_port = 8030;
+
+        String url = HttpURLUtil.buildInternalFeUrl("192.168.1.10", "/journal_id", null);
+        Assert.assertEquals("http://192.168.1.10:8030/journal_id", url);
+    }
+
+    @Test
+    public void testBuildInternalFeUrlEmptyQueryParams() {
+        Config.enable_https = false;
+        Config.http_port = 8030;
+
+        String url = HttpURLUtil.buildInternalFeUrl("192.168.1.10", "/version", "");
+        Assert.assertEquals("http://192.168.1.10:8030/version", url);
+    }
+
+    @Test
+    public void testBuildInternalFeUrlHttpsWithIPv6() {
+        Config.enable_https = true;
+        Config.https_port = 8050;
+
+        String url = HttpURLUtil.buildInternalFeUrl("fe80::1", "/role", "host=fe80::2&port=9010");
+        Assert.assertTrue(url.startsWith("https://"));
+        Assert.assertTrue(url.contains("/role?host=fe80::2&port=9010"));
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/InternalHttpsUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/InternalHttpsUtilsTest.java
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+
+public class InternalHttpsUtilsTest {
+
+    /**
+     * Verifies that getSslContext() returns the same SSLContext instance on every call —
+     * i.e. the double-checked locking cache works correctly and buildSslContext() is not
+     * invoked on subsequent calls.
+     *
+     * SSLContext.getInstance("TLS").init(null, null, null) is valid without a truststore,
+     * so the test does not require a truststore file on disk.
+     */
+    @Test
+    public void testGetSslContextReturnsCachedInstance() throws Exception {
+        SSLContext previous = InternalHttpsUtils.cachedSslContext;
+
+        SSLContext injected = SSLContext.getInstance("TLS");
+        injected.init(null, null, null);
+        InternalHttpsUtils.cachedSslContext = injected;
+
+        try {
+            SSLContext first = InternalHttpsUtils.getSslContext();
+            SSLContext second = InternalHttpsUtils.getSslContext();
+
+            Assert.assertSame("getSslContext() must return the injected cached instance", injected, first);
+            Assert.assertSame("getSslContext() must return the same instance on every call", first, second);
+        } finally {
+            InternalHttpsUtils.cachedSslContext = previous;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/InternalHttpsUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/InternalHttpsUtilsTest.java
@@ -17,37 +17,48 @@
 
 package org.apache.doris.common.util;
 
+import org.apache.doris.common.Config;
+
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
-import javax.net.ssl.SSLContext;
+import java.lang.reflect.Field;
 
 public class InternalHttpsUtilsTest {
 
-    /**
-     * Verifies that getSslContext() returns the same SSLContext instance on every call —
-     * i.e. the double-checked locking cache works correctly and buildSslContext() is not
-     * invoked on subsequent calls.
-     *
-     * SSLContext.getInstance("TLS").init(null, null, null) is valid without a truststore,
-     * so the test does not require a truststore file on disk.
-     */
+    private String originalCertPath;
+
+    @Before
+    public void setUp() throws Exception {
+        originalCertPath = Config.mysql_ssl_default_ca_certificate;
+        // Reset the cached SSLContext before each test so tests are independent.
+        resetCachedSslContext();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Config.mysql_ssl_default_ca_certificate = originalCertPath;
+        resetCachedSslContext();
+    }
+
+    private void resetCachedSslContext() throws Exception {
+        Field field = InternalHttpsUtils.class.getDeclaredField("cachedSslContext");
+        field.setAccessible(true);
+        field.set(null, null);
+    }
+
     @Test
-    public void testGetSslContextReturnsCachedInstance() throws Exception {
-        SSLContext previous = InternalHttpsUtils.cachedSslContext;
-
-        SSLContext injected = SSLContext.getInstance("TLS");
-        injected.init(null, null, null);
-        InternalHttpsUtils.cachedSslContext = injected;
-
+    public void testGetSslContextThrowsWhenCertMissing() {
+        Config.mysql_ssl_default_ca_certificate = "/non/existent/path/ca.p12";
         try {
-            SSLContext first = InternalHttpsUtils.getSslContext();
-            SSLContext second = InternalHttpsUtils.getSslContext();
-
-            Assert.assertSame("getSslContext() must return the injected cached instance", injected, first);
-            Assert.assertSame("getSslContext() must return the same instance on every call", first, second);
-        } finally {
-            InternalHttpsUtils.cachedSslContext = previous;
+            InternalHttpsUtils.getSslContext();
+            Assert.fail("Expected RuntimeException when cert file does not exist");
+        } catch (RuntimeException e) {
+            // Error message must mention the cert path so operators know what to fix.
+            Assert.assertTrue("Error message should contain cert path",
+                    e.getMessage() != null && e.getMessage().contains("/non/existent/path/ca.p12"));
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/minidump/MinidumpUtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/minidump/MinidumpUtTest.java
@@ -17,9 +17,17 @@
 
 package org.apache.doris.nereids.minidump;
 
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.proc.FrontendsProcNode;
+import org.apache.doris.system.Frontend;
+
 import org.json.JSONObject;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * Used for add unit test of minidump
@@ -45,5 +53,42 @@ class MinidumpUtTest {
         JSONObject resultPlan = MinidumpUtils.executeSql("select * from t1 where l1 = 1");
         assert (minidump != null);
         assert (resultPlan != null);
+    }
+
+    @Test
+    public void testSaveMinidumpStringUsesHttpsWhenEnabled() {
+        Frontend fe = Mockito.mock(Frontend.class);
+        Mockito.when(fe.getHost()).thenReturn("192.168.1.1");
+        Env mockEnv = Mockito.mock(Env.class);
+
+        boolean originalEnableHttps = Config.enable_https;
+        int originalHttpPort = Config.http_port;
+        int originalHttpsPort = Config.https_port;
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class);
+                MockedStatic<FrontendsProcNode> procStatic = Mockito.mockStatic(FrontendsProcNode.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(mockEnv);
+            procStatic.when(() -> FrontendsProcNode.getCurrentFrontendVersion(mockEnv)).thenReturn(fe);
+
+            // enable_https=true: URL must use https scheme and https_port
+            Config.enable_https = true;
+            Config.https_port = 8050;
+            Config.http_port = 0;
+            MinidumpUtils.saveMinidumpString(new JSONObject(), "query-001");
+            String url = MinidumpUtils.getHttpGetString();
+            Assertions.assertTrue(url.startsWith("https://"), "Expected https scheme but got: " + url);
+            Assertions.assertTrue(url.contains(":8050/"), "Expected https_port 8050 but got: " + url);
+
+            // enable_https=false: URL must use http scheme and http_port
+            Config.enable_https = false;
+            Config.http_port = 8030;
+            MinidumpUtils.saveMinidumpString(new JSONObject(), "query-002");
+            url = MinidumpUtils.getHttpGetString();
+            Assertions.assertTrue(url.startsWith("http://"), "Expected http scheme but got: " + url);
+            Assertions.assertTrue(url.contains(":8030/"), "Expected http_port 8030 but got: " + url);
+        } finally {
+            Config.enable_https = originalEnableHttps;
+            Config.http_port = originalHttpPort;
+            Config.https_port = originalHttpsPort;
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/system/HeartbeatMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/system/HeartbeatMgrTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.system;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.FsBroker;
 import org.apache.doris.common.ClientPool;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.GenericPool;
 import org.apache.doris.ha.FrontendNodeType;
 import org.apache.doris.system.HeartbeatMgr.BrokerHeartbeatHandler;
@@ -33,6 +34,7 @@ import org.apache.doris.thrift.TBrokerPingBrokerRequest;
 import org.apache.doris.thrift.TFrontendPingFrontendRequest;
 import org.apache.doris.thrift.TFrontendPingFrontendResult;
 import org.apache.doris.thrift.TFrontendPingFrontendStatusCode;
+import org.apache.doris.thrift.TMasterInfo;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TPaloBrokerService;
 
@@ -42,6 +44,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class HeartbeatMgrTest {
 
@@ -119,6 +124,39 @@ public class HeartbeatMgrTest {
             Assert.assertEquals("not ready", hbResponse.getMsg());
         } finally {
             ClientPool.frontendHeartbeatPool = originalPool;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSetMasterHttpPort() throws Exception {
+        int originalHttpPort = Config.http_port;
+        int originalHttpsPort = Config.https_port;
+        boolean originalEnableHttps = Config.enable_https;
+
+        try {
+            HeartbeatMgr mgr = new HeartbeatMgr(null, false);
+            Field masterInfoField = HeartbeatMgr.class.getDeclaredField("masterInfo");
+            masterInfoField.setAccessible(true);
+
+            // enable_https=false: must send http_port to BEs
+            Config.enable_https = false;
+            Config.http_port = 8030;
+            Config.https_port = 8050;
+            mgr.setMaster(1, "token", 1L);
+            AtomicReference<TMasterInfo> masterInfo =
+                    (AtomicReference<TMasterInfo>) masterInfoField.get(null);
+            Assert.assertEquals(8030, masterInfo.get().getHttpPort());
+
+            // enable_https=true: must send https_port to BEs so small_file_mgr can connect
+            Config.enable_https = true;
+            mgr.setMaster(1, "token", 1L);
+            masterInfo = (AtomicReference<TMasterInfo>) masterInfoField.get(null);
+            Assert.assertEquals(8050, masterInfo.get().getHttpPort());
+        } finally {
+            Config.http_port = originalHttpPort;
+            Config.https_port = originalHttpsPort;
+            Config.enable_https = originalEnableHttps;
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary: 

Currently, Doris provides an enable_https switch to enforce HTTPS connections. In hardened deployments, HTTP is completely disabled by setting http_port = 0. However, intra FE-to-FE communication still relies on HTTP, causing failures in edit log and checkpoint synchronisation when HTTPS is enabled.

This PR enhances HTTPS support by automatically converting intra FE-to-FE communication to HTTPS when enable_https=true, without introducing any new configuration, leveraging mysql_ssl_default_ca_certificate created for https connection. When enable_https=false, behavior remains unchanged. This ensures secure and seamless FE-to-FE communication without breaking existing workflows.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [X] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [X] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

