### PR TITLE
[fix](regression) simplify iceberg table cache schema-change checks

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -111,6 +111,7 @@ class Suite implements GroovyInterceptable {
 
     private AmazonS3 s3Client = null
     private FileSystem fs = null
+    private String sparkIcebergContainerNameCache = null
 
     Suite(String name, String group, SuiteContext context, SuiteCluster cluster) {
         this.name = name
@@ -1603,6 +1604,10 @@ class Suite implements GroovyInterceptable {
      * Uses 'docker ps --filter name=spark-iceberg' to find the container.
      */
     private String getSparkIcebergContainerName() {
+        if (!Strings.isNullOrEmpty(sparkIcebergContainerNameCache)) {
+            return sparkIcebergContainerNameCache
+        }
+
         try {
             // Use docker ps with filter to find containers with 'spark-iceberg' in the name
             String command = "docker ps --filter name=spark-iceberg --format {{.Names}}"
@@ -1614,6 +1619,7 @@ class Suite implements GroovyInterceptable {
                 // Get the first matching container
                 String containerName = output.split('\n')[0].trim()
                 if (containerName) {
+                    sparkIcebergContainerNameCache = containerName
                     logger.info("Found spark-iceberg container: ${containerName}".toString())
                     return containerName
                 }
@@ -1666,6 +1672,7 @@ class Suite implements GroovyInterceptable {
     /**
      * Execute multiple Spark SQL statements on the spark-iceberg container.
      * Statements are separated by semicolons.
+     * All statements are executed in one spark-sql process to reduce startup overhead.
      * 
      * Usage:
      *   spark_iceberg_multi '''
@@ -1675,17 +1682,14 @@ class Suite implements GroovyInterceptable {
      *   '''
      */
     List<String> spark_iceberg_multi(String sqlStatements, int timeoutSeconds = 300) {
-        // Split by semicolon and execute each statement
         def statements = sqlStatements.split(';').collect { it.trim() }.findAll { it }
-        def results = []
 
-        for (stmt in statements) {
-            if (stmt) {
-                results << spark_iceberg(stmt, timeoutSeconds)
-            }
+        if (statements.isEmpty()) {
+            return []
         }
 
-        return results
+        String combinedSql = statements.collect { "${it};" }.join(" ")
+        return [spark_iceberg(combinedSql, timeoutSeconds)]
     }
 
     /**

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_table_cache.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_table_cache.groovy
@@ -206,73 +206,9 @@ suite("test_iceberg_table_cache", "p0,external") {
         // ==================== Test 2: Schema Change Operations ====================
         logger.info("========== Test 2: Schema Change Operations ==========")
 
-        // Test 2.1: ADD COLUMN
-        logger.info("--- Test 2.1: External ADD COLUMN ---")
-        spark_iceberg "DROP TABLE IF EXISTS demo.${testDb}.test_add_column"
-        spark_iceberg "CREATE TABLE demo.${testDb}.test_add_column (id INT, name STRING) USING iceberg"
-        spark_iceberg "INSERT INTO demo.${testDb}.test_add_column VALUES (1, 'test')"
-
-        // Cache the schema
-        sql """switch ${catalogWithCache}"""
-        def add_col_desc1 = sql """desc ${testDb}.test_add_column"""
-        logger.info("Initial schema (with cache): ${add_col_desc1}")
-        assertEquals(2, add_col_desc1.size())
-
-        sql """switch ${catalogNoCache}"""
-        def add_col_desc1_nc = sql """desc ${testDb}.test_add_column"""
-        assertEquals(2, add_col_desc1_nc.size())
-
-        // External ADD COLUMN via Spark
-        spark_iceberg "ALTER TABLE demo.${testDb}.test_add_column ADD COLUMN new_col INT"
-
-        // Verify cache behavior
-        sql """switch ${catalogWithCache}"""
-        def add_col_desc2 = sql """desc ${testDb}.test_add_column"""
-        logger.info("After external ADD COLUMN (with cache, no refresh): ${add_col_desc2}")
-        assertEquals(2, add_col_desc2.size())  // Should still see 2 columns
-
-        sql """switch ${catalogNoCache}"""
-        def add_col_desc2_nc = sql """desc ${testDb}.test_add_column"""
-        logger.info("After external ADD COLUMN (no cache): ${add_col_desc2_nc}")
-        assertEquals(3, add_col_desc2_nc.size())  // Should see 3 columns
-
-        sql """switch ${catalogWithCache}"""
-        sql """refresh table ${testDb}.test_add_column"""
-        def add_col_desc3 = sql """desc ${testDb}.test_add_column"""
-        assertEquals(3, add_col_desc3.size())
-
-        // Test 2.2: DROP COLUMN
-        logger.info("--- Test 2.2: External DROP COLUMN ---")
-        spark_iceberg "DROP TABLE IF EXISTS demo.${testDb}.test_drop_column"
-        spark_iceberg "CREATE TABLE demo.${testDb}.test_drop_column (id INT, name STRING, to_drop INT) USING iceberg"
-        spark_iceberg "INSERT INTO demo.${testDb}.test_drop_column VALUES (1, 'test', 100)"
-
-        // Cache the schema
-        sql """switch ${catalogWithCache}"""
-        def drop_col_desc1 = sql """desc ${testDb}.test_drop_column"""
-        assertEquals(3, drop_col_desc1.size())
-
-        // External DROP COLUMN via Spark
-        spark_iceberg "ALTER TABLE demo.${testDb}.test_drop_column DROP COLUMN to_drop"
-
-        // Verify cache behavior
-        sql """switch ${catalogWithCache}"""
-        def drop_col_desc2 = sql """desc ${testDb}.test_drop_column"""
-        logger.info("After external DROP COLUMN (with cache, no refresh): ${drop_col_desc2}")
-        assertEquals(3, drop_col_desc2.size())  // Should still see 3 columns
-
-        sql """switch ${catalogNoCache}"""
-        def drop_col_desc2_nc = sql """desc ${testDb}.test_drop_column"""
-        logger.info("After external DROP COLUMN (no cache): ${drop_col_desc2_nc}")
-        assertEquals(2, drop_col_desc2_nc.size())  // Should see 2 columns
-
-        sql """switch ${catalogWithCache}"""
-        sql """refresh table ${testDb}.test_drop_column"""
-        def drop_col_desc3 = sql """desc ${testDb}.test_drop_column"""
-        assertEquals(2, drop_col_desc3.size())
-
-        // Test 2.3: RENAME COLUMN
-        logger.info("--- Test 2.3: External RENAME COLUMN ---")
+        // Keep representative schema changes only to reduce Spark execution cost.
+        // Test 2.1: RENAME COLUMN
+        logger.info("--- Test 2.1: External RENAME COLUMN ---")
         spark_iceberg "DROP TABLE IF EXISTS demo.${testDb}.test_rename_column"
         spark_iceberg "CREATE TABLE demo.${testDb}.test_rename_column (id INT, old_name STRING) USING iceberg"
         spark_iceberg "INSERT INTO demo.${testDb}.test_rename_column VALUES (1, 'test')"
@@ -302,8 +238,8 @@ suite("test_iceberg_table_cache", "p0,external") {
         def rename_col_desc3 = sql """desc ${testDb}.test_rename_column"""
         assertTrue(rename_col_desc3.toString().contains("new_name"))
 
-        // Test 2.4: ALTER COLUMN TYPE
-        logger.info("--- Test 2.4: External ALTER COLUMN TYPE ---")
+        // Test 2.2: ALTER COLUMN TYPE
+        logger.info("--- Test 2.2: External ALTER COLUMN TYPE ---")
         spark_iceberg "DROP TABLE IF EXISTS demo.${testDb}.test_alter_type"
         spark_iceberg "CREATE TABLE demo.${testDb}.test_alter_type (id INT, value INT) USING iceberg"
         spark_iceberg "INSERT INTO demo.${testDb}.test_alter_type VALUES (1, 100)"

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_table_cache.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_table_cache.groovy
@@ -206,9 +206,45 @@ suite("test_iceberg_table_cache", "p0,external") {
         // ==================== Test 2: Schema Change Operations ====================
         logger.info("========== Test 2: Schema Change Operations ==========")
 
-        // Keep representative schema changes only to reduce Spark execution cost.
-        // Test 2.1: RENAME COLUMN
-        logger.info("--- Test 2.1: External RENAME COLUMN ---")
+        // Keep representative schema changes and one column-count-change case
+        // to reduce Spark execution cost while preserving key coverage.
+        // Test 2.1: ADD COLUMN
+        logger.info("--- Test 2.1: External ADD COLUMN ---")
+        spark_iceberg "DROP TABLE IF EXISTS demo.${testDb}.test_add_column"
+        spark_iceberg "CREATE TABLE demo.${testDb}.test_add_column (id INT, name STRING) USING iceberg"
+        spark_iceberg "INSERT INTO demo.${testDb}.test_add_column VALUES (1, 'test')"
+
+        // Cache the schema
+        sql """switch ${catalogWithCache}"""
+        def add_col_desc1 = sql """desc ${testDb}.test_add_column"""
+        logger.info("Initial schema (with cache): ${add_col_desc1}")
+        assertEquals(2, add_col_desc1.size())
+
+        sql """switch ${catalogNoCache}"""
+        def add_col_desc1_nc = sql """desc ${testDb}.test_add_column"""
+        assertEquals(2, add_col_desc1_nc.size())
+
+        // External ADD COLUMN via Spark
+        spark_iceberg "ALTER TABLE demo.${testDb}.test_add_column ADD COLUMN new_col INT"
+
+        // Verify cache behavior
+        sql """switch ${catalogWithCache}"""
+        def add_col_desc2 = sql """desc ${testDb}.test_add_column"""
+        logger.info("After external ADD COLUMN (with cache, no refresh): ${add_col_desc2}")
+        assertEquals(2, add_col_desc2.size())  // Should still see 2 columns
+
+        sql """switch ${catalogNoCache}"""
+        def add_col_desc2_nc = sql """desc ${testDb}.test_add_column"""
+        logger.info("After external ADD COLUMN (no cache): ${add_col_desc2_nc}")
+        assertEquals(3, add_col_desc2_nc.size())  // Should see 3 columns
+
+        sql """switch ${catalogWithCache}"""
+        sql """refresh table ${testDb}.test_add_column"""
+        def add_col_desc3 = sql """desc ${testDb}.test_add_column"""
+        assertEquals(3, add_col_desc3.size())
+
+        // Test 2.2: RENAME COLUMN
+        logger.info("--- Test 2.2: External RENAME COLUMN ---")
         spark_iceberg "DROP TABLE IF EXISTS demo.${testDb}.test_rename_column"
         spark_iceberg "CREATE TABLE demo.${testDb}.test_rename_column (id INT, old_name STRING) USING iceberg"
         spark_iceberg "INSERT INTO demo.${testDb}.test_rename_column VALUES (1, 'test')"
@@ -238,8 +274,8 @@ suite("test_iceberg_table_cache", "p0,external") {
         def rename_col_desc3 = sql """desc ${testDb}.test_rename_column"""
         assertTrue(rename_col_desc3.toString().contains("new_name"))
 
-        // Test 2.2: ALTER COLUMN TYPE
-        logger.info("--- Test 2.2: External ALTER COLUMN TYPE ---")
+        // Test 2.3: ALTER COLUMN TYPE
+        logger.info("--- Test 2.3: External ALTER COLUMN TYPE ---")
         spark_iceberg "DROP TABLE IF EXISTS demo.${testDb}.test_alter_type"
         spark_iceberg "CREATE TABLE demo.${testDb}.test_alter_type (id INT, value INT) USING iceberg"
         spark_iceberg "INSERT INTO demo.${testDb}.test_alter_type VALUES (1, 100)"

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_table_cache.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_table_cache.groovy
@@ -71,9 +71,11 @@ suite("test_iceberg_table_cache", "p0,external") {
 
         // Test 1.1: INSERT
         logger.info("--- Test 1.1: External INSERT ---")
-        spark_iceberg "DROP TABLE IF EXISTS demo.${testDb}.test_insert"
-        spark_iceberg "CREATE TABLE demo.${testDb}.test_insert (id INT, name STRING) USING iceberg"
-        spark_iceberg "INSERT INTO demo.${testDb}.test_insert VALUES (1, 'initial')"
+        spark_iceberg_multi """
+            DROP TABLE IF EXISTS demo.${testDb}.test_insert;
+            CREATE TABLE demo.${testDb}.test_insert (id INT, name STRING) USING iceberg;
+            INSERT INTO demo.${testDb}.test_insert VALUES (1, 'initial');
+        """
 
         // Query from Doris to cache the data
         sql """switch ${catalogWithCache}"""
@@ -110,9 +112,12 @@ suite("test_iceberg_table_cache", "p0,external") {
 
         // Test 1.2: DELETE
         logger.info("--- Test 1.2: External DELETE ---")
-        spark_iceberg "DROP TABLE IF EXISTS demo.${testDb}.test_delete"
-        spark_iceberg "CREATE TABLE demo.${testDb}.test_delete (id INT, name STRING) USING iceberg TBLPROPERTIES ('format-version'='2')"
-        spark_iceberg "INSERT INTO demo.${testDb}.test_delete VALUES (1, 'row1'), (2, 'row2'), (3, 'row3')"
+        spark_iceberg_multi """
+            DROP TABLE IF EXISTS demo.${testDb}.test_delete;
+            CREATE TABLE demo.${testDb}.test_delete (id INT, name STRING) USING iceberg
+                TBLPROPERTIES ('format-version'='2');
+            INSERT INTO demo.${testDb}.test_delete VALUES (1, 'row1'), (2, 'row2'), (3, 'row3');
+        """
 
         // Cache the data
         sql """switch ${catalogWithCache}"""
@@ -144,9 +149,12 @@ suite("test_iceberg_table_cache", "p0,external") {
 
         // Test 1.3: UPDATE
         logger.info("--- Test 1.3: External UPDATE ---")
-        spark_iceberg "DROP TABLE IF EXISTS demo.${testDb}.test_update"
-        spark_iceberg "CREATE TABLE demo.${testDb}.test_update (id INT, value INT) USING iceberg TBLPROPERTIES ('format-version'='2')"
-        spark_iceberg "INSERT INTO demo.${testDb}.test_update VALUES (1, 100), (2, 200)"
+        spark_iceberg_multi """
+            DROP TABLE IF EXISTS demo.${testDb}.test_update;
+            CREATE TABLE demo.${testDb}.test_update (id INT, value INT) USING iceberg
+                TBLPROPERTIES ('format-version'='2');
+            INSERT INTO demo.${testDb}.test_update VALUES (1, 100), (2, 200);
+        """
 
         // Cache the data
         sql """switch ${catalogWithCache}"""
@@ -175,9 +183,11 @@ suite("test_iceberg_table_cache", "p0,external") {
 
         // Test 1.4: INSERT OVERWRITE
         logger.info("--- Test 1.4: External INSERT OVERWRITE ---")
-        spark_iceberg "DROP TABLE IF EXISTS demo.${testDb}.test_overwrite"
-        spark_iceberg "CREATE TABLE demo.${testDb}.test_overwrite (id INT, name STRING) USING iceberg"
-        spark_iceberg "INSERT INTO demo.${testDb}.test_overwrite VALUES (1, 'old1'), (2, 'old2')"
+        spark_iceberg_multi """
+            DROP TABLE IF EXISTS demo.${testDb}.test_overwrite;
+            CREATE TABLE demo.${testDb}.test_overwrite (id INT, name STRING) USING iceberg;
+            INSERT INTO demo.${testDb}.test_overwrite VALUES (1, 'old1'), (2, 'old2');
+        """
 
         // Cache the data
         sql """switch ${catalogWithCache}"""
@@ -210,9 +220,11 @@ suite("test_iceberg_table_cache", "p0,external") {
         // to reduce Spark execution cost while preserving key coverage.
         // Test 2.1: ADD COLUMN
         logger.info("--- Test 2.1: External ADD COLUMN ---")
-        spark_iceberg "DROP TABLE IF EXISTS demo.${testDb}.test_add_column"
-        spark_iceberg "CREATE TABLE demo.${testDb}.test_add_column (id INT, name STRING) USING iceberg"
-        spark_iceberg "INSERT INTO demo.${testDb}.test_add_column VALUES (1, 'test')"
+        spark_iceberg_multi """
+            DROP TABLE IF EXISTS demo.${testDb}.test_add_column;
+            CREATE TABLE demo.${testDb}.test_add_column (id INT, name STRING) USING iceberg;
+            INSERT INTO demo.${testDb}.test_add_column VALUES (1, 'test');
+        """
 
         // Cache the schema
         sql """switch ${catalogWithCache}"""
@@ -245,9 +257,11 @@ suite("test_iceberg_table_cache", "p0,external") {
 
         // Test 2.2: RENAME COLUMN
         logger.info("--- Test 2.2: External RENAME COLUMN ---")
-        spark_iceberg "DROP TABLE IF EXISTS demo.${testDb}.test_rename_column"
-        spark_iceberg "CREATE TABLE demo.${testDb}.test_rename_column (id INT, old_name STRING) USING iceberg"
-        spark_iceberg "INSERT INTO demo.${testDb}.test_rename_column VALUES (1, 'test')"
+        spark_iceberg_multi """
+            DROP TABLE IF EXISTS demo.${testDb}.test_rename_column;
+            CREATE TABLE demo.${testDb}.test_rename_column (id INT, old_name STRING) USING iceberg;
+            INSERT INTO demo.${testDb}.test_rename_column VALUES (1, 'test');
+        """
 
         // Cache the schema
         sql """switch ${catalogWithCache}"""
@@ -276,9 +290,11 @@ suite("test_iceberg_table_cache", "p0,external") {
 
         // Test 2.3: ALTER COLUMN TYPE
         logger.info("--- Test 2.3: External ALTER COLUMN TYPE ---")
-        spark_iceberg "DROP TABLE IF EXISTS demo.${testDb}.test_alter_type"
-        spark_iceberg "CREATE TABLE demo.${testDb}.test_alter_type (id INT, value INT) USING iceberg"
-        spark_iceberg "INSERT INTO demo.${testDb}.test_alter_type VALUES (1, 100)"
+        spark_iceberg_multi """
+            DROP TABLE IF EXISTS demo.${testDb}.test_alter_type;
+            CREATE TABLE demo.${testDb}.test_alter_type (id INT, value INT) USING iceberg;
+            INSERT INTO demo.${testDb}.test_alter_type VALUES (1, 100);
+        """
 
         // Cache the schema
         sql """switch ${catalogWithCache}"""
@@ -311,20 +327,22 @@ suite("test_iceberg_table_cache", "p0,external") {
 
         // Test 3.1: ADD PARTITION FIELD
         logger.info("--- Test 3.1: External ADD PARTITION FIELD ---")
-        spark_iceberg "DROP TABLE IF EXISTS demo.${testDb}.test_add_partition"
-        spark_iceberg "CREATE TABLE demo.${testDb}.test_add_partition (id INT, dt DATE, value INT) USING iceberg"
-        spark_iceberg "INSERT INTO demo.${testDb}.test_add_partition VALUES (1, DATE'2024-01-15', 100)"
+        spark_iceberg_multi """
+            DROP TABLE IF EXISTS demo.${testDb}.test_add_partition;
+            CREATE TABLE demo.${testDb}.test_add_partition (id INT, dt DATE, value INT) USING iceberg;
+            INSERT INTO demo.${testDb}.test_add_partition VALUES (1, DATE'2024-01-15', 100);
+        """
 
         // Cache the partition spec by querying data (show partitions is not supported for Iceberg tables)
         sql """switch ${catalogWithCache}"""
         def add_part_result_initial = sql """select count(*) from ${testDb}.test_add_partition"""
         logger.info("Initial data count (with cache): ${add_part_result_initial}")
 
-        // External ADD PARTITION FIELD via Spark
-        spark_iceberg "ALTER TABLE demo.${testDb}.test_add_partition ADD PARTITION FIELD month(dt)"
-
-        // Insert data after partition evolution
-        spark_iceberg "INSERT INTO demo.${testDb}.test_add_partition VALUES (2, DATE'2024-02-20', 200)"
+        // External ADD PARTITION FIELD via Spark and insert evolved data
+        spark_iceberg_multi """
+            ALTER TABLE demo.${testDb}.test_add_partition ADD PARTITION FIELD month(dt);
+            INSERT INTO demo.${testDb}.test_add_partition VALUES (2, DATE'2024-02-20', 200);
+        """
 
         // Verify cache behavior - check data count as partition spec is harder to verify directly
         sql """switch ${catalogWithCache}"""
@@ -344,20 +362,23 @@ suite("test_iceberg_table_cache", "p0,external") {
 
         // Test 3.2: DROP PARTITION FIELD
         logger.info("--- Test 3.2: External DROP PARTITION FIELD ---")
-        spark_iceberg "DROP TABLE IF EXISTS demo.${testDb}.test_drop_partition"
-        spark_iceberg "CREATE TABLE demo.${testDb}.test_drop_partition (id INT, category STRING, value INT) USING iceberg PARTITIONED BY (category)"
-        spark_iceberg "INSERT INTO demo.${testDb}.test_drop_partition VALUES (1, 'A', 100), (2, 'B', 200)"
+        spark_iceberg_multi """
+            DROP TABLE IF EXISTS demo.${testDb}.test_drop_partition;
+            CREATE TABLE demo.${testDb}.test_drop_partition (id INT, category STRING, value INT)
+                USING iceberg PARTITIONED BY (category);
+            INSERT INTO demo.${testDb}.test_drop_partition VALUES (1, 'A', 100), (2, 'B', 200);
+        """
 
         // Cache the partition spec
         sql """switch ${catalogWithCache}"""
         def drop_part_result1 = sql """select * from ${testDb}.test_drop_partition order by id"""
         assertEquals(2, drop_part_result1.size())
 
-        // External DROP PARTITION FIELD via Spark
-        spark_iceberg "ALTER TABLE demo.${testDb}.test_drop_partition DROP PARTITION FIELD category"
-
-        // Insert data after partition evolution
-        spark_iceberg "INSERT INTO demo.${testDb}.test_drop_partition VALUES (3, 'C', 300)"
+        // External DROP PARTITION FIELD via Spark and insert evolved data
+        spark_iceberg_multi """
+            ALTER TABLE demo.${testDb}.test_drop_partition DROP PARTITION FIELD category;
+            INSERT INTO demo.${testDb}.test_drop_partition VALUES (3, 'C', 300);
+        """
 
         // Verify cache behavior
         sql """switch ${catalogWithCache}"""
@@ -377,20 +398,26 @@ suite("test_iceberg_table_cache", "p0,external") {
 
         // Test 3.3: REPLACE PARTITION FIELD
         logger.info("--- Test 3.3: External REPLACE PARTITION FIELD ---")
-        spark_iceberg "DROP TABLE IF EXISTS demo.${testDb}.test_replace_partition"
-        spark_iceberg "CREATE TABLE demo.${testDb}.test_replace_partition (id INT, ts TIMESTAMP, value INT) USING iceberg PARTITIONED BY (days(ts))"
-        spark_iceberg "INSERT INTO demo.${testDb}.test_replace_partition VALUES (1, TIMESTAMP'2024-01-15 10:00:00', 100)"
+        spark_iceberg_multi """
+            DROP TABLE IF EXISTS demo.${testDb}.test_replace_partition;
+            CREATE TABLE demo.${testDb}.test_replace_partition (id INT, ts TIMESTAMP, value INT)
+                USING iceberg PARTITIONED BY (days(ts));
+            INSERT INTO demo.${testDb}.test_replace_partition VALUES
+                (1, TIMESTAMP'2024-01-15 10:00:00', 100);
+        """
 
         // Cache the partition spec
         sql """switch ${catalogWithCache}"""
         def replace_part_result1 = sql """select * from ${testDb}.test_replace_partition order by id"""
         assertEquals(1, replace_part_result1.size())
 
-        // External REPLACE PARTITION FIELD via Spark (days -> months)
-        spark_iceberg "ALTER TABLE demo.${testDb}.test_replace_partition REPLACE PARTITION FIELD days(ts) WITH months(ts)"
-
-        // Insert data after partition evolution
-        spark_iceberg "INSERT INTO demo.${testDb}.test_replace_partition VALUES (2, TIMESTAMP'2024-02-20 15:00:00', 200)"
+        // External REPLACE PARTITION FIELD via Spark (days -> months) and insert evolved data
+        spark_iceberg_multi """
+            ALTER TABLE demo.${testDb}.test_replace_partition
+                REPLACE PARTITION FIELD days(ts) WITH months(ts);
+            INSERT INTO demo.${testDb}.test_replace_partition VALUES
+                (2, TIMESTAMP'2024-02-20 15:00:00', 200);
+        """
 
         // Verify cache behavior
         sql """switch ${catalogWithCache}"""


### PR DESCRIPTION
## Summary
- simplify schema-change section in `test_iceberg_table_cache`
- keep `ADD COLUMN`, `RENAME COLUMN`, `ALTER COLUMN TYPE`
- remove `DROP COLUMN` subcase to reduce heavy external Spark calls

## Why
- keep key schema-cache coverage (including column-count increase path)
- reduce externregression runtime with a moderate cut instead of removing all column add/drop checks

## Impact
- `spark_iceberg` calls reduced from 48 to about 44 in this case

## Test
- not run in local environment (pipeline validation expected)

## Update (follow-up optimization)
- cache spark-iceberg container name in framework to avoid repeated `docker ps`
- execute `spark_iceberg_multi` statements in a single `spark-sql` process
- batch setup/evolution Spark SQL in `test_iceberg_table_cache` with `spark_iceberg_multi`

### Runtime result
- in externregression, this case is now reduced by about **3-4 minutes** (observed in pipeline runs)
- estimated Spark-side invocation count in this case is reduced from about 44 to about 21 after this follow-up
