### PR TITLE
[chore](openblas) Add DYNAMIC_ARCH control option to build.sh

### DIFF
--- a/be/src/olap/rowset/segment_v2/ann_index/cmake-protect/CMakeLists.txt
+++ b/be/src/olap/rowset/segment_v2/ann_index/cmake-protect/CMakeLists.txt
@@ -31,8 +31,16 @@ set(BUILD_BENCHMARKS OFF CACHE BOOL "Build benchmarks in OpenBLAS")
 set(NO_LAPACK OFF CACHE BOOL "Disable LAPACK in OpenBLAS")
 set(NO_CBLAS ON CACHE BOOL "Disable CBLAS in OpenBLAS")
 set(NO_AVX512 ON CACHE BOOL "Disable AVX512 in OpenBLAS")
-if (NOT CMAKE_SYSTEM_NAME MATCHES "Darwin" AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
-    set(DYNAMIC_ARCH ON CACHE BOOL "Enable runtime CPU detection in OpenBLAS")
+
+# Allow overriding DYNAMIC_ARCH from build.sh via ENABLE_DYNAMIC_ARCH variable
+if (DEFINED ENABLE_DYNAMIC_ARCH)
+    if (NOT CMAKE_SYSTEM_NAME MATCHES "Darwin" AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+        set(DYNAMIC_ARCH "${ENABLE_DYNAMIC_ARCH}" CACHE BOOL "Enable runtime CPU detection in OpenBLAS")
+    endif ()
+else()
+    if (NOT CMAKE_SYSTEM_NAME MATCHES "Darwin" AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+        set(DYNAMIC_ARCH ON CACHE BOOL "Enable runtime CPU detection in OpenBLAS")
+    endif ()
 endif ()
 
 # EXCLUDE_FROM_ALL so that binary in openblas is not installed.

--- a/build.sh
+++ b/build.sh
@@ -57,12 +57,15 @@ Usage: $0 <options>
      --be-java-extensions       build Backend java extensions. Default ON.
      --be-cdc-client            build Cdc Client for backend. Default ON.
      --be-extension-ignore      build be-java-extensions package, choose which modules to ignore. Multiple modules separated by commas.
+     --enable-dynamic-arch      enable dynamic CPU detection in OpenBLAS. Default ON.
+     --disable-dynamic-arch     disable dynamic CPU detection in OpenBLAS.
      --clean                    clean and build target
      --output                   specify the output directory
      -j                         build Backend parallel
 
   Environment variables:
     USE_AVX2                    If the CPU does not support AVX2 instruction set, please set USE_AVX2=0. Default is ON.
+    ENABLE_DYNAMIC_ARCH         If set ENABLE_DYNAMIC_ARCH=ON, it will enable dynamic CPU detection in OpenBLAS. Default is ON. Can also use --enable-dynamic-arch flag.
     ARM_MARCH                   Specify the ARM architecture instruction set. Default is armv8-a+crc.
     STRIP_DEBUG_INFO            If set STRIP_DEBUG_INFO=ON, the debug information in the compiled binaries will be stored separately in the 'be/lib/debug_info' directory. Default is OFF.
     DISABLE_BE_JAVA_EXTENSIONS  If set DISABLE_BE_JAVA_EXTENSIONS=ON, we will do not build binary with java-udf,hadoop-hudi-scanner,jdbc-scanner and so on Default is OFF.
@@ -89,6 +92,8 @@ Usage: $0 <options>
     USE_AVX2=0 $0 --be                      build Backend and not using AVX2 instruction.
     USE_AVX2=0 STRIP_DEBUG_INFO=ON $0       build all and not using AVX2 instruction, and strip the debug info for Backend
     ARM_MARCH=armv8-a+crc+simd $0 --be      build Backend with specified ARM architecture instruction set
+    $0 --be --disable-dynamic-arch          build Backend with DYNAMIC_ARCH disabled in OpenBLAS
+    ENABLE_DYNAMIC_ARCH=OFF $0 --be         build Backend with DYNAMIC_ARCH disabled via environment variable
   "
     exit 1
 }
@@ -145,6 +150,8 @@ if ! OPTS="$(getopt \
     -l 'be-java-extensions' \
     -l 'be-cdc-client' \
     -l 'be-extension-ignore:' \
+    -l 'enable-dynamic-arch' \
+    -l 'disable-dynamic-arch' \
     -l 'clean' \
     -l 'coverage' \
     -l 'help' \
@@ -171,6 +178,7 @@ BUILD_BE_CDC_CLIENT=0
 BUILD_OBS_DEPENDENCIES=1
 BUILD_COS_DEPENDENCIES=1
 BUILD_HIVE_UDF=0
+ENABLE_DYNAMIC_ARCH='ON'
 CLEAN=0
 HELP=0
 PARAMETER_COUNT="$#"
@@ -262,6 +270,14 @@ else
             ;; 
         --exclude-cos-dependencies)
             BUILD_COS_DEPENDENCIES=0
+            shift
+            ;;
+        --enable-dynamic-arch)
+            ENABLE_DYNAMIC_ARCH='ON'
+            shift
+            ;;
+        --disable-dynamic-arch)
+            ENABLE_DYNAMIC_ARCH='OFF'
             shift
             ;;           
         --clean)
