### PR TITLE
[opt](cloud) Enable compaction on new tablets during schema change queuing

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -211,7 +211,8 @@ void AgentServer::cloud_start_workers(CloudStorageEngine& engine, ExecEnv* exec_
 
     _workers[TTaskType::ALTER] = std::make_unique<TaskWorkerPool>(
             "ALTER_TABLE", config::alter_tablet_worker_count,
-            [&engine](auto&& task) { return alter_cloud_tablet_callback(engine, task); });
+            [&engine](auto&& task) { return alter_cloud_tablet_callback(engine, task); },
+            [&engine](auto&& task) { set_alter_version_before_enqueue(engine, task); });
 
     _workers[TTaskType::CALCULATE_DELETE_BITMAP] = std::make_unique<TaskWorkerPool>(
             "CALC_DBM_TASK", config::calc_delete_bitmap_worker_count,

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -524,9 +524,11 @@ bvar::Adder<uint64_t> report_index_policy_failed("report", "index_policy_failed"
 
 } // namespace
 
-TaskWorkerPool::TaskWorkerPool(std::string_view name, int worker_count,
-                               std::function<void(const TAgentTaskRequest& task)> callback)
-        : _callback(std::move(callback)) {
+TaskWorkerPool::TaskWorkerPool(
+        std::string_view name, int worker_count,
+        std::function<void(const TAgentTaskRequest& task)> callback,
+        std::function<void(const TAgentTaskRequest& task)> pre_submit_callback)
+        : _callback(std::move(callback)), _pre_submit_callback(std::move(pre_submit_callback)) {
     auto st = ThreadPoolBuilder(fmt::format("TaskWP_{}", name))
                       .set_min_threads(worker_count)
                       .set_max_threads(worker_count)
@@ -550,6 +552,9 @@ void TaskWorkerPool::stop() {
 
 Status TaskWorkerPool::submit_task(const TAgentTaskRequest& task) {
     return _submit_task(task, [this](auto&& task) {
+        if (_pre_submit_callback) {
+            _pre_submit_callback(task);
+        }
         add_task_count(task, 1);
         return _thread_pool->submit_func([this, task]() {
             _callback(task);
@@ -2238,7 +2243,46 @@ void alter_cloud_tablet_callback(CloudStorageEngine& engine, const TAgentTaskReq
                           std::chrono::system_clock::now().time_since_epoch())
                           .count();
     g_fragment_last_active_time.set_value(now);
+
+    // Clean up alter_version before remove_task_info to avoid race:
+    // remove_task_info allows same-signature re-submit, whose pre_submit_callback
+    // would set alter_version, then this cleanup would wipe it.
+    if (req.__isset.alter_tablet_req_v2) {
+        const auto& alter_req = req.alter_tablet_req_v2;
+        auto new_tablet = engine.tablet_mgr().get_tablet(alter_req.new_tablet_id);
+        auto base_tablet = engine.tablet_mgr().get_tablet(alter_req.base_tablet_id);
+        if (new_tablet.has_value()) {
+            new_tablet.value()->set_alter_version(-1);
+        }
+        if (base_tablet.has_value()) {
+            base_tablet.value()->set_alter_version(-1);
+        }
+    }
+
     remove_task_info(req.task_type, req.signature);
+}
+
+void set_alter_version_before_enqueue(CloudStorageEngine& engine, const TAgentTaskRequest& req) {
+    if (!req.__isset.alter_tablet_req_v2) {
+        return;
+    }
+    const auto& alter_req = req.alter_tablet_req_v2;
+    if (alter_req.alter_version <= 1) {
+        return;
+    }
+    auto new_tablet = engine.tablet_mgr().get_tablet(alter_req.new_tablet_id);
+    if (!new_tablet.has_value() || new_tablet.value()->tablet_state() == TABLET_RUNNING) {
+        return;
+    }
+    auto base_tablet = engine.tablet_mgr().get_tablet(alter_req.base_tablet_id);
+    if (!base_tablet.has_value()) {
+        return;
+    }
+    new_tablet.value()->set_alter_version(alter_req.alter_version);
+    base_tablet.value()->set_alter_version(alter_req.alter_version);
+    LOG(INFO) << "set alter_version=" << alter_req.alter_version
+              << " before enqueue, base_tablet=" << alter_req.base_tablet_id
+              << ", new_tablet=" << alter_req.new_tablet_id;
 }
 
 void gc_binlog_callback(StorageEngine& engine, const TAgentTaskRequest& req) {

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -50,7 +50,8 @@ public:
 class TaskWorkerPool : public TaskWorkerPoolIf {
 public:
     TaskWorkerPool(std::string_view name, int worker_count,
-                   std::function<void(const TAgentTaskRequest&)> callback);
+                   std::function<void(const TAgentTaskRequest&)> callback,
+                   std::function<void(const TAgentTaskRequest&)> pre_submit_callback = nullptr);
 
     ~TaskWorkerPool() override;
 
@@ -62,6 +63,7 @@ protected:
     std::atomic_bool _stopped {false};
     std::unique_ptr<ThreadPool> _thread_pool;
     std::function<void(const TAgentTaskRequest&)> _callback;
+    std::function<void(const TAgentTaskRequest&)> _pre_submit_callback;
 };
 
 class PublishVersionWorkerPool final : public TaskWorkerPool {
@@ -179,6 +181,8 @@ void update_tablet_meta_callback(StorageEngine& engine, const TAgentTaskRequest&
 void alter_tablet_callback(StorageEngine& engine, const TAgentTaskRequest& req);
 
 void alter_cloud_tablet_callback(CloudStorageEngine& engine, const TAgentTaskRequest& req);
+
+void set_alter_version_before_enqueue(CloudStorageEngine& engine, const TAgentTaskRequest& req);
 
 void clone_callback(StorageEngine& engine, const ClusterInfo* cluster_info,
                     const TAgentTaskRequest& req);

--- a/be/src/cloud/cloud_cumulative_compaction.cpp
+++ b/be/src/cloud/cloud_cumulative_compaction.cpp
@@ -292,6 +292,22 @@ Status CloudCumulativeCompaction::modify_rowsets() {
         LOG(INFO) << "CloudCumulativeCompaction::modify_rowsets.enable_spin_wait, exit";
     });
 
+    // Block only NOTREADY tablets (SC new tablets) before compaction commit.
+    // RUNNING tablets (system tables, base tablets) are not affected.
+    DBUG_EXECUTE_IF("CloudCumulativeCompaction::modify_rowsets.block_notready", {
+        if (_tablet->tablet_state() == TABLET_NOTREADY) {
+            LOG(INFO) << "block NOTREADY tablet compaction before commit"
+                      << ", tablet_id=" << _tablet->tablet_id() << ", output=["
+                      << _input_rowsets.front()->start_version() << "-"
+                      << _input_rowsets.back()->end_version() << "]";
+            while (DebugPoints::instance()->is_enable(
+                    "CloudCumulativeCompaction::modify_rowsets.block_notready")) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            }
+            LOG(INFO) << "release NOTREADY tablet compaction, tablet_id=" << _tablet->tablet_id();
+        }
+    });
+
     DeleteBitmapPtr output_rowset_delete_bitmap = nullptr;
     int64_t initiator = this->initiator();
     int64_t get_delete_bitmap_lock_start_time = 0;

--- a/be/src/cloud/cloud_schema_change_job.cpp
+++ b/be/src/cloud/cloud_schema_change_job.cpp
@@ -111,6 +111,13 @@ Status CloudSchemaChangeJob::process_alter_tablet(const TAlterTabletReqV2& reque
     _output_cumulative_point = _base_tablet->cumulative_layer_point();
     std::vector<RowSetSplits> rs_splits;
     int64_t base_max_version = _base_tablet->max_version_unlocked();
+    DBUG_EXECUTE_IF("CloudSchemaChangeJob::process_alter_tablet.override_base_max_version", {
+        auto v = dp->param<int64_t>("version", -1);
+        if (v > 0) {
+            LOG(INFO) << "override base_max_version from " << base_max_version << " to " << v;
+            base_max_version = v;
+        }
+    });
     cloud::TabletJobInfoPB job;
     auto* idx = job.mutable_idx();
     idx->set_tablet_id(_base_tablet->tablet_id());
@@ -148,6 +155,32 @@ Status CloudSchemaChangeJob::process_alter_tablet(const TAlterTabletReqV2& reque
         LOG(WARNING) << "inject error. res=" << res;
         return res;
     });
+
+    // Check for cross-V1 compaction rowsets on new tablet.
+    // During queue wait, compaction may have committed a rowset that crosses the
+    // alter_version boundary (V1). This happens when compaction commits before
+    // prepare_tablet_job registers the SC job in meta-service.
+    // If such a rowset exists, SC commit would create version overlap, so we
+    // fail early and let FE retry (with a higher V1 next time).
+    {
+        RETURN_IF_ERROR(_new_tablet->sync_rowsets());
+        std::shared_lock rlock(_new_tablet->get_header_lock());
+        for (auto& [v, rs] : _new_tablet->rowset_map()) {
+            if (v.first > 1 && v.first <= start_resp.alter_version() &&
+                v.second > start_resp.alter_version()) {
+                LOG(WARNING) << "cross-V1 compaction detected on new tablet"
+                             << ", tablet_id=" << _new_tablet->tablet_id() << ", rowset=["
+                             << v.first << "-" << v.second << "]"
+                             << ", alter_version=" << start_resp.alter_version()
+                             << ", job_id=" << _job_id << ". Will retry with higher alter_version.";
+                return Status::Error<ErrorCode::INTERNAL_ERROR>(
+                        "cross-V1 compaction detected on new tablet, tablet_id={}, "
+                        "rowset=[{}-{}], alter_version={}",
+                        _new_tablet->tablet_id(), v.first, v.second, start_resp.alter_version());
+            }
+        }
+    }
+
     if (request.alter_version > 1) {
         // [0-1] is a placeholder rowset, no need to convert
         RETURN_IF_ERROR(_base_tablet->capture_rs_readers({2, start_resp.alter_version()},
@@ -156,6 +189,10 @@ Status CloudSchemaChangeJob::process_alter_tablet(const TAlterTabletReqV2& reque
                                                           .enable_prefer_cached_rowset = false,
                                                           .query_freshness_tolerance_ms = -1}));
     }
+    // Between prepare_tablet_job (SC job registered in meta-service) and
+    // set_alter_version (local alter_version update). Used to test cross-V1 race.
+    DBUG_EXECUTE_IF("CloudSchemaChangeJob::process_alter_tablet.after_prepare_job", DBUG_BLOCK);
+
     Defer defer2 {[&]() {
         _new_tablet->set_alter_version(-1);
         _base_tablet->set_alter_version(-1);

--- a/be/test/agent/task_worker_pool_test.cpp
+++ b/be/test/agent/task_worker_pool_test.cpp
@@ -54,6 +54,31 @@ TEST(TaskWorkerPoolTest, TaskWorkerPool) {
     EXPECT_EQ(count.load(), 2);
 }
 
+TEST(TaskWorkerPoolTest, PreSubmitCallback) {
+    std::atomic_int callback_count {0};
+    std::atomic_int pre_submit_count {0};
+    TaskWorkerPool workers(
+            "test", 1,
+            [&](auto&& task) {
+                std::this_thread::sleep_for(200ms);
+                ++callback_count;
+            },
+            [&](auto&& task) { ++pre_submit_count; });
+
+    TAgentTaskRequest task;
+    task.__set_signature(-1);
+    auto _ = workers.submit_task(task);
+    _ = workers.submit_task(task);
+
+    // pre_submit_callback is called synchronously before enqueue
+    EXPECT_EQ(pre_submit_count.load(), 2);
+
+    std::this_thread::sleep_for(600ms);
+    workers.stop();
+    EXPECT_EQ(callback_count.load(), 2);
+    EXPECT_EQ(pre_submit_count.load(), 2);
+}
+
 TEST(TaskWorkerPoolTest, PriorTaskWorkerPool) {
     std::atomic_int normal_count {0};
     std::atomic_int high_prior_count {0};

--- a/be/test/agent/task_worker_pool_test.cpp
+++ b/be/test/agent/task_worker_pool_test.cpp
@@ -79,6 +79,30 @@ TEST(TaskWorkerPoolTest, PreSubmitCallback) {
     EXPECT_EQ(pre_submit_count.load(), 2);
 }
 
+TEST(TaskWorkerPoolTest, PreSubmitCallbackWithDedup) {
+    std::atomic_int pre_submit_count {0};
+    std::atomic_int callback_count {0};
+    TaskWorkerPool workers(
+            "test", 1,
+            [&](auto&& task) {
+                std::this_thread::sleep_for(500ms);
+                ++callback_count;
+            },
+            [&](auto&& task) { ++pre_submit_count; });
+
+    TAgentTaskRequest task;
+    task.__set_task_type(TTaskType::ALTER);
+    task.__set_signature(12345);
+    auto _ = workers.submit_task(task);
+    _ = workers.submit_task(task); // Should be deduped by register_task_info
+
+    EXPECT_EQ(pre_submit_count.load(), 1); // Only called once, second was deduped
+
+    std::this_thread::sleep_for(600ms);
+    workers.stop();
+    EXPECT_EQ(callback_count.load(), 1);
+}
+
 TEST(TaskWorkerPoolTest, PriorTaskWorkerPool) {
     std::atomic_int normal_count {0};
     std::atomic_int high_prior_count {0};

--- a/regression-test/suites/cloud_p1/schema_change/compaction_optimization/test_sc_compaction_cross_v1_race.groovy
+++ b/regression-test/suites/cloud_p1/schema_change/compaction_optimization/test_sc_compaction_cross_v1_race.groovy
@@ -1,0 +1,136 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Test: Reproduce cross-V1 compaction race that causes BE crash.
+//
+// Timeline:
+//   SC blocked → compaction commits [5-10] on new tablet → SC runs with V1=6 (override)
+//   → SC commit replaces [2,6] but [5-10] not deleted (crosses V1) → version overlap → BE crash
+//
+// This simulates the multi-BE scenario where the SC-executing BE has a stale
+// base tablet version, causing V1 to be lower than compaction output max.
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_sc_compaction_cross_v1_race', 'docker') {
+
+    def options = new ClusterOptions()
+    options.cloudMode = true
+    options.enableDebugPoints()
+    options.beConfigs += ["enable_java_support=false"]
+    options.beConfigs += ["enable_new_tablet_do_compaction=true"]
+    options.beConfigs += ["alter_tablet_worker_count=1"]
+    options.beConfigs += ["cumulative_compaction_min_deltas=2"]
+    options.beNum = 1
+
+    docker(options) {
+        def tableName = "sc_cross_v1_test"
+
+        def getJobState = { tbl ->
+            def result = sql """SHOW ALTER TABLE COLUMN WHERE IndexName='${tbl}' ORDER BY createtime DESC LIMIT 1"""
+            logger.info("getJobState: ${result}")
+            return result[0][9]
+        }
+
+        sql "DROP TABLE IF EXISTS ${tableName}"
+        sql """
+            CREATE TABLE ${tableName} (
+                k1 int NOT NULL,
+                v1 varchar(100) NOT NULL,
+                v2 int NOT NULL
+            )
+            DISTRIBUTED BY HASH(k1) BUCKETS 1
+            PROPERTIES (
+                "replication_num" = "1"
+            )
+        """
+
+        // Phase 1: Insert initial data (versions 2, 3, 4)
+        for (int i = 0; i < 3; i++) {
+            StringBuilder sb = new StringBuilder()
+            sb.append("INSERT INTO ${tableName} VALUES ")
+            for (int j = 0; j < 20; j++) {
+                if (j > 0) sb.append(", ")
+                def key = i * 20 + j + 1
+                sb.append("(${key}, 'val_${key}', ${key * 10})")
+            }
+            sql sb.toString()
+        }
+        assertEquals(60L, (sql "SELECT count(*) FROM ${tableName}")[0][0])
+
+        // Phase 2: Block SC at entry, let compaction run freely during block
+        def scBlock = 'CloudSchemaChangeJob::process_alter_tablet.block'
+        GetDebugPoint().enableDebugPointForAllBEs(scBlock)
+
+        try {
+            sql "ALTER TABLE ${tableName} MODIFY COLUMN v2 bigint"
+            sleep(10000)
+            assertEquals("RUNNING", getJobState(tableName))
+
+            // Phase 3: Insert 6 batches (versions 5-10), compaction runs freely
+            for (int i = 0; i < 6; i++) {
+                StringBuilder sb = new StringBuilder()
+                sb.append("INSERT INTO ${tableName} VALUES ")
+                for (int j = 0; j < 10; j++) {
+                    if (j > 0) sb.append(", ")
+                    def key = 100 + i * 10 + j + 1
+                    sb.append("(${key}, 'new_${key}', ${key * 10})")
+                }
+                sql sb.toString()
+            }
+
+            // Phase 4: Wait for compaction to merge [5-10] on new tablet
+            sleep(30000)
+
+            // Phase 5: Override V1=6, then release SC
+            // Compaction [5-10] already committed to meta-service (no SC job yet → success)
+            // SC will run with V1=6 → SC commit replaces [2,6] → [5-10] not deleted → overlap
+            GetDebugPoint().enableDebugPointForAllBEs(
+                'CloudSchemaChangeJob::process_alter_tablet.override_base_max_version',
+                [version: 6])
+
+        } finally {
+            GetDebugPoint().disableDebugPointForAllBEs(scBlock)
+        }
+
+        // Wait for SC to finish
+        int maxTries = 120
+        def finalState = ""
+        while (maxTries-- > 0) {
+            finalState = getJobState(tableName)
+            if (finalState == "FINISHED" || finalState == "CANCELLED") {
+                break
+            }
+            sleep(1000)
+        }
+
+        // Clean up debug point
+        GetDebugPoint().disableDebugPointForAllBEs(
+            'CloudSchemaChangeJob::process_alter_tablet.override_base_max_version')
+
+        logger.info("SC final state: ${finalState}")
+
+        // Wait for potential BE crash from overlapping rowsets
+        sleep(15000)
+
+        // Verify BE is still alive
+        def backendsAfter = sql_return_maparray("show backends")
+        logger.info("BE alive status after SC: ${backendsAfter.collect { it.Alive }}")
+        assertTrue(backendsAfter.every { it.Alive.toString() == "true" },
+            "BE crashed after SC due to cross-V1 compaction rowset overlap")
+    }
+}

--- a/regression-test/suites/cloud_p1/schema_change/compaction_optimization/test_sc_compaction_optimization.groovy
+++ b/regression-test/suites/cloud_p1/schema_change/compaction_optimization/test_sc_compaction_optimization.groovy
@@ -1,0 +1,196 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Test: During schema change with multiple tablets queued, new tablets can do
+// compaction (version > V0). This verifies the core optimization:
+// - BE pre_submit_callback sets alter_version (V0) before task enqueue
+// - New tablets in queue can do cumulative compaction immediately
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_sc_compaction_optimization', 'docker') {
+
+    def options = new ClusterOptions()
+    options.cloudMode = true
+    options.enableDebugPoints()
+    options.beConfigs += ["enable_java_support=false"]
+    options.beConfigs += ["disable_auto_compaction=true"]
+    options.beConfigs += ["enable_new_tablet_do_compaction=true"]
+    options.beConfigs += ["alter_tablet_worker_count=1"]  // Only 1 SC worker thread to force queuing
+    options.beNum = 1
+
+    docker(options) {
+        def tableName = "sc_opt_test"
+
+        def getJobState = { tbl ->
+            def result = sql """SHOW ALTER TABLE COLUMN WHERE IndexName='${tbl}' ORDER BY createtime DESC LIMIT 1"""
+            logger.info("getJobState: ${result}")
+            return result[0][9]
+        }
+
+        // Create table with 2 buckets -> 2 base tablets -> 2 SC tasks
+        // With alter_tablet_worker_count=1: one task executes (blocked), one task queues
+        sql "DROP TABLE IF EXISTS ${tableName}"
+        sql """
+            CREATE TABLE ${tableName} (
+                k1 int NOT NULL,
+                v1 varchar(100) NOT NULL,
+                v2 int NOT NULL
+            )
+            DISTRIBUTED BY HASH(k1) BUCKETS 2
+            PROPERTIES (
+                "replication_num" = "1",
+                "disable_auto_compaction" = "true"
+            )
+        """
+
+        // Insert initial data in multiple batches to create multiple rowsets
+        for (int i = 0; i < 3; i++) {
+            StringBuilder sb = new StringBuilder()
+            sb.append("INSERT INTO ${tableName} VALUES ")
+            for (int j = 0; j < 20; j++) {
+                if (j > 0) sb.append(", ")
+                def key = i * 20 + j + 1
+                sb.append("(${key}, 'val_${key}', ${key * 10})")
+            }
+            sql sb.toString()
+        }
+
+        def initialCount = sql "SELECT count(*) FROM ${tableName}"
+        assertEquals(60L, initialCount[0][0])
+
+        // Record base tablet IDs before SC
+        def baseTablets = sql_return_maparray("SHOW TABLETS FROM ${tableName}")
+        logger.info("Base tablets before SC: ${baseTablets}")
+        assertEquals(2, baseTablets.size())
+        def baseTabletIds = baseTablets.collect { it.TabletId.toString() }
+
+        def backends = sql_return_maparray("show backends")
+        def be = backends[0]
+
+        // Block SC execution at the end of process_alter_tablet
+        def injectName = 'CloudSchemaChangeJob.process_alter_tablet.sleep'
+        GetDebugPoint().enableDebugPointForAllBEs(injectName)
+
+        try {
+            // Trigger schema change: 2 tablets -> 2 SC tasks submitted to BE
+            // With alter_tablet_worker_count=1: 1 task dequeued and blocked at DebugPoint,
+            // 1 task still in queue.
+            // Optimization: pre_submit_callback sets alter_version on BOTH tablet pairs
+            // before they are enqueued, so even the queued new tablet has alter_version = V0
+            sql "ALTER TABLE ${tableName} MODIFY COLUMN v2 bigint"
+
+            // Wait for SC tasks to be submitted and one to start executing (blocked)
+            sleep(10000)
+
+            // Verify SC is in RUNNING state
+            def scState = getJobState(tableName)
+            assertEquals("RUNNING", scState)
+
+            // Get all tablets including new (shadow) tablets
+            def allTablets = sql_return_maparray("SHOW TABLETS FROM ${tableName}")
+            logger.info("All tablets during SC: ${allTablets}")
+            assertEquals(4, allTablets.size())
+
+            // Identify new (shadow) tablets
+            def newTablets = allTablets.findAll { !(it.TabletId.toString() in baseTabletIds) }
+            logger.info("New (shadow) tablets: ${newTablets}")
+            assertEquals(2, newTablets.size())
+
+            // Load more data during SC — double-write creates rowsets on both base and new tablets
+            // These rowsets have version > V0, and should be compactable with the optimization
+            for (int i = 0; i < 3; i++) {
+                StringBuilder sb = new StringBuilder()
+                sb.append("INSERT INTO ${tableName} VALUES ")
+                for (int j = 0; j < 10; j++) {
+                    if (j > 0) sb.append(", ")
+                    def key = 100 + i * 10 + j + 1
+                    sb.append("(${key}, 'new_${key}', ${key * 10})")
+                }
+                sql sb.toString()
+            }
+
+            // Key verification: trigger cumulative compaction on new tablets
+            // With optimization (pre_submit_callback): alter_version = V0 -> compaction accepted
+            // Without optimization: alter_version = -1 for queued tablet -> compaction rejected
+            def compactionAccepted = 0
+            for (def tablet : newTablets) {
+                def (code, out, err) = be_run_cumulative_compaction(be.Host, be.HttpPort, tablet.TabletId)
+                logger.info("Trigger cu compaction on new tablet ${tablet.TabletId}: code=${code}, out=${out}")
+                if (code == 0) {
+                    def triggerResult = parseJson(out.trim())
+                    def status = triggerResult.status.toLowerCase()
+                    if (status == "success" || status == "already_exist") {
+                        compactionAccepted++
+                        logger.info("Cumulative compaction accepted for new tablet ${tablet.TabletId}")
+                    } else {
+                        logger.info("Cumulative compaction not accepted for new tablet ${tablet.TabletId}: ${status}")
+                    }
+                }
+            }
+
+            // ALL new tablets should accept cumulative compaction.
+            // The executing tablet has alter_version set by SC execution code;
+            // the queued tablet has alter_version set by pre_submit_callback (the optimization).
+            // Without the optimization, the queued tablet would have alter_version=-1 and reject compaction.
+            logger.info("Compaction accepted on ${compactionAccepted} out of ${newTablets.size()} new tablet(s)")
+            assertEquals(newTablets.size(), compactionAccepted)
+
+            // Wait for compactions to finish
+            for (def tablet : newTablets) {
+                boolean running = true
+                int maxWait = 60
+                while (running && maxWait-- > 0) {
+                    Thread.sleep(1000)
+                    def (code, out, err) = be_get_compaction_status(be.Host, be.HttpPort, tablet.TabletId)
+                    if (code == 0) {
+                        def compactionStatus = parseJson(out.trim())
+                        running = compactionStatus.run_status
+                    } else {
+                        break
+                    }
+                }
+            }
+
+        } finally {
+            // Release SC execution block
+            GetDebugPoint().disableDebugPointForAllBEs(injectName)
+        }
+
+        // Wait for SC to finish
+        int maxTries = 300
+        def finalState = ""
+        while (maxTries-- > 0) {
+            finalState = getJobState(tableName)
+            if (finalState == "FINISHED" || finalState == "CANCELLED") {
+                sleep(3000)
+                break
+            }
+            sleep(1000)
+        }
+        assertEquals("FINISHED", finalState)
+
+        // Verify data correctness: 60 initial + 30 during SC = 90 rows
+        def finalCount = sql "SELECT count(*) FROM ${tableName}"
+        logger.info("Final row count: ${finalCount}")
+        assertEquals(90L, finalCount[0][0])
+
+        // Verify data integrity — all keys should be distinct
+        def distinctKeys = sql "SELECT count(distinct k1) FROM ${tableName}"
+        assertEquals(90L, distinctKeys[0][0])
+    }
+}

--- a/regression-test/suites/cloud_p1/schema_change/compaction_optimization/test_sc_compaction_optimization.groovy
+++ b/regression-test/suites/cloud_p1/schema_change/compaction_optimization/test_sc_compaction_optimization.groovy
@@ -102,8 +102,37 @@ suite('test_sc_compaction_optimization', 'docker') {
                 sql sb.toString()
             }
 
-            // Wait for auto compaction to trigger (don't query tablet status while SC is blocked)
-            sleep(15000)
+            // Wait for auto compaction to sync double-write rowsets and compact them
+            sleep(30000)
+
+            // Verify compaction happened: check if any non-placeholder rowset spans multiple
+            // versions (e.g. [4-6]). Each INSERT creates a single-version rowset [v-v],
+            // so a multi-version rowset is direct proof of compaction.
+            boolean compactionHappened = false
+            for (def tablet : newTablets) {
+                def tabletId = tablet.TabletId.toString()
+                def (code, out, err) = curl("GET", tablet.CompactionStatus)
+                if (code == 0) {
+                    def status = parseJson(out.trim())
+                    if (status.rowsets instanceof List) {
+                        logger.info("New tablet ${tabletId} rowsets: ${status.rowsets}")
+                        for (def rowset : status.rowsets) {
+                            def match = (rowset =~ /\[(\d+)-(\d+)\]/)
+                            if (match) {
+                                def start = match[0][1] as int
+                                def end = match[0][2] as int
+                                if (start > 1 && end > start) {
+                                    logger.info("New tablet ${tabletId} has merged rowset [${start}-${end}], compaction confirmed")
+                                    compactionHappened = true
+                                    break
+                                }
+                            }
+                        }
+                    }
+                }
+                if (compactionHappened) break
+            }
+            assertTrue(compactionHappened, "Expected auto compaction on new tablets during SC queue wait")
 
         } finally {
             GetDebugPoint().disableDebugPointForAllBEs(injectName)
@@ -126,41 +155,5 @@ suite('test_sc_compaction_optimization', 'docker') {
         assertEquals(120L, (sql "SELECT count(*) FROM ${tableName}")[0][0])
         assertEquals(120L, (sql "SELECT count(distinct k1) FROM ${tableName}")[0][0])
 
-        // Manually trigger cumulative compaction to verify SC compaction optimization
-        def allTablets = sql_return_maparray("SHOW TABLETS FROM ${tableName}")
-        def newTablets = allTablets.findAll { !(it.TabletId.toString() in baseTabletIds) }
-        assertTrue(newTablets.size() > 0, "Should have new tablets after SC")
-
-        for (def tablet : newTablets) {
-            def tabletId = tablet.TabletId.toString()
-
-            // Trigger cumulative compaction
-            def (code, out, err) = be_run_cumulative_compaction(be.Host, be.HttpPort, tabletId)
-            logger.info("Trigger cumulative compaction on tablet ${tabletId}: code=${code}")
-
-            // Wait for compaction to complete
-            boolean running = true
-            int waitCount = 0
-            while (running && waitCount < 100) {
-                sleep(100)
-                def (code2, out2, err2) = be_get_compaction_status(be.Host, be.HttpPort, tabletId)
-                if (code2 == 0) {
-                    def status = parseJson(out2.trim())
-                    running = status.run_status
-                }
-                waitCount++
-            }
-
-            // Verify rowset count after compaction
-            def (code3, out3, err3) = curl("GET", tablet.CompactionStatus)
-            if (code3 == 0) {
-                def status = parseJson(out3.trim())
-                if (status.rowsets instanceof List) {
-                    def rowsetCount = status.rowsets.size()
-                    logger.info("Tablet ${tabletId} has ${rowsetCount} rowsets after compaction")
-                    assertTrue(rowsetCount <= 2, "Expected rowset count <= 2, got ${rowsetCount}")
-                }
-            }
-        }
     }
 }

--- a/regression-test/suites/cloud_p1/schema_change/compaction_optimization/test_sc_compaction_optimization.groovy
+++ b/regression-test/suites/cloud_p1/schema_change/compaction_optimization/test_sc_compaction_optimization.groovy
@@ -15,10 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Test: During schema change with multiple tablets queued, new tablets can do
-// compaction (version > V0). This verifies the core optimization:
-// - BE pre_submit_callback sets alter_version (V0) before task enqueue
-// - New tablets in queue can do cumulative compaction immediately
+// Test: Verify that pre_submit_callback correctly sets alter_version on new tablets
+// so that auto cumulative compaction can compact double-write rowsets during SC.
+// Without the optimization, alter_version=-1 and auto compaction skips NOTREADY tablets.
 
 import org.apache.doris.regression.suite.ClusterOptions
 
@@ -28,9 +27,9 @@ suite('test_sc_compaction_optimization', 'docker') {
     options.cloudMode = true
     options.enableDebugPoints()
     options.beConfigs += ["enable_java_support=false"]
-    options.beConfigs += ["disable_auto_compaction=true"]
     options.beConfigs += ["enable_new_tablet_do_compaction=true"]
-    options.beConfigs += ["alter_tablet_worker_count=1"]  // Only 1 SC worker thread to force queuing
+    options.beConfigs += ["alter_tablet_worker_count=1"]
+    options.beConfigs += ["cumulative_compaction_min_deltas=2"]
     options.beNum = 1
 
     docker(options) {
@@ -42,8 +41,6 @@ suite('test_sc_compaction_optimization', 'docker') {
             return result[0][9]
         }
 
-        // Create table with 2 buckets -> 2 base tablets -> 2 SC tasks
-        // With alter_tablet_worker_count=1: one task executes (blocked), one task queues
         sql "DROP TABLE IF EXISTS ${tableName}"
         sql """
             CREATE TABLE ${tableName} (
@@ -53,12 +50,11 @@ suite('test_sc_compaction_optimization', 'docker') {
             )
             DISTRIBUTED BY HASH(k1) BUCKETS 2
             PROPERTIES (
-                "replication_num" = "1",
-                "disable_auto_compaction" = "true"
+                "replication_num" = "1"
             )
         """
 
-        // Insert initial data in multiple batches to create multiple rowsets
+        // Insert initial data
         for (int i = 0; i < 3; i++) {
             StringBuilder sb = new StringBuilder()
             sb.append("INSERT INTO ${tableName} VALUES ")
@@ -70,50 +66,32 @@ suite('test_sc_compaction_optimization', 'docker') {
             sql sb.toString()
         }
 
-        def initialCount = sql "SELECT count(*) FROM ${tableName}"
-        assertEquals(60L, initialCount[0][0])
+        assertEquals(60L, (sql "SELECT count(*) FROM ${tableName}")[0][0])
 
-        // Record base tablet IDs before SC
         def baseTablets = sql_return_maparray("SHOW TABLETS FROM ${tableName}")
-        logger.info("Base tablets before SC: ${baseTablets}")
         assertEquals(2, baseTablets.size())
         def baseTabletIds = baseTablets.collect { it.TabletId.toString() }
 
         def backends = sql_return_maparray("show backends")
         def be = backends[0]
 
-        // Block SC execution at the end of process_alter_tablet
-        def injectName = 'CloudSchemaChangeJob.process_alter_tablet.sleep'
+        // Block SC at the very beginning of process_alter_tablet, BEFORE prepare_tablet_job.
+        // This avoids meta-service tablet job lock which would block BE HTTP service.
+        def injectName = 'CloudSchemaChangeJob::process_alter_tablet.block'
         GetDebugPoint().enableDebugPointForAllBEs(injectName)
 
         try {
-            // Trigger schema change: 2 tablets -> 2 SC tasks submitted to BE
-            // With alter_tablet_worker_count=1: 1 task dequeued and blocked at DebugPoint,
-            // 1 task still in queue.
-            // Optimization: pre_submit_callback sets alter_version on BOTH tablet pairs
-            // before they are enqueued, so even the queued new tablet has alter_version = V0
             sql "ALTER TABLE ${tableName} MODIFY COLUMN v2 bigint"
-
-            // Wait for SC tasks to be submitted and one to start executing (blocked)
             sleep(10000)
+            assertEquals("RUNNING", getJobState(tableName))
 
-            // Verify SC is in RUNNING state
-            def scState = getJobState(tableName)
-            assertEquals("RUNNING", scState)
-
-            // Get all tablets including new (shadow) tablets
             def allTablets = sql_return_maparray("SHOW TABLETS FROM ${tableName}")
-            logger.info("All tablets during SC: ${allTablets}")
             assertEquals(4, allTablets.size())
-
-            // Identify new (shadow) tablets
             def newTablets = allTablets.findAll { !(it.TabletId.toString() in baseTabletIds) }
-            logger.info("New (shadow) tablets: ${newTablets}")
             assertEquals(2, newTablets.size())
 
-            // Load more data during SC — double-write creates rowsets on both base and new tablets
-            // These rowsets have version > V0, and should be compactable with the optimization
-            for (int i = 0; i < 3; i++) {
+            // Insert 6 batches during SC -> creates double-write rowsets on new tablets
+            for (int i = 0; i < 6; i++) {
                 StringBuilder sb = new StringBuilder()
                 sb.append("INSERT INTO ${tableName} VALUES ")
                 for (int j = 0; j < 10; j++) {
@@ -124,50 +102,10 @@ suite('test_sc_compaction_optimization', 'docker') {
                 sql sb.toString()
             }
 
-            // Key verification: trigger cumulative compaction on new tablets
-            // With optimization (pre_submit_callback): alter_version = V0 -> compaction accepted
-            // Without optimization: alter_version = -1 for queued tablet -> compaction rejected
-            def compactionAccepted = 0
-            for (def tablet : newTablets) {
-                def (code, out, err) = be_run_cumulative_compaction(be.Host, be.HttpPort, tablet.TabletId)
-                logger.info("Trigger cu compaction on new tablet ${tablet.TabletId}: code=${code}, out=${out}")
-                if (code == 0) {
-                    def triggerResult = parseJson(out.trim())
-                    def status = triggerResult.status.toLowerCase()
-                    if (status == "success" || status == "already_exist") {
-                        compactionAccepted++
-                        logger.info("Cumulative compaction accepted for new tablet ${tablet.TabletId}")
-                    } else {
-                        logger.info("Cumulative compaction not accepted for new tablet ${tablet.TabletId}: ${status}")
-                    }
-                }
-            }
-
-            // ALL new tablets should accept cumulative compaction.
-            // The executing tablet has alter_version set by SC execution code;
-            // the queued tablet has alter_version set by pre_submit_callback (the optimization).
-            // Without the optimization, the queued tablet would have alter_version=-1 and reject compaction.
-            logger.info("Compaction accepted on ${compactionAccepted} out of ${newTablets.size()} new tablet(s)")
-            assertEquals(newTablets.size(), compactionAccepted)
-
-            // Wait for compactions to finish
-            for (def tablet : newTablets) {
-                boolean running = true
-                int maxWait = 60
-                while (running && maxWait-- > 0) {
-                    Thread.sleep(1000)
-                    def (code, out, err) = be_get_compaction_status(be.Host, be.HttpPort, tablet.TabletId)
-                    if (code == 0) {
-                        def compactionStatus = parseJson(out.trim())
-                        running = compactionStatus.run_status
-                    } else {
-                        break
-                    }
-                }
-            }
+            // Wait for auto compaction to trigger (don't query tablet status while SC is blocked)
+            sleep(15000)
 
         } finally {
-            // Release SC execution block
             GetDebugPoint().disableDebugPointForAllBEs(injectName)
         }
 
@@ -177,20 +115,52 @@ suite('test_sc_compaction_optimization', 'docker') {
         while (maxTries-- > 0) {
             finalState = getJobState(tableName)
             if (finalState == "FINISHED" || finalState == "CANCELLED") {
-                sleep(3000)
+                sleep(10000)  // Wait 10s for BE to fully recover after SC
                 break
             }
             sleep(1000)
         }
         assertEquals("FINISHED", finalState)
 
-        // Verify data correctness: 60 initial + 30 during SC = 90 rows
-        def finalCount = sql "SELECT count(*) FROM ${tableName}"
-        logger.info("Final row count: ${finalCount}")
-        assertEquals(90L, finalCount[0][0])
+        // Verify data correctness after SC
+        assertEquals(120L, (sql "SELECT count(*) FROM ${tableName}")[0][0])
+        assertEquals(120L, (sql "SELECT count(distinct k1) FROM ${tableName}")[0][0])
 
-        // Verify data integrity — all keys should be distinct
-        def distinctKeys = sql "SELECT count(distinct k1) FROM ${tableName}"
-        assertEquals(90L, distinctKeys[0][0])
+        // Manually trigger cumulative compaction to verify SC compaction optimization
+        def allTablets = sql_return_maparray("SHOW TABLETS FROM ${tableName}")
+        def newTablets = allTablets.findAll { !(it.TabletId.toString() in baseTabletIds) }
+        assertTrue(newTablets.size() > 0, "Should have new tablets after SC")
+
+        for (def tablet : newTablets) {
+            def tabletId = tablet.TabletId.toString()
+
+            // Trigger cumulative compaction
+            def (code, out, err) = be_run_cumulative_compaction(be.Host, be.HttpPort, tabletId)
+            logger.info("Trigger cumulative compaction on tablet ${tabletId}: code=${code}")
+
+            // Wait for compaction to complete
+            boolean running = true
+            int waitCount = 0
+            while (running && waitCount < 100) {
+                sleep(100)
+                def (code2, out2, err2) = be_get_compaction_status(be.Host, be.HttpPort, tabletId)
+                if (code2 == 0) {
+                    def status = parseJson(out2.trim())
+                    running = status.run_status
+                }
+                waitCount++
+            }
+
+            // Verify rowset count after compaction
+            def (code3, out3, err3) = curl("GET", tablet.CompactionStatus)
+            if (code3 == 0) {
+                def status = parseJson(out3.trim())
+                if (status.rowsets instanceof List) {
+                    def rowsetCount = status.rowsets.size()
+                    logger.info("Tablet ${tabletId} has ${rowsetCount} rowsets after compaction")
+                    assertTrue(rowsetCount <= 2, "Expected rowset count <= 2, got ${rowsetCount}")
+                }
+            }
+        }
     }
 }

--- a/regression-test/suites/cloud_p1/schema_change/compaction_optimization/test_sc_compaction_optimization_with_load.groovy
+++ b/regression-test/suites/cloud_p1/schema_change/compaction_optimization/test_sc_compaction_optimization_with_load.groovy
@@ -101,8 +101,37 @@ suite('test_sc_compaction_optimization_with_load', 'docker') {
             def newTablets = allTablets.findAll { !(it.TabletId.toString() in baseTabletIds) }
             assertEquals(3, newTablets.size())
 
-            // Wait for auto compaction to trigger (don't query tablet status while SC is blocked)
-            sleep(15000)
+            // Wait for auto compaction to sync double-write rowsets and compact them
+            sleep(30000)
+
+            // Verify compaction happened: check if any non-placeholder rowset spans multiple
+            // versions (e.g. [4-6]). Each INSERT creates a single-version rowset [v-v],
+            // so a multi-version rowset is direct proof of compaction.
+            boolean compactionHappened = false
+            for (def tablet : newTablets) {
+                def tabletId = tablet.TabletId.toString()
+                def (code, out, err) = curl("GET", tablet.CompactionStatus)
+                if (code == 0) {
+                    def status = parseJson(out.trim())
+                    if (status.rowsets instanceof List) {
+                        logger.info("New tablet ${tabletId} rowsets: ${status.rowsets}")
+                        for (def rowset : status.rowsets) {
+                            def match = (rowset =~ /\[(\d+)-(\d+)\]/)
+                            if (match) {
+                                def start = match[0][1] as int
+                                def end = match[0][2] as int
+                                if (start > 1 && end > start) {
+                                    logger.info("New tablet ${tabletId} has merged rowset [${start}-${end}], compaction confirmed")
+                                    compactionHappened = true
+                                    break
+                                }
+                            }
+                        }
+                    }
+                }
+                if (compactionHappened) break
+            }
+            assertTrue(compactionHappened, "Expected auto compaction on new tablets during SC queue wait")
 
         } finally {
             GetDebugPoint().disableDebugPointForAllBEs(injectName)
@@ -129,56 +158,17 @@ suite('test_sc_compaction_optimization_with_load', 'docker') {
         def v1Type = schema.find { it[0] == "v1" }[1]
         assertEquals("bigint", v1Type.toLowerCase())
 
-        // Manually trigger cumulative compaction to verify SC compaction optimization
-        def allTablets = sql_return_maparray("SHOW TABLETS FROM ${tableName}")
-        def newTablets = allTablets.findAll { !(it.TabletId.toString() in baseTabletIds) }
-        assertTrue(newTablets.size() > 0, "Should have new tablets after SC")
-
-        for (def tablet : newTablets) {
-            def tabletId = tablet.TabletId.toString()
-
-            // Trigger cumulative compaction
-            def (code, out, err) = be_run_cumulative_compaction(be.Host, be.HttpPort, tabletId)
-            logger.info("Trigger cumulative compaction on tablet ${tabletId}: code=${code}")
-
-            // Wait for compaction to complete
-            boolean running = true
-            int waitCount = 0
-            while (running && waitCount < 100) {
-                sleep(100)
-                def (code2, out2, err2) = be_get_compaction_status(be.Host, be.HttpPort, tabletId)
-                if (code2 == 0) {
-                    def status = parseJson(out2.trim())
-                    running = status.run_status
-                }
-                waitCount++
-            }
-
-            // Verify rowset count after compaction
-            def (code3, out3, err3) = curl("GET", tablet.CompactionStatus)
-            if (code3 == 0) {
-                def status = parseJson(out3.trim())
-                if (status.rowsets instanceof List) {
-                    def rowsetCount = status.rowsets.size()
-                    logger.info("Tablet ${tabletId} has ${rowsetCount} rowsets after compaction")
-                    assertTrue(rowsetCount <= 2, "Expected rowset count <= 2, got ${rowsetCount}")
-                }
-            }
-        }
-
         // Phase 6: Post-SC loading (verify alter_version cleanup)
         for (int i = 0; i < 3; i++) {
             insertBatch(500 + i * 10, 10, "post_${i}")
         }
         // Phase 6: Verify data correctness and schema change
-        def expectedCount = 60 + 80 + 200  // initial + SC inserts + post-SC inserts
+        def expectedCount = 150 + 160 + 30  // initial(5*30) + SC inserts(8*20) + post-SC(3*10)
         assertEquals(expectedCount, (sql "SELECT count(*) FROM ${tableName}")[0][0])
         assertEquals(expectedCount, (sql "SELECT count(distinct k1) FROM ${tableName}")[0][0])
 
         def desc = sql "DESC ${tableName}"
         def v1Col = desc.find { it[0] == "v1" }
         assertTrue(v1Col[1].toString().toLowerCase().contains("bigint"))
-
-        // Note: Compaction on new tablets during SC was verified in BE logs during development.
     }
 }

--- a/regression-test/suites/cloud_p1/schema_change/compaction_optimization/test_sc_compaction_optimization_with_load.groovy
+++ b/regression-test/suites/cloud_p1/schema_change/compaction_optimization/test_sc_compaction_optimization_with_load.groovy
@@ -15,11 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Test: Schema change with concurrent data loading and compaction on multiple tablets.
-// Verifies end-to-end correctness with the optimization:
-// 1. SC completes successfully with multiple tablets and concurrent writes
-// 2. Compaction works on new tablets after SC completion
-// 3. Data is consistent after SC + compaction + continued loading
+// Test: End-to-end correctness with SC compaction optimization.
+// Verifies:
+// 1. SC completes successfully with concurrent writes and auto compaction on new tablets
+// 2. alter_version cleanup works — post-SC compaction runs normally
+// 3. Data consistency after SC + compaction + continued loading
 
 import org.apache.doris.regression.suite.ClusterOptions
 
@@ -29,9 +29,9 @@ suite('test_sc_compaction_optimization_with_load', 'docker') {
     options.cloudMode = true
     options.enableDebugPoints()
     options.beConfigs += ["enable_java_support=false"]
-    options.beConfigs += ["disable_auto_compaction=true"]
     options.beConfigs += ["enable_new_tablet_do_compaction=true"]
     options.beConfigs += ["alter_tablet_worker_count=1"]
+    options.beConfigs += ["cumulative_compaction_min_deltas=2"]
     options.beNum = 1
 
     docker(options) {
@@ -43,23 +43,6 @@ suite('test_sc_compaction_optimization_with_load', 'docker') {
             return result[0][9]
         }
 
-        // Create table with 3 buckets for more realistic multi-tablet scenario
-        sql "DROP TABLE IF EXISTS ${tableName}"
-        sql """
-            CREATE TABLE ${tableName} (
-                k1 int NOT NULL,
-                k2 varchar(50) NOT NULL,
-                v1 int NOT NULL,
-                v2 varchar(200) NOT NULL
-            )
-            DISTRIBUTED BY HASH(k1) BUCKETS 3
-            PROPERTIES (
-                "replication_num" = "1",
-                "disable_auto_compaction" = "true"
-            )
-        """
-
-        // Phase 1: Load initial data with multiple rowsets
         def insertBatch = { int startKey, int count, String prefix ->
             StringBuilder sb = new StringBuilder()
             sb.append("INSERT INTO ${tableName} VALUES ")
@@ -71,86 +54,55 @@ suite('test_sc_compaction_optimization_with_load', 'docker') {
             sql sb.toString()
         }
 
-        // Create 5 rowsets with 30 rows each = 150 rows
+        sql "DROP TABLE IF EXISTS ${tableName}"
+        sql """
+            CREATE TABLE ${tableName} (
+                k1 int NOT NULL,
+                k2 varchar(50) NOT NULL,
+                v1 int NOT NULL,
+                v2 varchar(200) NOT NULL
+            )
+            DISTRIBUTED BY HASH(k1) BUCKETS 3
+            PROPERTIES (
+                "replication_num" = "1"
+            )
+        """
+
+        // Phase 1: Load initial data
         for (int i = 0; i < 5; i++) {
             insertBatch(i * 30 + 1, 30, "init_${i}")
         }
-
-        def phase1Count = sql "SELECT count(*) FROM ${tableName}"
-        assertEquals(150L, phase1Count[0][0])
-
-        // Do cumulative compaction on base tablets to consolidate initial rowsets
-        trigger_and_wait_compaction(tableName, "cumulative")
+        assertEquals(150L, (sql "SELECT count(*) FROM ${tableName}")[0][0])
 
         def baseTablets = sql_return_maparray("SHOW TABLETS FROM ${tableName}")
-        logger.info("Base tablets: ${baseTablets}")
         assertEquals(3, baseTablets.size())
         def baseTabletIds = baseTablets.collect { it.TabletId.toString() }
 
         def backends = sql_return_maparray("show backends")
         def be = backends[0]
 
-        // Phase 2: Trigger SC with blocking — simulates queue scenario
-        def injectName = 'CloudSchemaChangeJob.process_alter_tablet.sleep'
+        // Block SC at the very beginning of process_alter_tablet, BEFORE prepare_tablet_job.
+        // This avoids meta-service tablet job lock which would block BE HTTP service.
+        def injectName = 'CloudSchemaChangeJob::process_alter_tablet.block'
         GetDebugPoint().enableDebugPointForAllBEs(injectName)
 
         try {
-            // ALTER adds a column — triggers SC for all 3 tablets
-            // With alter_tablet_worker_count=1: 1 executes (blocked), 2 queue
             sql "ALTER TABLE ${tableName} MODIFY COLUMN v1 bigint"
             sleep(10000)
+            assertEquals("RUNNING", getJobState(tableName))
 
-            def scState = getJobState(tableName)
-            assertEquals("RUNNING", scState)
-
-            // Phase 3: Heavy loading during SC — creates many rowsets via double-write
+            // Phase 3: Heavy loading during SC
             for (int i = 0; i < 8; i++) {
                 insertBatch(200 + i * 20, 20, "sc_${i}")
             }
-            // 160 more rows during SC
 
-            // Get all tablets
             def allTablets = sql_return_maparray("SHOW TABLETS FROM ${tableName}")
-            logger.info("All tablets during SC: ${allTablets}")
-            assertEquals(6, allTablets.size())  // 3 base + 3 new
-
+            assertEquals(6, allTablets.size())
             def newTablets = allTablets.findAll { !(it.TabletId.toString() in baseTabletIds) }
             assertEquals(3, newTablets.size())
 
-            // Trigger cumulative compaction on both base and new tablets
-            // Base tablets: compaction on versions <= V0 (within alter_version boundary)
-            // New tablets: compaction on versions > V0 (double-write data)
-            def newTabletCompactionAccepted = 0
-            for (def tablet : allTablets) {
-                def (code, out, err) = be_run_cumulative_compaction(be.Host, be.HttpPort, tablet.TabletId)
-                logger.info("Trigger cu compaction on tablet ${tablet.TabletId}: code=${code}, out=${out}")
-                if (code == 0 && tablet.TabletId.toString() in newTablets.collect { it.TabletId.toString() }) {
-                    def triggerResult = parseJson(out.trim())
-                    def status = triggerResult.status.toLowerCase()
-                    if (status == "success" || status == "already_exist") {
-                        newTabletCompactionAccepted++
-                    }
-                }
-            }
-            // All new tablets should accept compaction (alter_version set by pre_submit_callback)
-            logger.info("New tablet compaction accepted: ${newTabletCompactionAccepted} / ${newTablets.size()}")
-            assertEquals(newTablets.size(), newTabletCompactionAccepted)
-
-            // Wait for compactions
-            for (def tablet : allTablets) {
-                boolean running = true
-                int maxWait = 60
-                while (running && maxWait-- > 0) {
-                    Thread.sleep(1000)
-                    def (code, out, err) = be_get_compaction_status(be.Host, be.HttpPort, tablet.TabletId)
-                    if (code == 0) {
-                        def compactionStatus = parseJson(out.trim())
-                        running = compactionStatus.run_status
-                    } else {
-                        break
-                    }
-                }
-            }
+            // Wait for auto compaction to trigger (don't query tablet status while SC is blocked)
+            sleep(15000)
 
         } finally {
             GetDebugPoint().disableDebugPointForAllBEs(injectName)
@@ -162,44 +114,71 @@ suite('test_sc_compaction_optimization_with_load', 'docker') {
         while (maxTries-- > 0) {
             finalState = getJobState(tableName)
             if (finalState == "FINISHED" || finalState == "CANCELLED") {
-                sleep(3000)
+                sleep(10000)  // Wait 10s for BE to fully recover
                 break
             }
             sleep(1000)
         }
         assertEquals("FINISHED", finalState)
 
-        // Phase 5: Verify data after SC
-        def afterScCount = sql "SELECT count(*) FROM ${tableName}"
-        logger.info("Row count after SC: ${afterScCount}")
-        assertEquals(310L, afterScCount[0][0])  // 150 + 160
+        // Phase 5: Verify data correctness and compaction
+        assertEquals(310L, (sql "SELECT count(*) FROM ${tableName}")[0][0])
 
-        // Phase 6: Continue loading after SC (verifies no residual alter_version issues)
+        // Verify column type changed
+        def schema = sql "DESC ${tableName}"
+        def v1Type = schema.find { it[0] == "v1" }[1]
+        assertEquals("bigint", v1Type.toLowerCase())
+
+        // Manually trigger cumulative compaction to verify SC compaction optimization
+        def allTablets = sql_return_maparray("SHOW TABLETS FROM ${tableName}")
+        def newTablets = allTablets.findAll { !(it.TabletId.toString() in baseTabletIds) }
+        assertTrue(newTablets.size() > 0, "Should have new tablets after SC")
+
+        for (def tablet : newTablets) {
+            def tabletId = tablet.TabletId.toString()
+
+            // Trigger cumulative compaction
+            def (code, out, err) = be_run_cumulative_compaction(be.Host, be.HttpPort, tabletId)
+            logger.info("Trigger cumulative compaction on tablet ${tabletId}: code=${code}")
+
+            // Wait for compaction to complete
+            boolean running = true
+            int waitCount = 0
+            while (running && waitCount < 100) {
+                sleep(100)
+                def (code2, out2, err2) = be_get_compaction_status(be.Host, be.HttpPort, tabletId)
+                if (code2 == 0) {
+                    def status = parseJson(out2.trim())
+                    running = status.run_status
+                }
+                waitCount++
+            }
+
+            // Verify rowset count after compaction
+            def (code3, out3, err3) = curl("GET", tablet.CompactionStatus)
+            if (code3 == 0) {
+                def status = parseJson(out3.trim())
+                if (status.rowsets instanceof List) {
+                    def rowsetCount = status.rowsets.size()
+                    logger.info("Tablet ${tabletId} has ${rowsetCount} rowsets after compaction")
+                    assertTrue(rowsetCount <= 2, "Expected rowset count <= 2, got ${rowsetCount}")
+                }
+            }
+        }
+
+        // Phase 6: Post-SC loading (verify alter_version cleanup)
         for (int i = 0; i < 3; i++) {
             insertBatch(500 + i * 10, 10, "post_${i}")
         }
+        // Phase 6: Verify data correctness and schema change
+        def expectedCount = 60 + 80 + 200  // initial + SC inserts + post-SC inserts
+        assertEquals(expectedCount, (sql "SELECT count(*) FROM ${tableName}")[0][0])
+        assertEquals(expectedCount, (sql "SELECT count(distinct k1) FROM ${tableName}")[0][0])
 
-        def afterPostCount = sql "SELECT count(*) FROM ${tableName}"
-        assertEquals(340L, afterPostCount[0][0])  // 310 + 30
-
-        // Phase 7: Compaction after SC — verifies alter_version is properly cleaned up
-        trigger_and_wait_compaction(tableName, "cumulative")
-
-        // Base compaction should also work now
-        trigger_and_wait_compaction(tableName, "base")
-
-        // Final data verification
-        def finalCount = sql "SELECT count(*) FROM ${tableName}"
-        assertEquals(340L, finalCount[0][0])
-
-        // Verify all distinct keys
-        def distinctKeys = sql "SELECT count(distinct k1) FROM ${tableName}"
-        assertEquals(340L, distinctKeys[0][0])
-
-        // Verify column type changed successfully
         def desc = sql "DESC ${tableName}"
-        logger.info("Table description: ${desc}")
         def v1Col = desc.find { it[0] == "v1" }
         assertTrue(v1Col[1].toString().toLowerCase().contains("bigint"))
+
+        // Note: Compaction on new tablets during SC was verified in BE logs during development.
     }
 }

--- a/regression-test/suites/cloud_p1/schema_change/compaction_optimization/test_sc_compaction_optimization_with_load.groovy
+++ b/regression-test/suites/cloud_p1/schema_change/compaction_optimization/test_sc_compaction_optimization_with_load.groovy
@@ -1,0 +1,205 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Test: Schema change with concurrent data loading and compaction on multiple tablets.
+// Verifies end-to-end correctness with the optimization:
+// 1. SC completes successfully with multiple tablets and concurrent writes
+// 2. Compaction works on new tablets after SC completion
+// 3. Data is consistent after SC + compaction + continued loading
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_sc_compaction_optimization_with_load', 'docker') {
+
+    def options = new ClusterOptions()
+    options.cloudMode = true
+    options.enableDebugPoints()
+    options.beConfigs += ["enable_java_support=false"]
+    options.beConfigs += ["disable_auto_compaction=true"]
+    options.beConfigs += ["enable_new_tablet_do_compaction=true"]
+    options.beConfigs += ["alter_tablet_worker_count=1"]
+    options.beNum = 1
+
+    docker(options) {
+        def tableName = "sc_opt_load_test"
+
+        def getJobState = { tbl ->
+            def result = sql """SHOW ALTER TABLE COLUMN WHERE IndexName='${tbl}' ORDER BY createtime DESC LIMIT 1"""
+            logger.info("getJobState: ${result}")
+            return result[0][9]
+        }
+
+        // Create table with 3 buckets for more realistic multi-tablet scenario
+        sql "DROP TABLE IF EXISTS ${tableName}"
+        sql """
+            CREATE TABLE ${tableName} (
+                k1 int NOT NULL,
+                k2 varchar(50) NOT NULL,
+                v1 int NOT NULL,
+                v2 varchar(200) NOT NULL
+            )
+            DISTRIBUTED BY HASH(k1) BUCKETS 3
+            PROPERTIES (
+                "replication_num" = "1",
+                "disable_auto_compaction" = "true"
+            )
+        """
+
+        // Phase 1: Load initial data with multiple rowsets
+        def insertBatch = { int startKey, int count, String prefix ->
+            StringBuilder sb = new StringBuilder()
+            sb.append("INSERT INTO ${tableName} VALUES ")
+            for (int j = 0; j < count; j++) {
+                if (j > 0) sb.append(", ")
+                def key = startKey + j
+                sb.append("(${key}, '${prefix}_k2_${key}', ${key}, '${prefix}_v2_${key}')")
+            }
+            sql sb.toString()
+        }
+
+        // Create 5 rowsets with 30 rows each = 150 rows
+        for (int i = 0; i < 5; i++) {
+            insertBatch(i * 30 + 1, 30, "init_${i}")
+        }
+
+        def phase1Count = sql "SELECT count(*) FROM ${tableName}"
+        assertEquals(150L, phase1Count[0][0])
+
+        // Do cumulative compaction on base tablets to consolidate initial rowsets
+        trigger_and_wait_compaction(tableName, "cumulative")
+
+        def baseTablets = sql_return_maparray("SHOW TABLETS FROM ${tableName}")
+        logger.info("Base tablets: ${baseTablets}")
+        assertEquals(3, baseTablets.size())
+        def baseTabletIds = baseTablets.collect { it.TabletId.toString() }
+
+        def backends = sql_return_maparray("show backends")
+        def be = backends[0]
+
+        // Phase 2: Trigger SC with blocking — simulates queue scenario
+        def injectName = 'CloudSchemaChangeJob.process_alter_tablet.sleep'
+        GetDebugPoint().enableDebugPointForAllBEs(injectName)
+
+        try {
+            // ALTER adds a column — triggers SC for all 3 tablets
+            // With alter_tablet_worker_count=1: 1 executes (blocked), 2 queue
+            sql "ALTER TABLE ${tableName} MODIFY COLUMN v1 bigint"
+            sleep(10000)
+
+            def scState = getJobState(tableName)
+            assertEquals("RUNNING", scState)
+
+            // Phase 3: Heavy loading during SC — creates many rowsets via double-write
+            for (int i = 0; i < 8; i++) {
+                insertBatch(200 + i * 20, 20, "sc_${i}")
+            }
+            // 160 more rows during SC
+
+            // Get all tablets
+            def allTablets = sql_return_maparray("SHOW TABLETS FROM ${tableName}")
+            logger.info("All tablets during SC: ${allTablets}")
+            assertEquals(6, allTablets.size())  // 3 base + 3 new
+
+            def newTablets = allTablets.findAll { !(it.TabletId.toString() in baseTabletIds) }
+            assertEquals(3, newTablets.size())
+
+            // Trigger cumulative compaction on both base and new tablets
+            // Base tablets: compaction on versions <= V0 (within alter_version boundary)
+            // New tablets: compaction on versions > V0 (double-write data)
+            def newTabletCompactionAccepted = 0
+            for (def tablet : allTablets) {
+                def (code, out, err) = be_run_cumulative_compaction(be.Host, be.HttpPort, tablet.TabletId)
+                logger.info("Trigger cu compaction on tablet ${tablet.TabletId}: code=${code}, out=${out}")
+                if (code == 0 && tablet.TabletId.toString() in newTablets.collect { it.TabletId.toString() }) {
+                    def triggerResult = parseJson(out.trim())
+                    def status = triggerResult.status.toLowerCase()
+                    if (status == "success" || status == "already_exist") {
+                        newTabletCompactionAccepted++
+                    }
+                }
+            }
+            // All new tablets should accept compaction (alter_version set by pre_submit_callback)
+            logger.info("New tablet compaction accepted: ${newTabletCompactionAccepted} / ${newTablets.size()}")
+            assertEquals(newTablets.size(), newTabletCompactionAccepted)
+
+            // Wait for compactions
+            for (def tablet : allTablets) {
+                boolean running = true
+                int maxWait = 60
+                while (running && maxWait-- > 0) {
+                    Thread.sleep(1000)
+                    def (code, out, err) = be_get_compaction_status(be.Host, be.HttpPort, tablet.TabletId)
+                    if (code == 0) {
+                        def compactionStatus = parseJson(out.trim())
+                        running = compactionStatus.run_status
+                    } else {
+                        break
+                    }
+                }
+            }
+
+        } finally {
+            GetDebugPoint().disableDebugPointForAllBEs(injectName)
+        }
+
+        // Phase 4: Wait for SC completion
+        int maxTries = 300
+        def finalState = ""
+        while (maxTries-- > 0) {
+            finalState = getJobState(tableName)
+            if (finalState == "FINISHED" || finalState == "CANCELLED") {
+                sleep(3000)
+                break
+            }
+            sleep(1000)
+        }
+        assertEquals("FINISHED", finalState)
+
+        // Phase 5: Verify data after SC
+        def afterScCount = sql "SELECT count(*) FROM ${tableName}"
+        logger.info("Row count after SC: ${afterScCount}")
+        assertEquals(310L, afterScCount[0][0])  // 150 + 160
+
+        // Phase 6: Continue loading after SC (verifies no residual alter_version issues)
+        for (int i = 0; i < 3; i++) {
+            insertBatch(500 + i * 10, 10, "post_${i}")
+        }
+
+        def afterPostCount = sql "SELECT count(*) FROM ${tableName}"
+        assertEquals(340L, afterPostCount[0][0])  // 310 + 30
+
+        // Phase 7: Compaction after SC — verifies alter_version is properly cleaned up
+        trigger_and_wait_compaction(tableName, "cumulative")
+
+        // Base compaction should also work now
+        trigger_and_wait_compaction(tableName, "base")
+
+        // Final data verification
+        def finalCount = sql "SELECT count(*) FROM ${tableName}"
+        assertEquals(340L, finalCount[0][0])
+
+        // Verify all distinct keys
+        def distinctKeys = sql "SELECT count(distinct k1) FROM ${tableName}"
+        assertEquals(340L, distinctKeys[0][0])
+
+        // Verify column type changed successfully
+        def desc = sql "DESC ${tableName}"
+        logger.info("Table description: ${desc}")
+        def v1Col = desc.find { it[0] == "v1" }
+        assertTrue(v1Col[1].toString().toLowerCase().contains("bigint"))
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

## Summary

In cloud mode, schema change (SC) tasks for multi-tablet tables are submitted to a thread pool with limited workers. Tablets waiting in the queue cannot do compaction because their `alter_version` is unset (-1), which causes rowset accumulation during long queue waits.

This PR:

1. **Sets `alter_version = V0` before enqueue** via `pre_submit_callback` on `TaskWorkerPool`, allowing compaction on new tablets for versions > V0 during the queue wait period.

2. **Fixes a cross-V1 compaction race condition**: During the queue wait, compaction may commit a rowset that crosses the eventual V1 boundary (determined later by `prepare_tablet_job`). After SC commit, this creates version overlap and causes BE crash (`Check failed: versions are not continuity`). The fix adds a cross-V1 check in `process_alter_tablet` after `prepare_tablet_job` returns V1: sync new tablet and reject if any rowset crosses V1, letting FE retry with a higher V1.

## Changes

**BE only — no FE or meta-service changes.**

### Core logic

- `task_worker_pool.h/cpp`: Add optional `pre_submit_callback` to `TaskWorkerPool`, called synchronously before task enqueue.
- `agent_server.cpp`: Pass `set_alter_version_before_enqueue` as `pre_submit_callback` for ALTER workers.
- `task_worker_pool.cpp`: Implement `set_alter_version_before_enqueue` (sets alter_version=V0 on both tablets) and cleanup logic in `alter_cloud_tablet_callback` (resets alter_version=-1 before `remove_task_info` to avoid race with re-submission).
- `cloud_schema_change_job.cpp`: Add cross-V1 compaction check after `prepare_tablet_job` — sync new tablet and verify no rowset crosses V1 boundary. If detected, return error for FE retry (next retry V1 will be higher, cross-boundary rowset falls within [2, V1']).

### Key Design Points

- **V0** (partition visible version from FE) is set at pre-submit time to enable compaction during queue wait.
- **V1** (base_max_version) is still determined at SC execution time for rowset conversion alignment — unchanged behavior.
- SC commit atomically replaces rowsets [2, V1] on the new tablet, so any compaction results in (V0, V1] during queue time are harmlessly discarded.
- Cleanup order: `alter_version` is reset to -1 before `remove_task_info` to prevent race with same-signature re-submission.

### Cross-V1 race condition analysis

The dangerous timing window is: compaction commits to meta-service BEFORE `prepare_tablet_job` registers the SC job. At that point, no `JOB_CHECK_ALTER_VERSION` protection exists, so compaction succeeds. When SC later commits with a lower V1, meta-service cannot delete the cross-V1 rowset, creating version overlap.

After `prepare_tablet_job`, two existing mechanisms protect:
- `clear_compaction`: `prepare_tablet_job` clears all compaction jobs on new tablet, so in-flight compaction commits are rejected.
- `JOB_CHECK_ALTER_VERSION`: new compaction starts are rejected if input versions cross V1.

The fix covers the only unprotected window by checking for cross-V1 rowsets right after `prepare_tablet_job` returns.

### Tests

- `task_worker_pool_test.cpp`: UT for `pre_submit_callback` mechanism and task dedup behavior.
- `test_sc_compaction_optimization.groovy`: Verify compaction runs on new tablets during SC queue wait (merged rowset version range proves compaction happened).
- `test_sc_compaction_optimization_with_load.groovy`: End-to-end with concurrent writes, data consistency after SC + compaction.
- `test_sc_compaction_cross_v1_race.groovy`: Reproduce cross-V1 race using `override_base_max_version` debug point. Without fix: BE crash. With fix: SC detects cross-V1 and returns retryable error, BE stays alive.

### Release note

None

### Check List (For Author)

- Test
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test
    - [ ] No need to test

- Behavior changed:
    - [ ] No.
    - [x] Yes. Enables compaction on NOTREADY tablets during SC queue wait; adds cross-V1 safety check in process_alter_tablet.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
