### PR TITLE
Fix typo: seperate to separate

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -481,7 +481,7 @@ DECLARE_Bool(enable_parquet_cache_compressed_pages);
 // whether to disable pk page cache feature in storage
 DECLARE_Bool(disable_pk_storage_page_cache);
 
-// Cache for mow primary key storage page size, it's seperated from
+// Cache for mow primary key storage page size, it's separated from
 // storage_page_cache_limit
 DECLARE_String(pk_storage_page_cache_limit);
 // data page size for primary key index

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -443,7 +443,7 @@ Status CompactionMixin::build_basic_info(bool is_ordered_compaction) {
                    [](const RowsetSharedPtr& rowset) { return rowset->rowset_meta(); });
     _cur_tablet_schema = _tablet->tablet_schema_with_merged_max_schema_version(rowset_metas);
 
-    // if enable_vertical_compact_variant_subcolumns is true, we need to compact the variant subcolumns in seperate column groups
+    // if enable_vertical_compact_variant_subcolumns is true, we need to compact the variant subcolumns in separate column groups
     // so get_extended_compaction_schema will extended the schema for variant columns
     // for ordered compaction, we don't need to extend the schema for variant columns
     if (_enable_vertical_compact_variant_subcolumns && !is_ordered_compaction) {
@@ -1511,7 +1511,7 @@ Status CloudCompactionMixin::build_basic_info() {
         _cur_tablet_schema = _tablet->tablet_schema_with_merged_max_schema_version(rowset_metas);
     }
 
-    // if enable_vertical_compact_variant_subcolumns is true, we need to compact the variant subcolumns in seperate column groups
+    // if enable_vertical_compact_variant_subcolumns is true, we need to compact the variant subcolumns in separate column groups
     // so get_extended_compaction_schema will extended the schema for variant columns
     if (_enable_vertical_compact_variant_subcolumns) {
         RETURN_IF_ERROR(

--- a/be/src/olap/page_cache.h
+++ b/be/src/olap/page_cache.h
@@ -201,7 +201,7 @@ private:
     int32_t _index_cache_percentage = 0;
     std::unique_ptr<DataPageCache> _data_page_cache;
     std::unique_ptr<IndexPageCache> _index_page_cache;
-    // Cache data for primary key index data page, seperated from data
+    // Cache data for primary key index data page, separated from data
     // page cache to make it for flexible. we need this cache When construct
     // delete bitmap in unique key with mow
     std::unique_ptr<PKIndexPageCache> _pk_index_page_cache;

--- a/be/src/olap/partial_update_info.cpp
+++ b/be/src/olap/partial_update_info.cpp
@@ -618,7 +618,7 @@ static void fill_non_primary_key_cell_for_column_store(
             } else if (tablet_column.is_auto_increment()) {
                 // In flexible partial update, the skip bitmap indicates whether a cell
                 // is specified in the original load, so the generated auto-increment value is filled
-                // in current block in place if needed rather than using a seperate column to
+                // in current block in place if needed rather than using a separate column to
                 // store the generated auto-increment value in fixed partial update
                 new_col->insert_from(cur_col, block_pos);
             } else {
@@ -725,7 +725,7 @@ static void fill_non_primary_key_cell_for_row_store(
             } else if (tablet_column.is_auto_increment()) {
                 // In flexible partial update, the skip bitmap indicates whether a cell
                 // is specified in the original load, so the generated auto-increment value is filled
-                // in current block in place if needed rather than using a seperate column to
+                // in current block in place if needed rather than using a separate column to
                 // store the generated auto-increment value in fixed partial update
                 new_col->insert_from(cur_col, block_pos);
             } else {

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -202,7 +202,7 @@ Status Segment::_open(OlapReaderStatistics* stats) {
     _num_rows = footer_pb_shared->num_rows();
 
     // An estimated memory usage of a segment
-    // Footer is seperated to StoragePageCache so we don't need to add it to _meta_mem_usage
+    // Footer is separated to StoragePageCache so we don't need to add it to _meta_mem_usage
     // _meta_mem_usage += footer_pb_shared->ByteSizeLong();
     if (_pk_index_meta != nullptr) {
         _meta_mem_usage += _pk_index_meta->ByteSizeLong();

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -872,7 +872,7 @@ Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params,
     VLOG_ROW << "Query: " << print_id(params.query_id) << " exec_plan_fragment params is "
              << apache::thrift::ThriftDebugString(params).c_str();
     // sometimes TPipelineFragmentParams debug string is too long and glog
-    // will truncate the log line, so print query options seperately for debuggin purpose
+    // will truncate the log line, so print query options separately for debuggin purpose
     VLOG_ROW << "Query: " << print_id(params.query_id) << "query options is "
              << apache::thrift::ThriftDebugString(params.query_options).c_str();
 

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -302,7 +302,7 @@ inline Status MemTrackerLimiter::check_limit(int64_t bytes) {
     }
 
     // If reserve not enabled, then should check limit here to kill the query when limit exceed.
-    // For insert into select or pure load job, its memtable is accounted in a seperate memtracker limiter,
+    // For insert into select or pure load job, its memtable is accounted in a separate memtracker limiter,
     // and its reserve is set to true. So that it will not reach this logic.
     // Only query and load job has exec_mem_limit and the _limit > 0, other memtracker limiter's _limit is -1 so
     // it will not take effect.

--- a/be/src/vec/exec/executor/time_sharing/time_sharing_task_executor.cpp
+++ b/be/src/vec/exec/executor/time_sharing/time_sharing_task_executor.cpp
@@ -39,7 +39,7 @@ namespace vectorized {
 
 // Same with definations in threadpool.cpp
 // Why use same name:
-// We do not want to add seperate metrics for TimeSharingTaskExecutor.
+// We do not want to add separate metrics for TimeSharingTaskExecutor.
 // TimeSharingTaskExecutor is actually a specialized ThreadPool, which uses a time_sharing queuing policy.
 // So we want it have same metrics ends up in the finale prometheus.
 // This is safe:

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -249,7 +249,7 @@ struct TQueryOptions {
   82: optional i64 fe_process_uuid = 0;
 
   83: optional i32 inverted_index_conjunction_opt_threshold = 1000;
-  // A seperate flag to indicate whether to enable profile, not
+  // A separate flag to indicate whether to enable profile, not
   // use is_report_success any more
   84: optional bool enable_profile = false;
   85: optional bool enable_page_cache = false;

--- a/pytest/deploy/be.conf
+++ b/pytest/deploy/be.conf
@@ -8,7 +8,7 @@ heartbeat_service_port =
 be_rpc_port =
 brpc_port = 
 
-# data root path, seperate by ';' 
+# data root path, separate by ';' 
 storage_root_path = ${DORIS_HOME}/data/data.SSD;${DORIS_HOME}/data/data.HDD
 
 # Advanced configurations


### PR DESCRIPTION
Fixes typo in code comments and configuration. Corrects spelling of 'seperate' to 'separate' across multiple files including comments, configuration, and thrift definitions.