### PR TITLE
[fix](test) fix unstable tests

### DIFF
--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -2235,6 +2235,20 @@ std::string BlockFileCache::clear_file_cache_directly() {
     _disposable_queue.clear(cache_lock);
     _ttl_queue.clear(cache_lock);
 
+    // Synchronously update cache metrics so that information_schema.file_cache_statistics
+    // reflects the cleared state immediately, without waiting for the next
+    // run_background_monitor cycle.
+    _cur_cache_size_metrics->set_value(0);
+    _cur_ttl_cache_size_metrics->set_value(0);
+    _cur_ttl_cache_lru_queue_cache_size_metrics->set_value(0);
+    _cur_ttl_cache_lru_queue_element_count_metrics->set_value(0);
+    _cur_normal_queue_cache_size_metrics->set_value(0);
+    _cur_normal_queue_element_count_metrics->set_value(0);
+    _cur_index_queue_cache_size_metrics->set_value(0);
+    _cur_index_queue_element_count_metrics->set_value(0);
+    _cur_disposable_queue_cache_size_metrics->set_value(0);
+    _cur_disposable_queue_element_count_metrics->set_value(0);
+
     clear_need_update_lru_blocks();
 
     ss << "finish clear_file_cache_directly"

--- a/regression-test/suites/external_table_p0/cache/test_file_cache_statistics.groovy
+++ b/regression-test/suites/external_table_p0/cache/test_file_cache_statistics.groovy
@@ -108,15 +108,15 @@ suite("test_file_cache_statistics", "p0,external") {
 
     // ===== Hit Ratio Metrics Check =====
     // Check overall hit ratio hits_ratio
-    def hitsRatioResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics where METRIC_NAME = 'hits_ratio' limit 1;"""
+    def hitsRatioResult = sql """select MAX(CAST(METRIC_VALUE AS DOUBLE)) from information_schema.file_cache_statistics where METRIC_NAME = 'hits_ratio';"""
     logger.info("hits_ratio result: " + hitsRatioResult)
 
     // Check 1-hour hit ratio hits_ratio_1h
-    def hitsRatio1hResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics where METRIC_NAME = 'hits_ratio_1h' limit 1;"""
+    def hitsRatio1hResult = sql """select MAX(CAST(METRIC_VALUE AS DOUBLE)) from information_schema.file_cache_statistics where METRIC_NAME = 'hits_ratio_1h';"""
     logger.info("hits_ratio_1h result: " + hitsRatio1hResult)
 
     // Check 5-minute hit ratio hits_ratio_5m
-    def hitsRatio5mResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics where METRIC_NAME = 'hits_ratio_5m' limit 1;"""
+    def hitsRatio5mResult = sql """select MAX(CAST(METRIC_VALUE AS DOUBLE)) from information_schema.file_cache_statistics where METRIC_NAME = 'hits_ratio_5m';"""
     logger.info("hits_ratio_5m result: " + hitsRatio5mResult)
 
     // Check if all three metrics exist and are greater than 0
@@ -143,21 +143,21 @@ suite("test_file_cache_statistics", "p0,external") {
 
     // ===== Normal Queue Metrics Check =====
     // Check normal queue current size and max size
-    def normalQueueCurrSizeResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-        where METRIC_NAME = 'normal_queue_curr_size' limit 1;"""
+    def normalQueueCurrSizeResult = sql """select SUM(CAST(METRIC_VALUE AS DOUBLE)) from information_schema.file_cache_statistics
+        where METRIC_NAME = 'normal_queue_curr_size';"""
     logger.info("normal_queue_curr_size result: " + normalQueueCurrSizeResult)
 
-    def normalQueueMaxSizeResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-        where METRIC_NAME = 'normal_queue_max_size' limit 1;"""
+    def normalQueueMaxSizeResult = sql """select SUM(CAST(METRIC_VALUE AS DOUBLE)) from information_schema.file_cache_statistics
+        where METRIC_NAME = 'normal_queue_max_size';"""
     logger.info("normal_queue_max_size result: " + normalQueueMaxSizeResult)
 
     // Check normal queue current elements and max elements
-    def normalQueueCurrElementsResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-        where METRIC_NAME = 'normal_queue_curr_elements' limit 1;"""
+    def normalQueueCurrElementsResult = sql """select SUM(CAST(METRIC_VALUE AS DOUBLE)) from information_schema.file_cache_statistics
+        where METRIC_NAME = 'normal_queue_curr_elements';"""
     logger.info("normal_queue_curr_elements result: " + normalQueueCurrElementsResult)
 
-    def normalQueueMaxElementsResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-        where METRIC_NAME = 'normal_queue_max_elements' limit 1;"""
+    def normalQueueMaxElementsResult = sql """select SUM(CAST(METRIC_VALUE AS DOUBLE)) from information_schema.file_cache_statistics
+        where METRIC_NAME = 'normal_queue_max_elements';"""
     logger.info("normal_queue_max_elements result: " + normalQueueMaxElementsResult)
 
     // Check normal queue size metrics
@@ -191,12 +191,12 @@ suite("test_file_cache_statistics", "p0,external") {
 
     // ===== Hit and Read Counts Metrics Check =====
     // Get initial values for hit and read counts
-    def initialHitCountsResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-        where METRIC_NAME = 'total_hit_counts' limit 1;"""
+    def initialHitCountsResult = sql """select SUM(CAST(METRIC_VALUE AS DOUBLE)) from information_schema.file_cache_statistics
+        where METRIC_NAME = 'total_hit_counts';"""
     logger.info("Initial total_hit_counts result: " + initialHitCountsResult)
 
-    def initialReadCountsResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-        where METRIC_NAME = 'total_read_counts' limit 1;"""
+    def initialReadCountsResult = sql """select SUM(CAST(METRIC_VALUE AS DOUBLE)) from information_schema.file_cache_statistics
+        where METRIC_NAME = 'total_read_counts';"""
     logger.info("Initial total_read_counts result: " + initialReadCountsResult)
 
     // Check if initial values exist and are greater than 0
@@ -225,12 +225,12 @@ suite("test_file_cache_statistics", "p0,external") {
         where l_orderkey=1 and l_partkey=1534 limit 1;"""
 
     // Get updated values after cache operations
-    def updatedHitCountsResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-        where METRIC_NAME = 'total_hit_counts' limit 1;"""
+    def updatedHitCountsResult = sql """select SUM(CAST(METRIC_VALUE AS DOUBLE)) from information_schema.file_cache_statistics
+        where METRIC_NAME = 'total_hit_counts';"""
     logger.info("Updated total_hit_counts result: " + updatedHitCountsResult)
 
-    def updatedReadCountsResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-        where METRIC_NAME = 'total_read_counts' limit 1;"""
+    def updatedReadCountsResult = sql """select SUM(CAST(METRIC_VALUE AS DOUBLE)) from information_schema.file_cache_statistics
+        where METRIC_NAME = 'total_read_counts';"""
     logger.info("Updated total_read_counts result: " + updatedReadCountsResult)
 
     // Check if updated values are greater than initial values


### PR DESCRIPTION
After clearing file cache via clear_file_cache_directly(), the bvar metrics
(consumed by information_schema.file_cache_statistics) were not updated
synchronously. The metrics were only refreshed during the next
run_background_monitor() cycle (controlled by
file_cache_background_monitor_interval_ms).

This caused get_stats() to return stale non-zero values for queue sizes
even though the actual queues were already empty, leading to flaky test
failures in test_file_cache_query_limit and test_file_cache_statistics
where assertions expected normal_queue_curr_size to be 0 immediately
after a cache clear operation.

Fix by setting all queue size and element count metrics to 0 right after
clearing the queues in clear_file_cache_directly().