### PR TITLE
[opt](agg) Optimize the execution of GROUP BY count(*).

### DIFF
--- a/be/src/exec/operator/aggregation_sink_operator.cpp
+++ b/be/src/exec/operator/aggregation_sink_operator.cpp
@@ -652,42 +652,42 @@ void AggSinkLocalState::_emplace_into_hash_table_inline_count(ColumnRawPtrs& key
 void AggSinkLocalState::_merge_into_hash_table_inline_count(ColumnRawPtrs& key_columns,
                                                             const IColumn* merge_column,
                                                             uint32_t num_rows) {
-    std::visit(Overload {[&](std::monostate& arg) -> void {
-                             throw doris::Exception(ErrorCode::INTERNAL_ERROR,
-                                                    "uninited hash table");
-                         },
-                         [&](auto& agg_method) -> void {
-                             SCOPED_TIMER(_hash_table_compute_timer);
-                             using HashMethodType = std::decay_t<decltype(agg_method)>;
-                             using AggState = typename HashMethodType::State;
-                             AggState state(key_columns);
-                             agg_method.init_serialized_keys(key_columns, num_rows);
+    std::visit(
+            Overload {[&](std::monostate& arg) -> void {
+                          throw doris::Exception(ErrorCode::INTERNAL_ERROR, "uninited hash table");
+                      },
+                      [&](auto& agg_method) -> void {
+                          SCOPED_TIMER(_hash_table_compute_timer);
+                          using HashMethodType = std::decay_t<decltype(agg_method)>;
+                          using AggState = typename HashMethodType::State;
+                          AggState state(key_columns);
+                          agg_method.init_serialized_keys(key_columns, num_rows);
 
-                             const auto& col =
-                                     assert_cast<const ColumnFixedLengthObject&>(*merge_column);
-                             const auto* col_data =
-                                     reinterpret_cast<const AggregateFunctionCountData*>(
-                                             col.get_data().data());
+                          const auto& col =
+                                  assert_cast<const ColumnFixedLengthObject&>(*merge_column);
+                          const auto* col_data =
+                                  reinterpret_cast<const AggregateFunctionCountData*>(
+                                          col.get_data().data());
 
-                             auto creator = [&](const auto& ctor, auto& key, auto& origin) {
-                                 HashMethodType::try_presis_key_and_origin(
-                                         key, origin, Base::_shared_state->agg_arena_pool);
-                                 AggregateDataPtr mapped = nullptr;
-                                 ctor(key, mapped);
-                             };
+                          auto creator = [&](const auto& ctor, auto& key, auto& origin) {
+                              HashMethodType::try_presis_key_and_origin(
+                                      key, origin, Base::_shared_state->agg_arena_pool);
+                              AggregateDataPtr mapped = nullptr;
+                              ctor(key, mapped);
+                          };
 
-                             auto creator_for_null_key = [&](auto& mapped) { mapped = nullptr; };
+                          auto creator_for_null_key = [&](auto& mapped) { mapped = nullptr; };
 
-                             SCOPED_TIMER(_hash_table_emplace_timer);
-                             lazy_emplace_batch(
-                                     agg_method, state, num_rows, creator, creator_for_null_key,
-                                     [&](uint32_t i, auto& mapped) {
-                                         reinterpret_cast<UInt64&>(mapped) += col_data[i].count;
-                                     });
+                          SCOPED_TIMER(_hash_table_emplace_timer);
+                          lazy_emplace_batch(agg_method, state, num_rows, creator,
+                                             creator_for_null_key, [&](uint32_t i, auto& mapped) {
+                                                 reinterpret_cast<UInt64&>(mapped) +=
+                                                         col_data[i].count;
+                                             });
 
-                             COUNTER_UPDATE(_hash_table_input_counter, num_rows);
-                         }},
-               _agg_data->method_variant);
+                          COUNTER_UPDATE(_hash_table_input_counter, num_rows);
+                      }},
+            _agg_data->method_variant);
 }
 
 bool AggSinkLocalState::_emplace_into_hash_table_limit(AggregateDataPtr* places, Block* block,

--- a/be/src/exec/operator/aggregation_sink_operator.cpp
+++ b/be/src/exec/operator/aggregation_sink_operator.cpp
@@ -25,6 +25,7 @@
 #include "core/data_type/primitive_type.h"
 #include "exec/common/hash_table/hash.h"
 #include "exec/operator/operator.h"
+#include "exprs/aggregate/aggregate_function_count.h"
 #include "exprs/aggregate/aggregate_function_simple_factory.h"
 #include "exprs/vectorized_agg_fn.h"
 #include "runtime/runtime_profile.h"
@@ -156,6 +157,30 @@ Status AggSinkLocalState::open(RuntimeState* state) {
         RETURN_IF_ERROR(_create_agg_status(_agg_data->without_key));
         _shared_state->agg_data_created_without_key = true;
     }
+
+    // Determine whether to use simple count aggregation.
+    // For queries like: SELECT xxx, count(*) / count(not_null_column) FROM table GROUP BY xxx,
+    // count(*) / count(not_null_column) can store a uint64 counter directly in the hash table,
+    // instead of storing the full aggregate state, saving memory and computation overhead.
+    // Requirements:
+    // 0. The aggregation has a GROUP BY clause.
+    // 1. There is exactly one count aggregate function.
+    // 2. No limit optimization is applied.
+    // 3. Spill is not enabled (the spill path accesses aggregate_data_container, which is empty in inline count mode).
+    // Supports update / merge / finalize / serialize phases, since count's serialization format is UInt64 itself.
+
+    if (!Base::_shared_state->probe_expr_ctxs.empty() /* has GROUP BY */
+        && (p._aggregate_evaluators.size() == 1 &&
+            p._aggregate_evaluators[0]->function()->is_simple_count()) /* only one count(*) */
+        && !_should_limit_output /* no limit optimization */ &&
+        !Base::_shared_state->enable_spill /* spill not enabled */) {
+        _shared_state->use_simple_count = true;
+#ifndef NDEBUG
+        // Randomly enable/disable in debug mode to verify correctness of multi-phase agg promotion/demotion.
+        _shared_state->use_simple_count = rand() % 2 == 0;
+#endif
+    }
+
     return Status::OK();
 }
 
@@ -335,7 +360,18 @@ Status AggSinkLocalState::_merge_with_serialized_key_helper(Block* block) {
                                                          key_columns, (uint32_t)rows);
             rows = block->rows();
         } else {
-            _emplace_into_hash_table(_places.data(), key_columns, (uint32_t)rows);
+            if (_shared_state->use_simple_count) {
+                DCHECK(!for_spill);
+
+                auto col_id = AggSharedState::get_slot_column_id(
+                        Base::_shared_state->aggregate_evaluators[0]);
+
+                auto column = block->get_by_position(col_id).column;
+                _merge_into_hash_table_inline_count(key_columns, column.get(), (uint32_t)rows);
+                need_do_agg = false;
+            } else {
+                _emplace_into_hash_table(_places.data(), key_columns, (uint32_t)rows);
+            }
         }
 
         if (need_do_agg) {
@@ -496,7 +532,9 @@ Status AggSinkLocalState::_execute_with_serialized_key_helper(Block* block) {
             }
         } else {
             _emplace_into_hash_table(_places.data(), key_columns, rows);
-            RETURN_IF_ERROR(do_aggregate_evaluators());
+            if (!_shared_state->use_simple_count) {
+                RETURN_IF_ERROR(do_aggregate_evaluators());
+            }
 
             if (_should_limit_output && !Base::_shared_state->enable_spill) {
                 const size_t hash_table_size = get_hash_table_size();
@@ -524,6 +562,11 @@ size_t AggSinkLocalState::get_hash_table_size() const {
 
 void AggSinkLocalState::_emplace_into_hash_table(AggregateDataPtr* places,
                                                  ColumnRawPtrs& key_columns, uint32_t num_rows) {
+    if (_shared_state->use_simple_count) {
+        _emplace_into_hash_table_inline_count(key_columns, num_rows);
+        return;
+    }
+
     std::visit(Overload {[&](std::monostate& arg) -> void {
                              throw doris::Exception(ErrorCode::INTERNAL_ERROR,
                                                     "uninited hash table");
@@ -564,6 +607,84 @@ void AggSinkLocalState::_emplace_into_hash_table(AggregateDataPtr* places,
                              lazy_emplace_batch(
                                      agg_method, state, num_rows, creator, creator_for_null_key,
                                      [&](uint32_t row, auto& mapped) { places[row] = mapped; });
+
+                             COUNTER_UPDATE(_hash_table_input_counter, num_rows);
+                         }},
+               _agg_data->method_variant);
+}
+
+// For the agg hashmap<key, value>, the value is a char* type which is exactly 64 bits.
+// Here we treat it as a uint64 counter: each time the same key is encountered, the counter
+// is incremented by 1. This avoids storing the full aggregate state, saving memory and computation overhead.
+void AggSinkLocalState::_emplace_into_hash_table_inline_count(ColumnRawPtrs& key_columns,
+                                                              uint32_t num_rows) {
+    std::visit(Overload {[&](std::monostate& arg) -> void {
+                             throw doris::Exception(ErrorCode::INTERNAL_ERROR,
+                                                    "uninited hash table");
+                         },
+                         [&](auto& agg_method) -> void {
+                             SCOPED_TIMER(_hash_table_compute_timer);
+                             using HashMethodType = std::decay_t<decltype(agg_method)>;
+                             using AggState = typename HashMethodType::State;
+                             AggState state(key_columns);
+                             agg_method.init_serialized_keys(key_columns, num_rows);
+
+                             auto creator = [&](const auto& ctor, auto& key, auto& origin) {
+                                 HashMethodType::try_presis_key_and_origin(
+                                         key, origin, Base::_shared_state->agg_arena_pool);
+                                 AggregateDataPtr mapped = nullptr;
+                                 ctor(key, mapped);
+                             };
+
+                             auto creator_for_null_key = [&](auto& mapped) { mapped = nullptr; };
+
+                             SCOPED_TIMER(_hash_table_emplace_timer);
+                             for (size_t i = 0; i < num_rows; ++i) {
+                                 auto* mapped_ptr = agg_method.lazy_emplace(state, i, creator,
+                                                                            creator_for_null_key);
+                                 ++reinterpret_cast<UInt64&>(*mapped_ptr);
+                             }
+
+                             COUNTER_UPDATE(_hash_table_input_counter, num_rows);
+                         }},
+               _agg_data->method_variant);
+}
+
+void AggSinkLocalState::_merge_into_hash_table_inline_count(ColumnRawPtrs& key_columns,
+                                                            const IColumn* merge_column,
+                                                            uint32_t num_rows) {
+    std::visit(Overload {[&](std::monostate& arg) -> void {
+                             throw doris::Exception(ErrorCode::INTERNAL_ERROR,
+                                                    "uninited hash table");
+                         },
+                         [&](auto& agg_method) -> void {
+                             SCOPED_TIMER(_hash_table_compute_timer);
+                             using HashMethodType = std::decay_t<decltype(agg_method)>;
+                             using AggState = typename HashMethodType::State;
+                             AggState state(key_columns);
+                             agg_method.init_serialized_keys(key_columns, num_rows);
+
+                             const auto& col =
+                                     assert_cast<const ColumnFixedLengthObject&>(*merge_column);
+                             const auto* col_data =
+                                     reinterpret_cast<const AggregateFunctionCountData*>(
+                                             col.get_data().data());
+
+                             auto creator = [&](const auto& ctor, auto& key, auto& origin) {
+                                 HashMethodType::try_presis_key_and_origin(
+                                         key, origin, Base::_shared_state->agg_arena_pool);
+                                 AggregateDataPtr mapped = nullptr;
+                                 ctor(key, mapped);
+                             };
+
+                             auto creator_for_null_key = [&](auto& mapped) { mapped = nullptr; };
+
+                             SCOPED_TIMER(_hash_table_emplace_timer);
+                             for (size_t i = 0; i < num_rows; ++i) {
+                                 auto* mapped_ptr = agg_method.lazy_emplace(state, i, creator,
+                                                                            creator_for_null_key);
+                                 reinterpret_cast<UInt64&>(*mapped_ptr) += col_data[i].count;
+                             }
 
                              COUNTER_UPDATE(_hash_table_input_counter, num_rows);
                          }},

--- a/be/src/exec/operator/aggregation_sink_operator.cpp
+++ b/be/src/exec/operator/aggregation_sink_operator.cpp
@@ -639,11 +639,10 @@ void AggSinkLocalState::_emplace_into_hash_table_inline_count(ColumnRawPtrs& key
                              auto creator_for_null_key = [&](auto& mapped) { mapped = nullptr; };
 
                              SCOPED_TIMER(_hash_table_emplace_timer);
-                             for (size_t i = 0; i < num_rows; ++i) {
-                                 auto* mapped_ptr = agg_method.lazy_emplace(state, i, creator,
-                                                                            creator_for_null_key);
-                                 ++reinterpret_cast<UInt64&>(*mapped_ptr);
-                             }
+                             lazy_emplace_batch(agg_method, state, num_rows, creator,
+                                                creator_for_null_key, [&](uint32_t, auto& mapped) {
+                                                    ++reinterpret_cast<UInt64&>(mapped);
+                                                });
 
                              COUNTER_UPDATE(_hash_table_input_counter, num_rows);
                          }},
@@ -680,11 +679,11 @@ void AggSinkLocalState::_merge_into_hash_table_inline_count(ColumnRawPtrs& key_c
                              auto creator_for_null_key = [&](auto& mapped) { mapped = nullptr; };
 
                              SCOPED_TIMER(_hash_table_emplace_timer);
-                             for (size_t i = 0; i < num_rows; ++i) {
-                                 auto* mapped_ptr = agg_method.lazy_emplace(state, i, creator,
-                                                                            creator_for_null_key);
-                                 reinterpret_cast<UInt64&>(*mapped_ptr) += col_data[i].count;
-                             }
+                             lazy_emplace_batch(
+                                     agg_method, state, num_rows, creator, creator_for_null_key,
+                                     [&](uint32_t i, auto& mapped) {
+                                         reinterpret_cast<UInt64&>(mapped) += col_data[i].count;
+                                     });
 
                              COUNTER_UPDATE(_hash_table_input_counter, num_rows);
                          }},

--- a/be/src/exec/operator/aggregation_sink_operator.h
+++ b/be/src/exec/operator/aggregation_sink_operator.h
@@ -88,6 +88,10 @@ protected:
                              uint32_t num_rows);
     void _emplace_into_hash_table(AggregateDataPtr* places, ColumnRawPtrs& key_columns,
                                   uint32_t num_rows);
+
+    void _emplace_into_hash_table_inline_count(ColumnRawPtrs& key_columns, uint32_t num_rows);
+    void _merge_into_hash_table_inline_count(ColumnRawPtrs& key_columns,
+                                             const IColumn* merge_column, uint32_t num_rows);
     bool _emplace_into_hash_table_limit(AggregateDataPtr* places, Block* block,
                                         const std::vector<int>& key_locs,
                                         ColumnRawPtrs& key_columns, uint32_t num_rows);

--- a/be/src/exec/operator/aggregation_source_operator.cpp
+++ b/be/src/exec/operator/aggregation_source_operator.cpp
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "common/exception.h"
+#include "core/column/column_fixed_length_object.h"
 #include "exec/operator/operator.h"
 #include "exprs/vectorized_agg_fn.h"
 #include "exprs/vexpr_fwd.h"
@@ -131,6 +132,76 @@ Status AggLocalState::_get_results_with_serialized_key(RuntimeState* state, Bloc
                         const auto size = std::min(data.size(), size_t(state->batch_size()));
                         using KeyType = std::decay_t<decltype(agg_method)>::Key;
                         std::vector<KeyType> keys(size);
+
+                        if (shared_state.use_simple_count) {
+                            DCHECK_EQ(shared_state.aggregate_evaluators.size(), 1);
+
+                            value_data_types[0] = shared_state.aggregate_evaluators[0]
+                                                          ->function()
+                                                          ->get_serialized_type();
+                            if (mem_reuse) {
+                                value_columns[0] =
+                                        std::move(*block->get_by_position(key_size).column)
+                                                .mutate();
+                            } else {
+                                value_columns[0] = shared_state.aggregate_evaluators[0]
+                                                           ->function()
+                                                           ->create_serialize_column();
+                            }
+
+                            std::vector<UInt64> inline_counts(size);
+                            uint32_t num_rows = 0;
+                            {
+                                SCOPED_TIMER(_hash_table_iterate_timer);
+                                auto& it = agg_method.begin;
+                                while (it != agg_method.end && num_rows < state->batch_size()) {
+                                    keys[num_rows] = it.get_first();
+                                    inline_counts[num_rows] =
+                                            reinterpret_cast<const UInt64&>(it.get_second());
+                                    ++it;
+                                    ++num_rows;
+                                }
+                            }
+
+                            {
+                                SCOPED_TIMER(_insert_keys_to_column_timer);
+                                agg_method.insert_keys_into_columns(keys, key_columns, num_rows);
+                            }
+
+                            // Write inline counts to serialized column
+                            // AggregateFunctionCountData = { UInt64 count }, same layout as inline
+                            auto& count_col =
+                                    assert_cast<ColumnFixedLengthObject&>(*value_columns[0]);
+                            count_col.resize(num_rows);
+                            auto* col_data = count_col.get_data().data();
+                            for (uint32_t i = 0; i < num_rows; ++i) {
+                                *reinterpret_cast<UInt64*>(col_data + i * sizeof(UInt64)) =
+                                        inline_counts[i];
+                            }
+
+                            // Handle null key if present
+                            if (agg_method.begin == agg_method.end) {
+                                if (agg_method.hash_table->has_null_key_data()) {
+                                    DCHECK(key_columns.size() == 1);
+                                    DCHECK(key_columns[0]->is_nullable());
+                                    if (num_rows < state->batch_size()) {
+                                        key_columns[0]->insert_data(nullptr, 0);
+                                        auto mapped =
+                                                agg_method.hash_table->template get_null_key_data<
+                                                        AggregateDataPtr>();
+                                        count_col.resize(num_rows + 1);
+                                        *reinterpret_cast<UInt64*>(count_col.get_data().data() +
+                                                                   num_rows * sizeof(UInt64)) =
+                                                std::bit_cast<UInt64>(mapped);
+                                        *eos = true;
+                                    }
+                                } else {
+                                    *eos = true;
+                                }
+                            }
+                            return;
+                        }
+
                         if (shared_state.values.size() < size + 1) {
                             shared_state.values.resize(size + 1);
                         }
@@ -255,6 +326,52 @@ Status AggLocalState::_get_with_serialized_key_result(RuntimeState* state, Block
                         const auto size = std::min(data.size(), size_t(state->batch_size()));
                         using KeyType = std::decay_t<decltype(agg_method)>::Key;
                         std::vector<KeyType> keys(size);
+
+                        if (shared_state.use_simple_count) {
+                            // Inline count: mapped slot stores UInt64 count directly
+                            // (not a real AggregateDataPtr). Iterate hash table directly.
+                            DCHECK_EQ(value_columns.size(), 1);
+                            auto& count_column = assert_cast<ColumnInt64&>(*value_columns[0]);
+                            uint32_t num_rows = 0;
+                            {
+                                SCOPED_TIMER(_hash_table_iterate_timer);
+                                auto& it = agg_method.begin;
+                                while (it != agg_method.end && num_rows < state->batch_size()) {
+                                    keys[num_rows] = it.get_first();
+                                    auto& mapped = it.get_second();
+                                    count_column.insert_value(static_cast<Int64>(
+                                            reinterpret_cast<const UInt64&>(mapped)));
+                                    ++it;
+                                    ++num_rows;
+                                }
+                            }
+                            {
+                                SCOPED_TIMER(_insert_keys_to_column_timer);
+                                agg_method.insert_keys_into_columns(keys, key_columns, num_rows);
+                            }
+
+                            // Handle null key if present
+                            if (agg_method.begin == agg_method.end) {
+                                if (agg_method.hash_table->has_null_key_data()) {
+                                    DCHECK(key_columns.size() == 1);
+                                    DCHECK(key_columns[0]->is_nullable());
+                                    if (key_columns[0]->size() < state->batch_size()) {
+                                        key_columns[0]->insert_data(nullptr, 0);
+                                        auto mapped =
+                                                agg_method.hash_table->template get_null_key_data<
+                                                        AggregateDataPtr>();
+                                        count_column.insert_value(
+                                                static_cast<Int64>(std::bit_cast<UInt64>(mapped)));
+                                        *eos = true;
+                                    }
+                                } else {
+                                    *eos = true;
+                                }
+                            }
+                            return;
+                        }
+
+                        // Normal (non-simple-count) path
                         if (shared_state.values.size() < size) {
                             shared_state.values.resize(size);
                         }

--- a/be/src/exec/operator/aggregation_source_operator.cpp
+++ b/be/src/exec/operator/aggregation_source_operator.cpp
@@ -149,15 +149,19 @@ Status AggLocalState::_get_results_with_serialized_key(RuntimeState* state, Bloc
                                                            ->create_serialize_column();
                             }
 
-                            std::vector<UInt64> inline_counts(size);
+                            auto& count_col =
+                                    assert_cast<ColumnFixedLengthObject&>(*value_columns[0]);
                             uint32_t num_rows = 0;
                             {
                                 SCOPED_TIMER(_hash_table_iterate_timer);
                                 auto& it = agg_method.begin;
                                 while (it != agg_method.end && num_rows < state->batch_size()) {
                                     keys[num_rows] = it.get_first();
-                                    inline_counts[num_rows] =
+                                    auto inline_count =
                                             reinterpret_cast<const UInt64&>(it.get_second());
+                                    count_col.insert_data(
+                                            reinterpret_cast<const char*>(&inline_count),
+                                            sizeof(UInt64));
                                     ++it;
                                     ++num_rows;
                                 }
@@ -166,17 +170,6 @@ Status AggLocalState::_get_results_with_serialized_key(RuntimeState* state, Bloc
                             {
                                 SCOPED_TIMER(_insert_keys_to_column_timer);
                                 agg_method.insert_keys_into_columns(keys, key_columns, num_rows);
-                            }
-
-                            // Write inline counts to serialized column
-                            // AggregateFunctionCountData = { UInt64 count }, same layout as inline
-                            auto& count_col =
-                                    assert_cast<ColumnFixedLengthObject&>(*value_columns[0]);
-                            count_col.resize(num_rows);
-                            auto* col_data = count_col.get_data().data();
-                            for (uint32_t i = 0; i < num_rows; ++i) {
-                                *reinterpret_cast<UInt64*>(col_data + i * sizeof(UInt64)) =
-                                        inline_counts[i];
                             }
 
                             // Handle null key if present

--- a/be/src/exec/operator/streaming_aggregation_operator.cpp
+++ b/be/src/exec/operator/streaming_aggregation_operator.cpp
@@ -103,7 +103,7 @@ Status StreamingAggLocalState::open(RuntimeState* state) {
     // StreamingAgg only operates in update + serialize mode: input is raw data, output is serialized intermediate state.
     // The serialization format of count is UInt64 itself, so it can be inlined into the hash table mapped slot.
     if (_aggregate_evaluators.size() == 1 &&
-        _aggregate_evaluators[0]->function()->is_simple_count() && limit == -1) {
+        _aggregate_evaluators[0]->function()->is_simple_count() && p._sort_limit == -1) {
         _use_simple_count = true;
 #ifndef NDEBUG
         // Randomly enable/disable in debug mode to verify correctness of multi-phase agg promotion/demotion.
@@ -496,15 +496,19 @@ Status StreamingAggLocalState::_get_results_with_serialized_key(RuntimeState* st
                                                            ->create_serialize_column();
                             }
 
-                            std::vector<UInt64> inline_counts(size);
+                            auto& count_col =
+                                    assert_cast<ColumnFixedLengthObject&>(*value_columns[0]);
                             uint32_t num_rows = 0;
                             {
                                 SCOPED_TIMER(_hash_table_iterate_timer);
                                 auto& it = agg_method.begin;
                                 while (it != agg_method.end && num_rows < state->batch_size()) {
                                     keys[num_rows] = it.get_first();
-                                    inline_counts[num_rows] =
+                                    auto inline_count =
                                             reinterpret_cast<const UInt64&>(it.get_second());
+                                    count_col.insert_data(
+                                            reinterpret_cast<const char*>(&inline_count),
+                                            sizeof(UInt64));
                                     ++it;
                                     ++num_rows;
                                 }
@@ -513,16 +517,6 @@ Status StreamingAggLocalState::_get_results_with_serialized_key(RuntimeState* st
                             {
                                 SCOPED_TIMER(_insert_keys_to_column_timer);
                                 agg_method.insert_keys_into_columns(keys, key_columns, num_rows);
-                            }
-
-                            // Write inline counts to serialized column
-                            auto& count_col =
-                                    assert_cast<ColumnFixedLengthObject&>(*value_columns[0]);
-                            count_col.resize(num_rows);
-                            auto* col_data = count_col.get_data().data();
-                            for (uint32_t i = 0; i < num_rows; ++i) {
-                                *reinterpret_cast<UInt64*>(col_data + i * sizeof(UInt64)) =
-                                        inline_counts[i];
                             }
 
                             // Handle null key if present

--- a/be/src/exec/operator/streaming_aggregation_operator.cpp
+++ b/be/src/exec/operator/streaming_aggregation_operator.cpp
@@ -24,8 +24,10 @@
 
 #include "common/cast_set.h"
 #include "common/compiler_util.h" // IWYU pragma: keep
+#include "core/column/column_fixed_length_object.h"
 #include "exec/operator/operator.h"
 #include "exec/operator/streaming_agg_min_reduction.h"
+#include "exprs/aggregate/aggregate_function_count.h"
 #include "exprs/aggregate/aggregate_function_simple_factory.h"
 #include "exprs/vectorized_agg_fn.h"
 #include "exprs/vslot_ref.h"
@@ -97,22 +99,36 @@ Status StreamingAggLocalState::open(RuntimeState* state) {
 
     RETURN_IF_ERROR(_init_hash_method(_probe_expr_ctxs));
 
-    std::visit(Overload {[&](std::monostate& arg) -> void {
-                             throw doris::Exception(ErrorCode::INTERNAL_ERROR,
-                                                    "uninited hash table");
-                         },
-                         [&](auto& agg_method) {
-                             using HashTableType = std::decay_t<decltype(agg_method)>;
-                             using KeyType = typename HashTableType::Key;
+    // Determine whether to use simple count aggregation.
+    // StreamingAgg only operates in update + serialize mode: input is raw data, output is serialized intermediate state.
+    // The serialization format of count is UInt64 itself, so it can be inlined into the hash table mapped slot.
+    if (_aggregate_evaluators.size() == 1 &&
+        _aggregate_evaluators[0]->function()->is_simple_count()) {
+        _use_simple_count = true;
+#ifndef NDEBUG
+        // Randomly enable/disable in debug mode to verify correctness of multi-phase agg promotion/demotion.
+        _use_simple_count = rand() % 2 == 0;
+#endif
+    }
 
-                             /// some aggregate functions (like AVG for decimal) have align issues.
-                             _aggregate_data_container = std::make_unique<AggregateDataContainer>(
-                                     sizeof(KeyType), ((p._total_size_of_aggregate_states +
-                                                        p._align_aggregate_states - 1) /
-                                                       p._align_aggregate_states) *
-                                                              p._align_aggregate_states);
-                         }},
-               _agg_data->method_variant);
+    std::visit(
+            Overload {[&](std::monostate& arg) -> void {
+                          throw doris::Exception(ErrorCode::INTERNAL_ERROR, "uninited hash table");
+                      },
+                      [&](auto& agg_method) {
+                          using HashTableType = std::decay_t<decltype(agg_method)>;
+                          using KeyType = typename HashTableType::Key;
+
+                          if (!_use_simple_count) {
+                              /// some aggregate functions (like AVG for decimal) have align issues.
+                              _aggregate_data_container = std::make_unique<AggregateDataContainer>(
+                                      sizeof(KeyType), ((p._total_size_of_aggregate_states +
+                                                         p._align_aggregate_states - 1) /
+                                                        p._align_aggregate_states) *
+                                                               p._align_aggregate_states);
+                          }
+                      }},
+            _agg_data->method_variant);
 
     limit = p._sort_limit;
     do_sort_limit = p._do_sort_limit;
@@ -139,8 +155,11 @@ void StreamingAggLocalState::_update_memusage_with_serialized_key() {
                          },
                          [&](auto& agg_method) -> void {
                              auto& data = *agg_method.hash_table;
-                             int64_t arena_memory_usage = _agg_arena_pool.size() +
-                                                          _aggregate_data_container->memory_usage();
+                             int64_t arena_memory_usage =
+                                     _agg_arena_pool.size() +
+                                     (_aggregate_data_container
+                                              ? _aggregate_data_container->memory_usage()
+                                              : 0);
                              int64_t hash_table_memory_usage = data.get_buffer_size_in_bytes();
 
                              COUNTER_SET(_memory_used_counter,
@@ -274,23 +293,22 @@ bool StreamingAggLocalState::_should_not_do_pre_agg(size_t rows) {
     const auto spill_streaming_agg_mem_limit = p._spill_streaming_agg_mem_limit;
     const bool used_too_much_memory =
             spill_streaming_agg_mem_limit > 0 && _memory_usage() > spill_streaming_agg_mem_limit;
-    std::visit(
-            Overload {
-                    [&](std::monostate& arg) {
-                        throw doris::Exception(ErrorCode::INTERNAL_ERROR, "uninited hash table");
-                    },
-                    [&](auto& agg_method) {
-                        auto& hash_tbl = *agg_method.hash_table;
-                        /// If too much memory is used during the pre-aggregation stage,
-                        /// it is better to output the data directly without performing further aggregation.
-                        // do not try to do agg, just init and serialize directly return the out_block
-                        if (used_too_much_memory || (hash_tbl.add_elem_size_overflow(rows) &&
-                                                     !_should_expand_preagg_hash_tables())) {
-                            SCOPED_TIMER(_streaming_agg_timer);
-                            ret_flag = true;
-                        }
-                    }},
-            _agg_data->method_variant);
+    std::visit(Overload {[&](std::monostate& arg) {
+                             throw doris::Exception(ErrorCode::INTERNAL_ERROR,
+                                                    "uninited hash table");
+                         },
+                         [&](auto& agg_method) {
+                             auto& hash_tbl = *agg_method.hash_table;
+                             /// If too much memory is used during the pre-aggregation stage,
+                             /// it is better to output the data directly without performing further aggregation.
+                             // do not try to do agg, just init and serialize directly return the out_block
+                             if (used_too_much_memory || (hash_tbl.add_elem_size_overflow(rows) &&
+                                                          !_should_expand_preagg_hash_tables())) {
+                                 SCOPED_TIMER(_streaming_agg_timer);
+                                 ret_flag = true;
+                             }
+                         }},
+               _agg_data->method_variant);
 
     return ret_flag;
 }
@@ -388,7 +406,12 @@ Status StreamingAggLocalState::_pre_agg_with_serialized_key(doris::Block* in_blo
     } else {
         bool need_agg = true;
         if (need_do_sort_limit != 1) {
-            _emplace_into_hash_table(_places.data(), key_columns, rows);
+            if (_use_simple_count) {
+                _emplace_into_hash_table_inline_count(key_columns, rows);
+                need_agg = false;
+            } else {
+                _emplace_into_hash_table(_places.data(), key_columns, rows);
+            }
         } else {
             need_agg = _emplace_into_hash_table_limit(_places.data(), in_block, key_columns, rows);
         }
@@ -456,6 +479,74 @@ Status StreamingAggLocalState::_get_results_with_serialized_key(RuntimeState* st
                         const auto size = std::min(data.size(), size_t(state->batch_size()));
                         using KeyType = std::decay_t<decltype(agg_method)>::Key;
                         std::vector<KeyType> keys(size);
+
+                        if (_use_simple_count) {
+                            DCHECK_EQ(_aggregate_evaluators.size(), 1);
+
+                            value_data_types[0] =
+                                    _aggregate_evaluators[0]->function()->get_serialized_type();
+                            if (mem_reuse) {
+                                value_columns[0] =
+                                        std::move(*block->get_by_position(key_size).column)
+                                                .mutate();
+                            } else {
+                                value_columns[0] = _aggregate_evaluators[0]
+                                                           ->function()
+                                                           ->create_serialize_column();
+                            }
+
+                            std::vector<UInt64> inline_counts(size);
+                            uint32_t num_rows = 0;
+                            {
+                                SCOPED_TIMER(_hash_table_iterate_timer);
+                                auto& it = agg_method.begin;
+                                while (it != agg_method.end && num_rows < state->batch_size()) {
+                                    keys[num_rows] = it.get_first();
+                                    inline_counts[num_rows] =
+                                            reinterpret_cast<const UInt64&>(it.get_second());
+                                    ++it;
+                                    ++num_rows;
+                                }
+                            }
+
+                            {
+                                SCOPED_TIMER(_insert_keys_to_column_timer);
+                                agg_method.insert_keys_into_columns(keys, key_columns, num_rows);
+                            }
+
+                            // Write inline counts to serialized column
+                            auto& count_col =
+                                    assert_cast<ColumnFixedLengthObject&>(*value_columns[0]);
+                            count_col.resize(num_rows);
+                            auto* col_data = count_col.get_data().data();
+                            for (uint32_t i = 0; i < num_rows; ++i) {
+                                *reinterpret_cast<UInt64*>(col_data + i * sizeof(UInt64)) =
+                                        inline_counts[i];
+                            }
+
+                            // Handle null key if present
+                            if (agg_method.begin == agg_method.end) {
+                                if (agg_method.hash_table->has_null_key_data()) {
+                                    DCHECK(key_columns.size() == 1);
+                                    DCHECK(key_columns[0]->is_nullable());
+                                    if (num_rows < state->batch_size()) {
+                                        key_columns[0]->insert_data(nullptr, 0);
+                                        auto mapped =
+                                                agg_method.hash_table->template get_null_key_data<
+                                                        AggregateDataPtr>();
+                                        count_col.resize(num_rows + 1);
+                                        *reinterpret_cast<UInt64*>(count_col.get_data().data() +
+                                                                   num_rows * sizeof(UInt64)) =
+                                                std::bit_cast<UInt64>(mapped);
+                                        *eos = true;
+                                    }
+                                } else {
+                                    *eos = true;
+                                }
+                            }
+                            return;
+                        }
+
                         if (_values.size() < size + 1) {
                             _values.resize(size + 1);
                         }
@@ -728,6 +819,11 @@ bool StreamingAggLocalState::_do_limit_filter(size_t num_rows, ColumnRawPtrs& ke
 void StreamingAggLocalState::_emplace_into_hash_table(AggregateDataPtr* places,
                                                       ColumnRawPtrs& key_columns,
                                                       const uint32_t num_rows) {
+    if (_use_simple_count) {
+        _emplace_into_hash_table_inline_count(key_columns, num_rows);
+        return;
+    }
+
     std::visit(Overload {[&](std::monostate& arg) -> void {
                              throw doris::Exception(ErrorCode::INTERNAL_ERROR,
                                                     "uninited hash table");
@@ -766,6 +862,40 @@ void StreamingAggLocalState::_emplace_into_hash_table(AggregateDataPtr* places,
                              lazy_emplace_batch(
                                      agg_method, state, num_rows, creator, creator_for_null_key,
                                      [&](uint32_t row, auto& mapped) { places[row] = mapped; });
+
+                             COUNTER_UPDATE(_hash_table_input_counter, num_rows);
+                         }},
+               _agg_data->method_variant);
+}
+
+void StreamingAggLocalState::_emplace_into_hash_table_inline_count(ColumnRawPtrs& key_columns,
+                                                                   uint32_t num_rows) {
+    std::visit(Overload {[&](std::monostate& arg) -> void {
+                             throw doris::Exception(ErrorCode::INTERNAL_ERROR,
+                                                    "uninited hash table");
+                         },
+                         [&](auto& agg_method) -> void {
+                             SCOPED_TIMER(_hash_table_compute_timer);
+                             using HashMethodType = std::decay_t<decltype(agg_method)>;
+                             using AggState = typename HashMethodType::State;
+                             AggState state(key_columns);
+                             agg_method.init_serialized_keys(key_columns, num_rows);
+
+                             auto creator = [&](const auto& ctor, auto& key, auto& origin) {
+                                 HashMethodType::try_presis_key_and_origin(key, origin,
+                                                                           _agg_arena_pool);
+                                 AggregateDataPtr mapped = nullptr;
+                                 ctor(key, mapped);
+                             };
+
+                             auto creator_for_null_key = [&](auto& mapped) { mapped = nullptr; };
+
+                             SCOPED_TIMER(_hash_table_emplace_timer);
+                             for (size_t i = 0; i < num_rows; ++i) {
+                                 auto* mapped_ptr = agg_method.lazy_emplace(state, i, creator,
+                                                                            creator_for_null_key);
+                                 ++reinterpret_cast<UInt64&>(*mapped_ptr);
+                             }
 
                              COUNTER_UPDATE(_hash_table_input_counter, num_rows);
                          }},

--- a/be/src/exec/operator/streaming_aggregation_operator.cpp
+++ b/be/src/exec/operator/streaming_aggregation_operator.cpp
@@ -293,22 +293,23 @@ bool StreamingAggLocalState::_should_not_do_pre_agg(size_t rows) {
     const auto spill_streaming_agg_mem_limit = p._spill_streaming_agg_mem_limit;
     const bool used_too_much_memory =
             spill_streaming_agg_mem_limit > 0 && _memory_usage() > spill_streaming_agg_mem_limit;
-    std::visit(Overload {[&](std::monostate& arg) {
-                             throw doris::Exception(ErrorCode::INTERNAL_ERROR,
-                                                    "uninited hash table");
-                         },
-                         [&](auto& agg_method) {
-                             auto& hash_tbl = *agg_method.hash_table;
-                             /// If too much memory is used during the pre-aggregation stage,
-                             /// it is better to output the data directly without performing further aggregation.
-                             // do not try to do agg, just init and serialize directly return the out_block
-                             if (used_too_much_memory || (hash_tbl.add_elem_size_overflow(rows) &&
-                                                          !_should_expand_preagg_hash_tables())) {
-                                 SCOPED_TIMER(_streaming_agg_timer);
-                                 ret_flag = true;
-                             }
-                         }},
-               _agg_data->method_variant);
+    std::visit(
+            Overload {
+                    [&](std::monostate& arg) {
+                        throw doris::Exception(ErrorCode::INTERNAL_ERROR, "uninited hash table");
+                    },
+                    [&](auto& agg_method) {
+                        auto& hash_tbl = *agg_method.hash_table;
+                        /// If too much memory is used during the pre-aggregation stage,
+                        /// it is better to output the data directly without performing further aggregation.
+                        // do not try to do agg, just init and serialize directly return the out_block
+                        if (used_too_much_memory || (hash_tbl.add_elem_size_overflow(rows) &&
+                                                     !_should_expand_preagg_hash_tables())) {
+                            SCOPED_TIMER(_streaming_agg_timer);
+                            ret_flag = true;
+                        }
+                    }},
+            _agg_data->method_variant);
 
     return ret_flag;
 }

--- a/be/src/exec/operator/streaming_aggregation_operator.cpp
+++ b/be/src/exec/operator/streaming_aggregation_operator.cpp
@@ -103,7 +103,7 @@ Status StreamingAggLocalState::open(RuntimeState* state) {
     // StreamingAgg only operates in update + serialize mode: input is raw data, output is serialized intermediate state.
     // The serialization format of count is UInt64 itself, so it can be inlined into the hash table mapped slot.
     if (_aggregate_evaluators.size() == 1 &&
-        _aggregate_evaluators[0]->function()->is_simple_count()) {
+        _aggregate_evaluators[0]->function()->is_simple_count() && limit == -1) {
         _use_simple_count = true;
 #ifndef NDEBUG
         // Randomly enable/disable in debug mode to verify correctness of multi-phase agg promotion/demotion.
@@ -892,11 +892,10 @@ void StreamingAggLocalState::_emplace_into_hash_table_inline_count(ColumnRawPtrs
                              auto creator_for_null_key = [&](auto& mapped) { mapped = nullptr; };
 
                              SCOPED_TIMER(_hash_table_emplace_timer);
-                             for (size_t i = 0; i < num_rows; ++i) {
-                                 auto* mapped_ptr = agg_method.lazy_emplace(state, i, creator,
-                                                                            creator_for_null_key);
-                                 ++reinterpret_cast<UInt64&>(*mapped_ptr);
-                             }
+                             lazy_emplace_batch(agg_method, state, num_rows, creator,
+                                                creator_for_null_key, [&](uint32_t, auto& mapped) {
+                                                    ++reinterpret_cast<UInt64&>(mapped);
+                                                });
 
                              COUNTER_UPDATE(_hash_table_input_counter, num_rows);
                          }},

--- a/be/src/exec/operator/streaming_aggregation_operator.h
+++ b/be/src/exec/operator/streaming_aggregation_operator.h
@@ -68,6 +68,7 @@ private:
     Status _get_results_with_serialized_key(RuntimeState* state, Block* block, bool* eos);
     void _emplace_into_hash_table(AggregateDataPtr* places, ColumnRawPtrs& key_columns,
                                   const uint32_t num_rows);
+    void _emplace_into_hash_table_inline_count(ColumnRawPtrs& key_columns, uint32_t num_rows);
     bool _emplace_into_hash_table_limit(AggregateDataPtr* places, Block* block,
                                         ColumnRawPtrs& key_columns, uint32_t num_rows);
     Status _create_agg_status(AggregateDataPtr data);
@@ -98,6 +99,7 @@ private:
     // group by k1,k2
     VExprContextSPtrs _probe_expr_ctxs;
     std::unique_ptr<AggregateDataContainer> _aggregate_data_container = nullptr;
+    bool _use_simple_count = false;
     bool _reach_limit = false;
     size_t _input_num_rows = 0;
 
@@ -178,6 +180,11 @@ private:
                                  // Do nothing
                              },
                              [&](auto& agg_method) -> void {
+                                 if (_use_simple_count) {
+                                     // Inline count: mapped slots hold UInt64,
+                                     // not real agg state pointers. Skip destroy.
+                                     return;
+                                 }
                                  auto& data = *agg_method.hash_table;
                                  data.for_each_mapped([&](auto& mapped) {
                                      if (mapped) {

--- a/be/src/exec/pipeline/dependency.cpp
+++ b/be/src/exec/pipeline/dependency.cpp
@@ -277,36 +277,39 @@ bool AggSharedState::do_limit_filter(Block* block, size_t num_rows,
 
 Status AggSharedState::reset_hash_table() {
     return std::visit(
-            Overload {[&](std::monostate& arg) -> Status {
-                          return Status::InternalError("Uninited hash table");
-                      },
-                      [&](auto& agg_method) {
-                          auto& hash_table = *agg_method.hash_table;
-                          using HashTableType = std::decay_t<decltype(hash_table)>;
+            Overload {
+                    [&](std::monostate& arg) -> Status {
+                        return Status::InternalError("Uninited hash table");
+                    },
+                    [&](auto& agg_method) {
+                        auto& hash_table = *agg_method.hash_table;
+                        using HashTableType = std::decay_t<decltype(hash_table)>;
 
-                          agg_method.arena.clear();
-                          agg_method.inited_iterator = false;
+                        agg_method.arena.clear();
+                        agg_method.inited_iterator = false;
 
-                          hash_table.for_each_mapped([&](auto& mapped) {
-                              if (mapped) {
-                                  _destroy_agg_status(mapped);
-                                  mapped = nullptr;
-                              }
-                          });
+                        if (!use_simple_count) {
+                            hash_table.for_each_mapped([&](auto& mapped) {
+                                if (mapped) {
+                                    _destroy_agg_status(mapped);
+                                    mapped = nullptr;
+                                }
+                            });
 
-                          if (hash_table.has_null_key_data()) {
-                              _destroy_agg_status(
-                                      hash_table.template get_null_key_data<AggregateDataPtr>());
-                          }
+                            if (hash_table.has_null_key_data()) {
+                                _destroy_agg_status(
+                                        hash_table.template get_null_key_data<AggregateDataPtr>());
+                            }
 
-                          aggregate_data_container.reset(new AggregateDataContainer(
-                                  sizeof(typename HashTableType::key_type),
-                                  ((total_size_of_aggregate_states + align_aggregate_states - 1) /
-                                   align_aggregate_states) *
-                                          align_aggregate_states));
-                          agg_method.hash_table.reset(new HashTableType());
-                          return Status::OK();
-                      }},
+                            aggregate_data_container.reset(new AggregateDataContainer(
+                                    sizeof(typename HashTableType::key_type),
+                                    ((total_size_of_aggregate_states + align_aggregate_states - 1) /
+                                     align_aggregate_states) *
+                                            align_aggregate_states));
+                        }
+                        agg_method.hash_table.reset(new HashTableType());
+                        return Status::OK();
+                    }},
             agg_data->method_variant);
 }
 

--- a/be/src/exec/pipeline/dependency.h
+++ b/be/src/exec/pipeline/dependency.h
@@ -320,6 +320,7 @@ public:
     bool enable_spill = false;
     bool reach_limit = false;
 
+    bool use_simple_count = false;
     int64_t limit = -1;
     bool do_sort_limit = false;
     MutableColumns limit_columns;
@@ -392,6 +393,11 @@ private:
                                  // Do nothing
                              },
                              [&](auto& agg_method) -> void {
+                                 if (use_simple_count) {
+                                     // Inline count: mapped slots hold UInt64,
+                                     // not real agg state pointers. Skip destroy.
+                                     return;
+                                 }
                                  auto& data = *agg_method.hash_table;
                                  data.for_each_mapped([&](auto& mapped) {
                                      if (mapped) {

--- a/be/src/exprs/aggregate/aggregate_function.h
+++ b/be/src/exprs/aggregate/aggregate_function.h
@@ -263,6 +263,8 @@ public:
 
     virtual bool is_blockable() const { return false; }
 
+    virtual bool is_simple_count() const { return false; }
+
     /**
     * Executes the aggregate function in incremental mode.
     * This is a virtual function that should be overridden by aggregate functions supporting incremental calculation.

--- a/be/src/exprs/aggregate/aggregate_function_count.h
+++ b/be/src/exprs/aggregate/aggregate_function_count.h
@@ -57,6 +57,7 @@ public:
     AggregateFunctionCount(const DataTypes& argument_types_)
             : IAggregateFunctionDataHelper(argument_types_) {}
 
+    bool is_simple_count() const override { return true; }
     String get_name() const override { return "count"; }
 
     DataTypePtr get_return_type() const override { return std::make_shared<DataTypeInt64>(); }


### PR DESCRIPTION
### What problem does this PR solve?

For SQL like:
```mysql
SELECT xxx, count(*) FROM table GROUP BY ...
```
we can apply the following optimization:

In the agg hashmap<key, value>, the value is a char*, which happens to be 64-bit. We can treat this pointer directly as a uint64 counter. This avoids creating an AggState. However, this introduces extra if/else branches in many places where we operate on the hashmap. We plan to refactor this area in the future.


```mysql
MySQL [hits]> SELECT ClientIP,sum(ClientIP) AS c
    -> FROM hits
    -> GROUP BY ClientIP
    -> ORDER BY c DESC
    -> LIMIT 10;

10 rows in set (0.374 sec)

MySQL [hits]> SELECT ClientIP, COUNT(*) AS c
    -> FROM hits
    -> GROUP BY ClientIP
    -> ORDER BY c DESC
    -> LIMIT 10;

10 rows in set (0.312 sec)

```



### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

