### PR TITLE
[refine](hashmap) Provide a foreach interface for the hashmap.

### DIFF
--- a/be/src/exec/common/hash_table/hash_map_context.h
+++ b/be/src/exec/common/hash_table/hash_map_context.h
@@ -777,7 +777,7 @@ struct MethodKeysFixed : public MethodBase<TData> {
 };
 
 template <typename Base>
-struct DataWithNullKeyImpl : public Base {
+struct DataWithNullKey : public Base {
     bool& has_null_key_data() { return has_null_key; }
     bool has_null_key_data() const { return has_null_key; }
     template <typename MappedType>
@@ -800,62 +800,6 @@ struct DataWithNullKeyImpl : public Base {
 protected:
     bool has_null_key = false;
     Base::Value null_key_data;
-};
-
-template <typename Base>
-struct DataWithNullKey : public DataWithNullKeyImpl<Base> {};
-
-template <IteratoredMap Base>
-struct DataWithNullKey<Base> : public DataWithNullKeyImpl<Base> {
-    using DataWithNullKeyImpl<Base>::null_key_data;
-    using DataWithNullKeyImpl<Base>::has_null_key;
-
-    struct Iterator {
-        typename Base::iterator base_iterator = {};
-        bool current_null = false;
-        Base::Value* null_key_data = nullptr;
-
-        Iterator() = default;
-        Iterator(typename Base::iterator it, bool null, Base::Value* null_key)
-                : base_iterator(it), current_null(null), null_key_data(null_key) {}
-        bool operator==(const Iterator& rhs) const {
-            return current_null == rhs.current_null && base_iterator == rhs.base_iterator;
-        }
-
-        bool operator!=(const Iterator& rhs) const { return !(*this == rhs); }
-
-        Iterator& operator++() {
-            if (current_null) {
-                current_null = false;
-            } else {
-                ++base_iterator;
-            }
-            return *this;
-        }
-
-        Base::Value& get_second() {
-            if (current_null) {
-                return *null_key_data;
-            } else {
-                return base_iterator->get_second();
-            }
-        }
-    };
-
-    Iterator begin() { return {Base::begin(), has_null_key, &null_key_data}; }
-
-    Iterator end() { return {Base::end(), false, &null_key_data}; }
-
-    void insert(const Iterator& other_iter) {
-        if (other_iter.current_null) {
-            has_null_key = true;
-            null_key_data = *other_iter.null_key_data;
-        } else {
-            Base::insert(other_iter.base_iterator);
-        }
-    }
-
-    using iterator = Iterator;
 };
 
 /// Single low cardinality column.

--- a/be/src/exec/common/hash_table/ph_hash_map.h
+++ b/be/src/exec/common/hash_table/ph_hash_map.h
@@ -188,6 +188,12 @@ public:
         for (auto& v : *this) func(v.get_second());
     }
 
+    /// Call func(const Key &, Mapped &) for each hash map element.
+    template <typename Func>
+    void for_each(Func&& func) {
+        for (auto& v : *this) func(v.get_first(), v.get_second());
+    }
+
     size_t get_buffer_size_in_bytes() const {
         const auto capacity = _hash_map.capacity();
         return capacity * sizeof(typename HashMapImpl::slot_type);

--- a/be/src/exec/common/hash_table/string_hash_map.h
+++ b/be/src/exec/common/hash_table/string_hash_map.h
@@ -68,7 +68,7 @@ struct StringHashMapCell<doris::StringRef, TMapped>
     using Base::Base;
     static constexpr bool need_zero_value_storage = false;
     // external
-    using Base::get_key;
+    const doris::StringRef& get_key() const { return this->value.first; } /// NOLINT
     // internal
     static const doris::StringRef& get_key(const value_type& value_) { return value_.first; }
 
@@ -150,6 +150,29 @@ public:
             func(v.get_second());
         }
     }
