### PR TITLE
[fix](schema-change) guard alter with base replica catch-up quorum

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.OlapTable.OlapTableState;
+import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.MetaNotFoundException;
@@ -301,6 +302,10 @@ public abstract class AlterJobV2 implements Writable {
             maxFailedTimes = Config.schema_change_max_retry_time;
         }
         return maxFailedTimes;
+    }
+
+    protected boolean isReplicaVersionComplete(Replica replica, long visibleVersion) {
+        return replica.getLastFailedVersion() < 0 && replica.checkVersionCatchUp(visibleVersion, false);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
@@ -22,8 +22,10 @@ import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.OlapTable.OlapTableState;
+import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.Table;
+import org.apache.doris.catalog.Tablet;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.io.Text;
@@ -306,6 +308,24 @@ public abstract class AlterJobV2 implements Writable {
 
     protected boolean isReplicaVersionComplete(Replica replica, long visibleVersion) {
         return replica.getLastFailedVersion() < 0 && replica.checkVersionCatchUp(visibleVersion, false);
+    }
+
+    protected boolean canWaitBaseReplicaCatchUp(OlapTable tbl, Partition partition, Tablet baseTablet,
+            Replica baseReplica, long visibleVersion) throws AlterCancelException {
+        if (isReplicaVersionComplete(baseReplica, visibleVersion)) {
+            return true;
+        }
+
+        Tablet.TabletHealth tabletHealth = baseTablet.getHealth(Env.getCurrentSystemInfo(), visibleVersion,
+                tbl.getPartitionInfo().getReplicaAllocation(partition.getId()),
+                Env.getCurrentSystemInfo().getAllBackendIds(true));
+        if (tabletHealth.status == Tablet.TabletStatus.UNRECOVERABLE) {
+            throw new AlterCancelException(String.format(
+                    "base tablet %d is unrecoverable while waiting replica %d on backend %d to catch up version %d",
+                    baseTablet.getId(), baseReplica.getId(), baseReplica.getBackendIdWithoutException(),
+                    visibleVersion));
+        }
+        return false;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
@@ -310,22 +310,17 @@ public abstract class AlterJobV2 implements Writable {
         return replica.getLastFailedVersion() < 0 && replica.checkVersionCatchUp(visibleVersion, false);
     }
 
-    protected boolean canWaitBaseReplicaCatchUp(OlapTable tbl, Partition partition, Tablet baseTablet,
-            Replica baseReplica, long visibleVersion) throws AlterCancelException {
-        if (isReplicaVersionComplete(baseReplica, visibleVersion)) {
-            return true;
-        }
-
+    protected void ensureBaseTabletCatchUpPossible(OlapTable tbl, Partition partition, Tablet baseTablet,
+            long visibleVersion) throws AlterCancelException {
         Tablet.TabletHealth tabletHealth = baseTablet.getHealth(Env.getCurrentSystemInfo(), visibleVersion,
                 tbl.getPartitionInfo().getReplicaAllocation(partition.getId()),
                 Env.getCurrentSystemInfo().getAllBackendIds(true));
         if (tabletHealth.status == Tablet.TabletStatus.UNRECOVERABLE) {
             throw new AlterCancelException(String.format(
-                    "base tablet %d is unrecoverable while waiting replica %d on backend %d to catch up version %d",
-                    baseTablet.getId(), baseReplica.getId(), baseReplica.getBackendIdWithoutException(),
+                    "base tablet %d is unrecoverable while waiting it to catch up version %d",
+                    baseTablet.getId(),
                     visibleVersion));
         }
-        return false;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -511,7 +511,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         LOG.info("transfer rollup job {} state to {}", jobId, this.jobState);
     }
 
-    private boolean allBaseReplicasCaughtUp(OlapTable tbl) {
+    private boolean allBaseReplicasCaughtUp(OlapTable tbl) throws AlterCancelException {
         for (Map.Entry<Long, MaterializedIndex> entry : partitionIdToRollupIndex.entrySet()) {
             long partitionId = entry.getKey();
             Partition partition = tbl.getPartition(partitionId);
@@ -533,7 +533,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                     Preconditions.checkNotNull(baseReplica,
                             "base replica does not exist on backend " + backendId + " for base tablet "
                                     + baseTabletId);
-                    if (!isReplicaVersionComplete(baseReplica, visibleVersion)) {
+                    if (!canWaitBaseReplicaCatchUp(tbl, partition, baseTablet, baseReplica, visibleVersion)) {
                         LOG.info("wait base replica {} on backend {} to catch up visible version {} before sending "
                                         + "rollup tasks, job: {}, partition: {}, rollup tablet: {}, base tablet: {}",
                                 baseReplica.getId(), backendId, visibleVersion, jobId, partitionId,

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -517,6 +517,8 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
             Partition partition = tbl.getPartition(partitionId);
             Preconditions.checkNotNull(partition, partitionId);
             long visibleVersion = partition.getVisibleVersion();
+            int requiredReadyReplicaNum = tbl.getPartitionInfo()
+                    .getReplicaAllocation(partitionId).getTotalReplicaNum() / 2 + 1;
             MaterializedIndex baseIndex = partition.getIndex(baseIndexId);
             Preconditions.checkNotNull(baseIndex, baseIndexId);
             Map<Long, Long> tabletIdMap = partitionIdToBaseRollupTabletIdMap.get(partitionId);
@@ -527,19 +529,25 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                         "base tablet does not exist for rollup tablet " + rollupTablet.getId());
                 Tablet baseTablet = baseIndex.getTablet(baseTabletId);
                 Preconditions.checkNotNull(baseTablet, baseTabletId);
+                int readyReplicaNum = 0;
                 for (Replica rollupReplica : rollupTablet.getReplicas()) {
                     long backendId = rollupReplica.getBackendIdWithoutException();
                     Replica baseReplica = baseTablet.getReplicaByBackendId(backendId);
                     Preconditions.checkNotNull(baseReplica,
                             "base replica does not exist on backend " + backendId + " for base tablet "
                                     + baseTabletId);
-                    if (!canWaitBaseReplicaCatchUp(tbl, partition, baseTablet, baseReplica, visibleVersion)) {
-                        LOG.info("wait base replica {} on backend {} to catch up visible version {} before sending "
-                                        + "rollup tasks, job: {}, partition: {}, rollup tablet: {}, base tablet: {}",
-                                baseReplica.getId(), backendId, visibleVersion, jobId, partitionId,
-                                rollupTablet.getId(), baseTabletId);
-                        return false;
+                    if (isReplicaVersionComplete(baseReplica, visibleVersion)) {
+                        readyReplicaNum++;
                     }
+                }
+                if (readyReplicaNum < requiredReadyReplicaNum) {
+                    ensureBaseTabletCatchUpPossible(tbl, partition, baseTablet, visibleVersion);
+                    LOG.info("wait base tablet {} to have enough ready replicas before sending rollup tasks, "
+                                    + "job: {}, partition: {}, rollup tablet: {}, readyReplicaNum: {}, "
+                                    + "requiredReadyReplicaNum: {}, visibleVersion: {}",
+                            baseTabletId, jobId, partitionId, rollupTablet.getId(), readyReplicaNum,
+                            requiredReadyReplicaNum, visibleVersion);
+                    return false;
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -401,9 +401,13 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
 
         tbl.readLock();
         String vaultId = tbl.getStorageVaultId();
+        AgentBatchTask newRollupBatchTask = new AgentBatchTask();
         try {
             long expiration = (createTimeMs + timeoutMs) / 1000;
             Preconditions.checkState(tbl.getState() == OlapTableState.ROLLUP);
+            if (!allBaseReplicasCaughtUp(tbl)) {
+                return;
+            }
             // Create object pool per MaterializedIndex
             Map<Long, Map<Object, Object>> indexObjectPoolMap = Maps.newHashMap();
             for (Map.Entry<Long, MaterializedIndex> entry : this.partitionIdToRollupIndex.entrySet()) {
@@ -490,7 +494,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                                 rollupReplica.getId(), rollupSchemaHash, baseSchemaHash, visibleVersion, jobId,
                                 JobType.ROLLUP, defineExprs, descTable, tbl.getSchemaByIndexId(baseIndexId, true),
                                 objectPool, whereClause, expiration, vaultId, queryOptions, queryGlobals);
-                        rollupBatchTask.addTask(rollupTask);
+                        newRollupBatchTask.addTask(rollupTask);
                     }
                 }
             }
@@ -498,12 +502,48 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
             tbl.readUnlock();
         }
 
+        rollupBatchTask = newRollupBatchTask;
         AgentTaskQueue.addBatchTask(rollupBatchTask);
         AgentTaskExecutor.submit(rollupBatchTask);
         setJobState(JobState.RUNNING);
 
         // DO NOT write edit log here, tasks will be send again if FE restart or master changed.
         LOG.info("transfer rollup job {} state to {}", jobId, this.jobState);
+    }
+
+    private boolean allBaseReplicasCaughtUp(OlapTable tbl) {
+        for (Map.Entry<Long, MaterializedIndex> entry : partitionIdToRollupIndex.entrySet()) {
+            long partitionId = entry.getKey();
+            Partition partition = tbl.getPartition(partitionId);
+            Preconditions.checkNotNull(partition, partitionId);
+            long visibleVersion = partition.getVisibleVersion();
+            MaterializedIndex baseIndex = partition.getIndex(baseIndexId);
+            Preconditions.checkNotNull(baseIndex, baseIndexId);
+            Map<Long, Long> tabletIdMap = partitionIdToBaseRollupTabletIdMap.get(partitionId);
+            Preconditions.checkNotNull(tabletIdMap, "base tablet map does not exist for partition " + partitionId);
+            for (Tablet rollupTablet : entry.getValue().getTablets()) {
+                Long baseTabletId = tabletIdMap.get(rollupTablet.getId());
+                Preconditions.checkNotNull(baseTabletId,
+                        "base tablet does not exist for rollup tablet " + rollupTablet.getId());
+                Tablet baseTablet = baseIndex.getTablet(baseTabletId);
+                Preconditions.checkNotNull(baseTablet, baseTabletId);
+                for (Replica rollupReplica : rollupTablet.getReplicas()) {
+                    long backendId = rollupReplica.getBackendIdWithoutException();
+                    Replica baseReplica = baseTablet.getReplicaByBackendId(backendId);
+                    Preconditions.checkNotNull(baseReplica,
+                            "base replica does not exist on backend " + backendId + " for base tablet "
+                                    + baseTabletId);
+                    if (!isReplicaVersionComplete(baseReplica, visibleVersion)) {
+                        LOG.info("wait base replica {} on backend {} to catch up visible version {} before sending "
+                                        + "rollup tasks, job: {}, partition: {}, rollup tablet: {}, base tablet: {}",
+                                baseReplica.getId(), backendId, visibleVersion, jobId, partitionId,
+                                rollupTablet.getId(), baseTabletId);
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -405,7 +405,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         try {
             long expiration = (createTimeMs + timeoutMs) / 1000;
             Preconditions.checkState(tbl.getState() == OlapTableState.ROLLUP);
-            if (!allBaseReplicasCaughtUp(tbl)) {
+            if (!baseTabletsHaveReadyReplicaQuorum(tbl)) {
                 return;
             }
             // Create object pool per MaterializedIndex
@@ -511,7 +511,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         LOG.info("transfer rollup job {} state to {}", jobId, this.jobState);
     }
 
-    private boolean allBaseReplicasCaughtUp(OlapTable tbl) throws AlterCancelException {
+    private boolean baseTabletsHaveReadyReplicaQuorum(OlapTable tbl) throws AlterCancelException {
         for (Map.Entry<Long, MaterializedIndex> entry : partitionIdToRollupIndex.entrySet()) {
             long partitionId = entry.getKey();
             Partition partition = tbl.getPartition(partitionId);

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -498,6 +498,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 implements GsonPostProcessable
 
         tbl.readLock();
         String vaultId = tbl.getStorageVaultId();
+        AgentBatchTask newSchemaChangeBatchTask = new AgentBatchTask();
         try {
             long expiration = (createTimeMs + timeoutMs) / 1000;
             Map<String, Column> indexColumnMap = Maps.newHashMap();
@@ -508,6 +509,9 @@ public class SchemaChangeJobV2 extends AlterJobV2 implements GsonPostProcessable
             }
 
             Preconditions.checkState(tbl.getState() == OlapTableState.SCHEMA_CHANGE);
+            if (!allBaseReplicasCaughtUp(tbl)) {
+                return;
+            }
             // Create object pool per MaterializedIndex
             Map<Long, Map<Object, Object>> indexObjectPoolMap = Maps.newHashMap();
             for (long partitionId : partitionIndexMap.rowKeySet()) {
@@ -576,7 +580,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 implements GsonPostProcessable
                                     shadowReplica.getId(), shadowSchemaHash, originSchemaHash, visibleVersion, jobId,
                                     JobType.SCHEMA_CHANGE, defineExprs, descTable, originSchemaColumns, objectPool,
                                     null, expiration, vaultId, queryOptions, queryGlobals);
-                            schemaChangeBatchTask.addTask(rollupTask);
+                            newSchemaChangeBatchTask.addTask(rollupTask);
                         }
                     }
                 }
@@ -589,6 +593,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 implements GsonPostProcessable
             tbl.readUnlock();
         }
 
+        schemaChangeBatchTask = newSchemaChangeBatchTask;
         AgentTaskQueue.addBatchTask(schemaChangeBatchTask);
         AgentTaskExecutor.submit(schemaChangeBatchTask);
 
@@ -596,6 +601,47 @@ public class SchemaChangeJobV2 extends AlterJobV2 implements GsonPostProcessable
 
         // DO NOT write edit log here, tasks will be sent again if FE restart or master changed.
         LOG.info("transfer schema change job {} state to {}", jobId, this.jobState);
+    }
+
+    private boolean allBaseReplicasCaughtUp(OlapTable tbl) {
+        for (long partitionId : partitionIndexMap.rowKeySet()) {
+            Partition partition = tbl.getPartition(partitionId);
+            Preconditions.checkNotNull(partition, partitionId);
+            long visibleVersion = partition.getVisibleVersion();
+            Map<Long, MaterializedIndex> shadowIndexMap = partitionIndexMap.row(partitionId);
+            for (Map.Entry<Long, MaterializedIndex> entry : shadowIndexMap.entrySet()) {
+                long shadowIdxId = entry.getKey();
+                long originIdxId = indexIdMap.get(shadowIdxId);
+                MaterializedIndex originIdx = partition.getIndex(originIdxId);
+                Preconditions.checkNotNull(originIdx, originIdxId);
+                Map<Long, Long> tabletIdMap = partitionIndexTabletMap.get(partitionId, shadowIdxId);
+                Preconditions.checkNotNull(tabletIdMap,
+                        "tablet id map does not exist for partition " + partitionId + ", shadow index " + shadowIdxId);
+                for (Tablet shadowTablet : entry.getValue().getTablets()) {
+                    Long originTabletId = tabletIdMap.get(shadowTablet.getId());
+                    Preconditions.checkNotNull(originTabletId,
+                            "origin tablet does not exist for shadow tablet " + shadowTablet.getId());
+                    Tablet originTablet = originIdx.getTablet(originTabletId);
+                    Preconditions.checkNotNull(originTablet, originTabletId);
+                    for (Replica shadowReplica : shadowTablet.getReplicas()) {
+                        long backendId = shadowReplica.getBackendIdWithoutException();
+                        Replica originReplica = originTablet.getReplicaByBackendId(backendId);
+                        Preconditions.checkNotNull(originReplica,
+                                "origin replica does not exist on backend " + backendId
+                                        + " for origin tablet " + originTabletId);
+                        if (!isReplicaVersionComplete(originReplica, visibleVersion)) {
+                            LOG.info("wait origin replica {} on backend {} to catch up visible version {} before "
+                                            + "sending schema change tasks, job: {}, partition: {}, shadow tablet: {}, "
+                                            + "origin tablet: {}",
+                                    originReplica.getId(), backendId, visibleVersion, jobId, partitionId,
+                                    shadowTablet.getId(), originTabletId);
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+        return true;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -608,6 +608,8 @@ public class SchemaChangeJobV2 extends AlterJobV2 implements GsonPostProcessable
             Partition partition = tbl.getPartition(partitionId);
             Preconditions.checkNotNull(partition, partitionId);
             long visibleVersion = partition.getVisibleVersion();
+            int requiredReadyReplicaNum = tbl.getPartitionInfo()
+                    .getReplicaAllocation(partition.getId()).getTotalReplicaNum() / 2 + 1;
             Map<Long, MaterializedIndex> shadowIndexMap = partitionIndexMap.row(partitionId);
             for (Map.Entry<Long, MaterializedIndex> entry : shadowIndexMap.entrySet()) {
                 long shadowIdxId = entry.getKey();
@@ -623,20 +625,25 @@ public class SchemaChangeJobV2 extends AlterJobV2 implements GsonPostProcessable
                             "origin tablet does not exist for shadow tablet " + shadowTablet.getId());
                     Tablet originTablet = originIdx.getTablet(originTabletId);
                     Preconditions.checkNotNull(originTablet, originTabletId);
+                    int readyReplicaNum = 0;
                     for (Replica shadowReplica : shadowTablet.getReplicas()) {
                         long backendId = shadowReplica.getBackendIdWithoutException();
                         Replica originReplica = originTablet.getReplicaByBackendId(backendId);
                         Preconditions.checkNotNull(originReplica,
                                 "origin replica does not exist on backend " + backendId
                                         + " for origin tablet " + originTabletId);
-                        if (!canWaitBaseReplicaCatchUp(tbl, partition, originTablet, originReplica, visibleVersion)) {
-                            LOG.info("wait origin replica {} on backend {} to catch up visible version {} before "
-                                            + "sending schema change tasks, job: {}, partition: {}, shadow tablet: {}, "
-                                            + "origin tablet: {}",
-                                    originReplica.getId(), backendId, visibleVersion, jobId, partitionId,
-                                    shadowTablet.getId(), originTabletId);
-                            return false;
+                        if (isReplicaVersionComplete(originReplica, visibleVersion)) {
+                            readyReplicaNum++;
                         }
+                    }
+                    if (readyReplicaNum < requiredReadyReplicaNum) {
+                        ensureBaseTabletCatchUpPossible(tbl, partition, originTablet, visibleVersion);
+                        LOG.info("wait origin tablet {} to have enough ready replicas before sending schema "
+                                        + "change tasks, job: {}, partition: {}, shadow tablet: {}, "
+                                        + "readyReplicaNum: {}, requiredReadyReplicaNum: {}, visibleVersion: {}",
+                                originTabletId, jobId, partitionId, shadowTablet.getId(), readyReplicaNum,
+                                requiredReadyReplicaNum, visibleVersion);
+                        return false;
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -509,7 +509,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 implements GsonPostProcessable
             }
 
             Preconditions.checkState(tbl.getState() == OlapTableState.SCHEMA_CHANGE);
-            if (!allBaseReplicasCaughtUp(tbl)) {
+            if (!baseTabletsHaveReadyReplicaQuorum(tbl)) {
                 return;
             }
             // Create object pool per MaterializedIndex
@@ -603,7 +603,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 implements GsonPostProcessable
         LOG.info("transfer schema change job {} state to {}", jobId, this.jobState);
     }
 
-    private boolean allBaseReplicasCaughtUp(OlapTable tbl) throws AlterCancelException {
+    private boolean baseTabletsHaveReadyReplicaQuorum(OlapTable tbl) throws AlterCancelException {
         for (long partitionId : partitionIndexMap.rowKeySet()) {
             Partition partition = tbl.getPartition(partitionId);
             Preconditions.checkNotNull(partition, partitionId);

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -603,7 +603,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 implements GsonPostProcessable
         LOG.info("transfer schema change job {} state to {}", jobId, this.jobState);
     }
 
-    private boolean allBaseReplicasCaughtUp(OlapTable tbl) {
+    private boolean allBaseReplicasCaughtUp(OlapTable tbl) throws AlterCancelException {
         for (long partitionId : partitionIndexMap.rowKeySet()) {
             Partition partition = tbl.getPartition(partitionId);
             Preconditions.checkNotNull(partition, partitionId);
@@ -629,7 +629,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 implements GsonPostProcessable
                         Preconditions.checkNotNull(originReplica,
                                 "origin replica does not exist on backend " + backendId
                                         + " for origin tablet " + originTabletId);
-                        if (!isReplicaVersionComplete(originReplica, visibleVersion)) {
+                        if (!canWaitBaseReplicaCatchUp(tbl, partition, originTablet, originReplica, visibleVersion)) {
                             LOG.info("wait origin replica {} on backend {} to catch up visible version {} before "
                                             + "sending schema change tasks, job: {}, partition: {}, shadow tablet: {}, "
                                             + "origin tablet: {}",

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
@@ -217,7 +217,7 @@ public class RollupJobV2Test {
     }
 
     @Test
-    public void testRollupWaitsBaseReplicaCatchUp() throws Exception {
+    public void testRollupAllowsMinorityLaggingBaseReplica() throws Exception {
         fakeEnv = new FakeEnv();
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
@@ -249,10 +249,47 @@ public class RollupJobV2Test {
         }
 
         materializedViewHandler.runAfterCatalogReady();
+        Assert.assertEquals(JobState.RUNNING, rollupJob.getJobState());
+        Assert.assertEquals(3, AgentTaskQueue.getTask(TTaskType.ALTER).size());
+    }
+
+    @Test
+    public void testRollupWaitsForBaseReplicaCatchUpQuorum() throws Exception {
+        fakeEnv = new FakeEnv();
+        fakeEditLog = new FakeEditLog();
+        FakeEnv.setEnv(masterEnv);
+        MaterializedViewHandler materializedViewHandler = Env.getCurrentEnv().getMaterializedViewHandler();
+
+        ArrayList<AlterOp> alterOps = new ArrayList<>();
+        alterOps.add(op);
+        Database db = masterEnv.getInternalCatalog().getDbOrDdlException(CatalogTestUtil.testDbId1);
+        OlapTable olapTable = (OlapTable) db.getTableOrDdlException(CatalogTestUtil.testTableId1);
+        Partition testPartition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
+        materializedViewHandler.process(alterOps, db, olapTable);
+        RollupJobV2 rollupJob = (RollupJobV2) materializedViewHandler.getAlterJobsV2()
+                .values().stream().findAny().get();
+
+        materializedViewHandler.runAfterCatalogReady();
+        Assert.assertEquals(JobState.WAITING_TXN, rollupJob.getJobState());
+
+        Tablet baseTablet = testPartition.getBaseIndex().getTablets().get(0);
+        List<Replica> baseReplicas = baseTablet.getReplicas();
+        long visibleVersion = testPartition.getVisibleVersion() + 1;
+        testPartition.updateVisibleVersion(visibleVersion);
+        for (int i = 0; i < baseReplicas.size(); i++) {
+            Replica replica = baseReplicas.get(i);
+            if (i == baseReplicas.size() - 1) {
+                replica.updateVersionWithFailed(visibleVersion, -1, visibleVersion);
+            } else {
+                replica.updateVersionWithFailed(visibleVersion - 1, visibleVersion, visibleVersion - 1);
+            }
+        }
+
+        materializedViewHandler.runAfterCatalogReady();
         Assert.assertEquals(JobState.WAITING_TXN, rollupJob.getJobState());
         Assert.assertEquals(0, AgentTaskQueue.getTask(TTaskType.ALTER).size());
 
-        laggingReplica.updateVersionWithFailed(visibleVersion, -1, visibleVersion);
+        baseReplicas.get(0).updateVersionWithFailed(visibleVersion, -1, visibleVersion);
 
         materializedViewHandler.runAfterCatalogReady();
         Assert.assertEquals(JobState.RUNNING, rollupJob.getJobState());

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
@@ -217,6 +217,49 @@ public class RollupJobV2Test {
     }
 
     @Test
+    public void testRollupWaitsBaseReplicaCatchUp() throws Exception {
+        fakeEnv = new FakeEnv();
+        fakeEditLog = new FakeEditLog();
+        FakeEnv.setEnv(masterEnv);
+        MaterializedViewHandler materializedViewHandler = Env.getCurrentEnv().getMaterializedViewHandler();
+
+        ArrayList<AlterOp> alterOps = new ArrayList<>();
+        alterOps.add(op);
+        Database db = masterEnv.getInternalCatalog().getDbOrDdlException(CatalogTestUtil.testDbId1);
+        OlapTable olapTable = (OlapTable) db.getTableOrDdlException(CatalogTestUtil.testTableId1);
+        Partition testPartition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
+        materializedViewHandler.process(alterOps, db, olapTable);
+        RollupJobV2 rollupJob = (RollupJobV2) materializedViewHandler.getAlterJobsV2()
+                .values().stream().findAny().get();
+
+        materializedViewHandler.runAfterCatalogReady();
+        Assert.assertEquals(JobState.WAITING_TXN, rollupJob.getJobState());
+
+        Tablet baseTablet = testPartition.getBaseIndex().getTablets().get(0);
+        List<Replica> baseReplicas = baseTablet.getReplicas();
+        Replica laggingReplica = baseReplicas.get(0);
+        long visibleVersion = testPartition.getVisibleVersion() + 1;
+        testPartition.updateVisibleVersion(visibleVersion);
+        for (Replica replica : baseReplicas) {
+            if (replica == laggingReplica) {
+                replica.updateVersionWithFailed(visibleVersion - 1, visibleVersion, visibleVersion - 1);
+            } else {
+                replica.updateVersionWithFailed(visibleVersion, -1, visibleVersion);
+            }
+        }
+
+        materializedViewHandler.runAfterCatalogReady();
+        Assert.assertEquals(JobState.WAITING_TXN, rollupJob.getJobState());
+        Assert.assertEquals(0, AgentTaskQueue.getTask(TTaskType.ALTER).size());
+
+        laggingReplica.updateVersionWithFailed(visibleVersion, -1, visibleVersion);
+
+        materializedViewHandler.runAfterCatalogReady();
+        Assert.assertEquals(JobState.RUNNING, rollupJob.getJobState());
+        Assert.assertEquals(3, AgentTaskQueue.getTask(TTaskType.ALTER).size());
+    }
+
+    @Test
     public void testSchemaChangeWhileTabletNotStable() throws Exception {
         fakeEnv = new FakeEnv();
         fakeEditLog = new FakeEditLog();

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
@@ -260,6 +260,37 @@ public class RollupJobV2Test {
     }
 
     @Test
+    public void testRollupCancelsWhenBaseTabletUnrecoverable() throws Exception {
+        fakeEnv = new FakeEnv();
+        fakeEditLog = new FakeEditLog();
+        FakeEnv.setEnv(masterEnv);
+        MaterializedViewHandler materializedViewHandler = Env.getCurrentEnv().getMaterializedViewHandler();
+
+        ArrayList<AlterOp> alterOps = new ArrayList<>();
+        alterOps.add(op);
+        Database db = masterEnv.getInternalCatalog().getDbOrDdlException(CatalogTestUtil.testDbId1);
+        OlapTable olapTable = (OlapTable) db.getTableOrDdlException(CatalogTestUtil.testTableId1);
+        Partition testPartition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
+        materializedViewHandler.process(alterOps, db, olapTable);
+        RollupJobV2 rollupJob = (RollupJobV2) materializedViewHandler.getAlterJobsV2()
+                .values().stream().findAny().get();
+
+        materializedViewHandler.runAfterCatalogReady();
+        Assert.assertEquals(JobState.WAITING_TXN, rollupJob.getJobState());
+
+        Tablet baseTablet = testPartition.getBaseIndex().getTablets().get(0);
+        long visibleVersion = testPartition.getVisibleVersion() + 1;
+        testPartition.updateVisibleVersion(visibleVersion);
+        for (Replica replica : baseTablet.getReplicas()) {
+            replica.updateVersionWithFailed(visibleVersion - 1, visibleVersion, visibleVersion - 1);
+        }
+
+        materializedViewHandler.runAfterCatalogReady();
+        Assert.assertEquals(JobState.CANCELLED, rollupJob.getJobState());
+        Assert.assertEquals(0, AgentTaskQueue.getTask(TTaskType.ALTER).size());
+    }
+
+    @Test
     public void testSchemaChangeWhileTabletNotStable() throws Exception {
         fakeEnv = new FakeEnv();
         fakeEditLog = new FakeEditLog();

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
@@ -218,7 +218,7 @@ public class SchemaChangeJobV2Test {
     }
 
     @Test
-    public void testSchemaChangeWaitsBaseReplicaCatchUp() throws Exception {
+    public void testSchemaChangeAllowsMinorityLaggingBaseReplica() throws Exception {
         fakeEnv = new FakeEnv();
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
@@ -250,10 +250,47 @@ public class SchemaChangeJobV2Test {
         }
 
         schemaChangeHandler.runAfterCatalogReady();
+        Assert.assertEquals(JobState.RUNNING, schemaChangeJob.getJobState());
+        Assert.assertEquals(3, AgentTaskQueue.getTask(TTaskType.ALTER).size());
+    }
+
+    @Test
+    public void testSchemaChangeWaitsForBaseReplicaCatchUpQuorum() throws Exception {
+        fakeEnv = new FakeEnv();
+        fakeEditLog = new FakeEditLog();
+        FakeEnv.setEnv(masterEnv);
+        SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
+
+        ArrayList<AlterOp> alterOps = new ArrayList<>();
+        alterOps.add(addColumnOp);
+        Database db = masterEnv.getInternalCatalog().getDbOrDdlException(CatalogTestUtil.testDbId1);
+        OlapTable olapTable = (OlapTable) db.getTableOrDdlException(CatalogTestUtil.testTableId1);
+        Partition testPartition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
+        schemaChangeHandler.process(alterOps, db, olapTable);
+        SchemaChangeJobV2 schemaChangeJob = (SchemaChangeJobV2) schemaChangeHandler.getAlterJobsV2()
+                .values().stream().findAny().get();
+
+        schemaChangeHandler.runAfterCatalogReady();
+        Assert.assertEquals(JobState.WAITING_TXN, schemaChangeJob.getJobState());
+
+        Tablet baseTablet = testPartition.getBaseIndex().getTablets().get(0);
+        List<Replica> baseReplicas = baseTablet.getReplicas();
+        long visibleVersion = testPartition.getVisibleVersion() + 1;
+        testPartition.updateVisibleVersion(visibleVersion);
+        for (int i = 0; i < baseReplicas.size(); i++) {
+            Replica replica = baseReplicas.get(i);
+            if (i == baseReplicas.size() - 1) {
+                replica.updateVersionWithFailed(visibleVersion, -1, visibleVersion);
+            } else {
+                replica.updateVersionWithFailed(visibleVersion - 1, visibleVersion, visibleVersion - 1);
+            }
+        }
+
+        schemaChangeHandler.runAfterCatalogReady();
         Assert.assertEquals(JobState.WAITING_TXN, schemaChangeJob.getJobState());
         Assert.assertEquals(0, AgentTaskQueue.getTask(TTaskType.ALTER).size());
 
-        laggingReplica.updateVersionWithFailed(visibleVersion, -1, visibleVersion);
+        baseReplicas.get(0).updateVersionWithFailed(visibleVersion, -1, visibleVersion);
 
         schemaChangeHandler.runAfterCatalogReady();
         Assert.assertEquals(JobState.RUNNING, schemaChangeJob.getJobState());

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
@@ -218,6 +218,49 @@ public class SchemaChangeJobV2Test {
     }
 
     @Test
+    public void testSchemaChangeWaitsBaseReplicaCatchUp() throws Exception {
+        fakeEnv = new FakeEnv();
+        fakeEditLog = new FakeEditLog();
+        FakeEnv.setEnv(masterEnv);
+        SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
+
+        ArrayList<AlterOp> alterOps = new ArrayList<>();
+        alterOps.add(addColumnOp);
+        Database db = masterEnv.getInternalCatalog().getDbOrDdlException(CatalogTestUtil.testDbId1);
+        OlapTable olapTable = (OlapTable) db.getTableOrDdlException(CatalogTestUtil.testTableId1);
+        Partition testPartition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
+        schemaChangeHandler.process(alterOps, db, olapTable);
+        SchemaChangeJobV2 schemaChangeJob = (SchemaChangeJobV2) schemaChangeHandler.getAlterJobsV2()
+                .values().stream().findAny().get();
+
+        schemaChangeHandler.runAfterCatalogReady();
+        Assert.assertEquals(JobState.WAITING_TXN, schemaChangeJob.getJobState());
+
+        Tablet baseTablet = testPartition.getBaseIndex().getTablets().get(0);
+        List<Replica> baseReplicas = baseTablet.getReplicas();
+        Replica laggingReplica = baseReplicas.get(0);
+        long visibleVersion = testPartition.getVisibleVersion() + 1;
+        testPartition.updateVisibleVersion(visibleVersion);
+        for (Replica replica : baseReplicas) {
+            if (replica == laggingReplica) {
+                replica.updateVersionWithFailed(visibleVersion - 1, visibleVersion, visibleVersion - 1);
+            } else {
+                replica.updateVersionWithFailed(visibleVersion, -1, visibleVersion);
+            }
+        }
+
+        schemaChangeHandler.runAfterCatalogReady();
+        Assert.assertEquals(JobState.WAITING_TXN, schemaChangeJob.getJobState());
+        Assert.assertEquals(0, AgentTaskQueue.getTask(TTaskType.ALTER).size());
+
+        laggingReplica.updateVersionWithFailed(visibleVersion, -1, visibleVersion);
+
+        schemaChangeHandler.runAfterCatalogReady();
+        Assert.assertEquals(JobState.RUNNING, schemaChangeJob.getJobState());
+        Assert.assertEquals(3, AgentTaskQueue.getTask(TTaskType.ALTER).size());
+    }
+
+    @Test
     public void testSchemaChangeWhileTabletNotStable() throws Exception {
         fakeEnv = new FakeEnv();
         fakeEditLog = new FakeEditLog();

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
@@ -261,6 +261,37 @@ public class SchemaChangeJobV2Test {
     }
 
     @Test
+    public void testSchemaChangeCancelsWhenBaseTabletUnrecoverable() throws Exception {
+        fakeEnv = new FakeEnv();
+        fakeEditLog = new FakeEditLog();
+        FakeEnv.setEnv(masterEnv);
+        SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
+
+        ArrayList<AlterOp> alterOps = new ArrayList<>();
+        alterOps.add(addColumnOp);
+        Database db = masterEnv.getInternalCatalog().getDbOrDdlException(CatalogTestUtil.testDbId1);
+        OlapTable olapTable = (OlapTable) db.getTableOrDdlException(CatalogTestUtil.testTableId1);
+        Partition testPartition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
+        schemaChangeHandler.process(alterOps, db, olapTable);
+        SchemaChangeJobV2 schemaChangeJob = (SchemaChangeJobV2) schemaChangeHandler.getAlterJobsV2()
+                .values().stream().findAny().get();
+
+        schemaChangeHandler.runAfterCatalogReady();
+        Assert.assertEquals(JobState.WAITING_TXN, schemaChangeJob.getJobState());
+
+        Tablet baseTablet = testPartition.getBaseIndex().getTablets().get(0);
+        long visibleVersion = testPartition.getVisibleVersion() + 1;
+        testPartition.updateVisibleVersion(visibleVersion);
+        for (Replica replica : baseTablet.getReplicas()) {
+            replica.updateVersionWithFailed(visibleVersion - 1, visibleVersion, visibleVersion - 1);
+        }
+
+        schemaChangeHandler.runAfterCatalogReady();
+        Assert.assertEquals(JobState.CANCELLED, schemaChangeJob.getJobState());
+        Assert.assertEquals(0, AgentTaskQueue.getTask(TTaskType.ALTER).size());
+    }
+
+    @Test
     public void testSchemaChangeWhileTabletNotStable() throws Exception {
         fakeEnv = new FakeEnv();
         fakeEditLog = new FakeEditLog();

--- a/regression-test/suites/schema_change/test_schema_change_waits_for_lagging_base_replica.groovy
+++ b/regression-test/suites/schema_change/test_schema_change_waits_for_lagging_base_replica.groovy
@@ -1,0 +1,144 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_schema_change_waits_for_lagging_base_replica', 'docker') {
+    def options = new ClusterOptions()
+    options.beNum = 3
+    options.enableDebugPoints()
+    options.feConfigs.add('disable_tablet_scheduler=true')
+    docker(options) {
+        def blockedBe = cluster.getBeByIndex(1)
+        def normalBe = cluster.getBeByIndex(2)
+        def debugToken = 'schema_change_wait_base_replica'
+
+        onFinish {
+            blockedBe.clearDebugPoints()
+        }
+
+        sql ''' DROP TABLE IF EXISTS test_schema_change_waits_for_lagging_base_replica '''
+        sql '''
+            CREATE TABLE test_schema_change_waits_for_lagging_base_replica (
+                k1 INT,
+                k2 INT
+            )
+            DUPLICATE KEY(k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 1
+            PROPERTIES (
+                "replication_num" = "3",
+                "light_schema_change" = "false"
+            )
+        '''
+
+        sql ''' INSERT INTO test_schema_change_waits_for_lagging_base_replica VALUES (1, 10) '''
+
+        blockedBe.enableDebugPoint('EnginePublishVersionTask::execute.enable_spin_wait', ['token': debugToken])
+        blockedBe.enableDebugPoint('EnginePublishVersionTask::execute.block', ['pass_token': 'keep_blocked'])
+
+        sql ''' SET GLOBAL insert_visible_timeout_ms = 2000 '''
+        sql ''' INSERT INTO test_schema_change_waits_for_lagging_base_replica VALUES (2, 20) '''
+
+        def visibleRows = sql '''
+            SELECT k1, k2 FROM test_schema_change_waits_for_lagging_base_replica ORDER BY k1
+        '''
+        assertEquals([[1, 10], [2, 20]], visibleRows)
+
+        def tabletInfo = sql_return_maparray(
+                ''' SHOW TABLETS FROM test_schema_change_waits_for_lagging_base_replica ''')
+                .find { (it.BackendId as long) == blockedBe.backendId }
+        assertNotNull(tabletInfo)
+        def tabletId = tabletInfo.TabletId
+
+        def (code, out, err) = be_show_tablet_status(normalBe.host, normalBe.httpPort, tabletId)
+        assertEquals(0, code)
+        assertTrue(out.contains('[3-3]'))
+
+        (code, out, err) = be_show_tablet_status(blockedBe.host, blockedBe.httpPort, tabletId)
+        assertEquals(0, code)
+        assertTrue(out.contains('[2-2]'))
+        assertFalse(out.contains('[3-3]'))
+
+        sql '''
+            ALTER TABLE test_schema_change_waits_for_lagging_base_replica
+            ORDER BY (k2, k1)
+        '''
+
+        def waitingTxnObserved = false
+        for (int i = 0; i < 15; i++) {
+            def jobs = sql_return_maparray("""
+                SHOW ALTER TABLE COLUMN
+                WHERE TableName = 'test_schema_change_waits_for_lagging_base_replica'
+                ORDER BY CreateTime DESC LIMIT 1
+            """)
+            assertEquals(1, jobs.size())
+            def state = jobs[0].State
+            if (state == 'WAITING_TXN') {
+                waitingTxnObserved = true
+                break
+            }
+            assertNotEquals('CANCELLED', state)
+            sleep(1000)
+        }
+        assertTrue(waitingTxnObserved)
+
+        sleep(5000)
+        def waitingJobs = sql_return_maparray("""
+            SHOW ALTER TABLE COLUMN
+            WHERE TableName = 'test_schema_change_waits_for_lagging_base_replica'
+            ORDER BY CreateTime DESC LIMIT 1
+        """)
+        assertEquals('WAITING_TXN', waitingJobs[0].State)
+
+        blockedBe.clearDebugPoints()
+
+        def publishCaughtUp = false
+        for (int i = 0; i < 30; i++) {
+            (code, out, err) = be_show_tablet_status(blockedBe.host, blockedBe.httpPort, tabletId)
+            assertEquals(0, code)
+            if (out.contains('[3-3]')) {
+                publishCaughtUp = true
+                break
+            }
+            sleep(1000)
+        }
+        assertTrue(publishCaughtUp)
+
+        def finished = false
+        for (int i = 0; i < 60; i++) {
+            def jobs = sql_return_maparray("""
+                SHOW ALTER TABLE COLUMN
+                WHERE TableName = 'test_schema_change_waits_for_lagging_base_replica'
+                ORDER BY CreateTime DESC LIMIT 1
+            """)
+            assertEquals(1, jobs.size())
+            def state = jobs[0].State
+            if (state == 'FINISHED') {
+                finished = true
+                break
+            }
+            assertNotEquals('CANCELLED', state)
+            sleep(1000)
+        }
+        assertTrue(finished)
+
+        def result = sql '''
+            SELECT k1, k2 FROM test_schema_change_waits_for_lagging_base_replica ORDER BY k1
+        '''
+        assertEquals([[1, 10], [2, 20]], result)
+    }
+}

--- a/regression-test/suites/schema_change/test_schema_change_waits_for_lagging_base_replica.groovy
+++ b/regression-test/suites/schema_change/test_schema_change_waits_for_lagging_base_replica.groovy
@@ -146,8 +146,6 @@ suite('test_schema_change_waits_for_base_replica_catch_up_quorum', 'docker') {
         }
         assertTrue(leftWaitingTxn)
 
-        blockedBe2.clearDebugPoints()
-
         def finished = false
         for (int i = 0; i < 60; i++) {
             def jobs = sql_return_maparray("""
@@ -165,6 +163,11 @@ suite('test_schema_change_waits_for_base_replica_catch_up_quorum', 'docker') {
             sleep(1000)
         }
         assertTrue(finished)
+
+        (code, out, err) = be_show_tablet_status(blockedBe2.host, blockedBe2.httpPort, tabletId)
+        assertEquals(0, code)
+        assertTrue(out.contains('[2-2]'))
+        assertFalse(out.contains('[3-3]'))
 
         def result = sql '''
             SELECT k1, k2 FROM test_schema_change_waits_for_lagging_base_replica ORDER BY k1

--- a/regression-test/suites/schema_change/test_schema_change_waits_for_lagging_base_replica.groovy
+++ b/regression-test/suites/schema_change/test_schema_change_waits_for_lagging_base_replica.groovy
@@ -17,18 +17,20 @@
 
 import org.apache.doris.regression.suite.ClusterOptions
 
-suite('test_schema_change_waits_for_lagging_base_replica', 'docker') {
+suite('test_schema_change_waits_for_base_replica_catch_up_quorum', 'docker') {
     def options = new ClusterOptions()
     options.beNum = 3
     options.enableDebugPoints()
     options.feConfigs.add('disable_tablet_scheduler=true')
     docker(options) {
-        def blockedBe = cluster.getBeByIndex(1)
-        def normalBe = cluster.getBeByIndex(2)
+        def blockedBe1 = cluster.getBeByIndex(1)
+        def blockedBe2 = cluster.getBeByIndex(2)
+        def normalBe = cluster.getBeByIndex(3)
         def debugToken = 'schema_change_wait_base_replica'
 
         onFinish {
-            blockedBe.clearDebugPoints()
+            blockedBe1.clearDebugPoints()
+            blockedBe2.clearDebugPoints()
         }
 
         sql ''' DROP TABLE IF EXISTS test_schema_change_waits_for_lagging_base_replica '''
@@ -47,8 +49,10 @@ suite('test_schema_change_waits_for_lagging_base_replica', 'docker') {
 
         sql ''' INSERT INTO test_schema_change_waits_for_lagging_base_replica VALUES (1, 10) '''
 
-        blockedBe.enableDebugPoint('EnginePublishVersionTask::execute.enable_spin_wait', ['token': debugToken])
-        blockedBe.enableDebugPoint('EnginePublishVersionTask::execute.block', ['pass_token': 'keep_blocked'])
+        [blockedBe1, blockedBe2].each { be ->
+            be.enableDebugPoint('EnginePublishVersionTask::execute.enable_spin_wait', ['token': debugToken])
+            be.enableDebugPoint('EnginePublishVersionTask::execute.block', ['pass_token': 'keep_blocked'])
+        }
 
         sql ''' SET GLOBAL insert_visible_timeout_ms = 2000 '''
         sql ''' INSERT INTO test_schema_change_waits_for_lagging_base_replica VALUES (2, 20) '''
@@ -60,7 +64,7 @@ suite('test_schema_change_waits_for_lagging_base_replica', 'docker') {
 
         def tabletInfo = sql_return_maparray(
                 ''' SHOW TABLETS FROM test_schema_change_waits_for_lagging_base_replica ''')
-                .find { (it.BackendId as long) == blockedBe.backendId }
+                .find { (it.BackendId as long) == blockedBe1.backendId }
         assertNotNull(tabletInfo)
         def tabletId = tabletInfo.TabletId
 
@@ -68,7 +72,12 @@ suite('test_schema_change_waits_for_lagging_base_replica', 'docker') {
         assertEquals(0, code)
         assertTrue(out.contains('[3-3]'))
 
-        (code, out, err) = be_show_tablet_status(blockedBe.host, blockedBe.httpPort, tabletId)
+        (code, out, err) = be_show_tablet_status(blockedBe1.host, blockedBe1.httpPort, tabletId)
+        assertEquals(0, code)
+        assertTrue(out.contains('[2-2]'))
+        assertFalse(out.contains('[3-3]'))
+
+        (code, out, err) = be_show_tablet_status(blockedBe2.host, blockedBe2.httpPort, tabletId)
         assertEquals(0, code)
         assertTrue(out.contains('[2-2]'))
         assertFalse(out.contains('[3-3]'))
@@ -104,11 +113,11 @@ suite('test_schema_change_waits_for_lagging_base_replica', 'docker') {
         """)
         assertEquals('WAITING_TXN', waitingJobs[0].State)
 
-        blockedBe.clearDebugPoints()
+        blockedBe1.clearDebugPoints()
 
         def publishCaughtUp = false
         for (int i = 0; i < 30; i++) {
-            (code, out, err) = be_show_tablet_status(blockedBe.host, blockedBe.httpPort, tabletId)
+            (code, out, err) = be_show_tablet_status(blockedBe1.host, blockedBe1.httpPort, tabletId)
             assertEquals(0, code)
             if (out.contains('[3-3]')) {
                 publishCaughtUp = true
@@ -117,6 +126,26 @@ suite('test_schema_change_waits_for_lagging_base_replica', 'docker') {
             sleep(1000)
         }
         assertTrue(publishCaughtUp)
+
+        def leftWaitingTxn = false
+        for (int i = 0; i < 30; i++) {
+            def jobs = sql_return_maparray("""
+                SHOW ALTER TABLE COLUMN
+                WHERE TableName = 'test_schema_change_waits_for_lagging_base_replica'
+                ORDER BY CreateTime DESC LIMIT 1
+            """)
+            assertEquals(1, jobs.size())
+            def state = jobs[0].State
+            if (state != 'WAITING_TXN') {
+                leftWaitingTxn = true
+                assertNotEquals('CANCELLED', state)
+                break
+            }
+            sleep(1000)
+        }
+        assertTrue(leftWaitingTxn)
+
+        blockedBe2.clearDebugPoints()
 
         def finished = false
         for (int i = 0; i < 60; i++) {

--- a/regression-test/suites/schema_change/test_schema_change_waits_for_lagging_base_replica.groovy
+++ b/regression-test/suites/schema_change/test_schema_change_waits_for_lagging_base_replica.groovy
@@ -43,6 +43,7 @@ suite('test_schema_change_waits_for_base_replica_catch_up_quorum', 'docker') {
             DISTRIBUTED BY HASH(k1) BUCKETS 1
             PROPERTIES (
                 "replication_num" = "3",
+                "disable_auto_compaction" = "true",
                 "light_schema_change" = "false"
             )
         '''


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

When a transaction is in `TIMEOUT_SUCC` state (partial publish success), the partition visible version can advance while some base replicas still lag locally. Previously, schema change and rollup jobs could send alter tasks before the corresponding base replicas had actually caught up, which may lead to BE failures such as `base tablet's max version < request version`.

This PR adds a guard in the `WAITING_TXN` phase for both schema change and rollup, and aligns that guard with alter job success semantics:

- Before sending alter tasks, require each base tablet to have a quorum of version-complete base replicas
- If a tablet has not reached quorum yet, keep the job in `WAITING_TXN` and retry in the next scheduler round
- If the tablet still lacks quorum and is already `UNRECOVERABLE`, cancel the alter job immediately instead of waiting until alter timeout

Why quorum is sufficient:
- Alter task failure threshold is already quorum-based
- Final shadow/rollup tablet integrity check is also quorum-based
- So gating on all base replicas is stricter than necessary and may delay valid alter execution

Changes:
- `AlterJobV2`: add shared helper for unrecoverable base tablet detection during catch-up gating
- `SchemaChangeJobV2`: require base replica catch-up quorum before dispatching schema change tasks
- `RollupJobV2`: same quorum gating and fail-fast behavior for consistency
- Add FE unit tests covering:
  - minority lagging replicas are allowed
  - below-quorum lagging replicas keep the job in `WAITING_TXN`
  - unrecoverable tablets fail fast
- Add docker regression coverage for leaving `WAITING_TXN` once publish catch-up reaches quorum

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. Alter jobs now dispatch once base replica catch-up reaches quorum, and fail fast if the base tablet is already unrecoverable.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->