### PR TITLE
[Improvement](scanner) Include open() time in PerScannerRunningTime

### DIFF
--- a/be/src/vec/exec/scan/es_scanner.cpp
+++ b/be/src/vec/exec/scan/es_scanner.cpp
@@ -78,7 +78,7 @@ Status EsScanner::init(RuntimeState* state, const VExprContextSPtrs& conjuncts) 
     return Status::OK();
 }
 
-Status EsScanner::open(RuntimeState* state) {
+Status EsScanner::_open_impl(RuntimeState* state) {
     VLOG_CRITICAL << NEW_SCANNER_TYPE << "::open";
 
     if (nullptr == state) {
@@ -90,7 +90,7 @@ Status EsScanner::open(RuntimeState* state) {
     }
 
     RETURN_IF_CANCELLED(state);
-    RETURN_IF_ERROR(Scanner::open(state));
+    RETURN_IF_ERROR(Scanner::_open_impl(state));
 
     RETURN_IF_ERROR(_es_reader->open());
 

--- a/be/src/vec/exec/scan/es_scanner.h
+++ b/be/src/vec/exec/scan/es_scanner.h
@@ -54,7 +54,7 @@ public:
               const std::map<std::string, std::string>& docvalue_context, bool doc_value_mode,
               RuntimeProfile* profile);
 
-    Status open(RuntimeState* state) override;
+    Status _open_impl(RuntimeState* state) override;
     Status close(RuntimeState* state) override;
     Status init(RuntimeState* state, const VExprContextSPtrs& conjuncts) override;
 

--- a/be/src/vec/exec/scan/file_scanner.cpp
+++ b/be/src/vec/exec/scan/file_scanner.cpp
@@ -379,9 +379,9 @@ void FileScanner::_get_slot_ids(VExpr* expr, std::vector<int>* slot_ids) {
     }
 }
 
-Status FileScanner::open(RuntimeState* state) {
+Status FileScanner::_open_impl(RuntimeState* state) {
     RETURN_IF_CANCELLED(state);
-    RETURN_IF_ERROR(Scanner::open(state));
+    RETURN_IF_ERROR(Scanner::_open_impl(state));
     RETURN_IF_ERROR(_split_source->get_next(&_first_scan_range, &_current_range));
     if (_first_scan_range) {
         RETURN_IF_ERROR(_init_expr_ctxes());

--- a/be/src/vec/exec/scan/file_scanner.h
+++ b/be/src/vec/exec/scan/file_scanner.h
@@ -70,7 +70,7 @@ public:
                 RuntimeProfile* profile, ShardedKVCache* kv_cache,
                 const std::unordered_map<std::string, int>* colname_to_slot_id);
 
-    Status open(RuntimeState* state) override;
+    Status _open_impl(RuntimeState* state) override;
 
     Status close(RuntimeState* state) override;
 

--- a/be/src/vec/exec/scan/jdbc_scanner.cpp
+++ b/be/src/vec/exec/scan/jdbc_scanner.cpp
@@ -101,7 +101,7 @@ Status JdbcScanner::init(RuntimeState* state, const VExprContextSPtrs& conjuncts
     return Status::OK();
 }
 
-Status JdbcScanner::open(RuntimeState* state) {
+Status JdbcScanner::_open_impl(RuntimeState* state) {
     VLOG_CRITICAL << "JdbcScanner::open";
     if (state == nullptr) {
         return Status::InternalError("input pointer is NULL of VJdbcScanNode::open.");
@@ -111,7 +111,7 @@ Status JdbcScanner::open(RuntimeState* state) {
         return Status::InternalError("used before initialize of VJdbcScanNode::open.");
     }
     RETURN_IF_CANCELLED(state);
-    RETURN_IF_ERROR(Scanner::open(state));
+    RETURN_IF_ERROR(Scanner::_open_impl(state));
     RETURN_IF_ERROR(_jdbc_connector->open(state, true));
     RETURN_IF_ERROR(_jdbc_connector->query());
     return Status::OK();

--- a/be/src/vec/exec/scan/jdbc_scanner.h
+++ b/be/src/vec/exec/scan/jdbc_scanner.h
@@ -48,7 +48,7 @@ public:
     JdbcScanner(RuntimeState* state, doris::pipeline::JDBCScanLocalState* parent, int64_t limit,
                 const TupleId& tuple_id, const std::string& query_string,
                 TOdbcTableType::type table_type, bool is_tvf, RuntimeProfile* profile);
-    Status open(RuntimeState* state) override;
+    Status _open_impl(RuntimeState* state) override;
     Status close(RuntimeState* state) override;
 
     Status init(RuntimeState* state, const VExprContextSPtrs& conjuncts) override;

--- a/be/src/vec/exec/scan/meta_scanner.cpp
+++ b/be/src/vec/exec/scan/meta_scanner.cpp
@@ -64,9 +64,9 @@ MetaScanner::MetaScanner(RuntimeState* state, pipeline::ScanLocalStateBase* loca
           _user_identity(user_identity),
           _scan_range(scan_range.scan_range) {}
 
-Status MetaScanner::open(RuntimeState* state) {
+Status MetaScanner::_open_impl(RuntimeState* state) {
     VLOG_CRITICAL << "MetaScanner::open";
-    RETURN_IF_ERROR(Scanner::open(state));
+    RETURN_IF_ERROR(Scanner::_open_impl(state));
     if (_scan_range.meta_scan_range.metadata_type == TMetadataType::ICEBERG) {
         // TODO: refactor this code
         auto reader = IcebergSysTableJniReader::create_unique(_tuple_desc->slots(), state, _profile,

--- a/be/src/vec/exec/scan/meta_scanner.h
+++ b/be/src/vec/exec/scan/meta_scanner.h
@@ -54,7 +54,7 @@ public:
                 const TScanRangeParams& scan_range, int64_t limit, RuntimeProfile* profile,
                 TUserIdentity user_identity);
 
-    Status open(RuntimeState* state) override;
+    Status _open_impl(RuntimeState* state) override;
     Status close(RuntimeState* state) override;
     Status init(RuntimeState* state, const VExprContextSPtrs& conjuncts) override;
 

--- a/be/src/vec/exec/scan/olap_scanner.cpp
+++ b/be/src/vec/exec/scan/olap_scanner.cpp
@@ -306,8 +306,8 @@ Status OlapScanner::prepare() {
     return Status::OK();
 }
 
-Status OlapScanner::open(RuntimeState* state) {
-    RETURN_IF_ERROR(Scanner::open(state));
+Status OlapScanner::_open_impl(RuntimeState* state) {
+    RETURN_IF_ERROR(Scanner::_open_impl(state));
     SCOPED_TIMER(_local_state->cast<pipeline::OlapScanLocalState>()._reader_init_timer);
 
     auto res = _tablet_reader->init(_tablet_reader_params);

--- a/be/src/vec/exec/scan/olap_scanner.h
+++ b/be/src/vec/exec/scan/olap_scanner.h
@@ -75,7 +75,7 @@ public:
 
     Status prepare() override;
 
-    Status open(RuntimeState* state) override;
+    Status _open_impl(RuntimeState* state) override;
 
     Status close(RuntimeState* state) override;
 

--- a/be/src/vec/exec/scan/scanner.h
+++ b/be/src/vec/exec/scan/scanner.h
@@ -79,9 +79,10 @@ public:
         _has_prepared = true;
         return Status::OK();
     }
-    virtual Status open(RuntimeState* state) {
-        _block_avg_bytes = state->batch_size() * 8;
-        return Status::OK();
+
+    Status open(RuntimeState* state) {
+        SCOPED_RAW_TIMER(&_per_scanner_timer);
+        return _open_impl(state);
     }
 
     Status get_block(RuntimeState* state, Block* block, bool* eos);
@@ -99,6 +100,11 @@ public:
     virtual std::string get_current_scan_range_name() { return "not implemented"; }
 
 protected:
+    virtual Status _open_impl(RuntimeState* state) {
+        _block_avg_bytes = state->batch_size() * 8;
+        return Status::OK();
+    }
+
     // Subclass should implement this to return data.
     virtual Status _get_block_impl(RuntimeState* state, Block* block, bool* eof) = 0;
 


### PR DESCRIPTION
Use NVI (Non-Virtual Interface) pattern for Scanner::open(), similar to Scanner::get_block() / _get_block_impl(). Add SCOPED_RAW_TIMER in the base class open() method to include scanner initialization time (ReaderInitTime, BlockReaderBuildHeapInitTimer, etc.) in PerScannerRunningTime profile counter.

This fixes the issue where PerScannerRunningTime showed only microseconds while ReaderInitTime showed several seconds, making the profile misleading.

Changes:
- scanner.h: Change open() to non-virtual NVI, add _open_impl() virtual
- 5 subclasses: Rename open() to _open_impl() and call base::_open_impl() (OlapScanner, FileScanner, MetaScanner, JdbcScanner, EsScanner)

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

