### PR TITLE
[fix](lazy materialize) set uniqueId for lazy materialized slots

### DIFF
--- a/be/src/exec/operator/materialization_opertor.cpp
+++ b/be/src/exec/operator/materialization_opertor.cpp
@@ -57,8 +57,15 @@ Status MaterializationSharedState::merge_multi_response() {
     std::unordered_map<int64_t, std::pair<Block, int>> block_maps;
 
     for (int i = 0; i < block_order_results.size(); ++i) {
+        // block_maps must be rebuilt for each relation (each i), because a backend that
+        // returned a non-empty block for relation i-1 may return an empty block for
+        // relation i (e.g. it holds rows only from one of the two tables in a UNION ALL).
+        // Keeping block_maps across iterations would leave stale entries from the previous
+        // relation and miss entries for the current one, causing the
+        // "backend_id not found in block_maps" error.
+        std::unordered_map<int64_t, std::pair<vectorized::Block, int>> block_maps;
         for (auto& [backend_id, rpc_struct] : rpc_struct_map) {
-            Block partial_block;
+            vectorized::Block partial_block;
             size_t uncompressed_size = 0;
             int64_t uncompressed_time = 0;
             DCHECK(rpc_struct.response.blocks_size() > i);

--- a/be/src/exec/operator/materialization_opertor.cpp
+++ b/be/src/exec/operator/materialization_opertor.cpp
@@ -54,8 +54,6 @@ void MaterializationSharedState::get_block(Block* block) {
 }
 
 Status MaterializationSharedState::merge_multi_response() {
-    std::unordered_map<int64_t, std::pair<Block, int>> block_maps;
-
     for (int i = 0; i < block_order_results.size(); ++i) {
         // block_maps must be rebuilt for each relation (each i), because a backend that
         // returned a non-empty block for relation i-1 may return an empty block for
@@ -63,9 +61,9 @@ Status MaterializationSharedState::merge_multi_response() {
         // Keeping block_maps across iterations would leave stale entries from the previous
         // relation and miss entries for the current one, causing the
         // "backend_id not found in block_maps" error.
-        std::unordered_map<int64_t, std::pair<vectorized::Block, int>> block_maps;
+        std::unordered_map<int64_t, std::pair<Block, int>> block_maps;
         for (auto& [backend_id, rpc_struct] : rpc_struct_map) {
-            vectorized::Block partial_block;
+            Block partial_block;
             size_t uncompressed_size = 0;
             int64_t uncompressed_time = 0;
             DCHECK(rpc_struct.response.blocks_size() > i);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -2756,7 +2756,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
 
         materializeNode.setLazyColumns(materialize.getLazyColumns());
         materializeNode.setLocations(materialize.getLazySlotLocations());
-        materializeNode.setIdxs(materialize.getlazyTableIdxs());
+        materializeNode.setColumnIdxsLists(materialize.getLazyBaseColumnIndices());
 
         List<Boolean> rowStoreFlags = new ArrayList<>();
         for (Relation relation : materialize.getRelations()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalLazyMaterialize.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalLazyMaterialize.java
@@ -61,11 +61,44 @@ public class PhysicalLazyMaterialize<CHILD_TYPE extends Plan> extends PhysicalUn
 
     private final List<Slot> materializeInput;
     private final List<Slot> materializeOutput;
-    // used for BE
+    /**
+     * The following four fields are used by BE to perform the actual lazy fetch.
+     * They are indexed by relation: index i corresponds to relations.get(i).
+     *
+     * Example:
+     *   SQL: SELECT t1.a, t1.b, t2.c, t2.d FROM t1 JOIN t2 ON ... WHERE t1.a > 5
+     *   Assume t1.b and t2.d are lazily materialized (fetched after filtering).
+     *
+     *   materializedSlots (non-lazy, computed eagerly) = [t1.a, t2.c]
+     *   Output slot order = [t1.a(0), t2.c(1), t1.b(2), t2.d(3)]
+     *
+     *   rowIdList         = [row_id_t1, row_id_t2]
+     *                       The row-id slots passed to BE to locate the original rows.
+     *
+     *   relations         = [t1, t2]
+     *
+     *   lazyColumns       = [[Column(b)],          [Column(d)]]
+     *                       For each relation, the Column objects to be lazily fetched.
+     *
+     *   lazyBaseColumnIndices = [[colIdxOf(b) in t1],  [colIdxOf(d) in t2]]
+     *                       For each relation, the physical column index inside the table
+     *                       for each lazy column (used by BE to locate the column on disk).
+     *
+     *   lazySlotLocations = [[2],                  [3]]
+     *                       A two-level array: the outer level is indexed by relation
+     *                       (same as relations / rowIdList), and the inner level lists the
+     *                       output-tuple position for each lazy column of that relation.
+     *                       Two levels are needed because a single relation can have
+     *                       multiple lazy columns.  For example, if both t1.b and t1.e
+     *                       were lazy, the entry for t1 would be [2, 4] (positions of b
+     *                       and e in the output tuple), while t2 remains [3].
+     *                       BE uses each position to know which output slot to fill in
+     *                       after fetching the column value from disk.
+     */
     private final List<Slot> rowIdList;
     private List<List<Column>> lazyColumns = new ArrayList<>();
     private List<List<Integer>> lazySlotLocations = new ArrayList<>();
-    private List<List<Integer>> lazyTableIdxs = new ArrayList<>();
+    private List<List<Integer>> lazyBaseColumnIndices = new ArrayList<>();
 
     private final List<Relation> relations;
 
@@ -100,7 +133,7 @@ public class PhysicalLazyMaterialize<CHILD_TYPE extends Plan> extends PhysicalUn
         this.materializedSlots = ImmutableList.copyOf(materializedSlots);
         this.materializeMap = materializeMap;
         lazySlotLocations = new ArrayList<>();
-        lazyTableIdxs = new ArrayList<>();
+        lazyBaseColumnIndices = new ArrayList<>();
         lazyColumns = new ArrayList<>();
 
         ImmutableList.Builder<Slot> outputBuilder = ImmutableList.builder();
@@ -125,15 +158,19 @@ public class PhysicalLazyMaterialize<CHILD_TYPE extends Plan> extends PhysicalUn
 
             List<Column> lazyColumnForRel = new ArrayList<>();
             lazyColumns.add(lazyColumnForRel);
-            List<Integer> lazyIdxForRel = new ArrayList<>();
-            lazyTableIdxs.add(lazyIdxForRel);
+            List<Integer> lazyBaseColumnIdxForRel = new ArrayList<>();
+            lazyBaseColumnIndices.add(lazyBaseColumnIdxForRel);
 
             List<Integer> lazySlotLocationForRel = new ArrayList<>();
             lazySlotLocations.add(lazySlotLocationForRel);
             for (Slot lazySlot : relationToLazySlotMap.get(rel)) {
-                outputBuilder.add(lazySlot);
-                lazyColumnForRel.add(materializeMap.get(lazySlot).baseSlot.getOriginalColumn().get());
-                lazyIdxForRel.add(relationTable.getBaseColumnIdxByName(lazySlot.getName()));
+                // Set originalColumn on the lazy slot so that createSlotDesc can write
+                // colUniqueId into the thrift SlotDescriptor — BE needs it to resolve
+                // the column during remote fetch.
+                Column originalColumn = materializeMap.get(lazySlot).baseSlot.getOriginalColumn().get();
+                outputBuilder.add(((SlotReference) lazySlot).withColumn(originalColumn));
+                lazyColumnForRel.add(originalColumn);
+                lazyBaseColumnIdxForRel.add(relationTable.getBaseColumnIdxByName(lazySlot.getName()));
                 lazySlotLocationForRel.add(loc);
                 loc++;
             }
@@ -248,8 +285,8 @@ public class PhysicalLazyMaterialize<CHILD_TYPE extends Plan> extends PhysicalUn
         return lazySlotLocations;
     }
 
-    public List<List<Integer>> getlazyTableIdxs() {
-        return lazyTableIdxs;
+    public List<List<Integer>> getLazyBaseColumnIndices() {
+        return lazyBaseColumnIndices;
     }
 
     public List<Slot> getRowIds() {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/MaterializationNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/MaterializationNode.java
@@ -71,6 +71,50 @@ import java.util.List;
  * }
  */
 public class MaterializationNode extends PlanNode {
+    /**
+     * Example to illustrate the fields below:
+     *
+     *   SQL:  SELECT pk, col_date FROM t ORDER BY pk LIMIT 10
+     *         (col_date is chosen for lazy materialization)
+     *
+     *   The child plan produces:  [pk(eager), row_id_t]
+     *   row_id_t is a "global row-id" slot that encodes where the real col_date lives on disk.
+     *
+     *   materializeTupleDescriptor (intermediate tuple, e.g. tuple 5):
+     *     index 0 → pk          (eager slot, already in the child block)
+     *     index 1 → col_date    (lazy slot, to be fetched remotely via row_id)
+     *
+     *   outputTupleDesc (final output tuple, e.g. tuple 6):
+     *     contains the columns actually returned to the parent node after
+     *     applying projectList on top of materializeTupleDescriptor.
+     *     In simple cases it is the same set of columns.
+     *     Example: projectList = [pk#0, col_date#1]  →  outputTupleDesc = {pk, col_date}
+     *
+     *   Relationship:
+     *     materializeTupleDescriptor  =  "working" tuple that holds eager + lazy columns,
+     *                                    used to build the RPC fetch request and place the
+     *                                    fetched values back into the block.
+     *     outputTupleDesc             =  "public" tuple visible to the parent; produced by
+     *                                    projecting materializeTupleDescriptor through projectList.
+     *
+     *   locations (= PhysicalLazyMaterialize.lazySlotLocations):
+     *     For each relation, the index of each lazy slot inside materializeTupleDescriptor.
+     *     In the example above: [[1]]
+     *       → outer list index 0 = first (only) relation t
+     *       → inner value 1      = col_date is at index 1 in materializeTupleDescriptor.slots()
+     *     BE uses this to call  slots[location]->to_protobuf(...)  when building the fetch
+     *     request so the remote side knows the schema of what to return.
+     *
+    *   columnIdxsLists (= PhysicalLazyMaterialize.lazyBaseColumnIndices):
+     *     For each relation, the physical column index in the table for each lazy column.
+     *     In the example above: [[3]]   (col_date is the 3rd column in t, 0-indexed)
+     *     BE sends this index to the storage layer so it can locate the column on disk
+     *     without needing the full schema.
+     *
+     *   If two columns b and c from table t were both lazy, and the column indices in the
+     *   table are 2 and 5 respectively, and they occupy slots at index 1 and 2 in the tuple:
+     *     locations = [[1, 2]],  columnIdxsLists = [[2, 5]]
+     */
     private TPaloNodesInfo nodesInfo;
     private TupleDescriptor materializeTupleDescriptor;
 
@@ -79,7 +123,7 @@ public class MaterializationNode extends PlanNode {
     private List<List<Column>> lazyColumns;
 
     private List<List<Integer>> locations;
-    private List<List<Integer>> idxs;
+    private List<List<Integer>> columnIdxsLists;
 
     private List<Boolean> rowStoreFlags;
 
@@ -124,7 +168,7 @@ public class MaterializationNode extends PlanNode {
         }
         output.append(detailPrefix).append("column_descs_lists").append(lazyColumns).append("\n");
         output.append(detailPrefix).append("locations: ").append(locations).append("\n");
-        output.append(detailPrefix).append("table_idxs: ").append(idxs).append("\n");
+        output.append(detailPrefix).append("column_idxs_lists: ").append(columnIdxsLists).append("\n");
         output.append(detailPrefix).append("row_ids: ").append(rowIds).append("\n");
         output.append(detailPrefix).append("isTopMaterializeNode: ").append(isTopMaterializeNode).append("\n");
         printNestedColumns(output, detailPrefix, outputTupleDesc);
@@ -152,7 +196,7 @@ public class MaterializationNode extends PlanNode {
         msg.materialization_node.setColumnDescsLists(thriftCols);
 
         msg.materialization_node.setSlotLocsLists(locations);
-        msg.materialization_node.setColumnIdxsLists(idxs);
+        msg.materialization_node.setColumnIdxsLists(columnIdxsLists);
         msg.materialization_node.setFetchRowStores(rowStoreFlags);
         msg.materialization_node.setGcIdMap(isTopMaterializeNode);
     }
@@ -169,8 +213,8 @@ public class MaterializationNode extends PlanNode {
         this.locations = locations;
     }
 
-    public void setIdxs(List<List<Integer>> idxs) {
-        this.idxs = idxs;
+    public void setColumnIdxsLists(List<List<Integer>> columnIdxsLists) {
+        this.columnIdxsLists = columnIdxsLists;
     }
 
     public void setRowStoreFlags(List<Boolean> rowStoreFlags) {

--- a/regression-test/suites/external_table_p0/hive/test_hive_topn_lazy_mat.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_topn_lazy_mat.groovy
@@ -210,7 +210,7 @@ suite("test_hive_topn_lazy_mat", "p0,external") {
             contains("projectList:[id, name, value, active, score, file_id]")
             contains("column_descs_lists[[`name` text NULL, `value` double NULL, `active` boolean NULL, `score` double NULL, `file_id` int NULL]]")
             contains("locations: [[1, 2, 3, 4, 5]]")
-            contains("table_idxs: [[1, 2, 3, 4, 5]]")
+            contains("column_idxs_lists: [[1, 2, 3, 4, 5]]")
             contains("row_ids: [__DORIS_GLOBAL_ROWID_COL__orc_topn_lazy_mat_table]")
         }
        
@@ -219,7 +219,7 @@ suite("test_hive_topn_lazy_mat", "p0,external") {
             contains("projectList:[file_id, id]")
             contains("column_descs_lists[[`id` int NULL, `file_id` int NULL]]")
             contains("locations: [[1, 2]]")
-            contains("table_idxs: [[0, 5]]")
+            contains("column_idxs_lists: [[0, 5]]")
             contains("row_ids: [__DORIS_GLOBAL_ROWID_COL__orc_topn_lazy_mat_table]")
         }
 
@@ -229,7 +229,7 @@ suite("test_hive_topn_lazy_mat", "p0,external") {
             contains("projectList:[name, length(a.name), value, id, name, value, active, score, file_id, id, name, value, active, score, file_id]")
             contains("column_descs_lists[[`name` text NULL, `value` double NULL, `active` boolean NULL, `score` double NULL, `file_id` int NULL], [`value` double NULL, `active` boolean NULL, `score` double NULL, `file_id` int NULL]]")
             contains("locations: [[5, 6, 7, 8, 9], [10, 11, 12, 13]]")
-            contains("table_idxs: [[1, 2, 3, 4, 5], [2, 3, 4, 5]]")
+            contains("column_idxs_lists: [[1, 2, 3, 4, 5], [2, 3, 4, 5]]")
             contains("row_ids: [__DORIS_GLOBAL_ROWID_COL__orc_topn_lazy_mat_table, __DORIS_GLOBAL_ROWID_COL__parquet_topn_lazy_mat_table]")
         }
 

--- a/regression-test/suites/external_table_p0/tvf/test_tvf_topn_lazy_mat.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_tvf_topn_lazy_mat.groovy
@@ -148,7 +148,7 @@ suite("test_tvf_topn_lazy_mat", "p0,external") {
 
             contains("column_descs_lists[[`name` text NULL, `value` double NULL, `active` boolean NULL, `score` double NULL]]")
             contains("locations: [[1, 2, 3, 4]]")
-            contains("table_idxs: [[1, 2, 3, 4]]")
+            contains("column_idxs_lists: [[1, 2, 3, 4]]")
             contains("row_ids: [__DORIS_GLOBAL_ROWID_COL__hdfs]")
             contains("isTopMaterializeNode: true")
             contains("SlotDescriptor{id=0, col=id, colUniqueId=-1, type=bigint, nullable=true")
@@ -163,7 +163,7 @@ suite("test_tvf_topn_lazy_mat", "p0,external") {
             contains("projectList:[name, value, score]")
             contains("column_descs_lists[[`name` text NULL, `value` double NULL, `score` double NULL]]")
             contains("locations: [[1, 2, 3]]")
-            contains("table_idxs: [[1, 2, 4]]")
+            contains("column_idxs_lists: [[1, 2, 4]]")
             contains("row_ids: [__DORIS_GLOBAL_ROWID_COL__hdfs]")
             contains("isTopMaterializeNode: true")
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

This pull request refactors and clarifies the handling of lazy materialization in both the frontend (FE) and backend (BE) code, especially focusing on how lazy columns are tracked and communicated between components. The main change is the replacement of ambiguous or inaccurately named fields and methods related to lazy column indices with clearer, more descriptive names and documentation. This improves maintainability and reduces confusion for future development.

Key changes include:

**Refactoring and Renaming for Clarity:**
- Replaced the ambiguous `lazyTableIdxs`/`idxs` fields and related methods with `lazyBaseColumnIndices`/`columnIdxsLists` throughout the FE and BE code, making it clear these represent the physical column indices in the table for lazy columns. [[1]](diffhunk://#diff-05d3dfe7eb1041f3befc2e1f6964f0a3c72025daaf7d66ca22bef96974cf57cdL64-R101) [[2]](diffhunk://#diff-05d3dfe7eb1041f3befc2e1f6964f0a3c72025daaf7d66ca22bef96974cf57cdL103-R136) [[3]](diffhunk://#diff-05d3dfe7eb1041f3befc2e1f6964f0a3c72025daaf7d66ca22bef96974cf57cdL128-R173) [[4]](diffhunk://#diff-05d3dfe7eb1041f3befc2e1f6964f0a3c72025daaf7d66ca22bef96974cf57cdL251-R289) [[5]](diffhunk://#diff-cebaf7c5d7c73205dcdefd593acda2e1bc3a64c5b6b79ceb297b5c004d6cf50bL81-R125) [[6]](diffhunk://#diff-cebaf7c5d7c73205dcdefd593acda2e1bc3a64c5b6b79ceb297b5c004d6cf50bL154-R198) [[7]](diffhunk://#diff-cebaf7c5d7c73205dcdefd593acda2e1bc3a64c5b6b79ceb297b5c004d6cf50bL171-R216) [[8]](diffhunk://#diff-f363369b49ec5af5a087420f31ec3d9a8c5147eacabdf051792017cfab289dacL2751-R2751) [[9]](diffhunk://#diff-cebaf7c5d7c73205dcdefd593acda2e1bc3a64c5b6b79ceb297b5c004d6cf50bL126-R170)

**Improved Documentation and Examples:**
- Added detailed comments and examples in both `PhysicalLazyMaterialize` and `MaterializationNode` classes to explain the purpose and usage of key fields (like `lazyBaseColumnIndices`, `lazySlotLocations`, and their relationship to query execution and column fetching). [[1]](diffhunk://#diff-05d3dfe7eb1041f3befc2e1f6964f0a3c72025daaf7d66ca22bef96974cf57cdL64-R101) [[2]](diffhunk://#diff-cebaf7c5d7c73205dcdefd593acda2e1bc3a64c5b6b79ceb297b5c004d6cf50bR73-R116)

**Correctness Fixes:**
- Updated the construction logic to ensure that the correct original column and physical index are set for each lazy slot, including setting the `originalColumn` property for proper BE resolution.

**Robustness Improvements:**
- Fixed a potential bug in the backend materialization merge logic by reinitializing the `block_maps` for each relation, preventing stale entries and related errors when handling multiple relations (e.g., in UNION ALL queries).

These changes make the lazy materialization mechanism more robust and much easier to understand and maintain.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

