### PR TITLE
[fix](fe) prevent recycle daemon exit on stale recycle-time entries

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -292,6 +292,20 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
 
     private synchronized void eraseDatabaseWithSameName(String dbName, long currentTimeMs,
                                                         int maxSameNameTrashNum, List<Long> sameNameDbIdList) {
+        // clean up stale ids that lost their recycleTime to avoid NPE during sort
+        Iterator<Long> staleIt = sameNameDbIdList.iterator();
+        while (staleIt.hasNext()) {
+            Long id = staleIt.next();
+            if (!idToRecycleTime.containsKey(id)) {
+                LOG.warn("eraseDatabaseWithSameName: db[{}] in dbNameToIds[{}] but not in idToRecycleTime,"
+                        + " cleaning up stale entry", id, dbName);
+                staleIt.remove();
+                dbNameToIds.computeIfPresent(dbName, (k, v) -> {
+                    v.remove(id);
+                    return v.isEmpty() ? null : v;
+                });
+            }
+        }
         List<Long> dbIdToErase = getIdListToEraseByRecycleTime(sameNameDbIdList, maxSameNameTrashNum);
         for (Long dbId : dbIdToErase) {
             RecycleDatabaseInfo dbInfo = idToDatabase.get(dbId);
@@ -376,6 +390,8 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                 long tableId = table.getId();
 
                 if (isExpire(tableId, currentTimeMs)) {
+                    LOG.info("eraseTable: about to erase table[{}-{}], isManagedTable={}, type={}",
+                            tableId, table.getName(), table.isManagedTable(), table.getType());
                     if (table.isManagedTable()) {
                         Env.getCurrentEnv().onEraseOlapTable(tableInfo.dbId, (OlapTable) table, false);
                     }
@@ -413,6 +429,20 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
 
     private synchronized void eraseTableWithSameName(long dbId, String tableName, long currentTimeMs,
             int maxSameNameTrashNum, List<Long> sameNameTableIdList) {
+        // clean up stale ids that lost their recycleTime to avoid NPE during sort
+        Iterator<Long> staleIt = sameNameTableIdList.iterator();
+        while (staleIt.hasNext()) {
+            Long id = staleIt.next();
+            if (!idToRecycleTime.containsKey(id)) {
+                LOG.warn("eraseTableWithSameName: table[{}] in dbIdTableNameToIds[{}-{}] but not in"
+                        + " idToRecycleTime, cleaning up stale entry", id, dbId, tableName);
+                staleIt.remove();
+                dbIdTableNameToIds.computeIfPresent(Pair.of(dbId, tableName), (k, v) -> {
+                    v.remove(id);
+                    return v.isEmpty() ? null : v;
+                });
+            }
+        }
         List<Long> tableIdToErase = getIdListToEraseByRecycleTime(sameNameTableIdList, maxSameNameTrashNum);
         for (Long tableId : tableIdToErase) {
             RecycleTableInfo tableInfo = idToTable.get(tableId);
@@ -444,6 +474,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         if (tableInfo == null) {
             // FIXME(walter): Sometimes `eraseTable` in 'DROP DB ... FORCE' may be executed earlier than
             // finish drop db, especially in the case of drop db with many tables.
+            LOG.warn("replayEraseTable: tableInfo is null for table[{}], skip onEraseOlapTable!", tableId);
             return;
         }
 
@@ -569,8 +600,14 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         if (ids.size() <= maxTrashNum) {
             return idToErase;
         }
+        // filter out ids whose recycleTime has already been removed to avoid NPE during sort
+        ids.removeIf(id -> !idToRecycleTime.containsKey(id));
+        if (ids.size() <= maxTrashNum) {
+            return idToErase;
+        }
         // order by recycle time desc
-        ids.sort((x, y) -> Long.compare(idToRecycleTime.get(y), idToRecycleTime.get(x)));
+        ids.sort((x, y) -> Long.compare(idToRecycleTime.getOrDefault(y, 0L),
+                                         idToRecycleTime.getOrDefault(x, 0L)));
 
         for (int i = maxTrashNum; i < ids.size(); i++) {
             idToErase.add(ids.get(i));
@@ -1189,6 +1226,9 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         erasePartition(currentTimeMs, keepNum);
         eraseTable(currentTimeMs, keepNum);
         eraseDatabase(currentTimeMs, keepNum);
+        LOG.info("recycleBin cleanup done. idToTable={}, idToPartition={}, idToDatabase={}, invertedIndexSize={}",
+                idToTable.size(), idToPartition.size(), idToDatabase.size(),
+                Env.getCurrentInvertedIndex().getTabletMetaMap().size());
     }
 
     public synchronized List<List<String>> getInfo() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -7011,13 +7011,18 @@ public class Env {
         // inverted index
         TabletInvertedIndex invertedIndex = Env.getCurrentInvertedIndex();
         Collection<Partition> allPartitions = olapTable.getAllPartitions();
+        int tabletCount = 0;
         for (Partition partition : allPartitions) {
             for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.ALL)) {
                 for (Tablet tablet : index.getTablets()) {
                     invertedIndex.deleteTablet(tablet.getId());
+                    tabletCount++;
                 }
             }
         }
+        LOG.info("onEraseOlapTable table[{}-{}] isReplay={}, partitions={}, tablets={}, invertedIndexSize={}",
+                olapTable.getId(), olapTable.getName(), isReplay,
+                allPartitions.size(), tabletCount, invertedIndex.getTabletMetaMap().size());
 
         // TODO: does checkpoint need update colocate index ?
         // colocation


### PR DESCRIPTION
### What problem does this PR solve?

  ## Summary
  This PR fixes an FE recycle-bin cleanup bug that could cause the recycle daemon to fail with an unexpected NPE.

  ## Root cause
  In some edge cases, an ID could still exist in same-name index structures while its recycle-time entry was already
  removed.
  The cleanup path then sorted IDs by recycle time and dereferenced missing values.

  ## Changes
  - Clean stale IDs before same-name erase logic.
  - Filter IDs without recycle-time entries before sorting.
  - Use safer recycle-time lookup during sort.
  - Add defensive logging around erase/replay paths for easier diagnosis.

  ## Impact
  - Prevents recycle daemon abnormal exit due to NPE in cleanup flow.
  - Improves robustness of recycle-bin maintenance under inconsistent metadata states.

  ## Validation
  - Reproduced and verified locally in the target scenario.
  - Confirmed daemon no longer exits on this path.


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

