### PR TITLE
[chore](fe) remove job when table dropped

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -7024,6 +7024,13 @@ public class Env {
         Env.getCurrentColocateIndex().removeTable(olapTable.getId());
 
         getInternalCatalog().eraseTableDropBackendReplicas(dbId, olapTable, isReplay);
+
+        // clean up alter jobs for this table to avoid holding OlapTable references
+        long erasedTableId = olapTable.getId();
+        getMaterializedViewHandler().getAlterJobsV2().values()
+                .removeIf(job -> job.getTableId() == erasedTableId);
+        getSchemaChangeHandler().getAlterJobsV2().values()
+                .removeIf(job -> job.getTableId() == erasedTableId);
     }
 
     public void onErasePartition(Partition partition) {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/EnvTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/EnvTest.java
@@ -17,12 +17,21 @@
 
 package org.apache.doris.catalog;
 
+import org.apache.doris.alter.AlterJobV2;
+import org.apache.doris.alter.MaterializedViewHandler;
+import org.apache.doris.alter.SchemaChangeHandler;
+import org.apache.doris.alter.SchemaChangeJobV2;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.io.CountingDataOutputStream;
 import org.apache.doris.meta.MetaContext;
 import org.apache.doris.persist.meta.MetaHeader;
 
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import mockit.Verifications;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,7 +43,10 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class EnvTest {
 
@@ -139,5 +151,91 @@ public class EnvTest {
         dis.close();
 
         deleteDir(dir);
+    }
+
+    @Test
+    public void testOnEraseOlapTableCleansAlterJobs(@Mocked InternalCatalog internalCatalog,
+                                                    @Mocked TabletInvertedIndex invertedIndex,
+                                                    @Mocked ColocateTableIndex colocateTableIndex,
+                                                    @Mocked OlapTable olapTable) {
+        Env env = new Env(true);
+        MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
+        SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
+
+        long erasedTableId = 10001L;
+        AlterJobV2 mvTargetJob = new SchemaChangeJobV2("sql", 1L, 1L, erasedTableId, "t1", 1000L);
+        AlterJobV2 mvOtherJob = new SchemaChangeJobV2("sql", 2L, 1L, 20002L, "t2", 1000L);
+        AlterJobV2 scTargetJob = new SchemaChangeJobV2("sql", 3L, 1L, erasedTableId, "t1", 1000L);
+        AlterJobV2 scOtherJob = new SchemaChangeJobV2("sql", 4L, 1L, 30003L, "t3", 1000L);
+
+        Map<Long, AlterJobV2> mvJobs = materializedViewHandler.getAlterJobsV2();
+        Map<Long, AlterJobV2> scJobs = schemaChangeHandler.getAlterJobsV2();
+        mvJobs.put(mvTargetJob.getJobId(), mvTargetJob);
+        mvJobs.put(mvOtherJob.getJobId(), mvOtherJob);
+        scJobs.put(scTargetJob.getJobId(), scTargetJob);
+        scJobs.put(scOtherJob.getJobId(), scOtherJob);
+
+        new MockUp<Env>() {
+            @Mock
+            public static TabletInvertedIndex getCurrentInvertedIndex() {
+                return invertedIndex;
+            }
+
+            @Mock
+            public static ColocateTableIndex getCurrentColocateIndex() {
+                return colocateTableIndex;
+            }
+        };
+
+        new Expectations(env, olapTable) {
+            {
+                invertedIndex.getTabletMetaMap();
+                result = new ConcurrentHashMap<>();
+                minTimes = 0;
+
+                env.getInternalCatalog();
+                result = internalCatalog;
+                minTimes = 0;
+
+                env.getMaterializedViewHandler();
+                result = materializedViewHandler;
+                minTimes = 0;
+
+                env.getSchemaChangeHandler();
+                result = schemaChangeHandler;
+                minTimes = 0;
+
+                olapTable.getId();
+                result = erasedTableId;
+                minTimes = 0;
+
+                olapTable.getName();
+                result = "test_tbl";
+                minTimes = 0;
+
+                olapTable.getAllPartitions();
+                result = Collections.emptyList();
+                minTimes = 0;
+            }
+        };
+
+        env.onEraseOlapTable(1L, olapTable, false);
+
+        Assert.assertEquals(1, mvJobs.size());
+        Assert.assertTrue(mvJobs.containsValue(mvOtherJob));
+        Assert.assertFalse(mvJobs.containsValue(mvTargetJob));
+
+        Assert.assertEquals(1, scJobs.size());
+        Assert.assertTrue(scJobs.containsValue(scOtherJob));
+        Assert.assertFalse(scJobs.containsValue(scTargetJob));
+
+        new Verifications() {
+            {
+                internalCatalog.eraseTableDropBackendReplicas(1L, olapTable, false);
+                times = 1;
+                colocateTableIndex.removeTable(erasedTableId);
+                times = 1;
+            }
+        };
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/EnvTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/EnvTest.java
@@ -177,12 +177,12 @@ public class EnvTest {
 
         new MockUp<Env>() {
             @Mock
-            public static TabletInvertedIndex getCurrentInvertedIndex() {
+            public TabletInvertedIndex getCurrentInvertedIndex() {
                 return invertedIndex;
             }
 
             @Mock
-            public static ColocateTableIndex getCurrentColocateIndex() {
+            public ColocateTableIndex getCurrentColocateIndex() {
                 return colocateTableIndex;
             }
         };

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/EnvTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/EnvTest.java
@@ -21,9 +21,9 @@ import org.apache.doris.alter.AlterJobV2;
 import org.apache.doris.alter.MaterializedViewHandler;
 import org.apache.doris.alter.SchemaChangeHandler;
 import org.apache.doris.alter.SchemaChangeJobV2;
-import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.io.CountingDataOutputStream;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.meta.MetaContext;
 import org.apache.doris.persist.meta.MetaHeader;
 


### PR DESCRIPTION
### What problem does this PR solve?
## Summary

  This PR fixes a metadata-retention issue in FE when an OLAP table is erased (drop/recycle path).

  Env.onEraseOlapTable(...) now proactively removes alter jobs for the erased table from:

  - MaterializedViewHandler.alterJobsV2
  - SchemaChangeHandler.alterJobsV2

  ## Problem

  After a table is dropped/erased, alter-job entries for that table may remain in handler job maps until periodic
  expiration cleanup.
  Those stale entries can keep table-related metadata reachable longer than necessary and contribute to FE memory growth in
  drop-table-heavy workloads.

  ## Fix

  During table erase, clean alter jobs by tableId immediately:

  - remove MV alter jobs whose job.getTableId() == erasedTableId
  - remove schema-change alter jobs whose job.getTableId() == erasedTableId

  This aligns job lifecycle with table lifecycle and avoids unnecessary retention.

  ## Test

  Added unit test in EnvTest to verify:

  - jobs targeting the erased table are removed from both handlers
  - jobs targeting other tables remain intact
  - existing erase flow (eraseTableDropBackendReplicas, colocate cleanup) is still invoked

  ## Impact

  - No behavior change for normal alter execution paths
  - Improves FE memory hygiene and metadata cleanup correctness after table erase

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

