### PR TITLE
[Feat](tvf)Query AUTHENTICATION_INTEGRATIONS

### DIFF
--- a/be/src/exec/scan/meta_scanner.cpp
+++ b/be/src/exec/scan/meta_scanner.cpp
@@ -264,6 +264,10 @@ Status MetaScanner::_fetch_metadata(const TMetaScanRange& meta_scan_range) {
     case TMetadataType::CATALOGS:
         RETURN_IF_ERROR(_build_catalogs_metadata_request(meta_scan_range, &request));
         break;
+    case TMetadataType::AUTHENTICATION_INTEGRATIONS:
+        RETURN_IF_ERROR(
+                _build_authentication_integrations_metadata_request(meta_scan_range, &request));
+        break;
     case TMetadataType::MATERIALIZED_VIEWS:
         RETURN_IF_ERROR(_build_materialized_views_metadata_request(meta_scan_range, &request));
         break;
@@ -415,6 +419,20 @@ Status MetaScanner::_build_catalogs_metadata_request(const TMetaScanRange& meta_
     // create TMetadataTableRequestParams
     TMetadataTableRequestParams metadata_table_params;
     metadata_table_params.__set_metadata_type(TMetadataType::CATALOGS);
+    metadata_table_params.__set_current_user_ident(_user_identity);
+
+    request->__set_metada_table_params(metadata_table_params);
+    return Status::OK();
+}
+
+Status MetaScanner::_build_authentication_integrations_metadata_request(
+        const TMetaScanRange& meta_scan_range, TFetchSchemaTableDataRequest* request) {
+    VLOG_CRITICAL << "MetaScanner::_build_authentication_integrations_metadata_request";
+
+    request->__set_schema_table_name(TSchemaTableName::METADATA_TABLE);
+
+    TMetadataTableRequestParams metadata_table_params;
+    metadata_table_params.__set_metadata_type(TMetadataType::AUTHENTICATION_INTEGRATIONS);
     metadata_table_params.__set_current_user_ident(_user_identity);
 
     request->__set_metada_table_params(metadata_table_params);

--- a/be/src/exec/scan/meta_scanner.h
+++ b/be/src/exec/scan/meta_scanner.h
@@ -76,6 +76,8 @@ private:
                                                          TFetchSchemaTableDataRequest* request);
     Status _build_catalogs_metadata_request(const TMetaScanRange& meta_scan_range,
                                             TFetchSchemaTableDataRequest* request);
+    Status _build_authentication_integrations_metadata_request(
+            const TMetaScanRange& meta_scan_range, TFetchSchemaTableDataRequest* request);
     Status _build_materialized_views_metadata_request(const TMetaScanRange& meta_scan_range,
                                                       TFetchSchemaTableDataRequest* request);
     Status _build_partitions_metadata_request(const TMetaScanRange& meta_scan_range,

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinTableValuedFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinTableValuedFunctions.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.catalog;
 
+import org.apache.doris.nereids.trees.expressions.functions.table.AuthenticationIntegrations;
 import org.apache.doris.nereids.trees.expressions.functions.table.Backends;
 import org.apache.doris.nereids.trees.expressions.functions.table.Catalogs;
 import org.apache.doris.nereids.trees.expressions.functions.table.File;
@@ -53,6 +54,7 @@ import com.google.common.collect.ImmutableList;
 public class BuiltinTableValuedFunctions implements FunctionHelper {
     public final ImmutableList<TableValuedFunc> tableValuedFunctions = ImmutableList.of(
             tableValued(Backends.class, "backends"),
+            tableValued(AuthenticationIntegrations.class, "authentication_integrations"),
             tableValued(Catalogs.class, "catalogs"),
             tableValued(Frontends.class, "frontends"),
             tableValued(FrontendsDisks.class, "frontends_disks"),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/table/AuthenticationIntegrations.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/table/AuthenticationIntegrations.java
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.expressions.functions.table;
+
+import org.apache.doris.catalog.FunctionSignature;
+import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.trees.expressions.Properties;
+import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
+import org.apache.doris.nereids.types.coercion.AnyDataType;
+import org.apache.doris.tablefunction.AuthenticationIntegrationsTableValuedFunction;
+import org.apache.doris.tablefunction.TableValuedFunctionIf;
+
+import java.util.Map;
+
+/** authentication_integrations */
+public class AuthenticationIntegrations extends TableValuedFunction {
+    public AuthenticationIntegrations(Properties properties) {
+        super("authentication_integrations", properties);
+    }
+
+    @Override
+    public FunctionSignature customSignature() {
+        return FunctionSignature.of(AnyDataType.INSTANCE_WITHOUT_INDEX, getArgumentsTypes());
+    }
+
+    @Override
+    protected TableValuedFunctionIf toCatalogFunction() {
+        try {
+            Map<String, String> arguments = getTVFProperties().getMap();
+            return new AuthenticationIntegrationsTableValuedFunction(arguments);
+        } catch (Throwable t) {
+            throw new AnalysisException("Can not build AuthenticationIntegrationsTableValuedFunction by "
+                    + this + ": " + t.getMessage(), t);
+        }
+    }
+
+    @Override
+    public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
+        return visitor.visitAuthenticationIntegrations(this, context);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/TableValuedFunctionVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/TableValuedFunctionVisitor.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.trees.expressions.visitor;
 
+import org.apache.doris.nereids.trees.expressions.functions.table.AuthenticationIntegrations;
 import org.apache.doris.nereids.trees.expressions.functions.table.Backends;
 import org.apache.doris.nereids.trees.expressions.functions.table.Catalogs;
 import org.apache.doris.nereids.trees.expressions.functions.table.File;
@@ -46,6 +47,10 @@ public interface TableValuedFunctionVisitor<R, C> {
 
     default R visitBackends(Backends backends, C context) {
         return visitTableValuedFunction(backends, context);
+    }
+
+    default R visitAuthenticationIntegrations(AuthenticationIntegrations authenticationIntegrations, C context) {
+        return visitTableValuedFunction(authenticationIntegrations, context);
     }
 
     default R visitCatalogs(Catalogs catalogs, C context) {

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/AuthenticationIntegrationsTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/AuthenticationIntegrationsTableValuedFunction.java
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.tablefunction;
+
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.thrift.TMetaScanRange;
+import org.apache.doris.thrift.TMetadataType;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The implement of table valued function
+ * authentication_integrations().
+ */
+public class AuthenticationIntegrationsTableValuedFunction extends MetadataTableValuedFunction {
+    public static final String NAME = "authentication_integrations";
+
+    private static final ImmutableList<Column> SCHEMA = ImmutableList.of(
+            new Column("IntegrationName", ScalarType.createStringType()),
+            new Column("Type", ScalarType.createStringType()),
+            new Column("Property", ScalarType.createStringType()),
+            new Column("Value", ScalarType.createStringType()),
+            new Column("Comment", ScalarType.createType(PrimitiveType.STRING))
+    );
+
+    private static final ImmutableMap<String, Integer> COLUMN_TO_INDEX;
+
+    static {
+        ImmutableMap.Builder<String, Integer> builder = new ImmutableMap.Builder();
+        for (int i = 0; i < SCHEMA.size(); i++) {
+            builder.put(SCHEMA.get(i).getName().toLowerCase(), i);
+        }
+        COLUMN_TO_INDEX = builder.build();
+    }
+
+    public AuthenticationIntegrationsTableValuedFunction(Map<String, String> params) throws AnalysisException {
+        if (params.size() != 0) {
+            throw new AnalysisException("authentication_integrations table-valued-function does not support any "
+                    + "params");
+        }
+    }
+
+    public static Integer getColumnIndexFromColumnName(String columnName) {
+        return COLUMN_TO_INDEX.get(columnName.toLowerCase());
+    }
+
+    @Override
+    public String getTableName() {
+        return "AuthenticationIntegrationsTableValuedFunction";
+    }
+
+    @Override
+    public List<Column> getTableColumns() {
+        return SCHEMA;
+    }
+
+    @Override
+    public TMetadataType getMetadataType() {
+        return TMetadataType.AUTHENTICATION_INTEGRATIONS;
+    }
+
+    @Override
+    public TMetaScanRange getMetaScanRange(List<String> requiredFileds) {
+        TMetaScanRange metaScanRange = new TMetaScanRange();
+        metaScanRange.setMetadataType(TMetadataType.AUTHENTICATION_INTEGRATIONS);
+        return metaScanRange;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/AuthenticationIntegrationsTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/AuthenticationIntegrationsTableValuedFunction.java
@@ -18,7 +18,6 @@
 package org.apache.doris.tablefunction;
 
 import org.apache.doris.catalog.Column;
-import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.thrift.TMetaScanRange;
@@ -26,6 +25,7 @@ import org.apache.doris.thrift.TMetadataType;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.commons.collections4.MapUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -42,13 +42,13 @@ public class AuthenticationIntegrationsTableValuedFunction extends MetadataTable
             new Column("Type", ScalarType.createStringType()),
             new Column("Property", ScalarType.createStringType()),
             new Column("Value", ScalarType.createStringType()),
-            new Column("Comment", ScalarType.createType(PrimitiveType.STRING))
+            new Column("Comment", ScalarType.createStringType())
     );
 
     private static final ImmutableMap<String, Integer> COLUMN_TO_INDEX;
 
     static {
-        ImmutableMap.Builder<String, Integer> builder = new ImmutableMap.Builder();
+        ImmutableMap.Builder<String, Integer> builder = new ImmutableMap.Builder<String, Integer>();
         for (int i = 0; i < SCHEMA.size(); i++) {
             builder.put(SCHEMA.get(i).getName().toLowerCase(), i);
         }
@@ -56,7 +56,7 @@ public class AuthenticationIntegrationsTableValuedFunction extends MetadataTable
     }
 
     public AuthenticationIntegrationsTableValuedFunction(Map<String, String> params) throws AnalysisException {
-        if (params.size() != 0) {
+        if (MapUtils.isNotEmpty(params)) {
             throw new AnalysisException("authentication_integrations table-valued-function does not support any "
                     + "params");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
@@ -18,6 +18,7 @@
 package org.apache.doris.tablefunction;
 
 import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.authentication.AuthenticationIntegrationMeta;
 import org.apache.doris.blockrule.SqlBlockRule;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DataProperty;
@@ -43,12 +44,14 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.catalog.View;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ClientPool;
+import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.proc.FrontendsProcNode;
 import org.apache.doris.common.proc.PartitionsProcDir;
 import org.apache.doris.common.profile.RuntimeProfile;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.NetUtils;
+import org.apache.doris.common.util.PrintableMap;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.CatalogIf;
@@ -129,7 +132,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
@@ -265,6 +270,9 @@ public class MetadataGenerator {
                 break;
             case CATALOGS:
                 result = catalogsMetadataResult(params);
+                break;
+            case AUTHENTICATION_INTEGRATIONS:
+                result = authenticationIntegrationsMetadataResult(params);
                 break;
             case MATERIALIZED_VIEWS:
                 result = mtmvMetadataResult(params);
@@ -603,6 +611,68 @@ public class MetadataGenerator {
         result.setDataBatch(dataBatch);
         result.setStatus(new TStatus(TStatusCode.OK));
         return result;
+    }
+
+    private static TFetchSchemaTableDataResult authenticationIntegrationsMetadataResult(
+            TMetadataTableRequestParams params) {
+        if (!params.isSetCurrentUserIdent()) {
+            return errorResult("current user ident is not set.");
+        }
+
+        UserIdentity currentUserIdentity = UserIdentity.fromThrift(params.getCurrentUserIdent());
+        if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(currentUserIdentity, PrivPredicate.ADMIN)) {
+            return errorResult(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR.formatErrorMsg("ADMIN"));
+        }
+
+        TFetchSchemaTableDataResult result = new TFetchSchemaTableDataResult();
+        List<TRow> dataBatch = Lists.newArrayList();
+
+        Map<String, AuthenticationIntegrationMeta> integrationMap = new TreeMap<>(
+                Env.getCurrentEnv().getAuthenticationIntegrationMgr().getAuthenticationIntegrations());
+        for (AuthenticationIntegrationMeta integrationMeta : integrationMap.values()) {
+            String comment = Strings.nullToEmpty(integrationMeta.getComment());
+            TRow trow = new TRow();
+            trow.addToColumnValue(new TCell().setStringVal(integrationMeta.getName()));
+            trow.addToColumnValue(new TCell().setStringVal(integrationMeta.getType()));
+
+            Map<String, String> properties = new TreeMap<>(integrationMeta.getProperties());
+            for (Map.Entry<String, String> entry : properties.entrySet()) {
+                TRow subTrow = new TRow(trow);
+                subTrow.addToColumnValue(new TCell().setStringVal(entry.getKey()));
+                subTrow.addToColumnValue(new TCell().setStringVal(
+                        maskAuthenticationIntegrationPropertyValue(entry.getKey(), entry.getValue())));
+                subTrow.addToColumnValue(new TCell().setStringVal(comment));
+                dataBatch.add(subTrow);
+            }
+            if (properties.isEmpty()) {
+                trow.addToColumnValue(new TCell().setStringVal("NULL"));
+                trow.addToColumnValue(new TCell().setStringVal("NULL"));
+                trow.addToColumnValue(new TCell().setStringVal(comment));
+                dataBatch.add(trow);
+            }
+        }
+
+        result.setDataBatch(dataBatch);
+        result.setStatus(new TStatus(TStatusCode.OK));
+        return result;
+    }
+
+    private static String maskAuthenticationIntegrationPropertyValue(String key, String value) {
+        if (isSensitiveAuthenticationIntegrationKey(key)) {
+            return PrintableMap.PASSWORD_MASK;
+        }
+        return Strings.nullToEmpty(value);
+    }
+
+    private static boolean isSensitiveAuthenticationIntegrationKey(String key) {
+        if (PrintableMap.SENSITIVE_KEY.contains(key)) {
+            return true;
+        }
+        String normalized = key.toLowerCase(Locale.ROOT);
+        return normalized.contains("password")
+                || normalized.contains("secret")
+                || normalized.contains("token")
+                || normalized.contains("keytab");
     }
 
     private static TFetchSchemaTableDataResult workloadGroupsMetadataResult(TSchemaTableRequestParams params) {

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataTableValuedFunction.java
@@ -45,6 +45,8 @@ public abstract class MetadataTableValuedFunction extends TableValuedFunctionIf 
                 return HudiTableValuedFunction.getColumnIndexFromColumnName(columnName);
             case CATALOGS:
                 return CatalogsTableValuedFunction.getColumnIndexFromColumnName(columnName);
+            case AUTHENTICATION_INTEGRATIONS:
+                return AuthenticationIntegrationsTableValuedFunction.getColumnIndexFromColumnName(columnName);
             case MATERIALIZED_VIEWS:
                 return MvInfosTableValuedFunction.getColumnIndexFromColumnName(columnName);
             case PARTITIONS:

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/TableValuedFunctionIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/TableValuedFunctionIf.java
@@ -69,6 +69,8 @@ public abstract class TableValuedFunctionIf {
                 return new FrontendsDisksTableValuedFunction(params);
             case CatalogsTableValuedFunction.NAME:
                 return new CatalogsTableValuedFunction(params);
+            case AuthenticationIntegrationsTableValuedFunction.NAME:
+                return new AuthenticationIntegrationsTableValuedFunction(params);
             case MvInfosTableValuedFunction.NAME:
                 return new MvInfosTableValuedFunction(params);
             case PartitionsTableValuedFunction.NAME:

--- a/fe/fe-core/src/test/java/org/apache/doris/tablefunction/AuthenticationIntegrationsMetadataGeneratorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/tablefunction/AuthenticationIntegrationsMetadataGeneratorTest.java
@@ -1,0 +1,145 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.tablefunction;
+
+import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.authentication.AuthenticationIntegrationMeta;
+import org.apache.doris.authentication.AuthenticationIntegrationMgr;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.util.PrintableMap;
+import org.apache.doris.mysql.privilege.AccessControllerManager;
+import org.apache.doris.mysql.privilege.PrivPredicate;
+import org.apache.doris.thrift.TFetchSchemaTableDataRequest;
+import org.apache.doris.thrift.TFetchSchemaTableDataResult;
+import org.apache.doris.thrift.TMetadataTableRequestParams;
+import org.apache.doris.thrift.TMetadataType;
+import org.apache.doris.thrift.TSchemaTableName;
+import org.apache.doris.thrift.TStatusCode;
+
+import com.google.common.collect.ImmutableMap;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class AuthenticationIntegrationsMetadataGeneratorTest {
+
+    @Mocked
+    private Env env;
+
+    @Mocked
+    private AccessControllerManager accessManager;
+
+    @Mocked
+    private AuthenticationIntegrationMgr authenticationIntegrationMgr;
+
+    @Test
+    public void testAuthenticationIntegrationsMetadataResultWithMasking() throws Exception {
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put("ldap.server", "ldap://127.0.0.1:389");
+        properties.put("ldap.admin_password", "plain-text-pwd");
+        AuthenticationIntegrationMeta meta =
+                new AuthenticationIntegrationMeta("corp_ldap", "ldap", properties, "ldap integration");
+        Map<String, AuthenticationIntegrationMeta> integrationMap = ImmutableMap.of("corp_ldap", meta);
+
+        new Expectations() {
+            {
+                Env.getCurrentEnv();
+                minTimes = 0;
+                result = env;
+
+                env.getAccessManager();
+                minTimes = 0;
+                result = accessManager;
+
+                accessManager.checkGlobalPriv((UserIdentity) any, PrivPredicate.ADMIN);
+                minTimes = 0;
+                result = true;
+
+                env.getAuthenticationIntegrationMgr();
+                minTimes = 0;
+                result = authenticationIntegrationMgr;
+
+                authenticationIntegrationMgr.getAuthenticationIntegrations();
+                minTimes = 0;
+                result = integrationMap;
+            }
+        };
+
+        TFetchSchemaTableDataResult result = MetadataGenerator.getMetadataTable(buildRequest());
+        Assertions.assertEquals(TStatusCode.OK, result.getStatus().getStatusCode());
+        Assertions.assertEquals(2, result.getDataBatchSize());
+
+        Map<String, String> propertyToValue = new HashMap<>();
+        for (int i = 0; i < result.getDataBatchSize(); i++) {
+            String integrationName = result.getDataBatch().get(i).getColumnValue().get(0).getStringVal();
+            String type = result.getDataBatch().get(i).getColumnValue().get(1).getStringVal();
+            String property = result.getDataBatch().get(i).getColumnValue().get(2).getStringVal();
+            String value = result.getDataBatch().get(i).getColumnValue().get(3).getStringVal();
+            String comment = result.getDataBatch().get(i).getColumnValue().get(4).getStringVal();
+
+            Assertions.assertEquals("corp_ldap", integrationName);
+            Assertions.assertEquals("ldap", type);
+            Assertions.assertEquals("ldap integration", comment);
+            propertyToValue.put(property, value);
+        }
+
+        Assertions.assertEquals("ldap://127.0.0.1:389", propertyToValue.get("ldap.server"));
+        Assertions.assertEquals(PrintableMap.PASSWORD_MASK, propertyToValue.get("ldap.admin_password"));
+    }
+
+    @Test
+    public void testAuthenticationIntegrationsMetadataResultDenied() throws Exception {
+        new Expectations() {
+            {
+                Env.getCurrentEnv();
+                minTimes = 0;
+                result = env;
+
+                env.getAccessManager();
+                minTimes = 0;
+                result = accessManager;
+
+                accessManager.checkGlobalPriv((UserIdentity) any, PrivPredicate.ADMIN);
+                minTimes = 0;
+                result = false;
+            }
+        };
+
+        TFetchSchemaTableDataResult result = MetadataGenerator.getMetadataTable(buildRequest());
+        Assertions.assertEquals(TStatusCode.INTERNAL_ERROR, result.getStatus().getStatusCode());
+        Assertions.assertTrue(result.getStatus().getErrorMsgs().get(0).contains("ADMIN"));
+    }
+
+    private TFetchSchemaTableDataRequest buildRequest() {
+        TFetchSchemaTableDataRequest request = new TFetchSchemaTableDataRequest();
+        request.setSchemaTableName(TSchemaTableName.METADATA_TABLE);
+
+        TMetadataTableRequestParams params = new TMetadataTableRequestParams();
+        params.setMetadataType(TMetadataType.AUTHENTICATION_INTEGRATIONS);
+        params.setCurrentUserIdent(UserIdentity.ROOT.toThrift());
+        params.setColumnsName(Arrays.asList("integrationname", "type", "property", "value", "comment"));
+        request.setMetadaTableParams(params);
+        return request;
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/tablefunction/AuthenticationIntegrationsTableValuedFunctionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/tablefunction/AuthenticationIntegrationsTableValuedFunctionTest.java
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.tablefunction;
+
+import org.apache.doris.catalog.Column;
+import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.thrift.TMetadataType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+public class AuthenticationIntegrationsTableValuedFunctionTest {
+
+    @Test
+    public void testBasicMetadata() throws Exception {
+        AuthenticationIntegrationsTableValuedFunction tvf =
+                new AuthenticationIntegrationsTableValuedFunction(Collections.emptyMap());
+
+        Assertions.assertEquals(TMetadataType.AUTHENTICATION_INTEGRATIONS, tvf.getMetadataType());
+
+        List<Column> columns = tvf.getTableColumns();
+        Assertions.assertEquals(5, columns.size());
+        Assertions.assertEquals("IntegrationName", columns.get(0).getName());
+        Assertions.assertEquals("Type", columns.get(1).getName());
+        Assertions.assertEquals("Property", columns.get(2).getName());
+        Assertions.assertEquals("Value", columns.get(3).getName());
+        Assertions.assertEquals("Comment", columns.get(4).getName());
+
+        Assertions.assertEquals(0,
+                AuthenticationIntegrationsTableValuedFunction.getColumnIndexFromColumnName("integrationname"));
+        Assertions.assertEquals(1,
+                AuthenticationIntegrationsTableValuedFunction.getColumnIndexFromColumnName("type"));
+        Assertions.assertEquals(2,
+                AuthenticationIntegrationsTableValuedFunction.getColumnIndexFromColumnName("property"));
+        Assertions.assertEquals(3,
+                AuthenticationIntegrationsTableValuedFunction.getColumnIndexFromColumnName("value"));
+        Assertions.assertEquals(4,
+                AuthenticationIntegrationsTableValuedFunction.getColumnIndexFromColumnName("comment"));
+    }
+
+    @Test
+    public void testRejectUnsupportedParams() {
+        HashMap<String, String> params = new HashMap<>();
+        params.put("k", "v");
+        Assertions.assertThrows(AnalysisException.class,
+                () -> new AuthenticationIntegrationsTableValuedFunction(params));
+    }
+}

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -758,6 +758,7 @@ enum TMetadataType {
   HUDI = 11,
   PAIMON = 12,
   PARQUET = 13,
+  AUTHENTICATION_INTEGRATIONS = 14,
 }
 
 // deprecated

--- a/regression-test/suites/auth_p0/test_authentication_integration_auth.groovy
+++ b/regression-test/suites/auth_p0/test_authentication_integration_auth.groovy
@@ -18,8 +18,11 @@
 suite("test_authentication_integration_auth", "p0,auth") {
     String suiteName = "test_authentication_integration_auth"
     String integrationName = "${suiteName}_ldap"
+    String user = "${suiteName}_user"
+    String pwd = 'C123_567p'
 
     try_sql("DROP AUTHENTICATION INTEGRATION IF EXISTS ${integrationName}")
+    try_sql("DROP USER ${user}")
 
     try {
         test {
@@ -39,6 +42,25 @@ suite("test_authentication_integration_auth", "p0,auth") {
             )
             COMMENT 'for regression test'
         """
+
+        def typeRes = sql """
+            SELECT Type
+            FROM authentication_integrations()
+            WHERE IntegrationName = '${integrationName}'
+            ORDER BY Type
+            LIMIT 1
+        """
+        assertTrue(typeRes.size() == 1)
+        assertTrue(typeRes[0][0] == "ldap")
+
+        def maskedRes = sql """
+            SELECT Value
+            FROM authentication_integrations()
+            WHERE IntegrationName = '${integrationName}' AND Property = 'ldap.admin_password'
+            ORDER BY Property
+        """
+        assertTrue(maskedRes.size() == 1)
+        assertTrue(maskedRes[0][0] == "*XXX")
 
         test {
             sql """
@@ -66,6 +88,35 @@ suite("test_authentication_integration_auth", "p0,auth") {
 
         sql """ALTER AUTHENTICATION INTEGRATION ${integrationName} SET COMMENT 'updated comment'"""
 
+        def updatedRes = sql """
+            SELECT Value, Comment
+            FROM authentication_integrations()
+            WHERE IntegrationName = '${integrationName}' AND Property = 'ldap.server'
+            ORDER BY Property
+        """
+        assertTrue(updatedRes.size() == 1)
+        assertTrue(updatedRes[0][0] == "ldap://127.0.0.1:1389")
+        assertTrue(updatedRes[0][1] == "updated comment")
+
+        sql """CREATE USER '${user}' IDENTIFIED BY '${pwd}'"""
+
+        // cloud-mode
+        if (isCloudMode()) {
+            def clusters = sql " SHOW CLUSTERS; "
+            assertTrue(!clusters.isEmpty())
+            def validCluster = clusters[0][0]
+            sql """GRANT USAGE_PRIV ON CLUSTER `${validCluster}` TO ${user}""";
+        }
+
+        sql """grant select_priv on regression_test to ${user}"""
+
+        connect(user, "${pwd}", context.config.jdbcUrl) {
+            test {
+                sql """SELECT * FROM authentication_integrations()"""
+                exception "denied"
+            }
+        }
+
         test {
             sql """DROP AUTHENTICATION INTEGRATION ${integrationName}_not_exist"""
             exception "does not exist"
@@ -73,6 +124,7 @@ suite("test_authentication_integration_auth", "p0,auth") {
 
         sql """DROP AUTHENTICATION INTEGRATION IF EXISTS ${integrationName}_not_exist"""
     } finally {
+        try_sql("DROP USER ${user}")
         try_sql("DROP AUTHENTICATION INTEGRATION IF EXISTS ${integrationName}")
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?
、

### Example SQL

  Doris supports creating and managing authentication integrations, but there is
  no table-valued function to inspect them in a queryable form.

  This PR adds a new metadata TVF: `authentication_integrations()`.

  It allows users to query authentication integration metadata through SQL,
  which makes it easier to inspect and verify current configurations.

  The current output columns are:

  - IntegrationName
  - Type
  - Property
  - Value
  - Comment

  Each property of an authentication integration is returned as one row.
```

  Create an authentication integration:
  ```sql
  CREATE AUTHENTICATION INTEGRATION test_ldap
  PROPERTIES (
      "type" = "ldap",
      "ldap.server" = "ldap://127.0.0.1:389",
      "ldap.base_dn" = "dc=example,dc=com",
      "ldap.bind_root_dn" = "cn=admin,dc=example,dc=com",
      "ldap.admin_password" = "123456"
  )
  COMMENT "ldap integration for test";

  Query all authentication integrations:

  SELECT * FROM authentication_integrations();

  Query one integration:

  SELECT *
  FROM authentication_integrations()
  WHERE IntegrationName = 'test_ldap'
  ORDER BY Property;

  Query selected fields:

  SELECT IntegrationName, Type, Property, Value, Comment
  FROM authentication_integrations()
  WHERE IntegrationName = 'test_ldap'
  ORDER BY Property;

  Alter and query again:

  ALTER AUTHENTICATION INTEGRATION test_ldap
  SET COMMENT 'updated comment';

  SELECT Property, Value, Comment
  FROM authentication_integrations()
  WHERE IntegrationName = 'test_ldap'
  ORDER BY Property;

```