### PR TITLE
[fix](cloud fe) guard partition type in cloud partition erase path

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
@@ -885,6 +885,13 @@ public class CloudInternalCatalog extends InternalCatalog {
             }
         }
 
+        if (!(partitions.get(0) instanceof CloudPartition)) {
+            Partition p = partitions.get(0);
+            LOG.warn("partition is not CloudPartition, skip drop cloud partition. partitionIds={}, "
+                    + "actualClass={}, partitionName={}, partitionId={}",
+                    partitionIds, p.getClass().getName(), p.getName(), p.getId());
+            return;
+        }
         CloudPartition partition0 = (CloudPartition) partitions.get(0);
 
         int tryCnt = 0;


### PR DESCRIPTION
### What problem does this PR solve?
## Summary
  This PR adds a defensive type guard in cloud partition erase logic to avoid runtime class-cast failures.

  ## Root cause
  `erasePartitionDropBackendReplicas` assumed the first partition was always `CloudPartition` and cast directly.
  When the partition type did not match, it could throw `ClassCastException` and break the recycle-related flow.

  ## Changes
  - Add `instanceof CloudPartition` check before casting.
  - If not `CloudPartition`, log warning details and skip cloud partition drop for that batch.

  ## Impact
  - Prevents unexpected exception in recycle-related partition erase flow.
  - Keeps daemon/task execution stable with mixed or unexpected partition object types.

  ## Validation
  - Reproduced and verified locally in the target scenario.
  - Confirmed no class-cast failure after the guard.


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

