### PR TITLE
[fix](ci) Fix BE UT macOS workflow for ARM64 runner

### DIFF
--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -77,7 +77,7 @@ jobs:
             'gettext'
             'wget'
             'pcre'
-            'openjdk@11'
+            'openjdk@17'
             'maven'
             'node'
             'llvm@16'
@@ -87,14 +87,14 @@ jobs:
           pushd thirdparty
           branch="${{ github.base_ref }}"
           if [[ -z "${branch}" ]] || [[ "${branch}" == 'master' ]]; then
-            curl -L https://github.com/apache/doris-thirdparty/releases/download/automation/doris-thirdparty-prebuilt-darwin-x86_64.tar.xz \
-              -o doris-thirdparty-prebuilt-darwin-x86_64.tar.xz
+            curl -L https://github.com/apache/doris-thirdparty/releases/download/automation/doris-thirdparty-prebuilt-darwin-arm64.tar.xz \
+              -o doris-thirdparty-prebuilt-darwin-arm64.tar.xz
           else
-            curl -L "https://github.com/apache/doris-thirdparty/releases/download/automation-${branch/branch-/}/doris-thirdparty-prebuilt-darwin-x86_64.tar.xz" \
-              -o doris-thirdparty-prebuilt-darwin-x86_64.tar.xz
+            curl -L "https://github.com/apache/doris-thirdparty/releases/download/automation-${branch/branch-/}/doris-thirdparty-prebuilt-darwin-arm64.tar.xz" \
+              -o doris-thirdparty-prebuilt-darwin-arm64.tar.xz
           fi
-          tar -xvf doris-thirdparty-prebuilt-darwin-x86_64.tar.xz
+          tar -xvf doris-thirdparty-prebuilt-darwin-arm64.tar.xz
           popd
 
-          export JAVA_HOME="${JAVA_HOME_17_X64%\/}"
+          export JAVA_HOME="${JAVA_HOME_17_ARM64%\/}"
           ./run-be-ut.sh --run -j "$(nproc)" --clean

--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -96,5 +96,5 @@ jobs:
           tar -xvf doris-thirdparty-prebuilt-darwin-arm64.tar.xz
           popd
 
-          export JAVA_HOME="${JAVA_HOME_17_ARM64%\/}"
+          export JAVA_HOME="${JAVA_HOME_17_arm64%\/}"
           ./run-be-ut.sh --run -j "$(nproc)" --clean

--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -98,4 +98,17 @@ jobs:
 
           export JAVA_HOME="${JAVA_HOME_17_arm64%\/}"
           export DORIS_CLANG_HOME="$(brew --prefix llvm@18)"
+
+          # Debug: verify compiler and OpenMP library availability
+          echo "DORIS_CLANG_HOME=${DORIS_CLANG_HOME}"
+          ls -la "${DORIS_CLANG_HOME}/bin/clang" || true
+          ls -la "${DORIS_CLANG_HOME}/lib/libomp"* || true
+          "${DORIS_CLANG_HOME}/bin/clang" --version || true
+
+          # Set CFLAGS/CXXFLAGS so cmake initializes CMAKE_C/CXX_FLAGS (cached globally)
+          # with the LLVM lib/include paths. This ensures FindOpenMP's try_compile can
+          # find libomp.dylib during linking (macOS -isysroot restricts default search paths).
+          export CFLAGS="-L${DORIS_CLANG_HOME}/lib -I${DORIS_CLANG_HOME}/include"
+          export CXXFLAGS="-L${DORIS_CLANG_HOME}/lib -I${DORIS_CLANG_HOME}/include"
+
           ./run-be-ut.sh --run -j "$(nproc)" --clean

--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -80,8 +80,7 @@ jobs:
             'openjdk@17'
             'maven'
             'node'
-            'llvm@16'
-            'libomp'
+            'llvm@18'
           )
           brew install "${cellars[@]}" || true
 
@@ -98,4 +97,5 @@ jobs:
           popd
 
           export JAVA_HOME="${JAVA_HOME_17_arm64%\/}"
