### PR TITLE
[fix](cloud) Align colocate proc output and tablet health in cloud mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ColocateTableIndex.java
@@ -711,7 +711,11 @@ public class ColocateTableIndex implements Writable {
                 info.add(Joiner.on(", ").join(group2Tables.get(groupId)));
                 ColocateGroupSchema groupSchema = group2Schema.get(groupId);
                 info.add(String.valueOf(groupSchema.getBucketsNum()));
-                info.add(String.valueOf(groupSchema.getReplicaAlloc().toCreateStmt()));
+                if (Config.isCloudMode()) {
+                    info.add("null");
+                } else {
+                    info.add(String.valueOf(groupSchema.getReplicaAlloc().toCreateStmt()));
+                }
                 List<String> cols = groupSchema.getDistributionColTypes().stream().map(
                         e -> e.toSql()).collect(Collectors.toList());
                 info.add(Joiner.on(", ").join(cols));

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ColocateTableIndex.java
@@ -437,6 +437,19 @@ public class ColocateTableIndex implements Writable {
         }
     }
 
+    public Long getDbIdByTblIdNullable(GroupId groupId, long tableId) {
+        readLock();
+        try {
+            GroupId tableGroupId = table2Group.get(tableId);
+            if (tableGroupId == null || !tableGroupId.equals(groupId)) {
+                return null;
+            }
+            return tableGroupId.tblId2DbId.get(tableId);
+        } finally {
+            readUnlock();
+        }
+    }
+
     public Set<GroupId> getAllGroupIds() {
         readLock();
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -185,10 +186,12 @@ public abstract class Replica {
         return getBackendIdValue();
     }
 
-    // For proc display only. Returns a "scope key -> backendId" mapping used to render
-    // the replica's placement. In local deployment there is a single scope (empty key);
-    // in cloud deployment each compute group is a separate scope (see CloudReplica).
-    public Map<String, Long> getClusterToBackendForProcDisplay() {
+    // For proc display only. Returns a "scope key -> backendId" mapping used to render the
+    // replica's placement. In local deployment there is a single scope (empty key) and the
+    // cache is unused; in cloud deployment each compute group is a separate scope and the
+    // cache lets a single proc call fetch each compute group's backends once (see
+    // CloudReplica). The cache is keyed by compute group id.
+    public Map<String, Long> getClusterToBackendForProcDisplay(Map<String, List<Backend>> computeGroupBackendCache) {
         Map<String, Long> result = new HashMap<>();
         long backendId = getBackendIdForProcDisplay();
         if (backendId != -1L) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
@@ -29,6 +29,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * This class represents the olap replica related metadata.
@@ -177,6 +179,22 @@ public abstract class Replica {
 
     protected long getBackendIdValue() {
         return -1L;
+    }
+
+    public long getBackendIdForProcDisplay() {
+        return getBackendIdValue();
+    }
+
+    // For proc display only. Returns a "scope key -> backendId" mapping used to render
+    // the replica's placement. In local deployment there is a single scope (empty key);
+    // in cloud deployment each compute group is a separate scope (see CloudReplica).
+    public Map<String, Long> getClusterToBackendForProcDisplay() {
+        Map<String, Long> result = new HashMap<>();
+        long backendId = getBackendIdForProcDisplay();
+        if (backendId != -1L) {
+            result.put("", backendId);
+        }
+        return result;
     }
 
     public void setBackendId(long backendId) {

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
@@ -44,6 +44,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -214,6 +215,16 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
         }
 
         return primaryClusterToBackend.getOrDefault(clusterId, -1L);
+    }
+
+    // For proc display only. In cloud mode a replica is hashed to a different BE in
+    // each compute group, so expose the whole clusterId -> backendId cache. The proc
+    // display builds a separate bucket sequence per compute group from this map so the
+    // sequence is consistent within each group. Do not collapse this into a single BE
+    // (e.g. the first one): backends differ across compute groups and would not match.
+    @Override
+    public Map<String, Long> getClusterToBackendForProcDisplay() {
+        return new HashMap<>(primaryClusterToBackend);
     }
 
     private String getCurrentClusterId() throws ComputeGroupException {

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
@@ -112,8 +112,17 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
     }
 
     public long getColocatedBeId(String clusterId) throws ComputeGroupException {
+        List<Backend> clusterBackends = ((CloudSystemInfoService) Env.getCurrentSystemInfo())
+                .getBackendsByClusterId(clusterId);
+        return getColocatedBeId(clusterId, clusterBackends);
+    }
+
+    // Same as getColocatedBeId(clusterId) but reuses an already fetched backend list of
+    // the compute group. Lets callers that resolve many replicas across the same compute
+    // groups (e.g. the colocate proc display) fetch each group's backends only once.
+    public long getColocatedBeId(String clusterId, List<Backend> clusterBackends) throws ComputeGroupException {
         CloudSystemInfoService infoService = ((CloudSystemInfoService) Env.getCurrentSystemInfo());
-        List<Backend> bes = infoService.getBackendsByClusterId(clusterId).stream()
+        List<Backend> bes = clusterBackends.stream()
                 .filter(be -> be.isQueryAvailable()).collect(Collectors.toList());
         String clusterName = infoService.getClusterNameByClusterId(clusterId);
         if (bes.isEmpty()) {
@@ -217,14 +226,45 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
         return primaryClusterToBackend.getOrDefault(clusterId, -1L);
     }
 
-    // For proc display only. In cloud mode a replica is hashed to a different BE in
-    // each compute group, so expose the whole clusterId -> backendId cache. The proc
-    // display builds a separate bucket sequence per compute group from this map so the
-    // sequence is consistent within each group. Do not collapse this into a single BE
-    // (e.g. the first one): backends differ across compute groups and would not match.
+    // For proc display only. In cloud mode a replica is hashed to a different BE in each
+    // compute group, so expose a clusterId -> backendId mapping; the proc display builds
+    // a separate bucket sequence per compute group from it so each group's sequence is
+    // self-consistent. Do not collapse this into a single BE (e.g. the first one):
+    // backends differ across compute groups and would not match.
+    //
+    // ATTN: colocated replicas do NOT use primaryClusterToBackend (see getBackendIdImpl /
+    // getClusterPrimaryBackendId, which short-circuit to getColocatedBeId), so that cache
+    // is empty for them. Resolve their placement per compute group on the fly instead.
+    // This reads CloudSystemInfoService / the colocate index, so callers must invoke it
+    // OUTSIDE any table lock to avoid nested lock acquisition. It does not auto-start any
+    // compute group: getColocatedBeId only reads the already-known backends of a clusterId.
+    // computeGroupBackendCache maps compute group id -> getBackendsByClusterId() result and
+    // is shared across all replicas resolved in a single proc call, so each compute group's
+    // backend list is fetched only once instead of once per replica.
     @Override
-    public Map<String, Long> getClusterToBackendForProcDisplay() {
-        return new HashMap<>(primaryClusterToBackend);
+    public Map<String, Long> getClusterToBackendForProcDisplay(Map<String, List<Backend>> computeGroupBackendCache) {
+        if (!isColocated()) {
+            return new HashMap<>(primaryClusterToBackend);
+        }
+        Map<String, Long> result = new HashMap<>();
+        CloudSystemInfoService infoService = (CloudSystemInfoService) Env.getCurrentSystemInfo();
+        for (String clusterId : infoService.getCloudClusterIds()) {
+            try {
+                List<Backend> clusterBackends =
+                        computeGroupBackendCache.computeIfAbsent(clusterId, infoService::getBackendsByClusterId);
+                long backendId = getColocatedBeId(clusterId, clusterBackends);
+                if (backendId != -1L) {
+                    result.put(clusterId, backendId);
+                }
+            } catch (ComputeGroupException e) {
+                // Skip compute groups that currently have no available backend.
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("skip compute group {} for colocate proc display, replica {}",
+                            clusterId, getId(), e);
+                }
+            }
+        }
+        return result;
     }
 
     private String getCurrentClusterId() throws ComputeGroupException {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ColocationGroupBackendSeqsProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ColocationGroupBackendSeqsProcNode.java
@@ -39,26 +39,26 @@ public class ColocationGroupBackendSeqsProcNode implements ProcNodeInterface {
     @Override
     public ProcResult fetchResult() throws AnalysisException {
         BaseProcResult result = new BaseProcResult();
-        List<String> titleNames = Lists.newArrayList();
-        titleNames.add("BucketIndex");
+        List<String> titleNames = Lists.newArrayList("BucketIndex", "BackendIds");
         int bucketNum = 0;
-        for (Tag tag : backendsSeq.keySet()) {
-            titleNames.add(tag.toString());
+        for (Map.Entry<Tag, List<List<Long>>> entry : backendsSeq.entrySet()) {
+            List<List<Long>> bucketBackends = entry.getValue();
             if (bucketNum == 0) {
-                bucketNum = backendsSeq.get(tag).size();
-            } else if (bucketNum != backendsSeq.get(tag).size()) {
+                bucketNum = bucketBackends.size();
+            } else if (bucketNum != bucketBackends.size()) {
                 throw new AnalysisException("Invalid bucket number: "
-                        + bucketNum + " vs. " + backendsSeq.get(tag).size());
+                        + bucketNum + " vs. " + bucketBackends.size());
             }
         }
         result.setNames(titleNames);
         for (int i = 0; i < bucketNum; i++) {
             List<String> info = Lists.newArrayList();
             info.add(String.valueOf(i)); // bucket index
-            for (Tag tag : backendsSeq.keySet()) {
-                List<List<Long>> bucketBackends = backendsSeq.get(tag);
-                info.add(Joiner.on(", ").join(bucketBackends.get(i)));
+            List<Long> mergedBackendIds = Lists.newArrayList();
+            for (List<List<Long>> bucketBackends : backendsSeq.values()) {
+                mergedBackendIds.addAll(bucketBackends.get(i));
             }
+            info.add(Joiner.on(", ").join(mergedBackendIds));
             result.addRow(info);
         }
         return result;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ColocationGroupBackendSeqsProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ColocationGroupBackendSeqsProcNode.java
@@ -31,34 +31,53 @@ import java.util.Map;
  */
 public class ColocationGroupBackendSeqsProcNode implements ProcNodeInterface {
     private Map<Tag, List<List<Long>>> backendsSeq;
+    private boolean showBackendIdsColumn;
 
     public ColocationGroupBackendSeqsProcNode(Map<Tag, List<List<Long>>> backendsSeq) {
+        this(backendsSeq, false);
+    }
+
+    public ColocationGroupBackendSeqsProcNode(Map<Tag, List<List<Long>>> backendsSeq, boolean showBackendIdsColumn) {
         this.backendsSeq = backendsSeq;
+        this.showBackendIdsColumn = showBackendIdsColumn;
     }
 
     @Override
     public ProcResult fetchResult() throws AnalysisException {
         BaseProcResult result = new BaseProcResult();
-        List<String> titleNames = Lists.newArrayList("BucketIndex", "BackendIds");
+        List<String> titleNames = Lists.newArrayList();
+        titleNames.add("BucketIndex");
         int bucketNum = 0;
-        for (Map.Entry<Tag, List<List<Long>>> entry : backendsSeq.entrySet()) {
-            List<List<Long>> bucketBackends = entry.getValue();
-            if (bucketNum == 0) {
-                bucketNum = bucketBackends.size();
-            } else if (bucketNum != bucketBackends.size()) {
-                throw new AnalysisException("Invalid bucket number: "
-                        + bucketNum + " vs. " + bucketBackends.size());
+        for (Tag tag : backendsSeq.keySet()) {
+            if (!showBackendIdsColumn) {
+                titleNames.add(tag.toString());
             }
+            if (bucketNum == 0) {
+                bucketNum = backendsSeq.get(tag).size();
+            } else if (bucketNum != backendsSeq.get(tag).size()) {
+                throw new AnalysisException("Invalid bucket number: "
+                        + bucketNum + " vs. " + backendsSeq.get(tag).size());
+            }
+        }
+        if (showBackendIdsColumn) {
+            titleNames.add("BackendIds");
         }
         result.setNames(titleNames);
         for (int i = 0; i < bucketNum; i++) {
             List<String> info = Lists.newArrayList();
             info.add(String.valueOf(i)); // bucket index
-            List<Long> mergedBackendIds = Lists.newArrayList();
-            for (List<List<Long>> bucketBackends : backendsSeq.values()) {
-                mergedBackendIds.addAll(bucketBackends.get(i));
+            if (showBackendIdsColumn) {
+                List<Long> mergedBackendIds = Lists.newArrayList();
+                for (List<List<Long>> bucketBackends : backendsSeq.values()) {
+                    mergedBackendIds.addAll(bucketBackends.get(i));
+                }
+                info.add(Joiner.on(", ").join(mergedBackendIds));
+            } else {
+                for (Tag tag : backendsSeq.keySet()) {
+                    List<List<Long>> bucketBackends = backendsSeq.get(tag);
+                    info.add(Joiner.on(", ").join(bucketBackends.get(i)));
+                }
             }
-            info.add(Joiner.on(", ").join(mergedBackendIds));
             result.addRow(info);
         }
         return result;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ColocationGroupBackendSeqsProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ColocationGroupBackendSeqsProcNode.java
@@ -18,7 +18,6 @@
 package org.apache.doris.common.proc;
 
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.resource.Tag;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
@@ -30,16 +29,13 @@ import java.util.Map;
  * show proc "/colocation_group/group_name";
  */
 public class ColocationGroupBackendSeqsProcNode implements ProcNodeInterface {
-    private Map<Tag, List<List<Long>>> backendsSeq;
-    private boolean showBackendIdsColumn;
+    // Column name -> per-bucket backend id sequence. The column name is a resource Tag in
+    // local mode, a compute group name in cloud mode, or "BackendIds" when there is no
+    // per-scope breakdown.
+    private Map<String, List<List<Long>>> backendsSeqByColumn;
 
-    public ColocationGroupBackendSeqsProcNode(Map<Tag, List<List<Long>>> backendsSeq) {
-        this(backendsSeq, false);
-    }
-
-    public ColocationGroupBackendSeqsProcNode(Map<Tag, List<List<Long>>> backendsSeq, boolean showBackendIdsColumn) {
-        this.backendsSeq = backendsSeq;
-        this.showBackendIdsColumn = showBackendIdsColumn;
+    public ColocationGroupBackendSeqsProcNode(Map<String, List<List<Long>>> backendsSeqByColumn) {
+        this.backendsSeqByColumn = backendsSeqByColumn;
     }
 
     @Override
@@ -48,35 +44,22 @@ public class ColocationGroupBackendSeqsProcNode implements ProcNodeInterface {
         List<String> titleNames = Lists.newArrayList();
         titleNames.add("BucketIndex");
         int bucketNum = 0;
-        for (Tag tag : backendsSeq.keySet()) {
-            if (!showBackendIdsColumn) {
-                titleNames.add(tag.toString());
-            }
+        for (String column : backendsSeqByColumn.keySet()) {
+            titleNames.add(column);
             if (bucketNum == 0) {
-                bucketNum = backendsSeq.get(tag).size();
-            } else if (bucketNum != backendsSeq.get(tag).size()) {
+                bucketNum = backendsSeqByColumn.get(column).size();
+            } else if (bucketNum != backendsSeqByColumn.get(column).size()) {
                 throw new AnalysisException("Invalid bucket number: "
-                        + bucketNum + " vs. " + backendsSeq.get(tag).size());
+                        + bucketNum + " vs. " + backendsSeqByColumn.get(column).size());
             }
-        }
-        if (showBackendIdsColumn) {
-            titleNames.add("BackendIds");
         }
         result.setNames(titleNames);
         for (int i = 0; i < bucketNum; i++) {
             List<String> info = Lists.newArrayList();
             info.add(String.valueOf(i)); // bucket index
-            if (showBackendIdsColumn) {
-                List<Long> mergedBackendIds = Lists.newArrayList();
-                for (List<List<Long>> bucketBackends : backendsSeq.values()) {
-                    mergedBackendIds.addAll(bucketBackends.get(i));
-                }
-                info.add(Joiner.on(", ").join(mergedBackendIds));
-            } else {
-                for (Tag tag : backendsSeq.keySet()) {
-                    List<List<Long>> bucketBackends = backendsSeq.get(tag);
-                    info.add(Joiner.on(", ").join(bucketBackends.get(i)));
-                }
+            for (String column : backendsSeqByColumn.keySet()) {
+                List<List<Long>> bucketBackends = backendsSeqByColumn.get(column);
+                info.add(Joiner.on(", ").join(bucketBackends.get(i)));
             }
             result.addRow(info);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ColocationGroupProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ColocationGroupProcDir.java
@@ -19,12 +19,24 @@ package org.apache.doris.common.proc;
 
 import org.apache.doris.catalog.ColocateTableIndex;
 import org.apache.doris.catalog.ColocateTableIndex.GroupId;
+import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.MaterializedIndex;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Partition;
+import org.apache.doris.catalog.Replica;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.catalog.Tablet;
+import org.apache.doris.cloud.catalog.CloudReplica;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.resource.Tag;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -61,6 +73,11 @@ public class ColocationGroupProcDir implements ProcDirInterface {
         GroupId groupId = new GroupId(dbId, grpId);
         ColocateTableIndex index = Env.getCurrentColocateIndex();
         Map<Tag, List<List<Long>>> beSeqs = index.getBackendsPerBucketSeq(groupId);
+        if ((beSeqs == null || beSeqs.isEmpty()) && Config.isCloudMode()) {
+            // In cloud mode, legacy backend sequence metadata may be empty.
+            // Build bucket->backend mapping from current tablet replicas for proc display.
+            beSeqs = getCloudBackendSeqsFromTablets(groupId, index);
+        }
         return new ColocationGroupBackendSeqsProcNode(beSeqs);
     }
 
@@ -73,5 +90,58 @@ public class ColocationGroupProcDir implements ProcDirInterface {
         List<List<String>> infos = index.getInfos();
         result.setRows(infos);
         return result;
+    }
+
+    private Map<Tag, List<List<Long>>> getCloudBackendSeqsFromTablets(GroupId groupId, ColocateTableIndex index) {
+        Map<Tag, List<List<Long>>> backendsSeq = Maps.newHashMap();
+        List<Long> tableIds = index.getAllTableIds(groupId);
+        if (tableIds.isEmpty()) {
+            return backendsSeq;
+        }
+
+        long targetTableId = tableIds.get(0);
+        long targetDbId = groupId.dbId == 0 ? groupId.getDbIdByTblId(targetTableId) : groupId.dbId;
+        Database db = Env.getCurrentInternalCatalog().getDbNullable(targetDbId);
+        if (db == null) {
+            return backendsSeq;
+        }
+        Table table = db.getTableNullable(targetTableId);
+        if (!(table instanceof OlapTable)) {
+            return backendsSeq;
+        }
+        OlapTable olapTable = (OlapTable) table;
+        olapTable.readLock();
+        try {
+            Partition firstPartition = null;
+            for (Partition partition : olapTable.getAllPartitions()) {
+                firstPartition = partition;
+                break;
+            }
+            if (firstPartition == null) {
+                return backendsSeq;
+            }
+            MaterializedIndex baseIndex = firstPartition.getBaseIndex();
+            List<Tablet> tablets = baseIndex.getTablets();
+            List<List<Long>> bucketSeq = Lists.newArrayListWithCapacity(tablets.size());
+            backendsSeq.put(null, bucketSeq);
+            for (int i = 0; i < tablets.size(); i++) {
+                List<Long> bucketBackends = new ArrayList<>();
+                for (Replica replica : tablets.get(i).getReplicas()) {
+                    long backendId = replica.getBackendIdWithoutException();
+                    if (backendId < 0 && replica instanceof CloudReplica) {
+                        backendId = ((CloudReplica) replica).getPrimaryBackendId();
+                    }
+                    if (backendId < 0) {
+                        continue;
+                    }
+                    bucketBackends.add(backendId);
+                }
+                // Cloud mode should not expose real tag here, use null as placeholder.
+                bucketSeq.add(bucketBackends);
+            }
+        } finally {
+            olapTable.readUnlock();
+        }
+        return backendsSeq;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ColocationGroupProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ColocationGroupProcDir.java
@@ -77,17 +77,22 @@ public class ColocationGroupProcDir implements ProcDirInterface {
         GroupId groupId = new GroupId(dbId, grpId);
         ColocateTableIndex index = Env.getCurrentColocateIndex();
         Map<Tag, List<List<Long>>> beSeqs = index.getBackendsPerBucketSeq(groupId);
-        boolean showBackendIdsColumn = false;
+        Map<String, List<List<Long>>> columns;
         if ((beSeqs == null || beSeqs.isEmpty()) && Config.isCloudMode()) {
-            // In cloud mode, legacy backend sequence metadata may be empty.
-            // Use only local replica metadata for proc display. This path must not
-            // resolve cloud backends because that may auto-start a compute group.
-            beSeqs = getCloudBackendSeqsFromTablets(groupId, index);
-            // A null tag key means there is no per-compute-group information (e.g.
-            // local-style replicas), so fall back to a single merged BackendIds column.
-            showBackendIdsColumn = beSeqs.containsKey(null);
+            // In cloud mode, legacy backend sequence metadata may be empty. Derive the
+            // sequence from current tablets, one column per compute group. This path must
+            // not resolve cloud backends in a way that auto-starts a compute group.
+            columns = getCloudBackendSeqsFromTablets(groupId, index);
+        } else {
+            // Local mode: one column per resource tag.
+            columns = Maps.newLinkedHashMap();
+            if (beSeqs != null) {
+                for (Map.Entry<Tag, List<List<Long>>> entry : beSeqs.entrySet()) {
+                    columns.put(entry.getKey().toString(), entry.getValue());
+                }
+            }
         }
-        return new ColocationGroupBackendSeqsProcNode(beSeqs, showBackendIdsColumn);
+        return new ColocationGroupBackendSeqsProcNode(columns);
     }
 
     @Override
@@ -101,8 +106,8 @@ public class ColocationGroupProcDir implements ProcDirInterface {
         return result;
     }
 
-    private Map<Tag, List<List<Long>>> getCloudBackendSeqsFromTablets(GroupId groupId, ColocateTableIndex index) {
-        Map<Tag, List<List<Long>>> backendsSeq = Maps.newHashMap();
+    private Map<String, List<List<Long>>> getCloudBackendSeqsFromTablets(GroupId groupId, ColocateTableIndex index) {
+        Map<String, List<List<Long>>> backendsSeq = Maps.newLinkedHashMap();
         List<Long> tableIds = index.getAllTableIds(groupId);
         for (Long tableId : tableIds) {
             long dbId = groupId.dbId;
@@ -129,7 +134,7 @@ public class ColocationGroupProcDir implements ProcDirInterface {
         return backendsSeq;
     }
 
-    private Map<Tag, List<List<Long>>> getCloudBackendSeqsFromTable(OlapTable olapTable) {
+    private Map<String, List<List<Long>>> getCloudBackendSeqsFromTable(OlapTable olapTable) {
         // Snapshot replicas (ordered by bucket) under the table lock only. Resolving the
         // per-compute-group placement of colocate cloud replicas calls into
         // CloudSystemInfoService / the colocate index, which must run outside the table
@@ -197,33 +202,32 @@ public class ColocationGroupProcDir implements ProcDirInterface {
             }
         }
 
-        // Resolve scope keys to display tags (also outside the table lock): name
+        // Resolve scope keys to display column names (also outside the table lock): name
         // resolution acquires CloudSystemInfoService's lock.
-        Map<Tag, List<List<Long>>> backendsSeq = Maps.newLinkedHashMap();
+        Map<String, List<List<Long>>> backendsSeq = Maps.newLinkedHashMap();
         for (Map.Entry<String, List<List<Long>>> entry : seqByScopeKey.entrySet()) {
-            backendsSeq.put(scopeKeyToTag(entry.getKey()), entry.getValue());
+            backendsSeq.put(scopeKeyToColumnName(entry.getKey()), entry.getValue());
         }
         return backendsSeq;
     }
 
-    // Map a proc-display scope key to its display tag. An empty key means there is no
-    // per-compute-group information (local-style replicas), rendered as null so the
-    // caller falls back to a single merged BackendIds column. Otherwise the key is a
-    // cloud compute group id, shown as a compute group tag (resolved to its name).
-    private Tag scopeKeyToTag(String scopeKey) {
+    // Map a proc-display scope key to its column name. An empty key means there is no
+    // per-compute-group breakdown (local-style replicas), shown as a single "BackendIds"
+    // column. Otherwise the key is a cloud compute group id, shown by its compute group
+    // name (falling back to the raw id when the name cannot be resolved).
+    private String scopeKeyToColumnName(String scopeKey) {
         if (Strings.isNullOrEmpty(scopeKey)) {
-            return null;
+            return "BackendIds";
         }
-        String computeGroupName = scopeKey;
         try {
             String name = ((CloudSystemInfoService) Env.getCurrentSystemInfo())
                     .getClusterNameByClusterId(scopeKey);
             if (!Strings.isNullOrEmpty(name)) {
-                computeGroupName = name;
+                return name;
             }
         } catch (Exception e) {
             // Fall back to the raw compute group id if name resolution is unavailable.
         }
-        return Tag.createNotCheck(Tag.COMPUTE_GROUP_NAME, computeGroupName);
+        return scopeKey;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ColocationGroupProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ColocationGroupProcDir.java
@@ -27,18 +27,21 @@ import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.Tablet;
-import org.apache.doris.cloud.catalog.CloudReplica;
+import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.resource.Tag;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /*
  * show proc "/colocation_group";
@@ -76,9 +79,12 @@ public class ColocationGroupProcDir implements ProcDirInterface {
         boolean showBackendIdsColumn = false;
         if ((beSeqs == null || beSeqs.isEmpty()) && Config.isCloudMode()) {
             // In cloud mode, legacy backend sequence metadata may be empty.
-            // Build bucket->backend mapping from current tablet replicas for proc display.
+            // Use only local replica metadata for proc display. This path must not
+            // resolve cloud backends because that may auto-start a compute group.
             beSeqs = getCloudBackendSeqsFromTablets(groupId, index);
-            showBackendIdsColumn = true;
+            // A null tag key means there is no per-compute-group information (e.g.
+            // local-style replicas), so fall back to a single merged BackendIds column.
+            showBackendIdsColumn = beSeqs.containsKey(null);
         }
         return new ColocationGroupBackendSeqsProcNode(beSeqs, showBackendIdsColumn);
     }
@@ -123,7 +129,12 @@ public class ColocationGroupProcDir implements ProcDirInterface {
     }
 
     private Map<Tag, List<List<Long>>> getCloudBackendSeqsFromTable(OlapTable olapTable) {
-        Map<Tag, List<List<Long>>> backendsSeq = Maps.newHashMap();
+        // In cloud mode a replica is hashed to a different BE in each compute group,
+        // so build a separate bucket sequence per compute group (keyed by the raw scope
+        // key while holding the table lock). Merging across groups (picking an arbitrary
+        // first BE) would mix BEs from different compute groups into one bucket sequence,
+        // which is meaningless.
+        Map<String, List<List<Long>>> seqByScopeKey = Maps.newLinkedHashMap();
         olapTable.readLock();
         try {
             Partition firstPartition = null;
@@ -132,34 +143,74 @@ public class ColocationGroupProcDir implements ProcDirInterface {
                 break;
             }
             if (firstPartition == null) {
-                return backendsSeq;
+                return Maps.newLinkedHashMap();
             }
             MaterializedIndex baseIndex = firstPartition.getBaseIndex();
             List<Tablet> tablets = baseIndex.getTablets();
-            List<List<Long>> bucketSeq = Lists.newArrayListWithCapacity(tablets.size());
-            boolean hasBackend = false;
-            for (int i = 0; i < tablets.size(); i++) {
-                List<Long> bucketBackends = new ArrayList<>();
-                for (Replica replica : tablets.get(i).getReplicas()) {
-                    long backendId = replica.getBackendIdWithoutException();
-                    if (backendId < 0 && replica instanceof CloudReplica) {
-                        backendId = ((CloudReplica) replica).getPrimaryBackendId();
-                    }
-                    if (backendId < 0) {
-                        continue;
-                    }
-                    bucketBackends.add(backendId);
-                    hasBackend = true;
+
+            // Collect the cached clusterId -> backendId mapping of every replica once.
+            List<List<Map<String, Long>>> tabletReplicaBackends = Lists.newArrayListWithCapacity(tablets.size());
+            Set<String> scopeKeys = Sets.newLinkedHashSet();
+            for (Tablet tablet : tablets) {
+                List<Map<String, Long>> replicaBackends = new ArrayList<>();
+                for (Replica replica : tablet.getReplicas()) {
+                    Map<String, Long> clusterToBackend = replica.getClusterToBackendForProcDisplay();
+                    replicaBackends.add(clusterToBackend);
+                    scopeKeys.addAll(clusterToBackend.keySet());
                 }
-                // Cloud mode should not expose real tag here, use null as placeholder.
-                bucketSeq.add(bucketBackends);
+                tabletReplicaBackends.add(replicaBackends);
             }
-            if (hasBackend) {
-                backendsSeq.put(null, bucketSeq);
+
+            for (String scopeKey : scopeKeys) {
+                List<List<Long>> bucketSeq = Lists.newArrayListWithCapacity(tablets.size());
+                boolean hasBackend = false;
+                for (List<Map<String, Long>> replicaBackends : tabletReplicaBackends) {
+                    List<Long> bucketBackends = new ArrayList<>();
+                    for (Map<String, Long> clusterToBackend : replicaBackends) {
+                        Long backendId = clusterToBackend.get(scopeKey);
+                        if (backendId == null || backendId < 0) {
+                            continue;
+                        }
+                        bucketBackends.add(backendId);
+                        hasBackend = true;
+                    }
+                    bucketSeq.add(bucketBackends);
+                }
+                if (hasBackend) {
+                    seqByScopeKey.put(scopeKey, bucketSeq);
+                }
             }
         } finally {
             olapTable.readUnlock();
         }
+
+        // Resolve scope keys to display tags outside the table lock: tag/name resolution
+        // acquires CloudSystemInfoService's lock and must not nest under olapTable's lock.
+        Map<Tag, List<List<Long>>> backendsSeq = Maps.newLinkedHashMap();
+        for (Map.Entry<String, List<List<Long>>> entry : seqByScopeKey.entrySet()) {
+            backendsSeq.put(scopeKeyToTag(entry.getKey()), entry.getValue());
+        }
         return backendsSeq;
+    }
+
+    // Map a proc-display scope key to its display tag. An empty key means there is no
+    // per-compute-group information (local-style replicas), rendered as null so the
+    // caller falls back to a single merged BackendIds column. Otherwise the key is a
+    // cloud compute group id, shown as a compute group tag (resolved to its name).
+    private Tag scopeKeyToTag(String scopeKey) {
+        if (Strings.isNullOrEmpty(scopeKey)) {
+            return null;
+        }
+        String computeGroupName = scopeKey;
+        try {
+            String name = ((CloudSystemInfoService) Env.getCurrentSystemInfo())
+                    .getClusterNameByClusterId(scopeKey);
+            if (!Strings.isNullOrEmpty(name)) {
+                computeGroupName = name;
+            }
+        } catch (Exception e) {
+            // Fall back to the raw compute group id if name resolution is unavailable.
+        }
+        return Tag.createNotCheck(Tag.COMPUTE_GROUP_NAME, computeGroupName);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ColocationGroupProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ColocationGroupProcDir.java
@@ -73,12 +73,14 @@ public class ColocationGroupProcDir implements ProcDirInterface {
         GroupId groupId = new GroupId(dbId, grpId);
         ColocateTableIndex index = Env.getCurrentColocateIndex();
         Map<Tag, List<List<Long>>> beSeqs = index.getBackendsPerBucketSeq(groupId);
+        boolean showBackendIdsColumn = false;
         if ((beSeqs == null || beSeqs.isEmpty()) && Config.isCloudMode()) {
             // In cloud mode, legacy backend sequence metadata may be empty.
             // Build bucket->backend mapping from current tablet replicas for proc display.
             beSeqs = getCloudBackendSeqsFromTablets(groupId, index);
+            showBackendIdsColumn = true;
         }
-        return new ColocationGroupBackendSeqsProcNode(beSeqs);
+        return new ColocationGroupBackendSeqsProcNode(beSeqs, showBackendIdsColumn);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ColocationGroupProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ColocationGroupProcDir.java
@@ -31,6 +31,7 @@ import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.resource.Tag;
+import org.apache.doris.system.Backend;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -129,12 +130,11 @@ public class ColocationGroupProcDir implements ProcDirInterface {
     }
 
     private Map<Tag, List<List<Long>>> getCloudBackendSeqsFromTable(OlapTable olapTable) {
-        // In cloud mode a replica is hashed to a different BE in each compute group,
-        // so build a separate bucket sequence per compute group (keyed by the raw scope
-        // key while holding the table lock). Merging across groups (picking an arbitrary
-        // first BE) would mix BEs from different compute groups into one bucket sequence,
-        // which is meaningless.
-        Map<String, List<List<Long>>> seqByScopeKey = Maps.newLinkedHashMap();
+        // Snapshot replicas (ordered by bucket) under the table lock only. Resolving the
+        // per-compute-group placement of colocate cloud replicas calls into
+        // CloudSystemInfoService / the colocate index, which must run outside the table
+        // lock to avoid nested lock acquisition.
+        List<List<Replica>> bucketReplicas = Lists.newArrayList();
         olapTable.readLock();
         try {
             Partition firstPartition = null;
@@ -146,46 +146,59 @@ public class ColocationGroupProcDir implements ProcDirInterface {
                 return Maps.newLinkedHashMap();
             }
             MaterializedIndex baseIndex = firstPartition.getBaseIndex();
-            List<Tablet> tablets = baseIndex.getTablets();
-
-            // Collect the cached clusterId -> backendId mapping of every replica once.
-            List<List<Map<String, Long>>> tabletReplicaBackends = Lists.newArrayListWithCapacity(tablets.size());
-            Set<String> scopeKeys = Sets.newLinkedHashSet();
-            for (Tablet tablet : tablets) {
-                List<Map<String, Long>> replicaBackends = new ArrayList<>();
-                for (Replica replica : tablet.getReplicas()) {
-                    Map<String, Long> clusterToBackend = replica.getClusterToBackendForProcDisplay();
-                    replicaBackends.add(clusterToBackend);
-                    scopeKeys.addAll(clusterToBackend.keySet());
-                }
-                tabletReplicaBackends.add(replicaBackends);
-            }
-
-            for (String scopeKey : scopeKeys) {
-                List<List<Long>> bucketSeq = Lists.newArrayListWithCapacity(tablets.size());
-                boolean hasBackend = false;
-                for (List<Map<String, Long>> replicaBackends : tabletReplicaBackends) {
-                    List<Long> bucketBackends = new ArrayList<>();
-                    for (Map<String, Long> clusterToBackend : replicaBackends) {
-                        Long backendId = clusterToBackend.get(scopeKey);
-                        if (backendId == null || backendId < 0) {
-                            continue;
-                        }
-                        bucketBackends.add(backendId);
-                        hasBackend = true;
-                    }
-                    bucketSeq.add(bucketBackends);
-                }
-                if (hasBackend) {
-                    seqByScopeKey.put(scopeKey, bucketSeq);
-                }
+            for (Tablet tablet : baseIndex.getTablets()) {
+                bucketReplicas.add(new ArrayList<>(tablet.getReplicas()));
             }
         } finally {
             olapTable.readUnlock();
         }
 
-        // Resolve scope keys to display tags outside the table lock: tag/name resolution
-        // acquires CloudSystemInfoService's lock and must not nest under olapTable's lock.
+        // Resolve each replica's per-compute-group placement outside the table lock. In
+        // cloud mode a replica is hashed to a different BE in each compute group, so build
+        // a separate bucket sequence per compute group. Merging across groups (picking an
+        // arbitrary first BE) would mix BEs from different compute groups into one bucket
+        // sequence, which is meaningless. For colocate cloud tables placement is computed
+        // on the fly; otherwise it comes from the cached clusterId -> backendId map (or an
+        // empty scope key for local-style replicas).
+        List<List<Map<String, Long>>> tabletReplicaBackends = Lists.newArrayListWithCapacity(bucketReplicas.size());
+        Set<String> scopeKeys = Sets.newLinkedHashSet();
+        // Shared across all replicas in this proc call so each compute group's backend
+        // list is fetched only once (colocate placement is resolved per compute group).
+        Map<String, List<Backend>> computeGroupBackendCache = Maps.newHashMap();
+        for (List<Replica> replicas : bucketReplicas) {
+            List<Map<String, Long>> replicaBackends = new ArrayList<>();
+            for (Replica replica : replicas) {
+                Map<String, Long> clusterToBackend =
+                        replica.getClusterToBackendForProcDisplay(computeGroupBackendCache);
+                replicaBackends.add(clusterToBackend);
+                scopeKeys.addAll(clusterToBackend.keySet());
+            }
+            tabletReplicaBackends.add(replicaBackends);
+        }
+
+        Map<String, List<List<Long>>> seqByScopeKey = Maps.newLinkedHashMap();
+        for (String scopeKey : scopeKeys) {
+            List<List<Long>> bucketSeq = Lists.newArrayListWithCapacity(tabletReplicaBackends.size());
+            boolean hasBackend = false;
+            for (List<Map<String, Long>> replicaBackends : tabletReplicaBackends) {
+                List<Long> bucketBackends = new ArrayList<>();
+                for (Map<String, Long> clusterToBackend : replicaBackends) {
+                    Long backendId = clusterToBackend.get(scopeKey);
+                    if (backendId == null || backendId < 0) {
+                        continue;
+                    }
+                    bucketBackends.add(backendId);
+                    hasBackend = true;
+                }
+                bucketSeq.add(bucketBackends);
+            }
+            if (hasBackend) {
+                seqByScopeKey.put(scopeKey, bucketSeq);
+            }
+        }
+
+        // Resolve scope keys to display tags (also outside the table lock): name
+        // resolution acquires CloudSystemInfoService's lock.
         Map<Tag, List<List<Long>>> backendsSeq = Maps.newLinkedHashMap();
         for (Map.Entry<String, List<List<Long>>> entry : seqByScopeKey.entrySet()) {
             backendsSeq.put(scopeKeyToTag(entry.getKey()), entry.getValue());

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ColocationGroupProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ColocationGroupProcDir.java
@@ -97,21 +97,33 @@ public class ColocationGroupProcDir implements ProcDirInterface {
     private Map<Tag, List<List<Long>>> getCloudBackendSeqsFromTablets(GroupId groupId, ColocateTableIndex index) {
         Map<Tag, List<List<Long>>> backendsSeq = Maps.newHashMap();
         List<Long> tableIds = index.getAllTableIds(groupId);
-        if (tableIds.isEmpty()) {
-            return backendsSeq;
+        for (Long tableId : tableIds) {
+            long dbId = groupId.dbId;
+            if (dbId == 0) {
+                Long tableDbId = index.getDbIdByTblIdNullable(groupId, tableId);
+                if (tableDbId == null) {
+                    continue;
+                }
+                dbId = tableDbId;
+            }
+            Database db = Env.getCurrentInternalCatalog().getDbNullable(dbId);
+            if (db == null) {
+                continue;
+            }
+            Table table = db.getTableNullable(tableId);
+            if (!(table instanceof OlapTable)) {
+                continue;
+            }
+            backendsSeq = getCloudBackendSeqsFromTable((OlapTable) table);
+            if (!backendsSeq.isEmpty()) {
+                return backendsSeq;
+            }
         }
+        return backendsSeq;
+    }
 
-        long targetTableId = tableIds.get(0);
-        long targetDbId = groupId.dbId == 0 ? groupId.getDbIdByTblId(targetTableId) : groupId.dbId;
-        Database db = Env.getCurrentInternalCatalog().getDbNullable(targetDbId);
-        if (db == null) {
-            return backendsSeq;
-        }
-        Table table = db.getTableNullable(targetTableId);
-        if (!(table instanceof OlapTable)) {
-            return backendsSeq;
-        }
-        OlapTable olapTable = (OlapTable) table;
+    private Map<Tag, List<List<Long>>> getCloudBackendSeqsFromTable(OlapTable olapTable) {
+        Map<Tag, List<List<Long>>> backendsSeq = Maps.newHashMap();
         olapTable.readLock();
         try {
             Partition firstPartition = null;
@@ -125,7 +137,7 @@ public class ColocationGroupProcDir implements ProcDirInterface {
             MaterializedIndex baseIndex = firstPartition.getBaseIndex();
             List<Tablet> tablets = baseIndex.getTablets();
             List<List<Long>> bucketSeq = Lists.newArrayListWithCapacity(tablets.size());
-            backendsSeq.put(null, bucketSeq);
+            boolean hasBackend = false;
             for (int i = 0; i < tablets.size(); i++) {
                 List<Long> bucketBackends = new ArrayList<>();
                 for (Replica replica : tablets.get(i).getReplicas()) {
@@ -137,9 +149,13 @@ public class ColocationGroupProcDir implements ProcDirInterface {
                         continue;
                     }
                     bucketBackends.add(backendId);
+                    hasBackend = true;
                 }
                 // Cloud mode should not expose real tag here, use null as placeholder.
                 bucketSeq.add(bucketBackends);
+            }
+            if (hasBackend) {
+                backendsSeq.put(null, bucketSeq);
             }
         } finally {
             olapTable.readUnlock();

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/TabletHealthProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/TabletHealthProcDir.java
@@ -199,7 +199,12 @@ public class TabletHealthProcDir implements ProcDirInterface {
                                 Tablet tablet = tablets.get(i);
                                 ++tabletNum;
                                 Tablet.TabletStatus res = null;
-                                if (groupId != null) {
+                                if (Config.isCloudMode()) {
+                                    // In cloud mode, tablet replica health is managed by cloud components.
+                                    // getHealth/getColocateHealth follows local deployment logic and may
+                                    // misclassify tablets as UNRECOVERABLE.
+                                    res = Tablet.TabletStatus.HEALTHY;
+                                } else if (groupId != null) {
                                     ColocateGroupSchema groupSchema = colocateTableIndex.getGroupSchema(groupId);
                                     if (groupSchema != null) {
                                         replicaAlloc = groupSchema.getReplicaAlloc();

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/CloudProcVersionDisplayTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/CloudProcVersionDisplayTest.java
@@ -69,7 +69,7 @@ public class CloudProcVersionDisplayTest {
     private SystemInfoService systemInfoService;
     private TabletInvertedIndex invertedIndex;
     private InternalCatalog internalCatalog;
-    private MockedStatic<Env> envStatic;
+    private MockedStatic<Env> mockedEnv;
 
     private String originDeployMode;
     private String originCloudUniqueId;
@@ -92,15 +92,15 @@ public class CloudProcVersionDisplayTest {
         Mockito.when(env.isReady()).thenReturn(true);
         Mockito.when(systemInfoService.getAllBackendsByAllCluster()).thenReturn(ImmutableMap.of());
 
-        envStatic = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS);
-        envStatic.when(Env::getServingEnv).thenReturn(env);
-        envStatic.when(Env::getCurrentSystemInfo).thenReturn(systemInfoService);
+        mockedEnv = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS);
+        mockedEnv.when(Env::getServingEnv).thenReturn(env);
+        mockedEnv.when(Env::getCurrentSystemInfo).thenReturn(systemInfoService);
     }
 
     @After
     public void tearDown() {
-        if (envStatic != null) {
-            envStatic.close();
+        if (mockedEnv != null) {
+            mockedEnv.close();
         }
         Config.deploy_mode = originDeployMode;
         Config.cloud_unique_id = originCloudUniqueId;
@@ -124,9 +124,9 @@ public class CloudProcVersionDisplayTest {
     public void testReplicasProcNodeShowsPartitionCachedVersionInCloudMode() throws AnalysisException {
         ProcTestContext context = createProcTestContext();
 
-        envStatic.when(Env::getCurrentInvertedIndex).thenReturn(invertedIndex);
-        envStatic.when(Env::getCurrentInternalCatalog).thenReturn(internalCatalog);
+        mockedEnv.when(Env::getCurrentInvertedIndex).thenReturn(invertedIndex);
         Mockito.when(invertedIndex.getTabletMeta(TABLET_ID)).thenReturn(context.tabletMeta);
+        mockedEnv.when(Env::getCurrentInternalCatalog).thenReturn(internalCatalog);
         Mockito.when(internalCatalog.getDbNullable(DB_ID)).thenReturn(context.db);
 
         ReplicasProcNode procNode = new ReplicasProcNode(TABLET_ID, context.tablet.getReplicas());

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/ColocationGroupProcDirTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/ColocationGroupProcDirTest.java
@@ -108,6 +108,61 @@ public class ColocationGroupProcDirTest extends TestWithFeService {
     }
 
     @Test
+    public void testCloudGlobalColocationGroupDetailFallback() throws Exception {
+        String originDeployMode = Config.deploy_mode;
+        createTable("CREATE TABLE global_colocate_t1 (k INT) DISTRIBUTED BY HASH(k) BUCKETS 2 "
+                + "PROPERTIES ('replication_num' = '1', 'colocate_with' = '__global__g1')");
+
+        OlapTable table1 = (OlapTable) db.getTableOrMetaException("global_colocate_t1");
+        GroupId groupId = Env.getCurrentColocateIndex().getGroup(table1.getId());
+        Assertions.assertEquals(0L, groupId.dbId.longValue());
+
+        ColocateTableIndex colocateTableIndex = Mockito.spy(Env.getCurrentColocateIndex());
+        Mockito.doReturn(Maps.<Tag, List<List<Long>>>newHashMap()).when(colocateTableIndex)
+                .getBackendsPerBucketSeq(groupId);
+        Config.deploy_mode = "cloud";
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedEnv.when(Env::getCurrentColocateIndex).thenReturn(colocateTableIndex);
+            ProcNodeInterface node = new ColocationGroupProcDir().lookup(groupId.toString());
+            ProcResult result = node.fetchResult();
+            Assertions.assertEquals(Lists.newArrayList("BucketIndex", "BackendIds"), result.getColumnNames());
+            Assertions.assertFalse(result.getRows().isEmpty());
+            Assertions.assertTrue(result.getRows().stream().anyMatch(row -> row.size() == 2 && !row.get(1).isEmpty()));
+        } finally {
+            Config.deploy_mode = originDeployMode;
+        }
+    }
+
+    @Test
+    public void testCloudColocationGroupDetailFallbackSkipsUnusableFirstTable() throws Exception {
+        String originDeployMode = Config.deploy_mode;
+        createTable("CREATE TABLE colocate_t5 (k INT) DISTRIBUTED BY HASH(k) BUCKETS 2 "
+                + "PROPERTIES ('replication_num' = '1', 'colocate_with' = 'g3')");
+        createTable("CREATE TABLE colocate_t6 (k INT) DISTRIBUTED BY HASH(k) BUCKETS 2 "
+                + "PROPERTIES ('replication_num' = '1', 'colocate_with' = 'g3')");
+
+        OlapTable table1 = (OlapTable) db.getTableOrMetaException("colocate_t5");
+        GroupId groupId = Env.getCurrentColocateIndex().getGroup(table1.getId());
+        db.unregisterTable(table1.getId());
+
+        ColocateTableIndex colocateTableIndex = Mockito.spy(Env.getCurrentColocateIndex());
+        Mockito.doReturn(Maps.<Tag, List<List<Long>>>newHashMap()).when(colocateTableIndex)
+                .getBackendsPerBucketSeq(groupId);
+        Config.deploy_mode = "cloud";
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedEnv.when(Env::getCurrentColocateIndex).thenReturn(colocateTableIndex);
+            ProcNodeInterface node = new ColocationGroupProcDir().lookup(groupId.toString());
+            ProcResult result = node.fetchResult();
+            Assertions.assertEquals(Lists.newArrayList("BucketIndex", "BackendIds"), result.getColumnNames());
+            Assertions.assertFalse(result.getRows().isEmpty());
+            Assertions.assertTrue(result.getRows().stream().anyMatch(row -> row.size() == 2 && !row.get(1).isEmpty()));
+        } finally {
+            db.registerTable(table1);
+            Config.deploy_mode = originDeployMode;
+        }
+    }
+
+    @Test
     public void testCloudColocationGroupReplicaAllocationIsNull() throws Exception {
         String originDeployMode = Config.deploy_mode;
         createTable("CREATE TABLE colocate_t3 (k INT) DISTRIBUTED BY HASH(k) BUCKETS 2 "

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/ColocationGroupProcDirTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/ColocationGroupProcDirTest.java
@@ -1,0 +1,111 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.proc;
+
+import org.apache.doris.catalog.ColocateTableIndex;
+import org.apache.doris.catalog.ColocateTableIndex.GroupId;
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.common.Config;
+import org.apache.doris.resource.Tag;
+import org.apache.doris.utframe.TestWithFeService;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+public class ColocationGroupProcDirTest extends TestWithFeService {
+    private Database db;
+
+    @Override
+    protected int backendNum() {
+        return 1;
+    }
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        createDatabase("test");
+        useDatabase("test");
+        db = Env.getCurrentInternalCatalog().getDbOrMetaException("test");
+    }
+
+    @Override
+    protected void runBeforeEach() throws Exception {
+        for (Table table : db.getTables()) {
+            dropTable(table.getName(), true);
+        }
+    }
+
+    @Test
+    public void testCloudColocationGroupDetailWithoutTag() throws Exception {
+        String originDeployMode = Config.deploy_mode;
+        createTable("CREATE TABLE colocate_t1 (k INT) DISTRIBUTED BY HASH(k) BUCKETS 2 "
+                + "PROPERTIES ('replication_num' = '1', 'colocate_with' = 'g1')");
+        createTable("CREATE TABLE colocate_t2 (k INT) DISTRIBUTED BY HASH(k) BUCKETS 2 "
+                + "PROPERTIES ('replication_num' = '1', 'colocate_with' = 'g1')");
+
+        OlapTable table1 = (OlapTable) db.getTableOrMetaException("colocate_t1");
+        GroupId groupId = Env.getCurrentColocateIndex().getGroup(table1.getId());
+        Assertions.assertNotNull(groupId);
+
+        ColocateTableIndex colocateTableIndex = Mockito.spy(Env.getCurrentColocateIndex());
+        Mockito.doReturn(Maps.<Tag, List<List<Long>>>newHashMap()).when(colocateTableIndex)
+                .getBackendsPerBucketSeq(groupId);
+        Config.deploy_mode = "cloud";
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedEnv.when(Env::getCurrentColocateIndex).thenReturn(colocateTableIndex);
+            ProcNodeInterface node = new ColocationGroupProcDir().lookup(groupId.toString());
+            ProcResult result = node.fetchResult();
+            Assertions.assertEquals(Lists.newArrayList("BucketIndex", "BackendIds"), result.getColumnNames());
+            Assertions.assertFalse(result.getRows().isEmpty());
+            Assertions.assertTrue(result.getRows().stream().anyMatch(row -> row.size() == 2 && !row.get(1).isEmpty()));
+        } finally {
+            Config.deploy_mode = originDeployMode;
+        }
+    }
+
+    @Test
+    public void testCloudColocationGroupReplicaAllocationIsNull() throws Exception {
+        String originDeployMode = Config.deploy_mode;
+        createTable("CREATE TABLE colocate_t3 (k INT) DISTRIBUTED BY HASH(k) BUCKETS 2 "
+                + "PROPERTIES ('replication_num' = '1', 'colocate_with' = 'g2')");
+        createTable("CREATE TABLE colocate_t4 (k INT) DISTRIBUTED BY HASH(k) BUCKETS 2 "
+                + "PROPERTIES ('replication_num' = '1', 'colocate_with' = 'g2')");
+
+        Config.deploy_mode = "cloud";
+        try {
+            ProcResult result = new ColocationGroupProcDir().fetchResult();
+            int groupNameIdx = ColocationGroupProcDir.TITLE_NAMES.indexOf("GroupName");
+            int replicaAllocIdx = ColocationGroupProcDir.TITLE_NAMES.indexOf("ReplicaAllocation");
+            List<String> groupRow = result.getRows().stream()
+                    .filter(row -> "test.g2".equals(row.get(groupNameIdx)))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("can not find colocate group test.g2"));
+            Assertions.assertEquals("null", groupRow.get(replicaAllocIdx));
+        } finally {
+            Config.deploy_mode = originDeployMode;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/ColocationGroupProcDirTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/ColocationGroupProcDirTest.java
@@ -68,11 +68,11 @@ public class ColocationGroupProcDirTest extends TestWithFeService {
     public void testLocalColocationGroupDetailKeepsTagColumns() throws Exception {
         Tag tag1 = Tag.create(Tag.TYPE_LOCATION, "tag1");
         Tag tag2 = Tag.create(Tag.TYPE_LOCATION, "tag2");
-        Map<Tag, List<List<Long>>> backendsSeq = Maps.newLinkedHashMap();
-        backendsSeq.put(tag1, Lists.newArrayList(
+        Map<String, List<List<Long>>> backendsSeq = Maps.newLinkedHashMap();
+        backendsSeq.put(tag1.toString(), Lists.newArrayList(
                 Lists.newArrayList(10001L, 10002L),
                 Lists.newArrayList(10003L)));
-        backendsSeq.put(tag2, Lists.newArrayList(
+        backendsSeq.put(tag2.toString(), Lists.newArrayList(
                 Lists.newArrayList(20001L),
                 Lists.newArrayList(20002L, 20003L)));
 
@@ -273,21 +273,20 @@ public class ColocationGroupProcDirTest extends TestWithFeService {
 
     @Test
     public void testColocationGroupDetailPerComputeGroupColumns() throws Exception {
-        // Two compute groups each get their own column, and within a compute group the
-        // per-bucket backend sequence is self-consistent (not mixed across groups).
-        Tag cgA = Tag.createNotCheck(Tag.COMPUTE_GROUP_NAME, "cg_a");
-        Tag cgB = Tag.createNotCheck(Tag.COMPUTE_GROUP_NAME, "cg_b");
-        Map<Tag, List<List<Long>>> backendsSeq = Maps.newLinkedHashMap();
-        backendsSeq.put(cgA, Lists.newArrayList(
+        // Two compute groups each get their own column (named by the compute group), and
+        // within a compute group the per-bucket backend sequence is self-consistent (not
+        // mixed across groups).
+        Map<String, List<List<Long>>> backendsSeq = Maps.newLinkedHashMap();
+        backendsSeq.put("cg_a", Lists.newArrayList(
                 Lists.newArrayList(10001L),
                 Lists.newArrayList(10002L)));
-        backendsSeq.put(cgB, Lists.newArrayList(
+        backendsSeq.put("cg_b", Lists.newArrayList(
                 Lists.newArrayList(20001L),
                 Lists.newArrayList(20002L)));
 
-        ProcResult result = new ColocationGroupBackendSeqsProcNode(backendsSeq, false).fetchResult();
+        ProcResult result = new ColocationGroupBackendSeqsProcNode(backendsSeq).fetchResult();
 
-        Assertions.assertEquals(Lists.newArrayList("BucketIndex", cgA.toString(), cgB.toString()),
+        Assertions.assertEquals(Lists.newArrayList("BucketIndex", "cg_a", "cg_b"),
                 result.getColumnNames());
         Assertions.assertEquals(Lists.newArrayList("0", "10001", "20001"), result.getRows().get(0));
         Assertions.assertEquals(Lists.newArrayList("1", "10002", "20002"), result.getRows().get(1));

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/ColocationGroupProcDirTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/ColocationGroupProcDirTest.java
@@ -25,8 +25,11 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Replica.ReplicaState;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.cloud.catalog.CloudReplica;
+import org.apache.doris.cloud.qe.ComputeGroupException;
+import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.common.Config;
 import org.apache.doris.resource.Tag;
+import org.apache.doris.system.Backend;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.Lists;
@@ -192,15 +195,80 @@ public class ColocationGroupProcDirTest extends TestWithFeService {
         CloudReplica replica = new CloudReplica(1L, null, ReplicaState.NORMAL, 1L, 1,
                 db.getId(), 2L, 3L, 4L, 0L);
 
-        Assertions.assertTrue(replica.getClusterToBackendForProcDisplay().isEmpty());
+        Assertions.assertTrue(replica.getClusterToBackendForProcDisplay(Maps.newHashMap()).isEmpty());
 
         replica.updateClusterToPrimaryBe("cluster_a", 10001L);
         replica.updateClusterToPrimaryBe("cluster_b", 20001L);
 
-        Map<String, Long> clusterToBackend = replica.getClusterToBackendForProcDisplay();
+        Map<String, Long> clusterToBackend = replica.getClusterToBackendForProcDisplay(Maps.newHashMap());
         Assertions.assertEquals(2, clusterToBackend.size());
         Assertions.assertEquals(Long.valueOf(10001L), clusterToBackend.get("cluster_a"));
         Assertions.assertEquals(Long.valueOf(20001L), clusterToBackend.get("cluster_b"));
+    }
+
+    @Test
+    public void testCloudColocatedReplicaProcDisplayResolvesPerComputeGroup() throws Exception {
+        // A colocate cloud replica does not use primaryClusterToBackend (placement is
+        // resolved on the fly via getColocatedBeId), so that cache stays empty. The proc
+        // display must still produce one backend per compute group instead of nothing.
+        CloudReplica replica = Mockito.spy(new CloudReplica(1L, null, ReplicaState.NORMAL, 1L, 1,
+                db.getId(), 2L, 3L, 4L, 0L));
+
+        ColocateTableIndex colocateTableIndex = Mockito.mock(ColocateTableIndex.class);
+        Mockito.when(colocateTableIndex.isColocateTableNoLock(2L)).thenReturn(true);
+        CloudSystemInfoService infoService = Mockito.mock(CloudSystemInfoService.class);
+        Mockito.when(infoService.getCloudClusterIds()).thenReturn(Lists.newArrayList("cg_a", "cg_b"));
+        // Backend list is resolved through the per-clusterId cache; return a non-null list
+        // so the cache stores it (placement itself is stubbed on getColocatedBeId below).
+        Mockito.when(infoService.getBackendsByClusterId(Mockito.anyString())).thenReturn(Lists.newArrayList());
+
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedEnv.when(Env::getCurrentColocateIndex).thenReturn(colocateTableIndex);
+            mockedEnv.when(Env::getCurrentSystemInfo).thenReturn(infoService);
+            Mockito.doReturn(10001L).when(replica).getColocatedBeId(Mockito.eq("cg_a"), Mockito.any());
+            // cg_b currently has no available backend; it must be skipped, not fail.
+            Mockito.doThrow(new ComputeGroupException("no alive be",
+                            ComputeGroupException.FailedTypeEnum.COMPUTE_GROUPS_NO_ALIVE_BE))
+                    .when(replica).getColocatedBeId(Mockito.eq("cg_b"), Mockito.any());
+
+            Map<String, Long> clusterToBackend =
+                    replica.getClusterToBackendForProcDisplay(Maps.newHashMap());
+            Assertions.assertEquals(1, clusterToBackend.size());
+            Assertions.assertEquals(Long.valueOf(10001L), clusterToBackend.get("cg_a"));
+            Assertions.assertFalse(clusterToBackend.containsKey("cg_b"));
+        }
+    }
+
+    @Test
+    public void testColocateProcDisplayCachesBackendsPerComputeGroup() throws Exception {
+        // A shared cache makes a single proc call fetch each compute group's backend list
+        // only once, even when many replicas resolve placement across the same groups.
+        CloudReplica replica1 = Mockito.spy(new CloudReplica(1L, null, ReplicaState.NORMAL, 1L, 1,
+                db.getId(), 2L, 3L, 4L, 0L));
+        CloudReplica replica2 = Mockito.spy(new CloudReplica(2L, null, ReplicaState.NORMAL, 1L, 1,
+                db.getId(), 2L, 3L, 4L, 1L));
+
+        ColocateTableIndex colocateTableIndex = Mockito.mock(ColocateTableIndex.class);
+        Mockito.when(colocateTableIndex.isColocateTableNoLock(2L)).thenReturn(true);
+        CloudSystemInfoService infoService = Mockito.mock(CloudSystemInfoService.class);
+        Mockito.when(infoService.getCloudClusterIds()).thenReturn(Lists.newArrayList("cg_a"));
+        Mockito.when(infoService.getBackendsByClusterId(Mockito.anyString())).thenReturn(Lists.newArrayList());
+
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedEnv.when(Env::getCurrentColocateIndex).thenReturn(colocateTableIndex);
+            mockedEnv.when(Env::getCurrentSystemInfo).thenReturn(infoService);
+            Mockito.doReturn(10001L).when(replica1).getColocatedBeId(Mockito.eq("cg_a"), Mockito.any());
+            Mockito.doReturn(10002L).when(replica2).getColocatedBeId(Mockito.eq("cg_a"), Mockito.any());
+
+            Map<String, List<Backend>> computeGroupBackendCache = Maps.newHashMap();
+            Assertions.assertEquals(Long.valueOf(10001L),
+                    replica1.getClusterToBackendForProcDisplay(computeGroupBackendCache).get("cg_a"));
+            Assertions.assertEquals(Long.valueOf(10002L),
+                    replica2.getClusterToBackendForProcDisplay(computeGroupBackendCache).get("cg_a"));
+
+            // Fetched once for cg_a despite two replicas resolving against it.
+            Mockito.verify(infoService, Mockito.times(1)).getBackendsByClusterId("cg_a");
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/ColocationGroupProcDirTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/ColocationGroupProcDirTest.java
@@ -35,6 +35,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.List;
+import java.util.Map;
 
 public class ColocationGroupProcDirTest extends TestWithFeService {
     private Database db;
@@ -56,6 +57,26 @@ public class ColocationGroupProcDirTest extends TestWithFeService {
         for (Table table : db.getTables()) {
             dropTable(table.getName(), true);
         }
+    }
+
+    @Test
+    public void testLocalColocationGroupDetailKeepsTagColumns() throws Exception {
+        Tag tag1 = Tag.create(Tag.TYPE_LOCATION, "tag1");
+        Tag tag2 = Tag.create(Tag.TYPE_LOCATION, "tag2");
+        Map<Tag, List<List<Long>>> backendsSeq = Maps.newLinkedHashMap();
+        backendsSeq.put(tag1, Lists.newArrayList(
+                Lists.newArrayList(10001L, 10002L),
+                Lists.newArrayList(10003L)));
+        backendsSeq.put(tag2, Lists.newArrayList(
+                Lists.newArrayList(20001L),
+                Lists.newArrayList(20002L, 20003L)));
+
+        ProcResult result = new ColocationGroupBackendSeqsProcNode(backendsSeq).fetchResult();
+
+        Assertions.assertEquals(Lists.newArrayList("BucketIndex", tag1.toString(), tag2.toString()),
+                result.getColumnNames());
+        Assertions.assertEquals(Lists.newArrayList("0", "10001, 10002", "20001"), result.getRows().get(0));
+        Assertions.assertEquals(Lists.newArrayList("1", "10003", "20002, 20003"), result.getRows().get(1));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/ColocationGroupProcDirTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/ColocationGroupProcDirTest.java
@@ -22,7 +22,9 @@ import org.apache.doris.catalog.ColocateTableIndex.GroupId;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Replica.ReplicaState;
 import org.apache.doris.catalog.Table;
+import org.apache.doris.cloud.catalog.CloudReplica;
 import org.apache.doris.common.Config;
 import org.apache.doris.resource.Tag;
 import org.apache.doris.utframe.TestWithFeService;
@@ -183,5 +185,43 @@ public class ColocationGroupProcDirTest extends TestWithFeService {
         } finally {
             Config.deploy_mode = originDeployMode;
         }
+    }
+
+    @Test
+    public void testCloudReplicaProcDisplayExposesPerComputeGroup() {
+        CloudReplica replica = new CloudReplica(1L, null, ReplicaState.NORMAL, 1L, 1,
+                db.getId(), 2L, 3L, 4L, 0L);
+
+        Assertions.assertTrue(replica.getClusterToBackendForProcDisplay().isEmpty());
+
+        replica.updateClusterToPrimaryBe("cluster_a", 10001L);
+        replica.updateClusterToPrimaryBe("cluster_b", 20001L);
+
+        Map<String, Long> clusterToBackend = replica.getClusterToBackendForProcDisplay();
+        Assertions.assertEquals(2, clusterToBackend.size());
+        Assertions.assertEquals(Long.valueOf(10001L), clusterToBackend.get("cluster_a"));
+        Assertions.assertEquals(Long.valueOf(20001L), clusterToBackend.get("cluster_b"));
+    }
+
+    @Test
+    public void testColocationGroupDetailPerComputeGroupColumns() throws Exception {
+        // Two compute groups each get their own column, and within a compute group the
+        // per-bucket backend sequence is self-consistent (not mixed across groups).
+        Tag cgA = Tag.createNotCheck(Tag.COMPUTE_GROUP_NAME, "cg_a");
+        Tag cgB = Tag.createNotCheck(Tag.COMPUTE_GROUP_NAME, "cg_b");
+        Map<Tag, List<List<Long>>> backendsSeq = Maps.newLinkedHashMap();
+        backendsSeq.put(cgA, Lists.newArrayList(
+                Lists.newArrayList(10001L),
+                Lists.newArrayList(10002L)));
+        backendsSeq.put(cgB, Lists.newArrayList(
+                Lists.newArrayList(20001L),
+                Lists.newArrayList(20002L)));
+
+        ProcResult result = new ColocationGroupBackendSeqsProcNode(backendsSeq, false).fetchResult();
+
+        Assertions.assertEquals(Lists.newArrayList("BucketIndex", cgA.toString(), cgB.toString()),
+                result.getColumnNames());
+        Assertions.assertEquals(Lists.newArrayList("0", "10001", "20001"), result.getRows().get(0));
+        Assertions.assertEquals(Lists.newArrayList("1", "10002", "20002"), result.getRows().get(1));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/TabletHealthProcDirTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/TabletHealthProcDirTest.java
@@ -1,0 +1,110 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.proc;
+
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Partition;
+import org.apache.doris.catalog.Replica;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.catalog.Tablet;
+import org.apache.doris.catalog.Tablet.TabletStatus;
+import org.apache.doris.common.Config;
+import org.apache.doris.utframe.TestWithFeService;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class TabletHealthProcDirTest extends TestWithFeService {
+    private Database db;
+
+    @Override
+    protected int backendNum() {
+        return 1;
+    }
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        createDatabase("test");
+        useDatabase("test");
+        db = Env.getCurrentInternalCatalog().getDbOrMetaException("test");
+    }
+
+    @Override
+    protected void runBeforeEach() throws Exception {
+        for (Table table : db.getTables()) {
+            dropTable(table.getName(), true);
+        }
+    }
+
+    @Test
+    public void testCloudModeCountsTabletAsHealthy() throws Exception {
+        String originDeployMode = Config.deploy_mode;
+        createTable("CREATE TABLE tbl_proc_health (k INT) DISTRIBUTED BY HASH(k) BUCKETS 1"
+                + " PROPERTIES ('replication_num' = '1')");
+
+        OlapTable table = (OlapTable) db.getTableOrMetaException("tbl_proc_health");
+        Partition partition = table.getPartitions().iterator().next();
+        Tablet tablet = partition.getMaterializedIndices(IndexExtState.ALL).iterator().next()
+                .getTablets().iterator().next();
+
+        partition.updateVisibleVersion(10L);
+        Replica replica = tablet.getReplicas().get(0);
+        replica.updateVersion(10L);
+        replica.setBad(true);
+
+        TabletStatus localStatus = tablet.getHealth(Env.getCurrentSystemInfo(), partition.getVisibleVersion(),
+                table.getPartitionInfo().getReplicaAllocation(partition.getId()),
+                Env.getCurrentSystemInfo().getAllBackendIds(true)).status;
+        Assertions.assertEquals(TabletStatus.UNRECOVERABLE, localStatus);
+
+        Config.deploy_mode = "cloud";
+        try (MockedStatic<Partition> mockedPartition = Mockito.mockStatic(Partition.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedPartition.when(() -> Partition.getVisibleVersions(Mockito.anyList())).thenAnswer(invocation -> {
+                List<? extends Partition> partitions = invocation.getArgument(0);
+                return partitions.stream().map(Partition::getVisibleVersion).collect(Collectors.toList());
+            });
+            TabletHealthProcDir.DBTabletStatistic statistic = new TabletHealthProcDir.DBTabletStatistic(db);
+            List<String> row = statistic.toRow();
+            int tabletNumIdx = TabletHealthProcDir.TITLE_NAMES.indexOf("TabletNum");
+            int healthyNumIdx = TabletHealthProcDir.TITLE_NAMES.indexOf("HealthyNum");
+            int unrecoverableNumIdx = TabletHealthProcDir.TITLE_NAMES.indexOf("UnrecoverableNum");
+
+            Assertions.assertEquals("1", row.get(tabletNumIdx));
+            Assertions.assertEquals("1", row.get(healthyNumIdx));
+            Assertions.assertEquals("0", row.get(unrecoverableNumIdx));
+        } finally {
+            Config.deploy_mode = originDeployMode;
+        }
+    }
+
+    private List<String> findDbRow(ProcResult result, long dbId) {
+        int dbIdIdx = TabletHealthProcDir.TITLE_NAMES.indexOf("DbId");
+        return result.getRows().stream()
+                .filter(row -> String.valueOf(dbId).equals(row.get(dbIdIdx)))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("can not find db row in tablet health proc result"));
+    }
+}


### PR DESCRIPTION
PR Description:

- Fix incorrect tablet health statistics in cloud mode for SHOW PROC '/cluster_health/tablet_health': avoid reporting UNRECOVERABLE due to local-mode health checks.

- Add cloud fallback for colocation group detail: when backend sequence metadata is empty, derive backend ids from current tablets.

- In cloud mode, show ReplicaAllocation as null in SHOW PROC '/colocation_group/{GroupId}' for consistent output semantics.

- Keep local mode behavior unchanged (real tag-based allocation/display remains intact).

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

