### PR TITLE
[feat](auth integration)unify auth integration audit metadata

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/authentication/AuthenticationIntegrationMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/authentication/AuthenticationIntegrationMeta.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.authentication;
 
+import org.apache.doris.common.UserAuditMetadata;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
@@ -36,7 +37,7 @@ import java.util.Set;
 /**
  * Persistent metadata for AUTHENTICATION INTEGRATION.
  */
-public class AuthenticationIntegrationMeta implements Writable {
+public class AuthenticationIntegrationMeta extends UserAuditMetadata implements Writable {
     public static final String TYPE_PROPERTY = "type";
 
     @SerializedName(value = "n")
@@ -49,13 +50,16 @@ public class AuthenticationIntegrationMeta implements Writable {
     private String comment;
 
     private AuthenticationIntegrationMeta() {
+        super();
         this.name = "";
         this.type = "";
         this.properties = Collections.emptyMap();
         this.comment = null;
     }
 
-    public AuthenticationIntegrationMeta(String name, String type, Map<String, String> properties, String comment) {
+    public AuthenticationIntegrationMeta(String name, String type, Map<String, String> properties, String comment,
+            String createUser, long createTime, String alterUser, long modifyTime) {
+        super(createUser, createTime, alterUser, modifyTime);
         this.name = Objects.requireNonNull(name, "name can not be null");
         this.type = Objects.requireNonNull(type, "type can not be null");
         this.properties = Collections.unmodifiableMap(
@@ -67,7 +71,8 @@ public class AuthenticationIntegrationMeta implements Writable {
      * Build metadata from CREATE SQL arguments.
      */
     public static AuthenticationIntegrationMeta fromCreateSql(
-            String integrationName, Map<String, String> properties, String comment) throws DdlException {
+            String integrationName, Map<String, String> properties, String comment, String createUser)
+            throws DdlException {
         if (properties == null || properties.isEmpty()) {
             throw new DdlException("Property 'type' is required in CREATE AUTHENTICATION INTEGRATION");
         }
@@ -87,13 +92,17 @@ public class AuthenticationIntegrationMeta implements Writable {
         if (type == null || type.isEmpty()) {
             throw new DdlException("Property 'type' is required in CREATE AUTHENTICATION INTEGRATION");
         }
-        return new AuthenticationIntegrationMeta(integrationName, type, copiedProperties, comment);
+        long currentTime = System.currentTimeMillis();
+        return new AuthenticationIntegrationMeta(integrationName, type, copiedProperties, comment,
+                Objects.requireNonNull(createUser, "createUser can not be null"),
+                currentTime, createUser, currentTime);
     }
 
     /**
      * Build a new metadata object after ALTER ... SET PROPERTIES.
      */
-    public AuthenticationIntegrationMeta withAlterProperties(Map<String, String> propertiesDelta) throws DdlException {
+    public AuthenticationIntegrationMeta withAlterProperties(Map<String, String> propertiesDelta, String alterUser)
+            throws DdlException {
         if (propertiesDelta == null || propertiesDelta.isEmpty()) {
             throw new DdlException("ALTER AUTHENTICATION INTEGRATION should contain at least one property");
         }
@@ -104,13 +113,16 @@ public class AuthenticationIntegrationMeta implements Writable {
         }
         Map<String, String> mergedProperties = new LinkedHashMap<>(properties);
         mergedProperties.putAll(propertiesDelta);
-        return new AuthenticationIntegrationMeta(name, type, mergedProperties, comment);
+        return new AuthenticationIntegrationMeta(name, type, mergedProperties, comment,
+                getCreateUser(), getCreateTime(),
+                Objects.requireNonNull(alterUser, "alterUser can not be null"), System.currentTimeMillis());
     }
 
     /**
      * Build a new metadata object after ALTER ... UNSET PROPERTIES.
      */
-    public AuthenticationIntegrationMeta withUnsetProperties(Set<String> propertiesToUnset) throws DdlException {
+    public AuthenticationIntegrationMeta withUnsetProperties(Set<String> propertiesToUnset, String alterUser)
+            throws DdlException {
         if (propertiesToUnset == null || propertiesToUnset.isEmpty()) {
             throw new DdlException("ALTER AUTHENTICATION INTEGRATION should contain at least one property");
         }
@@ -121,11 +133,15 @@ public class AuthenticationIntegrationMeta implements Writable {
             }
             reducedProperties.remove(key);
         }
-        return new AuthenticationIntegrationMeta(name, type, reducedProperties, comment);
+        return new AuthenticationIntegrationMeta(name, type, reducedProperties, comment,
+                getCreateUser(), getCreateTime(),
+                Objects.requireNonNull(alterUser, "alterUser can not be null"), System.currentTimeMillis());
     }
 
-    public AuthenticationIntegrationMeta withComment(String newComment) {
-        return new AuthenticationIntegrationMeta(name, type, properties, newComment);
+    public AuthenticationIntegrationMeta withComment(String newComment, String alterUser) {
+        return new AuthenticationIntegrationMeta(name, type, properties, newComment,
+                getCreateUser(), getCreateTime(),
+                Objects.requireNonNull(alterUser, "alterUser can not be null"), System.currentTimeMillis());
     }
 
     public String getName() {

--- a/fe/fe-core/src/main/java/org/apache/doris/authentication/AuthenticationIntegrationMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/authentication/AuthenticationIntegrationMeta.java
@@ -17,8 +17,8 @@
 
 package org.apache.doris.authentication;
 
-import org.apache.doris.common.UserAuditMetadata;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.UserAuditMetadata;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.persist.gson.GsonUtils;

--- a/fe/fe-core/src/main/java/org/apache/doris/authentication/AuthenticationIntegrationMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/authentication/AuthenticationIntegrationMgr.java
@@ -60,10 +60,11 @@ public class AuthenticationIntegrationMgr implements Writable {
     }
 
     public void createAuthenticationIntegration(
-            String integrationName, boolean ifNotExists, Map<String, String> properties, String comment)
+            String integrationName, boolean ifNotExists, Map<String, String> properties, String comment,
+            String createUser)
             throws DdlException {
         AuthenticationIntegrationMeta meta =
-                AuthenticationIntegrationMeta.fromCreateSql(integrationName, properties, comment);
+                AuthenticationIntegrationMeta.fromCreateSql(integrationName, properties, comment, createUser);
         writeLock();
         try {
             if (nameToIntegration.containsKey(integrationName)) {
@@ -82,11 +83,11 @@ public class AuthenticationIntegrationMgr implements Writable {
     }
 
     public void alterAuthenticationIntegrationProperties(
-            String integrationName, Map<String, String> properties) throws DdlException {
+            String integrationName, Map<String, String> properties, String alterUser) throws DdlException {
         writeLock();
         try {
             AuthenticationIntegrationMeta current = getOrThrow(integrationName);
-            AuthenticationIntegrationMeta updated = current.withAlterProperties(properties);
+            AuthenticationIntegrationMeta updated = current.withAlterProperties(properties, alterUser);
             nameToIntegration.put(integrationName, updated);
             // TODO(authentication-integration): Re-enable edit log persistence
             // when authentication integration is fully integrated.
@@ -97,11 +98,11 @@ public class AuthenticationIntegrationMgr implements Writable {
     }
 
     public void alterAuthenticationIntegrationUnsetProperties(
-            String integrationName, Set<String> propertiesToUnset) throws DdlException {
+            String integrationName, Set<String> propertiesToUnset, String alterUser) throws DdlException {
         writeLock();
         try {
             AuthenticationIntegrationMeta current = getOrThrow(integrationName);
-            AuthenticationIntegrationMeta updated = current.withUnsetProperties(propertiesToUnset);
+            AuthenticationIntegrationMeta updated = current.withUnsetProperties(propertiesToUnset, alterUser);
             nameToIntegration.put(integrationName, updated);
             // TODO(authentication-integration): Re-enable edit log persistence
             // when authentication integration is fully integrated.
@@ -111,11 +112,12 @@ public class AuthenticationIntegrationMgr implements Writable {
         }
     }
 
-    public void alterAuthenticationIntegrationComment(String integrationName, String comment) throws DdlException {
+    public void alterAuthenticationIntegrationComment(String integrationName, String comment, String alterUser)
+            throws DdlException {
         writeLock();
         try {
             AuthenticationIntegrationMeta current = getOrThrow(integrationName);
-            AuthenticationIntegrationMeta updated = current.withComment(comment);
+            AuthenticationIntegrationMeta updated = current.withComment(comment, alterUser);
             nameToIntegration.put(integrationName, updated);
             // TODO(authentication-integration): Re-enable edit log persistence
             // when authentication integration is fully integrated.

--- a/fe/fe-core/src/main/java/org/apache/doris/common/UserAuditMetadata.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/UserAuditMetadata.java
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import org.apache.doris.common.util.TimeUtils;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Objects;
+
+/**
+ * Common persisted audit metadata for user-driven DDL objects.
+ * Time is stored as epoch millis and formatted lazily with Doris/session timezone when needed.
+ */
+public abstract class UserAuditMetadata {
+    @SerializedName(value = "cu")
+    private String createUser;
+    @SerializedName(value = "ct")
+    private long createTime;
+    @SerializedName(value = "au")
+    private String alterUser;
+    @SerializedName(value = "mt")
+    private long modifyTime;
+
+    protected UserAuditMetadata() {
+    }
+
+    protected UserAuditMetadata(String createUser, long createTime, String alterUser, long modifyTime) {
+        this.createUser = Objects.requireNonNull(createUser, "createUser can not be null");
+        this.alterUser = Objects.requireNonNull(alterUser, "alterUser can not be null");
+        Preconditions.checkArgument(createTime > 0, "createTime must be positive");
+        Preconditions.checkArgument(modifyTime > 0, "modifyTime must be positive");
+        Preconditions.checkArgument(modifyTime >= createTime, "modifyTime can not be earlier than createTime");
+        this.createTime = createTime;
+        this.modifyTime = modifyTime;
+    }
+
+    public String getCreateUser() {
+        return createUser;
+    }
+
+    public long getCreateTime() {
+        return createTime;
+    }
+
+    public String getAlterUser() {
+        return alterUser;
+    }
+
+    public long getModifyTime() {
+        return modifyTime;
+    }
+
+    public String getCreateTimeString() {
+        return TimeUtils.longToTimeString(createTime);
+    }
+
+    public String getModifyTimeString() {
+        return TimeUtils.longToTimeString(modifyTime);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AlterAuthenticationIntegrationCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AlterAuthenticationIntegrationCommand.java
@@ -87,21 +87,22 @@ public class AlterAuthenticationIntegrationCommand extends AlterCommand implemen
 
     @Override
     public void doRun(ConnectContext ctx, StmtExecutor executor) throws Exception {
-        if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)) {
+        if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ctx, PrivPredicate.ADMIN)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "ADMIN");
         }
+        String alterUser = Objects.requireNonNull(ctx.getQualifiedUser(), "qualifiedUser can not be null");
         switch (alterType) {
             case SET_PROPERTIES:
                 Env.getCurrentEnv().getAuthenticationIntegrationMgr()
-                        .alterAuthenticationIntegrationProperties(integrationName, properties);
+                        .alterAuthenticationIntegrationProperties(integrationName, properties, alterUser);
                 return;
             case UNSET_PROPERTIES:
                 Env.getCurrentEnv().getAuthenticationIntegrationMgr()
-                        .alterAuthenticationIntegrationUnsetProperties(integrationName, unsetProperties);
+                        .alterAuthenticationIntegrationUnsetProperties(integrationName, unsetProperties, alterUser);
                 return;
             case SET_COMMENT:
                 Env.getCurrentEnv().getAuthenticationIntegrationMgr()
-                        .alterAuthenticationIntegrationComment(integrationName, comment);
+                        .alterAuthenticationIntegrationComment(integrationName, comment, alterUser);
                 return;
             default:
                 throw new AnalysisException("Unsupported alter type for AUTHENTICATION INTEGRATION: " + alterType);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateAuthenticationIntegrationCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateAuthenticationIntegrationCommand.java
@@ -59,11 +59,12 @@ public class CreateAuthenticationIntegrationCommand extends Command implements F
 
     @Override
     public void run(ConnectContext ctx, StmtExecutor executor) throws Exception {
-        if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)) {
+        if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ctx, PrivPredicate.ADMIN)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "ADMIN");
         }
         Env.getCurrentEnv().getAuthenticationIntegrationMgr()
-                .createAuthenticationIntegration(integrationName, ifNotExists, properties, comment);
+                .createAuthenticationIntegration(integrationName, ifNotExists, properties, comment,
+                        Objects.requireNonNull(ctx.getQualifiedUser(), "qualifiedUser can not be null"));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/authentication/AuthenticationIntegrationMetaTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/authentication/AuthenticationIntegrationMetaTest.java
@@ -34,6 +34,8 @@ import java.util.Map;
 import java.util.Set;
 
 public class AuthenticationIntegrationMetaTest {
+    private static final String CREATE_USER = "creator";
+    private static final String ALTER_USER = "modifier";
 
     private static Map<String, String> map(String... kvs) {
         Map<String, String> result = new LinkedHashMap<>();
@@ -57,11 +59,16 @@ public class AuthenticationIntegrationMetaTest {
         properties.put("ldap.admin_dn", "cn=admin,dc=example,dc=com");
 
         AuthenticationIntegrationMeta meta =
-                AuthenticationIntegrationMeta.fromCreateSql("corp_ldap", properties, "ldap integration");
+                AuthenticationIntegrationMeta.fromCreateSql("corp_ldap", properties, "ldap integration", CREATE_USER);
 
         Assertions.assertEquals("corp_ldap", meta.getName());
         Assertions.assertEquals("ldap", meta.getType());
         Assertions.assertEquals("ldap integration", meta.getComment());
+        Assertions.assertEquals(CREATE_USER, meta.getCreateUser());
+        Assertions.assertEquals(CREATE_USER, meta.getAlterUser());
+        Assertions.assertTrue(meta.getCreateTime() > 0);
+        Assertions.assertEquals(meta.getCreateTime(), meta.getModifyTime());
+        Assertions.assertEquals(meta.getCreateTimeString(), meta.getModifyTimeString());
         Assertions.assertEquals(2, meta.getProperties().size());
         Assertions.assertEquals("ldap://127.0.0.1:389", meta.getProperties().get("ldap.server"));
         Assertions.assertFalse(meta.getProperties().containsKey("type"));
@@ -78,13 +85,13 @@ public class AuthenticationIntegrationMetaTest {
     @Test
     public void testFromCreateSqlRequireType() {
         Assertions.assertThrows(DdlException.class,
-                () -> AuthenticationIntegrationMeta.fromCreateSql("i1", null, null));
+                () -> AuthenticationIntegrationMeta.fromCreateSql("i1", null, null, CREATE_USER));
         Assertions.assertThrows(DdlException.class,
-                () -> AuthenticationIntegrationMeta.fromCreateSql("i1", Collections.emptyMap(), null));
+                () -> AuthenticationIntegrationMeta.fromCreateSql("i1", Collections.emptyMap(), null, CREATE_USER));
         Assertions.assertThrows(DdlException.class,
-                () -> AuthenticationIntegrationMeta.fromCreateSql("i1", map("k", "v"), null));
+                () -> AuthenticationIntegrationMeta.fromCreateSql("i1", map("k", "v"), null, CREATE_USER));
         Assertions.assertThrows(DdlException.class,
-                () -> AuthenticationIntegrationMeta.fromCreateSql("i1", map("type", ""), null));
+                () -> AuthenticationIntegrationMeta.fromCreateSql("i1", map("type", ""), null, CREATE_USER));
     }
 
     @Test
@@ -94,7 +101,7 @@ public class AuthenticationIntegrationMetaTest {
         properties.put("TYPE", "oidc");
 
         Assertions.assertThrows(DdlException.class,
-                () -> AuthenticationIntegrationMeta.fromCreateSql("i1", properties, null));
+                () -> AuthenticationIntegrationMeta.fromCreateSql("i1", properties, null, CREATE_USER));
     }
 
     @Test
@@ -104,21 +111,26 @@ public class AuthenticationIntegrationMetaTest {
                 map("type", "ldap",
                         "ldap.server", "ldap://old",
                         "ldap.base_dn", "dc=example,dc=com"),
-                "old comment");
+                "old comment",
+                CREATE_USER);
 
         AuthenticationIntegrationMeta altered = meta.withAlterProperties(map(
                 "ldap.server", "ldap://new",
-                "ldap.user_filter", "(uid={login})"));
+                "ldap.user_filter", "(uid={login})"), ALTER_USER);
 
         Assertions.assertEquals("ldap", altered.getType());
         Assertions.assertEquals("old comment", altered.getComment());
+        Assertions.assertEquals(CREATE_USER, altered.getCreateUser());
+        Assertions.assertEquals(ALTER_USER, altered.getAlterUser());
+        Assertions.assertEquals(meta.getCreateTime(), altered.getCreateTime());
+        Assertions.assertTrue(altered.getModifyTime() >= meta.getModifyTime());
         Assertions.assertEquals("ldap://new", altered.getProperties().get("ldap.server"));
         Assertions.assertEquals("(uid={login})", altered.getProperties().get("ldap.user_filter"));
 
         Assertions.assertThrows(DdlException.class,
-                () -> meta.withAlterProperties(Collections.emptyMap()));
+                () -> meta.withAlterProperties(Collections.emptyMap(), ALTER_USER));
         Assertions.assertThrows(DdlException.class,
-                () -> meta.withAlterProperties(map("TYPE", "oidc")));
+                () -> meta.withAlterProperties(map("TYPE", "oidc"), ALTER_USER));
     }
 
     @Test
@@ -128,17 +140,22 @@ public class AuthenticationIntegrationMetaTest {
                 map("type", "ldap",
                         "ldap.server", "ldap://old",
                         "ldap.base_dn", "dc=example,dc=com"),
-                "old comment");
+                "old comment",
+                CREATE_USER);
 
-        AuthenticationIntegrationMeta altered = meta.withUnsetProperties(set("ldap.base_dn"));
+        AuthenticationIntegrationMeta altered = meta.withUnsetProperties(set("ldap.base_dn"), ALTER_USER);
         Assertions.assertEquals("ldap", altered.getType());
+        Assertions.assertEquals(CREATE_USER, altered.getCreateUser());
+        Assertions.assertEquals(ALTER_USER, altered.getAlterUser());
+        Assertions.assertEquals(meta.getCreateTime(), altered.getCreateTime());
+        Assertions.assertTrue(altered.getModifyTime() >= meta.getModifyTime());
         Assertions.assertFalse(altered.getProperties().containsKey("ldap.base_dn"));
         Assertions.assertEquals("ldap://old", altered.getProperties().get("ldap.server"));
 
         Assertions.assertThrows(DdlException.class,
-                () -> meta.withUnsetProperties(Collections.emptySet()));
+                () -> meta.withUnsetProperties(Collections.emptySet(), ALTER_USER));
         Assertions.assertThrows(DdlException.class,
-                () -> meta.withUnsetProperties(set("TYPE")));
+                () -> meta.withUnsetProperties(set("TYPE"), ALTER_USER));
     }
 
     @Test
@@ -148,7 +165,8 @@ public class AuthenticationIntegrationMetaTest {
                 map("type", "ldap",
                         "ldap.server", "ldap://127.0.0.1:389",
                         "ldap.admin_password", "123456"),
-                "comment");
+                "comment",
+                CREATE_USER);
 
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         try (DataOutputStream dos = new DataOutputStream(bos)) {
@@ -164,5 +182,9 @@ public class AuthenticationIntegrationMetaTest {
         Assertions.assertEquals(meta.getType(), read.getType());
         Assertions.assertEquals(meta.getComment(), read.getComment());
         Assertions.assertEquals(meta.getProperties(), read.getProperties());
+        Assertions.assertEquals(meta.getCreateUser(), read.getCreateUser());
+        Assertions.assertEquals(meta.getCreateTime(), read.getCreateTime());
+        Assertions.assertEquals(meta.getAlterUser(), read.getAlterUser());
+        Assertions.assertEquals(meta.getModifyTime(), read.getModifyTime());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/authentication/AuthenticationIntegrationMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/authentication/AuthenticationIntegrationMgrTest.java
@@ -39,6 +39,8 @@ import java.util.Map;
 import java.util.Set;
 
 public class AuthenticationIntegrationMgrTest {
+    private static final String CREATE_USER = "creator";
+    private static final String ALTER_USER = "modifier";
 
     @Mocked
     private Env env;
@@ -89,21 +91,26 @@ public class AuthenticationIntegrationMgrTest {
         createProperties.put("ldap.server", "ldap://127.0.0.1:389");
         createProperties.put("ldap.admin_password", "123456");
 
-        mgr.createAuthenticationIntegration("corp_ldap", false, createProperties, "comment");
+        mgr.createAuthenticationIntegration("corp_ldap", false, createProperties, "comment", CREATE_USER);
         AuthenticationIntegrationMeta created = mgr.getAuthenticationIntegrations().get("corp_ldap");
         Assertions.assertNotNull(created);
         Assertions.assertEquals("ldap", created.getType());
+        Assertions.assertEquals(CREATE_USER, created.getCreateUser());
+        Assertions.assertEquals(CREATE_USER, created.getAlterUser());
         Assertions.assertEquals("ldap://127.0.0.1:389", created.getProperties().get("ldap.server"));
 
-        mgr.alterAuthenticationIntegrationProperties("corp_ldap", map("ldap.server", "ldap://127.0.0.1:1389"));
+        mgr.alterAuthenticationIntegrationProperties(
+                "corp_ldap", map("ldap.server", "ldap://127.0.0.1:1389"), ALTER_USER);
+        Assertions.assertEquals(ALTER_USER,
+                mgr.getAuthenticationIntegrations().get("corp_ldap").getAlterUser());
         Assertions.assertEquals("ldap://127.0.0.1:1389",
                 mgr.getAuthenticationIntegrations().get("corp_ldap").getProperties().get("ldap.server"));
 
-        mgr.alterAuthenticationIntegrationUnsetProperties("corp_ldap", set("ldap.admin_password"));
+        mgr.alterAuthenticationIntegrationUnsetProperties("corp_ldap", set("ldap.admin_password"), ALTER_USER);
         Assertions.assertFalse(mgr.getAuthenticationIntegrations()
                 .get("corp_ldap").getProperties().containsKey("ldap.admin_password"));
 
-        mgr.alterAuthenticationIntegrationComment("corp_ldap", "new comment");
+        mgr.alterAuthenticationIntegrationComment("corp_ldap", "new comment", ALTER_USER);
         Assertions.assertEquals("new comment", mgr.getAuthenticationIntegrations().get("corp_ldap").getComment());
 
         mgr.dropAuthenticationIntegration("corp_ldap", false);
@@ -133,12 +140,12 @@ public class AuthenticationIntegrationMgrTest {
         AuthenticationIntegrationMgr mgr = new AuthenticationIntegrationMgr();
         mgr.createAuthenticationIntegration("corp_ldap", false, map(
                 "type", "ldap",
-                "ldap.server", "ldap://127.0.0.1:389"), null);
+                "ldap.server", "ldap://127.0.0.1:389"), null, CREATE_USER);
 
         Assertions.assertThrows(DdlException.class,
-                () -> mgr.createAuthenticationIntegration("corp_ldap", false, map("type", "ldap"), null));
+                () -> mgr.createAuthenticationIntegration("corp_ldap", false, map("type", "ldap"), null, CREATE_USER));
         Assertions.assertDoesNotThrow(
-                () -> mgr.createAuthenticationIntegration("corp_ldap", true, map("type", "ldap"), null));
+                () -> mgr.createAuthenticationIntegration("corp_ldap", true, map("type", "ldap"), null, CREATE_USER));
 
         Assertions.assertDoesNotThrow(() -> mgr.dropAuthenticationIntegration("not_exist", true));
         Assertions.assertThrows(DdlException.class,
@@ -149,11 +156,11 @@ public class AuthenticationIntegrationMgrTest {
     public void testAlterNotExistThrows() {
         AuthenticationIntegrationMgr mgr = new AuthenticationIntegrationMgr();
         Assertions.assertThrows(DdlException.class,
-                () -> mgr.alterAuthenticationIntegrationProperties("not_exist", map("k", "v")));
+                () -> mgr.alterAuthenticationIntegrationProperties("not_exist", map("k", "v"), ALTER_USER));
         Assertions.assertThrows(DdlException.class,
-                () -> mgr.alterAuthenticationIntegrationUnsetProperties("not_exist", set("k")));
+                () -> mgr.alterAuthenticationIntegrationUnsetProperties("not_exist", set("k"), ALTER_USER));
         Assertions.assertThrows(DdlException.class,
-                () -> mgr.alterAuthenticationIntegrationComment("not_exist", "comment"));
+                () -> mgr.alterAuthenticationIntegrationComment("not_exist", "comment", ALTER_USER));
     }
 
     @Test
@@ -161,8 +168,8 @@ public class AuthenticationIntegrationMgrTest {
         AuthenticationIntegrationMgr mgr = new AuthenticationIntegrationMgr();
 
         AuthenticationIntegrationMeta meta1 = AuthenticationIntegrationMeta.fromCreateSql(
-                "corp_ldap", map("type", "ldap", "ldap.server", "ldap://old"), null);
-        AuthenticationIntegrationMeta meta2 = meta1.withAlterProperties(map("ldap.server", "ldap://new"));
+                "corp_ldap", map("type", "ldap", "ldap.server", "ldap://old"), null, CREATE_USER);
+        AuthenticationIntegrationMeta meta2 = meta1.withAlterProperties(map("ldap.server", "ldap://new"), ALTER_USER);
 
         mgr.replayCreateAuthenticationIntegration(meta1);
         mgr.replayAlterAuthenticationIntegration(meta2);
@@ -183,7 +190,8 @@ public class AuthenticationIntegrationMgrTest {
                 "corp_ldap", map(
                         "type", "ldap",
                         "ldap.server", "ldap://127.0.0.1:389"),
-                "comment");
+                "comment",
+                CREATE_USER);
         mgr.replayCreateAuthenticationIntegration(meta);
 
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -202,5 +210,7 @@ public class AuthenticationIntegrationMgrTest {
         Assertions.assertEquals("ldap", readMeta.getType());
         Assertions.assertEquals("ldap://127.0.0.1:389", readMeta.getProperties().get("ldap.server"));
         Assertions.assertEquals("comment", readMeta.getComment());
+        Assertions.assertEquals(CREATE_USER, readMeta.getCreateUser());
+        Assertions.assertEquals(CREATE_USER, readMeta.getAlterUser());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AuthenticationIntegrationCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AuthenticationIntegrationCommandTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.analysis.StmtType;
+import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.authentication.AuthenticationIntegrationMgr;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
@@ -66,6 +67,7 @@ public class AuthenticationIntegrationCommandTest {
 
     @Test
     public void testCreateCommandRunAndDenied() throws Exception {
+        UserIdentity currentUser = UserIdentity.createAnalyzedUserIdentWithIp("admin", "%");
         CreateAuthenticationIntegrationCommand createCommand =
                 new CreateAuthenticationIntegrationCommand("corp_ldap", false,
                         map("type", "ldap", "ldap.server", "ldap://127.0.0.1:389"), "comment");
@@ -83,12 +85,16 @@ public class AuthenticationIntegrationCommandTest {
                 accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
                 result = true;
 
+                connectContext.getQualifiedUser();
+                minTimes = 0;
+                result = currentUser.getQualifiedUser();
+
                 env.getAuthenticationIntegrationMgr();
                 minTimes = 0;
                 result = authenticationIntegrationMgr;
 
                 authenticationIntegrationMgr.createAuthenticationIntegration(
-                        anyString, anyBoolean, (Map<String, String>) any, anyString);
+                        anyString, anyBoolean, (Map<String, String>) any, anyString, anyString);
                 times = 1;
             }
         };
@@ -117,6 +123,7 @@ public class AuthenticationIntegrationCommandTest {
 
     @Test
     public void testAlterCommandRun() throws Exception {
+        UserIdentity currentUser = UserIdentity.createAnalyzedUserIdentWithIp("admin", "%");
         AlterAuthenticationIntegrationCommand setPropertiesCommand =
                 AlterAuthenticationIntegrationCommand.forSetProperties(
                         "corp_ldap", map("ldap.server", "ldap://127.0.0.1:1389"));
@@ -140,19 +147,23 @@ public class AuthenticationIntegrationCommandTest {
                 minTimes = 0;
                 result = true;
 
+                connectContext.getQualifiedUser();
+                minTimes = 0;
+                result = currentUser.getQualifiedUser();
+
                 env.getAuthenticationIntegrationMgr();
                 minTimes = 0;
                 result = authenticationIntegrationMgr;
 
                 authenticationIntegrationMgr.alterAuthenticationIntegrationProperties(
-                        anyString, (Map<String, String>) any);
+                        anyString, (Map<String, String>) any, anyString);
                 times = 1;
 
                 authenticationIntegrationMgr.alterAuthenticationIntegrationUnsetProperties(
-                        anyString, (Set<String>) any);
+                        anyString, (Set<String>) any, anyString);
                 times = 1;
 
-                authenticationIntegrationMgr.alterAuthenticationIntegrationComment(anyString, anyString);
+                authenticationIntegrationMgr.alterAuthenticationIntegrationComment(anyString, anyString, anyString);
                 times = 1;
             }
         };


### PR DESCRIPTION
### What problem does this PR solve?


  `AUTHENTICATION INTEGRATION` metadata does not currently keep unified audit information such as creator, creation time, last modifier,
  and last modification time. This makes it inconsistent with other user-driven metadata objects and makes future audit/display/
  persistence work harder to extend.

  This PR unifies audit metadata for authentication integrations.

  ### What is changed

  - Introduce a reusable `UserAuditMetadata` base class for persisted audit fields of user-driven DDL objects.
  - Make `AuthenticationIntegrationMeta` inherit from `UserAuditMetadata`.
  - Persist the following fields for authentication integrations:
    - `createUser`
    - `createTime`
    - `alterUser`
    - `modifyTime`
  - Update create/alter metadata builders so that:
    - `CREATE AUTHENTICATION INTEGRATION` initializes creator/modifier and timestamps
    - `ALTER AUTHENTICATION INTEGRATION` preserves creator/create time and only updates last modifier/modify time