### PR TITLE
[fix](filecache) fix out-of-range exception when external query (#58082)

### DIFF
--- a/be/src/olap/storage_policy.cpp
+++ b/be/src/olap/storage_policy.cpp
@@ -221,6 +221,10 @@ std::optional<int64_t> StorageResource::parse_tablet_id_from_path(const std::str
         return std::nullopt;
     }
 
+    if (data_prefix.length() + data_pos >= path_view.length()) {
+        return std::nullopt;
+    }
+
     // Extract the part after "data/"
     path_view = path_view.substr(data_pos + data_prefix.length() + 1);
 

--- a/be/test/olap/storage_resource_test.cpp
+++ b/be/test/olap/storage_resource_test.cpp
@@ -159,6 +159,7 @@ TEST(StorageResourceTest, ParseTabletIdFromPath) {
     // Test invalid cases
     EXPECT_EQ(StorageResource::parse_tablet_id_from_path(""), std::nullopt);
     EXPECT_EQ(StorageResource::parse_tablet_id_from_path("invalid_path"), std::nullopt);
+    EXPECT_EQ(StorageResource::parse_tablet_id_from_path("/mnt/data"), std::nullopt);
     EXPECT_EQ(StorageResource::parse_tablet_id_from_path("data/"), std::nullopt);
     EXPECT_EQ(StorageResource::parse_tablet_id_from_path("/data/abc/rowset_001_0.dat"),
               std::nullopt);


### PR DESCRIPTION
add check for external data (lakehouse data) when get_tablet_id to avoid out-of-range exception

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

