### PR TITLE
[Fix](agent task) avoid nullptr dereference in create_tablet_callback

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -324,10 +324,7 @@ void alter_cloud_tablet(CloudStorageEngine& engine, const TAgentTaskRequest& age
 Status check_migrate_request(StorageEngine& engine, const TStorageMediumMigrateReq& req,
                              TabletSharedPtr& tablet, DataDir** dest_store) {
     int64_t tablet_id = req.tablet_id;
-    tablet = engine.tablet_manager()->get_tablet(tablet_id);
-    if (tablet == nullptr) {
-        return Status::InternalError("could not find tablet {}", tablet_id);
-    }
+    tablet = DORIS_TRY(engine.tablet_manager()->get_tablet_temp(tablet_id));
 
     if (req.__isset.data_dir) {
         // request specify the data dir
@@ -827,8 +824,8 @@ void alter_inverted_index_callback(StorageEngine& engine, const TAgentTaskReques
               << ", job_id=" << alter_inverted_index_rq.job_id;
 
     Status status = Status::OK();
-    auto tablet_ptr = engine.tablet_manager()->get_tablet(alter_inverted_index_rq.tablet_id);
-    if (tablet_ptr != nullptr) {
+    auto res = engine.tablet_manager()->get_tablet_temp(alter_inverted_index_rq.tablet_id);
+    if (res.has_value()) {
         EngineIndexChangeTask engine_task(engine, alter_inverted_index_rq);
         SCOPED_ATTACH_TASK(engine_task.mem_tracker());
         status = engine_task.execute();
@@ -869,13 +866,14 @@ void update_tablet_meta_callback(StorageEngine& engine, const TAgentTaskRequest&
     Status status;
     const auto& update_tablet_meta_req = req.update_tablet_meta_info_req;
     for (const auto& tablet_meta_info : update_tablet_meta_req.tabletMetaInfos) {
-        auto tablet = engine.tablet_manager()->get_tablet(tablet_meta_info.tablet_id);
-        if (tablet == nullptr) {
+        auto tablet_res = engine.tablet_manager()->get_tablet_temp(tablet_meta_info.tablet_id);
+        if (!tablet_res.has_value()) {
             status = Status::NotFound("tablet not found");
             LOG(WARNING) << "could not find tablet when update tablet meta. tablet_id="
                          << tablet_meta_info.tablet_id;
             continue;
         }
+        auto &tablet = tablet_res.value();
         bool need_to_save = false;
         if (tablet_meta_info.__isset.partition_id) {
             // for fix partition_id = 0
@@ -1537,13 +1535,13 @@ void move_dir_callback(StorageEngine& engine, ExecEnv* env, const TAgentTaskRequ
     LOG(INFO) << "get move dir task. signature=" << req.signature
               << ", job_id=" << move_dir_req.job_id;
     Status status;
-    auto tablet = engine.tablet_manager()->get_tablet(move_dir_req.tablet_id);
-    if (tablet == nullptr) {
-        status = Status::InvalidArgument("Could not find tablet");
+    auto res = engine.tablet_manager()->get_tablet_temp(move_dir_req.tablet_id);
+    if (!res.has_value()) {
+        status = res.error();
     } else {
         SnapshotLoader loader(engine, env, move_dir_req.job_id, move_dir_req.tablet_id);
         SCOPED_ATTACH_TASK(loader.resource_ctx());
-        status = loader.move(move_dir_req.src, tablet, true);
+        status = loader.move(move_dir_req.src, res.value(), true);
     }
 
     if (!status.ok()) {
@@ -1614,16 +1612,16 @@ void submit_table_compaction_callback(StorageEngine& engine, const TAgentTaskReq
         compaction_type = CompactionType::CUMULATIVE_COMPACTION;
     }
 
-    auto tablet_ptr = engine.tablet_manager()->get_tablet(compaction_req.tablet_id);
-    if (tablet_ptr != nullptr) {
-        auto* data_dir = tablet_ptr->data_dir();
-        if (!tablet_ptr->can_do_compaction(data_dir->path_hash(), compaction_type)) {
-            LOG(WARNING) << "could not do compaction. tablet_id=" << tablet_ptr->tablet_id()
+    auto res = engine.tablet_manager()->get_tablet_temp(compaction_req.tablet_id);
+    if (res.has_value()) {
+        auto* data_dir = res.value()->data_dir();
+        if (!res.value()->can_do_compaction(data_dir->path_hash(), compaction_type)) {
+            LOG(WARNING) << "could not do compaction. tablet_id=" << res.value()->tablet_id()
                          << ", compaction_type=" << compaction_type;
             return;
         }
 
-        Status status = engine.submit_compaction_task(tablet_ptr, compaction_type, false);
+        Status status = engine.submit_compaction_task(res.value(), compaction_type, false);
         if (!status.ok()) {
             LOG(WARNING) << "failed to submit table compaction task. error=" << status;
         }
@@ -1755,16 +1753,16 @@ void push_cooldown_conf_callback(StorageEngine& engine, const TAgentTaskRequest&
     const auto& push_cooldown_conf_req = req.push_cooldown_conf;
     for (const auto& cooldown_conf : push_cooldown_conf_req.cooldown_confs) {
         int64_t tablet_id = cooldown_conf.tablet_id;
-        TabletSharedPtr tablet = engine.tablet_manager()->get_tablet(tablet_id);
-        if (tablet == nullptr) {
+        auto tablet = engine.tablet_manager()->get_tablet_temp(tablet_id);
+        if (!tablet.has_value()) {
             LOG(WARNING) << "failed to get tablet. tablet_id=" << tablet_id;
             continue;
         }
-        if (tablet->update_cooldown_conf(cooldown_conf.cooldown_term,
+        if (tablet.value()->update_cooldown_conf(cooldown_conf.cooldown_term,
                                          cooldown_conf.cooldown_replica_id) &&
-            cooldown_conf.cooldown_replica_id == tablet->replica_id() &&
-            tablet->tablet_meta()->cooldown_meta_id().initialized()) {
-            Tablet::async_write_cooldown_meta(tablet);
+            cooldown_conf.cooldown_replica_id == tablet.value()->replica_id() &&
+            tablet.value()->tablet_meta()->cooldown_meta_id().initialized()) {
+            Tablet::async_write_cooldown_meta(tablet.value());
         }
     }
 }
@@ -1805,37 +1803,38 @@ void create_tablet_callback(StorageEngine& engine, const TAgentTaskRequest& req)
         std::string error_msg;
         {
             SCOPED_TIMER(ADD_TIMER(profile, "GetTablet"));
-            tablet = engine.tablet_manager()->get_tablet(create_tablet_req.tablet_id, false,
+            auto tablet_res = engine.tablet_manager()->get_tablet_temp(create_tablet_req.tablet_id, false,
                                                          &error_msg);
+            if (tablet_res.has_value()) {
+                tablet = tablet_res.value();
+                TTabletInfo tablet_info;
+                tablet_info.tablet_id = tablet->tablet_id();
+                tablet_info.schema_hash = tablet->schema_hash();
+                tablet_info.version = create_tablet_req.version;
+                // Useless but it is a required field in TTabletInfo
+                tablet_info.version_hash = 0;
+                tablet_info.row_count = 0;
+                tablet_info.data_size = 0;
+                tablet_info.__set_path_hash(tablet->data_dir()->path_hash());
+                tablet_info.__set_replica_id(tablet->replica_id());
+                finish_tablet_infos.push_back(tablet_info);
+                LOG_INFO("successfully create tablet")
+                        .tag("signature", req.signature)
+                        .tag("tablet_id", create_tablet_req.tablet_id);
+            } else {
+                // This is not a normal path, a possible case is that DataDir::health_check()
+                // encounters an IO_ERROR, causing get_tablet() to return nullptr even though
+                // the create_tablet succeeded.
+                status = Status::NotFound("failed to get tablet, reason={}", error_msg);
+                DorisMetrics::instance()->create_tablet_requests_failed->increment(1);
+                LOG_WARNING("created tablet is missing before finishing create task, reason={}",
+                            status.to_string())
+                        .tag("signature", req.signature)
+                        .tag("tablet_id", create_tablet_req.tablet_id)
+                        .error(status);
+            }
         }
 
-        if (tablet) {
-            TTabletInfo tablet_info;
-            tablet_info.tablet_id = tablet->tablet_id();
-            tablet_info.schema_hash = tablet->schema_hash();
-            tablet_info.version = create_tablet_req.version;
-            // Useless but it is a required field in TTabletInfo
-            tablet_info.version_hash = 0;
-            tablet_info.row_count = 0;
-            tablet_info.data_size = 0;
-            tablet_info.__set_path_hash(tablet->data_dir()->path_hash());
-            tablet_info.__set_replica_id(tablet->replica_id());
-            finish_tablet_infos.push_back(tablet_info);
-            LOG_INFO("successfully create tablet")
-                    .tag("signature", req.signature)
-                    .tag("tablet_id", create_tablet_req.tablet_id);
-        } else {
-            // This is not a normal path, a possible case is that DataDir::health_check()
-            // encounters an IO_ERROR, causing get_tablet() to return nullptr even though
-            // the create_tablet succeeded.
-            status = Status::NotFound("failed to get tablet, reason={}", error_msg);
-            DorisMetrics::instance()->create_tablet_requests_failed->increment(1);
-            LOG_WARNING("created tablet is missing before finishing create task, reason={}",
-                        status.to_string())
-                    .tag("signature", req.signature)
-                    .tag("tablet_id", create_tablet_req.tablet_id)
-                    .error(status);
-        }
     }
     TFinishTaskRequest finish_task_request;
     finish_task_request.__set_finish_tablet_infos(finish_tablet_infos);
@@ -1851,8 +1850,8 @@ void create_tablet_callback(StorageEngine& engine, const TAgentTaskRequest& req)
 void drop_tablet_callback(StorageEngine& engine, const TAgentTaskRequest& req) {
     const auto& drop_tablet_req = req.drop_tablet_req;
     Status status;
-    auto dropped_tablet = engine.tablet_manager()->get_tablet(drop_tablet_req.tablet_id, false);
-    if (dropped_tablet != nullptr) {
+    auto res = engine.tablet_manager()->get_tablet_temp(drop_tablet_req.tablet_id, false);
+    if (res.has_value()) {
         status = engine.tablet_manager()->drop_tablet(drop_tablet_req.tablet_id,
                                                       drop_tablet_req.replica_id,
                                                       drop_tablet_req.is_drop_table_or_partition);
@@ -1862,8 +1861,8 @@ void drop_tablet_callback(StorageEngine& engine, const TAgentTaskRequest& req) {
     if (status.ok()) {
         // if tablet is dropped by fe, then the related txn should also be removed
         engine.txn_manager()->force_rollback_tablet_related_txns(
-                dropped_tablet->data_dir()->get_meta(), drop_tablet_req.tablet_id,
-                dropped_tablet->tablet_uid());
+                res.value()->data_dir()->get_meta(), drop_tablet_req.tablet_id,
+                res.value()->tablet_uid());
         LOG_INFO("successfully drop tablet")
                 .tag("signature", req.signature)
                 .tag("tablet_id", drop_tablet_req.tablet_id)
@@ -2136,18 +2135,18 @@ void PublishVersionWorkerPool::publish_version_callback(const TAgentTaskRequest&
             (!config::enable_compaction_pause_on_high_memory ||
              !GlobalMemoryArbitrator::is_exceed_soft_mem_limit(GB_EXCHANGE_BYTE))) {
             for (auto [tablet_id, _] : succ_tablets) {
-                TabletSharedPtr tablet = _engine.tablet_manager()->get_tablet(tablet_id);
-                if (tablet != nullptr) {
-                    if (!tablet->tablet_meta()->tablet_schema()->disable_auto_compaction()) {
-                        tablet->published_count.fetch_add(1);
-                        int64_t published_count = tablet->published_count.load();
-                        int32_t max_version_config = tablet->max_version_config();
-                        if (tablet->exceed_version_limit(
+                auto tablet = _engine.tablet_manager()->get_tablet_temp(tablet_id);
+                if (tablet.has_value()) {
+                    if (!tablet.value()->tablet_meta()->tablet_schema()->disable_auto_compaction()) {
+                        tablet.value()->published_count.fetch_add(1);
+                        int64_t published_count = tablet.value()->published_count.load();
+                        int32_t max_version_config = tablet.value()->max_version_config();
+                        if (tablet.value()->exceed_version_limit(
                                     max_version_config *
                                     config::load_trigger_compaction_version_percent / 100) &&
                             published_count % 20 == 0) {
                             auto st = _engine.submit_compaction_task(
-                                    tablet, CompactionType::CUMULATIVE_COMPACTION, true, false);
+                                    tablet.value(), CompactionType::CUMULATIVE_COMPACTION, true, false);
                             if (!st.ok()) [[unlikely]] {
                                 LOG(WARNING) << "trigger compaction failed, tablet_id=" << tablet_id
                                              << ", published=" << published_count << " : " << st;

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1825,6 +1825,9 @@ void create_tablet_callback(StorageEngine& engine, const TAgentTaskRequest& req)
                     .tag("signature", req.signature)
                     .tag("tablet_id", create_tablet_req.tablet_id);
         } else {
+            // This is not a normal path, a possible case is that DataDir::health_check()
+            // encounters an IO_ERROR, causing get_tablet() to return nullptr even though
+            // the create_tablet succeeded.
             status = Status::NotFound("failed to get tablet, reason={}", error_msg);
             DorisMetrics::instance()->create_tablet_requests_failed->increment(1);
             LOG_WARNING("created tablet is missing before finishing create task, reason={}",

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -565,8 +565,8 @@ PriorTaskWorkerPool::PriorTaskWorkerPool(
         std::function<void(const TAgentTaskRequest& task)> callback)
         : _callback(std::move(callback)) {
     for (int i = 0; i < normal_worker_count; ++i) {
-        auto st =
-                Thread::create("Normal", name, [this] { normal_loop(); }, &_workers.emplace_back());
+        auto st = Thread::create(
+                "Normal", name, [this] { normal_loop(); }, &_workers.emplace_back());
         CHECK(st.ok()) << name << ": " << st;
     }
 

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -565,8 +565,8 @@ PriorTaskWorkerPool::PriorTaskWorkerPool(
         std::function<void(const TAgentTaskRequest& task)> callback)
         : _callback(std::move(callback)) {
     for (int i = 0; i < normal_worker_count; ++i) {
-        auto st = Thread::create(
-                "Normal", name, [this] { normal_loop(); }, &_workers.emplace_back());
+        auto st =
+                Thread::create("Normal", name, [this] { normal_loop(); }, &_workers.emplace_back());
         CHECK(st.ok()) << name << ": " << st;
     }
 
@@ -873,7 +873,7 @@ void update_tablet_meta_callback(StorageEngine& engine, const TAgentTaskRequest&
                          << tablet_meta_info.tablet_id;
             continue;
         }
-        auto &tablet = tablet_res.value();
+        auto& tablet = tablet_res.value();
         bool need_to_save = false;
         if (tablet_meta_info.__isset.partition_id) {
             // for fix partition_id = 0
@@ -1759,7 +1759,7 @@ void push_cooldown_conf_callback(StorageEngine& engine, const TAgentTaskRequest&
             continue;
         }
         if (tablet.value()->update_cooldown_conf(cooldown_conf.cooldown_term,
-                                         cooldown_conf.cooldown_replica_id) &&
+                                                 cooldown_conf.cooldown_replica_id) &&
             cooldown_conf.cooldown_replica_id == tablet.value()->replica_id() &&
             tablet.value()->tablet_meta()->cooldown_meta_id().initialized()) {
             Tablet::async_write_cooldown_meta(tablet.value());
@@ -1803,8 +1803,8 @@ void create_tablet_callback(StorageEngine& engine, const TAgentTaskRequest& req)
         std::string error_msg;
         {
             SCOPED_TIMER(ADD_TIMER(profile, "GetTablet"));
-            auto tablet_res = engine.tablet_manager()->get_tablet(create_tablet_req.tablet_id, false,
-                                                         &error_msg);
+            auto tablet_res = engine.tablet_manager()->get_tablet(create_tablet_req.tablet_id,
+                                                                  false, &error_msg);
             if (tablet_res.has_value()) {
                 tablet = tablet_res.value();
                 TTabletInfo tablet_info;
@@ -1834,7 +1834,6 @@ void create_tablet_callback(StorageEngine& engine, const TAgentTaskRequest& req)
                         .error(status);
             }
         }
-
     }
     TFinishTaskRequest finish_task_request;
     finish_task_request.__set_finish_tablet_infos(finish_tablet_infos);
@@ -2137,7 +2136,10 @@ void PublishVersionWorkerPool::publish_version_callback(const TAgentTaskRequest&
             for (auto [tablet_id, _] : succ_tablets) {
                 auto tablet = _engine.tablet_manager()->get_tablet(tablet_id);
                 if (tablet.has_value()) {
-                    if (!tablet.value()->tablet_meta()->tablet_schema()->disable_auto_compaction()) {
+                    if (!tablet.value()
+                                 ->tablet_meta()
+                                 ->tablet_schema()
+                                 ->disable_auto_compaction()) {
                         tablet.value()->published_count.fetch_add(1);
                         int64_t published_count = tablet.value()->published_count.load();
                         int32_t max_version_config = tablet.value()->max_version_config();
@@ -2146,7 +2148,8 @@ void PublishVersionWorkerPool::publish_version_callback(const TAgentTaskRequest&
                                     config::load_trigger_compaction_version_percent / 100) &&
                             published_count % 20 == 0) {
                             auto st = _engine.submit_compaction_task(
-                                    tablet.value(), CompactionType::CUMULATIVE_COMPACTION, true, false);
+                                    tablet.value(), CompactionType::CUMULATIVE_COMPACTION, true,
+                                    false);
                             if (!st.ok()) [[unlikely]] {
                                 LOG(WARNING) << "trigger compaction failed, tablet_id=" << tablet_id
                                              << ", published=" << published_count << " : " << st;

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -324,7 +324,7 @@ void alter_cloud_tablet(CloudStorageEngine& engine, const TAgentTaskRequest& age
 Status check_migrate_request(StorageEngine& engine, const TStorageMediumMigrateReq& req,
                              TabletSharedPtr& tablet, DataDir** dest_store) {
     int64_t tablet_id = req.tablet_id;
-    tablet = DORIS_TRY(engine.tablet_manager()->get_tablet_temp(tablet_id));
+    tablet = DORIS_TRY(engine.tablet_manager()->get_tablet(tablet_id));
 
     if (req.__isset.data_dir) {
         // request specify the data dir
@@ -824,7 +824,7 @@ void alter_inverted_index_callback(StorageEngine& engine, const TAgentTaskReques
               << ", job_id=" << alter_inverted_index_rq.job_id;
 
     Status status = Status::OK();
-    auto res = engine.tablet_manager()->get_tablet_temp(alter_inverted_index_rq.tablet_id);
+    auto res = engine.tablet_manager()->get_tablet(alter_inverted_index_rq.tablet_id);
     if (res.has_value()) {
         EngineIndexChangeTask engine_task(engine, alter_inverted_index_rq);
         SCOPED_ATTACH_TASK(engine_task.mem_tracker());
@@ -866,7 +866,7 @@ void update_tablet_meta_callback(StorageEngine& engine, const TAgentTaskRequest&
     Status status;
     const auto& update_tablet_meta_req = req.update_tablet_meta_info_req;
     for (const auto& tablet_meta_info : update_tablet_meta_req.tabletMetaInfos) {
-        auto tablet_res = engine.tablet_manager()->get_tablet_temp(tablet_meta_info.tablet_id);
+        auto tablet_res = engine.tablet_manager()->get_tablet(tablet_meta_info.tablet_id);
         if (!tablet_res.has_value()) {
             status = Status::NotFound("tablet not found");
             LOG(WARNING) << "could not find tablet when update tablet meta. tablet_id="
@@ -1535,7 +1535,7 @@ void move_dir_callback(StorageEngine& engine, ExecEnv* env, const TAgentTaskRequ
     LOG(INFO) << "get move dir task. signature=" << req.signature
               << ", job_id=" << move_dir_req.job_id;
     Status status;
-    auto res = engine.tablet_manager()->get_tablet_temp(move_dir_req.tablet_id);
+    auto res = engine.tablet_manager()->get_tablet(move_dir_req.tablet_id);
     if (!res.has_value()) {
         status = res.error();
     } else {
@@ -1612,7 +1612,7 @@ void submit_table_compaction_callback(StorageEngine& engine, const TAgentTaskReq
         compaction_type = CompactionType::CUMULATIVE_COMPACTION;
     }
 
-    auto res = engine.tablet_manager()->get_tablet_temp(compaction_req.tablet_id);
+    auto res = engine.tablet_manager()->get_tablet(compaction_req.tablet_id);
     if (res.has_value()) {
         auto* data_dir = res.value()->data_dir();
         if (!res.value()->can_do_compaction(data_dir->path_hash(), compaction_type)) {
@@ -1753,7 +1753,7 @@ void push_cooldown_conf_callback(StorageEngine& engine, const TAgentTaskRequest&
     const auto& push_cooldown_conf_req = req.push_cooldown_conf;
     for (const auto& cooldown_conf : push_cooldown_conf_req.cooldown_confs) {
         int64_t tablet_id = cooldown_conf.tablet_id;
-        auto tablet = engine.tablet_manager()->get_tablet_temp(tablet_id);
+        auto tablet = engine.tablet_manager()->get_tablet(tablet_id);
         if (!tablet.has_value()) {
             LOG(WARNING) << "failed to get tablet. tablet_id=" << tablet_id;
             continue;
@@ -1803,7 +1803,7 @@ void create_tablet_callback(StorageEngine& engine, const TAgentTaskRequest& req)
         std::string error_msg;
         {
             SCOPED_TIMER(ADD_TIMER(profile, "GetTablet"));
-            auto tablet_res = engine.tablet_manager()->get_tablet_temp(create_tablet_req.tablet_id, false,
+            auto tablet_res = engine.tablet_manager()->get_tablet(create_tablet_req.tablet_id, false,
                                                          &error_msg);
             if (tablet_res.has_value()) {
                 tablet = tablet_res.value();
@@ -1850,7 +1850,7 @@ void create_tablet_callback(StorageEngine& engine, const TAgentTaskRequest& req)
 void drop_tablet_callback(StorageEngine& engine, const TAgentTaskRequest& req) {
     const auto& drop_tablet_req = req.drop_tablet_req;
     Status status;
-    auto res = engine.tablet_manager()->get_tablet_temp(drop_tablet_req.tablet_id, false);
+    auto res = engine.tablet_manager()->get_tablet(drop_tablet_req.tablet_id, false);
     if (res.has_value()) {
         status = engine.tablet_manager()->drop_tablet(drop_tablet_req.tablet_id,
                                                       drop_tablet_req.replica_id,
@@ -2135,7 +2135,7 @@ void PublishVersionWorkerPool::publish_version_callback(const TAgentTaskRequest&
             (!config::enable_compaction_pause_on_high_memory ||
              !GlobalMemoryArbitrator::is_exceed_soft_mem_limit(GB_EXCHANGE_BYTE))) {
             for (auto [tablet_id, _] : succ_tablets) {
-                auto tablet = _engine.tablet_manager()->get_tablet_temp(tablet_id);
+                auto tablet = _engine.tablet_manager()->get_tablet(tablet_id);
                 if (tablet.has_value()) {
                     if (!tablet.value()->tablet_meta()->tablet_schema()->disable_auto_compaction()) {
                         tablet.value()->published_count.fetch_add(1);

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1802,25 +1802,37 @@ void create_tablet_callback(StorageEngine& engine, const TAgentTaskRequest& req)
         increase_report_version();
         // get path hash of the created tablet
         TabletSharedPtr tablet;
+        std::string error_msg;
         {
             SCOPED_TIMER(ADD_TIMER(profile, "GetTablet"));
-            tablet = engine.tablet_manager()->get_tablet(create_tablet_req.tablet_id);
+            tablet = engine.tablet_manager()->get_tablet(create_tablet_req.tablet_id, false,
+                                                         &error_msg);
         }
-        DCHECK(tablet != nullptr);
-        TTabletInfo tablet_info;
-        tablet_info.tablet_id = tablet->tablet_id();
-        tablet_info.schema_hash = tablet->schema_hash();
-        tablet_info.version = create_tablet_req.version;
-        // Useless but it is a required field in TTabletInfo
-        tablet_info.version_hash = 0;
-        tablet_info.row_count = 0;
-        tablet_info.data_size = 0;
-        tablet_info.__set_path_hash(tablet->data_dir()->path_hash());
-        tablet_info.__set_replica_id(tablet->replica_id());
-        finish_tablet_infos.push_back(tablet_info);
-        LOG_INFO("successfully create tablet")
-                .tag("signature", req.signature)
-                .tag("tablet_id", create_tablet_req.tablet_id);
+
+        if (tablet) {
+            TTabletInfo tablet_info;
+            tablet_info.tablet_id = tablet->tablet_id();
+            tablet_info.schema_hash = tablet->schema_hash();
+            tablet_info.version = create_tablet_req.version;
+            // Useless but it is a required field in TTabletInfo
+            tablet_info.version_hash = 0;
+            tablet_info.row_count = 0;
+            tablet_info.data_size = 0;
+            tablet_info.__set_path_hash(tablet->data_dir()->path_hash());
+            tablet_info.__set_replica_id(tablet->replica_id());
+            finish_tablet_infos.push_back(tablet_info);
+            LOG_INFO("successfully create tablet")
+                    .tag("signature", req.signature)
+                    .tag("tablet_id", create_tablet_req.tablet_id);
+        } else {
+            status = Status::NotFound("failed to get tablet, reason={}", error_msg);
+            DorisMetrics::instance()->create_tablet_requests_failed->increment(1);
+            LOG_WARNING("created tablet is missing before finishing create task, reason={}",
+                        status.to_string())
+                    .tag("signature", req.signature)
+                    .tag("tablet_id", create_tablet_req.tablet_id)
+                    .error(status);
+        }
     }
     TFinishTaskRequest finish_task_request;
     finish_task_request.__set_finish_tablet_infos(finish_tablet_infos);

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -937,13 +937,7 @@ Status SnapshotLoader::download(const std::map<std::string, std::string>& src_to
             return Status::InternalError(ss.str());
         }
 
-        TabletSharedPtr tablet = _engine.tablet_manager()->get_tablet(local_tablet_id);
-        if (tablet == nullptr) {
-            std::stringstream ss;
-            ss << "failed to get local tablet: " << local_tablet_id;
-            LOG(WARNING) << ss.str();
-            return Status::InternalError(ss.str());
-        }
+        auto tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(local_tablet_id));
         DataDir* data_dir = tablet->data_dir();
 
         for (auto& remote_iter : remote_files) {
@@ -1083,18 +1077,13 @@ Status SnapshotLoader::remote_http_download(
                 "download snapshots via http. job: {}, task id: {}, local dir: {}, remote dir: {}",
                 _job_id, _task_id, local_path, remote_path);
 
-        TabletSharedPtr tablet = _engine.tablet_manager()->get_tablet(local_tablet_id);
-        if (tablet == nullptr) {
-            std::string msg = fmt::format("failed to get local tablet: {}", local_tablet_id);
-            LOG(WARNING) << msg;
-            return Status::RuntimeError(std::move(msg));
-        }
+        auto tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(local_tablet_id));
 
         if (downloaded_tablet_ids != nullptr) {
             downloaded_tablet_ids->push_back(local_tablet_id);
         }
 
-        SnapshotHttpDownloader downloader(remote_tablet_snapshot, std::move(tablet), *this);
+        SnapshotHttpDownloader downloader(remote_tablet_snapshot, tablet, *this);
 #ifndef BE_TEST
         int report_counter = 0;
         int finished_num = 0;

--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -937,7 +937,7 @@ Status SnapshotLoader::download(const std::map<std::string, std::string>& src_to
             return Status::InternalError(ss.str());
         }
 
-        auto tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(local_tablet_id));
+        auto tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet(local_tablet_id));
         DataDir* data_dir = tablet->data_dir();
 
         for (auto& remote_iter : remote_files) {
@@ -1077,7 +1077,7 @@ Status SnapshotLoader::remote_http_download(
                 "download snapshots via http. job: {}, task id: {}, local dir: {}, remote dir: {}",
                 _job_id, _task_id, local_path, remote_path);
 
-        auto tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(local_tablet_id));
+        auto tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet(local_tablet_id));
 
         if (downloaded_tablet_ids != nullptr) {
             downloaded_tablet_ids->push_back(local_tablet_id);

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -1038,7 +1038,8 @@ void BackendService::ingest_binlog(TIngestBinlogResult& result,
 
     {
         // TODO: Before push_lock is not held, but I think it should hold.
-        auto status = local_tablet.value()->prepare_txn(partition_id, txn_id, p_load_id, is_ingrest);
+        auto status =
+                local_tablet.value()->prepare_txn(partition_id, txn_id, p_load_id, is_ingrest);
         if (!status.ok()) {
             LOG(WARNING) << "prepare txn failed. txn_id=" << txn_id
                          << ", status=" << status.to_string();

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -1020,8 +1020,8 @@ void BackendService::ingest_binlog(TIngestBinlogResult& result,
     auto txn_id = request.txn_id;
     // Step 1: get local tablet
     auto const& local_tablet_id = request.local_tablet_id;
-    auto local_tablet = _engine.tablet_manager()->get_tablet(local_tablet_id);
-    if (local_tablet == nullptr) {
+    auto local_tablet = _engine.tablet_manager()->get_tablet_temp(local_tablet_id);
+    if (!local_tablet.has_value()) {
         auto error_msg = fmt::format("tablet {} not found", local_tablet_id);
         LOG(WARNING) << error_msg;
         set_tstatus(TStatusCode::TABLET_MISSING, std::move(error_msg));
@@ -1038,7 +1038,7 @@ void BackendService::ingest_binlog(TIngestBinlogResult& result,
 
     {
         // TODO: Before push_lock is not held, but I think it should hold.
-        auto status = local_tablet->prepare_txn(partition_id, txn_id, p_load_id, is_ingrest);
+        auto status = local_tablet.value()->prepare_txn(partition_id, txn_id, p_load_id, is_ingrest);
         if (!status.ok()) {
             LOG(WARNING) << "prepare txn failed. txn_id=" << txn_id
                          << ", status=" << status.to_string();
@@ -1055,7 +1055,7 @@ void BackendService::ingest_binlog(TIngestBinlogResult& result,
                 .txn_id = txn_id,
                 .partition_id = partition_id,
                 .local_tablet_id = local_tablet_id,
-                .local_tablet = local_tablet,
+                .local_tablet = local_tablet.value(),
 
                 .request = request,
                 .tstatus = is_async ? nullptr : tstatus,
@@ -1115,8 +1115,8 @@ void BackendService::query_ingest_binlog(TQueryIngestBinlogResult& result,
     auto tablet_id = request.tablet_id;
 
     // Step 1: get local tablet
-    auto local_tablet = _engine.tablet_manager()->get_tablet(tablet_id);
-    if (local_tablet == nullptr) {
+    auto local_tablet = _engine.tablet_manager()->get_tablet_temp(tablet_id);
+    if (!local_tablet.has_value()) {
         auto error_msg = fmt::format("tablet {} not found", tablet_id);
         LOG(WARNING) << error_msg;
         set_result(TIngestBinlogStatus::NOT_FOUND, std::move(error_msg));
@@ -1124,7 +1124,7 @@ void BackendService::query_ingest_binlog(TQueryIngestBinlogResult& result,
     }
 
     // Step 2: get txn state
-    auto tablet_uid = local_tablet->tablet_uid();
+    auto tablet_uid = local_tablet.value()->tablet_uid();
     auto txn_state =
             _engine.txn_manager()->get_txn_state(partition_id, txn_id, tablet_id, tablet_uid);
     switch (txn_state) {

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -1020,7 +1020,7 @@ void BackendService::ingest_binlog(TIngestBinlogResult& result,
     auto txn_id = request.txn_id;
     // Step 1: get local tablet
     auto const& local_tablet_id = request.local_tablet_id;
-    auto local_tablet = _engine.tablet_manager()->get_tablet_temp(local_tablet_id);
+    auto local_tablet = _engine.tablet_manager()->get_tablet(local_tablet_id);
     if (!local_tablet.has_value()) {
         auto error_msg = fmt::format("tablet {} not found", local_tablet_id);
         LOG(WARNING) << error_msg;
@@ -1115,7 +1115,7 @@ void BackendService::query_ingest_binlog(TQueryIngestBinlogResult& result,
     auto tablet_id = request.tablet_id;
 
     // Step 1: get local tablet
-    auto local_tablet = _engine.tablet_manager()->get_tablet_temp(tablet_id);
+    auto local_tablet = _engine.tablet_manager()->get_tablet(tablet_id);
     if (!local_tablet.has_value()) {
         auto error_msg = fmt::format("tablet {} not found", tablet_id);
         LOG(WARNING) << error_msg;

--- a/be/src/service/http/action/calc_file_crc_action.cpp
+++ b/be/src/service/http/action/calc_file_crc_action.cpp
@@ -66,7 +66,7 @@ Status CalcFileCrcAction::_handle_calc_crc(HttpRequest* req, uint32_t* crc_value
         // sync all rowsets
         RETURN_IF_ERROR(std::dynamic_pointer_cast<CloudTablet>(tablet)->sync_rowsets());
     } else if (auto storageEngine = dynamic_cast<StorageEngine*>(&_engine)) {
-        auto tabletPtr = storageEngine->tablet_manager()->get_tablet(tablet_id);
+        auto tabletPtr = DORIS_TRY(storageEngine->tablet_manager()->get_tablet_temp(tablet_id));
         tablet = std::dynamic_pointer_cast<Tablet>(tabletPtr);
     } else {
         return Status::InternalError("convert _engine failed");

--- a/be/src/service/http/action/calc_file_crc_action.cpp
+++ b/be/src/service/http/action/calc_file_crc_action.cpp
@@ -66,7 +66,7 @@ Status CalcFileCrcAction::_handle_calc_crc(HttpRequest* req, uint32_t* crc_value
         // sync all rowsets
         RETURN_IF_ERROR(std::dynamic_pointer_cast<CloudTablet>(tablet)->sync_rowsets());
     } else if (auto storageEngine = dynamic_cast<StorageEngine*>(&_engine)) {
-        auto tabletPtr = DORIS_TRY(storageEngine->tablet_manager()->get_tablet_temp(tablet_id));
+        auto tabletPtr = DORIS_TRY(storageEngine->tablet_manager()->get_tablet(tablet_id));
         tablet = std::dynamic_pointer_cast<Tablet>(tabletPtr);
     } else {
         return Status::InternalError("convert _engine failed");

--- a/be/src/service/http/action/compaction_action.cpp
+++ b/be/src/service/http/action/compaction_action.cpp
@@ -117,7 +117,7 @@ Status CompactionAction::_handle_show_compaction(HttpRequest* req, std::string* 
         return Status::InternalError("check param failed: missing tablet_id");
     }
 
-    TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(tablet_id));
+    TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet(tablet_id));
 
     tablet->get_compaction_status(json_result);
     return Status::OK();
@@ -157,7 +157,7 @@ Status CompactionAction::_handle_run_compaction(HttpRequest* req, std::string* j
         }
     } else {
         // 2. fetch the tablet by tablet_id
-        TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(tablet_id));
+        TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet(tablet_id));
 
         if (fetch_from_remote && !tablet->should_fetch_from_peer()) {
             return Status::NotSupported("tablet should do compaction locally");
@@ -220,7 +220,7 @@ Status CompactionAction::_handle_run_status_compaction(HttpRequest* req, std::st
         return Status::OK();
     } else {
         // fetch the tablet by tablet_id
-        TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(tablet_id));
+        TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet(tablet_id));
 
         std::string json_template = R"({
             "status" : "Success",

--- a/be/src/service/http/action/compaction_action.cpp
+++ b/be/src/service/http/action/compaction_action.cpp
@@ -117,10 +117,7 @@ Status CompactionAction::_handle_show_compaction(HttpRequest* req, std::string* 
         return Status::InternalError("check param failed: missing tablet_id");
     }
 
-    TabletSharedPtr tablet = _engine.tablet_manager()->get_tablet(tablet_id);
-    if (tablet == nullptr) {
-        return Status::NotFound("Tablet not found. tablet_id={}", tablet_id);
-    }
+    TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(tablet_id));
 
     tablet->get_compaction_status(json_result);
     return Status::OK();
@@ -160,10 +157,7 @@ Status CompactionAction::_handle_run_compaction(HttpRequest* req, std::string* j
         }
     } else {
         // 2. fetch the tablet by tablet_id
-        TabletSharedPtr tablet = _engine.tablet_manager()->get_tablet(tablet_id);
-        if (tablet == nullptr) {
-            return Status::NotFound("Tablet not found. tablet_id={}", tablet_id);
-        }
+        TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(tablet_id));
 
         if (fetch_from_remote && !tablet->should_fetch_from_peer()) {
             return Status::NotSupported("tablet should do compaction locally");
@@ -226,11 +220,7 @@ Status CompactionAction::_handle_run_status_compaction(HttpRequest* req, std::st
         return Status::OK();
     } else {
         // fetch the tablet by tablet_id
-        TabletSharedPtr tablet = _engine.tablet_manager()->get_tablet(tablet_id);
-        if (tablet == nullptr) {
-            LOG(WARNING) << "invalid argument.tablet_id:" << tablet_id;
-            return Status::InternalError("fail to get {}", tablet_id);
-        }
+        TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(tablet_id));
 
         std::string json_template = R"({
             "status" : "Success",

--- a/be/src/service/http/action/delete_bitmap_action.cpp
+++ b/be/src/service/http/action/delete_bitmap_action.cpp
@@ -155,7 +155,7 @@ Status DeleteBitmapAction::_handle_show_local_delete_bitmap_count(HttpRequest* r
                 "DeleteBitmapAction._handle_show_local_delete_bitmap_count.vacuum_stale_rowsets",
                 { _engine.to_cloud().tablet_mgr().vacuum_stale_rowsets(CountDownLatch(1)); });
     } else {
-        tablet = DORIS_TRY(_engine.to_local().tablet_manager()->get_tablet_temp(tablet_id));
+        tablet = DORIS_TRY(_engine.to_local().tablet_manager()->get_tablet(tablet_id));
         DBUG_EXECUTE_IF(
                 "DeleteBitmapAction._handle_show_local_delete_bitmap_count.start_delete_unused_"
                 "rowset",
@@ -207,7 +207,7 @@ Status DeleteBitmapAction::_handle_show_agg_cache_delete_bitmap_count(HttpReques
                 "DeleteBitmapAction._handle_show_local_delete_bitmap_count.vacuum_stale_rowsets",
                 { _engine.to_cloud().tablet_mgr().vacuum_stale_rowsets(CountDownLatch(1)); });
     } else {
-        tablet = DORIS_TRY(_engine.to_local().tablet_manager()->get_tablet_temp(tablet_id));
+        tablet = DORIS_TRY(_engine.to_local().tablet_manager()->get_tablet(tablet_id));
         DBUG_EXECUTE_IF(
                 "DeleteBitmapAction._handle_show_local_delete_bitmap_count.start_delete_unused_"
                 "rowset",

--- a/be/src/service/http/action/delete_bitmap_action.cpp
+++ b/be/src/service/http/action/delete_bitmap_action.cpp
@@ -155,15 +155,13 @@ Status DeleteBitmapAction::_handle_show_local_delete_bitmap_count(HttpRequest* r
                 "DeleteBitmapAction._handle_show_local_delete_bitmap_count.vacuum_stale_rowsets",
                 { _engine.to_cloud().tablet_mgr().vacuum_stale_rowsets(CountDownLatch(1)); });
     } else {
-        tablet = _engine.to_local().tablet_manager()->get_tablet(tablet_id);
+        tablet = DORIS_TRY(_engine.to_local().tablet_manager()->get_tablet_temp(tablet_id));
         DBUG_EXECUTE_IF(
                 "DeleteBitmapAction._handle_show_local_delete_bitmap_count.start_delete_unused_"
                 "rowset",
                 { _engine.to_local().start_delete_unused_rowset(); });
     }
-    if (tablet == nullptr) {
-        return Status::NotFound("Tablet not found. tablet_id={}", tablet_id);
-    }
+
     auto dm = tablet->tablet_meta()->delete_bitmap().snapshot();
     _show_delete_bitmap(dm, verbose, json_result);
     return Status::OK();
@@ -209,15 +207,13 @@ Status DeleteBitmapAction::_handle_show_agg_cache_delete_bitmap_count(HttpReques
                 "DeleteBitmapAction._handle_show_local_delete_bitmap_count.vacuum_stale_rowsets",
                 { _engine.to_cloud().tablet_mgr().vacuum_stale_rowsets(CountDownLatch(1)); });
     } else {
-        tablet = _engine.to_local().tablet_manager()->get_tablet(tablet_id);
+        tablet = DORIS_TRY(_engine.to_local().tablet_manager()->get_tablet_temp(tablet_id));
         DBUG_EXECUTE_IF(
                 "DeleteBitmapAction._handle_show_local_delete_bitmap_count.start_delete_unused_"
                 "rowset",
                 { _engine.to_local().start_delete_unused_rowset(); });
     }
-    if (tablet == nullptr) {
-        return Status::NotFound("Tablet not found. tablet_id={}", tablet_id);
-    }
+
     auto dbm = tablet->tablet_meta()->delete_bitmap().agg_cache_snapshot();
     _show_delete_bitmap(dbm, verbose, json_result);
     return Status::OK();

--- a/be/src/service/http/action/download_binlog_action.cpp
+++ b/be/src/service/http/action/download_binlog_action.cpp
@@ -67,7 +67,7 @@ const auto& get_http_param(HttpRequest* req, const std::string& param_name) {
 TabletSharedPtr get_tablet(StorageEngine& engine, const std::string& tablet_id_str) {
     int64_t tablet_id = std::atoll(tablet_id_str.data());
 
-    auto tablet = engine.tablet_manager()->get_tablet_temp(tablet_id);
+    auto tablet = engine.tablet_manager()->get_tablet(tablet_id);
     if (!tablet.has_value()) {
         auto error = fmt::format("tablet is not exist, tablet_id={}", tablet_id);
         LOG(WARNING) << error;

--- a/be/src/service/http/action/download_binlog_action.cpp
+++ b/be/src/service/http/action/download_binlog_action.cpp
@@ -64,17 +64,17 @@ const auto& get_http_param(HttpRequest* req, const std::string& param_name) {
     return param;
 }
 
-auto get_tablet(StorageEngine& engine, const std::string& tablet_id_str) {
+TabletSharedPtr get_tablet(StorageEngine& engine, const std::string& tablet_id_str) {
     int64_t tablet_id = std::atoll(tablet_id_str.data());
 
-    TabletSharedPtr tablet = engine.tablet_manager()->get_tablet(tablet_id);
-    if (tablet == nullptr) {
+    auto tablet = engine.tablet_manager()->get_tablet_temp(tablet_id);
+    if (!tablet.has_value()) {
         auto error = fmt::format("tablet is not exist, tablet_id={}", tablet_id);
         LOG(WARNING) << error;
         throw std::runtime_error(error);
     }
 
-    return tablet;
+    return tablet.value();
 }
 
 // need binlog_version, tablet_id

--- a/be/src/service/http/action/pad_rowset_action.cpp
+++ b/be/src/service/http/action/pad_rowset_action.cpp
@@ -89,7 +89,7 @@ Status PadRowsetAction::_handle(HttpRequest* req) {
         return Status::InternalError("Invalid input version");
     }
 
-    auto tablet = _engine.tablet_manager()->get_tablet(tablet_id);
+    auto tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(tablet_id));
     if (nullptr == tablet) {
         return Status::InternalError("Unknown tablet id {}", tablet_id);
     }

--- a/be/src/service/http/action/pad_rowset_action.cpp
+++ b/be/src/service/http/action/pad_rowset_action.cpp
@@ -89,7 +89,7 @@ Status PadRowsetAction::_handle(HttpRequest* req) {
         return Status::InternalError("Invalid input version");
     }
 
-    auto tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(tablet_id));
+    auto tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet(tablet_id));
     if (nullptr == tablet) {
         return Status::InternalError("Unknown tablet id {}", tablet_id);
     }

--- a/be/src/service/http/action/restore_tablet_action.cpp
+++ b/be/src/service/http/action/restore_tablet_action.cpp
@@ -88,11 +88,12 @@ Status RestoreTabletAction::_handle(HttpRequest* req) {
     int32_t schema_hash = std::atoi(schema_hash_str.c_str());
     LOG(INFO) << "get restore tablet action request: " << tablet_id << "-" << schema_hash;
 
-    TabletSharedPtr tablet = _engine.tablet_manager()->get_tablet(tablet_id);
-    if (tablet != nullptr) {
+    auto tablet = _engine.tablet_manager()->get_tablet_temp(tablet_id);
+    if (tablet.has_value()) {
         LOG(WARNING) << "find tablet. tablet_id=" << tablet_id << " schema_hash=" << schema_hash;
         return Status::InternalError("tablet already exists, can not restore.");
     }
+
     std::string key = tablet_id_str + "_" + schema_hash_str;
     {
         // check tablet_id + schema_hash already is restoring

--- a/be/src/service/http/action/restore_tablet_action.cpp
+++ b/be/src/service/http/action/restore_tablet_action.cpp
@@ -88,7 +88,7 @@ Status RestoreTabletAction::_handle(HttpRequest* req) {
     int32_t schema_hash = std::atoi(schema_hash_str.c_str());
     LOG(INFO) << "get restore tablet action request: " << tablet_id << "-" << schema_hash;
 
-    auto tablet = _engine.tablet_manager()->get_tablet_temp(tablet_id);
+    auto tablet = _engine.tablet_manager()->get_tablet(tablet_id);
     if (tablet.has_value()) {
         LOG(WARNING) << "find tablet. tablet_id=" << tablet_id << " schema_hash=" << schema_hash;
         return Status::InternalError("tablet already exists, can not restore.");

--- a/be/src/service/http/action/tablet_migration_action.cpp
+++ b/be/src/service/http/action/tablet_migration_action.cpp
@@ -187,11 +187,7 @@ Status TabletMigrationAction::_check_param(HttpRequest* req, int64_t& tablet_id,
 Status TabletMigrationAction::_check_migrate_request(int64_t tablet_id, unsigned long schema_hash,
                                                      std::string dest_disk, TabletSharedPtr& tablet,
                                                      DataDir** dest_store) {
-    tablet = _engine.tablet_manager()->get_tablet(tablet_id);
-    if (tablet == nullptr) {
-        LOG(WARNING) << "no tablet for tablet_id:" << tablet_id;
-        return Status::NotFound("Tablet not found");
-    }
+    tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(tablet_id));
 
     // request specify the data dir
     *dest_store = _engine.get_store(dest_disk);

--- a/be/src/service/http/action/tablet_migration_action.cpp
+++ b/be/src/service/http/action/tablet_migration_action.cpp
@@ -187,7 +187,7 @@ Status TabletMigrationAction::_check_param(HttpRequest* req, int64_t& tablet_id,
 Status TabletMigrationAction::_check_migrate_request(int64_t tablet_id, unsigned long schema_hash,
                                                      std::string dest_disk, TabletSharedPtr& tablet,
                                                      DataDir** dest_store) {
-    tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(tablet_id));
+    tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet(tablet_id));
 
     // request specify the data dir
     *dest_store = _engine.get_store(dest_disk);

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1122,8 +1122,8 @@ void PInternalServiceImpl::_get_column_ids_by_tablet_ids(
         std::set<std::set<int32_t>> filter_set;
         std::map<int32_t, const TabletColumn*> id_to_column;
         for (const int64_t tablet_id : tablet_ids) {
-            TabletSharedPtr tablet = tablet_mgr->get_tablet(tablet_id);
-            if (tablet == nullptr) {
+            auto tablet = tablet_mgr->get_tablet_temp(tablet_id);
+            if (!tablet.has_value()) {
                 std::stringstream ss;
                 ss << "cannot get tablet by id:" << tablet_id;
                 LOG(WARNING) << ss.str();
@@ -1132,7 +1132,7 @@ void PInternalServiceImpl::_get_column_ids_by_tablet_ids(
                 return;
             }
             // check schema consistency, column ids should be the same
-            const auto& columns = tablet->tablet_schema()->columns();
+            const auto& columns = tablet.value()->tablet_schema()->columns();
 
             std::set<int32_t> column_ids;
             for (const auto& col : columns) {
@@ -1178,8 +1178,8 @@ void PInternalServiceImpl::_get_column_ids_by_tablet_ids(
             return;
         }
         // consistency check passed, use the first tablet to be the representative
-        TabletSharedPtr tablet = tablet_mgr->get_tablet(tablet_ids[0]);
-        const auto& columns = tablet->tablet_schema()->columns();
+        auto tablet = tablet_mgr->get_tablet_temp(tablet_ids[0]);
+        const auto& columns = tablet.value()->tablet_schema()->columns();
         auto entry = response->add_entries();
         entry->set_index_id(index_id);
         auto col_name_to_id = entry->mutable_col_name_to_id();
@@ -1951,9 +1951,9 @@ void PInternalServiceImpl::request_slave_tablet_pull_rowset(
     int64_t node_id = request->node_id();
     bool ret = _heavy_work_pool.try_offer([rowset_meta_pb, host, brpc_port, node_id, segments_size,
                                            indices_size, http_port, token, rowset_path, this]() {
-        TabletSharedPtr tablet = _engine.tablet_manager()->get_tablet(
+        auto tablet = _engine.tablet_manager()->get_tablet_temp(
                 rowset_meta_pb.tablet_id(), rowset_meta_pb.tablet_schema_hash());
-        if (tablet == nullptr) {
+        if (!tablet.has_value()) {
             LOG(WARNING) << "failed to pull rowset for slave replica. tablet ["
                          << rowset_meta_pb.tablet_id()
                          << "] is not exist. txn_id=" << rowset_meta_pb.txn_id();
@@ -1992,7 +1992,7 @@ void PInternalServiceImpl::request_slave_tablet_pull_rowset(
         RowsetId new_rowset_id = _engine.next_rowset_id();
         auto pending_rs_guard = _engine.pending_local_rowsets().add(new_rowset_id);
         rowset_meta->set_rowset_id(new_rowset_id);
-        rowset_meta->set_tablet_uid(tablet->tablet_uid());
+        rowset_meta->set_tablet_uid(tablet.value()->tablet_uid());
         VLOG_CRITICAL << "succeed to init rowset meta for slave replica. rowset_id="
                       << rowset_meta->rowset_id() << ", tablet_id=" << rowset_meta->tablet_id()
                       << ", txn_id=" << rowset_meta->txn_id();
@@ -2011,7 +2011,7 @@ void PInternalServiceImpl::request_slave_tablet_pull_rowset(
                     construct_url(get_host_port(host, http_port), token, remote_file_path);
 
             std::string local_file_path = local_segment_path(
-                    tablet->tablet_path(), rowset_meta->rowset_id().to_string(), segment.first);
+                    tablet.value()->tablet_path(), rowset_meta->rowset_id().to_string(), segment.first);
 
             auto st = download_file_action(remote_file_url, local_file_path, estimate_timeout,
                                            file_size);
@@ -2089,7 +2089,7 @@ void PInternalServiceImpl::request_slave_tablet_pull_rowset(
 
         RowsetSharedPtr rowset;
         Status create_status = RowsetFactory::create_rowset(
-                tablet->tablet_schema(), tablet->tablet_path(), rowset_meta, &rowset);
+                tablet.value()->tablet_schema(), tablet.value()->tablet_path(), rowset_meta, &rowset);
         if (!create_status) {
             LOG(WARNING) << "failed to create rowset from rowset meta for slave replica"
                          << ". rowset_id: " << rowset_meta->rowset_id()
@@ -2112,8 +2112,8 @@ void PInternalServiceImpl::request_slave_tablet_pull_rowset(
             return;
         }
         Status commit_txn_status = _engine.txn_manager()->commit_txn(
-                tablet->data_dir()->get_meta(), rowset_meta->partition_id(), rowset_meta->txn_id(),
-                rowset_meta->tablet_id(), tablet->tablet_uid(), rowset_meta->load_id(), rowset,
+                tablet.value()->data_dir()->get_meta(), rowset_meta->partition_id(), rowset_meta->txn_id(),
+                rowset_meta->tablet_id(), tablet.value()->tablet_uid(), rowset_meta->load_id(), rowset,
                 std::move(pending_rs_guard), false);
         if (!commit_txn_status && !commit_txn_status.is<PUSH_TRANSACTION_ALREADY_EXIST>()) {
             LOG(WARNING) << "failed to add committed rowset for slave replica. rowset_id="

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1744,17 +1744,17 @@ void PInternalService::transmit_block(google::protobuf::RpcController* controlle
         // pool here.
         _transmit_block(controller, request, response, done, Status::OK(), 0);
     } else {
-        bool ret = _light_work_pool.try_offer(
-                [this, controller, request, response, done, receive_time]() {
-                    response->set_receive_time(receive_time);
-                    // Sometimes transmit block function is the last owner of PlanFragmentExecutor
-                    // It will release the object. And the object maybe a JNIContext.
-                    // JNIContext will hold some TLS object. It could not work correctly under bthread
-                    // Context. So that put the logic into pthread.
-                    // But this is rarely happens, so this config is disabled by default.
-                    _transmit_block(controller, request, response, done, Status::OK(),
-                                    GetCurrentTimeNanos() - receive_time);
-                });
+        bool ret = _light_work_pool.try_offer([this, controller, request, response, done,
+                                               receive_time]() {
+            response->set_receive_time(receive_time);
+            // Sometimes transmit block function is the last owner of PlanFragmentExecutor
+            // It will release the object. And the object maybe a JNIContext.
+            // JNIContext will hold some TLS object. It could not work correctly under bthread
+            // Context. So that put the logic into pthread.
+            // But this is rarely happens, so this config is disabled by default.
+            _transmit_block(controller, request, response, done, Status::OK(),
+                            GetCurrentTimeNanos() - receive_time);
+        });
         if (!ret) {
             offer_failed(response, done, _light_work_pool);
             return;

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1122,7 +1122,7 @@ void PInternalServiceImpl::_get_column_ids_by_tablet_ids(
         std::set<std::set<int32_t>> filter_set;
         std::map<int32_t, const TabletColumn*> id_to_column;
         for (const int64_t tablet_id : tablet_ids) {
-            auto tablet = tablet_mgr->get_tablet_temp(tablet_id);
+            auto tablet = tablet_mgr->get_tablet(tablet_id);
             if (!tablet.has_value()) {
                 std::stringstream ss;
                 ss << "cannot get tablet by id:" << tablet_id;
@@ -1178,7 +1178,7 @@ void PInternalServiceImpl::_get_column_ids_by_tablet_ids(
             return;
         }
         // consistency check passed, use the first tablet to be the representative
-        auto tablet = tablet_mgr->get_tablet_temp(tablet_ids[0]);
+        auto tablet = tablet_mgr->get_tablet(tablet_ids[0]);
         const auto& columns = tablet.value()->tablet_schema()->columns();
         auto entry = response->add_entries();
         entry->set_index_id(index_id);
@@ -1951,7 +1951,7 @@ void PInternalServiceImpl::request_slave_tablet_pull_rowset(
     int64_t node_id = request->node_id();
     bool ret = _heavy_work_pool.try_offer([rowset_meta_pb, host, brpc_port, node_id, segments_size,
                                            indices_size, http_port, token, rowset_path, this]() {
-        auto tablet = _engine.tablet_manager()->get_tablet_temp(
+        auto tablet = _engine.tablet_manager()->get_tablet(
                 rowset_meta_pb.tablet_id(), rowset_meta_pb.tablet_schema_hash());
         if (!tablet.has_value()) {
             LOG(WARNING) << "failed to pull rowset for slave replica. tablet ["

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1744,17 +1744,17 @@ void PInternalService::transmit_block(google::protobuf::RpcController* controlle
         // pool here.
         _transmit_block(controller, request, response, done, Status::OK(), 0);
     } else {
-        bool ret = _light_work_pool.try_offer([this, controller, request, response, done,
-                                               receive_time]() {
-            response->set_receive_time(receive_time);
-            // Sometimes transmit block function is the last owner of PlanFragmentExecutor
-            // It will release the object. And the object maybe a JNIContext.
-            // JNIContext will hold some TLS object. It could not work correctly under bthread
-            // Context. So that put the logic into pthread.
-            // But this is rarely happens, so this config is disabled by default.
-            _transmit_block(controller, request, response, done, Status::OK(),
-                            GetCurrentTimeNanos() - receive_time);
-        });
+        bool ret = _light_work_pool.try_offer(
+                [this, controller, request, response, done, receive_time]() {
+                    response->set_receive_time(receive_time);
+                    // Sometimes transmit block function is the last owner of PlanFragmentExecutor
+                    // It will release the object. And the object maybe a JNIContext.
+                    // JNIContext will hold some TLS object. It could not work correctly under bthread
+                    // Context. So that put the logic into pthread.
+                    // But this is rarely happens, so this config is disabled by default.
+                    _transmit_block(controller, request, response, done, Status::OK(),
+                                    GetCurrentTimeNanos() - receive_time);
+                });
         if (!ret) {
             offer_failed(response, done, _light_work_pool);
             return;
@@ -1951,8 +1951,8 @@ void PInternalServiceImpl::request_slave_tablet_pull_rowset(
     int64_t node_id = request->node_id();
     bool ret = _heavy_work_pool.try_offer([rowset_meta_pb, host, brpc_port, node_id, segments_size,
                                            indices_size, http_port, token, rowset_path, this]() {
-        auto tablet = _engine.tablet_manager()->get_tablet(
-                rowset_meta_pb.tablet_id(), rowset_meta_pb.tablet_schema_hash());
+        auto tablet = _engine.tablet_manager()->get_tablet(rowset_meta_pb.tablet_id(),
+                                                           rowset_meta_pb.tablet_schema_hash());
         if (!tablet.has_value()) {
             LOG(WARNING) << "failed to pull rowset for slave replica. tablet ["
                          << rowset_meta_pb.tablet_id()
@@ -2010,8 +2010,9 @@ void PInternalServiceImpl::request_slave_tablet_pull_rowset(
             std::string remote_file_url =
                     construct_url(get_host_port(host, http_port), token, remote_file_path);
 
-            std::string local_file_path = local_segment_path(
-                    tablet.value()->tablet_path(), rowset_meta->rowset_id().to_string(), segment.first);
+            std::string local_file_path =
+                    local_segment_path(tablet.value()->tablet_path(),
+                                       rowset_meta->rowset_id().to_string(), segment.first);
 
             auto st = download_file_action(remote_file_url, local_file_path, estimate_timeout,
                                            file_size);
@@ -2088,8 +2089,9 @@ void PInternalServiceImpl::request_slave_tablet_pull_rowset(
         }
 
         RowsetSharedPtr rowset;
-        Status create_status = RowsetFactory::create_rowset(
-                tablet.value()->tablet_schema(), tablet.value()->tablet_path(), rowset_meta, &rowset);
+        Status create_status =
+                RowsetFactory::create_rowset(tablet.value()->tablet_schema(),
+                                             tablet.value()->tablet_path(), rowset_meta, &rowset);
         if (!create_status) {
             LOG(WARNING) << "failed to create rowset from rowset meta for slave replica"
                          << ". rowset_id: " << rowset_meta->rowset_id()
@@ -2112,9 +2114,9 @@ void PInternalServiceImpl::request_slave_tablet_pull_rowset(
             return;
         }
         Status commit_txn_status = _engine.txn_manager()->commit_txn(
-                tablet.value()->data_dir()->get_meta(), rowset_meta->partition_id(), rowset_meta->txn_id(),
-                rowset_meta->tablet_id(), tablet.value()->tablet_uid(), rowset_meta->load_id(), rowset,
-                std::move(pending_rs_guard), false);
+                tablet.value()->data_dir()->get_meta(), rowset_meta->partition_id(),
+                rowset_meta->txn_id(), rowset_meta->tablet_id(), tablet.value()->tablet_uid(),
+                rowset_meta->load_id(), rowset, std::move(pending_rs_guard), false);
         if (!commit_txn_status && !commit_txn_status.is<PUSH_TRANSACTION_ALREADY_EXIST>()) {
             LOG(WARNING) << "failed to add committed rowset for slave replica. rowset_id="
                          << rowset_meta->rowset_id() << ", tablet_id=" << rowset_meta->tablet_id()

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -478,7 +478,8 @@ Status DataDir::load() {
         auto tablet = _engine.tablet_manager()->get_tablet(tablet_id);
         if (tablet.has_value() && tablet.value()->set_tablet_schema_into_rowset_meta()) {
             RETURN_IF_ERROR(TabletMetaManager::save(this, tablet.value()->tablet_id(),
-                                                    tablet.value()->schema_hash(), tablet.value()->tablet_meta()));
+                                                    tablet.value()->schema_hash(),
+                                                    tablet.value()->tablet_meta()));
         }
     }
 
@@ -645,8 +646,8 @@ Status DataDir::load() {
                 continue;
             }
             auto bitmap = delete_bitmap_pb.segment_delete_bitmaps(i).data();
-            tablet.value()->tablet_meta()->delete_bitmap().delete_bitmap[{rst_id, seg_id, version}] =
-                    roaring::Roaring::read(bitmap);
+            tablet.value()->tablet_meta()->delete_bitmap().delete_bitmap[{
+                    rst_id, seg_id, version}] = roaring::Roaring::read(bitmap);
         }
         return true;
     };

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -475,7 +475,7 @@ Status DataDir::load() {
     }
 
     for (int64_t tablet_id : tablet_ids) {
-        auto tablet = _engine.tablet_manager()->get_tablet_temp(tablet_id);
+        auto tablet = _engine.tablet_manager()->get_tablet(tablet_id);
         if (tablet.has_value() && tablet.value()->set_tablet_schema_into_rowset_meta()) {
             RETURN_IF_ERROR(TabletMetaManager::save(this, tablet.value()->tablet_id(),
                                                     tablet.value()->schema_hash(), tablet.value()->tablet_meta()));
@@ -523,7 +523,7 @@ Status DataDir::load() {
     // ignore any errors when load tablet or rowset, because fe will repair them after report
     int64_t invalid_rowset_counter = 0;
     for (auto&& rowset_meta : dir_rowset_metas) {
-        auto tablet = _engine.tablet_manager()->get_tablet_temp(rowset_meta->tablet_id());
+        auto tablet = _engine.tablet_manager()->get_tablet(rowset_meta->tablet_id());
         // tablet maybe dropped, but not drop related rowset meta
         if (!tablet.has_value()) {
             VLOG_NOTICE << "could not find tablet id: " << rowset_meta->tablet_id()
@@ -611,7 +611,7 @@ Status DataDir::load() {
     auto load_delete_bitmap_func = [this, &dbm_cnt, &unknown_dbm_cnt](int64_t tablet_id,
                                                                       int64_t version,
                                                                       std::string_view val) {
-        auto tablet = _engine.tablet_manager()->get_tablet_temp(tablet_id);
+        auto tablet = _engine.tablet_manager()->get_tablet(tablet_id);
         if (!tablet.has_value()) {
             return true;
         }
@@ -685,7 +685,7 @@ void DataDir::_perform_tablet_gc(const std::string& tablet_schema_hash_path, int
         return;
     }
 
-    auto tablet = _engine.tablet_manager()->get_tablet_temp(tablet_id);
+    auto tablet = _engine.tablet_manager()->get_tablet(tablet_id);
     if (!tablet || tablet.value()->data_dir() != this) {
         if (tablet) {
             LOG(INFO) << "The tablet in path " << tablet_schema_hash_path
@@ -715,7 +715,7 @@ void DataDir::_perform_rowset_gc(const std::string& tablet_schema_hash_path) {
         return;
     }
 
-    auto tablet = _engine.tablet_manager()->get_tablet_temp(tablet_id);
+    auto tablet = _engine.tablet_manager()->get_tablet(tablet_id);
     if (!tablet) {
         // Could not found the tablet, maybe it's a dropped tablet, will be reclaimed
         // in the next time `_perform_path_gc_by_tablet`

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -475,10 +475,10 @@ Status DataDir::load() {
     }
 
     for (int64_t tablet_id : tablet_ids) {
-        TabletSharedPtr tablet = _engine.tablet_manager()->get_tablet(tablet_id);
-        if (tablet && tablet->set_tablet_schema_into_rowset_meta()) {
-            RETURN_IF_ERROR(TabletMetaManager::save(this, tablet->tablet_id(),
-                                                    tablet->schema_hash(), tablet->tablet_meta()));
+        auto tablet = _engine.tablet_manager()->get_tablet_temp(tablet_id);
+        if (tablet.has_value() && tablet.value()->set_tablet_schema_into_rowset_meta()) {
+            RETURN_IF_ERROR(TabletMetaManager::save(this, tablet.value()->tablet_id(),
+                                                    tablet.value()->schema_hash(), tablet.value()->tablet_meta()));
         }
     }
 
@@ -523,9 +523,9 @@ Status DataDir::load() {
     // ignore any errors when load tablet or rowset, because fe will repair them after report
     int64_t invalid_rowset_counter = 0;
     for (auto&& rowset_meta : dir_rowset_metas) {
-        TabletSharedPtr tablet = _engine.tablet_manager()->get_tablet(rowset_meta->tablet_id());
+        auto tablet = _engine.tablet_manager()->get_tablet_temp(rowset_meta->tablet_id());
         // tablet maybe dropped, but not drop related rowset meta
-        if (tablet == nullptr) {
+        if (!tablet.has_value()) {
             VLOG_NOTICE << "could not find tablet id: " << rowset_meta->tablet_id()
                         << ", schema hash: " << rowset_meta->tablet_schema_hash()
                         << ", for rowset: " << rowset_meta->rowset_id() << ", skip this rowset";
@@ -534,14 +534,14 @@ Status DataDir::load() {
         }
 
         if (rowset_meta->partition_id() == 0) {
-            LOG(WARNING) << "skip tablet_id=" << tablet->tablet_id()
+            LOG(WARNING) << "skip tablet_id=" << tablet.value()->tablet_id()
                          << " rowset: " << rowset_meta->rowset_id()
                          << " txn: " << rowset_meta->txn_id();
             continue;
         }
 
         RowsetSharedPtr rowset;
-        Status create_status = tablet->create_rowset(rowset_meta, &rowset);
+        Status create_status = tablet.value()->create_rowset(rowset_meta, &rowset);
         if (!create_status) {
             LOG(WARNING) << "could not create rowset from rowsetmeta: "
                          << " rowset_id: " << rowset_meta->rowset_id()
@@ -550,9 +550,9 @@ Status DataDir::load() {
             continue;
         }
         if (rowset_meta->rowset_state() == RowsetStatePB::COMMITTED &&
-            rowset_meta->tablet_uid() == tablet->tablet_uid()) {
+            rowset_meta->tablet_uid() == tablet.value()->tablet_uid()) {
             if (!rowset_meta->tablet_schema()) {
-                rowset_meta->set_tablet_schema(tablet->tablet_schema());
+                rowset_meta->set_tablet_schema(tablet.value()->tablet_schema());
                 RETURN_IF_ERROR(RowsetMetaManager::save(_meta, rowset_meta->tablet_uid(),
                                                         rowset_meta->rowset_id(),
                                                         rowset_meta->get_rowset_pb(), false));
@@ -580,14 +580,14 @@ Status DataDir::load() {
                              << " error: " << commit_txn_status;
             }
         } else if (rowset_meta->rowset_state() == RowsetStatePB::VISIBLE &&
-                   rowset_meta->tablet_uid() == tablet->tablet_uid()) {
+                   rowset_meta->tablet_uid() == tablet.value()->tablet_uid()) {
             if (!rowset_meta->tablet_schema()) {
-                rowset_meta->set_tablet_schema(tablet->tablet_schema());
+                rowset_meta->set_tablet_schema(tablet.value()->tablet_schema());
                 RETURN_IF_ERROR(RowsetMetaManager::save(_meta, rowset_meta->tablet_uid(),
                                                         rowset_meta->rowset_id(),
                                                         rowset_meta->get_rowset_pb(), false));
             }
-            Status publish_status = tablet->add_rowset(rowset);
+            Status publish_status = tablet.value()->add_rowset(rowset);
             if (!publish_status && !publish_status.is<PUSH_VERSION_ALREADY_EXIST>()) {
                 LOG(WARNING) << "add visible rowset to tablet failed rowset_id:"
                              << rowset->rowset_id() << " tablet id: " << rowset_meta->tablet_id()
@@ -601,7 +601,7 @@ Status DataDir::load() {
                          << " tablet uid: " << rowset_meta->tablet_uid()
                          << " schema hash: " << rowset_meta->tablet_schema_hash()
                          << " txn: " << rowset_meta->txn_id()
-                         << " current valid tablet uid: " << tablet->tablet_uid();
+                         << " current valid tablet uid: " << tablet.value()->tablet_uid();
             ++invalid_rowset_counter;
         }
     }
@@ -611,11 +611,11 @@ Status DataDir::load() {
     auto load_delete_bitmap_func = [this, &dbm_cnt, &unknown_dbm_cnt](int64_t tablet_id,
                                                                       int64_t version,
                                                                       std::string_view val) {
-        TabletSharedPtr tablet = _engine.tablet_manager()->get_tablet(tablet_id);
-        if (!tablet) {
+        auto tablet = _engine.tablet_manager()->get_tablet_temp(tablet_id);
+        if (!tablet.has_value()) {
             return true;
         }
-        const auto& all_rowsets = tablet->tablet_meta()->all_rs_metas();
+        const auto& all_rowsets = tablet.value()->tablet_meta()->all_rs_metas();
         RowsetIdUnorderedSet rowset_ids;
         for (const auto& [_, rowset_meta] : all_rowsets) {
             rowset_ids.insert(rowset_meta->rowset_id());
@@ -638,14 +638,14 @@ Status DataDir::load() {
             }
             ++dbm_cnt;
             auto seg_id = delete_bitmap_pb.segment_ids(i);
-            auto iter = tablet->tablet_meta()->delete_bitmap().delete_bitmap.find(
+            auto iter = tablet.value()->tablet_meta()->delete_bitmap().delete_bitmap.find(
                     {rst_id, seg_id, version});
             // This version of delete bitmap already exists
-            if (iter != tablet->tablet_meta()->delete_bitmap().delete_bitmap.end()) {
+            if (iter != tablet.value()->tablet_meta()->delete_bitmap().delete_bitmap.end()) {
                 continue;
             }
             auto bitmap = delete_bitmap_pb.segment_delete_bitmaps(i).data();
-            tablet->tablet_meta()->delete_bitmap().delete_bitmap[{rst_id, seg_id, version}] =
+            tablet.value()->tablet_meta()->delete_bitmap().delete_bitmap[{rst_id, seg_id, version}] =
                     roaring::Roaring::read(bitmap);
         }
         return true;
@@ -685,11 +685,11 @@ void DataDir::_perform_tablet_gc(const std::string& tablet_schema_hash_path, int
         return;
     }
 
-    auto tablet = _engine.tablet_manager()->get_tablet(tablet_id);
-    if (!tablet || tablet->data_dir() != this) {
+    auto tablet = _engine.tablet_manager()->get_tablet_temp(tablet_id);
+    if (!tablet || tablet.value()->data_dir() != this) {
         if (tablet) {
             LOG(INFO) << "The tablet in path " << tablet_schema_hash_path
-                      << " is not same with the running one: " << tablet->tablet_path()
+                      << " is not same with the running one: " << tablet.value()->tablet_path()
                       << ", might be the old tablet after migration, try to move it to trash";
         }
         _engine.tablet_manager()->try_delete_unused_tablet_path(this, tablet_id, schema_hash,
@@ -715,14 +715,14 @@ void DataDir::_perform_rowset_gc(const std::string& tablet_schema_hash_path) {
         return;
     }
 
-    auto tablet = _engine.tablet_manager()->get_tablet(tablet_id);
+    auto tablet = _engine.tablet_manager()->get_tablet_temp(tablet_id);
     if (!tablet) {
         // Could not found the tablet, maybe it's a dropped tablet, will be reclaimed
         // in the next time `_perform_path_gc_by_tablet`
         return;
     }
 
-    if (tablet->data_dir() != this) {
+    if (tablet.value()->data_dir() != this) {
         // Current running tablet is not in same data_dir, maybe it's a tablet after migration,
         // will be reclaimed in the next time `_perform_path_gc_by_tablet`
         return;
@@ -753,7 +753,7 @@ void DataDir::_perform_rowset_gc(const std::string& tablet_schema_hash_path) {
     }
 
     RowsetIdUnorderedSet rowsets_in_version_map;
-    tablet->traverse_rowsets(
+    tablet.value()->traverse_rowsets(
             [&rowsets_in_version_map](auto& rs) { rowsets_in_version_map.insert(rs->rowset_id()); },
             true);
 
@@ -777,7 +777,7 @@ void DataDir::_perform_rowset_gc(const std::string& tablet_schema_hash_path) {
     auto should_reclaim = [&, this](const RowsetId& rowset_id) {
         return !rowsets_in_version_map.contains(rowset_id) &&
                !_engine.check_rowset_id_in_unused_rowsets(rowset_id) &&
-               RowsetMetaManager::exists(get_meta(), tablet->tablet_uid(), rowset_id)
+               RowsetMetaManager::exists(get_meta(), tablet.value()->tablet_uid(), rowset_id)
                        .is<META_KEY_NOT_FOUND>();
     };
 

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -814,7 +814,7 @@ void StorageEngine::_update_replica_infos_callback() {
             std::unique_lock<std::mutex> lock(_peer_replica_infos_mutex);
             for (const auto& it : result.tablet_replica_infos) {
                 auto tablet_id = it.first;
-                auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+                auto tablet = _tablet_manager->get_tablet(tablet_id);
                 if (tablet == nullptr) {
                     VLOG_CRITICAL << "tablet ptr is nullptr";
                     continue;
@@ -902,7 +902,7 @@ Status StorageEngine::_submit_single_replica_compaction_task(TabletSharedPtr tab
 
 void StorageEngine::get_tablet_rowset_versions(const PGetTabletVersionsRequest* request,
                                                PGetTabletVersionsResponse* response) {
-    auto tablet = _tablet_manager->get_tablet_temp(request->tablet_id());
+    auto tablet = _tablet_manager->get_tablet(request->tablet_id());
     if (!tablet.has_value()) {
         response->mutable_status()->set_status_code(TStatusCode::CANCELLED);
         return;
@@ -1327,7 +1327,7 @@ Status StorageEngine::submit_seg_compaction_task(std::shared_ptr<SegcompactionWo
 
 Status StorageEngine::process_index_change_task(const TAlterInvertedIndexReq& request) {
     auto tablet_id = request.tablet_id;
-    auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+    auto tablet = _tablet_manager->get_tablet(tablet_id);
     DBUG_EXECUTE_IF("StorageEngine::process_index_change_task_tablet_error",
                     { tablet = ResultError(Status::InternalError("get tablet error")); })
     if (!tablet.has_value()) {
@@ -1725,7 +1725,7 @@ void StorageEngine::add_async_publish_task(int64_t partition_id, int64_t tablet_
         if (exists) {
             return;
         }
-        auto tablet = tablet_manager()->get_tablet_temp(tablet_id);
+        auto tablet = tablet_manager()->get_tablet(tablet_id);
         if (!tablet.has_value()) {
             LOG(INFO) << "tablet may be dropped when add async publish task, tablet_id: "
                       << tablet_id;
@@ -1770,7 +1770,7 @@ void StorageEngine::_process_async_publish() {
                 continue;
             }
             int64_t tablet_id = tablet_iter->first;
-            auto tablet = tablet_manager()->get_tablet_temp(tablet_id);
+            auto tablet = tablet_manager()->get_tablet(tablet_id);
             if (!tablet.has_value()) {
                 LOG(WARNING) << "tablet does not exist when async publush, tablet_id: "
                              << tablet_id;

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -1335,8 +1335,9 @@ Status StorageEngine::process_index_change_task(const TAlterInvertedIndexReq& re
         return Status::InternalError("tablet not exist, tablet_id={}.", tablet_id);
     }
 
-    IndexBuilderSharedPtr index_builder = std::make_shared<IndexBuilder>(
-            *this, tablet.value(), request.columns, request.alter_inverted_indexes, request.is_drop_op);
+    IndexBuilderSharedPtr index_builder =
+            std::make_shared<IndexBuilder>(*this, tablet.value(), request.columns,
+                                           request.alter_inverted_indexes, request.is_drop_op);
     RETURN_IF_ERROR(_handle_index_change(index_builder));
     return Status::OK();
 }

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -814,7 +814,7 @@ void StorageEngine::_update_replica_infos_callback() {
             std::unique_lock<std::mutex> lock(_peer_replica_infos_mutex);
             for (const auto& it : result.tablet_replica_infos) {
                 auto tablet_id = it.first;
-                auto tablet = _tablet_manager->get_tablet(tablet_id);
+                auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
                 if (tablet == nullptr) {
                     VLOG_CRITICAL << "tablet ptr is nullptr";
                     continue;
@@ -902,12 +902,12 @@ Status StorageEngine::_submit_single_replica_compaction_task(TabletSharedPtr tab
 
 void StorageEngine::get_tablet_rowset_versions(const PGetTabletVersionsRequest* request,
                                                PGetTabletVersionsResponse* response) {
-    TabletSharedPtr tablet = _tablet_manager->get_tablet(request->tablet_id());
-    if (tablet == nullptr) {
+    auto tablet = _tablet_manager->get_tablet_temp(request->tablet_id());
+    if (!tablet.has_value()) {
         response->mutable_status()->set_status_code(TStatusCode::CANCELLED);
         return;
     }
-    std::vector<Version> local_versions = tablet->get_all_local_versions();
+    std::vector<Version> local_versions = tablet.value()->get_all_local_versions();
     for (const auto& local_version : local_versions) {
         auto version = response->add_versions();
         version->set_first(local_version.first);
@@ -1327,16 +1327,16 @@ Status StorageEngine::submit_seg_compaction_task(std::shared_ptr<SegcompactionWo
 
 Status StorageEngine::process_index_change_task(const TAlterInvertedIndexReq& request) {
     auto tablet_id = request.tablet_id;
-    TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_id);
-    DBUG_EXECUTE_IF("StorageEngine::process_index_change_task_tablet_nullptr",
-                    { tablet = nullptr; })
-    if (tablet == nullptr) {
+    auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+    DBUG_EXECUTE_IF("StorageEngine::process_index_change_task_tablet_error",
+                    { tablet = ResultError(Status::InternalError("get tablet error")); })
+    if (!tablet.has_value()) {
         LOG(WARNING) << "tablet: " << tablet_id << " not exist";
         return Status::InternalError("tablet not exist, tablet_id={}.", tablet_id);
     }
 
     IndexBuilderSharedPtr index_builder = std::make_shared<IndexBuilder>(
-            *this, tablet, request.columns, request.alter_inverted_indexes, request.is_drop_op);
+            *this, tablet.value(), request.columns, request.alter_inverted_indexes, request.is_drop_op);
     RETURN_IF_ERROR(_handle_index_change(index_builder));
     return Status::OK();
 }
@@ -1725,8 +1725,8 @@ void StorageEngine::add_async_publish_task(int64_t partition_id, int64_t tablet_
         if (exists) {
             return;
         }
-        TabletSharedPtr tablet = tablet_manager()->get_tablet(tablet_id);
-        if (tablet == nullptr) {
+        auto tablet = tablet_manager()->get_tablet_temp(tablet_id);
+        if (!tablet.has_value()) {
             LOG(INFO) << "tablet may be dropped when add async publish task, tablet_id: "
                       << tablet_id;
             return;
@@ -1736,7 +1736,7 @@ void StorageEngine::add_async_publish_task(int64_t partition_id, int64_t tablet_
         pending_publish_info_pb.set_transaction_id(transaction_id);
         pending_publish_info_pb.set_commit_tso(commit_tso);
         static_cast<void>(TabletMetaManager::save_pending_publish_info(
-                tablet->data_dir(), tablet->tablet_id(), publish_version,
+                tablet.value()->data_dir(), tablet.value()->tablet_id(), publish_version,
                 pending_publish_info_pb.SerializeAsString()));
     }
     LOG(INFO) << "add pending publish task, tablet_id: " << tablet_id
@@ -1770,8 +1770,8 @@ void StorageEngine::_process_async_publish() {
                 continue;
             }
             int64_t tablet_id = tablet_iter->first;
-            TabletSharedPtr tablet = tablet_manager()->get_tablet(tablet_id);
-            if (!tablet) {
+            auto tablet = tablet_manager()->get_tablet_temp(tablet_id);
+            if (!tablet.has_value()) {
                 LOG(WARNING) << "tablet does not exist when async publush, tablet_id: "
                              << tablet_id;
                 tablet_iter = _async_publish_tasks.erase(tablet_iter);
@@ -1783,19 +1783,19 @@ void StorageEngine::_process_async_publish() {
             int64_t transaction_id = std::get<0>(task_iter->second);
             int64_t partition_id = std::get<1>(task_iter->second);
             int64_t commit_tso = std::get<2>(task_iter->second);
-            int64_t max_version = tablet->max_version().second;
+            int64_t max_version = tablet.value()->max_version().second;
 
             if (version <= max_version) {
-                need_removed_tasks.emplace_back(tablet, version);
+                need_removed_tasks.emplace_back(tablet.value(), version);
                 tablet_iter->second.erase(task_iter);
                 tablet_iter++;
                 continue;
             }
             if (version != max_version + 1) {
-                int32_t max_version_config = tablet->max_version_config();
+                int32_t max_version_config = tablet.value()->max_version_config();
                 // Keep only the most recent versions
                 while (tablet_iter->second.size() > max_version_config) {
-                    need_removed_tasks.emplace_back(tablet, version);
+                    need_removed_tasks.emplace_back(tablet.value(), version);
                     task_iter = tablet_iter->second.erase(task_iter);
                     version = task_iter->first;
                 }
@@ -1804,11 +1804,11 @@ void StorageEngine::_process_async_publish() {
             }
 
             auto async_publish_task = std::make_shared<AsyncTabletPublishTask>(
-                    *this, tablet, partition_id, transaction_id, version, commit_tso);
+                    *this, tablet.value(), partition_id, transaction_id, version, commit_tso);
             static_cast<void>(_tablet_publish_txn_thread_pool->submit_func(
                     [=]() { async_publish_task->handle(); }));
             tablet_iter->second.erase(task_iter);
-            need_removed_tasks.emplace_back(tablet, version);
+            need_removed_tasks.emplace_back(tablet.value(), version);
             tablet_iter++;
         }
     }

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -815,7 +815,7 @@ void StorageEngine::_update_replica_infos_callback() {
             for (const auto& it : result.tablet_replica_infos) {
                 auto tablet_id = it.first;
                 auto tablet = _tablet_manager->get_tablet(tablet_id);
-                if (tablet == nullptr) {
+                if (!tablet.has_value()) {
                     VLOG_CRITICAL << "tablet ptr is nullptr";
                     continue;
                 }

--- a/be/src/storage/schema_change/schema_change.cpp
+++ b/be/src/storage/schema_change/schema_change.cpp
@@ -810,11 +810,11 @@ Status SchemaChangeJob::process_alter_tablet(const TAlterTabletReqV2& request) {
                 "desc_tbl is not set. Maybe the FE version is not equal to the BE "
                 "version.");
     }
-    if (_base_tablet == nullptr) {
+    if (!_base_tablet.has_value()) {
         return Status::Error<TABLE_NOT_FOUND>("fail to find base tablet. base_tablet={}",
                                               request.base_tablet_id);
     }
-    if (_new_tablet == nullptr) {
+    if (!_new_tablet.has_value()) {
         return Status::Error<TABLE_NOT_FOUND>("fail to find new tablet. new_tablet={}",
                                               request.new_tablet_id);
     }

--- a/be/src/storage/schema_change/schema_change.cpp
+++ b/be/src/storage/schema_change/schema_change.cpp
@@ -825,7 +825,8 @@ Status SchemaChangeJob::process_alter_tablet(const TAlterTabletReqV2& request) {
 
     // Lock schema_change_lock util schema change info is stored in tablet header
     static constexpr long TRY_LOCK_TIMEOUT = 30;
-    std::unique_lock schema_change_lock(_base_tablet.value()->get_schema_change_lock(), std::defer_lock);
+    std::unique_lock schema_change_lock(_base_tablet.value()->get_schema_change_lock(),
+                                        std::defer_lock);
     bool owns_lock = schema_change_lock.try_lock_for(std::chrono::seconds(TRY_LOCK_TIMEOUT));
 
     if (!owns_lock) {
@@ -848,7 +849,8 @@ SchemaChangeJob::SchemaChangeJob(StorageEngine& local_storage_engine,
     _new_tablet = _local_storage_engine.tablet_manager()->get_tablet(request.new_tablet_id);
     if (_base_tablet.has_value() && _new_tablet.has_value()) {
         _base_tablet_schema = std::make_shared<TabletSchema>();
-        _base_tablet_schema->update_tablet_columns(*_base_tablet.value()->tablet_schema(), request.columns);
+        _base_tablet_schema->update_tablet_columns(*_base_tablet.value()->tablet_schema(),
+                                                   request.columns);
         // The request only include column info, do not include bitmap or bloomfilter index info,
         // So we also need to copy index info from the real base tablet
         _base_tablet_schema->update_index_info_from(*_base_tablet.value()->tablet_schema());
@@ -856,7 +858,8 @@ SchemaChangeJob::SchemaChangeJob(StorageEngine& local_storage_engine,
         // This is because the schema change for a variant needs to ignore the extracted columns.
         // Otherwise, the schema types in different rowsets might be inconsistent. When performing a schema change,
         // the complete variant is constructed by reading all the sub-columns of the variant.
-        _new_tablet_schema = _new_tablet.value()->tablet_schema()->copy_without_variant_extracted_columns();
+        _new_tablet_schema =
+                _new_tablet.value()->tablet_schema()->copy_without_variant_extracted_columns();
     }
     _job_id = job_id;
 }
@@ -893,12 +896,14 @@ Status SchemaChangeJob::_do_process_alter_tablet(const TAlterTabletReqV2& reques
               << " base_tablet=" << _base_tablet.value()->tablet_id()
               << " new_tablet=" << _new_tablet.value()->tablet_id();
 
-    std::shared_lock base_migration_rlock(_base_tablet.value()->get_migration_lock(), std::try_to_lock);
+    std::shared_lock base_migration_rlock(_base_tablet.value()->get_migration_lock(),
+                                          std::try_to_lock);
     if (!base_migration_rlock.owns_lock()) {
         return Status::Error<TRY_LOCK_FAILED>(
                 "SchemaChangeJob::_do_process_alter_tablet get lock failed");
     }
-    std::shared_lock new_migration_rlock(_new_tablet.value()->get_migration_lock(), std::try_to_lock);
+    std::shared_lock new_migration_rlock(_new_tablet.value()->get_migration_lock(),
+                                         std::try_to_lock);
     if (!new_migration_rlock.owns_lock()) {
         return Status::Error<TRY_LOCK_FAILED>(
                 "SchemaChangeJob::_do_process_alter_tablet get lock failed");
@@ -1028,8 +1033,8 @@ Status SchemaChangeJob::_do_process_alter_tablet(const TAlterTabletReqV2& reques
             }
 
             // acquire data sources correspond to history versions
-            RETURN_IF_ERROR(
-                    _base_tablet.value()->capture_rs_readers_unlocked(versions_to_be_changed, &rs_splits));
+            RETURN_IF_ERROR(_base_tablet.value()->capture_rs_readers_unlocked(
+                    versions_to_be_changed, &rs_splits));
             if (rs_splits.empty()) {
                 res = Status::Error<ALTER_DELTA_DOES_NOT_EXISTS>(
                         "fail to acquire all data sources. version_num={}, data_source_num={}",
@@ -1048,7 +1053,8 @@ Status SchemaChangeJob::_do_process_alter_tablet(const TAlterTabletReqV2& reques
             res = delete_handler.init(_base_tablet_schema, del_preds, end_version);
             if (!res) {
                 LOG(WARNING) << "init delete handler failed. base_tablet="
-                             << _base_tablet.value()->tablet_id() << ", end_version=" << end_version;
+                             << _base_tablet.value()->tablet_id()
+                             << ", end_version=" << end_version;
                 break;
             }
 
@@ -1073,7 +1079,8 @@ Status SchemaChangeJob::_do_process_alter_tablet(const TAlterTabletReqV2& reques
             for (auto& rs_split : rs_splits) {
                 res = rs_split.rs_reader->init(&reader_context);
                 if (!res) {
-                    LOG(WARNING) << "failed to init rowset reader: " << _base_tablet.value()->tablet_id();
+                    LOG(WARNING) << "failed to init rowset reader: "
+                                 << _base_tablet.value()->tablet_id();
                     break;
                 }
             }
@@ -1224,7 +1231,8 @@ Status SchemaChangeJob::_convert_historical_rowsets(const SchemaChangeParams& sc
     Status res = parse_request(sc_params, _base_tablet_schema.get(), _new_tablet_schema.get(),
                                &changer, &sc_sorting, &sc_directly);
     LOG(INFO) << "schema change type, sc_sorting: " << sc_sorting
-              << ", sc_directly: " << sc_directly << ", base_tablet=" << _base_tablet.value()->tablet_id()
+              << ", sc_directly: " << sc_directly
+              << ", base_tablet=" << _base_tablet.value()->tablet_id()
               << ", new_tablet=" << _new_tablet.value()->tablet_id();
 
     auto process_alter_exit = [&]() -> Status {
@@ -1303,8 +1311,9 @@ Status SchemaChangeJob::_convert_historical_rowsets(const SchemaChangeParams& sc
         auto rowset_writer = std::move(result).value();
         auto pending_rs_guard = _local_storage_engine.add_pending_rowset(context);
 
-        if (res = sc_procedure->process(rs_reader, rowset_writer.get(), _new_tablet.value(), _base_tablet.value(),
-                                        _base_tablet_schema, _new_tablet_schema);
+        if (res = sc_procedure->process(rs_reader, rowset_writer.get(), _new_tablet.value(),
+                                        _base_tablet.value(), _base_tablet_schema,
+                                        _new_tablet_schema);
             !res) {
             LOG(WARNING) << "failed to process the version."
                          << " version=" << rs_reader->version().first << "-"

--- a/be/src/storage/schema_change/schema_change.cpp
+++ b/be/src/storage/schema_change/schema_change.cpp
@@ -825,7 +825,7 @@ Status SchemaChangeJob::process_alter_tablet(const TAlterTabletReqV2& request) {
 
     // Lock schema_change_lock util schema change info is stored in tablet header
     static constexpr long TRY_LOCK_TIMEOUT = 30;
-    std::unique_lock schema_change_lock(_base_tablet->get_schema_change_lock(), std::defer_lock);
+    std::unique_lock schema_change_lock(_base_tablet.value()->get_schema_change_lock(), std::defer_lock);
     bool owns_lock = schema_change_lock.try_lock_for(std::chrono::seconds(TRY_LOCK_TIMEOUT));
 
     if (!owns_lock) {
@@ -844,19 +844,19 @@ Status SchemaChangeJob::process_alter_tablet(const TAlterTabletReqV2& request) {
 SchemaChangeJob::SchemaChangeJob(StorageEngine& local_storage_engine,
                                  const TAlterTabletReqV2& request, const std::string& job_id)
         : _local_storage_engine(local_storage_engine) {
-    _base_tablet = _local_storage_engine.tablet_manager()->get_tablet(request.base_tablet_id);
-    _new_tablet = _local_storage_engine.tablet_manager()->get_tablet(request.new_tablet_id);
-    if (_base_tablet && _new_tablet) {
+    _base_tablet = _local_storage_engine.tablet_manager()->get_tablet_temp(request.base_tablet_id);
+    _new_tablet = _local_storage_engine.tablet_manager()->get_tablet_temp(request.new_tablet_id);
+    if (_base_tablet.has_value() && _new_tablet.has_value()) {
         _base_tablet_schema = std::make_shared<TabletSchema>();
-        _base_tablet_schema->update_tablet_columns(*_base_tablet->tablet_schema(), request.columns);
+        _base_tablet_schema->update_tablet_columns(*_base_tablet.value()->tablet_schema(), request.columns);
         // The request only include column info, do not include bitmap or bloomfilter index info,
         // So we also need to copy index info from the real base tablet
-        _base_tablet_schema->update_index_info_from(*_base_tablet->tablet_schema());
+        _base_tablet_schema->update_index_info_from(*_base_tablet.value()->tablet_schema());
         // During a schema change, the extracted columns of a variant should not be included in the tablet schema.
         // This is because the schema change for a variant needs to ignore the extracted columns.
         // Otherwise, the schema types in different rowsets might be inconsistent. When performing a schema change,
         // the complete variant is constructed by reading all the sub-columns of the variant.
-        _new_tablet_schema = _new_tablet->tablet_schema()->copy_without_variant_extracted_columns();
+        _new_tablet_schema = _new_tablet.value()->tablet_schema()->copy_without_variant_extracted_columns();
     }
     _job_id = job_id;
 }
@@ -869,36 +869,36 @@ SchemaChangeJob::SchemaChangeJob(StorageEngine& local_storage_engine,
 Status SchemaChangeJob::_do_process_alter_tablet(const TAlterTabletReqV2& request) {
     DBUG_EXECUTE_IF("SchemaChangeJob._do_process_alter_tablet.sleep", { sleep(10); })
     Status res;
-    signal::tablet_id = _base_tablet->get_table_id();
+    signal::tablet_id = _base_tablet.value()->get_table_id();
 
     // check if tablet's state is not_ready, if it is ready, it means the tablet already finished
     // check whether the tablet's max continuous version == request.version
-    if (_new_tablet->tablet_state() != TABLET_NOTREADY) {
+    if (_new_tablet.value()->tablet_state() != TABLET_NOTREADY) {
         res = _validate_alter_result(request);
-        LOG(INFO) << "tablet's state=" << _new_tablet->tablet_state()
+        LOG(INFO) << "tablet's state=" << _new_tablet.value()->tablet_state()
                   << " the convert job already finished, check its version"
                   << " res=" << res;
         return res;
     }
-    _new_tablet->set_alter_failed(false);
+    _new_tablet.value()->set_alter_failed(false);
     Defer defer([this] {
         // if tablet state is not TABLET_RUNNING when return, indicates that alter has failed.
-        if (_new_tablet->tablet_state() != TABLET_RUNNING) {
-            _new_tablet->set_alter_failed(true);
+        if (_new_tablet.value()->tablet_state() != TABLET_RUNNING) {
+            _new_tablet.value()->set_alter_failed(true);
         }
     });
 
     LOG(INFO) << "finish to validate alter tablet request. begin to convert data from base tablet "
                  "to new tablet"
-              << " base_tablet=" << _base_tablet->tablet_id()
-              << " new_tablet=" << _new_tablet->tablet_id();
+              << " base_tablet=" << _base_tablet.value()->tablet_id()
+              << " new_tablet=" << _new_tablet.value()->tablet_id();
 
-    std::shared_lock base_migration_rlock(_base_tablet->get_migration_lock(), std::try_to_lock);
+    std::shared_lock base_migration_rlock(_base_tablet.value()->get_migration_lock(), std::try_to_lock);
     if (!base_migration_rlock.owns_lock()) {
         return Status::Error<TRY_LOCK_FAILED>(
                 "SchemaChangeJob::_do_process_alter_tablet get lock failed");
     }
-    std::shared_lock new_migration_rlock(_new_tablet->get_migration_lock(), std::try_to_lock);
+    std::shared_lock new_migration_rlock(_new_tablet.value()->get_migration_lock(), std::try_to_lock);
     if (!new_migration_rlock.owns_lock()) {
         return Status::Error<TRY_LOCK_FAILED>(
                 "SchemaChangeJob::_do_process_alter_tablet get lock failed");
@@ -952,11 +952,11 @@ Status SchemaChangeJob::_do_process_alter_tablet(const TAlterTabletReqV2& reques
     // begin to find deltas to convert from base tablet to new tablet so that
     // obtain base tablet and new tablet's push lock and header write lock to prevent loading data
     {
-        std::lock_guard base_tablet_lock(_base_tablet->get_push_lock());
-        std::lock_guard new_tablet_lock(_new_tablet->get_push_lock());
-        std::lock_guard base_tablet_wlock(_base_tablet->get_header_lock());
+        std::lock_guard base_tablet_lock(_base_tablet.value()->get_push_lock());
+        std::lock_guard new_tablet_lock(_new_tablet.value()->get_push_lock());
+        std::lock_guard base_tablet_wlock(_base_tablet.value()->get_header_lock());
         SCOPED_SIMPLE_TRACE_IF_TIMEOUT(TRACE_TABLET_LOCK_THRESHOLD);
-        std::lock_guard<std::shared_mutex> new_tablet_wlock(_new_tablet->get_header_lock());
+        std::lock_guard<std::shared_mutex> new_tablet_wlock(_new_tablet.value()->get_header_lock());
 
         do {
             RowsetSharedPtr max_rowset;
@@ -987,11 +987,11 @@ Status SchemaChangeJob::_do_process_alter_tablet(const TAlterTabletReqV2& reques
             // remove all data from new tablet, prevent to rewrite data(those double pushed when wait)
             LOG(INFO) << "begin to remove all data before end version from new tablet to prevent "
                          "rewrite."
-                      << " new_tablet=" << _new_tablet->tablet_id()
+                      << " new_tablet=" << _new_tablet.value()->tablet_id()
                       << ", end_version=" << max_rowset->end_version();
             std::vector<RowsetSharedPtr> rowsets_to_delete;
             std::vector<std::pair<Version, RowsetSharedPtr>> version_rowsets;
-            _new_tablet->acquire_version_and_rowsets(&version_rowsets);
+            _new_tablet.value()->acquire_version_and_rowsets(&version_rowsets);
             std::sort(version_rowsets.begin(), version_rowsets.end(),
                       [](const std::pair<Version, RowsetSharedPtr>& l,
                          const std::pair<Version, RowsetSharedPtr>& r) {
@@ -1011,12 +1011,12 @@ Status SchemaChangeJob::_do_process_alter_tablet(const TAlterTabletReqV2& reques
                 }
             }
             std::vector<RowsetSharedPtr> empty_vec;
-            RETURN_IF_ERROR(_new_tablet->delete_rowsets(rowsets_to_delete, false));
+            RETURN_IF_ERROR(_new_tablet.value()->delete_rowsets(rowsets_to_delete, false));
             // inherit cumulative_layer_point from base_tablet
             // check if new_tablet.ce_point > base_tablet.ce_point?
-            _new_tablet->set_cumulative_layer_point(-1);
+            _new_tablet.value()->set_cumulative_layer_point(-1);
             // save tablet meta
-            _new_tablet->save_meta();
+            _new_tablet.value()->save_meta();
             for (auto& rowset : rowsets_to_delete) {
                 // do not call rowset.remove directly, using gc thread to delete it
                 _local_storage_engine.add_unused_rowset(rowset);
@@ -1029,7 +1029,7 @@ Status SchemaChangeJob::_do_process_alter_tablet(const TAlterTabletReqV2& reques
 
             // acquire data sources correspond to history versions
             RETURN_IF_ERROR(
-                    _base_tablet->capture_rs_readers_unlocked(versions_to_be_changed, &rs_splits));
+                    _base_tablet.value()->capture_rs_readers_unlocked(versions_to_be_changed, &rs_splits));
             if (rs_splits.empty()) {
                 res = Status::Error<ALTER_DELTA_DOES_NOT_EXISTS>(
                         "fail to acquire all data sources. version_num={}, data_source_num={}",
@@ -1048,7 +1048,7 @@ Status SchemaChangeJob::_do_process_alter_tablet(const TAlterTabletReqV2& reques
             res = delete_handler.init(_base_tablet_schema, del_preds, end_version);
             if (!res) {
                 LOG(WARNING) << "init delete handler failed. base_tablet="
-                             << _base_tablet->tablet_id() << ", end_version=" << end_version;
+                             << _base_tablet.value()->tablet_id() << ", end_version=" << end_version;
                 break;
             }
 
@@ -1058,9 +1058,9 @@ Status SchemaChangeJob::_do_process_alter_tablet(const TAlterTabletReqV2& reques
             reader_context.delete_handler = &delete_handler;
             reader_context.return_columns = &return_columns;
             reader_context.sequence_id_idx = reader_context.tablet_schema->sequence_col_idx();
-            reader_context.is_unique = _base_tablet->keys_type() == UNIQUE_KEYS;
+            reader_context.is_unique = _base_tablet.value()->keys_type() == UNIQUE_KEYS;
             reader_context.batch_size = ALTER_TABLE_BATCH_SIZE;
-            reader_context.delete_bitmap = _base_tablet->tablet_meta()->delete_bitmap_ptr();
+            reader_context.delete_bitmap = _base_tablet.value()->tablet_meta()->delete_bitmap_ptr();
             reader_context.version = Version(0, end_version);
             if (!_base_tablet_schema->cluster_key_uids().empty()) {
                 for (const auto& uid : _base_tablet_schema->cluster_key_uids()) {
@@ -1073,7 +1073,7 @@ Status SchemaChangeJob::_do_process_alter_tablet(const TAlterTabletReqV2& reques
             for (auto& rs_split : rs_splits) {
                 res = rs_split.rs_reader->init(&reader_context);
                 if (!res) {
-                    LOG(WARNING) << "failed to init rowset reader: " << _base_tablet->tablet_id();
+                    LOG(WARNING) << "failed to init rowset reader: " << _base_tablet.value()->tablet_id();
                     break;
                 }
             }
@@ -1128,15 +1128,15 @@ Status SchemaChangeJob::_do_process_alter_tablet(const TAlterTabletReqV2& reques
         }
         {
             std::lock_guard<std::shared_mutex> wrlock(_mutex);
-            _tablet_ids_in_converting.insert(_new_tablet->tablet_id());
+            _tablet_ids_in_converting.insert(_new_tablet.value()->tablet_id());
         }
         int64_t real_alter_version = 0;
         sc_params.enable_unique_key_merge_on_write =
-                _new_tablet->enable_unique_key_merge_on_write();
+                _new_tablet.value()->enable_unique_key_merge_on_write();
         res = _convert_historical_rowsets(sc_params, &real_alter_version);
         {
             std::lock_guard<std::shared_mutex> wrlock(_mutex);
-            _tablet_ids_in_converting.erase(_new_tablet->tablet_id());
+            _tablet_ids_in_converting.erase(_new_tablet.value()->tablet_id());
         }
         if (!res) {
             break;
@@ -1144,21 +1144,21 @@ Status SchemaChangeJob::_do_process_alter_tablet(const TAlterTabletReqV2& reques
 
         DCHECK_GE(real_alter_version, request.alter_version);
 
-        if (_new_tablet->keys_type() == UNIQUE_KEYS &&
-            _new_tablet->enable_unique_key_merge_on_write()) {
+        if (_new_tablet.value()->keys_type() == UNIQUE_KEYS &&
+            _new_tablet.value()->enable_unique_key_merge_on_write()) {
             res = _calc_delete_bitmap_for_mow_table(real_alter_version);
             if (!res) {
                 break;
             }
         } else {
             // set state to ready
-            std::lock_guard<std::shared_mutex> new_wlock(_new_tablet->get_header_lock());
+            std::lock_guard<std::shared_mutex> new_wlock(_new_tablet.value()->get_header_lock());
             SCOPED_SIMPLE_TRACE_IF_TIMEOUT(TRACE_TABLET_LOCK_THRESHOLD);
-            res = _new_tablet->set_tablet_state(TabletState::TABLET_RUNNING);
+            res = _new_tablet.value()->set_tablet_state(TabletState::TABLET_RUNNING);
             if (!res) {
                 break;
             }
-            _new_tablet->save_meta();
+            _new_tablet.value()->save_meta();
         }
     } while (false);
 
@@ -1170,8 +1170,8 @@ Status SchemaChangeJob::_do_process_alter_tablet(const TAlterTabletReqV2& reques
 
     // if failed convert history data, then just remove the new tablet
     if (!res) {
-        LOG(WARNING) << "failed to alter tablet. base_tablet=" << _base_tablet->tablet_id()
-                     << ", drop new_tablet=" << _new_tablet->tablet_id();
+        LOG(WARNING) << "failed to alter tablet. base_tablet=" << _base_tablet.value()->tablet_id()
+                     << ", drop new_tablet=" << _new_tablet.value()->tablet_id();
         // do not drop the new tablet and its data. GC thread will
     }
 
@@ -1185,14 +1185,14 @@ bool SchemaChangeJob::tablet_in_converting(int64_t tablet_id) {
 
 Status SchemaChangeJob::_get_versions_to_be_changed(std::vector<Version>* versions_to_be_changed,
                                                     RowsetSharedPtr* max_rowset) {
-    RowsetSharedPtr rowset = _base_tablet->get_rowset_with_max_version();
+    RowsetSharedPtr rowset = _base_tablet.value()->get_rowset_with_max_version();
     if (rowset == nullptr) {
         return Status::Error<ALTER_DELTA_DOES_NOT_EXISTS>("Tablet has no version. base_tablet={}",
-                                                          _base_tablet->tablet_id());
+                                                          _base_tablet.value()->tablet_id());
     }
     *max_rowset = rowset;
 
-    *versions_to_be_changed = DORIS_TRY(_base_tablet->capture_consistent_versions_unlocked(
+    *versions_to_be_changed = DORIS_TRY(_base_tablet.value()->capture_consistent_versions_unlocked(
             Version(0, rowset->version().second), {}));
     return Status::OK();
 }
@@ -1202,8 +1202,8 @@ Status SchemaChangeJob::_get_versions_to_be_changed(std::vector<Version>* versio
 Status SchemaChangeJob::_convert_historical_rowsets(const SchemaChangeParams& sc_params,
                                                     int64_t* real_alter_version) {
     LOG(INFO) << "begin to convert historical rowsets for new_tablet from base_tablet."
-              << " base_tablet=" << _base_tablet->tablet_id()
-              << ", new_tablet=" << _new_tablet->tablet_id() << ", job_id=" << _job_id;
+              << " base_tablet=" << _base_tablet.value()->tablet_id()
+              << ", new_tablet=" << _new_tablet.value()->tablet_id() << ", job_id=" << _job_id;
 
     // find end version
     int64_t end_version = -1;
@@ -1224,24 +1224,24 @@ Status SchemaChangeJob::_convert_historical_rowsets(const SchemaChangeParams& sc
     Status res = parse_request(sc_params, _base_tablet_schema.get(), _new_tablet_schema.get(),
                                &changer, &sc_sorting, &sc_directly);
     LOG(INFO) << "schema change type, sc_sorting: " << sc_sorting
-              << ", sc_directly: " << sc_directly << ", base_tablet=" << _base_tablet->tablet_id()
-              << ", new_tablet=" << _new_tablet->tablet_id();
+              << ", sc_directly: " << sc_directly << ", base_tablet=" << _base_tablet.value()->tablet_id()
+              << ", new_tablet=" << _new_tablet.value()->tablet_id();
 
     auto process_alter_exit = [&]() -> Status {
         {
             // save tablet meta here because rowset meta is not saved during add rowset
-            std::lock_guard new_wlock(_new_tablet->get_header_lock());
+            std::lock_guard new_wlock(_new_tablet.value()->get_header_lock());
             SCOPED_SIMPLE_TRACE_IF_TIMEOUT(TRACE_TABLET_LOCK_THRESHOLD);
-            _new_tablet->save_meta();
+            _new_tablet.value()->save_meta();
         }
         if (res) {
             Version test_version(0, end_version);
-            res = _new_tablet->check_version_integrity(test_version);
+            res = _new_tablet.value()->check_version_integrity(test_version);
         }
 
         LOG(INFO) << "finish converting rowsets for new_tablet from base_tablet. "
-                  << "base_tablet=" << _base_tablet->tablet_id()
-                  << ", new_tablet=" << _new_tablet->tablet_id();
+                  << "base_tablet=" << _base_tablet.value()->tablet_id()
+                  << ", new_tablet=" << _new_tablet.value()->tablet_id();
         return res;
     };
 
@@ -1290,11 +1290,11 @@ Status SchemaChangeJob::_convert_historical_rowsets(const SchemaChangeParams& sc
         context.write_type = DataWriteType::TYPE_SCHEMA_CHANGE;
         // TODO if support VerticalSegmentWriter, also need to handle cluster key primary key index
         bool vertical = false;
-        if (sc_sorting && !_new_tablet->tablet_schema()->cluster_key_uids().empty()) {
+        if (sc_sorting && !_new_tablet.value()->tablet_schema()->cluster_key_uids().empty()) {
             // see VBaseSchemaChangeWithSorting::_external_sorting
             vertical = true;
         }
-        auto result = _new_tablet->create_rowset_writer(context, vertical);
+        auto result = _new_tablet.value()->create_rowset_writer(context, vertical);
         if (!result.has_value()) {
             res = Status::Error<ROWSET_BUILDER_INIT>("create_rowset_writer failed, reason={}",
                                                      result.error().to_string());
@@ -1303,7 +1303,7 @@ Status SchemaChangeJob::_convert_historical_rowsets(const SchemaChangeParams& sc
         auto rowset_writer = std::move(result).value();
         auto pending_rs_guard = _local_storage_engine.add_pending_rowset(context);
 
-        if (res = sc_procedure->process(rs_reader, rowset_writer.get(), _new_tablet, _base_tablet,
+        if (res = sc_procedure->process(rs_reader, rowset_writer.get(), _new_tablet.value(), _base_tablet.value(),
                                         _base_tablet_schema, _new_tablet_schema);
             !res) {
             LOG(WARNING) << "failed to process the version."
@@ -1313,29 +1313,29 @@ Status SchemaChangeJob::_convert_historical_rowsets(const SchemaChangeParams& sc
         }
         // Add the new version of the data to the header
         // In order to prevent the occurrence of deadlock, we must first lock the old table, and then lock the new table
-        std::lock_guard lock(_new_tablet->get_push_lock());
+        std::lock_guard lock(_new_tablet.value()->get_push_lock());
         RowsetSharedPtr new_rowset;
         if (!(res = rowset_writer->build(new_rowset)).ok()) {
             LOG(WARNING) << "failed to build rowset, exit alter process";
             return process_alter_exit();
         }
-        res = _new_tablet->add_rowset(new_rowset);
+        res = _new_tablet.value()->add_rowset(new_rowset);
         if (res.is<PUSH_VERSION_ALREADY_EXIST>()) {
             LOG(WARNING) << "version already exist, version revert occurred. "
-                         << "tablet=" << _new_tablet->tablet_id() << ", version='"
+                         << "tablet=" << _new_tablet.value()->tablet_id() << ", version='"
                          << rs_reader->version().first << "-" << rs_reader->version().second;
             _local_storage_engine.add_unused_rowset(new_rowset);
             have_failure_rowset = true;
             res = Status::OK();
         } else if (!res) {
             LOG(WARNING) << "failed to register new version. "
-                         << " tablet=" << _new_tablet->tablet_id()
+                         << " tablet=" << _new_tablet.value()->tablet_id()
                          << ", version=" << rs_reader->version().first << "-"
                          << rs_reader->version().second;
             _local_storage_engine.add_unused_rowset(new_rowset);
             return process_alter_exit();
         } else {
-            VLOG_NOTICE << "register new version. tablet=" << _new_tablet->tablet_id()
+            VLOG_NOTICE << "register new version. tablet=" << _new_tablet.value()->tablet_id()
                         << ", version=" << rs_reader->version().first << "-"
                         << rs_reader->version().second;
         }
@@ -1550,8 +1550,8 @@ Status SchemaChangeJob::_init_column_mapping(ColumnMapping* column_mapping,
 
 Status SchemaChangeJob::_validate_alter_result(const TAlterTabletReqV2& request) {
     Version max_continuous_version = {-1, 0};
-    _new_tablet->max_continuous_version_from_beginning(&max_continuous_version);
-    LOG(INFO) << "find max continuous version of tablet=" << _new_tablet->tablet_id()
+    _new_tablet.value()->max_continuous_version_from_beginning(&max_continuous_version);
+    LOG(INFO) << "find max continuous version of tablet=" << _new_tablet.value()->tablet_id()
               << ", start_version=" << max_continuous_version.first
               << ", end_version=" << max_continuous_version.second;
     if (max_continuous_version.second < request.alter_version) {
@@ -1561,8 +1561,8 @@ Status SchemaChangeJob::_validate_alter_result(const TAlterTabletReqV2& request)
 
     std::vector<std::pair<Version, RowsetSharedPtr>> version_rowsets;
     {
-        std::shared_lock rdlock(_new_tablet->get_header_lock());
-        _new_tablet->acquire_version_and_rowsets(&version_rowsets);
+        std::shared_lock rdlock(_new_tablet.value()->get_header_lock());
+        _new_tablet.value()->acquire_version_and_rowsets(&version_rowsets);
     }
     for (auto& pair : version_rowsets) {
         RowsetSharedPtr rowset = pair.second;
@@ -1594,47 +1594,47 @@ Status SchemaChangeJob::_calc_delete_bitmap_for_mow_table(int64_t alter_version)
 
     // can't do compaction when calc delete bitmap, if the rowset being calculated does
     // a compaction, it may cause the delete bitmap to be missed.
-    std::lock_guard base_compaction_lock(_new_tablet->get_base_compaction_lock());
-    std::lock_guard cumu_compaction_lock(_new_tablet->get_cumulative_compaction_lock());
+    std::lock_guard base_compaction_lock(_new_tablet.value()->get_base_compaction_lock());
+    std::lock_guard cumu_compaction_lock(_new_tablet.value()->get_cumulative_compaction_lock());
 
     // step 2
-    int64_t max_version = _new_tablet->max_version().second;
+    int64_t max_version = _new_tablet.value()->max_version().second;
     std::vector<RowsetSharedPtr> rowsets;
     if (alter_version < max_version) {
         LOG(INFO) << "alter table for unique with merge-on-write, calculate delete bitmap of "
                   << "double write rowsets for version: " << alter_version + 1 << "-" << max_version
-                  << " new_tablet=" << _new_tablet->tablet_id();
-        std::shared_lock rlock(_new_tablet->get_header_lock());
-        auto ret = DORIS_TRY(_new_tablet->capture_consistent_rowsets_unlocked(
+                  << " new_tablet=" << _new_tablet.value()->tablet_id();
+        std::shared_lock rlock(_new_tablet.value()->get_header_lock());
+        auto ret = DORIS_TRY(_new_tablet.value()->capture_consistent_rowsets_unlocked(
                 {alter_version + 1, max_version}, CaptureRowsetOps {}));
         rowsets = std::move(ret.rowsets);
     }
     for (auto rowset_ptr : rowsets) {
-        std::lock_guard rwlock(_new_tablet->get_rowset_update_lock());
-        std::shared_lock rlock(_new_tablet->get_header_lock());
-        RETURN_IF_ERROR(Tablet::update_delete_bitmap_without_lock(_new_tablet, rowset_ptr));
+        std::lock_guard rwlock(_new_tablet.value()->get_rowset_update_lock());
+        std::shared_lock rlock(_new_tablet.value()->get_header_lock());
+        RETURN_IF_ERROR(Tablet::update_delete_bitmap_without_lock(_new_tablet.value(), rowset_ptr));
     }
 
     // step 3
-    std::lock_guard rwlock(_new_tablet->get_rowset_update_lock());
-    std::lock_guard new_wlock(_new_tablet->get_header_lock());
+    std::lock_guard rwlock(_new_tablet.value()->get_rowset_update_lock());
+    std::lock_guard new_wlock(_new_tablet.value()->get_header_lock());
     SCOPED_SIMPLE_TRACE_IF_TIMEOUT(TRACE_TABLET_LOCK_THRESHOLD);
-    int64_t new_max_version = _new_tablet->max_version_unlocked();
+    int64_t new_max_version = _new_tablet.value()->max_version_unlocked();
     rowsets.clear();
     if (max_version < new_max_version) {
         LOG(INFO) << "alter table for unique with merge-on-write, calculate delete bitmap of "
                   << "incremental rowsets for version: " << max_version + 1 << "-"
-                  << new_max_version << " new_tablet=" << _new_tablet->tablet_id();
-        auto ret = DORIS_TRY(_new_tablet->capture_consistent_rowsets_unlocked(
+                  << new_max_version << " new_tablet=" << _new_tablet.value()->tablet_id();
+        auto ret = DORIS_TRY(_new_tablet.value()->capture_consistent_rowsets_unlocked(
                 {max_version + 1, new_max_version}, CaptureRowsetOps {}));
         rowsets = std::move(ret.rowsets);
     }
     for (auto&& rowset_ptr : rowsets) {
-        RETURN_IF_ERROR(Tablet::update_delete_bitmap_without_lock(_new_tablet, rowset_ptr));
+        RETURN_IF_ERROR(Tablet::update_delete_bitmap_without_lock(_new_tablet.value(), rowset_ptr));
     }
     // step 4
-    RETURN_IF_ERROR(_new_tablet->set_tablet_state(TabletState::TABLET_RUNNING));
-    _new_tablet->save_meta();
+    RETURN_IF_ERROR(_new_tablet.value()->set_tablet_state(TabletState::TABLET_RUNNING));
+    _new_tablet.value()->save_meta();
     return Status::OK();
 }
 

--- a/be/src/storage/schema_change/schema_change.cpp
+++ b/be/src/storage/schema_change/schema_change.cpp
@@ -844,8 +844,8 @@ Status SchemaChangeJob::process_alter_tablet(const TAlterTabletReqV2& request) {
 SchemaChangeJob::SchemaChangeJob(StorageEngine& local_storage_engine,
                                  const TAlterTabletReqV2& request, const std::string& job_id)
         : _local_storage_engine(local_storage_engine) {
-    _base_tablet = _local_storage_engine.tablet_manager()->get_tablet_temp(request.base_tablet_id);
-    _new_tablet = _local_storage_engine.tablet_manager()->get_tablet_temp(request.new_tablet_id);
+    _base_tablet = _local_storage_engine.tablet_manager()->get_tablet(request.base_tablet_id);
+    _new_tablet = _local_storage_engine.tablet_manager()->get_tablet(request.new_tablet_id);
     if (_base_tablet.has_value() && _new_tablet.has_value()) {
         _base_tablet_schema = std::make_shared<TabletSchema>();
         _base_tablet_schema->update_tablet_columns(*_base_tablet.value()->tablet_schema(), request.columns);

--- a/be/src/storage/schema_change/schema_change.h
+++ b/be/src/storage/schema_change/schema_change.h
@@ -326,8 +326,8 @@ private:
     Status _calc_delete_bitmap_for_mow_table(int64_t alter_version);
 
     StorageEngine& _local_storage_engine;
-    TabletSharedPtr _base_tablet;
-    TabletSharedPtr _new_tablet;
+    Result<TabletSharedPtr> _base_tablet;
+    Result<TabletSharedPtr> _new_tablet;
     TabletSchemaSPtr _base_tablet_schema;
     TabletSchemaSPtr _new_tablet_schema;
     std::shared_mutex _mutex;

--- a/be/src/storage/snapshot/snapshot_manager.cpp
+++ b/be/src/storage/snapshot/snapshot_manager.cpp
@@ -111,8 +111,9 @@ Status SnapshotManager::make_snapshot(const TSnapshotRequest& request, string* s
         return Status::Error<INVALID_ARGUMENT>("output parameter cannot be null");
     }
 
-    TabletSharedPtr target_tablet = _engine.tablet_manager()->get_tablet(request.tablet_id);
+    TabletSharedPtr target_tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(request.tablet_id));
 
+    // TODO: remove
     DBUG_EXECUTE_IF("SnapshotManager::make_snapshot.inject_failure", { target_tablet = nullptr; })
 
     if (target_tablet == nullptr) {
@@ -122,7 +123,7 @@ Status SnapshotManager::make_snapshot(const TSnapshotRequest& request, string* s
     TabletSharedPtr ref_tablet = target_tablet;
     if (request.__isset.ref_tablet_id) {
         int64_t ref_tablet_id = request.ref_tablet_id;
-        TabletSharedPtr base_tablet = _engine.tablet_manager()->get_tablet(ref_tablet_id);
+        TabletSharedPtr base_tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(ref_tablet_id));
 
         // Some tasks, like medium migration, cause the target tablet and base tablet to stay on
         // different disks. In this case, we fall through to the normal restore path.
@@ -182,11 +183,11 @@ Result<std::vector<PendingRowsetGuard>> SnapshotManager::convert_rowset_ids(
                 "clone dir not existed when convert rowsetids. clone_dir={}", clone_dir));
     }
 
-    TabletSharedPtr target_tablet = _engine.tablet_manager()->get_tablet(tablet_id);
+    auto target_tablet = _engine.tablet_manager()->get_tablet_temp(tablet_id);
     TabletSchemaSPtr target_tablet_schema = nullptr;
-    if (target_tablet != nullptr) {
+    if (target_tablet.has_value()) {
         target_tablet_schema = std::make_shared<TabletSchema>();
-        target_tablet_schema->copy_from(*target_tablet->tablet_schema());
+        target_tablet_schema->copy_from(*target_tablet.value()->tablet_schema());
     }
 
     // load original tablet meta

--- a/be/src/storage/snapshot/snapshot_manager.cpp
+++ b/be/src/storage/snapshot/snapshot_manager.cpp
@@ -111,7 +111,8 @@ Status SnapshotManager::make_snapshot(const TSnapshotRequest& request, string* s
         return Status::Error<INVALID_ARGUMENT>("output parameter cannot be null");
     }
 
-    TabletSharedPtr target_tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet(request.tablet_id));
+    TabletSharedPtr target_tablet =
+            DORIS_TRY(_engine.tablet_manager()->get_tablet(request.tablet_id));
 
     // TODO: remove
     DBUG_EXECUTE_IF("SnapshotManager::make_snapshot.inject_failure", { target_tablet = nullptr; })
@@ -123,7 +124,8 @@ Status SnapshotManager::make_snapshot(const TSnapshotRequest& request, string* s
     TabletSharedPtr ref_tablet = target_tablet;
     if (request.__isset.ref_tablet_id) {
         int64_t ref_tablet_id = request.ref_tablet_id;
-        TabletSharedPtr base_tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet(ref_tablet_id));
+        TabletSharedPtr base_tablet =
+                DORIS_TRY(_engine.tablet_manager()->get_tablet(ref_tablet_id));
 
         // Some tasks, like medium migration, cause the target tablet and base tablet to stay on
         // different disks. In this case, we fall through to the normal restore path.

--- a/be/src/storage/snapshot/snapshot_manager.cpp
+++ b/be/src/storage/snapshot/snapshot_manager.cpp
@@ -111,7 +111,7 @@ Status SnapshotManager::make_snapshot(const TSnapshotRequest& request, string* s
         return Status::Error<INVALID_ARGUMENT>("output parameter cannot be null");
     }
 
-    TabletSharedPtr target_tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(request.tablet_id));
+    TabletSharedPtr target_tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet(request.tablet_id));
 
     // TODO: remove
     DBUG_EXECUTE_IF("SnapshotManager::make_snapshot.inject_failure", { target_tablet = nullptr; })
@@ -123,7 +123,7 @@ Status SnapshotManager::make_snapshot(const TSnapshotRequest& request, string* s
     TabletSharedPtr ref_tablet = target_tablet;
     if (request.__isset.ref_tablet_id) {
         int64_t ref_tablet_id = request.ref_tablet_id;
-        TabletSharedPtr base_tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(ref_tablet_id));
+        TabletSharedPtr base_tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet(ref_tablet_id));
 
         // Some tasks, like medium migration, cause the target tablet and base tablet to stay on
         // different disks. In this case, we fall through to the normal restore path.
@@ -183,7 +183,7 @@ Result<std::vector<PendingRowsetGuard>> SnapshotManager::convert_rowset_ids(
                 "clone dir not existed when convert rowsetids. clone_dir={}", clone_dir));
     }
 
-    auto target_tablet = _engine.tablet_manager()->get_tablet_temp(tablet_id);
+    auto target_tablet = _engine.tablet_manager()->get_tablet(tablet_id);
     TabletSchemaSPtr target_tablet_schema = nullptr;
     if (target_tablet.has_value()) {
         target_tablet_schema = std::make_shared<TabletSchema>();

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -955,7 +955,7 @@ void StorageEngine::_clean_unused_rowset_metas() {
             return true;
         }
 
-        auto tablet = _tablet_manager->get_tablet_temp(rowset_meta->tablet_id());
+        auto tablet = _tablet_manager->get_tablet(rowset_meta->tablet_id());
         if (!tablet.has_value()) {
             // tablet may be dropped
             // TODO(cmy): this is better to be a VLOG, because drop table is a very common case.
@@ -995,7 +995,7 @@ void StorageEngine::_clean_unused_rowset_metas() {
         // 1. delete delete_bitmap
         std::set<int64_t> tablets_to_save_meta;
         for (auto& rowset_meta : invalid_rowset_metas) {
-            auto tablet = _tablet_manager->get_tablet_temp(rowset_meta->tablet_id());
+            auto tablet = _tablet_manager->get_tablet(rowset_meta->tablet_id());
             if (tablet.has_value() && tablet.value()->tablet_meta()->enable_unique_key_merge_on_write()) {
                 tablet.value()->tablet_meta()->remove_rowset_delete_bitmap(rowset_meta->rowset_id(),
                                                                    rowset_meta->version());
@@ -1003,7 +1003,7 @@ void StorageEngine::_clean_unused_rowset_metas() {
             }
         }
         for (const auto& tablet_id : tablets_to_save_meta) {
-            auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+            auto tablet = _tablet_manager->get_tablet(tablet_id);
             if (tablet) {
                 std::shared_lock rlock(tablet.value()->get_header_lock());
                 tablet.value()->save_meta();
@@ -1030,7 +1030,7 @@ void StorageEngine::_clean_unused_binlog_metas() {
             if (UNLIKELY(!binlog_meta_pb.ParseFromArray(value.data(),
                                                         cast_set<int>(value.size())))) {
                 LOG(WARNING) << "parse rowset meta string failed for binlog meta key: " << key;
-            } else if (_tablet_manager->get_tablet_temp(binlog_meta_pb.tablet_id()) == nullptr) {
+            } else if (_tablet_manager->get_tablet(binlog_meta_pb.tablet_id()) == nullptr) {
                 LOG(INFO) << "failed to find tablet " << binlog_meta_pb.tablet_id()
                           << " for binlog rowset: " << binlog_meta_pb.rowset_id()
                           << ", tablet may be dropped";
@@ -1059,7 +1059,7 @@ void StorageEngine::_clean_unused_delete_bitmap() {
     std::unordered_set<int64_t> removed_tablets;
     auto clean_delete_bitmap_func = [this, &removed_tablets](int64_t tablet_id, int64_t version,
                                                              std::string_view val) -> bool {
-        auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+        auto tablet = _tablet_manager->get_tablet(tablet_id);
         if (!tablet.has_value()) {
             if (removed_tablets.insert(tablet_id).second) {
                 LOG(INFO) << "clean ununsed delete bitmap for deleted tablet, tablet_id: "
@@ -1087,7 +1087,7 @@ void StorageEngine::_clean_unused_pending_publish_info() {
     auto clean_pending_publish_info_func = [this, &removed_infos](int64_t tablet_id,
                                                                   int64_t publish_version,
                                                                   std::string_view info) -> bool {
-        auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+        auto tablet = _tablet_manager->get_tablet(tablet_id);
         if (!tablet.has_value()) {
             removed_infos.emplace_back(tablet_id, publish_version);
         }
@@ -1112,7 +1112,7 @@ void StorageEngine::_clean_unused_partial_update_info() {
     auto unused_partial_update_info_collector =
             [this, &remove_infos](int64_t tablet_id, int64_t partition_id, int64_t txn_id,
                                   std::string_view value) -> bool {
-        auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+        auto tablet = _tablet_manager->get_tablet(tablet_id);
         if (!tablet.has_value()) {
             remove_infos.emplace_back(tablet_id, partition_id, txn_id);
             return true;
@@ -1140,7 +1140,7 @@ void StorageEngine::gc_binlogs(const std::unordered_map<int64_t, int64_t>& gc_ta
         LOG(INFO) << fmt::format("start to gc binlogs for tablet_id: {}, version: {}", tablet_id,
                                  version);
 
-        auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+        auto tablet = _tablet_manager->get_tablet(tablet_id);
         if (!tablet.has_value()) {
             LOG(WARNING) << fmt::format("tablet_id: {} not found", tablet_id);
             continue;
@@ -1281,7 +1281,7 @@ void StorageEngine::start_delete_unused_rowset() {
         // check remove delete bitmaps
         for (auto it = _unused_delete_bitmap.begin(); it != _unused_delete_bitmap.end();) {
             auto tablet_id = std::get<0>(*it);
-            auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+            auto tablet = _tablet_manager->get_tablet(tablet_id);
             if (tablet == nullptr) {
                 it = _unused_delete_bitmap.erase(it);
                 continue;
@@ -1316,7 +1316,7 @@ void StorageEngine::start_delete_unused_rowset() {
         VLOG_NOTICE << "start to remove rowset:" << rs->rowset_id()
                     << ", version:" << rs->version();
         // delete delete_bitmap of unused rowsets
-        if (auto tablet = _tablet_manager->get_tablet_temp(rs->rowset_meta()->tablet_id());
+        if (auto tablet = _tablet_manager->get_tablet(rs->rowset_meta()->tablet_id());
             tablet.has_value() && tablet.value()->enable_unique_key_merge_on_write()) {
             tablet.value()->tablet_meta()->remove_rowset_delete_bitmap(rs->rowset_id(), rs->version());
             tablets_to_save_meta.emplace(tablet.value()->tablet_id());
@@ -1326,7 +1326,7 @@ void StorageEngine::start_delete_unused_rowset() {
         VLOG_NOTICE << "remove rowset:" << rs->rowset_id() << " finished. status:" << status;
     }
     for (const auto& tablet_id : tablets_to_save_meta) {
-        auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+        auto tablet = _tablet_manager->get_tablet(tablet_id);
         if (tablet.has_value()) {
             std::shared_lock rlock(tablet.value()->get_header_lock());
             tablet.value()->save_meta();
@@ -1377,7 +1377,7 @@ Status StorageEngine::create_tablet(const TCreateTabletReq& request, RuntimeProf
 Result<BaseTabletSPtr> StorageEngine::get_tablet(int64_t tablet_id, SyncRowsetStats* sync_stats,
                                                  bool force_use_only_cached, bool cache_on_miss) {
     std::string err;
-    Result<BaseTabletSPtr> tablet = _tablet_manager->get_tablet_temp(tablet_id, true, &err);
+    Result<BaseTabletSPtr> tablet = _tablet_manager->get_tablet(tablet_id, true, &err);
     if (!tablet.has_value()) {
         return unexpected(
                 Status::InternalError("failed to get tablet: {}, reason: {}", tablet_id, err));
@@ -1542,7 +1542,7 @@ PendingRowsetGuard StorageEngine::add_pending_rowset(const RowsetWriterContext& 
 
 bool StorageEngine::get_peer_replica_info(int64_t tablet_id, TReplicaInfo* replica,
                                           std::string* token) {
-    auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+    auto tablet = _tablet_manager->get_tablet(tablet_id);
     if (!tablet.has_value()) {
         LOG(WARNING) << "tablet is no longer exist: tablet_id=" << tablet_id;
         return false;
@@ -1558,7 +1558,7 @@ bool StorageEngine::get_peer_replica_info(int64_t tablet_id, TReplicaInfo* repli
 }
 
 bool StorageEngine::get_peers_replica_backends(int64_t tablet_id, std::vector<TBackend>* backends) {
-    auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+    auto tablet = _tablet_manager->get_tablet(tablet_id);
     if (!tablet.has_value()) {
         LOG(WARNING) << "tablet is no longer exist: tablet_id=" << tablet_id;
         return false;
@@ -1642,7 +1642,7 @@ bool StorageEngine::should_fetch_from_peer(int64_t tablet_id) {
     }
     return false;
 #endif
-    auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+    auto tablet = _tablet_manager->get_tablet(tablet_id);
     if (!tablet.has_value()) {
         LOG(WARNING) << "tablet is no longer exist: tablet_id=" << tablet_id;
         return false;

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -996,9 +996,10 @@ void StorageEngine::_clean_unused_rowset_metas() {
         std::set<int64_t> tablets_to_save_meta;
         for (auto& rowset_meta : invalid_rowset_metas) {
             auto tablet = _tablet_manager->get_tablet(rowset_meta->tablet_id());
-            if (tablet.has_value() && tablet.value()->tablet_meta()->enable_unique_key_merge_on_write()) {
+            if (tablet.has_value() &&
+                tablet.value()->tablet_meta()->enable_unique_key_merge_on_write()) {
                 tablet.value()->tablet_meta()->remove_rowset_delete_bitmap(rowset_meta->rowset_id(),
-                                                                   rowset_meta->version());
+                                                                           rowset_meta->version());
                 tablets_to_save_meta.emplace(tablet.value()->tablet_id());
             }
         }
@@ -1117,8 +1118,8 @@ void StorageEngine::_clean_unused_partial_update_info() {
             remove_infos.emplace_back(tablet_id, partition_id, txn_id);
             return true;
         }
-        TxnState txn_state =
-                _txn_manager->get_txn_state(partition_id, txn_id, tablet_id, tablet.value()->tablet_uid());
+        TxnState txn_state = _txn_manager->get_txn_state(partition_id, txn_id, tablet_id,
+                                                         tablet.value()->tablet_uid());
         if (txn_state == TxnState::NOT_FOUND || txn_state == TxnState::ABORTED ||
             txn_state == TxnState::DELETED) {
             remove_infos.emplace_back(tablet_id, partition_id, txn_id);
@@ -1318,7 +1319,8 @@ void StorageEngine::start_delete_unused_rowset() {
         // delete delete_bitmap of unused rowsets
         if (auto tablet = _tablet_manager->get_tablet(rs->rowset_meta()->tablet_id());
             tablet.has_value() && tablet.value()->enable_unique_key_merge_on_write()) {
-            tablet.value()->tablet_meta()->remove_rowset_delete_bitmap(rs->rowset_id(), rs->version());
+            tablet.value()->tablet_meta()->remove_rowset_delete_bitmap(rs->rowset_id(),
+                                                                       rs->version());
             tablets_to_save_meta.emplace(tablet.value()->tablet_id());
         }
         Status status = rs->remove();

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -955,8 +955,8 @@ void StorageEngine::_clean_unused_rowset_metas() {
             return true;
         }
 
-        TabletSharedPtr tablet = _tablet_manager->get_tablet(rowset_meta->tablet_id());
-        if (tablet == nullptr) {
+        auto tablet = _tablet_manager->get_tablet_temp(rowset_meta->tablet_id());
+        if (!tablet.has_value()) {
             // tablet may be dropped
             // TODO(cmy): this is better to be a VLOG, because drop table is a very common case.
             // leave it as INFO log for observation. Maybe change it in future.
@@ -965,7 +965,7 @@ void StorageEngine::_clean_unused_rowset_metas() {
             invalid_rowset_metas.push_back(rowset_meta);
             return true;
         }
-        if (tablet->tablet_uid() != rowset_meta->tablet_uid()) {
+        if (tablet.value()->tablet_uid() != rowset_meta->tablet_uid()) {
             // In this case, we get the tablet using the tablet id recorded in the rowset meta.
             // but the uid in the tablet is different from the one recorded in the rowset meta.
             // How this happened:
@@ -975,12 +975,12 @@ void StorageEngine::_clean_unused_rowset_metas() {
             // And in the historical version, when we deleted the replica, we did not delete the corresponding rowset meta,
             // thus causing the original rowset meta to remain(with same tablet id but different uid).
             LOG(WARNING) << "rowset's tablet uid " << rowset_meta->tablet_uid()
-                         << " does not equal to tablet uid: " << tablet->tablet_uid();
+                         << " does not equal to tablet uid: " << tablet.value()->tablet_uid();
             invalid_rowset_metas.push_back(rowset_meta);
             return true;
         }
         if (rowset_meta->rowset_state() == RowsetStatePB::VISIBLE &&
-            (!tablet->rowset_meta_is_useful(rowset_meta)) &&
+            (!tablet.value()->rowset_meta_is_useful(rowset_meta)) &&
             !check_rowset_id_in_unused_rowsets(rowset_id)) {
             LOG(INFO) << "rowset meta is not used any more, remove it. rowset_id="
                       << rowset_meta->rowset_id();
@@ -995,18 +995,18 @@ void StorageEngine::_clean_unused_rowset_metas() {
         // 1. delete delete_bitmap
         std::set<int64_t> tablets_to_save_meta;
         for (auto& rowset_meta : invalid_rowset_metas) {
-            TabletSharedPtr tablet = _tablet_manager->get_tablet(rowset_meta->tablet_id());
-            if (tablet && tablet->tablet_meta()->enable_unique_key_merge_on_write()) {
-                tablet->tablet_meta()->remove_rowset_delete_bitmap(rowset_meta->rowset_id(),
+            auto tablet = _tablet_manager->get_tablet_temp(rowset_meta->tablet_id());
+            if (tablet.has_value() && tablet.value()->tablet_meta()->enable_unique_key_merge_on_write()) {
+                tablet.value()->tablet_meta()->remove_rowset_delete_bitmap(rowset_meta->rowset_id(),
                                                                    rowset_meta->version());
-                tablets_to_save_meta.emplace(tablet->tablet_id());
+                tablets_to_save_meta.emplace(tablet.value()->tablet_id());
             }
         }
         for (const auto& tablet_id : tablets_to_save_meta) {
-            auto tablet = _tablet_manager->get_tablet(tablet_id);
+            auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
             if (tablet) {
-                std::shared_lock rlock(tablet->get_header_lock());
-                tablet->save_meta();
+                std::shared_lock rlock(tablet.value()->get_header_lock());
+                tablet.value()->save_meta();
             }
         }
         // 2. delete rowset meta
@@ -1030,7 +1030,7 @@ void StorageEngine::_clean_unused_binlog_metas() {
             if (UNLIKELY(!binlog_meta_pb.ParseFromArray(value.data(),
                                                         cast_set<int>(value.size())))) {
                 LOG(WARNING) << "parse rowset meta string failed for binlog meta key: " << key;
-            } else if (_tablet_manager->get_tablet(binlog_meta_pb.tablet_id()) == nullptr) {
+            } else if (_tablet_manager->get_tablet_temp(binlog_meta_pb.tablet_id()) == nullptr) {
                 LOG(INFO) << "failed to find tablet " << binlog_meta_pb.tablet_id()
                           << " for binlog rowset: " << binlog_meta_pb.rowset_id()
                           << ", tablet may be dropped";
@@ -1059,8 +1059,8 @@ void StorageEngine::_clean_unused_delete_bitmap() {
     std::unordered_set<int64_t> removed_tablets;
     auto clean_delete_bitmap_func = [this, &removed_tablets](int64_t tablet_id, int64_t version,
                                                              std::string_view val) -> bool {
-        TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_id);
-        if (tablet == nullptr) {
+        auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+        if (!tablet.has_value()) {
             if (removed_tablets.insert(tablet_id).second) {
                 LOG(INFO) << "clean ununsed delete bitmap for deleted tablet, tablet_id: "
                           << tablet_id;
@@ -1087,8 +1087,8 @@ void StorageEngine::_clean_unused_pending_publish_info() {
     auto clean_pending_publish_info_func = [this, &removed_infos](int64_t tablet_id,
                                                                   int64_t publish_version,
                                                                   std::string_view info) -> bool {
-        TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_id);
-        if (tablet == nullptr) {
+        auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+        if (!tablet.has_value()) {
             removed_infos.emplace_back(tablet_id, publish_version);
         }
         return true;
@@ -1112,13 +1112,13 @@ void StorageEngine::_clean_unused_partial_update_info() {
     auto unused_partial_update_info_collector =
             [this, &remove_infos](int64_t tablet_id, int64_t partition_id, int64_t txn_id,
                                   std::string_view value) -> bool {
-        TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_id);
-        if (tablet == nullptr) {
+        auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+        if (!tablet.has_value()) {
             remove_infos.emplace_back(tablet_id, partition_id, txn_id);
             return true;
         }
         TxnState txn_state =
-                _txn_manager->get_txn_state(partition_id, txn_id, tablet_id, tablet->tablet_uid());
+                _txn_manager->get_txn_state(partition_id, txn_id, tablet_id, tablet.value()->tablet_uid());
         if (txn_state == TxnState::NOT_FOUND || txn_state == TxnState::ABORTED ||
             txn_state == TxnState::DELETED) {
             remove_infos.emplace_back(tablet_id, partition_id, txn_id);
@@ -1140,12 +1140,12 @@ void StorageEngine::gc_binlogs(const std::unordered_map<int64_t, int64_t>& gc_ta
         LOG(INFO) << fmt::format("start to gc binlogs for tablet_id: {}, version: {}", tablet_id,
                                  version);
 
-        TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_id);
-        if (tablet == nullptr) {
+        auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+        if (!tablet.has_value()) {
             LOG(WARNING) << fmt::format("tablet_id: {} not found", tablet_id);
             continue;
         }
-        tablet->gc_binlogs(version);
+        tablet.value()->gc_binlogs(version);
     }
 }
 
@@ -1281,7 +1281,7 @@ void StorageEngine::start_delete_unused_rowset() {
         // check remove delete bitmaps
         for (auto it = _unused_delete_bitmap.begin(); it != _unused_delete_bitmap.end();) {
             auto tablet_id = std::get<0>(*it);
-            auto tablet = _tablet_manager->get_tablet(tablet_id);
+            auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
             if (tablet == nullptr) {
                 it = _unused_delete_bitmap.erase(it);
                 continue;
@@ -1302,7 +1302,7 @@ void StorageEngine::start_delete_unused_rowset() {
                 ++it;
                 continue;
             }
-            tablet->tablet_meta()->delete_bitmap().remove(key_ranges);
+            tablet.value()->tablet_meta()->delete_bitmap().remove(key_ranges);
             tablets_to_save_meta.emplace(tablet_id);
             it = _unused_delete_bitmap.erase(it);
         }
@@ -1316,20 +1316,20 @@ void StorageEngine::start_delete_unused_rowset() {
         VLOG_NOTICE << "start to remove rowset:" << rs->rowset_id()
                     << ", version:" << rs->version();
         // delete delete_bitmap of unused rowsets
-        if (auto tablet = _tablet_manager->get_tablet(rs->rowset_meta()->tablet_id());
-            tablet && tablet->enable_unique_key_merge_on_write()) {
-            tablet->tablet_meta()->remove_rowset_delete_bitmap(rs->rowset_id(), rs->version());
-            tablets_to_save_meta.emplace(tablet->tablet_id());
+        if (auto tablet = _tablet_manager->get_tablet_temp(rs->rowset_meta()->tablet_id());
+            tablet.has_value() && tablet.value()->enable_unique_key_merge_on_write()) {
+            tablet.value()->tablet_meta()->remove_rowset_delete_bitmap(rs->rowset_id(), rs->version());
+            tablets_to_save_meta.emplace(tablet.value()->tablet_id());
         }
         Status status = rs->remove();
         unused_rowsets_counter << -1;
         VLOG_NOTICE << "remove rowset:" << rs->rowset_id() << " finished. status:" << status;
     }
     for (const auto& tablet_id : tablets_to_save_meta) {
-        auto tablet = _tablet_manager->get_tablet(tablet_id);
-        if (tablet) {
-            std::shared_lock rlock(tablet->get_header_lock());
-            tablet->save_meta();
+        auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+        if (tablet.has_value()) {
+            std::shared_lock rlock(tablet.value()->get_header_lock());
+            tablet.value()->save_meta();
         }
     }
     LOG(INFO) << "removed all collected unused rowsets";
@@ -1376,10 +1376,9 @@ Status StorageEngine::create_tablet(const TCreateTabletReq& request, RuntimeProf
 
 Result<BaseTabletSPtr> StorageEngine::get_tablet(int64_t tablet_id, SyncRowsetStats* sync_stats,
                                                  bool force_use_only_cached, bool cache_on_miss) {
-    BaseTabletSPtr tablet;
     std::string err;
-    tablet = _tablet_manager->get_tablet(tablet_id, true, &err);
-    if (tablet == nullptr) {
+    Result<BaseTabletSPtr> tablet = _tablet_manager->get_tablet_temp(tablet_id, true, &err);
+    if (!tablet.has_value()) {
         return unexpected(
                 Status::InternalError("failed to get tablet: {}, reason: {}", tablet_id, err));
     }
@@ -1543,14 +1542,14 @@ PendingRowsetGuard StorageEngine::add_pending_rowset(const RowsetWriterContext& 
 
 bool StorageEngine::get_peer_replica_info(int64_t tablet_id, TReplicaInfo* replica,
                                           std::string* token) {
-    TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_id);
-    if (tablet == nullptr) {
+    auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+    if (!tablet.has_value()) {
         LOG(WARNING) << "tablet is no longer exist: tablet_id=" << tablet_id;
         return false;
     }
     std::unique_lock<std::mutex> lock(_peer_replica_infos_mutex);
     if (_peer_replica_infos.contains(tablet_id) &&
-        _peer_replica_infos[tablet_id].replica_id != tablet->replica_id()) {
+        _peer_replica_infos[tablet_id].replica_id != tablet.value()->replica_id()) {
         *replica = _peer_replica_infos[tablet_id];
         *token = _token;
         return true;
@@ -1559,8 +1558,8 @@ bool StorageEngine::get_peer_replica_info(int64_t tablet_id, TReplicaInfo* repli
 }
 
 bool StorageEngine::get_peers_replica_backends(int64_t tablet_id, std::vector<TBackend>* backends) {
-    TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_id);
-    if (tablet == nullptr) {
+    auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+    if (!tablet.has_value()) {
         LOG(WARNING) << "tablet is no longer exist: tablet_id=" << tablet_id;
         return false;
     }
@@ -1607,7 +1606,7 @@ bool StorageEngine::get_peers_replica_backends(int64_t tablet_id, std::vector<TB
                        << tablet_id;
         }
         for (const auto& rep : reps) {
-            if (rep.replica_id != tablet->replica_id()) {
+            if (rep.replica_id != tablet.value()->replica_id()) {
                 TBackend backend;
                 backend.__set_host(rep.host);
                 backend.__set_be_port(rep.be_port);
@@ -1643,14 +1642,14 @@ bool StorageEngine::should_fetch_from_peer(int64_t tablet_id) {
     }
     return false;
 #endif
-    TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_id);
-    if (tablet == nullptr) {
+    auto tablet = _tablet_manager->get_tablet_temp(tablet_id);
+    if (!tablet.has_value()) {
         LOG(WARNING) << "tablet is no longer exist: tablet_id=" << tablet_id;
         return false;
     }
     std::unique_lock<std::mutex> lock(_peer_replica_infos_mutex);
     if (_peer_replica_infos.contains(tablet_id)) {
-        return _peer_replica_infos[tablet_id].replica_id != tablet->replica_id();
+        return _peer_replica_infos[tablet_id].replica_id != tablet.value()->replica_id();
     }
     return false;
 }

--- a/be/src/storage/tablet/tablet.cpp
+++ b/be/src/storage/tablet/tablet.cpp
@@ -400,7 +400,7 @@ Status Tablet::revise_tablet_meta(const std::vector<RowsetSharedPtr>& to_add,
             }
             calc_delete_bitmap_rowsets = std::move(ret->rowsets);
             // FIXME(plat1ko): Use `const TabletSharedPtr&` as parameter
-            auto self = _engine.tablet_manager()->get_tablet_temp(tablet_id());
+            auto self = _engine.tablet_manager()->get_tablet(tablet_id());
             CHECK(self.has_value());
             for (auto rs : calc_delete_bitmap_rowsets) {
                 if (is_incremental_clone) {
@@ -1959,7 +1959,7 @@ Result<std::unique_ptr<RowsetWriter>> Tablet::create_transient_rowset_writer(
     context.enable_segcompaction = false;
     // ATTN: context.tablet is a shared_ptr, can't simply set it's value to `this`. We should
     // get the shared_ptr from tablet_manager.
-    auto tablet = _engine.tablet_manager()->get_tablet_temp(tablet_id());
+    auto tablet = _engine.tablet_manager()->get_tablet(tablet_id());
     if (!tablet.has_value()) {
         LOG(WARNING) << "cant find tablet by tablet_id=" << tablet_id();
         return ResultError(tablet.error());
@@ -2131,7 +2131,7 @@ Status Tablet::_cooldown_data(RowsetSharedPtr rowset) {
     // Upload cooldowned rowset meta to remote fs
     // ATTN: Even if it is an empty rowset, in order for the followers to synchronize, the coolown meta must be
     // uploaded, otherwise followers may never completely cooldown.
-    if (auto t = _engine.tablet_manager()->get_tablet_temp(tablet_id());
+    if (auto t = _engine.tablet_manager()->get_tablet(tablet_id());
         t.has_value()) { // `t` can be nullptr if it has been dropped
         async_write_cooldown_meta(std::move(t.value()));
     }

--- a/be/src/storage/tablet/tablet.cpp
+++ b/be/src/storage/tablet/tablet.cpp
@@ -400,14 +400,14 @@ Status Tablet::revise_tablet_meta(const std::vector<RowsetSharedPtr>& to_add,
             }
             calc_delete_bitmap_rowsets = std::move(ret->rowsets);
             // FIXME(plat1ko): Use `const TabletSharedPtr&` as parameter
-            auto self = _engine.tablet_manager()->get_tablet(tablet_id());
-            CHECK(self);
+            auto self = _engine.tablet_manager()->get_tablet_temp(tablet_id());
+            CHECK(self.has_value());
             for (auto rs : calc_delete_bitmap_rowsets) {
                 if (is_incremental_clone) {
-                    calc_bm_status = update_delete_bitmap_without_lock(self, rs);
+                    calc_bm_status = update_delete_bitmap_without_lock(self.value(), rs);
                 } else {
                     calc_bm_status = update_delete_bitmap_without_lock(
-                            self, rs, &base_rowsets_for_full_clone);
+                            self.value(), rs, &base_rowsets_for_full_clone);
                     base_rowsets_for_full_clone.push_back(rs);
                 }
                 if (!calc_bm_status.ok()) {
@@ -1959,12 +1959,12 @@ Result<std::unique_ptr<RowsetWriter>> Tablet::create_transient_rowset_writer(
     context.enable_segcompaction = false;
     // ATTN: context.tablet is a shared_ptr, can't simply set it's value to `this`. We should
     // get the shared_ptr from tablet_manager.
-    auto tablet = _engine.tablet_manager()->get_tablet(tablet_id());
-    if (!tablet) {
+    auto tablet = _engine.tablet_manager()->get_tablet_temp(tablet_id());
+    if (!tablet.has_value()) {
         LOG(WARNING) << "cant find tablet by tablet_id=" << tablet_id();
-        return ResultError(Status::NotFound("cant find tablet by tablet_id={}", tablet_id()));
+        return ResultError(tablet.error());
     }
-    context.tablet = tablet;
+    context.tablet = tablet.value();
     context.write_type = DataWriteType::TYPE_DIRECT;
     context.partial_update_info = std::move(partial_update_info);
     context.is_transient_rowset_writer = true;
@@ -2131,9 +2131,9 @@ Status Tablet::_cooldown_data(RowsetSharedPtr rowset) {
     // Upload cooldowned rowset meta to remote fs
     // ATTN: Even if it is an empty rowset, in order for the followers to synchronize, the coolown meta must be
     // uploaded, otherwise followers may never completely cooldown.
-    if (auto t = _engine.tablet_manager()->get_tablet(tablet_id());
-        t != nullptr) { // `t` can be nullptr if it has been dropped
-        async_write_cooldown_meta(std::move(t));
+    if (auto t = _engine.tablet_manager()->get_tablet_temp(tablet_id());
+        t.has_value()) { // `t` can be nullptr if it has been dropped
+        async_write_cooldown_meta(std::move(t.value()));
     }
     return Status::OK();
 }

--- a/be/src/storage/tablet/tablet_manager.cpp
+++ b/be/src/storage/tablet/tablet_manager.cpp
@@ -590,7 +590,8 @@ Status TabletManager::_drop_tablet(TTabletId tablet_id, TReplicaId replica_id, b
     return Status::OK();
 }
 
-Result<TabletSharedPtr> TabletManager::get_tablet(TTabletId tablet_id, bool include_deleted, string* err) {
+Result<TabletSharedPtr> TabletManager::get_tablet(TTabletId tablet_id, bool include_deleted,
+                                                  string* err) {
     std::shared_lock rdlock(_get_tablets_shard_lock(tablet_id));
     return _get_tablet_unlocked(tablet_id, include_deleted, err);
 }

--- a/be/src/storage/tablet/tablet_manager.cpp
+++ b/be/src/storage/tablet/tablet_manager.cpp
@@ -593,7 +593,15 @@ Status TabletManager::_drop_tablet(TTabletId tablet_id, TReplicaId replica_id, b
 Result<TabletSharedPtr> TabletManager::get_tablet(TTabletId tablet_id, bool include_deleted,
                                                   string* err) {
     std::shared_lock rdlock(_get_tablets_shard_lock(tablet_id));
-    return _get_tablet_unlocked(tablet_id, include_deleted, err);
+    TabletSharedPtr tablet = _get_tablet_unlocked(tablet_id, include_deleted, err);
+    if (tablet == nullptr) {
+        if (err) {
+            return ResultError(Status::NotFound("failed to get tablet {}, {}", tablet_id, *err));
+        } else {
+            return ResultError(Status::NotFound("failed to get tablet {}", tablet_id));
+        }
+    }
+    return tablet;
 }
 
 std::vector<TabletSharedPtr> TabletManager::get_all_tablet(std::function<bool(Tablet*)>&& filter) {

--- a/be/src/storage/tablet/tablet_manager.cpp
+++ b/be/src/storage/tablet/tablet_manager.cpp
@@ -299,7 +299,7 @@ Status TabletManager::create_tablet(const TCreateTabletReq& request, std::vector
         // if base_tablet_id's lock diffrent with new_tablet_id, we need lock it.
         if (need_two_lock) {
             SCOPED_TIMER(ADD_TIMER(profile, "GetBaseTablet"));
-            base_tablet = get_tablet(request.base_tablet_id);
+            base_tablet = DORIS_TRY(get_tablet_temp(request.base_tablet_id));
             two_tablet_lock.unlock();
         } else {
             SCOPED_TIMER(ADD_TIMER(profile, "GetBaseTabletUnlocked"));
@@ -590,7 +590,7 @@ Status TabletManager::_drop_tablet(TTabletId tablet_id, TReplicaId replica_id, b
     return Status::OK();
 }
 
-TabletSharedPtr TabletManager::get_tablet(TTabletId tablet_id, bool include_deleted, string* err) {
+Result<TabletSharedPtr> TabletManager::get_tablet_temp(TTabletId tablet_id, bool include_deleted, string* err) {
     std::shared_lock rdlock(_get_tablets_shard_lock(tablet_id));
     return _get_tablet_unlocked(tablet_id, include_deleted, err);
 }
@@ -1069,10 +1069,7 @@ Status TabletManager::report_tablet_info(TTabletInfo* tablet_info) {
 
     Status res = Status::OK();
 
-    TabletSharedPtr tablet = get_tablet(tablet_info->tablet_id);
-    if (tablet == nullptr) {
-        return Status::Error<TABLE_NOT_FOUND>("can't find tablet={}", tablet_info->tablet_id);
-    }
+    TabletSharedPtr tablet = DORIS_TRY(get_tablet_temp(tablet_info->tablet_id));
 
     tablet->build_tablet_report_info(tablet_info);
     VLOG_TRACE << "success to process report tablet info.";
@@ -1236,8 +1233,9 @@ bool TabletManager::_move_tablet_to_trash(const TabletSharedPtr& tablet) {
     RETURN_IF_ERROR(register_transition_tablet(tablet->tablet_id(), "move to trash"));
     Defer defer {[&]() { unregister_transition_tablet(tablet->tablet_id(), "move to trash"); }};
 
-    TabletSharedPtr tablet_in_not_shutdown = get_tablet(tablet->tablet_id());
-    if (tablet_in_not_shutdown) {
+    auto tablet_in_not_shutdown_res = get_tablet_temp(tablet->tablet_id());
+    if (tablet_in_not_shutdown_res.has_value()) {
+        auto tablet_in_not_shutdown = tablet_in_not_shutdown_res.value();
         TSchemaHash schema_hash_not_shutdown = tablet_in_not_shutdown->schema_hash();
         size_t path_hash_not_shutdown = tablet_in_not_shutdown->data_dir()->path_hash();
         if (tablet->schema_hash() == schema_hash_not_shutdown &&
@@ -1658,12 +1656,12 @@ void TabletManager::get_tablets_distribution_on_different_disks(
 
         for (const auto& tablet_info : partition.tablets) {
             // get_tablet() will hold 'tablet_shard_lock'
-            TabletSharedPtr tablet = get_tablet(tablet_info.tablet_id);
-            if (tablet == nullptr) {
+            auto tablet = get_tablet_temp(tablet_info.tablet_id);
+            if (!tablet.has_value()) {
                 continue;
             }
-            DataDir* data_dir = tablet->data_dir();
-            size_t tablet_footprint = tablet->tablet_footprint();
+            DataDir* data_dir = tablet.value()->data_dir();
+            size_t tablet_footprint = tablet.value()->tablet_footprint();
             tablets_num[data_dir]++;
             TabletSize tablet_size(tablet_info.tablet_id, tablet_footprint);
             tablets_info[data_dir].push_back(tablet_size);

--- a/be/src/storage/tablet/tablet_manager.cpp
+++ b/be/src/storage/tablet/tablet_manager.cpp
@@ -299,7 +299,7 @@ Status TabletManager::create_tablet(const TCreateTabletReq& request, std::vector
         // if base_tablet_id's lock diffrent with new_tablet_id, we need lock it.
         if (need_two_lock) {
             SCOPED_TIMER(ADD_TIMER(profile, "GetBaseTablet"));
-            base_tablet = DORIS_TRY(get_tablet_temp(request.base_tablet_id));
+            base_tablet = DORIS_TRY(get_tablet(request.base_tablet_id));
             two_tablet_lock.unlock();
         } else {
             SCOPED_TIMER(ADD_TIMER(profile, "GetBaseTabletUnlocked"));
@@ -590,7 +590,7 @@ Status TabletManager::_drop_tablet(TTabletId tablet_id, TReplicaId replica_id, b
     return Status::OK();
 }
 
-Result<TabletSharedPtr> TabletManager::get_tablet_temp(TTabletId tablet_id, bool include_deleted, string* err) {
+Result<TabletSharedPtr> TabletManager::get_tablet(TTabletId tablet_id, bool include_deleted, string* err) {
     std::shared_lock rdlock(_get_tablets_shard_lock(tablet_id));
     return _get_tablet_unlocked(tablet_id, include_deleted, err);
 }
@@ -1069,7 +1069,7 @@ Status TabletManager::report_tablet_info(TTabletInfo* tablet_info) {
 
     Status res = Status::OK();
 
-    TabletSharedPtr tablet = DORIS_TRY(get_tablet_temp(tablet_info->tablet_id));
+    TabletSharedPtr tablet = DORIS_TRY(get_tablet(tablet_info->tablet_id));
 
     tablet->build_tablet_report_info(tablet_info);
     VLOG_TRACE << "success to process report tablet info.";
@@ -1233,7 +1233,7 @@ bool TabletManager::_move_tablet_to_trash(const TabletSharedPtr& tablet) {
     RETURN_IF_ERROR(register_transition_tablet(tablet->tablet_id(), "move to trash"));
     Defer defer {[&]() { unregister_transition_tablet(tablet->tablet_id(), "move to trash"); }};
 
-    auto tablet_in_not_shutdown_res = get_tablet_temp(tablet->tablet_id());
+    auto tablet_in_not_shutdown_res = get_tablet(tablet->tablet_id());
     if (tablet_in_not_shutdown_res.has_value()) {
         auto tablet_in_not_shutdown = tablet_in_not_shutdown_res.value();
         TSchemaHash schema_hash_not_shutdown = tablet_in_not_shutdown->schema_hash();
@@ -1656,7 +1656,7 @@ void TabletManager::get_tablets_distribution_on_different_disks(
 
         for (const auto& tablet_info : partition.tablets) {
             // get_tablet() will hold 'tablet_shard_lock'
-            auto tablet = get_tablet_temp(tablet_info.tablet_id);
+            auto tablet = get_tablet(tablet_info.tablet_id);
             if (!tablet.has_value()) {
                 continue;
             }

--- a/be/src/storage/tablet/tablet_manager.h
+++ b/be/src/storage/tablet/tablet_manager.h
@@ -86,7 +86,7 @@ public:
             const std::unordered_map<std::string_view, std::shared_ptr<CumulativeCompactionPolicy>>&
                     all_cumulative_compaction_policies);
 
-    Result<TabletSharedPtr> get_tablet_temp(TTabletId tablet_id, bool include_deleted = false,
+    Result<TabletSharedPtr> get_tablet(TTabletId tablet_id, bool include_deleted = false,
                                std::string* err = nullptr);
 
     TabletSharedPtr get_tablet(TTabletId tablet_id, TabletUid tablet_uid,

--- a/be/src/storage/tablet/tablet_manager.h
+++ b/be/src/storage/tablet/tablet_manager.h
@@ -87,7 +87,7 @@ public:
                     all_cumulative_compaction_policies);
 
     Result<TabletSharedPtr> get_tablet(TTabletId tablet_id, bool include_deleted = false,
-                               std::string* err = nullptr);
+                                       std::string* err = nullptr);
 
     TabletSharedPtr get_tablet(TTabletId tablet_id, TabletUid tablet_uid,
                                bool include_deleted = false, std::string* err = nullptr);

--- a/be/src/storage/tablet/tablet_manager.h
+++ b/be/src/storage/tablet/tablet_manager.h
@@ -86,7 +86,7 @@ public:
             const std::unordered_map<std::string_view, std::shared_ptr<CumulativeCompactionPolicy>>&
                     all_cumulative_compaction_policies);
 
-    TabletSharedPtr get_tablet(TTabletId tablet_id, bool include_deleted = false,
+    Result<TabletSharedPtr> get_tablet_temp(TTabletId tablet_id, bool include_deleted = false,
                                std::string* err = nullptr);
 
     TabletSharedPtr get_tablet(TTabletId tablet_id, TabletUid tablet_uid,

--- a/be/src/storage/task/engine_batch_load_task.cpp
+++ b/be/src/storage/task/engine_batch_load_task.cpp
@@ -105,7 +105,7 @@ Status EngineBatchLoadTask::_init() {
 
     // Check replica exist
     TabletSharedPtr tablet;
-    tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(_push_req.tablet_id));
+    tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet(_push_req.tablet_id));
 
     // check disk capacity
     if (_push_req.push_type == TPushType::LOAD_V2) {
@@ -273,7 +273,7 @@ Status EngineBatchLoadTask::_push(const TPushReq& request,
         return Status::InvalidArgument("invalid tablet_info_vec which is nullptr");
     }
 
-    TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(request.tablet_id));
+    TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet(request.tablet_id));
 
     PushType type = PushType::PUSH_NORMAL_V2;
     int64_t duration_ns = 0;
@@ -315,7 +315,7 @@ Status EngineBatchLoadTask::_delete_data(const TPushReq& request,
     }
 
     // 1. Get all tablets with same tablet_id
-    TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(request.tablet_id));
+    TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet(request.tablet_id));
 
     // 2. Process delete data by push interface
     PushHandler push_handler(_engine);

--- a/be/src/storage/task/engine_batch_load_task.cpp
+++ b/be/src/storage/task/engine_batch_load_task.cpp
@@ -105,10 +105,7 @@ Status EngineBatchLoadTask::_init() {
 
     // Check replica exist
     TabletSharedPtr tablet;
-    tablet = _engine.tablet_manager()->get_tablet(_push_req.tablet_id);
-    if (tablet == nullptr) {
-        return Status::InvalidArgument("Could not find tablet {}", _push_req.tablet_id);
-    }
+    tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(_push_req.tablet_id));
 
     // check disk capacity
     if (_push_req.push_type == TPushType::LOAD_V2) {
@@ -276,11 +273,7 @@ Status EngineBatchLoadTask::_push(const TPushReq& request,
         return Status::InvalidArgument("invalid tablet_info_vec which is nullptr");
     }
 
-    TabletSharedPtr tablet = _engine.tablet_manager()->get_tablet(request.tablet_id);
-    if (tablet == nullptr) {
-        DorisMetrics::instance()->push_requests_fail_total->increment(1);
-        return Status::InternalError("could not find tablet {}", request.tablet_id);
-    }
+    TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(request.tablet_id));
 
     PushType type = PushType::PUSH_NORMAL_V2;
     int64_t duration_ns = 0;
@@ -322,10 +315,7 @@ Status EngineBatchLoadTask::_delete_data(const TPushReq& request,
     }
 
     // 1. Get all tablets with same tablet_id
-    TabletSharedPtr tablet = _engine.tablet_manager()->get_tablet(request.tablet_id);
-    if (tablet == nullptr) {
-        return Status::InternalError("could not find tablet {}", request.tablet_id);
-    }
+    TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(request.tablet_id));
 
     // 2. Process delete data by push interface
     PushHandler push_handler(_engine);

--- a/be/src/storage/task/engine_checksum_task.cpp
+++ b/be/src/storage/task/engine_checksum_task.cpp
@@ -69,10 +69,7 @@ Status EngineChecksumTask::_compute_checksum() {
         return Status::InvalidArgument("invalid checksum which is nullptr");
     }
 
-    TabletSharedPtr tablet = _engine.tablet_manager()->get_tablet(_tablet_id);
-    if (nullptr == tablet) {
-        return Status::InternalError("could not find tablet {}", _tablet_id);
-    }
+    TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(_tablet_id));
 
     std::vector<RowsetSharedPtr> input_rowsets;
     Version version(0, _version);

--- a/be/src/storage/task/engine_checksum_task.cpp
+++ b/be/src/storage/task/engine_checksum_task.cpp
@@ -69,7 +69,7 @@ Status EngineChecksumTask::_compute_checksum() {
         return Status::InvalidArgument("invalid checksum which is nullptr");
     }
 
-    TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(_tablet_id));
+    TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet(_tablet_id));
 
     std::vector<RowsetSharedPtr> input_rowsets;
     Version version(0, _version);

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -201,11 +201,11 @@ Status EngineCloneTask::_do_clone() {
                                                               tablet.value()->replica_id(), false));
         tablet->reset();
     }
-    _is_new_tablet = tablet == nullptr;
+    _is_new_tablet = !tablet.has_value();
     // try to incremental clone
     Versions missed_versions;
     // try to repair a tablet with missing version
-    if (tablet != nullptr) {
+    if (tablet.has_value()) {
         std::shared_lock migration_rlock(tablet.value()->get_migration_lock(), std::try_to_lock);
         if (!migration_rlock.owns_lock()) {
             return Status::Error<TRY_LOCK_FAILED>(

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -189,42 +189,42 @@ Status EngineCloneTask::_do_clone() {
     }};
 
     // Check local tablet exist or not
-    TabletSharedPtr tablet = _engine.tablet_manager()->get_tablet(_clone_req.tablet_id);
+    auto tablet = _engine.tablet_manager()->get_tablet_temp(_clone_req.tablet_id);
 
     // The status of a tablet is not ready, indicating that it is a residual tablet after a schema
     // change failure. Clone a new tablet from remote be to overwrite it. This situation basically only
     // occurs when the be_rebalancer_fuzzy_test configuration is enabled.
-    if (tablet && tablet->tablet_state() == TABLET_NOTREADY) {
+    if (tablet.has_value() && tablet.value()->tablet_state() == TABLET_NOTREADY) {
         LOG(WARNING) << "tablet state is not ready when clone, need to drop old tablet, tablet_id="
-                     << tablet->tablet_id();
-        RETURN_IF_ERROR(_engine.tablet_manager()->drop_tablet(tablet->tablet_id(),
-                                                              tablet->replica_id(), false));
-        tablet.reset();
+                     << tablet.value()->tablet_id();
+        RETURN_IF_ERROR(_engine.tablet_manager()->drop_tablet(tablet.value()->tablet_id(),
+                                                              tablet.value()->replica_id(), false));
+        tablet->reset();
     }
     _is_new_tablet = tablet == nullptr;
     // try to incremental clone
     Versions missed_versions;
     // try to repair a tablet with missing version
     if (tablet != nullptr) {
-        std::shared_lock migration_rlock(tablet->get_migration_lock(), std::try_to_lock);
+        std::shared_lock migration_rlock(tablet.value()->get_migration_lock(), std::try_to_lock);
         if (!migration_rlock.owns_lock()) {
             return Status::Error<TRY_LOCK_FAILED>(
                     "EngineCloneTask::_do_clone meet try lock failed");
         }
-        if (tablet->replica_id() < _clone_req.replica_id) {
+        if (tablet.value()->replica_id() < _clone_req.replica_id) {
             // `tablet` may be a dropped replica in FE, e.g:
             //   BE1 migrates replica of tablet_1 to BE2, but before BE1 drop this replica, another new replica of tablet_1 is migrated to BE1.
             // Clone can still continue in this case. But to keep `replica_id` consitent with FE, MUST reset `replica_id` with request `replica_id`.
-            tablet->tablet_meta()->set_replica_id(_clone_req.replica_id);
+            tablet.value()->tablet_meta()->set_replica_id(_clone_req.replica_id);
         }
 
         // get download path
-        auto local_data_path = fmt::format("{}/{}", tablet->tablet_path(), CLONE_PREFIX);
+        auto local_data_path = fmt::format("{}/{}", tablet.value()->tablet_path(), CLONE_PREFIX);
         bool allow_incremental_clone = false;
 
         int64_t specified_version = _clone_req.version;
-        if (tablet->enable_unique_key_merge_on_write()) {
-            int64_t min_pending_ver = _engine.get_pending_publish_min_version(tablet->tablet_id());
+        if (tablet.value()->enable_unique_key_merge_on_write()) {
+            int64_t min_pending_ver = _engine.get_pending_publish_min_version(tablet.value()->tablet_id());
             if (min_pending_ver - 1 < specified_version) {
                 LOG(INFO) << "use min pending publish version for clone, min_pending_ver: "
                           << min_pending_ver << " visible_version: " << _clone_req.version;
@@ -232,7 +232,7 @@ Status EngineCloneTask::_do_clone() {
             }
         }
 
-        missed_versions = tablet->get_missed_versions(specified_version);
+        missed_versions = tablet.value()->get_missed_versions(specified_version);
 
         // if missed version size is 0, then it is useless to clone from remote be, it means local data is
         // completed. Or remote be will just return header not the rowset files. clone will failed.
@@ -252,10 +252,10 @@ Status EngineCloneTask::_do_clone() {
         // try to download missing version from src backend.
         // if tablet on src backend does not contains missing version, it will download all versions,
         // and set allow_incremental_clone to false
-        RETURN_IF_ERROR(_make_and_download_snapshots(*(tablet->data_dir()), local_data_path,
+        RETURN_IF_ERROR(_make_and_download_snapshots(*(tablet.value()->data_dir()), local_data_path,
                                                      &src_host, &src_file_path, missed_versions,
                                                      &allow_incremental_clone));
-        RETURN_IF_ERROR(_finish_clone(tablet.get(), local_data_path, specified_version,
+        RETURN_IF_ERROR(_finish_clone(tablet->get(), local_data_path, specified_version,
                                       allow_incremental_clone));
     } else {
         LOG(INFO) << "clone tablet not exist, begin clone a new tablet from remote be. "
@@ -306,13 +306,13 @@ Status EngineCloneTask::_do_clone() {
         RETURN_IF_ERROR_(status, tablet_manager->load_tablet_from_dir(store, _clone_req.tablet_id,
                                                                       _clone_req.schema_hash,
                                                                       tablet_dir, false));
-        auto nested_tablet = tablet_manager->get_tablet(_clone_req.tablet_id);
+        auto nested_tablet = tablet_manager->get_tablet_temp(_clone_req.tablet_id);
         if (!nested_tablet) {
             status = Status::NotFound("tablet not found, tablet_id={}", _clone_req.tablet_id);
             return status;
         }
         // MUST reset `replica_id` to request `replica_id` to keep consistent with FE
-        nested_tablet->tablet_meta()->set_replica_id(_clone_req.replica_id);
+        nested_tablet.value()->tablet_meta()->set_replica_id(_clone_req.replica_id);
         // clone success, delete .hdr file because tablet meta is stored in rocksdb
         std::string header_path =
                 TabletMeta::construct_header_file_path(tablet_dir, _clone_req.tablet_id);

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -224,7 +224,8 @@ Status EngineCloneTask::_do_clone() {
 
         int64_t specified_version = _clone_req.version;
         if (tablet.value()->enable_unique_key_merge_on_write()) {
-            int64_t min_pending_ver = _engine.get_pending_publish_min_version(tablet.value()->tablet_id());
+            int64_t min_pending_ver =
+                    _engine.get_pending_publish_min_version(tablet.value()->tablet_id());
             if (min_pending_ver - 1 < specified_version) {
                 LOG(INFO) << "use min pending publish version for clone, min_pending_ver: "
                           << min_pending_ver << " visible_version: " << _clone_req.version;

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -189,7 +189,7 @@ Status EngineCloneTask::_do_clone() {
     }};
 
     // Check local tablet exist or not
-    auto tablet = _engine.tablet_manager()->get_tablet_temp(_clone_req.tablet_id);
+    auto tablet = _engine.tablet_manager()->get_tablet(_clone_req.tablet_id);
 
     // The status of a tablet is not ready, indicating that it is a residual tablet after a schema
     // change failure. Clone a new tablet from remote be to overwrite it. This situation basically only
@@ -306,7 +306,7 @@ Status EngineCloneTask::_do_clone() {
         RETURN_IF_ERROR_(status, tablet_manager->load_tablet_from_dir(store, _clone_req.tablet_id,
                                                                       _clone_req.schema_hash,
                                                                       tablet_dir, false));
-        auto nested_tablet = tablet_manager->get_tablet_temp(_clone_req.tablet_id);
+        auto nested_tablet = tablet_manager->get_tablet(_clone_req.tablet_id);
         if (!nested_tablet) {
             status = Status::NotFound("tablet not found, tablet_id={}", _clone_req.tablet_id);
             return status;

--- a/be/src/storage/task/engine_publish_version_task.cpp
+++ b/be/src/storage/task/engine_publish_version_task.cpp
@@ -282,10 +282,9 @@ Status EnginePublishVersionTask::execute() {
                                                                 &partition_related_tablet_infos);
         Version version(par_ver_info.version, par_ver_info.version);
         for (auto& tablet_info : partition_related_tablet_infos) {
-            TabletSharedPtr tablet =
-                    DORIS_TRY(_engine.tablet_manager()->get_tablet(tablet_info.tablet_id));
+            auto tablet = _engine.tablet_manager()->get_tablet(tablet_info.tablet_id);
             auto tablet_id = tablet_info.tablet_id;
-            if (tablet == nullptr) {
+            if (!tablet.has_value()) {
                 add_error_tablet_id(tablet_id);
                 _succ_tablets->erase(tablet_id);
                 LOG(WARNING) << "publish version failed on transaction, not found tablet. "
@@ -294,7 +293,7 @@ Status EnginePublishVersionTask::execute() {
             } else {
                 // check if the version exist, if not exist, then set publish failed
                 if (_error_tablet_ids->find(tablet_id) == _error_tablet_ids->end()) {
-                    if (tablet->check_version_exist(version)) {
+                    if (tablet.value()->check_version_exist(version)) {
                         // it's better to report the max continous succ version,
                         // but it maybe time cost now.
                         // current just report 0
@@ -307,7 +306,7 @@ Status EnginePublishVersionTask::execute() {
                                        "exists. "
                                     << "transaction_id=" << transaction_id
                                     << ", tablet_id=" << tablet_id << ", tablet_state="
-                                    << tablet_state_name(tablet->tablet_state())
+                                    << tablet_state_name(tablet.value()->tablet_state())
                                     << ", version=" << par_ver_info.version;
                         }
                     }

--- a/be/src/storage/task/engine_publish_version_task.cpp
+++ b/be/src/storage/task/engine_publish_version_task.cpp
@@ -282,7 +282,8 @@ Status EnginePublishVersionTask::execute() {
                                                                 &partition_related_tablet_infos);
         Version version(par_ver_info.version, par_ver_info.version);
         for (auto& tablet_info : partition_related_tablet_infos) {
-            TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet(tablet_info.tablet_id));
+            TabletSharedPtr tablet =
+                    DORIS_TRY(_engine.tablet_manager()->get_tablet(tablet_info.tablet_id));
             auto tablet_id = tablet_info.tablet_id;
             if (tablet == nullptr) {
                 add_error_tablet_id(tablet_id);

--- a/be/src/storage/task/engine_publish_version_task.cpp
+++ b/be/src/storage/task/engine_publish_version_task.cpp
@@ -282,7 +282,7 @@ Status EnginePublishVersionTask::execute() {
                                                                 &partition_related_tablet_infos);
         Version version(par_ver_info.version, par_ver_info.version);
         for (auto& tablet_info : partition_related_tablet_infos) {
-            TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(tablet_info.tablet_id));
+            TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet(tablet_info.tablet_id));
             auto tablet_id = tablet_info.tablet_id;
             if (tablet == nullptr) {
                 add_error_tablet_id(tablet_id);
@@ -390,7 +390,7 @@ void EnginePublishVersionTask::_handle_publish_version_not_continuous(
 void EnginePublishVersionTask::_calculate_tbl_num_delta_rows(
         const std::unordered_map<int64_t, int64_t>& tablet_id_to_num_delta_rows) {
     for (const auto& kv : tablet_id_to_num_delta_rows) {
-        auto tablet = _engine.tablet_manager()->get_tablet_temp(kv.first);
+        auto tablet = _engine.tablet_manager()->get_tablet(kv.first);
         if (!tablet.has_value()) {
             LOG(WARNING) << "cant find tablet by tablet_id=" << kv.first;
             continue;

--- a/be/src/storage/task/engine_publish_version_task.cpp
+++ b/be/src/storage/task/engine_publish_version_task.cpp
@@ -282,7 +282,7 @@ Status EnginePublishVersionTask::execute() {
                                                                 &partition_related_tablet_infos);
         Version version(par_ver_info.version, par_ver_info.version);
         for (auto& tablet_info : partition_related_tablet_infos) {
-            TabletSharedPtr tablet = _engine.tablet_manager()->get_tablet(tablet_info.tablet_id);
+            TabletSharedPtr tablet = DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(tablet_info.tablet_id));
             auto tablet_id = tablet_info.tablet_id;
             if (tablet == nullptr) {
                 add_error_tablet_id(tablet_id);
@@ -390,12 +390,12 @@ void EnginePublishVersionTask::_handle_publish_version_not_continuous(
 void EnginePublishVersionTask::_calculate_tbl_num_delta_rows(
         const std::unordered_map<int64_t, int64_t>& tablet_id_to_num_delta_rows) {
     for (const auto& kv : tablet_id_to_num_delta_rows) {
-        auto tablet = _engine.tablet_manager()->get_tablet(kv.first);
-        if (!tablet) {
+        auto tablet = _engine.tablet_manager()->get_tablet_temp(kv.first);
+        if (!tablet.has_value()) {
             LOG(WARNING) << "cant find tablet by tablet_id=" << kv.first;
             continue;
         }
-        auto table_id = tablet->get_table_id();
+        auto table_id = tablet.value()->get_table_id();
         if (kv.second > 0) {
             (*_table_id_to_tablet_id_to_num_delta_rows)[table_id][kv.first] += kv.second;
             VLOG_DEBUG << "report delta rows to fe, table_id=" << table_id

--- a/be/src/storage/task/engine_storage_migration_task.cpp
+++ b/be/src/storage/task/engine_storage_migration_task.cpp
@@ -180,7 +180,7 @@ Status EngineStorageMigrationTask::_reload_tablet(const std::string& full_path) 
 
     // if old tablet finished schema change, then the schema change status of the new tablet is DONE
     // else the schema change status of the new tablet is FAILED
-    DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(tablet_id));
+    DORIS_TRY(_engine.tablet_manager()->get_tablet(tablet_id));
     return Status::OK();
 }
 

--- a/be/src/storage/task/engine_storage_migration_task.cpp
+++ b/be/src/storage/task/engine_storage_migration_task.cpp
@@ -180,10 +180,7 @@ Status EngineStorageMigrationTask::_reload_tablet(const std::string& full_path) 
 
     // if old tablet finished schema change, then the schema change status of the new tablet is DONE
     // else the schema change status of the new tablet is FAILED
-    TabletSharedPtr new_tablet = _engine.tablet_manager()->get_tablet(tablet_id);
-    if (new_tablet == nullptr) {
-        return Status::NotFound("could not find tablet {}", tablet_id);
-    }
+    DORIS_TRY(_engine.tablet_manager()->get_tablet_temp(tablet_id));
     return Status::OK();
 }
 

--- a/be/src/storage/txn/txn_manager.cpp
+++ b/be/src/storage/txn/txn_manager.cpp
@@ -462,11 +462,10 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
                                TabletPublishStatistics* stats,
                                std::shared_ptr<TabletTxnInfo>& extend_tablet_txn_info,
                                const int64_t commit_tso) {
-    auto tablet = _engine.tablet_manager()->get_tablet(tablet_id);
-    if (tablet == nullptr) {
+    auto tablet = _engine.tablet_manager()->get_tablet_temp(tablet_id);
+    if (!tablet.has_value()) {
         return Status::OK();
     }
-    DCHECK(stats != nullptr);
 
     pair<int64_t, int64_t> key(partition_id, transaction_id);
     TabletInfo tablet_info(tablet_id, tablet_uid);
@@ -549,23 +548,23 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
             // delete bitmap is empty, should re-calculate delete bitmaps between segments
             std::vector<segment_v2::SegmentSharedPtr> segments;
             RETURN_IF_ERROR(std::static_pointer_cast<BetaRowset>(rowset)->load_segments(&segments));
-            RETURN_IF_ERROR(tablet->calc_delete_bitmap_between_segments(
+            RETURN_IF_ERROR(tablet.value()->calc_delete_bitmap_between_segments(
                     rowset->tablet_schema(), rowset->rowset_id(), segments,
                     tablet_txn_info->delete_bitmap));
         }
 
         RETURN_IF_ERROR(
-                Tablet::update_delete_bitmap(tablet, tablet_txn_info.get(), transaction_id));
+                Tablet::update_delete_bitmap(tablet.value(), tablet_txn_info.get(), transaction_id));
         int64_t t3 = MonotonicMicros();
         stats->calc_delete_bitmap_time_us = t3 - t2;
         RETURN_IF_ERROR(TabletMetaManager::save_delete_bitmap(
-                tablet->data_dir(), tablet->tablet_id(), tablet_txn_info->delete_bitmap,
+                tablet.value()->data_dir(), tablet.value()->tablet_id(), tablet_txn_info->delete_bitmap,
                 version.second));
         stats->save_meta_time_us = MonotonicMicros() - t3;
     }
 
     /// Step 3:  add to binlog
-    auto enable_binlog = tablet->is_enable_binlog();
+    auto enable_binlog = tablet.value()->is_enable_binlog();
     if (enable_binlog) {
         auto status = rowset->add_to_binlog();
         if (!status.ok()) {
@@ -605,7 +604,7 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
     if (enable_binlog) {
         auto version_str = fmt::format("{}", version.first);
         VLOG_DEBUG << fmt::format("tabletid: {}, version: {}, binlog filepath: {}", tablet_id,
-                                  version_str, tablet->get_binlog_filepath(version_str));
+                                  version_str, tablet.value()->get_binlog_filepath(version_str));
     }
 
     /// Step 5: remove tablet_info from tnx_tablet_map

--- a/be/src/storage/txn/txn_manager.cpp
+++ b/be/src/storage/txn/txn_manager.cpp
@@ -553,13 +553,13 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
                     tablet_txn_info->delete_bitmap));
         }
 
-        RETURN_IF_ERROR(
-                Tablet::update_delete_bitmap(tablet.value(), tablet_txn_info.get(), transaction_id));
+        RETURN_IF_ERROR(Tablet::update_delete_bitmap(tablet.value(), tablet_txn_info.get(),
+                                                     transaction_id));
         int64_t t3 = MonotonicMicros();
         stats->calc_delete_bitmap_time_us = t3 - t2;
         RETURN_IF_ERROR(TabletMetaManager::save_delete_bitmap(
-                tablet.value()->data_dir(), tablet.value()->tablet_id(), tablet_txn_info->delete_bitmap,
-                version.second));
+                tablet.value()->data_dir(), tablet.value()->tablet_id(),
+                tablet_txn_info->delete_bitmap, version.second));
         stats->save_meta_time_us = MonotonicMicros() - t3;
     }
 

--- a/be/src/storage/txn/txn_manager.cpp
+++ b/be/src/storage/txn/txn_manager.cpp
@@ -462,7 +462,7 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
                                TabletPublishStatistics* stats,
                                std::shared_ptr<TabletTxnInfo>& extend_tablet_txn_info,
                                const int64_t commit_tso) {
-    auto tablet = _engine.tablet_manager()->get_tablet_temp(tablet_id);
+    auto tablet = _engine.tablet_manager()->get_tablet(tablet_id);
     if (!tablet.has_value()) {
         return Status::OK();
     }

--- a/be/test/load/delta_writer/delta_writer_cluster_key_test.cpp
+++ b/be/test/load/delta_writer/delta_writer_cluster_key_test.cpp
@@ -298,7 +298,7 @@ TEST_F(TestDeltaWriterClusterKey, vec_sequence_col) {
     ASSERT_TRUE(res.ok());
 
     // publish version success
-    TabletSharedPtr tablet = engine_ref->tablet_manager()->get_tablet(write_req.tablet_id);
+    TabletSharedPtr tablet = engine_ref->tablet_manager()->get_tablet(write_req.tablet_id).value();
     std::cout << "before publish, tablet row nums:" << tablet->num_rows() << std::endl;
     OlapMeta* meta = tablet->data_dir()->get_meta();
     Version version;

--- a/be/test/load/delta_writer/delta_writer_test.cpp
+++ b/be/test/load/delta_writer/delta_writer_test.cpp
@@ -688,7 +688,7 @@ TEST_F(TestDeltaWriter, vec_write) {
     ASSERT_TRUE(res.ok());
 
     // publish version success
-    TabletSharedPtr tablet = engine_ref->tablet_manager()->get_tablet(write_req.tablet_id);
+    TabletSharedPtr tablet = engine_ref->tablet_manager()->get_tablet(write_req.tablet_id).value();
     std::cout << "before publish, tablet row nums:" << tablet->num_rows() << std::endl;
     OlapMeta* meta = tablet->data_dir()->get_meta();
     Version version;
@@ -781,7 +781,7 @@ TEST_F(TestDeltaWriter, vec_sequence_col) {
     ASSERT_TRUE(res.ok());
 
     // publish version success
-    TabletSharedPtr tablet = engine_ref->tablet_manager()->get_tablet(write_req.tablet_id);
+    TabletSharedPtr tablet = engine_ref->tablet_manager()->get_tablet(write_req.tablet_id).value();
     std::cout << "before publish, tablet row nums:" << tablet->num_rows() << std::endl;
     OlapMeta* meta = tablet->data_dir()->get_meta();
     Version version;
@@ -924,7 +924,7 @@ TEST_F(TestDeltaWriter, vec_sequence_col_concurrent_write) {
         res = delta_writer2->wait_flush();
         ASSERT_TRUE(res.ok());
     }
-    TabletSharedPtr tablet = engine_ref->tablet_manager()->get_tablet(write_req.tablet_id);
+    TabletSharedPtr tablet = engine_ref->tablet_manager()->get_tablet(write_req.tablet_id).value();
     std::cout << "before publish, tablet row nums:" << tablet->num_rows() << std::endl;
     OlapMeta* meta = tablet->data_dir()->get_meta();
     RowsetSharedPtr rowset1 = nullptr;

--- a/be/test/runtime/load_stream_test.cpp
+++ b/be/test/runtime/load_stream_test.cpp
@@ -361,8 +361,8 @@ public:
 
             for (const auto& req : request->tablets()) {
                 TabletManager* tablet_mgr = engine_ref->tablet_manager();
-                TabletSharedPtr tablet = tablet_mgr->get_tablet(req.tablet_id());
-                if (tablet == nullptr) {
+                auto tablet = tablet_mgr->get_tablet(req.tablet_id());
+                if (!tablet.has_value()) {
                     cntl->SetFailed("Tablet not found");
                     status->set_status_code(TStatusCode::NOT_FOUND);
                     response->set_allocated_status(status.get());
@@ -372,8 +372,8 @@ public:
                 auto resp = response->add_tablet_schemas();
                 resp->set_index_id(req.index_id());
                 resp->set_enable_unique_key_merge_on_write(
-                        tablet->enable_unique_key_merge_on_write());
-                tablet->tablet_schema()->to_schema_pb(resp->mutable_tablet_schema());
+                        tablet.value()->enable_unique_key_merge_on_write());
+                tablet.value()->tablet_schema()->to_schema_pb(resp->mutable_tablet_schema());
             }
 
             LoadStream* load_stream;
@@ -630,7 +630,7 @@ public:
     }
 
     std::string read_data(int64_t txn_id, int64_t partition_id, int64_t tablet_id, uint32_t segid) {
-        auto tablet = engine_ref->tablet_manager()->get_tablet(tablet_id);
+        auto tablet = engine_ref->tablet_manager()->get_tablet(tablet_id).value();
         std::map<TabletInfo, RowsetSharedPtr> tablet_related_rs;
         engine_ref->txn_manager()->get_txn_related_tablets(txn_id, partition_id,
                                                            &tablet_related_rs);

--- a/be/test/runtime/snapshot_loader_test.cpp
+++ b/be/test/runtime/snapshot_loader_test.cpp
@@ -248,8 +248,8 @@ static void add_rowset(int64_t tablet_id, int32_t schema_hash, int64_t partition
 
     TabletPublishStatistics stats;
     std::shared_ptr<TabletTxnInfo> extend_tablet_txn_info_lifetime = nullptr;
-    res = engine_ref->txn_manager()->publish_txn(partition_id, tablet.value(), txn_id, version, &stats,
-                                                 extend_tablet_txn_info_lifetime);
+    res = engine_ref->txn_manager()->publish_txn(partition_id, tablet.value(), txn_id, version,
+                                                 &stats, extend_tablet_txn_info_lifetime);
     ASSERT_TRUE(res.ok()) << res;
     std::cout << "start to add inc rowset:" << rowset->rowset_id()
               << ", num rows:" << rowset->num_rows() << ", version:" << rowset->version().first

--- a/be/test/runtime/snapshot_loader_test.cpp
+++ b/be/test/runtime/snapshot_loader_test.cpp
@@ -230,13 +230,13 @@ static void add_rowset(int64_t tablet_id, int32_t schema_hash, int64_t partition
     res = delta_writer->commit_txn(PSlaveTabletNodes());
     ASSERT_TRUE(res.ok()) << res;
 
-    TabletSharedPtr tablet = engine_ref->tablet_manager()->get_tablet(tablet_id);
-    ASSERT_TRUE(tablet != nullptr);
+    auto tablet = engine_ref->tablet_manager()->get_tablet(tablet_id);
+    ASSERT_TRUE(tablet.has_value());
 
-    std::cout << "before publish, tablet row nums:" << tablet->num_rows() << std::endl;
+    std::cout << "before publish, tablet row nums:" << tablet.value()->num_rows() << std::endl;
     Version version;
-    version.first = tablet->get_rowset_with_max_version()->end_version() + 1;
-    version.second = tablet->get_rowset_with_max_version()->end_version() + 1;
+    version.first = tablet.value()->get_rowset_with_max_version()->end_version() + 1;
+    version.second = tablet.value()->get_rowset_with_max_version()->end_version() + 1;
     std::cout << "start to add rowset version:" << version.first << "-" << version.second
               << std::endl;
     std::map<TabletInfo, RowsetSharedPtr> tablet_related_rs;
@@ -248,13 +248,13 @@ static void add_rowset(int64_t tablet_id, int32_t schema_hash, int64_t partition
 
     TabletPublishStatistics stats;
     std::shared_ptr<TabletTxnInfo> extend_tablet_txn_info_lifetime = nullptr;
-    res = engine_ref->txn_manager()->publish_txn(partition_id, tablet, txn_id, version, &stats,
+    res = engine_ref->txn_manager()->publish_txn(partition_id, tablet.value(), txn_id, version, &stats,
                                                  extend_tablet_txn_info_lifetime);
     ASSERT_TRUE(res.ok()) << res;
     std::cout << "start to add inc rowset:" << rowset->rowset_id()
               << ", num rows:" << rowset->num_rows() << ", version:" << rowset->version().first
               << "-" << rowset->version().second << std::endl;
-    res = tablet->add_inc_rowset(rowset);
+    res = tablet.value()->add_inc_rowset(rowset);
     ASSERT_TRUE(res.ok()) << res;
 }
 
@@ -382,12 +382,12 @@ TEST_F(SnapshotLoaderTest, DirMoveTaskIsIdempotent) {
     RuntimeProfile profile("CreateTablet");
     Status status = engine_ref->create_tablet(req, &profile);
     EXPECT_TRUE(status.ok());
-    TabletSharedPtr tablet = engine_ref->tablet_manager()->get_tablet(tablet_id);
-    EXPECT_TRUE(tablet != nullptr);
+    auto tablet = engine_ref->tablet_manager()->get_tablet(tablet_id);
+    EXPECT_TRUE(tablet.has_value());
 
     // 2. add a rowset
     add_rowset(tablet_id, schema_hash, partition_id, 100, 100);
-    auto version = tablet->max_version();
+    auto version = tablet.value()->max_version();
     std::cout << "version: " << version.first << ", " << version.second << std::endl;
 
     // 3. make a snapshot
@@ -404,26 +404,28 @@ TEST_F(SnapshotLoaderTest, DirMoveTaskIsIdempotent) {
     // 4. load the snapshot to another tablet
     snapshot_path = fmt::format("{}/{}/{}", snapshot_path, tablet_id, schema_hash);
     SnapshotLoader loader1(*engine_ref, ExecEnv::GetInstance(), 1L, tablet_id);
-    status = loader1.move(snapshot_path, tablet, true);
+    status = loader1.move(snapshot_path, tablet.value(), true);
     ASSERT_TRUE(status.ok()) << status;
 
     // 5. Insert a rowset to the tablet
     // reload tablet
-    tablet = engine_ref->tablet_manager()->get_tablet(tablet_id);
-    EXPECT_TRUE(tablet != nullptr);
+    auto res = engine_ref->tablet_manager()->get_tablet(tablet_id);
+    EXPECT_TRUE(res.has_value());
+    tablet = res.value();
     add_rowset(tablet_id, schema_hash, partition_id, 200, 200);
-    version = tablet->max_version();
+    version = tablet.value()->max_version();
     std::cout << "version: " << version.first << ", " << version.second << std::endl;
 
     // 6. load the snapshot to the tablet again, this request should be idempotent
     SnapshotLoader loader2(*engine_ref, ExecEnv::GetInstance(), 2L, tablet_id);
-    status = loader2.move(snapshot_path, tablet, true);
+    status = loader2.move(snapshot_path, tablet.value(), true);
     ASSERT_TRUE(status.ok()) << status;
 
     // reload tablet
-    tablet = engine_ref->tablet_manager()->get_tablet(tablet_id);
-    EXPECT_TRUE(tablet != nullptr);
-    auto last_version = tablet->max_version();
+    res = engine_ref->tablet_manager()->get_tablet(tablet_id);
+    EXPECT_TRUE(res.has_value());
+    tablet = res.value();
+    auto last_version = tablet.value()->max_version();
     std::cout << "last version: " << last_version.first << ", " << last_version.second << std::endl;
     ASSERT_EQ(version.first, last_version.first);
     ASSERT_EQ(version.second, last_version.second);
@@ -437,12 +439,12 @@ TEST_F(SnapshotLoaderTest, TestLinkSameRowsetFiles) {
     RuntimeProfile profile("CreateTablet");
     Status status = engine_ref->create_tablet(req, &profile);
     EXPECT_TRUE(status.ok());
-    TabletSharedPtr tablet = engine_ref->tablet_manager()->get_tablet(tablet_id);
-    EXPECT_TRUE(tablet != nullptr);
+    auto tablet = engine_ref->tablet_manager()->get_tablet(tablet_id);
+    EXPECT_TRUE(tablet.has_value());
 
     // 2. Add a rowset to the tablet
     add_rowset(tablet_id, schema_hash, partition_id, 100, 100);
-    auto version = tablet->max_version();
+    auto version = tablet.value()->max_version();
     std::cout << "Original version: " << version.first << ", " << version.second << std::endl;
 
     // 3. Make a snapshot of the tablet

--- a/be/test/storage/delete/delete_handler_test.cpp
+++ b/be/test/storage/delete/delete_handler_test.cpp
@@ -328,15 +328,17 @@ protected:
         set_default_create_tablet_request(&_create_tablet);
         res = k_engine->create_tablet(_create_tablet, &profile);
         EXPECT_EQ(Status::OK(), res);
-        tablet = k_engine->tablet_manager()->get_tablet(_create_tablet.tablet_id);
-        EXPECT_NE(tablet.get(), nullptr);
+        auto tablet_res = k_engine->tablet_manager()->get_tablet(_create_tablet.tablet_id);
+        EXPECT_TRUE(tablet_res.has_value());
+        tablet = tablet_res.value();
         _tablet_path = tablet->tablet_path();
 
         set_create_duplicate_tablet_request(&_create_dup_tablet);
         res = k_engine->create_tablet(_create_dup_tablet, &profile);
         EXPECT_EQ(Status::OK(), res);
-        dup_tablet = k_engine->tablet_manager()->get_tablet(_create_dup_tablet.tablet_id);
-        EXPECT_TRUE(dup_tablet);
+        tablet_res = k_engine->tablet_manager()->get_tablet(_create_dup_tablet.tablet_id);
+        EXPECT_TRUE(tablet_res.has_value());
+        dup_tablet = tablet_res.value();
         _dup_tablet_path = tablet->tablet_path();
     }
 
@@ -557,8 +559,9 @@ protected:
         set_default_create_tablet_request(&_create_tablet);
         res = k_engine->create_tablet(_create_tablet, &profile);
         EXPECT_EQ(Status::OK(), res);
-        tablet = k_engine->tablet_manager()->get_tablet(_create_tablet.tablet_id);
-        EXPECT_TRUE(tablet.get() != nullptr);
+        auto tablet_res = k_engine->tablet_manager()->get_tablet(_create_tablet.tablet_id);
+        EXPECT_TRUE(tablet_res.has_value());
+        tablet = tablet_res.value();
         _tablet_path = tablet->tablet_path();
     }
 
@@ -986,8 +989,9 @@ protected:
         set_default_create_tablet_request(&_create_tablet);
         res = k_engine->create_tablet(_create_tablet, &profile);
         EXPECT_EQ(Status::OK(), res);
-        tablet = k_engine->tablet_manager()->get_tablet(_create_tablet.tablet_id);
-        EXPECT_TRUE(tablet != nullptr);
+        auto tablet_res = k_engine->tablet_manager()->get_tablet(_create_tablet.tablet_id);
+        EXPECT_TRUE(tablet_res.has_value());
+        tablet = tablet_res.value();
         _tablet_path = tablet->tablet_path();
 
         _json_rowset_meta = R"({

--- a/be/test/storage/path_gc_test.cpp
+++ b/be/test/storage/path_gc_test.cpp
@@ -145,7 +145,7 @@ TEST(PathGcTest, GcTabletAndRowset) {
         auto rs = create_rowset();
         st = create_rowset_files(*rs, false);
         ASSERT_TRUE(st.ok()) << st;
-        auto tablet = engine.tablet_manager()->get_tablet(rs->rowset_meta()->tablet_id());
+        auto tablet = engine.tablet_manager()->get_tablet(rs->rowset_meta()->tablet_id()).value();
         ASSERT_TRUE(tablet) << rs->rowset_meta()->tablet_id();
         auto max_version = tablet->max_version_unlocked();
         rs->rowset_meta()->set_version({max_version + 1, max_version + 1});

--- a/be/test/storage/schema_change/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/schema_change/engine_storage_migration_task_test.cpp
@@ -215,7 +215,7 @@ TEST_F(TestEngineStorageMigrationTask, write_and_migration) {
     EXPECT_EQ(Status::OK(), res);
 
     // publish version success
-    TabletSharedPtr tablet = engine_ref->tablet_manager()->get_tablet(write_req.tablet_id);
+    TabletSharedPtr tablet = engine_ref->tablet_manager()->get_tablet(write_req.tablet_id).value();
     OlapMeta* meta = tablet->data_dir()->get_meta();
     Version version;
     version.first = tablet->get_rowset_with_max_version()->end_version() + 1;
@@ -252,7 +252,7 @@ TEST_F(TestEngineStorageMigrationTask, write_and_migration) {
     res = engine_task.execute();
     EXPECT_EQ(Status::OK(), res);
     // reget the tablet from manager after migration
-    TabletSharedPtr tablet2 = engine_ref->tablet_manager()->get_tablet(request.tablet_id);
+    TabletSharedPtr tablet2 = engine_ref->tablet_manager()->get_tablet(request.tablet_id).value();
     // check path
     EXPECT_EQ(tablet2->data_dir()->path(), dest_store->path());
     // check rows
@@ -270,7 +270,7 @@ TEST_F(TestEngineStorageMigrationTask, write_and_migration) {
     EngineStorageMigrationTask engine_task2(*engine_ref, tablet2, dest_store);
     res = engine_task2.execute();
     EXPECT_EQ(Status::OK(), res);
-    TabletSharedPtr tablet3 = engine_ref->tablet_manager()->get_tablet(request.tablet_id);
+    TabletSharedPtr tablet3 = engine_ref->tablet_manager()->get_tablet(request.tablet_id).value();
     // check path
     EXPECT_EQ(tablet3->data_dir()->path(), tablet->data_dir()->path());
     // check rows

--- a/be/test/storage/segment/segment_cache_test.cpp
+++ b/be/test/storage/segment/segment_cache_test.cpp
@@ -282,7 +282,7 @@ TEST_F(SegmentCacheTest, vec_sequence_col) {
     ASSERT_TRUE(res.ok());
 
     // publish version success
-    TabletSharedPtr tablet = engine_ref->tablet_manager()->get_tablet(write_req.tablet_id);
+    TabletSharedPtr tablet = engine_ref->tablet_manager()->get_tablet(write_req.tablet_id).value();
     std::cout << "before publish, tablet row nums:" << tablet->num_rows() << std::endl;
     OlapMeta* meta = tablet->data_dir()->get_meta();
     Version version;

--- a/be/test/storage/storage_engine_test.cpp
+++ b/be/test/storage/storage_engine_test.cpp
@@ -139,7 +139,7 @@ TEST_F(StorageEngineTest, TestAsyncPublish) {
     RuntimeProfile profile("CreateTablet");
     st = _storage_engine->tablet_manager()->create_tablet(create_tablet_req, data_dirs, &profile);
     EXPECT_EQ(st, Status::OK());
-    TabletSharedPtr tablet = _storage_engine->tablet_manager()->get_tablet(tablet_id);
+    TabletSharedPtr tablet = _storage_engine->tablet_manager()->get_tablet(tablet_id).value();
     EXPECT_EQ(tablet->max_version().second, 10);
 
     for (int64_t i = 5; i < 12; ++i) {

--- a/be/test/storage/tablet/tablet_cooldown_test.cpp
+++ b/be/test/storage/tablet/tablet_cooldown_test.cpp
@@ -368,7 +368,7 @@ static void write_rowset(TabletSharedPtr* tablet, PUniqueId load_id, int64_t rep
     ASSERT_EQ(Status::OK(), st);
 
     // publish version success
-    *tablet = engine_ref->tablet_manager()->get_tablet(write_req.tablet_id, write_req.schema_hash);
+    *tablet = engine_ref->tablet_manager()->get_tablet(write_req.tablet_id, write_req.schema_hash).value();
     OlapMeta* meta = (*tablet)->data_dir()->get_meta();
     Version version;
     version.first = (*tablet)->get_rowset_with_max_version()->end_version() + 1;
@@ -403,7 +403,7 @@ void createTablet(TabletSharedPtr* tablet, int64_t replica_id, int32_t schema_ha
     Status st = engine_ref->create_tablet(request, profile.get());
     ASSERT_EQ(Status::OK(), st);
     if (!with_data) {
-        *tablet = engine_ref->tablet_manager()->get_tablet(tablet_id);
+        *tablet = engine_ref->tablet_manager()->get_tablet(tablet_id).value();
         return;
     }
 

--- a/be/test/storage/tablet/tablet_cooldown_test.cpp
+++ b/be/test/storage/tablet/tablet_cooldown_test.cpp
@@ -368,7 +368,9 @@ static void write_rowset(TabletSharedPtr* tablet, PUniqueId load_id, int64_t rep
     ASSERT_EQ(Status::OK(), st);
 
     // publish version success
-    *tablet = engine_ref->tablet_manager()->get_tablet(write_req.tablet_id, write_req.schema_hash).value();
+    *tablet = engine_ref->tablet_manager()
+                      ->get_tablet(write_req.tablet_id, write_req.schema_hash)
+                      .value();
     OlapMeta* meta = (*tablet)->data_dir()->get_meta();
     Version version;
     version.first = (*tablet)->get_rowset_with_max_version()->end_version() + 1;

--- a/be/test/storage/tablet/tablet_mgr_test.cpp
+++ b/be/test/storage/tablet/tablet_mgr_test.cpp
@@ -230,15 +230,15 @@ TEST_F(TabletMgrTest, DropTablet) {
     Status drop_st = _tablet_mgr->drop_tablet(1121, create_tablet_req.replica_id, false);
     EXPECT_TRUE(drop_st == Status::OK());
     tablet = _tablet_mgr->get_tablet(111);
-    EXPECT_TRUE(tablet != nullptr);
+    EXPECT_TRUE(tablet.has_value());
 
     // drop exist tablet will be success
     drop_st = _tablet_mgr->drop_tablet(111, create_tablet_req.replica_id, false);
     EXPECT_TRUE(drop_st == Status::OK());
     tablet = _tablet_mgr->get_tablet(111);
-    EXPECT_TRUE(tablet == nullptr);
+    EXPECT_FALSE(tablet.has_value());
     tablet = _tablet_mgr->get_tablet(111, true);
-    EXPECT_TRUE(tablet != nullptr);
+    EXPECT_TRUE(tablet.has_value());
 
     // check dir exist
     std::string tablet_path = tablet.value()->tablet_path();
@@ -251,7 +251,7 @@ TEST_F(TabletMgrTest, DropTablet) {
     Status trash_st = _tablet_mgr->start_trash_sweep();
     EXPECT_TRUE(trash_st == Status::OK());
     tablet = _tablet_mgr->get_tablet(111, true);
-    EXPECT_TRUE(tablet != nullptr);
+    EXPECT_TRUE(tablet.has_value());
     EXPECT_TRUE(io::global_local_filesystem()->exists(tablet_path, &dir_exist).ok());
     EXPECT_TRUE(dir_exist);
 
@@ -260,7 +260,7 @@ TEST_F(TabletMgrTest, DropTablet) {
     trash_st = _tablet_mgr->start_trash_sweep();
     EXPECT_TRUE(trash_st == Status::OK());
     tablet = _tablet_mgr->get_tablet(111, true);
-    EXPECT_TRUE(tablet == nullptr);
+    EXPECT_FALSE(tablet.has_value());
     EXPECT_TRUE(io::global_local_filesystem()->exists(tablet_path, &dir_exist).ok());
     EXPECT_FALSE(dir_exist);
 }

--- a/be/test/storage/tablet/tablet_mgr_test.cpp
+++ b/be/test/storage/tablet/tablet_mgr_test.cpp
@@ -124,7 +124,8 @@ TEST_F(TabletMgrTest, CreateTablet) {
     EXPECT_TRUE(tablet.has_value());
     // check dir exist
     bool dir_exist = false;
-    EXPECT_TRUE(io::global_local_filesystem()->exists(tablet.value()->tablet_path(), &dir_exist).ok());
+    EXPECT_TRUE(
+            io::global_local_filesystem()->exists(tablet.value()->tablet_path(), &dir_exist).ok());
     EXPECT_TRUE(dir_exist);
     // check meta has this tablet
     TabletMetaSharedPtr new_tablet_meta(new TabletMeta());
@@ -185,7 +186,8 @@ TEST_F(TabletMgrTest, CreateTabletWithSequence) {
     EXPECT_TRUE(tablet.has_value());
     // check dir exist
     bool dir_exist = false;
-    EXPECT_TRUE(io::global_local_filesystem()->exists(tablet.value()->tablet_path(), &dir_exist).ok());
+    EXPECT_TRUE(
+            io::global_local_filesystem()->exists(tablet.value()->tablet_path(), &dir_exist).ok());
     EXPECT_TRUE(dir_exist);
     // check meta has this tablet
     TabletMetaSharedPtr new_tablet_meta(new TabletMeta());
@@ -390,7 +392,8 @@ TEST_F(TabletMgrTest, FindTabletWithCompact) {
         ASSERT_TRUE(tablet.has_value());
         // check dir exist
         bool dir_exist = false;
-        Status exist_st = io::global_local_filesystem()->exists(tablet.value()->tablet_path(), &dir_exist);
+        Status exist_st =
+                io::global_local_filesystem()->exists(tablet.value()->tablet_path(), &dir_exist);
         ASSERT_TRUE(exist_st.ok()) << exist_st;
         ASSERT_TRUE(dir_exist);
         // check meta has this tablet
@@ -406,7 +409,8 @@ TEST_F(TabletMgrTest, FindTabletWithCompact) {
             rowset_meta->set_tablet_id(tablet.value()->tablet_id());
             rowset_meta->set_tablet_uid(tablet.value()->tablet_uid());
             rowset_meta->set_rowset_id(k_engine->next_rowset_id());
-            return std::make_shared<BetaRowset>(tablet.value()->tablet_schema(), std::move(rowset_meta),
+            return std::make_shared<BetaRowset>(tablet.value()->tablet_schema(),
+                                                std::move(rowset_meta),
                                                 tablet.value()->tablet_path());
         };
         auto st = tablet.value()->init();

--- a/be/test/storage/tablet/tablet_mgr_test.cpp
+++ b/be/test/storage/tablet/tablet_mgr_test.cpp
@@ -120,11 +120,11 @@ TEST_F(TabletMgrTest, CreateTablet) {
     RuntimeProfile profile("CreateTablet");
     Status create_st = _tablet_mgr->create_tablet(create_tablet_req, data_dirs, &profile);
     EXPECT_TRUE(create_st == Status::OK());
-    TabletSharedPtr tablet = _tablet_mgr->get_tablet(111);
-    EXPECT_TRUE(tablet != nullptr);
+    auto tablet = _tablet_mgr->get_tablet(111);
+    EXPECT_TRUE(tablet.has_value());
     // check dir exist
     bool dir_exist = false;
-    EXPECT_TRUE(io::global_local_filesystem()->exists(tablet->tablet_path(), &dir_exist).ok());
+    EXPECT_TRUE(io::global_local_filesystem()->exists(tablet.value()->tablet_path(), &dir_exist).ok());
     EXPECT_TRUE(dir_exist);
     // check meta has this tablet
     TabletMetaSharedPtr new_tablet_meta(new TabletMeta());
@@ -137,7 +137,7 @@ TEST_F(TabletMgrTest, CreateTablet) {
 
     Status drop_st = _tablet_mgr->drop_tablet(111, create_tablet_req.replica_id, false);
     EXPECT_TRUE(drop_st == Status::OK());
-    tablet.reset();
+    tablet->reset();
     Status trash_st = _tablet_mgr->start_trash_sweep();
     EXPECT_TRUE(trash_st == Status::OK());
 }
@@ -181,11 +181,11 @@ TEST_F(TabletMgrTest, CreateTabletWithSequence) {
     Status create_st = _tablet_mgr->create_tablet(create_tablet_req, data_dirs, &profile);
     EXPECT_TRUE(create_st == Status::OK());
 
-    TabletSharedPtr tablet = _tablet_mgr->get_tablet(111);
-    EXPECT_TRUE(tablet != nullptr);
+    auto tablet = _tablet_mgr->get_tablet(111);
+    EXPECT_TRUE(tablet.has_value());
     // check dir exist
     bool dir_exist = false;
-    EXPECT_TRUE(io::global_local_filesystem()->exists(tablet->tablet_path(), &dir_exist).ok());
+    EXPECT_TRUE(io::global_local_filesystem()->exists(tablet.value()->tablet_path(), &dir_exist).ok());
     EXPECT_TRUE(dir_exist);
     // check meta has this tablet
     TabletMetaSharedPtr new_tablet_meta(new TabletMeta());
@@ -194,7 +194,7 @@ TEST_F(TabletMgrTest, CreateTabletWithSequence) {
 
     Status drop_st = _tablet_mgr->drop_tablet(111, create_tablet_req.replica_id, false);
     EXPECT_TRUE(drop_st == Status::OK());
-    tablet.reset();
+    tablet->reset();
     Status trash_st = _tablet_mgr->start_trash_sweep();
     EXPECT_TRUE(trash_st == Status::OK());
 }
@@ -223,8 +223,8 @@ TEST_F(TabletMgrTest, DropTablet) {
     data_dirs.push_back(_data_dir);
     Status create_st = _tablet_mgr->create_tablet(create_tablet_req, data_dirs, &profile);
     EXPECT_TRUE(create_st == Status::OK());
-    TabletSharedPtr tablet = _tablet_mgr->get_tablet(111);
-    EXPECT_TRUE(tablet != nullptr);
+    auto tablet = _tablet_mgr->get_tablet(111);
+    EXPECT_TRUE(tablet.has_value());
 
     // drop unexist tablet will be success
     Status drop_st = _tablet_mgr->drop_tablet(1121, create_tablet_req.replica_id, false);
@@ -241,7 +241,7 @@ TEST_F(TabletMgrTest, DropTablet) {
     EXPECT_TRUE(tablet != nullptr);
 
     // check dir exist
-    std::string tablet_path = tablet->tablet_path();
+    std::string tablet_path = tablet.value()->tablet_path();
     bool dir_exist = false;
     EXPECT_TRUE(io::global_local_filesystem()->exists(tablet_path, &dir_exist).ok());
     EXPECT_TRUE(dir_exist);
@@ -256,7 +256,7 @@ TEST_F(TabletMgrTest, DropTablet) {
     EXPECT_TRUE(dir_exist);
 
     // reset tablet ptr
-    tablet.reset();
+    tablet->reset();
     trash_st = _tablet_mgr->start_trash_sweep();
     EXPECT_TRUE(trash_st == Status::OK());
     tablet = _tablet_mgr->get_tablet(111, true);
@@ -386,11 +386,11 @@ TEST_F(TabletMgrTest, FindTabletWithCompact) {
         Status create_st = _tablet_mgr->create_tablet(create_tablet_req, data_dirs, &profile);
         ASSERT_TRUE(create_st.ok()) << create_st;
 
-        TabletSharedPtr tablet = _tablet_mgr->get_tablet(tablet_id);
-        ASSERT_TRUE(tablet);
+        auto tablet = _tablet_mgr->get_tablet(tablet_id);
+        ASSERT_TRUE(tablet.has_value());
         // check dir exist
         bool dir_exist = false;
-        Status exist_st = io::global_local_filesystem()->exists(tablet->tablet_path(), &dir_exist);
+        Status exist_st = io::global_local_filesystem()->exists(tablet.value()->tablet_path(), &dir_exist);
         ASSERT_TRUE(exist_st.ok()) << exist_st;
         ASSERT_TRUE(dir_exist);
         // check meta has this tablet
@@ -403,17 +403,17 @@ TEST_F(TabletMgrTest, FindTabletWithCompact) {
             auto rowset_meta = std::make_shared<RowsetMeta>();
             Version version(start, end);
             rowset_meta->set_version(version);
-            rowset_meta->set_tablet_id(tablet->tablet_id());
-            rowset_meta->set_tablet_uid(tablet->tablet_uid());
+            rowset_meta->set_tablet_id(tablet.value()->tablet_id());
+            rowset_meta->set_tablet_uid(tablet.value()->tablet_uid());
             rowset_meta->set_rowset_id(k_engine->next_rowset_id());
-            return std::make_shared<BetaRowset>(tablet->tablet_schema(), std::move(rowset_meta),
-                                                tablet->tablet_path());
+            return std::make_shared<BetaRowset>(tablet.value()->tablet_schema(), std::move(rowset_meta),
+                                                tablet.value()->tablet_path());
         };
-        auto st = tablet->init();
+        auto st = tablet.value()->init();
         ASSERT_TRUE(st.ok()) << st;
         for (int i = 2; i <= rowset_size; ++i) {
             auto rs = create_rowset(i, i);
-            auto st = tablet->add_inc_rowset(rs);
+            auto st = tablet.value()->add_inc_rowset(rs);
             ASSERT_TRUE(st.ok()) << st;
         }
     };
@@ -579,11 +579,11 @@ TEST_F(TabletMgrTest, LoadTabletFromMeta) {
     Status create_st =
             k_engine->tablet_manager()->create_tablet(create_tablet_req, data_dirs, &profile);
     EXPECT_TRUE(create_st == Status::OK());
-    TabletSharedPtr tablet = k_engine->tablet_manager()->get_tablet(111);
-    EXPECT_TRUE(tablet != nullptr);
+    auto tablet = k_engine->tablet_manager()->get_tablet(111);
+    EXPECT_TRUE(tablet.has_value());
 
     std::string serialized_tablet_meta;
-    tablet->tablet_meta()->serialize(&serialized_tablet_meta);
+    tablet.value()->tablet_meta()->serialize(&serialized_tablet_meta);
     bool update_meta = true;
     bool force = true;
     bool restore = false;
@@ -594,7 +594,7 @@ TEST_F(TabletMgrTest, LoadTabletFromMeta) {
     ASSERT_TRUE(st.ok()) << st.to_string();
 
     // After reload, the original tablet should not be allowed to save meta.
-    ASSERT_FALSE(tablet->do_tablet_meta_checkpoint());
+    ASSERT_FALSE(tablet.value()->do_tablet_meta_checkpoint());
 }
 
 } // namespace doris


### PR DESCRIPTION
We get the following error (version 2.1.5):

```
*** Query id: 0-0 ***
*** is nereids: 0 ***
*** tablet id: 0 ***
*** Aborted at 1772767549 (unix time) try "date -d @1772767549" if you are using GNU date ***
*** Current BE git commitID: 654acde ***
*** SIGSEGV address not mapped to object (@0x40) received by PID 79914 (TID 81118 OR 0x7fc5b7fc8700) from PID 64; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/jenkins_agent/workspace/BigDataComponent_doris-unified-x86-release/be/src/common/signal_handler.h:421
 1# os::Linux::chained_handler(int, siginfo_t*, void*) in /usr/jdk64/current/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/jdk64/current/jre/lib/amd64/server/libjvm.so
 3# signalHandler(int, siginfo_t*, void*) in /usr/jdk64/current/jre/lib/amd64/server/libjvm.so
 4# 0x00007FC86CD24400 in /lib64/libc.so.6
 5# doris::create_tablet_callback(doris::StorageEngine&, doris::TAgentTaskRequest const&) at /home/jenkins_agent/workspace/BigDataComponent_doris-unified-x86-release/be/src/agent/task_worker_pool.cpp:1398
 6# std::_Function_handler<void (), doris::TaskWorkerPool::submit_task(doris::TAgentTaskRequest const&)::$_0::operator()<doris::TAgentTaskRequest const&>(doris::TAgentTaskRequest const&) const::{lambda()#1}>::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
 7# doris::ThreadPool::dispatch_thread() in /usr/local/doris-be/lib/doris_be
 8# doris::Thread::supervise_thread(void*) at /home/jenkins_agent/workspace/BigDataComponent_doris-unified-x86-release/be/src/util/thread.cpp:499
 9# start_thread in /lib64/libpthread.so.0
10# clone in /lib64/libc.so.6
```


This PR refactors tablet handling in BE by making get_tablet() return structured results.
We will not checking tablet == nullptr anymore, makes the control flow and error handling more explicit and consistent.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

