### PR TITLE
[Feature](scan) add variable adjust_tablet_reader_batch_size_by_limit

### DIFF
--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -135,6 +135,11 @@ public:
                                                             : 20000;
     }
 
+    bool adjust_tablet_reader_batch_size_by_limit() const {
+        return _query_options.__isset.adjust_tablet_reader_batch_size_by_limit &&
+               _query_options.adjust_tablet_reader_batch_size_by_limit;
+    }
+
     ObjectPool* obj_pool() const { return _obj_pool.get(); }
 
     const DescriptorTbl& desc_tbl() const { return *_desc_tbl; }

--- a/be/src/vec/exec/scan/olap_scanner.cpp
+++ b/be/src/vec/exec/scan/olap_scanner.cpp
@@ -164,6 +164,11 @@ Status OlapScanner::prepare() {
     // value (e.g. select a from t where a .. and b ... limit 1),
     // it will be very slow when reading data in segment iterator
     _tablet_reader->set_batch_size(_state->batch_size());
+    if (_state->adjust_tablet_reader_batch_size_by_limit()) {
+        _tablet_reader->set_batch_size(
+                _limit == -1 ? _state->batch_size()
+                             : std::min(static_cast<int64_t>(_state->batch_size()), _limit));
+    }
     TabletSchemaSPtr cached_schema;
     std::string schema_key;
     {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -3456,6 +3456,7 @@ public class SessionVariable implements Serializable, Writable {
     public int decomposeRepeatShuffleIndexInMaxGroup = -1;
 
     public static final String IGNORE_ICEBERG_DANGLING_DELETE = "ignore_iceberg_dangling_delete";
+    public static final String ADJUST_TABLET_READER_BATCH_SIZE_BY_LIMIT = "adjust_tablet_reader_batch_size_by_limit";
     @VariableMgr.VarAttr(name = IGNORE_ICEBERG_DANGLING_DELETE,
             description = {"是否忽略 Iceberg 表中 dangling delete 文件对 COUNT(*) 统计信息的影响。"
                     + "默认为 true，COUNT(*) 会直接从元信息中获取行数，性能更好，但是如果有 dangling delete，结果可能是不准确的。"
@@ -3468,6 +3469,11 @@ public class SessionVariable implements Serializable, Writable {
                             + "to exclude the impact of dangling delete files."})
     public boolean ignoreIcebergDanglingDelete = false;
 
+    @VariableMgr.VarAttr(name = ADJUST_TABLET_READER_BATCH_SIZE_BY_LIMIT, needForward = true, description = {
+            "是否根据查询中的 limit 调整 tablet reader 的 batch size。默认为 false。",
+            "Whether to adjust the batch size of tablet reader based on the limit in the query. The default is false."
+    })
+    public boolean adjustTabletReaderBatchSizeByLimit = false;
 
     // If this fe is in fuzzy mode, then will use initFuzzyModeVariables to generate some variables,
     // not the default value set in the code.
@@ -5305,6 +5311,7 @@ public class SessionVariable implements Serializable, Writable {
 
         // Set Iceberg write target file size
         tResult.setIcebergWriteTargetFileSizeBytes(icebergWriteTargetFileSizeBytes);
+        tResult.setAdjustTabletReaderBatchSizeByLimit(adjustTabletReaderBatchSizeByLimit);
 
         return tResult;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -3495,6 +3495,7 @@ public class SessionVariable implements Serializable, Writable {
         this.enableBroadcastJoinForcePassthrough = random.nextBoolean();
         this.enableShareHashTableForBroadcastJoin = random.nextBoolean();
         this.shortCircuitEvaluation = random.nextBoolean();
+        this.adjustTabletReaderBatchSizeByLimit = random.nextBoolean();
 
         // 4KB = 4 * 1024 bytes
         int minBytes = 4 * 1024;

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -445,6 +445,7 @@ struct TQueryOptions {
   // In read path, read from file cache or remote storage when execute query.
   1000: optional bool disable_file_cache = false
   1001: optional i32 file_cache_query_limit_percent = -1
+  1002: optional bool adjust_tablet_reader_batch_size_by_limit = false
 }
 
 

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -439,13 +439,14 @@ struct TQueryOptions {
   200: optional bool enable_adjust_conjunct_order_by_cost;
   // Use paimon-cpp to read Paimon splits on BE
   201: optional bool enable_paimon_cpp_reader = false;
+  202: optional bool adjust_tablet_reader_batch_size_by_limit = false;
+
 
   // For cloud, to control if the content would be written into file cache
   // In write path, to control if the content would be written into file cache.
   // In read path, read from file cache or remote storage when execute query.
   1000: optional bool disable_file_cache = false
   1001: optional i32 file_cache_query_limit_percent = -1
-  1002: optional bool adjust_tablet_reader_batch_size_by_limit = false
 }
 
 


### PR DESCRIPTION
### What problem does this PR solve?
after https://github.com/apache/doris/pull/22240, we do not push limit to tablet reader.
but sometime the row data is big, so we need use limit to scan less data.

adjust_tablet_reader_batch_size_by_limit=false;
- ScanRows: sum 16.32K (16320), avg 16.32K (16320), max 16.32K (16320), min 16.32K (16320)
adjust_tablet_reader_batch_size_by_limit=true;
- ScanRows: sum 200, avg 200, max 200, min 200
### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

