### PR TITLE
[fix](test) fix death tests crash in multi-threaded UT binary

### DIFF
--- a/be/test/storage/index/inverted/query_v2/phrase_prefix_query_test.cpp
+++ b/be/test/storage/index/inverted/query_v2/phrase_prefix_query_test.cpp
@@ -19,6 +19,7 @@
 
 #include <CLucene.h>
 #include <gtest/gtest.h>
+#include <sys/resource.h>
 
 #include <memory>
 #include <roaring/roaring.hh>
@@ -199,7 +200,13 @@ TEST_F(PhrasePrefixQueryV2Test, empty_terms_throws) {
     std::vector<TermInfo> empty_terms;
 
     // Constructor asserts !terms.empty(), which aborts in debug builds.
-    EXPECT_DEATH({ PhrasePrefixQuery q(ctx, field, empty_terms); }, "");
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+    EXPECT_DEATH(({
+                     struct rlimit core_limit {};
+                     setrlimit(RLIMIT_CORE, &core_limit);
+                     PhrasePrefixQuery q(ctx, field, empty_terms);
+                 }),
+                 "");
 }
 
 // --- PhrasePrefixWeight scorer: phrase + prefix match ---

--- a/be/test/storage/storage_resource_test.cpp
+++ b/be/test/storage/storage_resource_test.cpp
@@ -17,6 +17,7 @@
 
 #include <gen_cpp/cloud.pb.h>
 #include <gtest/gtest.h>
+#include <sys/resource.h>
 
 #include "io/fs/s3_file_system.h"
 #include "storage/rowset/rowset_meta.h"
@@ -78,7 +79,13 @@ TEST(StorageResourceTest, RemotePath) {
               "data/611/10005/10006.13.meta");
 
     path_format->set_path_version(2);
-    ASSERT_DEATH(StorageResource(res.value(), storage_vault_pb.path_format()), "unknown");
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+    ASSERT_DEATH(({
+                     struct rlimit core_limit {};
+                     setrlimit(RLIMIT_CORE, &core_limit);
+                     StorageResource(res.value(), storage_vault_pb.path_format());
+                 }),
+                 "unknown");
 }
 
 TEST(StorageResourceTest, ParseTabletIdFromPath) {

--- a/be/test/util/threadpool_test.cpp
+++ b/be/test/util/threadpool_test.cpp
@@ -23,6 +23,7 @@
 #include <gtest/gtest-param-test.h>
 #include <gtest/gtest-test-part.h>
 #include <sched.h>
+#include <sys/resource.h>
 #include <unistd.h>
 
 #include <atomic>
@@ -334,6 +335,8 @@ TEST_F(ThreadPoolTest, TestDeadlocks) {
 #endif
     EXPECT_DEATH(
             {
+                struct rlimit core_limit {};
+                setrlimit(RLIMIT_CORE, &core_limit);
                 EXPECT_TRUE(rebuild_pool_with_min_max(1, 1).ok());
                 EXPECT_TRUE(_pool->submit_func([pool = _pool.get()]() { pool->shutdown(); }).ok());
                 _pool->wait();
@@ -342,6 +345,8 @@ TEST_F(ThreadPoolTest, TestDeadlocks) {
 
     EXPECT_DEATH(
             {
+                struct rlimit core_limit {};
+                setrlimit(RLIMIT_CORE, &core_limit);
                 EXPECT_TRUE(rebuild_pool_with_min_max(1, 1).ok());
                 EXPECT_TRUE(_pool->submit_func([pool = _pool.get()]() { pool->wait(); }).ok());
                 _pool->wait();


### PR DESCRIPTION
ASSERT_DEATH/EXPECT_DEATH to crash due to unsafe fork() in multi-threaded context.

Fix: add GTEST_FLAG_SET(death_test_style, "threadsafe") so gtest uses fork+re-exec instead of plain fork, and setrlimit to suppress core dumps in death test child processes.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

