### PR TITLE
[opt](cache) fix LRU-K visits list key collision and stale entry on erase

### DIFF
--- a/be/src/util/lru_cache.cpp
+++ b/be/src/util/lru_cache.cpp
@@ -327,7 +327,7 @@ Cache::Handle* LRUCache::lookup(const CacheKey& key, uint32_t hash) {
     // then move the key to beginning of the visits list.
     // key in visits list indicates that the key has been inserted once after the cache is full.
     if (e == nullptr && _is_lru_k) {
-        auto it = _visits_lru_cache_map.find(hash);
+        auto it = _visits_lru_cache_map.find(key.to_string());
         if (it != _visits_lru_cache_map.end()) {
             _visits_lru_cache_list.splice(_visits_lru_cache_list.begin(), _visits_lru_cache_list,
                                           it->second);
@@ -445,10 +445,11 @@ bool LRUCache::_check_element_count_limit() {
 // key is allowed to be inserted into cache this time (this will trigger cache evict),
 // and key is removed from the visits list.
 // 2. Return true. If key not in visits list, insert it into visits list.
-bool LRUCache::_lru_k_insert_visits_list(size_t total_size, visits_lru_cache_key visits_key) {
+bool LRUCache::_lru_k_insert_visits_list(size_t total_size, const CacheKey& key) {
     if (_usage + total_size > _capacity ||
         _check_element_count_limit()) { // this line no lock required
-        auto it = _visits_lru_cache_map.find(visits_key);
+        std::string key_str = key.to_string();
+        auto it = _visits_lru_cache_map.find(key_str);
         if (it != _visits_lru_cache_map.end()) {
             _visits_lru_cache_usage -= it->second->second;
             _visits_lru_cache_list.erase(it->second);
@@ -466,8 +467,8 @@ bool LRUCache::_lru_k_insert_visits_list(size_t total_size, visits_lru_cache_key
             // 1. If true, insert key at the beginning of _visits_lru_cache_list.
             // 2. If false, it means total_size > cache _capacity, preventing this insert.
             if (_visits_lru_cache_usage + total_size <= _capacity) {
-                _visits_lru_cache_list.emplace_front(visits_key, total_size);
-                _visits_lru_cache_map[visits_key] = _visits_lru_cache_list.begin();
+                _visits_lru_cache_list.emplace_front(key_str, total_size);
+                _visits_lru_cache_map[std::move(key_str)] = _visits_lru_cache_list.begin();
                 _visits_lru_cache_usage += total_size;
             }
             return true;
@@ -499,7 +500,7 @@ Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value,
     {
         std::lock_guard l(_mutex);
 
-        if (_is_lru_k && _lru_k_insert_visits_list(e->total_size, hash)) {
+        if (_is_lru_k && _lru_k_insert_visits_list(e->total_size, key)) {
             return reinterpret_cast<Cache::Handle*>(e);
         }
 
@@ -567,6 +568,17 @@ void LRUCache::erase(const CacheKey& key, uint32_t hash) {
             // `entry->in_cache = false` and `_usage -= entry->total_size;` and `_unref(entry)` should appear together.
             // see the comment for old entry in `LRUCache::insert`.
             _usage -= e->total_size;
+        }
+        // Also remove from visits list if present. This handles the case where a key was
+        // erased (e.g., after compaction) before being promoted from visits list to cache,
+        // preventing stale entries from consuming visits list capacity.
+        if (_is_lru_k) {
+            auto it = _visits_lru_cache_map.find(key.to_string());
+            if (it != _visits_lru_cache_map.end()) {
+                _visits_lru_cache_usage -= it->second->second;
+                _visits_lru_cache_list.erase(it->second);
+                _visits_lru_cache_map.erase(it);
+            }
         }
     }
     // free handle out of mutex, when last_ref is true, e must not be nullptr

--- a/be/src/util/lru_cache.h
+++ b/be/src/util/lru_cache.h
@@ -330,11 +330,10 @@ public:
     LRUCache(LRUCacheType type, bool is_lru_k = DEFAULT_LRU_CACHE_IS_LRU_K);
     ~LRUCache();
 
-    // visits_lru_cache_key is the hash value of CacheKey.
-    // If there is a hash conflict, a cache entry may be inserted early
-    // and another cache entry with the same key hash may be inserted later.
-    // Otherwise, this does not affect the correctness of the cache.
-    using visits_lru_cache_key = uint32_t;
+    // visits_lru_cache_key is the full string of CacheKey to avoid hash collisions.
+    // Using only the 32-bit hash as key causes ~8% collision rate with ~27000 entries,
+    // leading to incorrect LRU-K promotion decisions and degraded cache hit ratio.
+    using visits_lru_cache_key = std::string;
     using visits_lru_cache_pair = std::pair<visits_lru_cache_key, size_t>;
 
     // Separate from constructor so caller can easily make an array of LRUCache
@@ -374,7 +373,7 @@ private:
     void _evict_from_lru_with_time(size_t total_size, LRUHandle** to_remove_head);
     void _evict_one_entry(LRUHandle* e);
     bool _check_element_count_limit();
-    bool _lru_k_insert_visits_list(size_t total_size, visits_lru_cache_key visits_key);
+    bool _lru_k_insert_visits_list(size_t total_size, const CacheKey& key);
 
 private:
     LRUCacheType _type;


### PR DESCRIPTION
### Problem

The LRU-K (K=2) implementation in LRUCache has two related bugs in the visits list, which is a ghost cache used to track whether a key has been accessed at least once before being promoted to the main cache.
#### Bug 1: Hash collision causes incorrect LRU-K promotion decisions
The visits list uses uint32_t (32-bit hash) as the map key instead of the full cache key string:
// Before
```
using visits_lru_cache_key = uint32_t;
```
With ~27,000 entries (typical for SegmentCache), the birthday-problem collision probability is ~8.1%:
```
P(at least one collision) ≈ 1 - e^(-n² / 2m)
                          = 1 - e^(-27000² / (2 × 2^32))
                          = 1 - e^(-729000000 / 8589934592)
                          = 1 - e^(-0.0849)
                          ≈ 8.1%
 ```
When two segments share the same hash, the visits list cannot distinguish them. A concrete collision scenario:

```
Segment A (hash=X) — 1st access (miss):
  → key=X not in visits list → insert {X, size_A}
  → visits list: [X]

Segment B (hash=X, collision) — 1st access (miss):
  → key=X found in visits list ← mistaken as "B's 2nd access"
  → remove X from visits list
  → B promoted to main cache  ← wrong! B was only accessed once

Segment A — next access (miss again):
  → key=X no longer in visits list (stolen by B)
  → A re-enters visits list, restarting the two-access sequence
  ```
This causes two types of harm:
- **False promotion**: B enters the main cache after only one access, polluting it with potentially cold data.
- **Lost visits record**: A's progress is reset, delaying its legitimate promotion and increasing miss rate.
The same issue affects lookup(), which refreshes the LRU position of a visits list entry on miss — under collision it refreshes the wrong entry's recency.
#### Bug 2: erase() leaves stale entries in the visits list
When erase() is called (e.g., after compaction removes old rowsets), it removes the key from the main cache but does not clean up the visits list:
```
void LRUCache::erase(const CacheKey& key, uint32_t hash) {
    e = _table.remove(key, hash);  // removed from main cache
    // visits list NOT cleaned up ← bug
}
```
If a segment was accessed once (entered visits list, not yet promoted) and then erased before its second access, the stale visits list entry remains and consumes _visits_lru_cache_usage capacity indefinitely, reducing the effective tracking window for other segments.

#### Fix
**Fix 1**: Change `visits_lru_cache_key` from `uint32_t` to `std::string`, using the full cache key string. Update `_lru_k_insert_visits_list()`, `lookup()`, and `insert()` accordingly. The visits list holds at most a few thousand entries (bounded by `_capacity`), so the per-entry string overhead (~120 bytes extra × ~30,000 entries = ~3.6 MB) is negligible.

**Fix 2**: In `LRUCache::erase()`, also remove the key from the visits list if present. This is now safe and correct because Fix 1 ensures exact key matching with no false positives.

Both fixes apply to **all LRU-K enabled caches**: SegmentCache, DataPageCache, InvertedIndexSearcherCache, ConditionCache, QueryCache, PointQueryLookupConnectionCache, and PointQueryRowCache.