### PR TITLE
[fix](profile) reduce log verbosity by changing LOG_INFO to VLOG_CRITICAL for profile operations

### DIFF
--- a/be/src/runtime/runtime_query_statistics_mgr.cpp
+++ b/be/src/runtime/runtime_query_statistics_mgr.cpp
@@ -161,7 +161,7 @@ static void _report_query_profiles_function(
             LOG_WARNING("Query {} send profile to {} failed", print_id(query_id),
                         PrintThriftNetworkAddress(coor_addr));
         } else {
-            LOG_INFO("Send {} profile succeed", print_id(query_id));
+            VLOG_CRITICAL << fmt::format("Send {} profile succeed", print_id(query_id));
         }
     }
 }
@@ -318,8 +318,8 @@ void RuntimeQueryStatisticsMgr::register_fragment_profile(
         _load_channel_profile_map[std::make_pair(query_id, fragment_id)] = load_channel_profile;
     }
 
-    LOG_INFO("register x profile done {}, fragment {}, profiles {}", print_id(query_id),
-             fragment_id, p_profiles.size());
+    VLOG_CRITICAL << fmt::format("register x profile done {}, fragment {}, profiles {}",
+                                 print_id(query_id), fragment_id, p_profiles.size());
 }
 
 void RuntimeQueryStatisticsMgr::register_resource_context(


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Replace LOG_INFO with VLOG_CRITICAL for profile send and registration success messages to reduce log noise in production environments. Profile is not a critical part of SQL execution, so it can be adjusted like this. It's not too late to open the verbose log if any issues are found.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

