### PR TITLE
branch-4.0: [fix](docker) avoid passing OSS bucket as Hive runtime conf

### DIFF
--- a/docker/thirdparties/docker-compose/kerberos/entrypoint-hive-master.sh
+++ b/docker/thirdparties/docker-compose/kerberos/entrypoint-hive-master.sh
@@ -90,7 +90,11 @@ hive  -f /usr/local/sql/create_kerberos_hive_table.sql
 if [[ ${enablePaimonHms} == "true" ]]; then
     echo "Creating Paimon HMS catalog and table"
     hadoop fs -put /tmp/paimon_data/* /user/hive/warehouse/
-    hive --hiveconf oss_bucket="${OSSBucket}" -f /usr/local/sql/create_paimon_hive_table.hql
+    # Render the OSS location directly to avoid passing oss_bucket as a Hive session conf.
+    paimon_hql=$(mktemp /tmp/create_paimon_hive_table.XXXXXX.hql)
+    sed "s|__OSS_BUCKET__|${OSSBucket}|g" /usr/local/sql/create_paimon_hive_table.hql > "${paimon_hql}"
+    hive -f "${paimon_hql}"
+    rm -f "${paimon_hql}"
 fi
 
 exec_success_hook

--- a/docker/thirdparties/docker-compose/kerberos/sql/create_paimon_hive_table.hql
+++ b/docker/thirdparties/docker-compose/kerberos/sql/create_paimon_hive_table.hql
@@ -12,4 +12,4 @@ USE ali_db;
 
 CREATE EXTERNAL TABLE external_test_table
     STORED BY 'org.apache.paimon.hive.PaimonStorageHandler'
-LOCATION 'oss://${hiveconf:oss_bucket}/regression/paimon_warehouse/ali_db.db/hive_test_table';
+LOCATION 'oss://__OSS_BUCKET__/regression/paimon_warehouse/ali_db.db/hive_test_table';


### PR DESCRIPTION
### What problem does this PR solve?

The kerberos thirdparty docker initializes the Paimon HMS table by invoking `hive --hiveconf oss_bucket=...`. HiveServer2 treats `oss_bucket` as a runtime session parameter and rejects the connection with `Cannot modify oss_bucket at runtime`, which breaks the external regression deploy-docker step.

### What is changed

- stop passing `oss_bucket` through `--hiveconf` during kerberos Paimon HMS initialization
- render the OSS bucket directly into the HQL file before running `hive -f`
- keep the resulting OSS warehouse path unchanged

### Test

- `bash -n docker/thirdparties/docker-compose/kerberos/entrypoint-hive-master.sh`
- render check for `docker/thirdparties/docker-compose/kerberos/sql/create_paimon_hive_table.hql` with `OSSBucket=doris-regression-bj`