### PR TITLE
[Fix](warmup) Fix wrong rowset data size when calculating timeout of waiting delay compaction

### DIFF
--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -1350,7 +1350,7 @@ Status CloudMetaMgr::commit_rowset(RowsetMeta& rs_meta, const std::string& job_i
         const double speed_mbps = 100.0; // 100MB/s
         const double safety_factor = 2.0;
         timeout_ms = std::min(
-                std::max(static_cast<int64_t>(static_cast<double>(rs_meta.data_disk_size()) /
+                std::max(static_cast<int64_t>(static_cast<double>(rs_meta.total_disk_size()) /
                                               (speed_mbps * 1024 * 1024) * safety_factor * 1000),
                          config::warm_up_rowset_sync_wait_min_timeout_ms),
                 config::warm_up_rowset_sync_wait_max_timeout_ms);

--- a/be/src/cloud/config.cpp
+++ b/be/src/cloud/config.cpp
@@ -128,7 +128,7 @@ DEFINE_mInt64(warm_up_rowset_slow_log_ms, "1000");
 
 DEFINE_mBool(enable_compaction_delay_commit_for_warm_up, "false");
 
-DEFINE_mInt64(warm_up_rowset_sync_wait_min_timeout_ms, "10000");
+DEFINE_mInt64(warm_up_rowset_sync_wait_min_timeout_ms, "500");
 
 DEFINE_mInt64(warm_up_rowset_sync_wait_max_timeout_ms, "120000");
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

