### PR TITLE
[feat](cloud) Add lock wait and bthread schedule delay metrics to SyncRowset profile

### DIFF
--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -593,9 +593,10 @@ Status CloudMetaMgr::sync_tablet_rowsets_unlocked(CloudTablet* tablet,
             auto lock_start = std::chrono::steady_clock::now();
             std::shared_lock rlock(tablet->get_header_lock());
             if (sync_stats) {
-                sync_stats->meta_lock_wait_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(
-                                                           std::chrono::steady_clock::now() - lock_start)
-                                                           .count();
+                sync_stats->meta_lock_wait_ns +=
+                        std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                std::chrono::steady_clock::now() - lock_start)
+                                .count();
             }
             if (options.full_sync) {
                 req.set_start_version(0);
@@ -702,9 +703,10 @@ Status CloudMetaMgr::sync_tablet_rowsets_unlocked(CloudTablet* tablet,
             auto lock_start = std::chrono::steady_clock::now();
             std::unique_lock wlock(tablet->get_header_lock());
             if (sync_stats) {
-                sync_stats->meta_lock_wait_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(
-                                                           std::chrono::steady_clock::now() - lock_start)
-                                                           .count();
+                sync_stats->meta_lock_wait_ns +=
+                        std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                std::chrono::steady_clock::now() - lock_start)
+                                .count();
             }
 
             // ATTN: we are facing following data race

--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -590,7 +590,13 @@ Status CloudMetaMgr::sync_tablet_rowsets_unlocked(CloudTablet* tablet,
         idx->set_index_id(index_id);
         idx->set_partition_id(tablet->partition_id());
         {
+            auto lock_start = std::chrono::steady_clock::now();
             std::shared_lock rlock(tablet->get_header_lock());
+            if (sync_stats) {
+                sync_stats->meta_lock_wait_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                                           std::chrono::steady_clock::now() - lock_start)
+                                                           .count();
+            }
             if (options.full_sync) {
                 req.set_start_version(0);
             } else {
@@ -693,7 +699,13 @@ Status CloudMetaMgr::sync_tablet_rowsets_unlocked(CloudTablet* tablet,
         });
         {
             const auto& stats = resp.stats();
+            auto lock_start = std::chrono::steady_clock::now();
             std::unique_lock wlock(tablet->get_header_lock());
+            if (sync_stats) {
+                sync_stats->meta_lock_wait_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                                           std::chrono::steady_clock::now() - lock_start)
+                                                           .count();
+            }
 
             // ATTN: we are facing following data race
             //

--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -291,10 +291,9 @@ Status CloudTablet::sync_rowsets(const SyncOptions& options, SyncRowsetStats* st
     auto sync_lock_start = std::chrono::steady_clock::now();
     std::unique_lock lock(_sync_meta_lock);
     if (stats) {
-        stats->sync_meta_lock_wait_ns +=
-                std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() -
-                                                                       sync_lock_start)
-                        .count();
+        stats->sync_meta_lock_wait_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                                 std::chrono::steady_clock::now() - sync_lock_start)
+                                                 .count();
     }
     if (options.query_version > 0) {
         auto lock_start = std::chrono::steady_clock::now();
@@ -329,10 +328,9 @@ Status CloudTablet::sync_if_not_running(SyncRowsetStats* stats) {
     auto sync_lock_start = std::chrono::steady_clock::now();
     std::unique_lock lock(_sync_meta_lock);
     if (stats) {
-        stats->sync_meta_lock_wait_ns +=
-                std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() -
-                                                                       sync_lock_start)
-                        .count();
+        stats->sync_meta_lock_wait_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                                 std::chrono::steady_clock::now() - sync_lock_start)
+                                                 .count();
     }
 
     {

--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -275,16 +275,35 @@ Status CloudTablet::sync_rowsets(const SyncOptions& options, SyncRowsetStats* st
     RETURN_IF_ERROR(sync_if_not_running(stats));
 
     if (options.query_version > 0) {
+        auto lock_start = std::chrono::steady_clock::now();
         std::shared_lock rlock(_meta_lock);
+        if (stats) {
+            stats->meta_lock_wait_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                                std::chrono::steady_clock::now() - lock_start)
+                                                .count();
+        }
         if (_max_version >= options.query_version) {
             return Status::OK();
         }
     }
 
     // serially execute sync to reduce unnecessary network overhead
+    auto sync_lock_start = std::chrono::steady_clock::now();
     std::unique_lock lock(_sync_meta_lock);
+    if (stats) {
+        stats->sync_meta_lock_wait_ns +=
+                std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() -
+                                                                       sync_lock_start)
+                        .count();
+    }
     if (options.query_version > 0) {
+        auto lock_start = std::chrono::steady_clock::now();
         std::shared_lock rlock(_meta_lock);
+        if (stats) {
+            stats->meta_lock_wait_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                                std::chrono::steady_clock::now() - lock_start)
+                                                .count();
+        }
         if (_max_version >= options.query_version) {
             return Status::OK();
         }
@@ -307,10 +326,23 @@ Status CloudTablet::sync_if_not_running(SyncRowsetStats* stats) {
     }
 
     // Serially execute sync to reduce unnecessary network overhead
+    auto sync_lock_start = std::chrono::steady_clock::now();
     std::unique_lock lock(_sync_meta_lock);
+    if (stats) {
+        stats->sync_meta_lock_wait_ns +=
+                std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() -
+                                                                       sync_lock_start)
+                        .count();
+    }
 
     {
+        auto lock_start = std::chrono::steady_clock::now();
         std::shared_lock rlock(_meta_lock);
+        if (stats) {
+            stats->meta_lock_wait_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                                std::chrono::steady_clock::now() - lock_start)
+                                                .count();
+        }
         if (tablet_state() == TABLET_RUNNING) {
             return Status::OK();
         }
