### PR TITLE
[enhancement](segment) Support streaming page flush for ScalarColumnWriter

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -454,6 +454,8 @@ DEFINE_mInt64(vertical_compaction_max_segment_size, "1073741824");
 DEFINE_mDouble(sparse_column_compaction_threshold_percent, "0.05");
 // Enable RLE batch Put optimization for compaction
 DEFINE_mBool(enable_rle_batch_put_optimization, "true");
+// When enabled, ScalarColumnWriter flushes each data page to disk immediately
+DEFINE_mBool(enable_streaming_page_flush, "false");
 
 // If enabled, segments will be flushed column by column
 DEFINE_mBool(enable_vertical_segment_writer, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -521,6 +521,11 @@ DECLARE_mDouble(sparse_column_compaction_threshold_percent);
 // Enable RLE batch Put optimization for compaction
 DECLARE_mBool(enable_rle_batch_put_optimization);
 
+// When enabled, ScalarColumnWriter flushes each data page to disk immediately
+// when the page is full, instead of caching all pages in memory until write_data().
+// This reduces memory consumption but may result in interleaved data pages across columns.
+DECLARE_mBool(enable_streaming_page_flush);
+
 // If enabled, segments will be flushed column by column
 DECLARE_mBool(enable_vertical_segment_writer);
 

--- a/be/src/storage/segment/column_writer.cpp
+++ b/be/src/storage/segment/column_writer.cpp
@@ -477,7 +477,8 @@ ScalarColumnWriter::ScalarColumnWriter(const ColumnWriterOptions& opts,
         : ColumnWriter(std::move(field), opts.meta->is_nullable(), opts.meta),
           _opts(opts),
           _file_writer(file_writer),
-          _data_size(0) {
+          _data_size(0),
+          _streaming_flush_enabled(config::enable_streaming_page_flush) {
     // these opts.meta fields should be set by client
     DCHECK(opts.meta->has_column_id());
     DCHECK(opts.meta->has_unique_id());
@@ -727,6 +728,12 @@ Status ScalarColumnWriter::append_nullable(const uint8_t* null_map, const uint8_
 
 uint64_t ScalarColumnWriter::estimate_buffer_size() {
     uint64_t size = _data_size;
+    if (_streaming_flush_enabled) {
+        // In streaming mode, _data_size is 0 (pages already flushed to disk).
+        // Include the already-written bytes so callers estimating segment file
+        // size get a correct answer.
+        size += _total_compressed_data_pages_size;
+    }
     size += _page_builder->size();
     if (is_nullable()) {
         size += _null_bitmap_builder->size();
@@ -748,17 +755,20 @@ Status ScalarColumnWriter::finish() {
 }
 
 Status ScalarColumnWriter::write_data() {
-    auto offset = _file_writer->bytes_appended();
-    auto collect_uncompressed_bytes = [](const PageFooterPB& footer) {
-        return footer.uncompressed_size() + footer.ByteSizeLong() +
-               sizeof(uint32_t) /* footer size */ + sizeof(uint32_t) /* checksum */;
-    };
-    for (auto& page : _pages) {
-        _total_uncompressed_data_pages_size += collect_uncompressed_bytes(page->footer);
-        RETURN_IF_ERROR(_write_data_page(page.get()));
+    if (!_streaming_flush_enabled) {
+        // Traditional mode: flush all cached pages to disk at once
+        auto offset = _file_writer->bytes_appended();
+        for (auto& page : _pages) {
+            _total_uncompressed_data_pages_size += _collect_uncompressed_bytes(page->footer);
+            RETURN_IF_ERROR(_write_data_page(page.get()));
+        }
+        _total_compressed_data_pages_size += _file_writer->bytes_appended() - offset;
+        _pages.clear();
     }
-    _pages.clear();
-    // write column dict
+    // else: streaming mode - data pages already flushed in finish_current_page()
+
+    // write column dict (must be after all data pages regardless of mode)
+    auto dict_offset = _file_writer->bytes_appended();
     if (_encoding_info->encoding() == DICT_ENCODING) {
         OwnedSlice dict_body;
         RETURN_IF_ERROR(_page_builder->get_dictionary_page(&dict_body));
@@ -769,7 +779,7 @@ Status ScalarColumnWriter::write_data() {
         footer.set_type(DICTIONARY_PAGE);
         footer.set_uncompressed_size(cast_set<uint32_t>(dict_body.slice().get_size()));
         footer.mutable_dict_page_footer()->set_encoding(dict_word_page_encoding);
-        _total_uncompressed_data_pages_size += collect_uncompressed_bytes(footer);
+        _total_uncompressed_data_pages_size += _collect_uncompressed_bytes(footer);
 
         PagePointer dict_pp;
         RETURN_IF_ERROR(PageIO::compress_and_write_page(
@@ -777,7 +787,7 @@ Status ScalarColumnWriter::write_data() {
                 {dict_body.slice()}, footer, &dict_pp));
         dict_pp.to_proto(_opts.meta->mutable_dict_page());
     }
-    _total_compressed_data_pages_size += _file_writer->bytes_appended() - offset;
+    _total_compressed_data_pages_size += _file_writer->bytes_appended() - dict_offset;
     _page_builder.reset();
     return Status::OK();
 }
@@ -880,7 +890,16 @@ Status ScalarColumnWriter::finish_current_page() {
         page->data.emplace_back(std::move(compressed_body));
     }
 
-    _push_back_page(std::move(page));
+    if (_streaming_flush_enabled) {
+        // Streaming mode: flush page to disk immediately and release memory
+        _total_uncompressed_data_pages_size += _collect_uncompressed_bytes(page->footer);
+        auto offset_before = _file_writer->bytes_appended();
+        RETURN_IF_ERROR(_write_data_page(page.get()));
+        _total_compressed_data_pages_size += _file_writer->bytes_appended() - offset_before;
+        // page unique_ptr destroyed at scope exit -> memory freed immediately
+    } else {
+        _push_back_page(std::move(page));
+    }
     _first_rowid = _next_rowid;
     return Status::OK();
 }

--- a/be/src/storage/segment/column_writer.h
+++ b/be/src/storage/segment/column_writer.h
@@ -310,12 +310,19 @@ private:
         _pages.emplace_back(std::move(page));
     }
 
+    static uint64_t _collect_uncompressed_bytes(const PageFooterPB& footer) {
+        return footer.uncompressed_size() + footer.ByteSizeLong() +
+               sizeof(uint32_t) /* footer size */ + sizeof(uint32_t) /* checksum */;
+    }
+
     Status _write_data_page(Page* page);
 
 private:
     io::FileWriter* _file_writer = nullptr;
     // total size of data page list
     uint64_t _data_size;
+    // Whether to flush pages to disk immediately in finish_current_page()
+    bool _streaming_flush_enabled = false;
 
     uint64_t _raw_data_bytes {0};
     uint64_t _total_uncompressed_data_pages_size {0};

--- a/be/test/storage/segment/streaming_page_flush_test.cpp
+++ b/be/test/storage/segment/streaming_page_flush_test.cpp
@@ -1,0 +1,379 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "common/config.h"
+#include "io/fs/file_system.h"
+#include "io/fs/file_writer.h"
+#include "io/fs/local_file_system.h"
+#include "olap/olap_common.h"
+#include "olap/rowset/segment_v2/column_reader.h"
+#include "olap/rowset/segment_v2/column_writer.h"
+#include "olap/tablet_schema_helper.h"
+#include "vec/columns/column_nullable.h"
+#include "vec/columns/column_string.h"
+#include "vec/columns/column_vector.h"
+
+using std::string;
+
+namespace doris {
+namespace segment_v2 {
+
+static const std::string TEST_DIR = "./ut_dir/streaming_page_flush_test";
+
+class StreamingPageFlushTest : public testing::Test {
+public:
+    StreamingPageFlushTest() = default;
+    ~StreamingPageFlushTest() override = default;
+
+protected:
+    void SetUp() override {
+        config::disable_storage_page_cache = true;
+        auto st = io::global_local_filesystem()->delete_directory(TEST_DIR);
+        ASSERT_TRUE(st.ok()) << st;
+        st = io::global_local_filesystem()->create_directory(TEST_DIR);
+        ASSERT_TRUE(st.ok()) << st;
+    }
+
+    void TearDown() override {
+        EXPECT_TRUE(io::global_local_filesystem()->delete_directory(TEST_DIR).ok());
+    }
+};
+
+// Helper: write INT column with BIT_SHUFFLE encoding, read back and verify.
+// Returns file size.
+static uint64_t write_and_verify_int_column(bool streaming_enabled, const std::string& suffix,
+                                            int num_rows) {
+    bool old_val = config::enable_streaming_page_flush;
+    config::enable_streaming_page_flush = streaming_enabled;
+
+    ColumnMetaPB meta;
+    std::string fname = TEST_DIR + "/int_col_" + suffix;
+    auto fs = io::global_local_filesystem();
+
+    TabletColumn tablet_col(FieldAggregationMethod::OLAP_FIELD_AGGREGATION_NONE,
+                            FieldType::OLAP_FIELD_TYPE_INT);
+
+    // Write
+    {
+        io::FileWriterPtr file_writer;
+        Status st = fs->create_file(fname, &file_writer);
+        EXPECT_TRUE(st.ok()) << st;
+
+        ColumnWriterOptions writer_opts;
+        writer_opts.meta = &meta;
+        writer_opts.meta->set_column_id(0);
+        writer_opts.meta->set_unique_id(0);
+        writer_opts.meta->set_type(static_cast<int32_t>(FieldType::OLAP_FIELD_TYPE_INT));
+        writer_opts.meta->set_length(0);
+        writer_opts.meta->set_encoding(BIT_SHUFFLE);
+        writer_opts.meta->set_compression(segment_v2::CompressionTypePB::LZ4F);
+        writer_opts.meta->set_is_nullable(true);
+        writer_opts.need_zone_map = true;
+
+        std::unique_ptr<ColumnWriter> writer;
+        EXPECT_TRUE(
+                ColumnWriter::create(writer_opts, &tablet_col, file_writer.get(), &writer).ok());
+        st = writer->init();
+        EXPECT_TRUE(st.ok()) << st.to_string();
+
+        for (int i = 0; i < num_rows; ++i) {
+            int32_t val = i;
+            bool is_null = (i % 7 == 0);
+            st = writer->append(is_null, &val);
+            EXPECT_TRUE(st.ok());
+        }
+
+        EXPECT_TRUE(writer->finish().ok());
+        EXPECT_TRUE(writer->write_data().ok());
+        EXPECT_TRUE(writer->write_ordinal_index().ok());
+        EXPECT_TRUE(writer->write_zone_map().ok());
+        EXPECT_TRUE(file_writer->close().ok());
+    }
+
+    config::enable_streaming_page_flush = old_val;
+
+    // Read and verify using vectorized API
+    io::FileReaderSPtr file_reader;
+    EXPECT_EQ(fs->open_file(fname, &file_reader), Status::OK());
+
+    int64_t file_size = 0;
+    EXPECT_TRUE(fs->file_size(fname, &file_size).ok());
+
+    // Sequential read
+    {
+        ColumnReaderOptions reader_opts;
+        std::shared_ptr<ColumnReader> reader;
+        auto st = ColumnReader::create(reader_opts, meta, num_rows, file_reader, &reader);
+        EXPECT_TRUE(st.ok()) << st;
+
+        ColumnIteratorUPtr iter;
+        st = reader->new_iterator(&iter, &tablet_col);
+        EXPECT_TRUE(st.ok());
+
+        ColumnIteratorOptions iter_opts;
+        OlapReaderStatistics stats;
+        iter_opts.stats = &stats;
+        iter_opts.file_reader = file_reader.get();
+        st = iter->init(iter_opts);
+        EXPECT_TRUE(st.ok());
+
+        int idx = 0;
+        st = iter->seek_to_ordinal(0);
+        EXPECT_TRUE(st.ok());
+        while (idx < num_rows) {
+            vectorized::MutableColumnPtr dst = vectorized::ColumnNullable::create(
+                    vectorized::ColumnInt32::create(), vectorized::ColumnUInt8::create());
+            size_t rows_read = 1024;
+            bool has_null = false;
+            st = iter->next_batch(&rows_read, dst, &has_null);
+            EXPECT_TRUE(st.ok());
+
+            auto& nullable_col = assert_cast<vectorized::ColumnNullable&>(*dst);
+            auto& null_map =
+                    assert_cast<const vectorized::ColumnUInt8&>(nullable_col.get_null_map_column())
+                            .get_data();
+            auto& data_col =
+                    assert_cast<const vectorized::ColumnInt32&>(nullable_col.get_nested_column());
+
+            for (size_t j = 0; j < rows_read; ++j) {
+                bool expected_null = (idx % 7 == 0);
+                EXPECT_EQ(expected_null, null_map[j] != 0) << "row " << idx;
+                if (!expected_null) {
+                    EXPECT_EQ(static_cast<int32_t>(idx), data_col.get_element(j)) << "row " << idx;
+                }
+                idx++;
+            }
+            if (rows_read < 1024) break;
+        }
+        EXPECT_EQ(idx, num_rows);
+    }
+
+    // Seek read (every 4025 rows)
+    {
+        ColumnReaderOptions reader_opts;
+        std::shared_ptr<ColumnReader> reader;
+        auto st = ColumnReader::create(reader_opts, meta, num_rows, file_reader, &reader);
+        EXPECT_TRUE(st.ok());
+
+        ColumnIteratorUPtr iter;
+        st = reader->new_iterator(&iter, &tablet_col);
+        EXPECT_TRUE(st.ok());
+
+        ColumnIteratorOptions iter_opts;
+        OlapReaderStatistics stats;
+        iter_opts.stats = &stats;
+        iter_opts.file_reader = file_reader.get();
+        st = iter->init(iter_opts);
+        EXPECT_TRUE(st.ok());
+
+        for (int rowid = 0; rowid < num_rows; rowid += 4025) {
+            st = iter->seek_to_ordinal(rowid);
+            EXPECT_TRUE(st.ok());
+
+            vectorized::MutableColumnPtr dst = vectorized::ColumnNullable::create(
+                    vectorized::ColumnInt32::create(), vectorized::ColumnUInt8::create());
+            size_t rows_read = 1024;
+            bool has_null = false;
+            st = iter->next_batch(&rows_read, dst, &has_null);
+            EXPECT_TRUE(st.ok());
+
+            auto& nullable_col = assert_cast<vectorized::ColumnNullable&>(*dst);
+            auto& null_map =
+                    assert_cast<const vectorized::ColumnUInt8&>(nullable_col.get_null_map_column())
+                            .get_data();
+            auto& data_col =
+                    assert_cast<const vectorized::ColumnInt32&>(nullable_col.get_nested_column());
+
+            for (size_t j = 0; j < rows_read; ++j) {
+                int idx = rowid + static_cast<int>(j);
+                if (idx >= num_rows) break;
+                bool expected_null = (idx % 7 == 0);
+                EXPECT_EQ(expected_null, null_map[j] != 0) << "row " << idx;
+                if (!expected_null) {
+                    EXPECT_EQ(idx, data_col.get_element(j)) << "row " << idx;
+                }
+            }
+        }
+    }
+    return file_size;
+}
+
+// Helper: write VARCHAR column with DICT_ENCODING, read back and verify.
+static void write_and_verify_varchar_column(bool streaming_enabled, const std::string& suffix,
+                                            int num_rows) {
+    bool old_val = config::enable_streaming_page_flush;
+    config::enable_streaming_page_flush = streaming_enabled;
+
+    ColumnMetaPB meta;
+    std::string fname = TEST_DIR + "/varchar_col_" + suffix;
+    auto fs = io::global_local_filesystem();
+
+    auto tablet_col_ptr = create_varchar_key(1);
+    TabletColumn& tablet_col = *tablet_col_ptr;
+
+    // Prepare data
+    std::vector<Slice> values(num_rows);
+    std::vector<std::string> str_storage(num_rows);
+    for (int i = 0; i < num_rows; ++i) {
+        str_storage[i] = "value_" + std::to_string(i % 100);
+        values[i] = Slice(str_storage[i]);
+    }
+
+    // Write
+    {
+        io::FileWriterPtr file_writer;
+        Status st = fs->create_file(fname, &file_writer);
+        EXPECT_TRUE(st.ok()) << st;
+
+        ColumnWriterOptions writer_opts;
+        writer_opts.meta = &meta;
+        writer_opts.meta->set_column_id(0);
+        writer_opts.meta->set_unique_id(0);
+        writer_opts.meta->set_type(static_cast<int32_t>(FieldType::OLAP_FIELD_TYPE_VARCHAR));
+        writer_opts.meta->set_length(128);
+        writer_opts.meta->set_encoding(DICT_ENCODING);
+        writer_opts.meta->set_compression(segment_v2::CompressionTypePB::LZ4F);
+        writer_opts.meta->set_is_nullable(true);
+        writer_opts.need_zone_map = false;
+
+        std::unique_ptr<ColumnWriter> writer;
+        EXPECT_TRUE(
+                ColumnWriter::create(writer_opts, &tablet_col, file_writer.get(), &writer).ok());
+        st = writer->init();
+        EXPECT_TRUE(st.ok()) << st.to_string();
+
+        for (int i = 0; i < num_rows; ++i) {
+            bool is_null = (i % 11 == 0);
+            st = writer->append(is_null, &values[i]);
+            EXPECT_TRUE(st.ok());
+        }
+
+        EXPECT_TRUE(writer->finish().ok());
+        EXPECT_TRUE(writer->write_data().ok());
+        EXPECT_TRUE(writer->write_ordinal_index().ok());
+        EXPECT_TRUE(file_writer->close().ok());
+    }
+
+    config::enable_streaming_page_flush = old_val;
+
+    // Read and verify using vectorized API
+    io::FileReaderSPtr file_reader;
+    EXPECT_EQ(fs->open_file(fname, &file_reader), Status::OK());
+
+    {
+        ColumnReaderOptions reader_opts;
+        std::shared_ptr<ColumnReader> reader;
+        auto st = ColumnReader::create(reader_opts, meta, num_rows, file_reader, &reader);
+        EXPECT_TRUE(st.ok()) << st;
+
+        ColumnIteratorUPtr iter;
+        st = reader->new_iterator(&iter, &tablet_col);
+        EXPECT_TRUE(st.ok());
+
+        ColumnIteratorOptions iter_opts;
+        OlapReaderStatistics stats;
+        iter_opts.stats = &stats;
+        iter_opts.file_reader = file_reader.get();
+        st = iter->init(iter_opts);
+        EXPECT_TRUE(st.ok());
+
+        int idx = 0;
+        st = iter->seek_to_ordinal(0);
+        EXPECT_TRUE(st.ok());
+        while (idx < num_rows) {
+            vectorized::MutableColumnPtr dst = vectorized::ColumnNullable::create(
+                    vectorized::ColumnString::create(), vectorized::ColumnUInt8::create());
+            size_t rows_read = 1024;
+            bool has_null = false;
+            st = iter->next_batch(&rows_read, dst, &has_null);
+            EXPECT_TRUE(st.ok());
+
+            auto& nullable_col = assert_cast<vectorized::ColumnNullable&>(*dst);
+            auto& null_map =
+                    assert_cast<const vectorized::ColumnUInt8&>(nullable_col.get_null_map_column())
+                            .get_data();
+            auto& data_col =
+                    assert_cast<const vectorized::ColumnString&>(nullable_col.get_nested_column());
+
+            for (size_t j = 0; j < rows_read; ++j) {
+                bool expected_null = (idx % 11 == 0);
+                EXPECT_EQ(expected_null, null_map[j] != 0) << "row " << idx;
+                if (!expected_null) {
+                    std::string expected = "value_" + std::to_string(idx % 100);
+                    auto actual = data_col.get_data_at(j);
+                    EXPECT_EQ(expected, std::string(actual.data, actual.size)) << "row " << idx;
+                }
+                idx++;
+            }
+            if (rows_read < 1024) break;
+        }
+        EXPECT_EQ(idx, num_rows);
+    }
+}
+
+// Test 1: streaming=false (traditional mode) with INT BIT_SHUFFLE
+TEST_F(StreamingPageFlushTest, test_int_traditional_mode) {
+    write_and_verify_int_column(false, "traditional", 10000);
+}
+
+// Test 2: streaming=true with INT BIT_SHUFFLE
+TEST_F(StreamingPageFlushTest, test_int_streaming_mode) {
+    write_and_verify_int_column(true, "streaming", 10000);
+}
+
+// Test 3: streaming=false (traditional mode) with VARCHAR DICT_ENCODING
+TEST_F(StreamingPageFlushTest, test_varchar_traditional_mode) {
+    write_and_verify_varchar_column(false, "traditional", 10000);
+}
+
+// Test 4: streaming=true with VARCHAR DICT_ENCODING
+TEST_F(StreamingPageFlushTest, test_varchar_streaming_mode) {
+    write_and_verify_varchar_column(true, "streaming", 10000);
+}
+
+// Test 5: Both modes produce the same file size (INT) — single column write
+TEST_F(StreamingPageFlushTest, test_int_both_modes_same_file_size) {
+    int num_rows = 5000;
+    auto file_size_traditional = write_and_verify_int_column(false, "cmp_traditional", num_rows);
+    auto file_size_streaming = write_and_verify_int_column(true, "cmp_streaming", num_rows);
+    EXPECT_EQ(file_size_traditional, file_size_streaming);
+}
+
+// Test 6: Both modes work for VARCHAR/DICT
+TEST_F(StreamingPageFlushTest, test_varchar_both_modes) {
+    write_and_verify_varchar_column(false, "dict_cmp_traditional", 5000);
+    write_and_verify_varchar_column(true, "dict_cmp_streaming", 5000);
+}
+
+// Test 7: Small data set (fits in single page) — streaming mode
+TEST_F(StreamingPageFlushTest, test_small_data_streaming) {
+    write_and_verify_int_column(true, "small_streaming", 10);
+}
+
+// Test 8: Small data set (fits in single page) — traditional mode
+TEST_F(StreamingPageFlushTest, test_small_data_traditional) {
+    write_and_verify_int_column(false, "small_traditional", 10);
+}
+
+} // namespace segment_v2
+} // namespace doris


### PR DESCRIPTION
Add streaming page flush feature to ScalarColumnWriter that flushes data pages to disk immediately when they become full, instead of buffering all pages in memory until segment finalization.

This reduces memory consumption during segment writing by releasing page memory as soon as pages are written to disk.

Changes:
- Add `enable_streaming_page_flush` config flag (default: false)
- Add `_streaming_flush_enabled` member to ScalarColumnWriter

