### PR TITLE
[fix](fe) fix VSCode Java Language Server initialization failure caused by maven-build-cache-extension

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -232,11 +232,6 @@ under the License.
                 <artifactId>os-maven-plugin</artifactId>
                 <version>1.7.0</version>
             </extension>
-            <extension>
-                <groupId>org.apache.maven.extensions</groupId>
-                <artifactId>maven-build-cache-extension</artifactId>
-                <version>1.2.2</version>
-            </extension>
         </extensions>
     </build>
     <modules>
@@ -433,6 +428,26 @@ under the License.
         <mockito.version>4.11.0</mockito.version>
     </properties>
     <profiles>
+        <!-- maven-build-cache-extension is excluded from m2e/IDE environment because
+             it requires MavenExecutionRequest.getMultiModuleProjectDirectory() which
+             m2e does not set, causing NullPointerException during project import. -->
+        <profile>
+            <id>build-cache</id>
+            <activation>
+                <property>
+                    <name>!m2e.version</name>
+                </property>
+            </activation>
+            <build>
+                <extensions>
+                    <extension>
+                        <groupId>org.apache.maven.extensions</groupId>
+                        <artifactId>maven-build-cache-extension</artifactId>
+                        <version>1.2.2</version>
+                    </extension>
+                </extensions>
+            </build>
+        </profile>
         <profile>
             <id>general-env</id>
             <activation>


### PR DESCRIPTION
### What problem does this PR solve?

maven-build-cache-extension:1.2.2 crashes during m2e project import because MavenExecutionRequest.getMultiModuleProjectDirectory() returns null in m2e context, while the extension requires it during initialization.

Move maven-build-cache-extension into a Maven profile activated only when m2e.version property is NOT set (i.e., command-line builds only). This prevents the extension from loading during IDE project import while keeping build cache fully functional for normal builds.


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

