### PR TITLE
[fix](http) Fix jetty_server_max_http_header_size not applied in Jetty 12

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebServerFactoryCustomizerConfig.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebServerFactoryCustomizerConfig.java
@@ -40,6 +40,21 @@ public class WebServerFactoryCustomizerConfig implements WebServerFactoryCustomi
     @Override
     public void customize(ConfigurableJettyWebServerFactory factory) {
 
+        // Set HTTP header size for all connectors
+        factory.addServerCustomizers(server -> {
+            for (org.eclipse.jetty.server.Connector connector : server.getConnectors()) {
+                if (connector instanceof ServerConnector) {
+                    ServerConnector serverConnector = (ServerConnector) connector;
+                    HttpConnectionFactory httpFactory =
+                            serverConnector.getConnectionFactory(HttpConnectionFactory.class);
+                    if (httpFactory != null) {
+                        HttpConfiguration httpConfig = httpFactory.getHttpConfiguration();
+                        httpConfig.setRequestHeaderSize(Config.jetty_server_max_http_header_size);
+                    }
+                }
+            }
+        });
+
         ((JettyServletWebServerFactory) factory).addServerCustomizers(server -> {
             WebAppContext context = server.getDescendant(WebAppContext.class);
             if (context != null) {

--- a/regression-test/suites/http_p0/test_large_http_header.groovy
+++ b/regression-test/suites/http_p0/test_large_http_header.groovy
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_large_http_header", "p0") {
+    def feHost = context.config.feHttpAddress
+    def (host, port) = feHost.split(":")
+
+    // Test with large HTTP header (100KB)
+    def largeHeaderValue = "x" * (100 * 1024)
+
+    def url = "http://${host}:${port}/api/health"
+
+    try {
+        def connection = new URL(url).openConnection()
+        connection.setRequestMethod("GET")
+        connection.setRequestProperty("X-Large-Header", largeHeaderValue)
+        connection.setConnectTimeout(5000)
+        connection.setReadTimeout(5000)
+
+        def responseCode = connection.getResponseCode()
+
+        // Should not return 431 (Request Header Fields Too Large)
+        assertTrue(responseCode != 431, "Should not return 431 error with large header")
+
+        logger.info("Response code: ${responseCode}")
+    } catch (Exception e) {
+        logger.error("Test failed with exception: ${e.message}")
+        throw e
+    }
+}


### PR DESCRIPTION
## Problem

HTTP 431 "Request Header Fields Too Large" error occurs when sending requests with large headers (>8KB) to FE, even though `jetty_server_max_http_header_size` is configured to 10MB.

This issue appears in cloud-4.1.2 (Jetty 12 + Spring Boot 3) but not in cloud-4.0.10 (Jetty 9 + Spring Boot 2).

## Root Cause

In Jetty 12 with Spring Boot 3, the `server.max-http-header-size` property does not automatically apply to custom `HttpConfiguration` objects created in `WebServerFactoryCustomizer`. The default 8KB limit remains in effect.

## Solution

Explicitly set `requestHeaderSize` on all server connectors in `WebServerFactoryCustomizerConfig` by adding a server customizer that configures the `HttpConfiguration` for each connector.

## Testing

- Added regression test `test_large_http_header.groovy` that verifies 100KB headers are accepted
- Verified before fix: HTTP 431 error with large headers
- Verified after fix: HTTP 200 success with large headers
