### PR TITLE
[fix](test) fix JsonBinaryValueTest and AcceptNullPredicateTest failures

### DIFF
--- a/be/test/core/value/jsonb_value_test.cpp
+++ b/be/test/core/value/jsonb_value_test.cpp
@@ -28,14 +28,21 @@ namespace doris {
 TEST(JsonBinaryValueTest, TestValidation) {
     JsonBinaryValue json_val;
 
-    // single value not wrapped as an arrar or object is invalid
-    std::vector<string> invalid_strs = {"", "1", "null", "false", "abc"};
+    // Empty string and non-JSON text should fail to parse
+    std::vector<string> invalid_strs = {"", "abc"};
     for (size_t i = 0; i < invalid_strs.size(); i++) {
         auto status = json_val.from_json_string(invalid_strs[i].c_str(), invalid_strs[i].size());
-        EXPECT_TRUE(status.ok());
+        EXPECT_FALSE(status.ok()) << "Should fail for: [" << invalid_strs[i] << "]";
     }
 
-    // valid enums
+    // Scalar JSON values (number, null, boolean) are valid JSON and should parse OK
+    std::vector<string> scalar_strs = {"1", "null", "false"};
+    for (size_t i = 0; i < scalar_strs.size(); i++) {
+        auto status = json_val.from_json_string(scalar_strs[i].c_str(), scalar_strs[i].size());
+        EXPECT_TRUE(status.ok()) << "Should succeed for: [" << scalar_strs[i] << "]";
+    }
+
+    // valid arrays and objects
     std::vector<string> valid_strs;
     valid_strs.push_back("[false]");
     valid_strs.push_back("[-123]");
@@ -45,7 +52,7 @@ TEST(JsonBinaryValueTest, TestValidation) {
     valid_strs.push_back("[123, {\"key1\": null, \"key2\": [\"val1\", \"val2\"]}]");
     for (size_t i = 0; i < valid_strs.size(); i++) {
         auto status = json_val.from_json_string(valid_strs[i].c_str(), valid_strs[i].size());
-        EXPECT_TRUE(status.ok());
+        EXPECT_TRUE(status.ok()) << "Should succeed for: [" << valid_strs[i] << "]";
     }
 }
 } // namespace doris

--- a/be/test/exec/operator/query_cache_operator_test.cpp
+++ b/be/test/exec/operator/query_cache_operator_test.cpp
@@ -62,6 +62,13 @@ struct QueryCacheOperatorTest : public ::testing::Test {
         scan_range.scan_range.__set_palo_scan_range(palp_scan_range);
         scan_ranges.push_back(scan_range);
     }
+    void TearDown() override {
+        // Must clear state before query_cache_uptr is destroyed, because
+        // local states inside `state` hold QueryCacheHandle which references
+        // the QueryCache. C++ destroys members in reverse declaration order,
+        // so state (declared before query_cache_uptr) would outlive the cache.
+        state.reset();
+    }
     void create_local_state() {
         shared_state = sink->create_shared_state();
         {
@@ -261,8 +268,6 @@ TEST_F(QueryCacheOperatorTest, test_hit_cache) {
         EXPECT_TRUE(eos);
         EXPECT_TRUE(block.empty());
     }
-
-    query_cache_uptr.release();
 }
 
 } // namespace doris

--- a/be/test/storage/predicate/accept_null_predicate_test.cpp
+++ b/be/test/storage/predicate/accept_null_predicate_test.cpp
@@ -29,6 +29,7 @@
 #include "storage/predicate/comparison_predicate.h"
 
 namespace doris {
+namespace {
 
 class MockLRUCachePolicy : public LRUCachePolicy {
 public:
@@ -102,6 +103,8 @@ private:
 
     std::shared_ptr<roaring::Roaring> _result_bitmap;
 };
+
+} // anonymous namespace
 
 class AcceptNullPredicateTest : public testing::Test {
 public:


### PR DESCRIPTION
1. JsonBinaryValueTest.TestValidation: fix assertions to match parser behavior
   - Empty string and non-JSON text ('abc') correctly return error since c3e418b8 refactored JsonbParser, update EXPECT_TRUE to EXPECT_FALSE
   - Scalar JSON values ('1', 'null', 'false') parse successfully, keep EXPECT_TRUE

2. AcceptNullPredicateTest: fix ODR violation with MockIndexIterator
   - MockIndexIterator was defined in both accept_null_predicate_test.cpp and function_ip_test.cpp with different has_null() implementations (true vs false)
   - Linker picked function_ip_test's vtable, causing has_null() to always return false
   - Wrap Mock classes in anonymous namespace to ensure each TU uses its own vtable

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

