### PR TITLE
[opt](insert) Make insert error message max length configurable

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3863,6 +3863,16 @@ public class Config extends ConfigBase {
     })
     public static int first_error_msg_max_length = 256;
 
+    @ConfField(mutable = true, description = {
+        "Insert 操作失败时，返回给客户端的错误信息的最大长度，默认 1024 字节。"
+                + "错误信息超过该长度会被截断。增大该值有助于在写入失败时保留完整的诊断信息。",
+        "The maximum length of the error message returned to client when insert operation fails, default is 1024 bytes."
+                + " Error messages exceeding this length will be truncated."
+                + " Increasing this value helps preserve complete diagnostic information"
+                + " when writing to tables fails."
+    })
+    public static int insert_error_msg_max_length = 1024;
+
     @ConfField
     public static String cloud_snapshot_handler_class = "org.apache.doris.cloud.snapshot.CloudSnapshotHandler";
     @ConfField

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertUtils.java
@@ -716,7 +716,7 @@ public class InsertUtils {
      * @return the final truncated error message
      */
     public static String getFinalErrorMsg(String msg, String firstErrorMsg, String url) {
-        int maxTotalBytes = 512;
+        int maxTotalBytes = Config.insert_error_msg_max_length;
 
         // For test
         // 1. error msg length > 512, we will truncate it first to make sure the URL

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertUtilsTest.java
@@ -17,7 +17,10 @@
 
 package org.apache.doris.nereids.trees.plans.commands.insert;
 
+import org.apache.doris.common.Config;
+
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -26,6 +29,12 @@ import org.junit.jupiter.api.Test;
 public class InsertUtilsTest {
 
     private static final int MAX_TOTAL_BYTES = 512;
+
+    @BeforeEach
+    public void setUp() {
+        // Use 512 to keep existing test assertions consistent
+        Config.insert_error_msg_max_length = MAX_TOTAL_BYTES;
+    }
 
     private String generateString(int length) {
         return generateString(length, "X");


### PR DESCRIPTION
### What problem does this PR solve?

Add a new FE config 'insert_error_msg_max_length' (default 1024) to control the maximum length of error messages returned to the client when insert operations fail.

Previously, the limit was hard-coded to 512 bytes in InsertUtils.getFinalErrorMsg(), which often truncated important diagnostic information (e.g., column names, partition details) in external table errors such as MaxCompute write failures.

The new config is mutable at runtime, allowing users to increase the limit if needed for better error diagnostics.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

