### PR TITLE
  [fix](auth) restrict skip_catalog_priv_check to SHOW and SELECT on catalog privilege checks

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3910,8 +3910,15 @@ public class Config extends ConfigBase {
             "agent tasks health check interval, default is five minutes, no health check when less than or equal to 0"
     })
     public static long agent_task_health_check_intervals_ms = 5 * 60 * 1000L; // 5 min
-    @ConfField(description = {"是否跳过 catalog 层级的鉴权",
-            "Whether to skip catalog level privilege check"})
+    @ConfField(description = {
+            "是否在 catalog 级权限检查中跳过 FE 内部的 catalog 权限校验。仅对配置了自定义 access controller 的外部 "
+                    + "catalog 的 SHOW/SELECT 生效；内部 catalog、未配置自定义 access controller 的 catalog，"
+                    + "以及 CREATE/LOAD/ALTER 等其他权限仍按默认逻辑校验",
+            "Whether to skip the FE internal catalog privilege check in catalog-level privilege validation. "
+                    + "This only applies to SHOW/SELECT on external catalogs with a custom access controller. "
+                    + "Internal catalogs, catalogs without a custom access controller, and other privileges such "
+                    + "as CREATE/LOAD/ALTER are still validated by the default logic"
+    })
     public static boolean skip_catalog_priv_check = false;
 
     @ConfField(mutable = true, description = {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/AccessControllerManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/AccessControllerManager.java
@@ -196,13 +196,17 @@ public class AccessControllerManager {
         return checkCtlPriv(ctx.getCurrentUserIdentity(), ctl, wanted);
     }
 
+    private boolean canSkipCatalogPrivCheck(PrivPredicate wanted) {
+        return wanted == PrivPredicate.SHOW || wanted == PrivPredicate.SELECT;
+    }
+
+    private boolean shouldSkipCatalogPrivCheck(PrivPredicate wanted) {
+        return Config.skip_catalog_priv_check && canSkipCatalogPrivCheck(wanted);
+    }
+
     public boolean checkCtlPriv(UserIdentity currentUser, String ctl, PrivPredicate wanted) {
         boolean hasGlobal = checkGlobalPriv(currentUser, wanted);
-        if (!Config.skip_catalog_priv_check) {
-            // for checking catalog priv, always use InternalAccessController.
-            // because catalog priv is only saved in InternalAccessController.
-            return defaultAccessController.checkCtlPriv(hasGlobal, currentUser, ctl, wanted);
-        } else {
+        if (shouldSkipCatalogPrivCheck(wanted)) {
             CatalogIf catalog = Env.getCurrentEnv().getCatalogMgr().getCatalog(ctl);
             if (catalog == null) {
                 return false;
@@ -217,10 +221,12 @@ public class AccessControllerManager {
             if (Strings.isNullOrEmpty(className)) {
                 // not set access controller, use internal access controller
                 return defaultAccessController.checkCtlPriv(hasGlobal, currentUser, ctl, wanted);
-            } else {
-                return true;
             }
+            return true;
         }
+        // for checking catalog priv, always use InternalAccessController.
+        // because catalog priv is only saved in InternalAccessController.
+        return defaultAccessController.checkCtlPriv(hasGlobal, currentUser, ctl, wanted);
     }
 
     // ==== Database ====

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/AccessControllerManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/AccessControllerManagerTest.java
@@ -48,7 +48,7 @@ public class AccessControllerManagerTest {
     }
 
     @Test
-    public void testCheckCtlPrivSkipCatalogPrivCheckWithCustomAccessController(
+    public void testCheckCtlPrivSkipCatalogPrivCheckWithCustomAccessControllerForSelect(
             @Injectable CatalogAccessController defaultAccessController,
             @Mocked Env env,
             @Mocked CatalogMgr catalogMgr,
@@ -86,6 +86,47 @@ public class AccessControllerManagerTest {
         };
 
         Assert.assertTrue(accessControllerManager.checkCtlPriv(userIdentity, "custom_catalog", PrivPredicate.SELECT));
+    }
+
+    @Test
+    public void testCheckCtlPrivSkipCatalogPrivCheckWithCustomAccessControllerForShow(
+            @Injectable CatalogAccessController defaultAccessController,
+            @Mocked Env env,
+            @Mocked CatalogMgr catalogMgr,
+            @Mocked CatalogIf catalog) {
+        AccessControllerManager accessControllerManager = createAccessControllerManager(defaultAccessController);
+        UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%");
+        Config.skip_catalog_priv_check = true;
+
+        new Expectations() {
+            {
+                defaultAccessController.checkGlobalPriv((UserIdentity) any, (PrivPredicate) any);
+                minTimes = 0;
+                result = false;
+
+                Env.getCurrentEnv();
+                minTimes = 0;
+                result = env;
+
+                env.getCatalogMgr();
+                minTimes = 0;
+                result = catalogMgr;
+
+                catalogMgr.getCatalog("custom_catalog");
+                minTimes = 0;
+                result = catalog;
+
+                catalog.isInternalCatalog();
+                minTimes = 0;
+                result = false;
+
+                catalog.getProperties();
+                minTimes = 0;
+                result = ImmutableMap.of(CatalogMgr.ACCESS_CONTROLLER_CLASS_PROP, "mock.access.controller");
+            }
+        };
+
+        Assert.assertTrue(accessControllerManager.checkCtlPriv(userIdentity, "custom_catalog", PrivPredicate.SHOW));
     }
 
     @Test
@@ -131,6 +172,87 @@ public class AccessControllerManagerTest {
         };
 
         Assert.assertFalse(accessControllerManager.checkCtlPriv(userIdentity, "custom_catalog", PrivPredicate.SELECT));
+    }
+
+    @Test
+    public void testCheckCtlPrivCreateMustCheckDefaultAccessController(
+            @Injectable CatalogAccessController defaultAccessController,
+            @Mocked Env env,
+            @Mocked CatalogMgr catalogMgr) {
+        AccessControllerManager accessControllerManager = createAccessControllerManager(defaultAccessController);
+        UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%");
+        Config.skip_catalog_priv_check = true;
+
+        new Expectations() {
+            {
+                defaultAccessController.checkGlobalPriv((UserIdentity) any, (PrivPredicate) any);
+                minTimes = 0;
+                result = false;
+
+                defaultAccessController.checkCtlPriv(anyBoolean, (UserIdentity) any, anyString, (PrivPredicate) any);
+                minTimes = 0;
+                result = true;
+
+                Env.getCurrentEnv();
+                minTimes = 0;
+                result = env;
+
+                env.getCatalogMgr();
+                minTimes = 0;
+                result = catalogMgr;
+
+                catalogMgr.getCatalog("not_exist_catalog");
+                minTimes = 0;
+                result = null;
+            }
+        };
+
+        Assert.assertTrue(accessControllerManager.checkCtlPriv(userIdentity, "not_exist_catalog", PrivPredicate.CREATE));
+    }
+
+    @Test
+    public void testCheckCtlPrivLoadMustCheckDefaultAccessController(
+            @Injectable CatalogAccessController defaultAccessController,
+            @Mocked Env env,
+            @Mocked CatalogMgr catalogMgr,
+            @Mocked CatalogIf catalog) {
+        AccessControllerManager accessControllerManager = createAccessControllerManager(defaultAccessController);
+        UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%");
+        Config.skip_catalog_priv_check = true;
+
+        new Expectations() {
+            {
+                defaultAccessController.checkGlobalPriv((UserIdentity) any, (PrivPredicate) any);
+                minTimes = 0;
+                result = false;
+
+                defaultAccessController.checkCtlPriv(anyBoolean, (UserIdentity) any, anyString, (PrivPredicate) any);
+                minTimes = 0;
+                result = false;
+
+                Env.getCurrentEnv();
+                minTimes = 0;
+                result = env;
+
+                env.getCatalogMgr();
+                minTimes = 0;
+                result = catalogMgr;
+
+                catalogMgr.getCatalog("custom_catalog");
+                minTimes = 0;
+                result = catalog;
+
+                catalog.isInternalCatalog();
+                minTimes = 0;
+                result = false;
+
+                catalog.getProperties();
+                minTimes = 0;
+                result = ImmutableMap.of(CatalogMgr.ACCESS_CONTROLLER_CLASS_PROP, "mock.access.controller");
+            }
+        };
+
+        Assert.assertFalse(accessControllerManager.checkCtlPriv(userIdentity, "custom_catalog", PrivPredicate.LOAD));
     }
 
     @Test


### PR DESCRIPTION
followup https://github.com/apache/doris/pull/60945

  ## What problem does this PR solve?

  When `skip_catalog_priv_check` is enabled, `AccessControllerManager#checkCtlPriv()` currently skips
  catalog privilege checks for external catalogs with a custom access controller.

  This behavior is too broad because it also affects non-read-only catalog privileges such as `CREATE`
  and `LOAD`, which should still be validated by the default internal access controller.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

