### PR TITLE
[fix](test) make hive compress split assertion multi-BE aware

### DIFF
--- a/regression-test/suites/external_table_p0/hive/test_hive_compress_type.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_compress_type.groovy
@@ -60,8 +60,8 @@ suite("test_hive_compress_type", "p0,external") {
         }
         explain {
             sql("select count(*) from test_compress_partitioned")
-            contains "inputSplitNum=${expectedSplitNumWithFileSplit}, totalFileSize=734675596, "
-                    + "scanRanges=${expectedSplitNumWithFileSplit}"
+            contains(("inputSplitNum=${expectedSplitNumWithFileSplit}, totalFileSize=734675596, "
+                    + "scanRanges=${expectedSplitNumWithFileSplit}"))
             contains "partition=8/8"
         }
 

--- a/regression-test/suites/external_table_p0/hive/test_hive_compress_type.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_compress_type.groovy
@@ -35,6 +35,42 @@ suite("test_hive_compress_type", "p0,external") {
         );"""
         sql """use `${catalog_name}`.`multi_catalog`"""
 
+        // table test_compress_partitioned has 6 partitions with different compressed file: plain, gzip, bzip2, deflate
+        sql """set file_split_size=0"""
+        // COUNT pushdown split behavior depends on:
+        // totalFileNum < parallel_fragment_exec_instance_num * backendNum
+        // test_compress_partitioned currently has 16 files.
+        def expectedSplitNum = 16
+        if (backendNum > 1) {
+            expectedSplitNum = (16 < parallelExecInstanceNum * backendNum) ? 28 : 16
+        }
+        explain {
+            sql("select count(*) from test_compress_partitioned")
+            contains "inputSplitNum=${expectedSplitNum}, totalFileSize=734675596, scanRanges=${expectedSplitNum}"
+            contains "partition=8/8"
+        }
+        qt_q21 """select count(*) from test_compress_partitioned where dt="gzip" or dt="mix""""
+        qt_q22 """select count(*) from test_compress_partitioned"""
+        order_qt_q23 """select * from test_compress_partitioned where watchid=4611870011201662970"""
+
+        sql """set file_split_size=8388608"""
+        def expectedSplitNumWithFileSplit = 16
+        if (backendNum > 1) {
+            expectedSplitNumWithFileSplit = (16 < parallelExecInstanceNum * backendNum) ? 82 : 16
+        }
+        explain {
+            sql("select count(*) from test_compress_partitioned")
+            contains "inputSplitNum=${expectedSplitNumWithFileSplit}, totalFileSize=734675596, "
+                    + "scanRanges=${expectedSplitNumWithFileSplit}"
+            contains "partition=8/8"
+        }
+
+        qt_q31 """select count(*) from test_compress_partitioned where dt="gzip" or dt="mix""""
+        qt_q32 """select count(*) from test_compress_partitioned"""
+        order_qt_q33 """select * from test_compress_partitioned where watchid=4611870011201662970"""
+        sql """set file_split_size=0"""
+
+
         order_qt_q42 """ select count(*) from parquet_lz4_compression ;       """
         order_qt_q43 """ select * from parquet_lz4_compression 
             order by col_int,col_smallint,col_tinyint,col_bigint,col_float,col_double,col_boolean,col_string,col_char,col_varchar,col_date,col_timestamp,col_decimal


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #60947

Problem Summary:

`external_table_p0/hive/test_hive_compress_type.groovy` uses a fixed split assertion (`16`) after `set file_split_size=8388608`.
This is stable in single-BE environments, but it can fail in multi-BE pipelines because Hive COUNT pushdown split behavior depends on both `backendNum` and `parallel_fragment_exec_instance_num`.

Community CI is typically single-BE and keeps the expected split count at `16`.
Internal CI runs with multiple BEs, so the same query can produce `82` scan ranges when `16 < parallel_fragment_exec_instance_num * backendNum`.

This PR makes the second explain assertion BE-aware and deterministic:
- reuse the existing `backendNum` and `parallel_fragment_exec_instance_num` inputs in the case
- compute the expected split count for the `file_split_size=8388608` branch with the same FE condition
- keep `16` for single-BE or low-parallelism environments, and expect `82` when the multi-BE split condition is met

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
