### PR TITLE
[fix](compile) auto-regenerate hadoop-deps/lib when missing due to Ma…

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -970,6 +970,12 @@ EOF
             mkdir "${BE_HADOOP_HDFS_DIR}"
             HADOOP_DEPS_JAR_DIR="${DORIS_HOME}/fe/be-java-extensions/${HADOOP_DEPS_NAME}/target"
             echo "HADOOP_DEPS_JAR_DIR: ${HADOOP_DEPS_JAR_DIR}"
+            if  [[ "${BUILD_BE_JAVA_EXTENSIONS}" -eq 1 && ! -d "${HADOOP_DEPS_JAR_DIR}/lib" ]]; then
+                echo "WARN: lib directory missing (likely due to Maven cache). Regenerating..."
+                pushd "${DORIS_HOME}/fe/be-java-extensions/${HADOOP_DEPS_NAME}"
+                "${MVN_CMD}" dependency:copy-dependencies -DskipTests -Dcheckstyle.skip=true
+                popd
+            fi
             if [[ -f "${HADOOP_DEPS_JAR_DIR}/${HADOOP_DEPS_NAME}.jar" ]]; then
                 echo "Copy Be Extensions hadoop deps jar to ${BE_HADOOP_HDFS_DIR}"
                 cp "${HADOOP_DEPS_JAR_DIR}/${HADOOP_DEPS_NAME}.jar" "${BE_HADOOP_HDFS_DIR}"

--- a/build.sh
+++ b/build.sh
@@ -974,6 +974,7 @@ EOF
                 echo "WARN: lib directory missing (likely due to Maven cache). Regenerating..."
                 pushd "${DORIS_HOME}/fe/be-java-extensions/${HADOOP_DEPS_NAME}"
                 "${MVN_CMD}" dependency:copy-dependencies -DskipTests -Dcheckstyle.skip=true
+                mv target/dependency target/lib
                 popd
             fi
             if [[ -f "${HADOOP_DEPS_JAR_DIR}/${HADOOP_DEPS_NAME}.jar" ]]; then


### PR DESCRIPTION
…ven cache

Problem:
- When Maven build cache is hit, the dependency:copy-dependencies plugin
  execution is skipped
- This causes target/lib directory to be missing in hadoop-deps module
- Results in an incomplete BE output package without Hadoop dependencies

Solution:
- Add automatic regeneration logic in build.sh copy phase
- When lib directory is missing and BUILD_BE_JAVA_EXTENSIONS=1,
  execute 'mvn dependency:copy-dependencies' to regenerate it
- Preserves Maven cache benefits while ensuring complete output

Impact:
- Fixes intermittent missing hadoop_hdfs jars in BE output
- No impact on normal build flow (only triggers when needed)
- Maintains build cache acceleration for other plugins

Related PR: #60819 

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