@@ -332,7 +364,13 @@ Status CloudTablet::sync_if_not_running(SyncRowsetStats* stats) {
 
     TimestampedVersionTracker empty_tracker;
     {
+        auto lock_start = std::chrono::steady_clock::now();
         std::lock_guard wlock(_meta_lock);
+        if (stats) {
+            stats->meta_lock_wait_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                                std::chrono::steady_clock::now() - lock_start)
+                                                .count();
+        }
         RETURN_IF_ERROR(set_tablet_state(TABLET_RUNNING));
         _rs_version_map.clear();
         _stale_rs_version_map.clear();

--- a/be/src/cloud/cloud_tablet.h
+++ b/be/src/cloud/cloud_tablet.h
@@ -53,6 +53,10 @@ struct SyncRowsetStats {
     int64_t get_remote_tablet_meta_rpc_ns {0};
     int64_t tablet_meta_cache_hit {0};
     int64_t tablet_meta_cache_miss {0};
+
+    int64_t bthread_schedule_delay_ns {0};
+    int64_t meta_lock_wait_ns {0};       // _meta_lock (std::shared_mutex) wait across all acquisitions
+    int64_t sync_meta_lock_wait_ns {0};  // _sync_meta_lock (bthread::Mutex) wait across all acquisitions
 };
 
 struct SyncOptions {

--- a/be/src/cloud/cloud_tablet.h
+++ b/be/src/cloud/cloud_tablet.h
@@ -55,8 +55,9 @@ struct SyncRowsetStats {
     int64_t tablet_meta_cache_miss {0};
 
     int64_t bthread_schedule_delay_ns {0};
-    int64_t meta_lock_wait_ns {0};       // _meta_lock (std::shared_mutex) wait across all acquisitions
-    int64_t sync_meta_lock_wait_ns {0};  // _sync_meta_lock (bthread::Mutex) wait across all acquisitions
+    int64_t meta_lock_wait_ns {0}; // _meta_lock (std::shared_mutex) wait across all acquisitions
+    int64_t sync_meta_lock_wait_ns {
+            0}; // _sync_meta_lock (bthread::Mutex) wait across all acquisitions
 };
 
 struct SyncOptions {

--- a/be/src/exec/operator/olap_scan_operator.cpp
+++ b/be/src/exec/operator/olap_scan_operator.cpp
@@ -173,8 +173,8 @@ Status OlapScanLocalState::_init_profile() {
                 _scanner_profile, "SyncRowsetGetRemoteDeleteBitmapRpcTime", sync_rowset_timer_name);
         _sync_rowset_bthread_schedule_wait_timer = ADD_CHILD_TIMER(
                 _scanner_profile, "SyncRowsetBthreadScheduleWaitTime", sync_rowset_timer_name);
-        _sync_rowset_meta_lock_wait_timer =
-                ADD_CHILD_TIMER(_scanner_profile, "SyncRowsetMetaLockWaitTime", sync_rowset_timer_name);
+        _sync_rowset_meta_lock_wait_timer = ADD_CHILD_TIMER(
+                _scanner_profile, "SyncRowsetMetaLockWaitTime", sync_rowset_timer_name);
         _sync_rowset_sync_meta_lock_wait_timer = ADD_CHILD_TIMER(
                 _scanner_profile, "SyncRowsetSyncMetaLockWaitTime", sync_rowset_timer_name);
     }
@@ -626,8 +626,8 @@ Status OlapScanLocalState::_sync_cloud_tablets(RuntimeState* state) {
                     auto task_start_time = std::chrono::steady_clock::now();
                     if (sync_stats) {
                         sync_stats->bthread_schedule_delay_ns +=
-                                std::chrono::duration_cast<std::chrono::nanoseconds>(task_start_time -
-                                                                                       task_create_time)
+                                std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                        task_start_time - task_create_time)
                                         .count();
                     }
                     auto task_lock = task_ctx.lock();
@@ -703,9 +703,11 @@ Status OlapScanLocalState::prepare(RuntimeState* state) {
                            sync_stats.get_remote_delete_bitmap_bytes);
             COUNTER_UPDATE(_sync_rowset_get_remote_delete_bitmap_rpc_timer,
                            sync_stats.get_remote_delete_bitmap_rpc_ns);
-            COUNTER_UPDATE(_sync_rowset_bthread_schedule_wait_timer, sync_stats.bthread_schedule_delay_ns);
+            COUNTER_UPDATE(_sync_rowset_bthread_schedule_wait_timer,
+                           sync_stats.bthread_schedule_delay_ns);
             COUNTER_UPDATE(_sync_rowset_meta_lock_wait_timer, sync_stats.meta_lock_wait_ns);
-            COUNTER_UPDATE(_sync_rowset_sync_meta_lock_wait_timer, sync_stats.sync_meta_lock_wait_ns);
+            COUNTER_UPDATE(_sync_rowset_sync_meta_lock_wait_timer,
+                           sync_stats.sync_meta_lock_wait_ns);
         }
         auto time_ms = _sync_cloud_tablets_watcher.elapsed_time_microseconds();
         if (time_ms >= config::sync_rowsets_slow_threshold_ms) {

--- a/be/src/exec/operator/olap_scan_operator.cpp
+++ b/be/src/exec/operator/olap_scan_operator.cpp
@@ -171,6 +171,12 @@ Status OlapScanLocalState::_init_profile() {
                                   TUnit::BYTES, sync_rowset_timer_name);
         _sync_rowset_get_remote_delete_bitmap_rpc_timer = ADD_CHILD_TIMER(
                 _scanner_profile, "SyncRowsetGetRemoteDeleteBitmapRpcTime", sync_rowset_timer_name);
+        _sync_rowset_bthread_schedule_wait_timer = ADD_CHILD_TIMER(
+                _scanner_profile, "SyncRowsetBthreadScheduleWaitTime", sync_rowset_timer_name);
+        _sync_rowset_meta_lock_wait_timer =
+                ADD_CHILD_TIMER(_scanner_profile, "SyncRowsetMetaLockWaitTime", sync_rowset_timer_name);
+        _sync_rowset_sync_meta_lock_wait_timer = ADD_CHILD_TIMER(
+                _scanner_profile, "SyncRowsetSyncMetaLockWaitTime", sync_rowset_timer_name);
     }
     _block_init_timer = ADD_TIMER(_segment_profile, "BlockInitTime");
     _block_init_seek_timer = ADD_TIMER(_segment_profile, "BlockInitSeekTime");
@@ -614,7 +620,16 @@ Status OlapScanLocalState::_sync_cloud_tablets(RuntimeState* state) {
                                 _scan_ranges[i]->version.data() + _scan_ranges[i]->version.size(),
                                 version);
                 auto task_ctx = state->get_task_execution_context();
-                tasks.emplace_back([this, sync_stats, version, i, task_ctx]() {
+                auto task_create_time = std::chrono::steady_clock::now();
+                tasks.emplace_back([this, sync_stats, version, i, task_ctx, task_create_time]() {
+                    // Record bthread scheduling delay
+                    auto task_start_time = std::chrono::steady_clock::now();
+                    if (sync_stats) {
+                        sync_stats->bthread_schedule_delay_ns +=
+                                std::chrono::duration_cast<std::chrono::nanoseconds>(task_start_time -
+                                                                                       task_create_time)
+                                        .count();
+                    }
                     auto task_lock = task_ctx.lock();
                     if (task_lock == nullptr) {
                         return Status::OK();
@@ -688,6 +703,9 @@ Status OlapScanLocalState::prepare(RuntimeState* state) {
                            sync_stats.get_remote_delete_bitmap_bytes);
             COUNTER_UPDATE(_sync_rowset_get_remote_delete_bitmap_rpc_timer,
                            sync_stats.get_remote_delete_bitmap_rpc_ns);
+            COUNTER_UPDATE(_sync_rowset_bthread_schedule_wait_timer, sync_stats.bthread_schedule_delay_ns);
+            COUNTER_UPDATE(_sync_rowset_meta_lock_wait_timer, sync_stats.meta_lock_wait_ns);
+            COUNTER_UPDATE(_sync_rowset_sync_meta_lock_wait_timer, sync_stats.sync_meta_lock_wait_ns);
         }
         auto time_ms = _sync_cloud_tablets_watcher.elapsed_time_microseconds();
         if (time_ms >= config::sync_rowsets_slow_threshold_ms) {

--- a/be/src/exec/operator/olap_scan_operator.h
+++ b/be/src/exec/operator/olap_scan_operator.h
@@ -179,6 +179,9 @@ private:
     RuntimeProfile::Counter* _sync_rowset_get_remote_delete_bitmap_key_count = nullptr;
     RuntimeProfile::Counter* _sync_rowset_get_remote_delete_bitmap_bytes = nullptr;
     RuntimeProfile::Counter* _sync_rowset_get_remote_delete_bitmap_rpc_timer = nullptr;
+    RuntimeProfile::Counter* _sync_rowset_bthread_schedule_wait_timer = nullptr;
+    RuntimeProfile::Counter* _sync_rowset_meta_lock_wait_timer = nullptr;
+    RuntimeProfile::Counter* _sync_rowset_sync_meta_lock_wait_timer = nullptr;
     RuntimeProfile::Counter* _block_load_timer = nullptr;
     RuntimeProfile::Counter* _block_load_counter = nullptr;
     // Add more detail seek timer and counter profile


### PR DESCRIPTION
## Proposed changes

This PR adds visibility into "hidden" time sinks in SyncRowset that are not covered by existing RPC metrics.

### Problem

### Solution

Added 3 new profile metrics under `SyncRowsetTime`:

- **SyncRowsetBthreadScheduleWaitTime**: bthread scheduling delay (from task creation to execution start)
- **SyncRowsetMetaLockWaitTime**: total wait time for `_meta_lock` (std::shared_mutex) acquisitions
- **SyncRowsetSyncMetaLockWaitTime**: total wait time for `_sync_meta_lock` (bthread::Mutex) acquisitions

These metrics track lock wait times in:
- `CloudTablet::sync_rowsets()`
- `CloudTablet::sync_if_not_running()`
- `CloudMetaMgr::sync_tablet_rowsets_unlocked()`

### Checklist

- [x] Compiles and builds successfully
- [ ] Existing UT passed (need verification)
- [ ] Manual testing done

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Docs Update / Doc Refactor
- [ ] Code Refactor (internal modification that does not change functionality)
- [ ] Test Case
- [ ] CI (CD related, like github action, k8s yaml, etc.)

## Further comments

Helps diagnose cases where high SyncRowsetTime is caused by:
- Lock contention between concurrent scans on the same tablet
- bthread worker pool saturation