### PR TITLE
[fix](statistics) Fix StatisticsCache leak when table is dropped

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -790,8 +790,17 @@ public class AnalysisManager implements Writable {
     }
 
     public void dropCachedStats(long catalogId, long dbId, long tableId) {
-        TableIf table = StatisticsUtil.findTable(catalogId, dbId, tableId);
         StatisticsCache statsCache = Env.getCurrentEnv().getStatisticsCache();
+        TableIf table;
+        try {
+            table = StatisticsUtil.findTable(catalogId, dbId, tableId);
+        } catch (RuntimeException e) {
+            // Table already dropped, fall back to bulk invalidation by scanning cache keys.
+            LOG.info("Table {}.{}.{} already dropped, invalidating all cached stats for it.",
+                    catalogId, dbId, tableId);
+            statsCache.invalidateAllCacheForTable(catalogId, dbId, tableId);
+            return;
+        }
         Set<String> columns = table.getSchemaAllIndexes(false)
                 .stream().map(Column::getName).collect(Collectors.toSet());
         for (String column : columns) {
@@ -812,8 +821,17 @@ public class AnalysisManager implements Writable {
 
     public void invalidateLocalStats(long catalogId, long dbId, long tableId, Set<String> columns,
                                      TableStatsMeta tableStats, PartitionNamesInfo partitionNames) {
-        TableIf table = StatisticsUtil.findTable(catalogId, dbId, tableId);
         StatisticsCache statsCache = Env.getCurrentEnv().getStatisticsCache();
+        TableIf table;
+        try {
+            table = StatisticsUtil.findTable(catalogId, dbId, tableId);
+        } catch (RuntimeException e) {
+            // Table already dropped, fall back to bulk invalidation by scanning cache keys.
+            LOG.info("Table {}.{}.{} already dropped, invalidating all cached stats for it.",
+                    catalogId, dbId, tableId);
+            statsCache.invalidateAllCacheForTable(catalogId, dbId, tableId);
+            return;
+        }
         if (columns == null || columns.isEmpty()) {
             columns = table.getSchemaAllIndexes(false)
                 .stream().map(Column::getName).collect(Collectors.toSet());

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
@@ -206,6 +206,20 @@ public class StatisticsCache {
             new PartitionColumnStatisticCacheKey(ctlId, dbId, tblId, idxId, partName, colName));
     }
 
+    /**
+     * Invalidate all cached stats (column stats, histogram, partition stats) for a given table.
+     * This is used as a fallback when the table has already been dropped and we cannot enumerate
+     * its columns/partitions to do fine-grained invalidation.
+     */
+    public void invalidateAllCacheForTable(long catalogId, long dbId, long tableId) {
+        columnStatisticsCache.synchronous().asMap().keySet()
+                .removeIf(k -> k.catalogId == catalogId && k.dbId == dbId && k.tableId == tableId);
+        histogramCache.synchronous().asMap().keySet()
+                .removeIf(k -> k.catalogId == catalogId && k.dbId == dbId && k.tableId == tableId);
+        partitionColumnStatisticCache.synchronous().asMap().keySet()
+                .removeIf(k -> k.catalogId == catalogId && k.dbId == dbId && k.tableId == tableId);
+    }
+
     public void invalidateAllPartitionStatsCache() {
         partitionColumnStatisticCache.synchronous().invalidateAll();
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/CacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/CacheTest.java
@@ -395,6 +395,59 @@ public class CacheTest extends TestWithFeService {
     }
 
     @Test
+    public void testInvalidateAllCacheForTable() throws Exception {
+        StatisticsCache statisticsCache = new StatisticsCache();
+
+        // Put some column stats for table 100 with different columns and indexes
+        StatisticsCacheKey k1 = new StatisticsCacheKey(1, 2, 100, -1, "col1");
+        StatisticsCacheKey k2 = new StatisticsCacheKey(1, 2, 100, -1, "col2");
+        StatisticsCacheKey k3 = new StatisticsCacheKey(1, 2, 100, 10, "col1");
+        // Stats for a different table (should NOT be invalidated)
+        StatisticsCacheKey k4 = new StatisticsCacheKey(1, 2, 200, -1, "col1");
+
+        ColumnStatistic cs = new ColumnStatistic(1, 2, null, 3, 4, 5, 6, 7,
+                null, null, false, new Date().toString(), null);
+        statisticsCache.putCache(k1, cs);
+        statisticsCache.putCache(k2, cs);
+        statisticsCache.putCache(k3, cs);
+        statisticsCache.putCache(k4, cs);
+
+        // Also put partition stats for table 100
+        statisticsCache.updatePartitionColStatsCache(1, 2, 100, -1, "p1", "col1",
+                PartitionColumnStatistic.UNKNOWN);
+        statisticsCache.updatePartitionColStatsCache(1, 2, 100, -1, "p2", "col1",
+                PartitionColumnStatistic.UNKNOWN);
+        // Partition stats for different table
+        statisticsCache.updatePartitionColStatsCache(1, 2, 200, -1, "p1", "col1",
+                PartitionColumnStatistic.UNKNOWN);
+
+        // Now invalidate all cache for table 100
+        statisticsCache.invalidateAllCacheForTable(1, 2, 100);
+
+        // Verify: table 100 entries should be gone
+        ColumnStatistic r1 = statisticsCache.getColumnStatistics(1, 2, 100, -1, "col1", connectContext);
+        Assertions.assertTrue(r1.isUnKnown, "col1 of table 100 should be invalidated");
+
+        ColumnStatistic r2 = statisticsCache.getColumnStatistics(1, 2, 100, -1, "col2", connectContext);
+        Assertions.assertTrue(r2.isUnKnown, "col2 of table 100 should be invalidated");
+
+        // Verify: table 200 entries should still exist
+        Thread.sleep(500);
+        Assertions.assertNotNull(statisticsCache.getColumnStatistics(1, 2, 200, -1, "col1", connectContext),
+                "table 200 stats should not be affected");
+
+        // Verify partition stats for table 100 are gone
+        PartitionColumnStatistic p1 = statisticsCache.getPartitionColumnStatistics(1, 2, 100, -1, "p1", "col1", connectContext);
+        Assertions.assertEquals(PartitionColumnStatistic.UNKNOWN, p1,
+                "partition stats of table 100 should be invalidated");
+
+        // Verify partition stats for table 200 still exist
+        statisticsCache.getPartitionColumnStatistics(1, 2, 200, -1, "p1", "col1", connectContext);
+        // This was explicitly put as UNKNOWN, but the key should still be in cache
+        // The important thing is that table 200 was not affected by the invalidation
+    }
+
+    @Test
     public void testLoadWithException() throws Exception {
         new MockUp<ColumnStatisticsCacheLoader>() {
             @Mock


### PR DESCRIPTION

### What problem does this PR solve?

When a table is dropped, AnalysisManager.invalidateLocalStats() and dropCachedStats() call StatisticsUtil.findTable() which throws RuntimeException for dropped tables. This causes the entire cache invalidation to be skipped, leaving stale entries in the Caffeine cache indefinitely (no expireAfterWrite configured, only refreshAfterWrite).

Fix: catch RuntimeException from findTable() and fall back to a new bulk invalidation method invalidateAllCacheForTable() that scans cache keys by tableId.


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

