### PR TITLE
[fix](fe) add column_data_sizes to BackendPartitionedSchemaScanNode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/BackendPartitionedSchemaScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/BackendPartitionedSchemaScanNode.java
@@ -75,6 +75,8 @@ public class BackendPartitionedSchemaScanNode extends SchemaScanNode {
 
         BACKEND_TABLE.add("backend_tablets");
         BACKEND_TABLE.add("backend_configuration");
+
+        BACKEND_TABLE.add("column_data_sizes");
     }
 
     public static boolean isBackendPartitionedSchemaTable(String tableName) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
The `information_schema.column_data_sizes` table is used to query column data size information across all BEs. However, when querying this table, only data from one BE is returned instead of all BEs. This is because the column_data_sizes table was not added to the BACKEND_TABLE in `BackendPartitionedSchemaScanNode`, causing the `PhysicalPlanTranslator` to use the default SchemaScanNode instead of BackendPartitionedSchemaScanNode.

fix:
Add column_data_sizes to BACKEND_TABLE in BackendPartitionedSchemaScanNode. This allows PhysicalPlanTranslator's `visitPhysicalSchemaScan` method to use BackendPartitionedSchemaScanNode instead of the default SchemaScanNode when querying the column_data_sizes table, enabling queries to return data from all BEs.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason <!-- Add your reason?  -->(This change only affects scenarios with multiple BEs. It is difficult to test in regression tests or unit tests. The fix has been verified manually.)

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