+          export DORIS_CLANG_HOME="$(brew --prefix llvm@18)"
           ./run-be-ut.sh --run -j "$(nproc)" --clean

--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -98,6 +98,4 @@ jobs:
 
           export JAVA_HOME="${JAVA_HOME_17_arm64%\/}"
           export DORIS_CLANG_HOME="$(brew --prefix llvm@18)"
-          export LIBRARY_PATH="$(brew --prefix llvm@18)/lib:${LIBRARY_PATH:-}"
-          export CPATH="$(brew --prefix llvm@18)/include:${CPATH:-}"
           ./run-be-ut.sh --run -j "$(nproc)" --clean

--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -81,6 +81,7 @@ jobs:
             'maven'
             'node'
             'llvm@18'
+            'libomp'
           )
           brew install "${cellars[@]}" || true
 
@@ -98,17 +99,18 @@ jobs:
 
           export JAVA_HOME="${JAVA_HOME_17_arm64%\/}"
           export DORIS_CLANG_HOME="$(brew --prefix llvm@18)"
+          LIBOMP_PREFIX="$(brew --prefix libomp)"
 
-          # Debug: verify compiler and OpenMP library availability
-          echo "DORIS_CLANG_HOME=${DORIS_CLANG_HOME}"
-          ls -la "${DORIS_CLANG_HOME}/bin/clang" || true
-          ls -la "${DORIS_CLANG_HOME}/lib/libomp"* || true
-          "${DORIS_CLANG_HOME}/bin/clang" --version || true
+          # Debug: verify libomp availability
+          echo "LIBOMP_PREFIX=${LIBOMP_PREFIX}"
+          ls -la "${LIBOMP_PREFIX}/lib/libomp"* || true
+          ls -la "${LIBOMP_PREFIX}/include/omp.h" || true
 
           # Set CFLAGS/CXXFLAGS so cmake initializes CMAKE_C/CXX_FLAGS (cached globally)
-          # with the LLVM lib/include paths. This ensures FindOpenMP's try_compile can
+          # with the libomp lib/include paths. This ensures FindOpenMP's try_compile can
           # find libomp.dylib during linking (macOS -isysroot restricts default search paths).
-          export CFLAGS="-L${DORIS_CLANG_HOME}/lib -I${DORIS_CLANG_HOME}/include"
-          export CXXFLAGS="-L${DORIS_CLANG_HOME}/lib -I${DORIS_CLANG_HOME}/include"
+          # Homebrew's llvm@18 does NOT bundle libomp, so we use the standalone libomp formula.
+          export CFLAGS="-I${LIBOMP_PREFIX}/include -L${LIBOMP_PREFIX}/lib"
+          export CXXFLAGS="-I${LIBOMP_PREFIX}/include -L${LIBOMP_PREFIX}/lib"
 
           ./run-be-ut.sh --run -j "$(nproc)" --clean

--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -81,6 +81,7 @@ jobs:
             'maven'
             'node'
             'llvm@16'
+            'libomp'
           )
           brew install "${cellars[@]}" || true
 

--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -98,4 +98,6 @@ jobs:
 
           export JAVA_HOME="${JAVA_HOME_17_arm64%\/}"
           export DORIS_CLANG_HOME="$(brew --prefix llvm@18)"
+          export LIBRARY_PATH="$(brew --prefix llvm@18)/lib:${LIBRARY_PATH:-}"
+          export CPATH="$(brew --prefix llvm@18)/include:${CPATH:-}"
           ./run-be-ut.sh --run -j "$(nproc)" --clean

--- a/be/src/storage/index/ann/cmake-protect/CMakeLists.txt
+++ b/be/src/storage/index/ann/cmake-protect/CMakeLists.txt
@@ -45,26 +45,40 @@ endif ()
 
 # On macOS, CMake's FindOpenMP auto-detection often fails because:
 # - Apple Clang doesn't support -fopenmp natively
