### PR TITLE
[feat](ms) Propagate table/index/partition metadata in tablet/rowset paths and reduce redundant tablet-index reads

### DIFF
--- a/be/src/cloud/cloud_meta_mgr.h
+++ b/be/src/cloud/cloud_meta_mgr.h
@@ -70,7 +70,8 @@ public:
     CloudMetaMgr(const CloudMetaMgr&) = delete;
     CloudMetaMgr& operator=(const CloudMetaMgr&) = delete;
 
-    Status get_tablet_meta(int64_t tablet_id, std::shared_ptr<TabletMeta>* tablet_meta);
+    Status get_tablet_meta(int64_t table_id, int64_t index_id, int64_t partition_id,
+                           int64_t tablet_id, TabletMetaSharedPtr* tablet_meta);
 
     Status sync_tablet_rowsets(CloudTablet* tablet, const SyncOptions& options = {},
                                SyncRowsetStats* sync_stats = nullptr);

--- a/be/src/cloud/cloud_rowset_writer.cpp
+++ b/be/src/cloud/cloud_rowset_writer.cpp
@@ -54,6 +54,7 @@ Status CloudRowsetWriter::init(const RowsetWriterContext& rowset_writer_context)
     _rowset_meta->set_rowset_id(_context.rowset_id);
     _rowset_meta->set_partition_id(_context.partition_id);
     _rowset_meta->set_tablet_id(_context.tablet_id);
+    _rowset_meta->set_table_id(_context.table_id);
     _rowset_meta->set_index_id(_context.index_id);
     _rowset_meta->set_tablet_schema_hash(_context.tablet_schema_hash);
     _rowset_meta->set_rowset_type(_context.rowset_type);

--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -316,7 +316,7 @@ Status CloudStorageEngine::get_tablet_meta(int64_t tablet_id, TabletMetaSharedPt
         return Status::InternalError("cloud meta manager is not initialized");
     }
 
