### PR TITLE
[fix](test) Fix ODR violation for MockFileReader across test files.

### DIFF
--- a/be/test/format/file_reader/file_meta_cache_test.cpp
+++ b/be/test/format/file_reader/file_meta_cache_test.cpp
@@ -22,6 +22,7 @@
 #include "io/fs/file_reader.h"
 
 namespace doris {
+namespace {
 
 class MockFileReader : public io::FileReader {
 public:
@@ -57,6 +58,7 @@ private:
     size_t _size;
     bool _closed;
 };
+} // anonymous namespace
 
 TEST(FileMetaCacheTest, KeyGenerationFromParams) {
     std::string file_name = "/path/to/file";

--- a/be/test/format/orc/orc_file_reader_test.cpp
+++ b/be/test/format/orc/orc_file_reader_test.cpp
@@ -23,6 +23,7 @@
 #include "util/slice.h"
 
 namespace doris {
+namespace {
 
 class MockFileReader : public io::FileReader {
 public:
@@ -61,6 +62,7 @@ private:
     bool _closed = false;
     io::Path _path = "/tmp/mock";
 };
+} // anonymous namespace
 
 class OrcMergeRangeFileReaderTest : public testing::Test {
 protected:

--- a/be/test/io/fs/packed_file_reader_test.cpp
+++ b/be/test/io/fs/packed_file_reader_test.cpp
@@ -33,6 +33,7 @@ namespace doris::io {
 using doris::Status;
 
 // Mock FileReader for testing PackedFileReader
+namespace {
 class MockFileReader : public FileReader {
 public:
     explicit MockFileReader(std::string content) : _content(std::move(content)) {}
@@ -48,15 +49,9 @@ public:
 
     bool closed() const override { return _closed; }
 
-    void set_read_status(Status st) { _read_status = std::move(st); }
-
 protected:
     Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                         const IOContext* /*io_ctx*/) override {
-        if (!_read_status.ok()) {
-            return _read_status;
-        }
-
         if (offset >= _content.size()) {
             *bytes_read = 0;
             return Status::OK();
@@ -75,8 +70,8 @@ private:
     Path _path = Path("mock_file");
     std::string _content;
     bool _closed = false;
-    Status _read_status = Status::OK();
 };
+} // anonymous namespace
 
 // Test fixture for PackedFileReader
 class PackedFileReaderTest : public testing::Test {

--- a/be/test/io/fs/packed_file_system_test.cpp
+++ b/be/test/io/fs/packed_file_system_test.cpp
@@ -38,6 +38,7 @@ namespace doris::io {
 using doris::Status;
 
 // Mock FileReader for testing PackedFileSystem
+namespace {
 class MockFileReader : public FileReader {
 public:
     explicit MockFileReader(std::string content) : _content(std::move(content)) {}
@@ -74,6 +75,7 @@ private:
     std::string _content;
     bool _closed = false;
 };
+} // anonymous namespace
 
 // Mock FileWriter for testing PackedFileSystem
 class MockFileWriterForMerge : public FileWriter {
@@ -128,7 +130,6 @@ public:
     void set_file_size(int64_t size) { _file_size = size; }
 
     MockFileWriterForMerge* last_writer() const { return _last_writer; }
-    MockFileReader* last_reader() const { return _last_reader; }
 
 protected:
     Status create_file_impl(const Path& file, FileWriterPtr* writer,
@@ -149,7 +150,6 @@ protected:
         }
         // Create a mock reader with some content
         auto mock_reader = std::make_shared<MockFileReader>("mock_content");
-        _last_reader = mock_reader.get();
         *reader = std::move(mock_reader);
         return Status::OK();
     }
@@ -195,7 +195,6 @@ private:
     bool _exists_result = true;
     int64_t _file_size = 0;
     MockFileWriterForMerge* _last_writer = nullptr;
-    MockFileReader* _last_reader = nullptr;
 };
 
 // Test fixture for PackedFileSystem


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

### Release note

Multiple test files defined different MockFileReader classes with the same fully-qualified name doris::MockFileReader but different member layouts and sizes (96 bytes vs 64 bytes). When linked into the single monolithic doris_be_test binary, the linker would deduplicate symbols and arbitrarily pick one version's template instantiations (e.g., make_shared, destructor), causing size mismatches at runtime. This resulted in ASAN errors:
- heap-buffer-overflow: allocating 80 bytes but writing 96 bytes
- new-delete-type-mismatch: allocated 96 bytes, deallocated 64 bytes The ODR conflict was exposed after #61142 removed the vectorized namespace, which moved orc_file_reader_test.cpp's MockFileReader into namespace doris, colliding with file_meta_cache_test.cpp's MockFileReader in the same namespace.
Fix: Wrap each MockFileReader class in an anonymous namespace to give them internal linkage, ensuring each translation unit uses its own independent symbols.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

