### PR TITLE
[fix](iceberg)fix iceberg rewrite_data_file fail when table had been updated.

### DIFF
--- a/docker/thirdparties/docker-compose/iceberg/scripts/create_preinstalled_scripts/iceberg/run27.sql
+++ b/docker/thirdparties/docker-compose/iceberg/scripts/create_preinstalled_scripts/iceberg/run27.sql
@@ -1,0 +1,40 @@
+use demo.test_db;
+
+
+create table if not exists test_rewrite_data_with_update (
+  id INT,
+  name STRING
+)
+USING iceberg
+TBLPROPERTIES (
+  'format-version' = '2',
+  'write.delete.mode' = 'merge-on-read',
+  'write.update.mode' = 'merge-on-read',
+  'write.merge.mode' = 'merge-on-read'
+);
+
+
+INSERT INTO test_rewrite_data_with_update VALUES
+(1, 'a'),(2, 'b'),(3, 'c');
+
+update test_rewrite_data_with_update set name = "bb"  where id = 1;
+
+
+
+create table if not exists test_rewrite_data_with_delete (
+  id INT,
+  name STRING
+)
+USING iceberg
+TBLPROPERTIES (
+  'format-version' = '2',
+  'write.delete.mode' = 'merge-on-read',
+  'write.update.mode' = 'merge-on-read',
+  'write.merge.mode' = 'merge-on-read'
+);
+
+
+INSERT INTO test_rewrite_data_with_delete VALUES
+(1, 'a'),(2, 'b'),(3, 'c');
+
+delete from test_rewrite_data_with_delete where id = 1;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergTransaction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergTransaction.java
@@ -73,6 +73,7 @@ public class IcebergTransaction implements Transaction {
     private String branchName;
 
     // Rewrite operation support
+    long startingSnapshotId = -1L; // Track the starting snapshot ID for rewrite operations
     private final List<DataFile> filesToDelete = Lists.newArrayList();
     private final List<DataFile> filesToAdd = Lists.newArrayList();
     private boolean isRewriteMode = false;
@@ -132,6 +133,9 @@ public class IcebergTransaction implements Transaction {
             ops.getExecutionAuthenticator().execute(() -> {
                 // create and start the iceberg transaction
                 this.table = IcebergUtils.getIcebergTable(dorisTable);
+
+                // Capture the starting snapshot ID for validation during rewrite commit
+                this.startingSnapshotId = table.currentSnapshot().snapshotId();
 
                 // For rewrite operations, we work directly on the main table
                 // No branch information needed
@@ -197,6 +201,8 @@ public class IcebergTransaction implements Transaction {
         }
 
         RewriteFiles rewriteFiles = transaction.newRewrite();
+
+        rewriteFiles = rewriteFiles.validateFromSnapshot(startingSnapshotId);
 
         // For rewrite operations, we work directly on the main table
         rewriteFiles = rewriteFiles.scanManifestsWith(ops.getThreadPoolWithPreAuth());

--- a/regression-test/data/external_table_p0/iceberg/action/test_iceberg_rewrite_data_files.out
+++ b/regression-test/data/external_table_p0/iceberg/action/test_iceberg_rewrite_data_files.out
@@ -68,3 +68,21 @@
 8	EAST	280.00	2024-01-02
 9	EAST	380.00	2024-01-02
 
+-- !before_rewrite_update --
+1	bb
+2	b
+3	c
+
+-- !after_rewrite_update --
+1	bb
+2	b
+3	c
+
+-- !before_rewrite_delete --
+2	b
+3	c
+
+-- !after_rewrite_delete --
+2	b
+3	c
+

--- a/regression-test/suites/external_table_p0/iceberg/action/test_iceberg_rewrite_data_files.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/action/test_iceberg_rewrite_data_files.groovy
@@ -493,4 +493,67 @@ suite("test_iceberg_rewrite_data_files", "p0,external") {
     
     logger.info("Specific partition rewrite test completed successfully")
 
+    // =====================================================================================
+    // Test Case 4: Rewrite data files for merge-on-read update table
+    //
+    // Tables `test_rewrite_data_with_update` and `test_rewrite_data_with_delete`
+    // are pre-created in Docker initialization (run23.sql) using Spark SQL with
+    // format-version = 2 and merge-on-read enabled for delete/update/merge.
+    //
+    // This case verifies that executing rewrite_data_files on a table that has
+    // already performed UPDATE operations (implemented via delete + insert) does
+    // not change the logical query results.
+    // =====================================================================================
+    logger.info("Starting rewrite_data_files test for merge-on-read UPDATE table")
+
+    def table_name_update = "test_rewrite_data_with_update"
+
+    // Verify data before rewrite: id = 1 should have been updated to 'bb'
+    qt_before_rewrite_update """SELECT id, name FROM ${table_name_update} ORDER BY id"""
+
+    def rewriteResultUpdate = sql """
+        ALTER TABLE ${catalog_name}.${db_name}.${table_name_update}
+        EXECUTE rewrite_data_files(
+            "target-file-size-bytes" = "10485760",
+            "min-input-files" = "1"
+        )
+    """
+    logger.info("Rewrite data files result for update table: ${rewriteResultUpdate}")
+
+    // Verify data after rewrite (logical rows should remain the same)
+    qt_after_rewrite_update """SELECT id, name FROM ${table_name_update} ORDER BY id"""
+
+    def totalUpdateRecords = sql """SELECT COUNT(*) FROM ${table_name_update}"""
+    assertTrue(totalUpdateRecords[0][0] == 3, "Update table should still have 3 logical records after rewrite")
+
+    // =====================================================================================
+    // Test Case 5: Rewrite data files for merge-on-read delete table
+    //
+    // This case verifies that executing rewrite_data_files on a table that has
+    // already performed DELETE operations does not resurrect deleted rows and
+    // keeps the logical result set unchanged.
+    // =====================================================================================
+    logger.info("Starting rewrite_data_files test for merge-on-read DELETE table")
+
+    def table_name_delete = "test_rewrite_data_with_delete"
+
+    // Verify data before rewrite: row with id = 1 should have been deleted
+    qt_before_rewrite_delete """SELECT id, name FROM ${table_name_delete} ORDER BY id"""
+
+    def rewriteResultDelete = sql """
+        ALTER TABLE ${catalog_name}.${db_name}.${table_name_delete}
+        EXECUTE rewrite_data_files(
+            "target-file-size-bytes" = "10485760",
+            "min-input-files" = "1"
+        )
+    """
+    logger.info("Rewrite data files result for delete table: ${rewriteResultDelete}")
+
+    // Verify data after rewrite (deleted rows should not reappear)
+    qt_after_rewrite_delete """SELECT id, name FROM ${table_name_delete} ORDER BY id"""
+
+    def totalDeleteRecords = sql """SELECT COUNT(*) FROM ${table_name_delete}"""
+    assertTrue(totalDeleteRecords[0][0] == 2, "Delete table should still have 2 logical records after rewrite")
+
+    logger.info("Merge-on-read update/delete rewrite_data_files tests completed successfully")
 }


### PR DESCRIPTION
### What problem does this PR solve?
Related PR: #56413
Problem Summary:
fix iceberg `rewrite_data_file` fail when table had been updated.

Reproduction steps:
spark-sql:
```
create table if not exists test_rewrite_data_with_update (
  id INT,name STRING )
USING iceberg
TBLPROPERTIES (
  'format-version' = '2','write.delete.mode' = 'merge-on-read',
  'write.update.mode' = 'merge-on-read','write.merge.mode' = 'merge-on-read'
);
INSERT INTO test_rewrite_data_with_update VALUES
(1, 'a'),(2, 'b'),(3, 'c');
update test_rewrite_data_with_update set name = "bb"  where id = 1;
```
then  doris:
```
mysql>         ALTER TABLE test_rewrite_data_with_update
    ->         EXECUTE rewrite_data_files(
    ->             "target-file-size-bytes" = "10485760",
    ->             "min-input-files" = "1"
    ->         );
```
Error: 
```
2026-03-06 16:59:08,524 WARN (mysql-nio-pool-0|204) [IcebergRewriteDataFilesAction.executeAction():199] Failed to rewrite data files for table: test_rewrite_data_with_update
java.lang.RuntimeException: org.apache.iceberg.exceptions.ValidationException: Cannot commit, found new delete for replaced data file: GenericDataFile{content=data, file_path=s3a://warehouse/wh/test_db/test_rewrite_data_with_update/data/d3b4489712ef4f52-aa754e4142723ff8_fddbaa4c-d5cd-4443-ab84-e2041608ad36-0.zstd.parquet, file_format=PARQUET, spec_id=0, partition=PartitionData{}, record_count=1, file_size_in_bytes=1451, column_sizes=null, value_counts=null, null_value_counts=null, nan_value_counts=null, lower_bounds=null, upper_bounds=null, key_metadata=null, split_offsets=null, equality_ids=null, sort_order_id=0, data_sequence_number=3, file_sequence_number=3, first_row_id=null, referenced_data_file=null, content_offset=null, content_size_in_bytes=null}
        at org.apache.doris.datasource.iceberg.IcebergTransaction.finishRewrite(IcebergTransaction.java:163)
        at org.apache.doris.datasource.iceberg.rewrite.RewriteDataFileExecutor.executeGroupsConcurrently(RewriteDataFileExecutor.java:107)
        at org.apache.doris.datasource.iceberg.action.IcebergRewriteDataFilesAction.executeAction(IcebergRewriteDataFilesAction.java:196)
        at org.apache.doris.nereids.trees.plans.commands.execute.BaseExecuteAction.execute(BaseExecuteAction.java:102)
        at org.apache.doris.nereids.trees.plans.commands.ExecuteActionCommand.run(ExecuteActionCommand.java:107)
        at org.apache.doris.qe.StmtExecutor.executeByNereids(StmtExecutor.java:678)
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:541)
        at org.apache.doris.qe.StmtExecutor.queryRetry(StmtExecutor.java:500)
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:485)
        at org.apache.doris.qe.ConnectProcessor.executeQuery(ConnectProcessor.java:311)
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:198)
        at org.apache.doris.qe.MysqlConnectProcessor.handleQuery(MysqlConnectProcessor.java:231)
        at org.apache.doris.qe.MysqlConnectProcessor.dispatch(MysqlConnectProcessor.java:259)
        at org.apache.doris.qe.MysqlConnectProcessor.processOnce(MysqlConnectProcessor.java:403)
        at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: org.apache.iceberg.exceptions.ValidationException: Cannot commit, found new delete for replaced data file: GenericDataFile{content=data, file_path=s3a://warehouse/wh/test_db/test_rewrite_data_with_update/data/d3b4489712ef4f52-aa754e4142723ff8_fddbaa4c-d5cd-4443-ab84-e2041608ad36-0.zstd.parquet, file_format=PARQUET, spec_id=0, partition=PartitionData{}, record_count=1, file_size_in_bytes=1451, column_sizes=null, value_counts=null, null_value_counts=null, nan_value_counts=null, lower_bounds=null, upper_bounds=null, key_metadata=null, split_offsets=null, equality_ids=null, sort_order_id=0, data_sequence_number=3, file_sequence_number=3, first_row_id=null, referenced_data_file=null, content_offset=null, content_size_in_bytes=null}
        at org.apache.iceberg.exceptions.ValidationException.check(ValidationException.java:49)
        at org.apache.iceberg.MergingSnapshotProducer.validateNoNewDeletesForDataFiles(MergingSnapshotProducer.java:530)
        at org.apache.iceberg.MergingSnapshotProducer.validateNoNewDeletesForDataFiles(MergingSnapshotProducer.java:462)
        at org.apache.iceberg.BaseRewriteFiles.validate(BaseRewriteFiles.java:140)
        at org.apache.iceberg.SnapshotProducer.apply(SnapshotProducer.java:260)
        at org.apache.iceberg.SnapshotProducer.lambda$commit$2(SnapshotProducer.java:439)
        at org.apache.iceberg.util.Tasks$Builder.runTaskWithRetry(Tasks.java:413)
        at org.apache.iceberg.util.Tasks$Builder.runSingleThreaded(Tasks.java:219)
        at org.apache.iceberg.util.Tasks$Builder.run(Tasks.java:203)
        at org.apache.iceberg.util.Tasks$Builder.run(Tasks.java:196)
        at org.apache.iceberg.SnapshotProducer.commit(SnapshotProducer.java:437)
        at org.apache.doris.datasource.iceberg.IcebergTransaction.updateManifestAfterRewrite(IcebergTransaction.java:213)
        at org.apache.doris.datasource.iceberg.IcebergTransaction.lambda$finishRewrite$3(IcebergTransaction.java:158)
        at org.apache.doris.common.security.authentication.ExecutionAuthenticator.execute(ExecutionAuthenticator.java:44)
        at org.apache.doris.datasource.iceberg.IcebergTransaction.finishRewrite(IcebergTransaction.java:157)
        ... 17 more
```


### Release note
fix iceberg rewrite_data_file fail when table had been updated.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

