### PR TITLE
[fix](cache) Invalidate ExternalRowCountCache entries when catalog is…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -227,6 +227,7 @@ public class ExternalMetaCacheMgr {
             paimonMetadataCache.invalidateCatalogCache(catalogId);
         }
         dorisExternalMetaCacheMgr.removeCache(catalogId);
+        rowCountCache.invalidateCatalog(catalogId);
     }
 
     public void invalidateTableCache(ExternalTable dorisTable) {
@@ -296,6 +297,7 @@ public class ExternalMetaCacheMgr {
             paimonMetadataCache.invalidateCatalogCache(catalogId);
         }
         dorisExternalMetaCacheMgr.invalidateCatalogCache(catalogId);
+        rowCountCache.invalidateCatalog(catalogId);
         if (LOG.isDebugEnabled()) {
             LOG.debug("invalid catalog cache for {}", catalogId);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalRowCountCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalRowCountCache.java
@@ -134,6 +134,16 @@ public class ExternalRowCountCache {
     }
 
     /**
+     * Invalidate all cached row counts for tables belonging to the given catalog.
+     * Should be called when a catalog is dropped or its cache is invalidated,
+     * to prevent stale entries from triggering endless refresh attempts.
+     */
+    public void invalidateCatalog(long catalogId) {
+        rowCountCache.synchronous().asMap().keySet()
+                .removeIf(key -> key.getCatalogId() == catalogId);
+    }
+
+    /**
      * Get cached row count for the given table if present. Return -1 if cached not loaded.
      * This method will not trigger async loading if cache is missing.
      * @return Cached row count or -1 if not exist

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalRowCountCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalRowCountCacheTest.java
@@ -99,4 +99,47 @@ public class ExternalRowCountCacheTest {
         }
         Assertions.assertEquals(3, counter.get());
     }
+
+    @Test
+    public void testInvalidateCatalog() throws Exception {
+        ThreadPoolExecutor executor = ThreadPoolManager.newDaemonFixedThreadPool(
+                1, Integer.MAX_VALUE, "TEST", true);
+
+        new MockUp<ExternalRowCountCache.RowCountCacheLoader>() {
+            @Mock
+            protected Optional<Long> doLoad(ExternalRowCountCache.RowCountKey rowCountKey) {
+                return Optional.of(100L);
+            }
+        };
+        ExternalRowCountCache cache = new ExternalRowCountCache(executor);
+
+        // Load entries for two different catalogs
+        long catalogId1 = 10;
+        long catalogId2 = 20;
+        cache.getCachedRowCount(catalogId1, 1, 101);
+        cache.getCachedRowCount(catalogId1, 1, 102);
+        cache.getCachedRowCount(catalogId2, 2, 201);
+
+        // Wait for async loads to complete
+        for (int i = 0; i < 60; i++) {
+            if (cache.getCachedRowCount(catalogId1, 1, 101) == 100
+                    && cache.getCachedRowCount(catalogId1, 1, 102) == 100
+                    && cache.getCachedRowCount(catalogId2, 2, 201) == 100) {
+                break;
+            }
+            Thread.sleep(1000);
+        }
+        Assertions.assertEquals(100, cache.getCachedRowCount(catalogId1, 1, 101));
+        Assertions.assertEquals(100, cache.getCachedRowCount(catalogId1, 1, 102));
+        Assertions.assertEquals(100, cache.getCachedRowCount(catalogId2, 2, 201));
+
+        // Invalidate catalog1
+        cache.invalidateCatalog(catalogId1);
+
+        // Catalog1 entries should be gone
+        Assertions.assertEquals(-1, cache.getCachedRowCountIfPresent(catalogId1, 1, 101));
+        Assertions.assertEquals(-1, cache.getCachedRowCountIfPresent(catalogId1, 1, 102));
+        // Catalog2 entries should still exist
+        Assertions.assertEquals(100, cache.getCachedRowCountIfPresent(catalogId2, 2, 201));
+    }
 }


### PR DESCRIPTION
… dropped

When an external catalog is dropped, ExternalRowCountCache entries for tables in that catalog were not invalidated. This caused Caffeine's refreshAfterWrite to endlessly retry loading row counts for non-existent tables, producing continuous WARN logs and wasting refresh thread pool resources.

Add invalidateCatalog() to ExternalRowCountCache and call it from ExternalMetaCacheMgr.removeCache() and invalidateCatalogCache().

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