-# - Even Homebrew LLVM's clang may fail try_compile if libomp isn't in the default search path
-# Provide explicit hints so find_package(OpenMP) succeeds.
+# - Even Homebrew LLVM's clang may fail FindOpenMP's try_compile if libomp
+#   isn't in the default search path (macOS -isysroot restricts library search)
+# We must:
+# 1. Provide OpenMP cache variable hints (so FindOpenMP knows which flags to use)
+# 2. Add -L<lib_dir> to CMAKE_C/CXX_FLAGS (so try_compile's linker can find libomp)
+#    NOTE: CMAKE_C_FLAGS IS propagated to check_c_source_compiles/try_compile,
+#    but CMAKE_EXE_LINKER_FLAGS is NOT for source-file try_compile.
 if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
     # Try to find libomp from the compiler's own lib directory (Homebrew LLVM bundles it)
     get_filename_component(_COMPILER_DIR "${CMAKE_C_COMPILER}" DIRECTORY)
     get_filename_component(_COMPILER_PREFIX "${_COMPILER_DIR}" DIRECTORY)
     if (EXISTS "${_COMPILER_PREFIX}/lib/libomp.dylib")
-        set(_OMP_LIB "${_COMPILER_PREFIX}/lib/libomp.dylib")
+        set(_OMP_LIB_DIR "${_COMPILER_PREFIX}/lib")
+        set(_OMP_INC_DIR "${_COMPILER_PREFIX}/include")
+        set(_OMP_LIB "${_OMP_LIB_DIR}/libomp.dylib")
         set(_OMP_FLAG "-fopenmp")
     else()
         # Fallback: try Homebrew's standalone libomp formula
         execute_process(COMMAND brew --prefix libomp
             OUTPUT_VARIABLE _LIBOMP_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
         if (_LIBOMP_PREFIX AND EXISTS "${_LIBOMP_PREFIX}/lib/libomp.dylib")
-            set(_OMP_LIB "${_LIBOMP_PREFIX}/lib/libomp.dylib")
+            set(_OMP_LIB_DIR "${_LIBOMP_PREFIX}/lib")
+            set(_OMP_INC_DIR "${_LIBOMP_PREFIX}/include")
+            set(_OMP_LIB "${_OMP_LIB_DIR}/libomp.dylib")
             set(_OMP_FLAG "-Xclang -fopenmp")
-            include_directories("${_LIBOMP_PREFIX}/include")
         endif()
     endif()
     if (DEFINED _OMP_LIB)
+        # Add lib/include paths to CMAKE_C/CXX_FLAGS so they are propagated to
+        # FindOpenMP's internal try_compile (check_c_source_compiles).
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${_OMP_INC_DIR} -L${_OMP_LIB_DIR}")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${_OMP_INC_DIR} -L${_OMP_LIB_DIR}")
+
+        # Set OpenMP cache hints so FindOpenMP knows exactly which flags/libs to use
         set(OpenMP_C_FLAGS "${_OMP_FLAG}" CACHE STRING "C compiler flags for OpenMP" FORCE)
         set(OpenMP_CXX_FLAGS "${_OMP_FLAG}" CACHE STRING "CXX compiler flags for OpenMP" FORCE)
         set(OpenMP_C_LIB_NAMES "omp" CACHE STRING "C OpenMP lib names" FORCE)

--- a/be/src/storage/index/ann/cmake-protect/CMakeLists.txt
+++ b/be/src/storage/index/ann/cmake-protect/CMakeLists.txt
@@ -43,6 +43,36 @@ else()
     endif ()
 endif ()
 