-    return _meta_mgr->get_tablet_meta(tablet_id, tablet_meta);
+    return _meta_mgr->get_tablet_meta(-1, -1, -1, tablet_id, tablet_meta);
 }
 
 Status CloudStorageEngine::start_bg_threads(std::shared_ptr<WorkloadGroup> wg_sptr) {

--- a/be/src/cloud/cloud_tablet_mgr.cpp
+++ b/be/src/cloud/cloud_tablet_mgr.cpp
@@ -216,7 +216,7 @@ Result<std::shared_ptr<CloudTablet>> CloudTabletMgr::get_tablet(int64_t tablet_i
                                    int64_t tablet_id) -> Result<std::shared_ptr<CloudTablet>> {
             TabletMetaSharedPtr tablet_meta;
             auto start = std::chrono::steady_clock::now();
-            auto st = _engine.meta_mgr().get_tablet_meta(tablet_id, &tablet_meta);
+            auto st = _engine.meta_mgr().get_tablet_meta(-1, -1, -1, tablet_id, &tablet_meta);
             auto end = std::chrono::steady_clock::now();
             if (sync_stats) {
                 sync_stats->get_remote_tablet_meta_rpc_ns +=

--- a/be/src/cloud/pb_convert.cpp
+++ b/be/src/cloud/pb_convert.cpp
@@ -84,6 +84,9 @@ void doris_rowset_meta_to_cloud(RowsetMetaCloudPB* out, const RowsetMetaPB& in) 
     out->mutable_num_segment_rows()->CopyFrom(in.num_segment_rows());
     out->mutable_segments_file_size()->CopyFrom(in.segments_file_size());
     out->set_index_id(in.index_id());
+    if (in.has_table_id()) {
+        out->set_table_id(in.table_id());
+    }
     if (in.has_schema_version()) {
         // See cloud/src/meta-service/meta_service_schema.cpp for details.
         out->set_schema_version(in.schema_version());
@@ -162,6 +165,9 @@ void doris_rowset_meta_to_cloud(RowsetMetaCloudPB* out, RowsetMetaPB&& in) {
     out->mutable_num_segment_rows()->Swap(in.mutable_num_segment_rows());
     out->mutable_segments_file_size()->Swap(in.mutable_segments_file_size());
     out->set_index_id(in.index_id());
+    if (in.has_table_id()) {
+        out->set_table_id(in.table_id());
+    }
     if (in.has_schema_version()) {
         // See cloud/src/meta-service/meta_service_schema.cpp for details.
         out->set_schema_version(in.schema_version());
@@ -252,6 +258,9 @@ void cloud_rowset_meta_to_doris(RowsetMetaPB* out, const RowsetMetaCloudPB& in) 
     out->mutable_num_segment_rows()->CopyFrom(in.num_segment_rows());
     out->mutable_segments_file_size()->CopyFrom(in.segments_file_size());
     out->set_index_id(in.index_id());
+    if (in.has_table_id()) {
+        out->set_table_id(in.table_id());
+    }
     if (in.has_schema_version()) {
         // See cloud/src/meta-service/meta_service_schema.cpp for details.
         out->set_schema_version(in.schema_version());
@@ -330,6 +339,9 @@ void cloud_rowset_meta_to_doris(RowsetMetaPB* out, RowsetMetaCloudPB&& in) {
     out->mutable_num_segment_rows()->Swap(in.mutable_num_segment_rows());
     out->mutable_segments_file_size()->Swap(in.mutable_segments_file_size());
     out->set_index_id(in.index_id());
+    if (in.has_table_id()) {
+        out->set_table_id(in.table_id());
+    }
     if (in.has_schema_version()) {
         // See cloud/src/meta-service/meta_service_schema.cpp for details.
         out->set_schema_version(in.schema_version());

--- a/be/src/service/http/action/delete_bitmap_action.cpp
+++ b/be/src/service/http/action/delete_bitmap_action.cpp
@@ -177,7 +177,7 @@ Status DeleteBitmapAction::_handle_show_ms_delete_bitmap_count(HttpRequest* req,
     RETURN_NOT_OK_STATUS_WITH_WARN(_check_param(req, &tablet_id, &verbose), "check param failed");
 
     TabletMetaSharedPtr tablet_meta;
-    auto st = _engine.to_cloud().meta_mgr().get_tablet_meta(tablet_id, &tablet_meta);
+    auto st = _engine.to_cloud().meta_mgr().get_tablet_meta(-1, -1, -1, tablet_id, &tablet_meta);
     if (!st.ok()) {
         LOG(WARNING) << "failed to get_tablet_meta for tablet=" << tablet_id
                      << ", st=" << st.to_string();

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -100,6 +100,10 @@ public:
 
     void set_index_id(int64_t index_id) { _rowset_meta_pb.set_index_id(index_id); }
 
+    int64_t table_id() const { return _rowset_meta_pb.table_id(); }
+
+    void set_table_id(int64_t table_id) { _rowset_meta_pb.set_table_id(table_id); }
+
     TabletUid tablet_uid() const { return _rowset_meta_pb.tablet_uid(); }
 
     void set_tablet_uid(TabletUid tablet_uid) {

--- a/be/src/storage/rowset/rowset_writer_context.h
+++ b/be/src/storage/rowset/rowset_writer_context.h
@@ -56,6 +56,7 @@ struct RowsetWriterContext {
     RowsetId rowset_id;
     int64_t tablet_id {0};
     int32_t tablet_schema_hash {0};
+    int64_t table_id {0};
     int64_t index_id {0};
     int64_t partition_id {0};
     RowsetTypePB rowset_type {BETA_ROWSET};

--- a/be/src/storage/tablet/base_tablet.h
+++ b/be/src/storage/tablet/base_tablet.h
@@ -69,6 +69,7 @@ public:
     Status set_tablet_state(TabletState state);
     int64_t table_id() const { return _tablet_meta->table_id(); }
     size_t row_size() const { return _tablet_meta->tablet_schema()->row_size(); }
+    int64_t db_id() const { return _tablet_meta->db_id(); }
     int64_t index_id() const { return _tablet_meta->index_id(); }
     int64_t partition_id() const { return _tablet_meta->partition_id(); }
     int64_t tablet_id() const { return _tablet_meta->tablet_id(); }

--- a/be/src/storage/tablet/tablet_meta.cpp
+++ b/be/src/storage/tablet/tablet_meta.cpp
@@ -1117,6 +1117,41 @@ Status TabletMeta::set_partition_id(int64_t partition_id) {
     return Status::OK();
 }
 
+Status TabletMeta::set_index_id(int64_t index_id) {
+    if ((index_id > 0 && _index_id != index_id) || index_id < 1) {
+        LOG(WARNING) << "cur index id=" << _index_id << " new index id=" << index_id
+                     << " not equal";
+    }
+    _index_id = index_id;
+    return Status::OK();
+}
+
+Status TabletMeta::set_table_id(int64_t table_id) {
+    if ((table_id > 0 && _table_id != table_id) || table_id < 1) {
+        LOG(WARNING) << "cur table id=" << _table_id << " new table id=" << table_id
+                     << " not equal";
+    }
+    _table_id = table_id;
+    return Status::OK();
+}
+
+Status TabletMeta::set_tablet_id(int64_t tablet_id) {
+    if ((tablet_id > 0 && _tablet_id != tablet_id) || tablet_id < 1) {
+        LOG(WARNING) << "cur tablet id=" << _tablet_id << " new tablet id=" << tablet_id
+                     << " not equal";
+    }
+    _tablet_id = tablet_id;
+    return Status::OK();
+}
+
+Status TabletMeta::set_db_id(int64_t db_id) {
+    if ((db_id > 0 && _db_id != db_id) || db_id < 1) {
+        LOG(WARNING) << "cur db id=" << _db_id << " new db id=" << db_id << " not equal";
+    }
+    _db_id = db_id;
+    return Status::OK();
+}
+
 void TabletMeta::clear_stale_rowset() {
     _stale_rs_metas.clear();
     if (_enable_unique_key_merge_on_write) {

--- a/be/src/storage/tablet/tablet_meta.h
+++ b/be/src/storage/tablet/tablet_meta.h
@@ -152,6 +152,7 @@ public:
     TabletTypePB tablet_type() const { return _tablet_type; }
     TabletUid tablet_uid() const;
     void set_tablet_uid(TabletUid uid) { _tablet_uid = uid; }
+    int64_t db_id() const;
     int64_t table_id() const;
     int64_t index_id() const;
     int64_t partition_id() const;
@@ -213,6 +214,14 @@ public:
     RowsetMetaSharedPtr acquire_stale_rs_meta_by_version(const Version& version) const;
 
     Status set_partition_id(int64_t partition_id);
+
+    Status set_index_id(int64_t index_id);
+
+    Status set_table_id(int64_t table_id);
+
+    Status set_tablet_id(int64_t tablet_id);
+
+    Status set_db_id(int64_t db_id);
 
     RowsetTypePB preferred_rowset_type() const { return _preferred_rowset_type; }
 
@@ -319,6 +328,7 @@ private:
     friend bool operator!=(const TabletMeta& a, const TabletMeta& b);
 
 private:
+    int64_t _db_id = 0; // only set when preload from ms
     int64_t _table_id = 0;
     int64_t _index_id = 0;
     int64_t _partition_id = 0;
@@ -635,6 +645,10 @@ private:
 
 inline TabletUid TabletMeta::tablet_uid() const {
     return _tablet_uid;
+}
+
+inline int64_t TabletMeta::db_id() const {
+    return _db_id;
 }
 
 inline int64_t TabletMeta::table_id() const {

--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -1040,15 +1040,20 @@ void MetaServiceImpl::create_tablets(::google::protobuf::RpcController* controll
 }
 
 void internal_get_tablet(MetaServiceCode& code, std::string& msg, const std::string& instance_id,
-                         Transaction* txn, int64_t tablet_id, doris::TabletMetaCloudPB* tablet_meta,
+                         Transaction* txn, int64_t table_id, int64_t index_id, int64_t partition_id,
+                         int64_t tablet_id, doris::TabletMetaCloudPB* tablet_meta,
                          bool skip_schema) {
     // TODO: validate request
     TabletIndexPB tablet_idx;
-    get_tablet_idx(code, msg, txn, instance_id, tablet_id, tablet_idx);
-    if (code != MetaServiceCode::OK) return;
+    if (table_id < 0 || index_id < 0 || partition_id < 0) {
+        get_tablet_idx(code, msg, txn, instance_id, tablet_id, tablet_idx);
+        if (code != MetaServiceCode::OK) return;
+        table_id = tablet_idx.table_id();
+        index_id = tablet_idx.index_id();
+        partition_id = tablet_idx.partition_id();
+    }
 
-    MetaTabletKeyInfo key_info1 {instance_id, tablet_idx.table_id(), tablet_idx.index_id(),
-                                 tablet_idx.partition_id(), tablet_id};
+    MetaTabletKeyInfo key_info1 {instance_id, table_id, index_id, partition_id, tablet_id};
     std::string key1, val1;
     meta_tablet_key(key_info1, &key1);
     TxnErrorCode err = txn->get(key1, &val1);
@@ -1158,8 +1163,8 @@ void MetaServiceImpl::update_tablet(::google::protobuf::RpcController* controlle
     for (const TabletMetaInfoPB& tablet_meta_info : request->tablet_meta_infos()) {
         doris::TabletMetaCloudPB tablet_meta;
         if (!is_versioned_read) {
-            internal_get_tablet(code, msg, instance_id, txn.get(), tablet_meta_info.tablet_id(),
-                                &tablet_meta, true);
+            internal_get_tablet(code, msg, instance_id, txn.get(), -1, -1, -1,
+                                tablet_meta_info.tablet_id(), &tablet_meta, true);
             if (code != MetaServiceCode::OK) {
                 return;
             }
@@ -1317,8 +1322,11 @@ void MetaServiceImpl::get_tablet(::google::protobuf::RpcController* controller,
         return;
     }
     if (!is_version_read_enabled(instance_id)) {
-        internal_get_tablet(code, msg, instance_id, txn.get(), request->tablet_id(),
-                            response->mutable_tablet_meta(), false);
+        int64_t table_id = request->has_table_id() ? request->table_id() : -1;
+        int64_t index_id = request->has_index_id() ? request->index_id() : -1;
+        int64_t partition_id = request->has_partition_id() ? request->partition_id() : -1;
+        internal_get_tablet(code, msg, instance_id, txn.get(), table_id, index_id, partition_id,
+                            request->tablet_id(), response->mutable_tablet_meta(), false);
         return;
     }
 
@@ -2322,14 +2330,20 @@ static void fill_schema_from_dict(MetaServiceCode& code, std::string& msg,
 }
 
 bool check_job_existed(Transaction* txn, MetaServiceCode& code, std::string& msg,
-                       const std::string& instance_id, int64_t tablet_id,
-                       const std::string& rowset_id, const std::string& job_id,
-                       bool is_versioned_read, ResourceManager* resource_mgr) {
+                       const std::string& instance_id, int64_t tablet_id, int64_t table_id,
+                       int64_t index_id, int64_t partition_id, const std::string& rowset_id,
+                       const std::string& job_id, bool is_versioned_read,
+                       ResourceManager* resource_mgr) {
     TabletIndexPB tablet_idx;
     if (!is_versioned_read) {
-        get_tablet_idx(code, msg, txn, instance_id, tablet_id, tablet_idx);
-        if (code != MetaServiceCode::OK) {
-            return false;
+        if (table_id <= 0 || index_id <= 0 || partition_id <= 0) {
+            get_tablet_idx(code, msg, txn, instance_id, tablet_id, tablet_idx);
+            if (code != MetaServiceCode::OK) {
+                return false;
+            }
+            table_id = tablet_idx.table_id();
+            index_id = tablet_idx.index_id();
+            partition_id = tablet_idx.partition_id();
         }
     } else {
         CloneChainReader reader(instance_id, resource_mgr);
@@ -2339,16 +2353,20 @@ bool check_job_existed(Transaction* txn, MetaServiceCode& code, std::string& msg
             msg = fmt::format("failed to get tablet index, tablet_id={} err={}", tablet_id, err);
             return false;
         }
+        table_id = tablet_idx.table_id();
+        index_id = tablet_idx.index_id();
+        partition_id = tablet_idx.partition_id();
     }
 
-    std::string job_key = job_tablet_key({instance_id, tablet_idx.table_id(), tablet_idx.index_id(),
-                                          tablet_idx.partition_id(), tablet_id});
+    std::string job_key =
+            job_tablet_key({instance_id, table_id, index_id, partition_id, tablet_id});
     std::string job_val;
     auto err = txn->get(job_key, &job_val);
     if (err != TxnErrorCode::TXN_OK) {
         std::stringstream ss;
         ss << (err == TxnErrorCode::TXN_KEY_NOT_FOUND ? "job not found," : "internal error,")
-           << " instance_id=" << instance_id << " tablet_id=" << tablet_id
+           << " instance_id=" << instance_id << " table_id=" << table_id << " index_id=" << index_id
+           << " partition_id=" << partition_id << " tablet_id=" << tablet_id
            << " rowset_id=" << rowset_id << " err=" << err;
         msg = ss.str();
         code = err == TxnErrorCode::TXN_KEY_NOT_FOUND ? MetaServiceCode::STALE_PREPARE_ROWSET
@@ -2499,8 +2517,12 @@ void MetaServiceImpl::prepare_rowset(::google::protobuf::RpcController* controll
     bool is_versioned_read = is_version_read_enabled(instance_id);
     if (config::enable_tablet_job_check && request->has_tablet_job_id() &&
         !request->tablet_job_id().empty()) {
-        if (!check_job_existed(txn.get(), code, msg, instance_id, tablet_id, rowset_id,
-                               request->tablet_job_id(), is_versioned_read, resource_mgr_.get())) {
+        if (!check_job_existed(txn.get(), code, msg, instance_id, tablet_id,
+                               rowset_meta.has_table_id() ? rowset_meta.table_id() : -1,
+                               rowset_meta.has_index_id() ? rowset_meta.index_id() : -1,
+                               rowset_meta.has_partition_id() ? rowset_meta.partition_id() : -1,
+                               rowset_id, request->tablet_job_id(), is_versioned_read,
+                               resource_mgr_.get())) {
             return;
         }
     }
@@ -2656,9 +2678,12 @@ int check_idempotent_for_txn_or_job(Transaction* txn, const std::string& recycle
             return -1;
         }
     } else if (!config::enable_recycle_delete_rowset_key_check) {
-        if (config::enable_tablet_job_check && tablet_job_id.empty() && !tablet_job_id.empty()) {
-            if (!check_job_existed(txn, code, msg, instance_id, tablet_id, rowset_id, tablet_job_id,
-                                   is_versioned_read, resource_mgr)) {
+        if (config::enable_tablet_job_check && !tablet_job_id.empty()) {
+            if (!check_job_existed(txn, code, msg, instance_id, tablet_id,
+                                   rowset_meta.has_table_id() ? rowset_meta.table_id() : -1,
+                                   rowset_meta.has_index_id() ? rowset_meta.index_id() : -1,
+                                   rowset_meta.has_partition_id() ? rowset_meta.partition_id() : -1,
+                                   rowset_id, tablet_job_id, is_versioned_read, resource_mgr)) {
                 return 1;
             }
         }
@@ -3217,12 +3242,21 @@ void MetaServiceImpl::get_rowset(::google::protobuf::RpcController* controller,
             stats.get_bytes += txn->get_bytes();
             stats.get_counter += txn->num_get_keys();
         };
+
+        DCHECK(request->has_idx());
+
         TabletIndexPB idx;
+        int64_t db_id = request->idx().has_db_id() ? request->idx().db_id() : -1;
         // Get tablet id index from kv
         if (!is_versioned_read) {
-            get_tablet_idx(code, msg, txn.get(), instance_id, tablet_id, idx);
-            if (code != MetaServiceCode::OK) {
-                return;
+            if (db_id <= 0) {
+                get_tablet_idx(code, msg, txn.get(), instance_id, tablet_id, idx);
+                if (code != MetaServiceCode::OK) {
+                    return;
+                }
+                db_id = idx.db_id();
+            } else {
+                db_id = request->idx().db_id();
             }
         } else {
             err = reader.get_tablet_index(txn.get(), tablet_id, &idx);
@@ -3233,10 +3267,11 @@ void MetaServiceImpl::get_rowset(::google::protobuf::RpcController* controller,
                 LOG(WARNING) << msg;
                 return;
             }
+            db_id = idx.db_id();
         }
-        DCHECK(request->has_idx());
 
-        if (idx.has_db_id() && config::advance_txn_lazy_commit_during_reads) {
+        DCHECK(db_id > 0);
+        if (db_id > 0 && config::advance_txn_lazy_commit_during_reads) {
             // there is maybe a lazy commit txn when call get_rowset
             // we need advance lazy commit txn here
             int64_t first_txn_id = -1;

--- a/cloud/src/meta-service/txn_lazy_committer.cpp
+++ b/cloud/src/meta-service/txn_lazy_committer.cpp
@@ -277,14 +277,27 @@ void convert_tmp_rowsets(
         }
 
         if (!tablet_ids.contains(tmp_rowset_pb.tablet_id())) {
-            TabletIndexPB tablet_idx_pb;
-            std::tie(code, msg) =
-                    get_tablet_index(meta_reader, txn.get(), instance_id, txn_id,
-                                     tmp_rowset_pb.tablet_id(), &tablet_idx_pb, is_versioned_read);
-            if (code != MetaServiceCode::OK) {
-                return;
+            if (tmp_rowset_pb.has_table_id() && tmp_rowset_pb.table_id() > 0 &&
+                tmp_rowset_pb.has_index_id() && tmp_rowset_pb.index_id() > 0 &&
+                tmp_rowset_pb.has_partition_id() && tmp_rowset_pb.partition_id() > 0) {
+                // Construct TabletIndexPB from rowset meta directly, skip FDB read
+                TabletIndexPB tablet_idx_pb;
+                tablet_idx_pb.set_table_id(tmp_rowset_pb.table_id());
+                tablet_idx_pb.set_index_id(tmp_rowset_pb.index_id());
+                tablet_idx_pb.set_partition_id(tmp_rowset_pb.partition_id());
+                tablet_idx_pb.set_tablet_id(tmp_rowset_pb.tablet_id());
+                tablet_ids.emplace(tmp_rowset_pb.tablet_id(), tablet_idx_pb);
+            } else {
+                // Fallback for old BEs that don't set table_id
+                TabletIndexPB tablet_idx_pb;
+                std::tie(code, msg) = get_tablet_index(meta_reader, txn.get(), instance_id, txn_id,
+                                                       tmp_rowset_pb.tablet_id(), &tablet_idx_pb,
+                                                       is_versioned_read);
+                if (code != MetaServiceCode::OK) {
+                    return;
+                }
+                tablet_ids.emplace(tmp_rowset_pb.tablet_id(), tablet_idx_pb);
             }
-            tablet_ids.emplace(tmp_rowset_pb.tablet_id(), tablet_idx_pb);
         }
         const TabletIndexPB& tablet_idx_pb = tablet_ids[tmp_rowset_pb.tablet_id()];
 
@@ -789,16 +802,31 @@ std::pair<MetaServiceCode, std::string> TxnLazyCommitTask::commit_partition(
     int64_t table_id = -1;
     {
         DCHECK(tmp_rowset_metas.size() > 0);
-        int64_t first_tablet_id = tmp_rowset_metas.begin()->second.tablet_id();
-        TabletIndexPB first_tablet_index;
-        std::tie(code, msg) =
-                get_tablet_index(meta_reader, txn_kv_.get(), instance_id_, txn_id_, first_tablet_id,
-                                 &first_tablet_index, is_versioned_read);
-        if (code != MetaServiceCode::OK) {
-            return {code, msg};
+        const auto& first_rowset = tmp_rowset_metas.begin()->second;
+        int64_t first_tablet_id = first_rowset.tablet_id();
+        if (first_rowset.has_table_id() && first_rowset.table_id() > 0 &&
+            first_rowset.has_index_id() && first_rowset.index_id() > 0 &&
+            first_rowset.has_partition_id() && first_rowset.partition_id() > 0) {
+            // Use table_id from rowset meta directly, skip FDB read
+            table_id = first_rowset.table_id();
+            TabletIndexPB first_tablet_index;
+            first_tablet_index.set_table_id(first_rowset.table_id());
+            first_tablet_index.set_index_id(first_rowset.index_id());
+            first_tablet_index.set_partition_id(first_rowset.partition_id());
+            first_tablet_index.set_tablet_id(first_tablet_id);
+            tablet_ids.emplace(first_tablet_id, first_tablet_index);
+        } else {
+            // Fallback for old BEs that don't set table_id
+            TabletIndexPB first_tablet_index;
+            std::tie(code, msg) =
+                    get_tablet_index(meta_reader, txn_kv_.get(), instance_id_, txn_id_,
+                                     first_tablet_id, &first_tablet_index, is_versioned_read);
+            if (code != MetaServiceCode::OK) {
+                return {code, msg};
+            }
+            table_id = first_tablet_index.table_id();
+            tablet_ids.emplace(first_tablet_id, first_tablet_index);
         }
-        table_id = first_tablet_index.table_id();
-        tablet_ids.emplace(first_tablet_id, first_tablet_index);
     }
 
     // The partition version key is constructed during the txn commit process, so the versionstamp

--- a/cloud/test/meta_service_job_test.cpp
+++ b/cloud/test/meta_service_job_test.cpp
@@ -1485,6 +1485,8 @@ TEST(MetaServiceJobVersionedReadTest, SchemaChangeJobTest) {
         rowset.set_txn_id(txn_id + i);
         output_rowsets.push_back(rowset);
         CreateRowsetResponse res;
+        prepare_rowset(meta_service.get(), output_rowsets.back(), res, txn_id + i);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
         commit_rowset(meta_service.get(), output_rowsets.back(), res, txn_id + i);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
     }

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -1314,6 +1314,9 @@ message GetTabletRequest {
     optional string cloud_unique_id = 1; // For auth
     optional int64 tablet_id = 2;
     optional string request_ip = 3;
+    optional int64 table_id = 4;
+    optional int64 index_id = 5;
+    optional int64 partition_id = 6;
     // TODO: There are more fields TBD
 }
 

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -165,6 +165,7 @@ message RowsetMetaPB {
     
     optional bool is_recycled = 1013; // for recycler mark rowset as recycled
     optional string job_id = 1014;
+    optional int64 table_id = 1015;
 }
 
 message SchemaDictKeyList {
@@ -270,6 +271,7 @@ message RowsetMetaCloudPB {
 
     optional bool is_recycled = 112;
     optional string job_id = 113;
+    optional int64 table_id = 114;
 }
 
 message SegmentStatisticsPB {


### PR DESCRIPTION
### What problem does this PR solve?

- Extend GetTabletRequest with table_id/index_id/partition_id and pass them from BE when available.
- Update CloudMetaMgr::get_tablet_meta signature and call sites to carry full tablet key context.
- Sync db_id/table_id/index_id/partition_id into TabletMeta during cloud tablet meta refresh.
- Add table_id to RowsetMetaPB/RowsetMetaCloudPB and propagate it through rowset writer and PB conversion.
- In meta service lazy-commit/job-check/read paths, prefer rowset/request metadata to build keys,
  and fallback to tablet-index lookup only for old BE compatibility.

This reduces unnecessary FDB reads.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