@@ -664,6 +680,7 @@ if [[ "${BUILD_BE}" -eq 1 ]]; then
         -DENABLE_CLANG_COVERAGE="${DENABLE_CLANG_COVERAGE}" \
         -DDORIS_JAVA_HOME="${JAVA_HOME}" \
         -DBUILD_AZURE="${BUILD_AZURE}" \
+        -DENABLE_DYNAMIC_ARCH="${ENABLE_DYNAMIC_ARCH}" \
         -DWITH_TDE_DIR="${WITH_TDE_DIR}" \
         "${DORIS_HOME}/be"
 
@@ -706,6 +723,7 @@ if [[ "${BUILD_CLOUD}" -eq 1 ]]; then
         -DEXTRA_CXX_FLAGS="${EXTRA_CXX_FLAGS}" \
         -DBUILD_AZURE="${BUILD_AZURE}" \
         -DBUILD_CHECK_META="${BUILD_CHECK_META:-OFF}" \
+        -DENABLE_DYNAMIC_ARCH="${ENABLE_DYNAMIC_ARCH}" \
         "${DORIS_HOME}/cloud/"
     "${BUILD_SYSTEM}" -j "${PARALLEL}"
     "${BUILD_SYSTEM}" install


### PR DESCRIPTION
# Add DYNAMIC_ARCH control option to build.sh

## Summary
Add command-line options to manually control the DYNAMIC_ARCH parameter in OpenBLAS compilation, allowing users to enable or disable dynamic CPU detection at build time.

## Changes Made

### 1. build.sh
- Added two new command-line options:
  - `--enable-dynamic-arch`: Enable dynamic CPU detection in OpenBLAS (default behavior)
  - `--disable-dynamic-arch`: Disable dynamic CPU detection in OpenBLAS
- Initialized `ENABLE_DYNAMIC_ARCH` variable with default value `'ON'`
- Added parameter handling for both new options in the argument parsing section
- Passed `ENABLE_DYNAMIC_ARCH` variable to BE and Cloud cmake build commands
- Updated help documentation with usage examples and environment variable info

### 2. be/src/olap/rowset/segment_v2/ann_index/cmake-protect/CMakeLists.txt
- Modified DYNAMIC_ARCH setting logic to support external `ENABLE_DYNAMIC_ARCH` variable
- Added conditional check: if `ENABLE_DYNAMIC_ARCH` is defined, use its value; otherwise, use default (ON)
- Maintained backward compatibility with existing behavior

## Usage

### Command-line options:
```bash
./build.sh --be --disable-dynamic-arch    # Disable DYNAMIC_ARCH
./build.sh --be --enable-dynamic-arch     # Enable DYNAMIC_ARCH (default)
./build.sh --be                           # Use default (ON)