### PR TITLE
[refactor](oss) unify FE OSS filesystem with Jindo

### DIFF
--- a/fe/be-java-extensions/hadoop-deps/pom.xml
+++ b/fe/be-java-extensions/hadoop-deps/pom.xml
@@ -39,10 +39,6 @@ under the License.
             <artifactId>commons-collections4</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-aliyun</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
         </dependency>

--- a/fe/be-java-extensions/preload-extensions/pom.xml
+++ b/fe/be-java-extensions/preload-extensions/pom.xml
@@ -84,11 +84,6 @@ under the License.
             <artifactId>paimon-s3</artifactId>
             <version>${paimon.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-oss</artifactId>
-            <version>${paimon.version}</version>
-        </dependency>
         <!-- For Avro and Hudi Scanner PreLoad -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -559,12 +559,6 @@ under the License.
         </dependency>
 
         <dependency>
-            <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-oss</artifactId>
-            <version>${paimon.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>glue</artifactId>
             <exclusions>

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSHdfsProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSHdfsProperties.java
@@ -174,8 +174,8 @@ public class OSSHdfsProperties extends HdfsCompatibleProperties {
         config.put("fs.oss.accessKeyId", accessKey);
         config.put("fs.oss.accessKeySecret", secretKey);
         config.put("fs.oss.region", region);
-        config.put("fs.oss.impl", "com.aliyun.jindodata.oss.JindoOssFileSystem");
-        config.put("fs.AbstractFileSystem.oss.impl", "com.aliyun.jindodata.oss.JindoOSS");
+        config.put("fs.oss.impl", OSSProperties.JINDO_OSS_FILE_SYSTEM_IMPL);
+        config.put("fs.AbstractFileSystem.oss.impl", OSSProperties.JINDO_OSS_ABSTRACT_FILE_SYSTEM_IMPL);
         if (StringUtils.isNotBlank(fsDefaultFS)) {
             config.put(HDFS_DEFAULT_FS_NAME, fsDefaultFS);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
@@ -163,6 +163,9 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
     private static List<String> DLF_TYPE_KEYWORDS = Arrays.asList("hive.metastore.type",
             "iceberg.catalog.type", "paimon.catalog.type");
 
+    static final String JINDO_OSS_FILE_SYSTEM_IMPL = "com.aliyun.jindodata.oss.JindoOssFileSystem";
+    static final String JINDO_OSS_ABSTRACT_FILE_SYSTEM_IMPL = "com.aliyun.jindodata.oss.JindoOSS";
+
     private static final String DLS_URI_KEYWORDS = "oss-dls.aliyuncs";
 
     protected OSSProperties(Map<String, String> origProps) {
@@ -311,10 +314,12 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
     @Override
     public void initializeHadoopStorageConfig() {
         super.initializeHadoopStorageConfig();
-        hadoopStorageConfig.set("fs.oss.impl", "org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystem");
+        hadoopStorageConfig.set("fs.oss.impl", JINDO_OSS_FILE_SYSTEM_IMPL);
+        hadoopStorageConfig.set("fs.AbstractFileSystem.oss.impl", JINDO_OSS_ABSTRACT_FILE_SYSTEM_IMPL);
         hadoopStorageConfig.set("fs.oss.accessKeyId", accessKey);
         hadoopStorageConfig.set("fs.oss.accessKeySecret", secretKey);
         hadoopStorageConfig.set("fs.oss.endpoint", endpoint);
+        hadoopStorageConfig.set("fs.oss.region", region);
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSPropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSPropertiesTest.java
@@ -273,6 +273,19 @@ public class OSSPropertiesTest {
     }
 
     @Test
+    public void testUseJindoFsForHadoopStorageConfig() throws UserException {
+        Map<String, String> props = Maps.newHashMap();
+        props.put("oss.endpoint", "oss-cn-hangzhou.aliyuncs.com");
+        props.put("oss.region", "cn-hangzhou");
+        OSSProperties ossProperties = (OSSProperties) StorageProperties.createPrimary(props);
+        Assertions.assertEquals(OSSProperties.JINDO_OSS_FILE_SYSTEM_IMPL,
+                ossProperties.hadoopStorageConfig.get("fs.oss.impl"));
+        Assertions.assertEquals(OSSProperties.JINDO_OSS_ABSTRACT_FILE_SYSTEM_IMPL,
+                ossProperties.hadoopStorageConfig.get("fs.AbstractFileSystem.oss.impl"));
+        Assertions.assertEquals("cn-hangzhou", ossProperties.hadoopStorageConfig.get("fs.oss.region"));
+    }
+
+    @Test
     public void testOSSBucketEndpointPathProperties() throws UserException {
         Assertions.assertEquals("oss://my-bucket/path/to/dir/", OSSProperties.rewriteOssBucketIfNecessary("oss://my-bucket/path/to/dir/"));
         Assertions.assertEquals("oss://my-bucket/path/to/dir/file.txt", OSSProperties.rewriteOssBucketIfNecessary("oss://my-bucket.oss-cn-hangzhou.aliyuncs.com/path/to/dir/file.txt"));
@@ -280,4 +293,3 @@ public class OSSPropertiesTest {
         Assertions.assertEquals("https://bucket-name.oss-cn-hangzhou.aliyuncs.com/path/to/dir/file.txt", OSSProperties.rewriteOssBucketIfNecessary("https://bucket-name.oss-cn-hangzhou.aliyuncs.com/path/to/dir/file.txt"));
     }
 }
-

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -758,18 +758,6 @@ under the License.
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.apache.hadoop</groupId>
-                <artifactId>hadoop-aliyun</artifactId>
-                <version>${hadoop.version}</version>
-                <exclusions>
-                    <!-- pls confirm if this is a mandatory dependency  -->
-                    <exclusion>
-                        <groupId>org.ini4j</groupId>
-                        <artifactId>ini4j</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.doris</groupId>
                 <artifactId>hive-catalog-shade</artifactId>
                 <version>${doris.hive.catalog.shade.version}</version>

--- a/regression-test/suites/external_table_p2/refactor_catalog_param/oss_hdfs_catalog_test.groovy
+++ b/regression-test/suites/external_table_p2/refactor_catalog_param/oss_hdfs_catalog_test.groovy
@@ -138,7 +138,7 @@ suite("oss_hdfs_catalog_test", "p2,external") {
           'oss.hdfs.enabled'='true',
     """
     String new_oss_hdfs_storage_properties = """
-              'fs.oss.support' = 'true',
+              'fs.oss-hdfs.support' = 'true',
               'oss.hdfs.access_key' = '${oss_hdfs_ak}',
               'oss.hdfs.secret_key' = '${oss_hdfs_sk}',
               'oss.hdfs.endpoint' = '${oss_hdfs_endpoint}',


### PR DESCRIPTION
This PR unifies the FE-side OSS Hadoop filesystem implementation to Jindo FS and removes legacy OSS filesystem dependencies that are no longer needed.

## Why

We currently have multiple OSS filesystem implementations on the FE classpath, including:
- `org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystem`
- `paimon-oss`

This makes OSS behavior inconsistent and increases the chance of classpath conflicts. Since Doris already packages and uses Jindo FS, FE should consistently use Jindo instead of mixing multiple OSS filesystem implementations.

## Changes

- Switch `OSSProperties` to use Jindo FS:
  - `fs.oss.impl = com.aliyun.jindodata.oss.JindoOssFileSystem`
  - `fs.AbstractFileSystem.oss.impl = com.aliyun.jindodata.oss.JindoOSS`
- Keep `OSSHdfsProperties` aligned with the same Jindo FS constants.
- Add FE unit test coverage to verify OSS Hadoop config is initialized with Jindo FS.
- Remove legacy OSS filesystem dependencies from FE modules:
  - remove `paimon-oss` from `fe-core`
  - remove `paimon-oss` from `preload-extensions`
  - remove `hadoop-aliyun` from FE dependency management and `hadoop-deps`

## Scope

This PR only updates FE-side OSS filesystem wiring and FE-related dependency cleanup.
Non-FE modules are intentionally left unchanged.

## Verification

- `run-fe-ut.sh --run org.apache.doris.datasource.property.storage.OSSPropertiesTest,org.apache.doris.datasource.property.storage.OSSHdfsPropertiesTest`
- Full FE reactor build passed

## Notes

`aliyun-sdk-oss` is still kept because it is still used by FE cloud storage code (`OssRemote`) and is not part of the Hadoop OSS filesystem implementation cleanup in this PR.