+# On macOS, CMake's FindOpenMP auto-detection often fails because:
+# - Apple Clang doesn't support -fopenmp natively
+# - Even Homebrew LLVM's clang may fail try_compile if libomp isn't in the default search path
+# Provide explicit hints so find_package(OpenMP) succeeds.
+if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+    # Try to find libomp from the compiler's own lib directory (Homebrew LLVM bundles it)
+    get_filename_component(_COMPILER_DIR "${CMAKE_C_COMPILER}" DIRECTORY)
+    get_filename_component(_COMPILER_PREFIX "${_COMPILER_DIR}" DIRECTORY)
+    if (EXISTS "${_COMPILER_PREFIX}/lib/libomp.dylib")
+        set(_OMP_LIB "${_COMPILER_PREFIX}/lib/libomp.dylib")
+        set(_OMP_FLAG "-fopenmp")
+    else()
+        # Fallback: try Homebrew's standalone libomp formula
+        execute_process(COMMAND brew --prefix libomp
+            OUTPUT_VARIABLE _LIBOMP_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+        if (_LIBOMP_PREFIX AND EXISTS "${_LIBOMP_PREFIX}/lib/libomp.dylib")
+            set(_OMP_LIB "${_LIBOMP_PREFIX}/lib/libomp.dylib")
+            set(_OMP_FLAG "-Xclang -fopenmp")
+            include_directories("${_LIBOMP_PREFIX}/include")
+        endif()
+    endif()
+    if (DEFINED _OMP_LIB)
+        set(OpenMP_C_FLAGS "${_OMP_FLAG}" CACHE STRING "C compiler flags for OpenMP" FORCE)
+        set(OpenMP_CXX_FLAGS "${_OMP_FLAG}" CACHE STRING "CXX compiler flags for OpenMP" FORCE)
+        set(OpenMP_C_LIB_NAMES "omp" CACHE STRING "C OpenMP lib names" FORCE)
+        set(OpenMP_CXX_LIB_NAMES "omp" CACHE STRING "CXX OpenMP lib names" FORCE)
+        set(OpenMP_omp_LIBRARY "${_OMP_LIB}" CACHE FILEPATH "Path to libomp" FORCE)
+    endif()
+endif()
+
 # EXCLUDE_FROM_ALL so that binary in openblas is not installed.
 add_subdirectory(${PROJECT_SOURCE_DIR}/../contrib/openblas ${PROJECT_BINARY_DIR}/openblas EXCLUDE_FROM_ALL)
 

--- a/be/src/storage/index/ann/cmake-protect/CMakeLists.txt
+++ b/be/src/storage/index/ann/cmake-protect/CMakeLists.txt
@@ -45,34 +45,36 @@ endif ()
 
 # On macOS, CMake's FindOpenMP auto-detection often fails because:
 # - Apple Clang doesn't support -fopenmp natively
-# - Even Homebrew LLVM's clang may fail FindOpenMP's try_compile if libomp
-#   isn't in the default search path (macOS -isysroot restricts library search)
-# We must:
-# 1. Provide OpenMP cache variable hints (so FindOpenMP knows which flags to use)
-# 2. Add -L<lib_dir> to CMAKE_C/CXX_FLAGS (so try_compile's linker can find libomp)
-#    NOTE: CMAKE_C_FLAGS IS propagated to check_c_source_compiles/try_compile,
-#    but CMAKE_EXE_LINKER_FLAGS is NOT for source-file try_compile.
+# - Homebrew LLVM's clang supports -fopenmp but doesn't bundle libomp
+# - libomp from Homebrew is in a non-standard path that try_compile can't find
+# We provide explicit hints and add -L/-I flags to CMAKE_C/CXX_FLAGS so that
+# FindOpenMP's internal try_compile (check_c_source_compiles) can find libomp.
 if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
-    # Try to find libomp from the compiler's own lib directory (Homebrew LLVM bundles it)
-    get_filename_component(_COMPILER_DIR "${CMAKE_C_COMPILER}" DIRECTORY)
-    get_filename_component(_COMPILER_PREFIX "${_COMPILER_DIR}" DIRECTORY)
-    if (EXISTS "${_COMPILER_PREFIX}/lib/libomp.dylib")
-        set(_OMP_LIB_DIR "${_COMPILER_PREFIX}/lib")
-        set(_OMP_INC_DIR "${_COMPILER_PREFIX}/include")
+    # Try Homebrew's standalone libomp formula first (most common case)
+    execute_process(COMMAND brew --prefix libomp
+        OUTPUT_VARIABLE _LIBOMP_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+    if (_LIBOMP_PREFIX AND EXISTS "${_LIBOMP_PREFIX}/lib/libomp.dylib")
+        set(_OMP_LIB_DIR "${_LIBOMP_PREFIX}/lib")
+        set(_OMP_INC_DIR "${_LIBOMP_PREFIX}/include")
         set(_OMP_LIB "${_OMP_LIB_DIR}/libomp.dylib")
-        set(_OMP_FLAG "-fopenmp")
     else()
-        # Fallback: try Homebrew's standalone libomp formula
-        execute_process(COMMAND brew --prefix libomp
-            OUTPUT_VARIABLE _LIBOMP_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
-        if (_LIBOMP_PREFIX AND EXISTS "${_LIBOMP_PREFIX}/lib/libomp.dylib")
-            set(_OMP_LIB_DIR "${_LIBOMP_PREFIX}/lib")
-            set(_OMP_INC_DIR "${_LIBOMP_PREFIX}/include")
+        # Fallback: check if libomp is bundled with the compiler (some LLVM distributions)
+        get_filename_component(_COMPILER_DIR "${CMAKE_C_COMPILER}" DIRECTORY)
+        get_filename_component(_COMPILER_PREFIX "${_COMPILER_DIR}" DIRECTORY)
+        if (EXISTS "${_COMPILER_PREFIX}/lib/libomp.dylib")
+            set(_OMP_LIB_DIR "${_COMPILER_PREFIX}/lib")
+            set(_OMP_INC_DIR "${_COMPILER_PREFIX}/include")
             set(_OMP_LIB "${_OMP_LIB_DIR}/libomp.dylib")
-            set(_OMP_FLAG "-Xclang -fopenmp")
         endif()
     endif()
     if (DEFINED _OMP_LIB)
+        # Detect the correct OpenMP flag based on compiler type
+        if (CMAKE_C_COMPILER_ID MATCHES "AppleClang")
+            set(_OMP_FLAG "-Xclang -fopenmp")
+        else()
+            set(_OMP_FLAG "-fopenmp")
+        endif()
+
         # Add lib/include paths to CMAKE_C/CXX_FLAGS so they are propagated to
         # FindOpenMP's internal try_compile (check_c_source_compiles).
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${_OMP_INC_DIR} -L${_OMP_LIB_DIR}")

--- a/be/test/exec/schema_scanner/schema_cluster_snapshot_properties_scanner_test.cpp
+++ b/be/test/exec/schema_scanner/schema_cluster_snapshot_properties_scanner_test.cpp
@@ -45,6 +45,7 @@ TEST_F(SchemaClusterSnapshotPropertiesScannerTest, test_get_next_block_internal)
     auto col = data_block->safe_get_by_position(2);
     auto v = (*col.column)[0].get<TYPE_BIGINT>();
     EXPECT_EQ(v, 30);
+
 }
 
 } // namespace doris

--- a/be/test/exec/schema_scanner/schema_cluster_snapshot_properties_scanner_test.cpp
+++ b/be/test/exec/schema_scanner/schema_cluster_snapshot_properties_scanner_test.cpp
@@ -30,6 +30,7 @@ class SchemaClusterSnapshotPropertiesScannerTest : public testing::Test {
 };
 
 TEST_F(SchemaClusterSnapshotPropertiesScannerTest, test_get_next_block_internal) {
+    // test
     SchemaClusterSnapshotPropertiesScanner scanner;
     scanner._switch_status = cloud::SnapshotSwitchStatus::SNAPSHOT_SWITCH_ON;
     scanner._max_reserved_snapshots = 30;
@@ -45,7 +46,6 @@ TEST_F(SchemaClusterSnapshotPropertiesScannerTest, test_get_next_block_internal)
     auto col = data_block->safe_get_by_position(2);
     auto v = (*col.column)[0].get<TYPE_BIGINT>();
     EXPECT_EQ(v, 30);
-
 }
 
 } // namespace doris


### PR DESCRIPTION
The macos-15 runner uses ARM64 (Apple Silicon), but the workflow was configured for x86_64, causing JDK version detection to fail with 'ERROR: The JAVA version is 25, it must be JDK-17'.

Changes:
- Use JAVA_HOME_17_ARM64 instead of JAVA_HOME_17_X64
- Download darwin-arm64 thirdparty prebuilt instead of darwin-x86_64
- Install openjdk@17 instead of openjdk@11 via brew
