### PR TITLE
[fix](inverted index) fix data race in AnalysisFactoryMgr causing std::bad_function_call crash

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index/analysis_factory_mgr.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index/analysis_factory_mgr.cpp
@@ -94,9 +94,7 @@ void AnalysisFactoryMgr::registerFactory(const std::string& name, FactoryCreator
 template <typename FactoryType>
 std::shared_ptr<FactoryType> AnalysisFactoryMgr::create(const std::string& name,
                                                         const Settings& params) {
-    if (registry_.empty()) {
-        initialise();
-    }
+    initialise();
 
     RegistryKey key = {std::type_index(typeid(FactoryType)), name};
     auto it = registry_.find(key);

--- a/be/test/olap/rowset/segment_v2/inverted_index/analysis_factory_mgr_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index/analysis_factory_mgr_test.cpp
@@ -19,6 +19,10 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <thread>
+#include <vector>
+
 #include "olap/rowset/segment_v2/inverted_index/char_filter/char_filter_factory.h"
 #include "olap/rowset/segment_v2/inverted_index/char_filter/empty_char_filter_factory.h"
 #include "olap/rowset/segment_v2/inverted_index/token_filter/empty_token_filter_factory.h"
@@ -244,6 +248,46 @@ TEST_F(AnalysisFactoryMgrTest, TypeSafetyForDifferentFactoryTypes) {
     EXPECT_THROW(AnalysisFactoryMgr::instance().create<TokenFilterFactory>("char_replace",
                                                                            empty_settings),
                  Exception);
+}
+
+TEST_F(AnalysisFactoryMgrTest, ConcurrentCreateIsThreadSafe) {
+    constexpr int kNumThreads = 16;
+    constexpr int kIterationsPerThread = 100;
+
+    std::vector<std::thread> threads;
+    std::atomic<int> success_count {0};
+    std::atomic<int> failure_count {0};
+
+    for (int i = 0; i < kNumThreads; ++i) {
+        threads.emplace_back([&]() {
+            Settings empty_settings;
+            std::vector<std::string> tokenizer_names = {"standard", "keyword", "basic", "icu"};
+            std::vector<std::string> filter_names = {"lowercase", "asciifolding"};
+
+            for (int j = 0; j < kIterationsPerThread; ++j) {
+                try {
+                    auto tk = AnalysisFactoryMgr::instance().create<TokenizerFactory>(
+                            tokenizer_names[j % tokenizer_names.size()], empty_settings);
+                    ASSERT_NE(tk, nullptr);
+
+                    auto tf = AnalysisFactoryMgr::instance().create<TokenFilterFactory>(
+                            filter_names[j % filter_names.size()], empty_settings);
+                    ASSERT_NE(tf, nullptr);
+
+                    success_count.fetch_add(1, std::memory_order_relaxed);
+                } catch (...) {
+                    failure_count.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_EQ(failure_count.load(), 0) << "Concurrent create() should not throw any exceptions";
+    EXPECT_EQ(success_count.load(), kNumThreads * kIterationsPerThread);
 }
 
 } // namespace doris::segment_v2::inverted_index


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

What problem does this PR solve?
Fix std::bad_function_call crash caused by data race in AnalysisFactoryMgr::create().

Root Cause
In AnalysisFactoryMgr::create(), the registry_.empty() check was performed outside std::call_once without any synchronization. When multiple flush threads concurrently called create(), one thread could be inserting into the std::map inside call_once, while another thread saw the map as non-empty, skipped initialise(), and read a partially-constructed std::function entry — resulting in std::bad_function_call.

Fix
Remove the unsafe registry_.empty() fast-path check and always call initialise(). std::call_once guarantees thread safety and has negligible overhead (single atomic read) after initialization.

Testing
Added ConcurrentCreateIsThreadSafe unit test: 16 threads × 100 iterations concurrently calling create().

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

