### PR TITLE
[fix](catalog) avoid catalog/cache lock inversion in resetToUninitialized

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -589,14 +589,24 @@ public abstract class ExternalCatalog
      * @param invalidCache if {@code true}, the catalog cache will be invalidated
      *                     and reloaded during the refresh process.
      */
-    public synchronized void resetToUninitialized(boolean invalidCache) {
+    public void resetToUninitialized(boolean invalidCache) {
+        synchronized (this) {
+            resetToUninitializedInLock();
+        }
+        onRefreshCache(invalidCache);
+    }
+
+    /**
+     * Reset catalog state under catalog monitor.
+     * Cache invalidation must be executed outside catalog monitor to avoid lock-order inversion.
+     */
+    protected void resetToUninitializedInLock() {
         this.objectCreated = false;
         this.initialized = false;
         synchronized (this.confLock) {
             this.cachedConf = null;
         }
         onClose();
-        onRefreshCache(invalidCache);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalCatalog.java
@@ -153,11 +153,6 @@ public class HMSExternalCatalog extends ExternalCatalog {
     }
 
     @Override
-    public synchronized void resetToUninitialized(boolean invalidCache) {
-        super.resetToUninitialized(invalidCache);
-    }
-
-    @Override
     public void onClose() {
         super.onClose();
         if (null != fileSystemExecutor) {
@@ -245,4 +240,3 @@ public class HMSExternalCatalog extends ExternalCatalog {
         return icebergMetadataOps;
     }
 }
-

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
@@ -130,12 +130,15 @@ public class JdbcExternalCatalog extends ExternalCatalog {
     }
 
     @Override
-    public synchronized void resetToUninitialized(boolean invalidCache) {
-        super.resetToUninitialized(invalidCache);
-        this.identifierMapping = new JdbcIdentifierMapping(
-                (Env.isTableNamesCaseInsensitive() || Env.isStoredTableNamesLowerCase()),
-                Boolean.parseBoolean(getLowerCaseMetaNames()),
-                getMetaNamesMapping());
+    public void resetToUninitialized(boolean invalidCache) {
+        synchronized (this) {
+            resetToUninitializedInLock();
+            this.identifierMapping = new JdbcIdentifierMapping(
+                    (Env.isTableNamesCaseInsensitive() || Env.isStoredTableNamesLowerCase()),
+                    Boolean.parseBoolean(getLowerCaseMetaNames()),
+                    getMetaNamesMapping());
+        }
+        onRefreshCache(invalidCache);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogResetToUninitializedTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogResetToUninitializedTest.java
@@ -1,0 +1,112 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource;
+
+import org.apache.doris.catalog.JdbcResource;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.datasource.jdbc.JdbcExternalCatalog;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ExternalCatalogResetToUninitializedTest {
+
+    @Test
+    public void testExternalCatalogRefreshRunsOutsideCatalogMonitor() {
+        LockAwareExternalCatalog catalog = new LockAwareExternalCatalog();
+
+        catalog.resetToUninitialized(true);
+
+        Assert.assertTrue(catalog.refreshCalled);
+        Assert.assertFalse(catalog.holdsCatalogMonitorInRefresh);
+    }
+
+    @Test
+    public void testJdbcCatalogRefreshRunsOutsideCatalogMonitor() throws DdlException {
+        LockAwareJdbcExternalCatalog catalog = new LockAwareJdbcExternalCatalog();
+
+        catalog.resetToUninitialized(true);
+
+        Assert.assertTrue(catalog.refreshCalled);
+        Assert.assertFalse(catalog.holdsCatalogMonitorInRefresh);
+    }
+
+    private static class LockAwareExternalCatalog extends ExternalCatalog {
+        private boolean refreshCalled;
+        private boolean holdsCatalogMonitorInRefresh;
+
+        LockAwareExternalCatalog() {
+            super(1L, "lock_test_catalog", InitCatalogLog.Type.TEST, "");
+            this.catalogProperty = new CatalogProperty("", new HashMap<>());
+        }
+
+        @Override
+        protected List<String> listTableNamesFromRemote(SessionContext ctx, String dbName) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public boolean tableExist(SessionContext ctx, String dbName, String tblName) {
+            return false;
+        }
+
+        @Override
+        protected void initLocalObjectsImpl() {
+        }
+
+        @Override
+        protected List<String> listDatabaseNames() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void onRefreshCache(boolean invalidCache) {
+            refreshCalled = true;
+            holdsCatalogMonitorInRefresh = Thread.holdsLock(this);
+        }
+    }
+
+    private static class LockAwareJdbcExternalCatalog extends JdbcExternalCatalog {
+        private boolean refreshCalled;
+        private boolean holdsCatalogMonitorInRefresh;
+
+        LockAwareJdbcExternalCatalog() throws DdlException {
+            super(2L, "lock_test_jdbc_catalog", null, buildJdbcProperties(), "");
+        }
+
+        @Override
+        public void onRefreshCache(boolean invalidCache) {
+            refreshCalled = true;
+            holdsCatalogMonitorInRefresh = Thread.holdsLock(this);
+        }
+
+        private static Map<String, String> buildJdbcProperties() {
+            Map<String, String> properties = new HashMap<>();
+            properties.put("type", "jdbc");
+            properties.put(JdbcResource.DRIVER_URL, "ojdbc8.jar");
+            properties.put(JdbcResource.JDBC_URL, "jdbc:oracle:thin:@127.0.0.1:1521:XE");
+            properties.put(JdbcResource.DRIVER_CLASS, "oracle.jdbc.driver.OracleDriver");
+            return properties;
+        }
+    }
+}


### PR DESCRIPTION
## What problem does this PR solve?

This fixes a potential Java deadlock caused by lock-order inversion between ExternalCatalog object monitor(synchronized methods) and Caffeine/ConcurrentHashMap internal key locks during cache invalidation/loading.

The deadlock can happen when one thread holds the catalog monitor and invalidates cache, while another thread holds cache-internal lock and calls back into catalog initialization.

## What is changed?

1. In ExternalCatalog, split reset flow into lock-protected state reset(resetToUninitializedInLock) and cache refresh outside catalog monitor.
2. In JdbcExternalCatalog, keep identifier mapping reset under lock, but perform onRefreshCache outside lock.
3. Add FE unit test ExternalCatalogResetToUninitializedTest to assert onRefreshCache runs without holding catalog monitor (both base external catalog and JDBC path).

## Testing

- Not rerun to completion in this turn after branch switch.
