### PR TITLE
[auth] skip catalog priv check if using customized access controller

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3757,4 +3757,8 @@ public class Config extends ConfigBase {
             "agent tasks health check interval, default is five minutes, no health check when less than or equal to 0"
     })
     public static long agent_task_health_check_intervals_ms = 5 * 60 * 1000L; // 5 min
+
+    @ConfField(description = {"是否跳过 catalog 层级的鉴权",
+            "Whether to skip catalog level privilege check"})
+    public static boolean skip_catalog_priv_check = false;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/AccessControllerManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/AccessControllerManager.java
@@ -25,14 +25,14 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.ClassLoaderUtils;
 import org.apache.doris.datasource.CatalogIf;
-import org.apache.doris.datasource.ExternalCatalog;
+import org.apache.doris.datasource.CatalogMgr;import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.plugin.PropertiesUtils;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
+import com.google.common.base.Strings;import com.google.common.collect.Maps;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -196,9 +196,29 @@ public class AccessControllerManager {
 
     public boolean checkCtlPriv(UserIdentity currentUser, String ctl, PrivPredicate wanted) {
         boolean hasGlobal = checkGlobalPriv(currentUser, wanted);
-        // for checking catalog priv, always use InternalAccessController.
-        // because catalog priv is only saved in InternalAccessController.
-        return defaultAccessController.checkCtlPriv(hasGlobal, currentUser, ctl, wanted);
+        if (!Config.skip_catalog_priv_check) {
+            // for checking catalog priv, always use InternalAccessController.
+            // because catalog priv is only saved in InternalAccessController.
+            return defaultAccessController.checkCtlPriv(hasGlobal, currentUser, ctl, wanted);
+        } else {
+            CatalogIf catalog = Env.getCurrentEnv().getCatalogMgr().getCatalog(ctl);
+            if (catalog == null) {
+                return false;
+            }
+            if (catalog.isInternalCatalog()) {
+                return defaultAccessController.checkCtlPriv(hasGlobal, currentUser, ctl, wanted);
+            }
+            // If catalog not set access controller, use internal access controller
+            // otherwise, skip catalog priv check
+            String className = (String) catalog.getProperties().getOrDefault(CatalogMgr.ACCESS_CONTROLLER_CLASS_PROP,
+                    "");
+            if (Strings.isNullOrEmpty(className)) {
+                // not set access controller, use internal access controller
+                return defaultAccessController.checkCtlPriv(hasGlobal, currentUser, ctl, wanted);
+            } else {
+                return true;
+            }
+        }
     }
 
     // ==== Database ====


### PR DESCRIPTION
Cherry-pick from selectdb/enterprise-core#20746197c17b49e7647d8a91a5c2ab4d573158d5

## Changes
- Add `Config.skip_catalog_priv_check` flag
- Modify `AccessControllerManager.checkCtlPriv` to respect the flag
- When enabled, skips catalog level privilege check for external catalogs with custom access controller

## Background
This change allows skipping catalog-level privilege checks when using a customized access controller. Useful for enterprise scenarios with custom authentication systems.

## Files Modified
1. `fe/fe-common/src/main/java/org/apache/doris/common/Config.java`
2. `fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/AccessControllerManager.java`

/cc @morningman