### PR TITLE
[fix](paimon) update ConnectorProperty import after fe-foundation refactor

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonJdbcMetaStoreProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonJdbcMetaStoreProperties.java
@@ -20,7 +20,7 @@ package org.apache.doris.datasource.property.metastore;
 import org.apache.doris.catalog.JdbcResource;
 import org.apache.doris.common.security.authentication.HadoopExecutionAuthenticator;
 import org.apache.doris.datasource.paimon.PaimonExternalCatalog;
-import org.apache.doris.datasource.property.ConnectorProperty;
+import org.apache.doris.foundation.property.ConnectorProperty;
 import org.apache.doris.datasource.property.storage.HdfsProperties;
 import org.apache.doris.datasource.property.storage.StorageProperties;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonJdbcMetaStoreProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonJdbcMetaStoreProperties.java
@@ -20,9 +20,9 @@ package org.apache.doris.datasource.property.metastore;
 import org.apache.doris.catalog.JdbcResource;
 import org.apache.doris.common.security.authentication.HadoopExecutionAuthenticator;
 import org.apache.doris.datasource.paimon.PaimonExternalCatalog;
-import org.apache.doris.foundation.property.ConnectorProperty;
 import org.apache.doris.datasource.property.storage.HdfsProperties;
 import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.foundation.property.ConnectorProperty;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;


### PR DESCRIPTION
## Problem
- commit #61175 moved `ConnectorProperty` from `org.apache.doris.datasource.property` to `org.apache.doris.foundation.property`
- `PaimonJdbcMetaStoreProperties` still imported the old package
- FE UT on latest master then failed with `cannot find symbol: class ConnectorProperty`

## Fix
- switch `PaimonJdbcMetaStoreProperties` to import `org.apache.doris.foundation.property.ConnectorProperty`

## Validation
- `./run-fe-ut.sh --run org.apache.doris.datasource.property.metastore.PaimonJdbcMetaStorePropertiesTest`
