### PR TITLE
[fix](json) fix RuntimeException when comparing JSONB literals

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/JsonLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/JsonLiteral.java
@@ -72,10 +72,19 @@ public class JsonLiteral extends LiteralExpr {
 
     @Override
     public int compareLiteral(LiteralExpr expr) {
+        if (expr instanceof PlaceHolderExpr) {
+            return this.compareLiteral(((PlaceHolderExpr) expr).getLiteral());
+        }
+        if (expr instanceof NullLiteral) {
+            return 1;
+        }
+        if (expr == MaxLiteral.MAX_VALUE) {
+            return -1;
+        }
         if (expr instanceof JsonLiteral) {
             return value.compareTo(((JsonLiteral) expr).value);
         }
-        return value.compareTo(expr.getStringValue());
+        throw new RuntimeException("Cannot compare JsonLiteral with " + expr.getClass().getSimpleName());
     }
 
     public String getValue() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/JsonLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/JsonLiteral.java
@@ -72,7 +72,10 @@ public class JsonLiteral extends LiteralExpr {
 
     @Override
     public int compareLiteral(LiteralExpr expr) {
-        throw new RuntimeException("Not support comparison between JSONB literals");
+        if (expr instanceof JsonLiteral) {
+            return value.compareTo(((JsonLiteral) expr).value);
+        }
+        return value.compareTo(expr.getStringValue());
     }
 
     public String getValue() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/JsonLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/JsonLiteral.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 /**
  * literal for json type.
  */
-public class JsonLiteral extends Literal {
+public class JsonLiteral extends Literal implements ComparableLiteral {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -71,6 +71,21 @@ public class JsonLiteral extends Literal {
         } catch (Throwable t) {
             throw new AnalysisException(t.getMessage(), t);
         }
+    }
+
+    @Override
+    public int compareTo(ComparableLiteral other) {
+        if (other instanceof JsonLiteral) {
+            return value.compareTo(((JsonLiteral) other).value);
+        }
+        if (other instanceof NullLiteral) {
+            return 1;
+        }
+        if (other instanceof MaxLiteral) {
+            return -1;
+        }
+        throw new RuntimeException("Cannot compare two values with different data types: "
+                + this + " (" + dataType + ") vs " + other + " (" + ((Literal) other).dataType + ")");
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/JsonLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/JsonLiteralTest.java
@@ -111,4 +111,13 @@ class JsonLiteralTest {
         StringLiteral str = new StringLiteral("[1,2]");
         Assertions.assertThrows(RuntimeException.class, () -> json.compareTo(str));
     }
+
+    @Test
+    public void testLegacyCompareWithDifferentTypeThrows() throws Exception {
+        org.apache.doris.analysis.JsonLiteral json =
+                new org.apache.doris.analysis.JsonLiteral("[1,2]");
+        org.apache.doris.analysis.StringLiteral str =
+                new org.apache.doris.analysis.StringLiteral("[1,2]");
+        Assertions.assertThrows(RuntimeException.class, () -> json.compareLiteral(str));
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/JsonLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/JsonLiteralTest.java
@@ -1,0 +1,114 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.expressions.literal;
+
+import org.apache.doris.nereids.exceptions.AnalysisException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class JsonLiteralTest {
+
+    @Test
+    public void testCompareSameJsonLiterals() {
+        JsonLiteral a = new JsonLiteral("[1,2,3]");
+        JsonLiteral b = new JsonLiteral("[1,2,3]");
+        Assertions.assertEquals(0, a.compareTo(b));
+        Assertions.assertEquals(0, b.compareTo(a));
+    }
+
+    @Test
+    public void testCompareDifferentJsonLiterals() {
+        JsonLiteral a = new JsonLiteral("{\"a\":1}");
+        JsonLiteral b = new JsonLiteral("{\"b\":2}");
+        Assertions.assertTrue(a.compareTo(b) < 0);
+        Assertions.assertTrue(b.compareTo(a) > 0);
+    }
+
+    @Test
+    public void testCompareJsonObjectLiterals() {
+        JsonLiteral a = new JsonLiteral("{\"key\":\"value1\"}");
+        JsonLiteral b = new JsonLiteral("{\"key\":\"value2\"}");
+        Assertions.assertTrue(a.compareTo(b) < 0);
+        Assertions.assertTrue(b.compareTo(a) > 0);
+    }
+
+    @Test
+    public void testCompareWithNullLiteral() {
+        JsonLiteral json = new JsonLiteral("[1,2]");
+        NullLiteral nullLit = NullLiteral.INSTANCE;
+        Assertions.assertEquals(1, json.compareTo(nullLit));
+    }
+
+    @Test
+    public void testCompareWithMaxLiteral() {
+        JsonLiteral json = new JsonLiteral("[1,2]");
+        MaxLiteral maxLit = new MaxLiteral(json.dataType);
+        Assertions.assertEquals(-1, json.compareTo(maxLit));
+    }
+
+    @Test
+    public void testInvalidJsonThrows() {
+        Assertions.assertThrows(AnalysisException.class, () -> new JsonLiteral("not valid json"));
+    }
+
+    @Test
+    public void testGetValue() {
+        JsonLiteral json = new JsonLiteral("{\"a\":1}");
+        Assertions.assertEquals("{\"a\":1}", json.getValue());
+    }
+
+    @Test
+    public void testGetStringValue() {
+        JsonLiteral json = new JsonLiteral("[1,2,3]");
+        Assertions.assertEquals("[1,2,3]", json.getStringValue());
+    }
+
+    @Test
+    public void testLegacyCompareLiteral() throws Exception {
+        org.apache.doris.analysis.JsonLiteral a =
+                new org.apache.doris.analysis.JsonLiteral("[1,2,3]");
+        org.apache.doris.analysis.JsonLiteral b =
+                new org.apache.doris.analysis.JsonLiteral("[1,2,3]");
+        Assertions.assertEquals(0, a.compareLiteral(b));
+    }
+
+    @Test
+    public void testLegacyCompareDifferent() throws Exception {
+        org.apache.doris.analysis.JsonLiteral a =
+                new org.apache.doris.analysis.JsonLiteral("{\"a\":1}");
+        org.apache.doris.analysis.JsonLiteral b =
+                new org.apache.doris.analysis.JsonLiteral("{\"b\":2}");
+        Assertions.assertTrue(a.compareLiteral(b) < 0);
+        Assertions.assertTrue(b.compareLiteral(a) > 0);
+    }
+
+    @Test
+    public void testToLegacyAndCompare() {
+        JsonLiteral a = new JsonLiteral("[1,2,3]");
+        JsonLiteral b = new JsonLiteral("[1,2,3]");
+        Assertions.assertEquals(0, a.toLegacyLiteral().compareLiteral(b.toLegacyLiteral()));
+    }
+
+    @Test
+    public void testCompareWithDifferentTypeThrows() {
+        JsonLiteral json = new JsonLiteral("[1,2]");
+        StringLiteral str = new StringLiteral("[1,2]");
+        Assertions.assertThrows(RuntimeException.class, () -> json.compareTo(str));
+    }
+}


### PR DESCRIPTION
## Proposed changes

Issue Number: close #59692

This PR addresses the remaining failure in reopened issue `#59692`.

The earlier incorrect-result cases for single `JSON_CONTAINS` calls were already fixed by `#53291`. However, chained predicates such as:

```sql
SELECT *
FROM table
WHERE JSON_CONTAINS('["1","2","3"]', '"1"')
  AND JSON_CONTAINS('["1","2","3"]', '"2"')
LIMIT 100;
```

can still fail in FE with:

```text
Not support comparison between JSONB literals
```

### Root cause

During FE optimization phases such as filter estimation and partition pruning, JSON literals may be compared through legacy literal comparison paths. The legacy `JsonLiteral.compareLiteral()` throws `RuntimeException` for JSON literal comparisons, which aborts planning before execution reaches the BE where `json_contains` itself is handled correctly.

### Changes

- Fix legacy `JsonLiteral.compareLiteral()` to support JSON literal comparison instead of throwing directly.
- Make Nereids `JsonLiteral` implement `ComparableLiteral` with `compareTo()`.
- Align legacy behavior with Nereids by explicitly handling `PlaceHolderExpr`, `NullLiteral`, and `MaxLiteral`, and rejecting incompatible cross-type comparisons.
- Add `JsonLiteralTest` covering both legacy and Nereids comparison behavior.

### Behavior

Before:
- Single `JSON_CONTAINS` incorrect-result cases were already fixed by `#53291`.
- Chained `JSON_CONTAINS` predicates could still fail during FE optimization with `Not support comparison between JSONB literals`.

After:
- Chained `JSON_CONTAINS` predicates no longer fail because of JSON literal comparison in FE optimization.
- Direct SQL-level invalid JSON comparisons are still rejected by normal semantic checks.

## Further comments

- This PR does not change SQL semantics for direct JSON comparison predicates such as `json_col = json_col`.
- The comparison support here is for internal FE optimization infrastructure only.
- String-based comparison is acceptable here because `JsonLiteral` stores normalized string content and the goal is to avoid planner crashes rather than introduce new SQL-visible comparison semantics.
