### PR TITLE
[Fix](pythonUdf) Fix pythonUdf helper cmd coredump when `enable_python_udf_support` is not set

### DIFF
--- a/be/src/udf/python/python_env.cpp
+++ b/be/src/udf/python/python_env.cpp
@@ -301,6 +301,11 @@ Status PythonVersionManager::init(PythonEnvType env_type, const fs::path& python
 }
 
 std::vector<TPythonEnvInfo> PythonVersionManager::env_infos_to_thrift() const {
+    if (!_env_scanner) {
+        throw Exception(
+                ErrorCode::NOT_INITIALIZED,
+                "Set 'enable_python_udf_support = true' in be.conf to enable PythonUDF feature");
+    }
     std::vector<TPythonEnvInfo> infos;
     const auto& envs = _env_scanner->get_envs();
     infos.reserve(envs.size());

--- a/be/src/udf/python/python_env.cpp
+++ b/be/src/udf/python/python_env.cpp
@@ -267,8 +267,8 @@ std::string VenvEnvScanner::to_string() const {
     return ss.str();
 }
 
-Status PythonVersionManager::init(PythonEnvType env_type, const fs::path& python_root_path,
-                                  const std::string& python_venv_interpreter_paths) {
+Status PythonEnvScannerHolder::init(PythonEnvType env_type, const fs::path& python_root_path,
+                                    const std::string& python_venv_interpreter_paths) {
     switch (env_type) {
     case PythonEnvType::CONDA: {
         if (!fs::exists(python_root_path) || !fs::is_directory(python_root_path)) {
@@ -301,16 +301,11 @@ Status PythonVersionManager::init(PythonEnvType env_type, const fs::path& python
 }
 
 std::vector<TPythonEnvInfo> PythonVersionManager::env_infos_to_thrift() const {
-    if (!_env_scanner) {
-        throw Exception(
-                ErrorCode::NOT_INITIALIZED,
-                "Set 'enable_python_udf_support = true' in be.conf to enable PythonUDF feature");
-    }
     std::vector<TPythonEnvInfo> infos;
-    const auto& envs = _env_scanner->get_envs();
+    const auto& envs = this->get_envs();
     infos.reserve(envs.size());
 
-    const auto env_type_str = _python_env_type_to_string(_env_scanner->env_type());
+    const auto env_type_str = _python_env_type_to_string(this->env_type());
     for (const auto& env : envs) {
         TPythonEnvInfo info;
         info.__set_env_name(env.env_name);

--- a/be/src/udf/python/python_env.h
+++ b/be/src/udf/python/python_env.h
@@ -22,6 +22,7 @@
 #include <filesystem>
 #include <utility>
 
+#include "common/exception.h"
 #include "common/status.h"
 
 namespace doris {
@@ -148,14 +149,39 @@ public:
                 const std::string& python_venv_interpreter_paths);
 
     Status get_version(const std::string& runtime_version, PythonVersion* version) const {
+        if (!_env_scanner) {
+            return Status::Uninitialized(
+                    "Set 'python_venv_interpreter_paths' in be.conf to enable PythonUDF feature");
+        }
         return _env_scanner->get_version(runtime_version, version);
     }
 
-    const std::vector<PythonEnvironment>& get_envs() const { return _env_scanner->get_envs(); }
+    const std::vector<PythonEnvironment>& get_envs() const {
+        if (!_env_scanner) {
+            throw Exception(
+                    ErrorCode::NOT_INITIALIZED,
+                    "Set 'python_venv_interpreter_paths' in be.conf to enable PythonUDF feature");
+        }
+        return _env_scanner->get_envs();
+    }
 
-    PythonEnvType env_type() const { return _env_scanner->env_type(); }
+    PythonEnvType env_type() const {
+        if (!_env_scanner) {
+            throw Exception(
+                    ErrorCode::NOT_INITIALIZED,
+                    "Set 'python_venv_interpreter_paths' in be.conf to enable PythonUDF feature");
+        }
+        return _env_scanner->env_type();
+    }
 
-    std::string to_string() const { return _env_scanner->to_string(); }
+    std::string to_string() const {
+        if (!_env_scanner) {
+            throw Exception(
+                    ErrorCode::NOT_INITIALIZED,
+                    "Set 'python_venv_interpreter_paths' in be.conf to enable PythonUDF feature");
+        }
+        return _env_scanner->to_string();
+    }
 
     std::vector<TPythonEnvInfo> env_infos_to_thrift() const;
 

--- a/be/src/udf/python/python_env.h
+++ b/be/src/udf/python/python_env.h
@@ -138,6 +138,29 @@ private:
     std::vector<std::string> _interpreter_paths;
 };
 
+// Holds a PythonEnvScanner instance and centralizes the initialization check
+// to avoid accessing the scanner when the Python UDF feature is disabled.
+// This class is intended for internal use by PythonVersionManager only.
+class PythonEnvScannerHolder {
+public:
+    Status init(PythonEnvType env_type, const fs::path& python_root_path,
+                const std::string& python_venv_interpreter_paths);
+
+    const PythonEnvScanner& get() const {
+        if (!_env_scanner) {
+            throw Exception(ErrorCode::NOT_INITIALIZED,
+                            "Set 'enable_python_udf_support = true' in be.conf to enable PythonUDF "
+                            "feature");
+        }
+        return *_env_scanner;
+    }
+
+    bool is_initialized() const { return _env_scanner != nullptr; }
+
+private:
+    std::unique_ptr<PythonEnvScanner> _env_scanner;
+};
+
 class PythonVersionManager {
 public:
     static PythonVersionManager& instance() {
@@ -146,42 +169,24 @@ public:
     }
 
     Status init(PythonEnvType env_type, const fs::path& python_root_path,
-                const std::string& python_venv_interpreter_paths);
+                const std::string& python_venv_interpreter_paths) {
+        return _holder.init(env_type, python_root_path, python_venv_interpreter_paths);
+    }
 
     Status get_version(const std::string& runtime_version, PythonVersion* version) const {
-        if (!_env_scanner) {
+        if (!_holder.is_initialized()) {
             return Status::Uninitialized(
-                    "Set 'python_venv_interpreter_paths' in be.conf to enable PythonUDF feature");
+                    "Set 'enable_python_udf_support = true' in be.conf to enable PythonUDF "
+                    "feature");
         }
-        return _env_scanner->get_version(runtime_version, version);
+        return _holder.get().get_version(runtime_version, version);
     }
 
-    const std::vector<PythonEnvironment>& get_envs() const {
-        if (!_env_scanner) {
-            throw Exception(
-                    ErrorCode::NOT_INITIALIZED,
-                    "Set 'python_venv_interpreter_paths' in be.conf to enable PythonUDF feature");
-        }
-        return _env_scanner->get_envs();
-    }
+    const std::vector<PythonEnvironment>& get_envs() const { return _holder.get().get_envs(); }
 
-    PythonEnvType env_type() const {
-        if (!_env_scanner) {
-            throw Exception(
-                    ErrorCode::NOT_INITIALIZED,
-                    "Set 'python_venv_interpreter_paths' in be.conf to enable PythonUDF feature");
-        }
-        return _env_scanner->env_type();
-    }
+    PythonEnvType env_type() const { return _holder.get().env_type(); }
 
-    std::string to_string() const {
-        if (!_env_scanner) {
-            throw Exception(
-                    ErrorCode::NOT_INITIALIZED,
-                    "Set 'python_venv_interpreter_paths' in be.conf to enable PythonUDF feature");
-        }
-        return _env_scanner->to_string();
-    }
+    std::string to_string() const { return _holder.get().to_string(); }
 
     std::vector<TPythonEnvInfo> env_infos_to_thrift() const;
 
@@ -189,7 +194,7 @@ public:
             const std::vector<std::pair<std::string, std::string>>& packages) const;
 
 private:
-    std::unique_ptr<PythonEnvScanner> _env_scanner;
+    PythonEnvScannerHolder _holder;
 };
 
 // List installed pip packages for a given Python version.

--- a/be/src/udf/python/python_env.h
+++ b/be/src/udf/python/python_env.h
@@ -155,8 +155,6 @@ public:
         return *_env_scanner;
     }
 
-    bool is_initialized() const { return _env_scanner != nullptr; }
-
 private:
     std::unique_ptr<PythonEnvScanner> _env_scanner;
 };
@@ -174,11 +172,6 @@ public:
     }
 
     Status get_version(const std::string& runtime_version, PythonVersion* version) const {
-        if (!_holder.is_initialized()) {
-            return Status::Uninitialized(
-                    "Set 'enable_python_udf_support = true' in be.conf to enable PythonUDF "
-                    "feature");
-        }
         return _holder.get().get_version(runtime_version, version);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowPythonPackagesCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowPythonPackagesCommand.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ClientPool;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
@@ -97,6 +98,7 @@ public class ShowPythonPackagesCommand extends ShowCommand {
         // Collect packages from each alive BE, tracking which BE each result came from
         List<Map<String, String>> allBePackages = new ArrayList<>();
         List<String> beIdentifiers = new ArrayList<>();
+        Exception lastException = null;
         for (Backend backend : backendsInfo.values()) {
             if (!backend.isAlive()) {
                 continue;
@@ -118,6 +120,7 @@ public class ShowPythonPackagesCommand extends ShowCommand {
                 beIdentifiers.add(backend.getHost() + ":" + backend.getBePort());
             } catch (Exception e) {
                 LOG.warn("Failed to get python packages from backend[{}]", backend.getId(), e);
+                lastException = e;
             } finally {
                 if (ok) {
                     ClientPool.backendPool.returnObject(address, client);
@@ -128,7 +131,14 @@ public class ShowPythonPackagesCommand extends ShowCommand {
         }
 
         if (allBePackages.isEmpty()) {
-            return new ShowResultSet(getMetaData(), Lists.newArrayList());
+            if (lastException != null) {
+                String msg = lastException.getMessage();
+                int newline = msg.indexOf('\n');
+                throw new AnalysisException("Failed to get python packages from any backend: "
+                        + (newline > 0 ? msg.substring(0, newline).trim() : msg));
+            } else {
+                throw new AnalysisException("No alive backends found to get python packages");
+            }
         }
 
         // Check consistency across BEs

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowPythonPackagesCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowPythonPackagesCommand.java
@@ -38,8 +38,6 @@ import org.apache.doris.thrift.TPythonPackageInfo;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -51,8 +49,6 @@ import java.util.Map;
  * Shows pip packages installed for the given Python version, collected from all alive BEs.
  */
 public class ShowPythonPackagesCommand extends ShowCommand {
-    private static final Logger LOG = LogManager.getLogger(ShowPythonPackagesCommand.class);
-
     private static final String[] TITLE_NAMES = {"Package", "Version"};
     private static final String[] TITLE_NAMES_INCONSISTENT = {"Package", "Version", "Consistent", "Backends"};
 
@@ -98,7 +94,6 @@ public class ShowPythonPackagesCommand extends ShowCommand {
         // Collect packages from each alive BE, tracking which BE each result came from
         List<Map<String, String>> allBePackages = new ArrayList<>();
         List<String> beIdentifiers = new ArrayList<>();
-        Exception lastException = null;
         for (Backend backend : backendsInfo.values()) {
             if (!backend.isAlive()) {
                 continue;
@@ -118,9 +113,6 @@ public class ShowPythonPackagesCommand extends ShowCommand {
                 }
                 allBePackages.add(pkgMap);
                 beIdentifiers.add(backend.getHost() + ":" + backend.getBePort());
-            } catch (Exception e) {
-                LOG.warn("Failed to get python packages from backend[{}]", backend.getId(), e);
-                lastException = e;
             } finally {
                 if (ok) {
                     ClientPool.backendPool.returnObject(address, client);
@@ -131,14 +123,7 @@ public class ShowPythonPackagesCommand extends ShowCommand {
         }
 
         if (allBePackages.isEmpty()) {
-            if (lastException != null) {
-                String msg = lastException.getMessage();
-                int newline = msg.indexOf('\n');
-                throw new AnalysisException("Failed to get python packages from any backend: "
-                        + (newline > 0 ? msg.substring(0, newline).trim() : msg));
-            } else {
-                throw new AnalysisException("No alive backends found to get python packages");
-            }
+            throw new AnalysisException("No alive backends found to get python packages");
         }
 
         // Check consistency across BEs

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowPythonVersionsCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowPythonVersionsCommand.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ClientPool;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
@@ -84,6 +85,7 @@ public class ShowPythonVersionsCommand extends ShowCommand {
         ImmutableMap<Long, Backend> backendsInfo = Env.getCurrentSystemInfo().getAllBackendsByAllCluster();
         List<List<TPythonEnvInfo>> allBeEnvs = new ArrayList<>();
         Set<String> commonVersions = null;
+        Exception lastException = null;
 
         for (Backend backend : backendsInfo.values()) {
             if (!backend.isAlive()) {
@@ -110,6 +112,7 @@ public class ShowPythonVersionsCommand extends ShowCommand {
                 }
             } catch (Exception e) {
                 LOG.warn("Failed to get python envs from backend[{}]", backend.getId(), e);
+                lastException = e;
             } finally {
                 if (ok) {
                     ClientPool.backendPool.returnObject(address, client);
@@ -120,7 +123,14 @@ public class ShowPythonVersionsCommand extends ShowCommand {
         }
 
         List<List<String>> rows = Lists.newArrayList();
-        if (commonVersions != null && !allBeEnvs.isEmpty()) {
+        if (allBeEnvs.isEmpty()) {
+            if (lastException != null) {
+                String msg = lastException.getMessage();
+                int newline = msg.indexOf('\n');
+                throw new AnalysisException("Failed to get python envs from any backend: "
+                        + (newline > 0 ? msg.substring(0, newline).trim() : msg));
+            }
+        } else if (commonVersions != null) {
             // Use envs from the first BE as reference, filtered to common versions
             for (TPythonEnvInfo env : allBeEnvs.get(0)) {
                 if (commonVersions.contains(env.getFullVersion())) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowPythonVersionsCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowPythonVersionsCommand.java
@@ -20,7 +20,6 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.ScalarType;
-import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ClientPool;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
@@ -38,8 +37,6 @@ import org.apache.doris.thrift.TPythonEnvInfo;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -51,8 +48,6 @@ import java.util.Set;
  * Shows Python versions available on all alive backends (intersection).
  */
 public class ShowPythonVersionsCommand extends ShowCommand {
-    private static final Logger LOG = LogManager.getLogger(ShowPythonVersionsCommand.class);
-
     private static final String[] TITLE_NAMES = {
         "Version", "EnvName", "EnvType", "BasePath", "ExecutablePath"
     };
@@ -85,7 +80,6 @@ public class ShowPythonVersionsCommand extends ShowCommand {
         ImmutableMap<Long, Backend> backendsInfo = Env.getCurrentSystemInfo().getAllBackendsByAllCluster();
         List<List<TPythonEnvInfo>> allBeEnvs = new ArrayList<>();
         Set<String> commonVersions = null;
-        Exception lastException = null;
 
         for (Backend backend : backendsInfo.values()) {
             if (!backend.isAlive()) {
@@ -110,9 +104,6 @@ public class ShowPythonVersionsCommand extends ShowCommand {
                 } else {
                     commonVersions.retainAll(versions);
                 }
-            } catch (Exception e) {
-                LOG.warn("Failed to get python envs from backend[{}]", backend.getId(), e);
-                lastException = e;
             } finally {
                 if (ok) {
                     ClientPool.backendPool.returnObject(address, client);
@@ -123,14 +114,7 @@ public class ShowPythonVersionsCommand extends ShowCommand {
         }
 
         List<List<String>> rows = Lists.newArrayList();
-        if (allBeEnvs.isEmpty()) {
-            if (lastException != null) {
-                String msg = lastException.getMessage();
-                int newline = msg.indexOf('\n');
-                throw new AnalysisException("Failed to get python envs from any backend: "
-                        + (newline > 0 ? msg.substring(0, newline).trim() : msg));
-            }
-        } else if (commonVersions != null) {
+        if (commonVersions != null) {
             // Use envs from the first BE as reference, filtered to common versions
             for (TPythonEnvInfo env : allBeEnvs.get(0)) {
                 if (commonVersions.contains(env.getFullVersion())) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

When `enable_python_udf_support` is not set to true, a null pointer dereference occurs when invoking helper commands (`SHOW PYTHON VERSION/ PACKAGES IN`).

```text
/home/zcp/repo_center/doris_master/doris/be/src/udf/python/python_env.cpp:305:38: runtime error: member call on null pointer of type 'doris::PythonEnvScanner'
    #0 0x559edede162c in doris::PythonVersionManager::env_infos_to_thrift() const /home/zcp/repo_center/doris_master/doris/be/src/udf/python/python_env.cpp:305:38
    #1 0x559ede63acd4 in doris::BaseBackendService::get_python_envs(std::vector>&) /home/zcp/repo_center/doris_master/doris/be/src/service/backend_service.cpp:1316:47
    #2 0x559edf99796a in doris::BackendServiceProcessor::process_get_python_envs(int, apache::thrift::protocol::TProtocol*, apache::thrift::protocol::TProtocol*, void*) /home/zcp/repo_center/doris_master/doris/gensrc/build/gen_cpp/BackendService.cpp:7789:13
    #3 0x559edf94a69c in doris::BackendServiceProcessor::dispatchCall(apache::thrift::protocol::TProtocol*, apache::thrift::protocol::TProtocol*, std::__cxx11::basic_string, std::allocator> const&, int, void*) /home/zcp/repo_center/doris_master/doris/gensrc/build/gen_cpp/BackendService.cpp:6466:3
    #4 0x559eac6bad06 in apache::thrift::TDispatchProcessor::process(std::shared_ptr, std::shared_ptr, void*) /home/zcp/repo_center/doris_master/doris/thirdparty/installed/include/thrift/TDispatchProcessor.h:121:12
    #5 0x559ee47c071a in apache::thrift::server::TConnectedClient::run() (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x8a1c871a)
    #6 0x559ee47c1a45 in apache::thrift::server::TThreadedServer::TConnectedClientRunner::run() (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x8a1c9a45)
    #7 0x559ee47c557f in apache::thrift::concurrency::Thread::threadMain(std::shared_ptr) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x8a1cd57f)
    #8 0x559ee47c52a5 in void std::__invoke_impl), std::shared_ptr>(std::__invoke_other, void (*&&)(std::shared_ptr), std::shared_ptr&&) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x8a1cd2a5)
    #9 0x559ee47c521c in std::__invoke_result), std::shared_ptr>::type std::__invoke), std::shared_ptr>(void (*&&)(std::shared_ptr), std::shared_ptr&&) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x8a1cd21c)
    #10 0x559ee47c51f1 in void std::thread::_Invoker), std::shared_ptr>>::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x8a1cd1f1)
    #11 0x559ee47c51b4 in std::thread::_Invoker), std::shared_ptr>>::operator()() (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x8a1cd1b4)
    #12 0x559ee47c4fd8 in std::thread::_State_impl), std::shared_ptr>>>::_M_run() (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x8a1ccfd8)
    #13 0x559ef61b5f3f in execute_native_thread_routine archive64.c
    #14 0x559eac535d26 in asan_thread_start(void*) (/mnt/hdd01/ci/doris-deploy-master-local/be/lib/doris_be+0x51f3dd26)
    #15 0x7fcba62bfac2 in start_thread nptl/pthread_create.c:442:8
    #16 0x7fcba635184f  misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/zcp/repo_center/doris_master/doris/be/src/udf/python/python_env.cpp:305:38 
```

now:
```text
Doris> show python packages in '3.19.18';
ERROR 1105 (HY000): errCode = 2, detailMessage = Failed to get python packages from any backend: [E42] Set 'python_venv_interpreter_paths' in be.conf to enable PythonUDF feature
Doris> show python versions;
ERROR 1105 (HY000): errCode = 2, detailMessage = Failed to get python envs from any backend: [E-236] Set 'python_venv_interpreter_paths' in be.conf to enable PythonUDF feature
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

