### PR TITLE
[opt](LRU cache) clean up LRU-K visits list entry on erase to prevent stale capacity consumption

### DIFF
--- a/be/src/util/lru_cache.cpp
+++ b/be/src/util/lru_cache.cpp
@@ -568,6 +568,17 @@ void LRUCache::erase(const CacheKey& key, uint32_t hash) {
             // see the comment for old entry in `LRUCache::insert`.
             _usage -= e->total_size;
         }
+        // Also remove from visits list if present. This handles the case where a key was
+        // erased (e.g., after compaction) before being promoted from visits list to cache,
+        // preventing stale entries from consuming visits list capacity.
+        if (_is_lru_k) {
+            auto it = _visits_lru_cache_map.find(key.to_string());
+            if (it != _visits_lru_cache_map.end()) {
+                _visits_lru_cache_usage -= it->second->second;
+                _visits_lru_cache_list.erase(it->second);
+                _visits_lru_cache_map.erase(it);
+            }
+        }
     }
     // free handle out of mutex, when last_ref is true, e must not be nullptr
     if (last_ref) {


### PR DESCRIPTION
### Problem
In the LRU-K implementation, when LRUCache::erase() is called, it removes the key from the main cache hash table but does not remove it from the visits list (_visits_lru_cache_map / _visits_lru_cache_list):
```
void LRUCache::erase(const CacheKey& key, uint32_t hash) {
    ...
    e = _table.remove(key, hash);   // removed from main cache
    ...
    // visits list is NOT cleaned up ← missing
}
```
This matters when a segment is accessed exactly once (enters the visits list, not yet promoted to main cache) and then gets erased before its second access — the typical scenario being compaction: when old rowsets are merged, SegmentLoader::erase_segments() is called for all segments of the old rowset.


**Timeline:**
  1. Segment S accessed once → enters visits list, not in main cache
  2. Compaction merges the rowset containing S
  3. erase(S) called → S removed from main cache (no-op, wasn't there)
                     → S's visits list entry remains ← stale
  4. visits list entry for S occupies _visits_lru_cache_usage indefinitely
     until it's evicted by LRU pressure from newer entries
The visits list capacity is bounded by _capacity (same as main cache, ~1.47 GB for SegmentCache). Stale entries accumulate and reduce the effective tracking window for legitimate segments waiting to be promoted, slightly increasing miss rate under compaction-heavy workloads.

### Fix
In LRUCache::erase(), after removing the entry from the main cache, also check the visits list and remove the entry if present:
```
if (_is_lru_k) {
    auto it = _visits_lru_cache_map.find(key.to_string());
    if (it != _visits_lru_cache_map.end()) {
        _visits_lru_cache_usage -= it->second->second;
        _visits_lru_cache_list.erase(it->second);
        _visits_lru_cache_map.erase(it);
    }
}
```