+
+    template <typename Func>
+    void for_each(Func&& func) {
+        if (this->m0.size()) {
+            func(this->m0.zero_value()->get_key(), this->m0.zero_value()->get_second());
+        }
+        for (auto& v : this->m1) {
+            func(v.get_key(), v.get_second());
+        }
+        for (auto& v : this->m2) {
+            func(v.get_key(), v.get_second());
+        }
+        for (auto& v : this->m3) {
+            func(v.get_key(), v.get_second());
+        }
+        for (auto& v : this->m4) {
+            func(v.get_key(), v.get_second());
+        }
+        for (auto& v : this->ms) {
+            func(v.get_key(), v.get_second());
+        }
+    }
+
     template <typename MappedType>
     char* get_null_key_data() {
         return nullptr;

--- a/be/src/exec/common/hash_table/string_hash_table.h
+++ b/be/src/exec/common/hash_table/string_hash_table.h
@@ -50,7 +50,9 @@ StringKey to_string_key(const doris::StringRef& key) {
 template <typename T>
 inline doris::StringRef ALWAYS_INLINE to_string_ref(const T& n) {
     assert(n != 0);
-    return {reinterpret_cast<const char*>(&n), sizeof(T) - (__builtin_clzll(n) >> 3)};
+    // __builtin_clzll counts leading zero bits in a 64-bit (8-byte) value,
+    // so we must use 8 here instead of sizeof(T) to get the correct byte count.
+    return {reinterpret_cast<const char*>(&n), static_cast<size_t>(8 - (__builtin_clzll(n) >> 3))};
 }
 inline doris::StringRef ALWAYS_INLINE to_string_ref(const StringKey16& n) {
     assert(n.items[1] != 0);
@@ -415,7 +417,7 @@ protected:
             return static_cast<Derived&>(*this);
         }
 
-        auto& operator*() const {
+        auto& operator*() {
             switch (sub_table_index) {
             case 0: {
                 this->cell = *(container->m0.zero_value());
@@ -444,9 +446,9 @@ protected:
             }
             return cell;
         }
-        auto* operator->() const { return &(this->operator*()); }
+        auto* operator->() { return &(this->operator*()); }
 
-        auto get_ptr() const { return &(this->operator*()); }
+        auto get_ptr() { return &(this->operator*()); }
 
         size_t get_hash() const {
             switch (sub_table_index) {

--- a/be/src/exec/operator/set_probe_sink_operator.cpp
+++ b/be/src/exec/operator/set_probe_sink_operator.cpp
@@ -233,6 +233,35 @@ void SetProbeSinkOperatorX<is_intersect>::_refresh_hash_table(
                                 std::make_shared<typename HashTableCtxType::HashMapType>();
                         tmp_hash_table->reserve(
                                 local_state._shared_state->valid_element_in_hash_tbl);
+
+                        // Handle null key separately since iterator does not cover it
+                        using NullMappedType =
+                                std::decay_t<decltype(arg.hash_table->template get_null_key_data<
+                                                      RowRefWithFlag>())>;
+                        if constexpr (std::is_same_v<NullMappedType, RowRefWithFlag>) {
+                            if (arg.hash_table->has_null_key_data()) {
+                                auto& null_mapped =
+                                        arg.hash_table
+                                                ->template get_null_key_data<RowRefWithFlag>();
+                                if constexpr (is_intersect) {
+                                    if (null_mapped.visited) {
+                                        null_mapped.visited = false;
+                                        tmp_hash_table->has_null_key_data() = true;
+                                        tmp_hash_table
+                                                ->template get_null_key_data<RowRefWithFlag>() =
+                                                null_mapped;
+                                    }
+                                } else {
+                                    if (!null_mapped.visited) {
+                                        tmp_hash_table->has_null_key_data() = true;
+                                        tmp_hash_table
+                                                ->template get_null_key_data<RowRefWithFlag>() =
+                                                null_mapped;
+                                    }
+                                }
+                            }
+                        }
+
                         while (iter != arg.end) {
                             auto& mapped = iter.get_second();
                             auto* it = &mapped;
@@ -252,6 +281,16 @@ void SetProbeSinkOperatorX<is_intersect>::_refresh_hash_table(
                         arg.hash_table = std::move(tmp_hash_table);
                     } else if (is_intersect) {
                         DCHECK_EQ(valid_element_in_hash_tbl, arg.hash_table->size());
+                        // Reset null key's visited flag separately
+                        using NullMappedType =
+                                std::decay_t<decltype(arg.hash_table->template get_null_key_data<
+                                                      RowRefWithFlag>())>;
+                        if constexpr (std::is_same_v<NullMappedType, RowRefWithFlag>) {
+                            if (arg.hash_table->has_null_key_data()) {
+                                arg.hash_table->template get_null_key_data<RowRefWithFlag>()
+                                        .visited = false;
+                            }
+                        }
                         while (iter != arg.end) {
                             auto& mapped = iter.get_second();
                             auto* it = &mapped;

--- a/be/src/exec/operator/set_source_operator.cpp
+++ b/be/src/exec/operator/set_source_operator.cpp
@@ -146,13 +146,25 @@ Status SetSourceOperatorX<is_intersect>::_get_data_in_hashtable(
         }
     };
 
+    // Output null key first (if present and not yet output)
+    if (!local_state._null_key_output && hash_table_ctx.hash_table->has_null_key_data()) {
+        auto value = hash_table_ctx.hash_table->template get_null_key_data<RowRefWithFlag>();
+        static_assert(std::is_same_v<RowRefWithFlag, std::decay_t<decltype(value)>> ||
+                      std::is_same_v<char*, std::decay_t<decltype(value)>>);
+        if constexpr (std::is_same_v<RowRefWithFlag, std::decay_t<decltype(value)>>) {
+            add_result(value);
+        }
+        local_state._null_key_output = true;
+    }
+
     auto& iter = hash_table_ctx.begin;
-    while (iter != hash_table_ctx.end && local_state._result_indexs.size() < batch_size) {
+    while (iter != hash_table_ctx.hash_table->end() &&
+           local_state._result_indexs.size() < batch_size) {
         add_result(iter.get_second());
         ++iter;
     }
 
-    *eos = iter == hash_table_ctx.end;
+    *eos = iter == hash_table_ctx.hash_table->end();
 
     COUNTER_UPDATE(local_state._get_data_from_hashtable_rows, local_state._result_indexs.size());
     local_state._add_result_columns();

--- a/be/src/exec/operator/set_source_operator.h
+++ b/be/src/exec/operator/set_source_operator.h
@@ -52,6 +52,7 @@ private:
     RuntimeProfile::Counter* _filter_timer = nullptr;
     RuntimeProfile::Counter* _get_data_from_hashtable_rows = nullptr;
     vectorized::IColumn::Selector _result_indexs;
+    bool _null_key_output = false;
 };
 
 template <bool is_intersect>

--- a/be/src/exec/pipeline/dependency.cpp
+++ b/be/src/exec/pipeline/dependency.cpp
@@ -224,14 +224,11 @@ vectorized::MutableColumns AggSharedState::_get_keys_hash_table() {
                         std::vector<KeyType> keys(size);
 
                         uint32_t num_rows = 0;
-                        auto iter = aggregate_data_container->begin();
-                        {
-                            while (iter != aggregate_data_container->end()) {
-                                keys[num_rows] = iter.get_key<KeyType>();
-                                ++iter;
-                                ++num_rows;
-                            }
-                        }
+                        data.for_each([&](const auto& key, auto&) {
+                            keys[num_rows] = key;
+                            ++num_rows;
+                        });
+
                         agg_method.insert_keys_into_columns(keys, key_columns, num_rows);
                         if (has_null_key) {
                             key_columns[0]->insert_data(nullptr, 0);

--- a/be/test/exec/hash_map/hash_table_method_test.cpp
+++ b/be/test/exec/hash_map/hash_table_method_test.cpp
@@ -20,6 +20,7 @@
 #include <set>
 
 #include "core/data_type/data_type_number.h"
+#include "exec/common/agg_utils.h"
 #include "exec/common/columns_hashing.h"
 #include "exec/common/hash_table/hash.h"
 #include "exec/common/hash_table/hash_map_context.h"
@@ -221,4 +222,619 @@ TEST(HashTableMethodTest, testNullableIteratorSkipsNullKey) {
     }
 }
 
+// Helper: create distinguishable AggregateDataPtr values for testing
+static AggregateDataPtr make_mapped(size_t val) {
+    return reinterpret_cast<AggregateDataPtr>(val);
+}
+
+// ========== MethodOneNumber<UInt32, AggData<UInt32>> ==========
+// AggData<UInt32> = PHHashMap<UInt32, AggregateDataPtr, HashCRC32<UInt32>>
+TEST(HashTableMethodTest, testMethodOneNumberAggInsertFindForEach) {
+    MethodOneNumber<UInt32, AggData<UInt32>> method;
+    using State = MethodOneNumber<UInt32, AggData<UInt32>>::State;
+
+    auto col = ColumnHelper::create_column<DataTypeInt32>({10, 20, 30, 40, 50});
+    ColumnRawPtrs key_columns = {col.get()};
+    const size_t rows = 5;
+
+    // Insert
+    {
+        State state(key_columns);
+        method.init_serialized_keys(key_columns, rows);
+        for (size_t i = 0; i < rows; i++) {
+            method.lazy_emplace(
+                    state, i,
+                    [&](const auto& ctor, auto& key, auto& origin) {
+                        ctor(key, make_mapped(i + 1));
+                    },
+                    [](auto& mapped) { FAIL() << "unexpected null"; });
+        }
+    }
+
+    // Find existing keys
+    {
+        State state(key_columns);
+        method.init_serialized_keys(key_columns, rows);
+        for (size_t i = 0; i < rows; i++) {
+            auto result = method.find(state, i);
+            ASSERT_TRUE(result.is_found());
+            EXPECT_EQ(result.get_mapped(), make_mapped(i + 1));
+        }
+    }
+
+    // Find non-existing key
+    {
+        auto miss_col = ColumnHelper::create_column<DataTypeInt32>({999});
+        ColumnRawPtrs miss_columns = {miss_col.get()};
+        State state(miss_columns);
+        method.init_serialized_keys(miss_columns, 1);
+        auto result = method.find(state, 0);
+        EXPECT_FALSE(result.is_found());
+    }
+
+    // for_each
+    {
+        size_t count = 0;
+        method.hash_table->for_each([&](const auto& key, auto& mapped) {
+            EXPECT_NE(mapped, nullptr);
+            count++;
+        });
+        EXPECT_EQ(count, 5);
+    }
+
+    // for_each_mapped
+    {
+        size_t count = 0;
+        method.hash_table->for_each_mapped([&](auto& mapped) {
+            EXPECT_NE(mapped, nullptr);
+            count++;
+        });
+        EXPECT_EQ(count, 5);
+    }
+}
+
+// ========== MethodOneNumber Phase2 (HashMixWrapper) ==========
+// AggregatedDataWithUInt32KeyPhase2 = PHHashMap<UInt32, AggregateDataPtr, HashMixWrapper<UInt32>>
+TEST(HashTableMethodTest, testMethodOneNumberPhase2AggInsertFindForEach) {
+    MethodOneNumber<UInt32, AggregatedDataWithUInt32KeyPhase2> method;
+    using State = MethodOneNumber<UInt32, AggregatedDataWithUInt32KeyPhase2>::State;
+
+    auto col = ColumnHelper::create_column<DataTypeInt32>({100, 200, 300});
+    ColumnRawPtrs key_columns = {col.get()};
+    const size_t rows = 3;
+
+    // Insert
+    {
+        State state(key_columns);
+        method.init_serialized_keys(key_columns, rows);
+        for (size_t i = 0; i < rows; i++) {
+            method.lazy_emplace(
+                    state, i,
+                    [&](const auto& ctor, auto& key, auto& origin) {
+                        ctor(key, make_mapped(i + 100));
+                    },
+                    [](auto& mapped) { FAIL(); });
+        }
+    }
+
+    // Find
+    {
+        State state(key_columns);
+        method.init_serialized_keys(key_columns, rows);
+        for (size_t i = 0; i < rows; i++) {
+            auto result = method.find(state, i);
+            ASSERT_TRUE(result.is_found());
+            EXPECT_EQ(result.get_mapped(), make_mapped(i + 100));
+        }
+    }
+
+    // for_each + for_each_mapped
+    {
+        size_t count = 0;
+        method.hash_table->for_each([&](const auto& key, auto& mapped) { count++; });
+        EXPECT_EQ(count, 3);
+    }
+    {
+        size_t count = 0;
+        method.hash_table->for_each_mapped([&](auto& mapped) { count++; });
+        EXPECT_EQ(count, 3);
+    }
+}
+
+// ========== MethodStringNoCache<AggregatedDataWithShortStringKey> ==========
+// AggregatedDataWithShortStringKey = StringHashMap<AggregateDataPtr>
+TEST(HashTableMethodTest, testMethodStringNoCacheAggInsertFindForEach) {
+    MethodStringNoCache<AggregatedDataWithShortStringKey> method;
+    using State = MethodStringNoCache<AggregatedDataWithShortStringKey>::State;
+
+    // Include strings of varying lengths to exercise different StringHashMap sub-maps
+    auto col = ColumnHelper::create_column<DataTypeString>(
+            {"hello", "world", "foo", "bar", "longstring_exceeding_16_bytes"});
+    ColumnRawPtrs key_columns = {col.get()};
+    const size_t rows = 5;
+
+    // Insert
+    {
+        State state(key_columns);
+        method.init_serialized_keys(key_columns, rows);
+        for (size_t i = 0; i < rows; i++) {
+            method.lazy_emplace(
+                    state, i,
+                    [&](const auto& ctor, auto& key, auto& origin) {
+                        ctor(key, make_mapped(i + 10));
+                    },
+                    [](auto& mapped) { FAIL(); });
+        }
+    }
+
+    // Find
+    {
+        State state(key_columns);
+        method.init_serialized_keys(key_columns, rows);
+        for (size_t i = 0; i < rows; i++) {
+            auto result = method.find(state, i);
+            ASSERT_TRUE(result.is_found());
+            EXPECT_EQ(result.get_mapped(), make_mapped(i + 10));
+        }
+    }
+
+    // for_each
+    {
+        size_t count = 0;
+        method.hash_table->for_each([&](const auto& key, auto& mapped) {
+            EXPECT_NE(mapped, nullptr);
+            count++;
+        });
+        EXPECT_EQ(count, 5);
+    }
+
+    // for_each_mapped
+    {
+        size_t count = 0;
+        method.hash_table->for_each_mapped([&](auto& mapped) { count++; });
+        EXPECT_EQ(count, 5);
+    }
+}
+
+// ========== MethodSerialized<AggregatedDataWithStringKey> ==========
+// AggregatedDataWithStringKey = PHHashMap<StringRef, AggregateDataPtr>
+// StringRef keys require arena persistence to survive across init_serialized_keys calls.
+TEST(HashTableMethodTest, testMethodSerializedAggInsertFindForEach) {
+    MethodSerialized<AggregatedDataWithStringKey> method;
+    using State = MethodSerialized<AggregatedDataWithStringKey>::State;
+
+    auto col1 = ColumnHelper::create_column<DataTypeInt32>({1, 2, 3});
+    auto col2 = ColumnHelper::create_column<DataTypeString>({"a", "bb", "ccc"});
+    ColumnRawPtrs key_columns = {col1.get(), col2.get()};
+    const size_t rows = 3;
+
+    // Use a separate arena to persist StringRef key data
+    Arena persist_arena;
+
+    // Insert
+    {
+        State state(key_columns);
+        method.init_serialized_keys(key_columns, rows);
+        for (size_t i = 0; i < rows; i++) {
+            method.lazy_emplace(
+                    state, i,
+                    [&](const auto& ctor, auto& key, auto& origin) {
+                        method.try_presis_key_and_origin(key, origin, persist_arena);
+                        ctor(key, make_mapped(i + 50));
+                    },
+                    [](auto& mapped) { FAIL(); });
+        }
+    }
+
+    // for_each (keys backed by persist_arena)
+    {
+        size_t count = 0;
+        method.hash_table->for_each([&](const auto& key, auto& mapped) {
+            EXPECT_GT(key.size, 0);
+            EXPECT_NE(mapped, nullptr);
+            count++;
+        });
+        EXPECT_EQ(count, 3);
+    }
+
+    // for_each_mapped
+    {
+        size_t count = 0;
+        method.hash_table->for_each_mapped([&](auto& mapped) {
+            EXPECT_NE(mapped, nullptr);
+            count++;
+        });
+        EXPECT_EQ(count, 3);
+    }
+
+    // Find (re-init serialized keys for lookup)
+    {
+        State state(key_columns);
+        method.init_serialized_keys(key_columns, rows);
+        for (size_t i = 0; i < rows; i++) {
+            auto result = method.find(state, i);
+            ASSERT_TRUE(result.is_found());
+            EXPECT_EQ(result.get_mapped(), make_mapped(i + 50));
+        }
+    }
+}
+
+// ========== MethodKeysFixed<AggData<UInt64>> ==========
+// Fixed-width multi-column keys packed into UInt64
+TEST(HashTableMethodTest, testMethodKeysFixedAggInsertFindForEach) {
+    MethodKeysFixed<AggData<UInt64>> method(Sizes {sizeof(int32_t), sizeof(int32_t)});
+    using State = MethodKeysFixed<AggData<UInt64>>::State;
+
+    auto col1 = ColumnHelper::create_column<DataTypeInt32>({1, 2, 3, 4});
+    auto col2 = ColumnHelper::create_column<DataTypeInt32>({10, 20, 30, 40});
+    ColumnRawPtrs key_columns = {col1.get(), col2.get()};
+    const size_t rows = 4;
+
+    // Insert
+    {
+        State state(key_columns);
+        method.init_serialized_keys(key_columns, rows);
+        for (size_t i = 0; i < rows; i++) {
+            method.lazy_emplace(
+                    state, i,
+                    [&](const auto& ctor, auto& key, auto& origin) {
+                        ctor(key, make_mapped(i + 200));
+                    },
+                    [](auto& mapped) { FAIL(); });
+        }
+    }
+
+    // Find
+    {
+        State state(key_columns);
+        method.init_serialized_keys(key_columns, rows);
+        for (size_t i = 0; i < rows; i++) {
+            auto result = method.find(state, i);
+            ASSERT_TRUE(result.is_found());
+            EXPECT_EQ(result.get_mapped(), make_mapped(i + 200));
+        }
+    }
+
+    // for_each
+    {
+        size_t count = 0;
+        method.hash_table->for_each([&](const auto& key, auto& mapped) {
+            EXPECT_NE(mapped, nullptr);
+            count++;
+        });
+        EXPECT_EQ(count, 4);
+    }
+}
+
+// ========== Nullable MethodOneNumber (MethodSingleNullableColumn + MethodOneNumber) ==========
+// AggDataNullable<UInt32> = DataWithNullKey<PHHashMap<UInt32, AggregateDataPtr, HashCRC32<UInt32>>>
+// Tests null key insertion, find, and for_each (which excludes null from PHHashMap::for_each).
+TEST(HashTableMethodTest, testNullableMethodOneNumberAggInsertFindForEach) {
+    using NullableMethod =
+            MethodSingleNullableColumn<MethodOneNumber<UInt32, AggDataNullable<UInt32>>>;
+    NullableMethod method;
+    using State = NullableMethod::State;
+
+    // values: {10, 20, 30, 40, 50}, null at rows 1 and 3
+    auto col = ColumnHelper::create_nullable_column<DataTypeInt32>({10, 20, 30, 40, 50},
+                                                                   {0, 1, 0, 1, 0});
+    ColumnRawPtrs key_columns = {col.get()};
+    const size_t rows = 5;
+
+    // Insert
+    size_t null_create_count = 0;
+    {
+        State state(key_columns);
+        method.init_serialized_keys(key_columns, rows);
+        for (size_t i = 0; i < rows; i++) {
+            method.lazy_emplace(
+                    state, i,
+                    [&](const auto& ctor, auto& key, auto& origin) {
+                        ctor(key, make_mapped(i + 1));
+                    },
+                    [&](auto& mapped) {
+                        null_create_count++;
+                        mapped = make_mapped(999);
+                    });
+        }
+    }
+
+    // null_creator called once for first null row (index 1); second null (index 3) is deduplicated
+    EXPECT_EQ(null_create_count, 1);
+
+    auto& ht = *method.hash_table;
+    EXPECT_TRUE(ht.has_null_key_data());
+    EXPECT_EQ(ht.get_null_key_data<AggregateDataPtr>(), make_mapped(999));
+
+    // Find
+    {
+        State state(key_columns);
+        method.init_serialized_keys(key_columns, rows);
+
+        // row 0: key=10, non-null
+        auto r0 = method.find(state, 0);
+        ASSERT_TRUE(r0.is_found());
+        EXPECT_EQ(r0.get_mapped(), make_mapped(1));
+
+        // row 1: null → returns null key data
+        auto r1 = method.find(state, 1);
+        ASSERT_TRUE(r1.is_found());
+        EXPECT_EQ(r1.get_mapped(), make_mapped(999));
+
+        // row 2: key=30, non-null
+        auto r2 = method.find(state, 2);
+        ASSERT_TRUE(r2.is_found());
+        EXPECT_EQ(r2.get_mapped(), make_mapped(3));
+
+        // row 4: key=50, non-null
+        auto r4 = method.find(state, 4);
+        ASSERT_TRUE(r4.is_found());
+        EXPECT_EQ(r4.get_mapped(), make_mapped(5));
+    }
+
+    // for_each_mapped: PHHashMap::for_each_mapped iterates only non-null keys
+    {
+        size_t count = 0;
+        ht.for_each_mapped([&](auto& mapped) { count++; });
+        EXPECT_EQ(count, 3); // keys 10, 30, 50
+    }
+
+    // DataWithNullKey::size() includes null key
+    EXPECT_EQ(ht.size(), 4); // 3 non-null + 1 null
+}
+
+// ========== Nullable MethodStringNoCache ==========
+// AggregatedDataWithNullableShortStringKey = DataWithNullKey<StringHashMap<AggregateDataPtr>>
+TEST(HashTableMethodTest, testNullableMethodStringNoCacheAggInsertFindForEach) {
+    using NullableMethod = MethodSingleNullableColumn<
+            MethodStringNoCache<AggregatedDataWithNullableShortStringKey>>;
+    NullableMethod method;
+    using State = NullableMethod::State;
+
+    // values: {"hello", <null>, "world", <null>}
+    auto col = ColumnHelper::create_nullable_column<DataTypeString>({"hello", "", "world", ""},
+                                                                    {0, 1, 0, 1});
+    ColumnRawPtrs key_columns = {col.get()};
+    const size_t rows = 4;
+
+    // Insert
+    size_t null_create_count = 0;
+    {
+        State state(key_columns);
+        method.init_serialized_keys(key_columns, rows);
+        for (size_t i = 0; i < rows; i++) {
+            method.lazy_emplace(
+                    state, i,
+                    [&](const auto& ctor, auto& key, auto& origin) {
+                        ctor(key, make_mapped(i + 1));
+                    },
+                    [&](auto& mapped) {
+                        null_create_count++;
+                        mapped = make_mapped(888);
+                    });
+        }
+    }
+
+    EXPECT_EQ(null_create_count, 1);
+
+    auto& ht = *method.hash_table;
+    EXPECT_TRUE(ht.has_null_key_data());
+    EXPECT_EQ(ht.get_null_key_data<AggregateDataPtr>(), make_mapped(888));
+
+    // Find
+    {
+        State state(key_columns);
+        method.init_serialized_keys(key_columns, rows);
+
+        // row 0: "hello"
+        auto r0 = method.find(state, 0);
+        ASSERT_TRUE(r0.is_found());
+        EXPECT_EQ(r0.get_mapped(), make_mapped(1));
+
+        // row 1: null
+        auto r1 = method.find(state, 1);
+        ASSERT_TRUE(r1.is_found());
+        EXPECT_EQ(r1.get_mapped(), make_mapped(888));
+
+        // row 2: "world"
+        auto r2 = method.find(state, 2);
+        ASSERT_TRUE(r2.is_found());
+        EXPECT_EQ(r2.get_mapped(), make_mapped(3));
+    }
+
+    // for_each: StringHashMap::for_each iterates only non-null keys
+    {
+        size_t count = 0;
+        ht.for_each([&](const auto& key, auto& mapped) { count++; });
+        EXPECT_EQ(count, 2); // "hello" and "world"
+    }
+
+    // DataWithNullKey::size() includes null key
+    EXPECT_EQ(ht.size(), 3); // 2 non-null + 1 null
+}
+
+// ========== PHHashMap iterator: traverse, sort, verify, assignment ==========
+TEST(HashTableMethodTest, testPHHashMapIterator) {
+    MethodOneNumber<UInt32, AggData<UInt32>> method;
+    using State = MethodOneNumber<UInt32, AggData<UInt32>>::State;
+
+    auto col = ColumnHelper::create_column<DataTypeInt32>({50, 10, 40, 20, 30});
+    ColumnRawPtrs key_columns = {col.get()};
+    const size_t rows = 5;
+
+    State state(key_columns);
+    method.init_serialized_keys(key_columns, rows);
+    for (size_t i = 0; i < rows; i++) {
+        method.lazy_emplace(
+                state, i,
+                [&](const auto& ctor, auto& key, auto& origin) { ctor(key, make_mapped(i + 1)); },
+                [](auto& mapped) { FAIL(); });
+    }
+
+    auto& ht = *method.hash_table;
+
+    // Collect all (key, mapped) pairs via iterator
+    std::vector<std::pair<UInt32, AggregateDataPtr>> entries;
+    for (auto it = ht.begin(); it != ht.end(); ++it) {
+        entries.emplace_back(it->get_first(), it->get_second());
+    }
+    ASSERT_EQ(entries.size(), 5);
+
+    // Sort by key and verify
+    std::sort(entries.begin(), entries.end(),
+              [](const auto& a, const auto& b) { return a.first < b.first; });
+    // Inserted: {50→1, 10→2, 40→3, 20→4, 30→5}
+    EXPECT_EQ(entries[0].first, 10);
+    EXPECT_EQ(entries[0].second, make_mapped(2));
+    EXPECT_EQ(entries[1].first, 20);
+    EXPECT_EQ(entries[1].second, make_mapped(4));
+    EXPECT_EQ(entries[2].first, 30);
+    EXPECT_EQ(entries[2].second, make_mapped(5));
+    EXPECT_EQ(entries[3].first, 40);
+    EXPECT_EQ(entries[3].second, make_mapped(3));
+    EXPECT_EQ(entries[4].first, 50);
+    EXPECT_EQ(entries[4].second, make_mapped(1));
+
+    // Iterator assignment: it = begin(), it2 = it
+    auto it = ht.begin();
+    auto it2 = it; // copy
+    EXPECT_TRUE(it == it2);
+    EXPECT_EQ(it->get_first(), it2->get_first());
+    EXPECT_EQ(it->get_second(), it2->get_second());
+
+    ++it;
+    EXPECT_TRUE(it != it2); // diverged after increment
+
+    it2 = it; // reassignment
+    EXPECT_TRUE(it == it2);
+    EXPECT_EQ(it->get_first(), it2->get_first());
+
+    // Empty hash table: begin == end
+    MethodOneNumber<UInt32, AggData<UInt32>> empty_method;
+    EXPECT_TRUE(empty_method.hash_table->begin() == empty_method.hash_table->end());
+}
+
+// ========== StringHashMap iterator: traverse, sort, verify, assignment ==========
+TEST(HashTableMethodTest, testStringHashMapIterator) {
+    MethodStringNoCache<AggregatedDataWithShortStringKey> method;
+    using State = MethodStringNoCache<AggregatedDataWithShortStringKey>::State;
+
+    // Different lengths to hit different sub-maps (m1: <=8, m2: <=16, m3: <=24, ms: >24)
+    auto col = ColumnHelper::create_column<DataTypeString>(
+            {"z", "ab", "hello_world_12345", "tiny", "a_very_long_string_over_24_chars"});
+    ColumnRawPtrs key_columns = {col.get()};
+    const size_t rows = 5;
+
+    State state(key_columns);
+    method.init_serialized_keys(key_columns, rows);
+    for (size_t i = 0; i < rows; i++) {
+        method.lazy_emplace(
+                state, i,
+                [&](const auto& ctor, auto& key, auto& origin) { ctor(key, make_mapped(i + 1)); },
+                [](auto& mapped) { FAIL(); });
+    }
+
+    auto& ht = *method.hash_table;
+
+    // Collect all (key_string, mapped) pairs via iterator
+    std::vector<std::pair<std::string, AggregateDataPtr>> entries;
+    for (auto it = ht.begin(); it != ht.end(); ++it) {
+        auto key = it->get_key();
+        entries.emplace_back(std::string(key.data, key.size), it->get_second());
+    }
+    ASSERT_EQ(entries.size(), 5);
+
+    // Sort by key string and verify
+    std::sort(entries.begin(), entries.end(),
+              [](const auto& a, const auto& b) { return a.first < b.first; });
+    // Sorted: "a_very_long...", "ab", "hello_world_12345", "tiny", "z"
+    EXPECT_EQ(entries[0].first, "a_very_long_string_over_24_chars");
+    EXPECT_EQ(entries[0].second, make_mapped(5));
+    EXPECT_EQ(entries[1].first, "ab");
+    EXPECT_EQ(entries[1].second, make_mapped(2));
+    EXPECT_EQ(entries[2].first, "hello_world_12345");
+    EXPECT_EQ(entries[2].second, make_mapped(3));
+    EXPECT_EQ(entries[3].first, "tiny");
+    EXPECT_EQ(entries[3].second, make_mapped(4));
+    EXPECT_EQ(entries[4].first, "z");
+    EXPECT_EQ(entries[4].second, make_mapped(1));
+
+    // Iterator assignment: copy and reassign
+    auto it = ht.begin();
+    auto it2 = it;
+    EXPECT_TRUE(it == it2);
+
+    auto key1 = it->get_key();
+    auto key2 = it2->get_key();
+    EXPECT_EQ(StringRef(key1.data, key1.size), StringRef(key2.data, key2.size));
+
+    ++it;
+    EXPECT_TRUE(it != it2);
+
+    it2 = it; // reassignment
+    EXPECT_TRUE(it == it2);
+
+    // Empty StringHashMap: begin == end
+    MethodStringNoCache<AggregatedDataWithShortStringKey> empty_method;
+    EXPECT_TRUE(empty_method.hash_table->begin() == empty_method.hash_table->end());
+}
+
+// ========== DataWithNullKey iterator: only non-null entries, null key accessed separately ==========
+TEST(HashTableMethodTest, testDataWithNullKeyIterator) {
+    using NullableMethod =
+            MethodSingleNullableColumn<MethodOneNumber<UInt32, AggDataNullable<UInt32>>>;
+    NullableMethod method;
+    using State = NullableMethod::State;
+
+    // values: {10, 20, 30}, null at row 1
+    auto col = ColumnHelper::create_nullable_column<DataTypeInt32>({10, 20, 30}, {0, 1, 0});
+    ColumnRawPtrs key_columns = {col.get()};
+    const size_t rows = 3;
+
+    State state(key_columns);
+    method.init_serialized_keys(key_columns, rows);
+    for (size_t i = 0; i < rows; i++) {
+        method.lazy_emplace(
+                state, i,
+                [&](const auto& ctor, auto& key, auto& origin) { ctor(key, make_mapped(i + 1)); },
+                [&](auto& mapped) { mapped = make_mapped(999); });
+    }
+
+    auto& ht = *method.hash_table;
+
+    // Null key is present and must be accessed separately (not via iterator)
+    EXPECT_TRUE(ht.has_null_key_data());
+    EXPECT_EQ(ht.get_null_key_data<AggregateDataPtr>(), make_mapped(999));
+
+    // DataWithNullKey::size() includes null key
+    EXPECT_EQ(ht.size(), 3); // 2 non-null + 1 null
+
+    // Iterator only visits non-null entries
+    std::vector<std::pair<UInt32, AggregateDataPtr>> non_null_entries;
+    for (auto it = ht.begin(); it != ht.end(); ++it) {
+        non_null_entries.emplace_back(it->get_first(), it->get_second());
+    }
+
+    // Only 2 non-null entries in iteration (null key excluded)
+    ASSERT_EQ(non_null_entries.size(), 2);
+    std::sort(non_null_entries.begin(), non_null_entries.end(),
+              [](const auto& a, const auto& b) { return a.first < b.first; });
+    // Inserted: row0=10→1, row2=30→3
+    EXPECT_EQ(non_null_entries[0].first, 10);
+    EXPECT_EQ(non_null_entries[0].second, make_mapped(1));
+    EXPECT_EQ(non_null_entries[1].first, 30);
+    EXPECT_EQ(non_null_entries[1].second, make_mapped(3));
+
+    // Iterator assignment
+    auto it = ht.begin();
+    auto it2 = it;
+    EXPECT_TRUE(it == it2);
+    EXPECT_EQ(it.get_second(), it2.get_second());
+
+    ++it;
+    EXPECT_TRUE(it != it2);
+
+    it2 = it;
+    EXPECT_TRUE(it == it2);
+}
 } // namespace doris::vectorized

--- a/be/test/exec/hash_map/hash_table_method_test.cpp
+++ b/be/test/exec/hash_map/hash_table_method_test.cpp
@@ -17,6 +17,8 @@
 
 #include <gtest/gtest.h>
 
+#include <set>
+
 #include "core/data_type/data_type_number.h"
 #include "exec/common/columns_hashing.h"
 #include "exec/common/hash_table/hash.h"
@@ -125,6 +127,98 @@ TEST(HashTableMethodTest, testMethodStringNoCache) {
 
     test_find(method, {ColumnHelper::create_column<DataTypeString>({"1", "2", "7", "4", "6", "5"})},
               {0, 1, -1, 3, -1, 4});
+}
+
+// Verify that iterating a DataWithNullKey hash map via init_iterator()/begin/end
+// does NOT visit the null key entry. The null key must be accessed separately
+// through has_null_key_data()/get_null_key_data().
+TEST(HashTableMethodTest, testNullableIteratorSkipsNullKey) {
+    using NullableMethod = MethodSingleNullableColumn<MethodOneNumber<
+            UInt32, DataWithNullKey<PHHashMap<UInt32, IColumn::ColumnIndex, HashCRC32<UInt32>>>>>;
+    NullableMethod method;
+
+    // data: {1, 0(null), 2, 0(null), 3}
+    // null_map: {0, 1, 0, 1, 0} — positions 1 and 3 are null
+    auto nullable_col =
+            ColumnHelper::create_nullable_column<DataTypeInt32>({1, 0, 2, 0, 3}, {0, 1, 0, 1, 0});
+
+    // Insert all rows including nulls
+    {
+        using State = typename NullableMethod::State;
+        ColumnRawPtrs key_raw_columns {nullable_col.get()};
+        State state(key_raw_columns);
+        const size_t rows = nullable_col->size();
+        method.init_serialized_keys(key_raw_columns, rows);
+
+        for (size_t i = 0; i < rows; i++) {
+            IColumn::ColumnIndex mapped_value = i;
+            auto creator = [&](const auto& ctor, auto& key, auto& origin) {
+                ctor(key, mapped_value);
+            };
+            auto creator_for_null_key = [&](auto& mapped) { mapped = mapped_value; };
+            method.lazy_emplace(state, i, creator, creator_for_null_key);
+        }
+    }
+
+    // hash_table->size() includes null key: 3 non-null + 1 null = 4
+    EXPECT_EQ(method.hash_table->size(), 4);
+
+    // The underlying hash map (excluding null) has 3 entries
+    EXPECT_TRUE(method.hash_table->has_null_key_data());
+
+    // Iterate via init_iterator — should only visit 3 non-null entries
+    method.init_iterator();
+    size_t iter_count = 0;
+    std::set<IColumn::ColumnIndex> visited_values;
+    auto iter = method.begin;
+    while (iter != method.end) {
+        visited_values.insert(iter.get_second());
+        ++iter;
+        ++iter_count;
+    }
+
+    // Iterator must visit exactly 3 entries (the non-null keys: 1, 2, 3)
+    EXPECT_EQ(iter_count, 3);
+    // Mapped values for non-null rows are 0 (key=1), 2 (key=2), 4 (key=3)
+    EXPECT_TRUE(visited_values.count(0)); // row 0: key=1
+    EXPECT_TRUE(visited_values.count(2)); // row 2: key=2
+    EXPECT_TRUE(visited_values.count(4)); // row 4: key=3
+    // The null key's mapped value (1, from the first null row) must NOT appear in iteration
+    EXPECT_FALSE(visited_values.count(1));
+
+    // Null key must be accessible separately
+    auto null_mapped = method.hash_table->template get_null_key_data<IColumn::ColumnIndex>();
+    EXPECT_EQ(null_mapped, 1); // first null insertion at row 1
+
+    // find should locate null keys correctly
+    {
+        using State = typename NullableMethod::State;
+        // Search: {1, null, 99, 2}
+        auto search_col =
+                ColumnHelper::create_nullable_column<DataTypeInt32>({1, 0, 99, 2}, {0, 1, 0, 0});
+        ColumnRawPtrs key_raw_columns {search_col.get()};
+        State state(key_raw_columns);
+        method.init_serialized_keys(key_raw_columns, 4);
+
+        // key=1 found
+        auto r0 = method.find(state, 0);
+        EXPECT_TRUE(r0.is_found());
+        EXPECT_EQ(r0.get_mapped(), 0);
+
+        // null found
+        auto r1 = method.find(state, 1);
+        EXPECT_TRUE(r1.is_found());
+        EXPECT_EQ(r1.get_mapped(), 1);
+
+        // key=99 not found
+        auto r2 = method.find(state, 2);
+        EXPECT_FALSE(r2.is_found());
+
+        // key=2 found
+        auto r3 = method.find(state, 3);
+        EXPECT_TRUE(r3.is_found());
+        EXPECT_EQ(r3.get_mapped(), 2);
+    }
 }
 
 } // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?

Previously, in the agg operator, we traversed the hashmap via aggregate_data_container. However, this may be a somewhat redundant structure, so we are adding a foreach to iterate over it. This is only a temporary PR for now. In the future, we will add full iterator support (currently, using iterators with some hashmap types fails to compile).


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

