### PR TITLE
[fix](test) make hive compress split assertion BE-aware

### DIFF
--- a/regression-test/suites/external_table_p0/hive/test_hive_compress_type.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_compress_type.groovy
@@ -26,7 +26,7 @@ suite("test_hive_compress_type", "p0,external,hive,external_docker,external_dock
     def backends = sql """show backends"""
     def backendNum = backends.size()
     logger.info("get backendNum: ${backendNum}")
-    def parallelExecInstanceNum = ((sql """show variables like 'parallel_fragment_exec_instance_num'""")[0][1] as String).toInteger()
+    def parallelExecInstanceNum = (sql("show variables like 'parallel_fragment_exec_instance_num'")[0][1] as String).toInteger()
     logger.info("get parallel_fragment_exec_instance_num: ${parallelExecInstanceNum}")
 
     for (String hivePrefix : ["hive3"]) {

--- a/regression-test/suites/external_table_p0/hive/test_hive_compress_type.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_compress_type.groovy
@@ -24,8 +24,10 @@ suite("test_hive_compress_type", "p0,external,hive,external_docker,external_dock
     }
 
     def backends = sql """show backends"""
-    def backendNum = backends.size();
-    logger.info("get backendNum:" + backendNum);    
+    def backendNum = backends.size()
+    logger.info("get backendNum: ${backendNum}")
+    def parallelExecInstanceNum = (sql """show variables like 'parallel_fragment_exec_instance_num'"""[0][1] as String).toInteger()
+    logger.info("get parallel_fragment_exec_instance_num: ${parallelExecInstanceNum}")
 
     for (String hivePrefix : ["hive3"]) {
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
@@ -41,18 +43,17 @@ suite("test_hive_compress_type", "p0,external,hive,external_docker,external_dock
 
         // table test_compress_partitioned has 6 partitions with different compressed file: plain, gzip, bzip2, deflate
         sql """set file_split_size=0"""
-        if (backendNum == 1) {
-            explain {
-                sql("select count(*) from test_compress_partitioned")
-                contains "inputSplitNum=16, totalFileSize=734675596, scanRanges=16"
-                contains "partition=8/8"
-            }
-        } else {
-            explain {
-                sql("select count(*) from test_compress_partitioned")
-                contains "inputSplitNum=28, totalFileSize=734675596, scanRanges=28"
-                contains "partition=8/8"
-            }
+        // COUNT pushdown split behavior depends on:
+        // totalFileNum < parallel_fragment_exec_instance_num * backendNum
+        // test_compress_partitioned currently has 16 files.
+        def expectedSplitNum = 16
+        if (backendNum > 1) {
+            expectedSplitNum = (16 < parallelExecInstanceNum * backendNum) ? 28 : 16
+        }
+        explain {
+            sql("select count(*) from test_compress_partitioned")
+            contains "inputSplitNum=${expectedSplitNum}, totalFileSize=734675596, scanRanges=${expectedSplitNum}"
+            contains "partition=8/8"
         }
         qt_q21 """select count(*) from test_compress_partitioned where dt="gzip" or dt="mix""""
         qt_q22 """select count(*) from test_compress_partitioned"""

--- a/regression-test/suites/external_table_p0/hive/test_hive_compress_type.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_compress_type.groovy
@@ -26,7 +26,7 @@ suite("test_hive_compress_type", "p0,external,hive,external_docker,external_dock
     def backends = sql """show backends"""
     def backendNum = backends.size()
     logger.info("get backendNum: ${backendNum}")
-    def parallelExecInstanceNum = (sql """show variables like 'parallel_fragment_exec_instance_num'"""[0][1] as String).toInteger()
+    def parallelExecInstanceNum = ((sql """show variables like 'parallel_fragment_exec_instance_num'""")[0][1] as String).toInteger()
     logger.info("get parallel_fragment_exec_instance_num: ${parallelExecInstanceNum}")
 
     for (String hivePrefix : ["hive3"]) {

--- a/regression-test/suites/external_table_p0/hive/test_hive_compress_type.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_compress_type.groovy
@@ -26,8 +26,12 @@ suite("test_hive_compress_type", "p0,external,hive,external_docker,external_dock
     def backends = sql """show backends"""
     def backendNum = backends.size()
     logger.info("get backendNum: ${backendNum}")
-    def parallelExecInstanceNum = (sql("show variables like 'parallel_fragment_exec_instance_num'")[0][1] as String).toInteger()
-    logger.info("get parallel_fragment_exec_instance_num: ${parallelExecInstanceNum}")
+    // `parallel_fragment_exec_instance_num` may be displayed as
+    // `deprecated_parallel_fragment_exec_instance_num` in newer branches.
+    def parallelExecInstanceRows = sql("show variables like '%parallel_fragment_exec_instance_num%'")
+    assertTrue(parallelExecInstanceRows.size() > 0)
+    def parallelExecInstanceNum = (parallelExecInstanceRows[0][1] as String).toInteger()
+    logger.info("get ${parallelExecInstanceRows[0][0]}: ${parallelExecInstanceNum}")
 
     for (String hivePrefix : ["hive3"]) {
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:
`external_table_p0/hive/test_hive_compress_type.groovy` had a fixed split assertion (`28`) for multi-BE, which is not stable across environments.
The split behavior for COUNT pushdown depends on both `backendNum` and `parallel_fragment_exec_instance_num`, so internal 3BE pipeline could still produce `16` and fail.

This PR makes the assertion BE-aware and deterministic:
- read `backendNum` via `show backends`
- read `parallel_fragment_exec_instance_num` via `show variables`
- compute expected split count with the same condition as FE logic
- add comments to explain why this check differs between environments

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
