### PR TITLE
Using Flink 1.20.3, starting sql-client.sh throws 'Failed to start th…

### DIFF
--- a/samples/datalake/iceberg_and_paimon/data/flink-conf/flink-conf.yaml
+++ b/samples/datalake/iceberg_and_paimon/data/flink-conf/flink-conf.yaml
@@ -204,6 +204,19 @@ rest.address: 0.0.0.0
 #
 rest.bind-address: 0.0.0.0
 
+#==============================================================================
+# SQL Gateway (Flink 1.20+)
+#==============================================================================
+
+# In Flink 1.20+, sql-client.sh starts an embedded SQL Gateway. Without an
+# explicit port, the gateway inherits rest.bind-port (default 8081) which is
+# already occupied by the JobManager's REST endpoint, causing a BindException:
+#   "Could not start rest endpoint on any port in port range 8081"
+#
+# Setting sql-gateway.endpoint.rest.port to a dedicated port avoids this
+# conflict. Use 0 for a random available port, or specify a fixed port.
+sql-gateway.endpoint.rest.port: 9091
+
 # Flag to specify whether job submission is enabled from the web-based
 # runtime monitor. Uncomment to disable.
 


### PR DESCRIPTION
…e embedded sql-gateway' error

### What problem does this PR solve?

Issue Number: close #60983

Related PR: None

Problem Summary:
在 Flink 1.20+ 中，`sql-client.sh` 的行为发生了重大变更：不再直接连接 JobManager
的 REST 端点，而是在本地启动一个嵌入式 SQL Gateway。该嵌入式网关在未显式配置
`sql-gateway.endpoint.rest.port` 时，会继承全局的 `rest.bind-port`（默认 8081）
作为自己的 REST 端口。
由于 JobManager 的 REST 端点已经占用了 8081，嵌入式 SQL Gateway 尝试绑定同一端口时
就会抛出以下异常：
java.net.BindException: Could not start rest endpoint on any port in port range 8081 at org.apache.flink.runtime.rest.RestServerEndpoint.start at org.apache.flink.table.gateway.SqlGateway.start

**修复方案：**
在 `samples/datalake/iceberg_and_paimon/data/flink-conf/flink-conf.yaml` 中新增
`sql-gateway.endpoint.rest.port: 9091`，为嵌入式 SQL Gateway 指定一个独立端口，
使其与 JobManager REST 端口（8081）隔离，避免端口冲突。

### Release note
When using Flink 1.20+ with `sql-client.sh`, add `sql-gateway.endpoint.rest.port`
configuration to avoid port conflict with JobManager's REST endpoint.

### Check List (For Author)
- Test
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - No runtime logic changed; only a configuration sample file is updated.
- Behavior changed:
    - [x] No.
- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

