### PR TITLE
[env](compiler)Optimize the compilation time of cast.

### DIFF
--- a/be/src/exprs/function/cast/cast_to_boolean.h
+++ b/be/src/exprs/function/cast/cast_to_boolean.h
@@ -198,40 +198,4 @@ public:
     }
 };
 
-namespace CastWrapper {
-inline WrapperType create_boolean_wrapper(FunctionContext* context, const DataTypePtr& from_type) {
-    std::shared_ptr<CastToBase> cast_to_bool;
-
-    auto make_bool_wrapper = [&](const auto& types) -> bool {
-        using Types = std::decay_t<decltype(types)>;
-        using FromDataType = typename Types::LeftType;
-        if constexpr (CastUtil::IsBaseCastFromType<FromDataType>) {
-            if (context->enable_strict_mode()) {
-                cast_to_bool = std::make_shared<
-                        CastToImpl<CastModeType::StrictMode, FromDataType, DataTypeBool>>();
-            } else {
-                cast_to_bool = std::make_shared<
-                        CastToImpl<CastModeType::NonStrictMode, FromDataType, DataTypeBool>>();
-            }
-            return true;
-        } else {
-            return false;
-        }
-    };
-
-    if (!call_on_index_and_data_type<void>(from_type->get_primitive_type(), make_bool_wrapper)) {
-        return create_unsupport_wrapper(
-                fmt::format("CAST AS bool not supported {}", from_type->get_name()));
-    }
-
-    return [cast_to_bool](FunctionContext* context, Block& block, const ColumnNumbers& arguments,
-                          uint32_t result, size_t input_rows_count,
-                          const NullMap::value_type* null_map = nullptr) {
-        return cast_to_bool->execute_impl(context, block, arguments, result, input_rows_count,
-                                          null_map);
-    };
-}
-
-}; // namespace CastWrapper
-
 } // namespace doris

--- a/be/src/exprs/function/cast/cast_to_date.h
+++ b/be/src/exprs/function/cast/cast_to_date.h
@@ -485,46 +485,5 @@ public:
         return Status::OK();
     }
 };
-
-namespace CastWrapper {
-
-template <typename ToDataType> // must datelike type
-WrapperType create_datelike_wrapper(FunctionContext* context, const DataTypePtr& from_type) {
-    std::shared_ptr<CastToBase> cast_to_datelike;
-
-    auto make_datelike_wrapper = [&](const auto& types) -> bool {
-        using Types = std::decay_t<decltype(types)>;
-        using FromDataType = typename Types::LeftType;
-        if constexpr (CastUtil::IsPureDigitType<FromDataType> || IsDatelikeTypes<FromDataType> ||
-                      IsStringType<FromDataType> ||
-                      std::is_same_v<FromDataType, DataTypeTimeStampTz>) {
-            if (context->enable_strict_mode()) {
-                cast_to_datelike = std::make_shared<
-                        CastToImpl<CastModeType::StrictMode, FromDataType, ToDataType>>();
-            } else {
-                cast_to_datelike = std::make_shared<
-                        CastToImpl<CastModeType::NonStrictMode, FromDataType, ToDataType>>();
-            }
-            return true;
-        } else {
-            return false;
-        }
-    };
-
-    if (!call_on_index_and_data_type<void>(from_type->get_primitive_type(),
-                                           make_datelike_wrapper)) {
-        return create_unsupport_wrapper(fmt::format(
-                "CAST AS {} not supported {}", ToDataType {}.get_name(), from_type->get_name()));
-    }
-
-    return [cast_to_datelike](FunctionContext* context, Block& block,
-                              const ColumnNumbers& arguments, const uint32_t result,
-                              size_t input_rows_count,
-                              const NullMap::value_type* null_map = nullptr) {
-        return cast_to_datelike->execute_impl(context, block, arguments, result, input_rows_count,
-                                              null_map);
-    };
-}
 #include "common/compile_check_end.h"
-}; // namespace CastWrapper
 } // namespace doris

--- a/be/src/exprs/function/cast/cast_to_decimal.h
+++ b/be/src/exprs/function/cast/cast_to_decimal.h
@@ -1078,45 +1078,5 @@ public:
     }
 };
 
-template <typename T>
-constexpr static bool type_allow_cast_to_decimal =
-        std::is_same_v<T, DataTypeString> || IsDataTypeNumber<T> || IsDataTypeDecimal<T>;
-
-namespace CastWrapper {
-
-template <typename ToDataType>
-WrapperType create_decimal_wrapper(FunctionContext* context, const DataTypePtr& from_type) {
-    std::shared_ptr<CastToBase> cast_impl;
-
-    auto make_cast_wrapper = [&](const auto& types) -> bool {
-        using Types = std::decay_t<decltype(types)>;
-        using FromDataType = typename Types::LeftType;
-        if constexpr (type_allow_cast_to_decimal<FromDataType>) {
-            if (context->enable_strict_mode()) {
-                cast_impl = std::make_shared<
-                        CastToImpl<CastModeType::StrictMode, FromDataType, ToDataType>>();
-            } else {
-                cast_impl = std::make_shared<
-                        CastToImpl<CastModeType::NonStrictMode, FromDataType, ToDataType>>();
-            }
-            return true;
-        } else {
-            return false;
-        }
-    };
-
-    if (!call_on_index_and_data_type<void>(from_type->get_primitive_type(), make_cast_wrapper)) {
-        return create_unsupport_wrapper(
-                fmt::format("CAST AS decimal not supported {}", from_type->get_name()));
-    }
-
-    return [cast_impl](FunctionContext* context, Block& block, const ColumnNumbers& arguments,
-                       uint32_t result, size_t input_rows_count,
-                       const NullMap::value_type* null_map = nullptr) {
-        return cast_impl->execute_impl(context, block, arguments, result, input_rows_count,
-                                       null_map);
-    };
-}
-} // namespace CastWrapper
 #include "common/compile_check_end.h"
 } // namespace doris

--- a/be/src/exprs/function/cast/cast_to_float.h
+++ b/be/src/exprs/function/cast/cast_to_float.h
@@ -96,48 +96,5 @@ public:
                                                                  input_rows_count);
     }
 };
-
-namespace CastWrapper {
-
-// max float: 3.40282e+38
-// max int128:
-// >> 0x7fffffffffffffffffffffffffffffff
-// 170141183460469231731687303715884105727
-// >>> len('170141183460469231731687303715884105727')
-// 39
-template <typename ToDataType>
-WrapperType create_float_wrapper(FunctionContext* context, const DataTypePtr& from_type) {
-    std::shared_ptr<CastToBase> cast_impl;
-
-    auto make_cast_wrapper = [&](const auto& types) -> bool {
-        using Types = std::decay_t<decltype(types)>;
-        using FromDataType = typename Types::LeftType;
-        if constexpr (type_allow_cast_to_basic_number<FromDataType>) {
-            if (context->enable_strict_mode()) {
-                cast_impl = std::make_shared<
-                        CastToImpl<CastModeType::StrictMode, FromDataType, ToDataType>>();
-            } else {
-                cast_impl = std::make_shared<
-                        CastToImpl<CastModeType::NonStrictMode, FromDataType, ToDataType>>();
-            }
-            return true;
-        } else {
-            return false;
-        }
-    };
-
-    if (!call_on_index_and_data_type<void>(from_type->get_primitive_type(), make_cast_wrapper)) {
-        return create_unsupport_wrapper(
-                fmt::format("CAST AS number not supported {}", from_type->get_name()));
-    }
-
-    return [cast_impl](FunctionContext* context, Block& block, const ColumnNumbers& arguments,
-                       uint32_t result, size_t input_rows_count,
-                       const NullMap::value_type* null_map = nullptr) {
-        return cast_impl->execute_impl(context, block, arguments, result, input_rows_count,
-                                       null_map);
-    };
-}
-} // namespace CastWrapper
 #include "common/compile_check_end.h"
 } // namespace doris

--- a/be/src/exprs/function/cast/cast_to_int.h
+++ b/be/src/exprs/function/cast/cast_to_int.h
@@ -230,41 +230,5 @@ public:
                                                                  input_rows_count);
     }
 };
-namespace CastWrapper {
-
-template <typename ToDataType>
-WrapperType create_int_wrapper(FunctionContext* context, const DataTypePtr& from_type) {
-    std::shared_ptr<CastToBase> cast_impl;
-
-    auto make_cast_wrapper = [&](const auto& types) -> bool {
-        using Types = std::decay_t<decltype(types)>;
-        using FromDataType = typename Types::LeftType;
-        if constexpr (type_allow_cast_to_basic_number<FromDataType>) {
-            if (context->enable_strict_mode()) {
-                cast_impl = std::make_shared<
-                        CastToImpl<CastModeType::StrictMode, FromDataType, ToDataType>>();
-            } else {
-                cast_impl = std::make_shared<
-                        CastToImpl<CastModeType::NonStrictMode, FromDataType, ToDataType>>();
-            }
-            return true;
-        } else {
-            return false;
-        }
-    };
-
-    if (!call_on_index_and_data_type<void>(from_type->get_primitive_type(), make_cast_wrapper)) {
-        return create_unsupport_wrapper(
-                fmt::format("CAST AS number not supported {}", from_type->get_name()));
-    }
-
-    return [cast_impl](FunctionContext* context, Block& block, const ColumnNumbers& arguments,
-                       uint32_t result, size_t input_rows_count,
-                       const NullMap::value_type* null_map = nullptr) {
-        return cast_impl->execute_impl(context, block, arguments, result, input_rows_count,
-                                       null_map);
-    };
-}
-} // namespace CastWrapper
 #include "common/compile_check_end.h"
 } // namespace doris

--- a/be/src/exprs/function/cast/cast_to_ip.h
+++ b/be/src/exprs/function/cast/cast_to_ip.h
@@ -104,45 +104,5 @@ public:
         return Status::OK();
     }
 };
-
-namespace CastWrapper {
-
-template <typename IpType>
-    requires(std::is_same_v<IpType, DataTypeIPv4> || std::is_same_v<IpType, DataTypeIPv6>)
-WrapperType create_ip_wrapper(FunctionContext* context, const DataTypePtr& from_type) {
-    std::shared_ptr<CastToBase> cast_to_ip;
-
-    auto make_ip_wrapper = [&](const auto& types) -> bool {
-        using Types = std::decay_t<decltype(types)>;
-        using FromDataType = typename Types::LeftType;
-        if constexpr (IsDataTypeNumber<FromDataType> || IsStringType<FromDataType> ||
-                      IsIPType<FromDataType>) {
-            if (context->enable_strict_mode()) {
-                cast_to_ip = std::make_shared<
-                        CastToImpl<CastModeType::StrictMode, FromDataType, IpType>>();
-            } else {
-                cast_to_ip = std::make_shared<
-                        CastToImpl<CastModeType::NonStrictMode, FromDataType, IpType>>();
-            }
-            return true;
-        } else {
-            return false;
-        }
-    };
-
-    if (!call_on_index_and_data_type<void>(from_type->get_primitive_type(), make_ip_wrapper)) {
-        return create_unsupport_wrapper(
-                fmt::format("CAST AS ip not supported {}", from_type->get_name()));
-    }
-
-    return [cast_to_ip](FunctionContext* context, Block& block, const ColumnNumbers& arguments,
-                        uint32_t result, size_t input_rows_count,
-                        const NullMap::value_type* null_map = nullptr) {
-        return cast_to_ip->execute_impl(context, block, arguments, result, input_rows_count,
-                                        null_map);
-    };
-}
 #include "common/compile_check_end.h"
-}; // namespace CastWrapper
-
 } // namespace doris

--- a/be/src/exprs/function/cast/cast_to_timestamptz.h
+++ b/be/src/exprs/function/cast/cast_to_timestamptz.h
@@ -224,45 +224,4 @@ public:
     }
 };
 
-namespace CastWrapper {
-inline WrapperType create_timestamptz_wrapper(FunctionContext* context,
-                                              const DataTypePtr& from_type) {
-    std::shared_ptr<CastToBase> cast_to_timestamptz;
-
-    auto make_timestamptz_wrapper = [&](const auto& types) -> bool {
-        using Types = std::decay_t<decltype(types)>;
-        using FromDataType = typename Types::LeftType;
-        if constexpr (CastUtil::IsBaseCastFromType<FromDataType> ||
-                      IsTimeStampTzType<FromDataType>) {
-            if (context->enable_strict_mode()) {
-                cast_to_timestamptz = std::make_shared<
-                        CastToImpl<CastModeType::StrictMode, FromDataType, DataTypeTimeStampTz>>();
-            } else {
-                cast_to_timestamptz =
-                        std::make_shared<CastToImpl<CastModeType::NonStrictMode, FromDataType,
-                                                    DataTypeTimeStampTz>>();
-            }
-            return true;
-        } else {
-            return false;
-        }
-    };
-
-    if (!call_on_index_and_data_type<void>(from_type->get_primitive_type(),
-                                           make_timestamptz_wrapper)) {
-        return create_unsupport_wrapper(
-                fmt::format("CAST AS timestamptz not supported {}", from_type->get_name()));
-    }
-
-    return [cast_to_timestamptz](FunctionContext* context, Block& block,
-                                 const ColumnNumbers& arguments, uint32_t result,
-                                 size_t input_rows_count,
-                                 const NullMap::value_type* null_map = nullptr) {
-        return cast_to_timestamptz->execute_impl(context, block, arguments, result,
-                                                 input_rows_count, null_map);
-    };
-}
-
-}; // namespace CastWrapper
-
 } // namespace doris

--- a/be/src/exprs/function/cast/cast_wrapper_decls.h
+++ b/be/src/exprs/function/cast/cast_wrapper_decls.h
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "exprs/function/cast/cast_base.h"
+
+namespace doris::CastWrapper {
+
+// Implemented in function_cast_int.cpp
+WrapperType create_int_wrapper(FunctionContext* context, const DataTypePtr& from_type,
+                               PrimitiveType to_type);
+
+// Implemented in function_cast_float.cpp
+WrapperType create_float_wrapper(FunctionContext* context, const DataTypePtr& from_type,
+                                 PrimitiveType to_type);
+
+// Implemented in function_cast_decimal.cpp
+WrapperType create_decimal_wrapper(FunctionContext* context, const DataTypePtr& from_type,
+                                   PrimitiveType to_type);
+
+// Implemented in function_cast_date.cpp (handles DATE / DATETIME / DATEv2 / DATETIMEv2 / TIMEv2)
+WrapperType create_datelike_wrapper(FunctionContext* context, const DataTypePtr& from_type,
+                                    PrimitiveType to_type);
+
+// Implemented in function_cast_date.cpp
+WrapperType create_timestamptz_wrapper(FunctionContext* context, const DataTypePtr& from_type);
+
+// Implemented in function_cast_ip.cpp
+WrapperType create_ip_wrapper(FunctionContext* context, const DataTypePtr& from_type,
+                              PrimitiveType to_type);
+
+// Implemented in function_cast_bool.cpp
+WrapperType create_boolean_wrapper(FunctionContext* context, const DataTypePtr& from_type);
+
+// Implemented in function_cast_string.cpp
+WrapperType create_string_wrapper(const DataTypePtr& from_type);
+
+} // namespace doris::CastWrapper

--- a/be/src/exprs/function/cast/function_cast.cpp
+++ b/be/src/exprs/function/cast/function_cast.cpp
@@ -23,18 +23,11 @@
 #include "core/data_type/data_type_quantilestate.h"
 #include "core/data_type/primitive_type.h"
 #include "exprs/function/cast/cast_to_array.h"
-#include "exprs/function/cast/cast_to_boolean.h"
-#include "exprs/function/cast/cast_to_date.h"
-#include "exprs/function/cast/cast_to_decimal.h"
-#include "exprs/function/cast/cast_to_float.h"
-#include "exprs/function/cast/cast_to_int.h"
-#include "exprs/function/cast/cast_to_ip.h"
 #include "exprs/function/cast/cast_to_jsonb.h"
 #include "exprs/function/cast/cast_to_map.h"
-#include "exprs/function/cast/cast_to_string.h"
 #include "exprs/function/cast/cast_to_struct.h"
-#include "exprs/function/cast/cast_to_timestamptz.h"
 #include "exprs/function/cast/cast_to_variant.h"
+#include "exprs/function/cast/cast_wrapper_decls.h"
 #include "exprs/function/simple_function_factory.h"
 
 namespace doris {
@@ -257,45 +250,31 @@ WrapperType prepare_impl(FunctionContext* context, const DataTypePtr& origin_fro
     case PrimitiveType::TYPE_BOOLEAN:
         return create_boolean_wrapper(context, from_type);
     case PrimitiveType::TYPE_TINYINT:
-        return create_int_wrapper<DataTypeInt8>(context, from_type);
     case PrimitiveType::TYPE_SMALLINT:
-        return create_int_wrapper<DataTypeInt16>(context, from_type);
     case PrimitiveType::TYPE_INT:
-        return create_int_wrapper<DataTypeInt32>(context, from_type);
     case PrimitiveType::TYPE_BIGINT:
-        return create_int_wrapper<DataTypeInt64>(context, from_type);
     case PrimitiveType::TYPE_LARGEINT:
-        return create_int_wrapper<DataTypeInt128>(context, from_type);
+        return create_int_wrapper(context, from_type, to_type->get_primitive_type());
     case PrimitiveType::TYPE_FLOAT:
-        return create_float_wrapper<DataTypeFloat32>(context, from_type);
     case PrimitiveType::TYPE_DOUBLE:
-        return create_float_wrapper<DataTypeFloat64>(context, from_type);
+        return create_float_wrapper(context, from_type, to_type->get_primitive_type());
     case PrimitiveType::TYPE_DATE:
-        return create_datelike_wrapper<DataTypeDate>(context, from_type);
     case PrimitiveType::TYPE_DATETIME:
-        return create_datelike_wrapper<DataTypeDateTime>(context, from_type);
     case PrimitiveType::TYPE_DATEV2:
-        return create_datelike_wrapper<DataTypeDateV2>(context, from_type);
     case PrimitiveType::TYPE_DATETIMEV2:
-        return create_datelike_wrapper<DataTypeDateTimeV2>(context, from_type);
+    case PrimitiveType::TYPE_TIMEV2:
+        return create_datelike_wrapper(context, from_type, to_type->get_primitive_type());
     case PrimitiveType::TYPE_TIMESTAMPTZ:
         return create_timestamptz_wrapper(context, from_type);
-    case PrimitiveType::TYPE_TIMEV2:
-        return create_datelike_wrapper<DataTypeTimeV2>(context, from_type);
     case PrimitiveType::TYPE_IPV4:
-        return create_ip_wrapper<DataTypeIPv4>(context, from_type);
     case PrimitiveType::TYPE_IPV6:
-        return create_ip_wrapper<DataTypeIPv6>(context, from_type);
+        return create_ip_wrapper(context, from_type, to_type->get_primitive_type());
     case PrimitiveType::TYPE_DECIMALV2:
-        return create_decimal_wrapper<DataTypeDecimalV2>(context, from_type);
     case PrimitiveType::TYPE_DECIMAL32:
-        return create_decimal_wrapper<DataTypeDecimal32>(context, from_type);
     case PrimitiveType::TYPE_DECIMAL64:
-        return create_decimal_wrapper<DataTypeDecimal64>(context, from_type);
     case PrimitiveType::TYPE_DECIMAL128I:
-        return create_decimal_wrapper<DataTypeDecimal128>(context, from_type);
     case PrimitiveType::TYPE_DECIMAL256:
-        return create_decimal_wrapper<DataTypeDecimal256>(context, from_type);
+        return create_decimal_wrapper(context, from_type, to_type->get_primitive_type());
     case PrimitiveType::TYPE_CHAR:
     case PrimitiveType::TYPE_VARCHAR:
     case PrimitiveType::TYPE_STRING:

--- a/be/src/exprs/function/cast/function_cast_bool.cpp
+++ b/be/src/exprs/function/cast/function_cast_bool.cpp
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "exprs/function/cast/cast_to_boolean.h"
+
+namespace doris::CastWrapper {
+
+WrapperType create_boolean_wrapper(FunctionContext* context, const DataTypePtr& from_type) {
+    std::shared_ptr<CastToBase> cast_to_bool;
+
+    auto make_bool_wrapper = [&](const auto& types) -> bool {
+        using Types = std::decay_t<decltype(types)>;
+        using FromDataType = typename Types::LeftType;
+        if constexpr (CastUtil::IsBaseCastFromType<FromDataType>) {
+            if (context->enable_strict_mode()) {
+                cast_to_bool = std::make_shared<
+                        CastToImpl<CastModeType::StrictMode, FromDataType, DataTypeBool>>();
+            } else {
+                cast_to_bool = std::make_shared<
+                        CastToImpl<CastModeType::NonStrictMode, FromDataType, DataTypeBool>>();
+            }
+            return true;
+        } else {
+            return false;
+        }
+    };
+
+    if (!call_on_index_and_data_type<void>(from_type->get_primitive_type(), make_bool_wrapper)) {
+        return create_unsupport_wrapper(
+                fmt::format("CAST AS bool not supported {}", from_type->get_name()));
+    }
+
+    return [cast_to_bool](FunctionContext* context, Block& block, const ColumnNumbers& arguments,
+                          uint32_t result, size_t input_rows_count,
+                          const NullMap::value_type* null_map = nullptr) {
+        return cast_to_bool->execute_impl(context, block, arguments, result, input_rows_count,
+                                          null_map);
+    };
+}
+
+} // namespace doris::CastWrapper

--- a/be/src/exprs/function/cast/function_cast_date.cpp
+++ b/be/src/exprs/function/cast/function_cast_date.cpp
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "core/data_type/data_type_date.h"
+#include "core/data_type/data_type_date_or_datetime_v2.h"
+#include "core/data_type/data_type_date_time.h"
+#include "core/data_type/data_type_time.h"
+#include "exprs/function/cast/cast_base.h"
+
+namespace doris::CastWrapper {
+
+template <typename ToDataType> // must datelike type
+WrapperType create_datelike_wrapper(FunctionContext* context, const DataTypePtr& from_type) {
+    std::shared_ptr<CastToBase> cast_to_datelike;
+
+    auto make_datelike_wrapper = [&](const auto& types) -> bool {
+        using Types = std::decay_t<decltype(types)>;
+        using FromDataType = typename Types::LeftType;
+        if constexpr (CastUtil::IsPureDigitType<FromDataType> || IsDatelikeTypes<FromDataType> ||
+                      IsStringType<FromDataType> ||
+                      std::is_same_v<FromDataType, DataTypeTimeStampTz>) {
+            if (context->enable_strict_mode()) {
+                cast_to_datelike = std::make_shared<
+                        CastToImpl<CastModeType::StrictMode, FromDataType, ToDataType>>();
+            } else {
+                cast_to_datelike = std::make_shared<
+                        CastToImpl<CastModeType::NonStrictMode, FromDataType, ToDataType>>();
+            }
+            return true;
+        } else {
+            return false;
+        }
+    };
+
+    if (!call_on_index_and_data_type<void>(from_type->get_primitive_type(),
+                                           make_datelike_wrapper)) {
+        return create_unsupport_wrapper(fmt::format(
+                "CAST AS {} not supported {}", ToDataType {}.get_name(), from_type->get_name()));
+    }
+
+    return [cast_to_datelike](FunctionContext* context, Block& block,
+                              const ColumnNumbers& arguments, const uint32_t result,
+                              size_t input_rows_count,
+                              const NullMap::value_type* null_map = nullptr) {
+        return cast_to_datelike->execute_impl(context, block, arguments, result, input_rows_count,
+                                              null_map);
+    };
+}
+
+WrapperType create_datelike_wrapper(FunctionContext* context, const DataTypePtr& from_type,
+                                    PrimitiveType to_type) {
+    switch (to_type) {
+    case TYPE_DATE:
+        return create_datelike_wrapper<DataTypeDate>(context, from_type);
+    case TYPE_DATETIME:
+        return create_datelike_wrapper<DataTypeDateTime>(context, from_type);
+    case TYPE_DATEV2:
+        return create_datelike_wrapper<DataTypeDateV2>(context, from_type);
+    case TYPE_DATETIMEV2:
+        return create_datelike_wrapper<DataTypeDateTimeV2>(context, from_type);
+    case TYPE_TIMEV2:
+        return create_datelike_wrapper<DataTypeTimeV2>(context, from_type);
+    default:
+        return create_unsupport_wrapper(
+                fmt::format("CAST AS date: unsupported to_type {}", type_to_string(to_type)));
+    }
+}
+
+} // namespace doris::CastWrapper

--- a/be/src/exprs/function/cast/function_cast_date.cpp
+++ b/be/src/exprs/function/cast/function_cast_date.cpp
@@ -19,7 +19,7 @@
 #include "core/data_type/data_type_date_or_datetime_v2.h"
 #include "core/data_type/data_type_date_time.h"
 #include "core/data_type/data_type_time.h"
-#include "exprs/function/cast/cast_base.h"
+#include "exprs/function/cast/cast_to_date.h"
 
 namespace doris::CastWrapper {
 

--- a/be/src/exprs/function/cast/function_cast_decimal.cpp
+++ b/be/src/exprs/function/cast/function_cast_decimal.cpp
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "core/data_type/data_type_decimal.h"
+#include "exprs/function/cast/cast_to_decimal.h"
+
+namespace doris::CastWrapper {
+
+template <typename T>
+constexpr static bool type_allow_cast_to_decimal =
+        std::is_same_v<T, DataTypeString> || IsDataTypeNumber<T> || IsDataTypeDecimal<T>;
+
+template <typename ToDataType>
+WrapperType create_decimal_wrapper(FunctionContext* context, const DataTypePtr& from_type) {
+    std::shared_ptr<CastToBase> cast_impl;
+
+    auto make_cast_wrapper = [&](const auto& types) -> bool {
+        using Types = std::decay_t<decltype(types)>;
+        using FromDataType = typename Types::LeftType;
+        if constexpr (type_allow_cast_to_decimal<FromDataType>) {
+            if (context->enable_strict_mode()) {
+                cast_impl = std::make_shared<
+                        CastToImpl<CastModeType::StrictMode, FromDataType, ToDataType>>();
+            } else {
+                cast_impl = std::make_shared<
+                        CastToImpl<CastModeType::NonStrictMode, FromDataType, ToDataType>>();
+            }
+            return true;
+        } else {
+            return false;
+        }
+    };
+
+    if (!call_on_index_and_data_type<void>(from_type->get_primitive_type(), make_cast_wrapper)) {
+        return create_unsupport_wrapper(
+                fmt::format("CAST AS decimal not supported {}", from_type->get_name()));
+    }
+
+    return [cast_impl](FunctionContext* context, Block& block, const ColumnNumbers& arguments,
+                       uint32_t result, size_t input_rows_count,
+                       const NullMap::value_type* null_map = nullptr) {
+        return cast_impl->execute_impl(context, block, arguments, result, input_rows_count,
+                                       null_map);
+    };
+}
+
+WrapperType create_decimal_wrapper(FunctionContext* context, const DataTypePtr& from_type,
+                                   PrimitiveType to_type) {
+    switch (to_type) {
+    case TYPE_DECIMALV2:
+        return create_decimal_wrapper<DataTypeDecimalV2>(context, from_type);
+    case TYPE_DECIMAL32:
+        return create_decimal_wrapper<DataTypeDecimal32>(context, from_type);
+    case TYPE_DECIMAL64:
+        return create_decimal_wrapper<DataTypeDecimal64>(context, from_type);
+    case TYPE_DECIMAL128I:
+        return create_decimal_wrapper<DataTypeDecimal128>(context, from_type);
+    case TYPE_DECIMAL256:
+        return create_decimal_wrapper<DataTypeDecimal256>(context, from_type);
+    default:
+        return create_unsupport_wrapper(
+                fmt::format("CAST AS decimal: unsupported to_type {}", type_to_string(to_type)));
+    }
+}
+
+} // namespace doris::CastWrapper

--- a/be/src/exprs/function/cast/function_cast_float.cpp
+++ b/be/src/exprs/function/cast/function_cast_float.cpp
@@ -16,7 +16,7 @@
 // under the License.
 
 #include "core/data_type/data_type_number.h"
-#include "exprs/function/cast/cast_to_basic_number_common.h"
+#include "exprs/function/cast/cast_to_float.h"
 
 namespace doris::CastWrapper {
 

--- a/be/src/exprs/function/cast/function_cast_float.cpp
+++ b/be/src/exprs/function/cast/function_cast_float.cpp
@@ -1,0 +1,70 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "core/data_type/data_type_number.h"
+#include "exprs/function/cast/cast_to_basic_number_common.h"
+
+namespace doris::CastWrapper {
+
+template <typename ToDataType>
+WrapperType create_float_wrapper(FunctionContext* context, const DataTypePtr& from_type) {
+    std::shared_ptr<CastToBase> cast_impl;
+
+    auto make_cast_wrapper = [&](const auto& types) -> bool {
+        using Types = std::decay_t<decltype(types)>;
+        using FromDataType = typename Types::LeftType;
+        if constexpr (type_allow_cast_to_basic_number<FromDataType>) {
+            if (context->enable_strict_mode()) {
+                cast_impl = std::make_shared<
+                        CastToImpl<CastModeType::StrictMode, FromDataType, ToDataType>>();
+            } else {
+                cast_impl = std::make_shared<
+                        CastToImpl<CastModeType::NonStrictMode, FromDataType, ToDataType>>();
+            }
+            return true;
+        } else {
+            return false;
+        }
+    };
+
+    if (!call_on_index_and_data_type<void>(from_type->get_primitive_type(), make_cast_wrapper)) {
+        return create_unsupport_wrapper(
+                fmt::format("CAST AS number not supported {}", from_type->get_name()));
+    }
+
+    return [cast_impl](FunctionContext* context, Block& block, const ColumnNumbers& arguments,
+                       uint32_t result, size_t input_rows_count,
+                       const NullMap::value_type* null_map = nullptr) {
+        return cast_impl->execute_impl(context, block, arguments, result, input_rows_count,
+                                       null_map);
+    };
+}
+
+WrapperType create_float_wrapper(FunctionContext* context, const DataTypePtr& from_type,
+                                 PrimitiveType to_type) {
+    switch (to_type) {
+    case TYPE_FLOAT:
+        return create_float_wrapper<DataTypeFloat32>(context, from_type);
+    case TYPE_DOUBLE:
+        return create_float_wrapper<DataTypeFloat64>(context, from_type);
+    default:
+        return create_unsupport_wrapper(
+                fmt::format("CAST AS float: unsupported to_type {}", type_to_string(to_type)));
+    }
+}
+
+} // namespace doris::CastWrapper

--- a/be/src/exprs/function/cast/function_cast_int.cpp
+++ b/be/src/exprs/function/cast/function_cast_int.cpp
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "core/data_type/data_type_number.h"
+#include "exprs/function/cast/cast_to_basic_number_common.h"
+
+namespace doris::CastWrapper {
+
+template <typename ToDataType>
+WrapperType create_int_wrapper(FunctionContext* context, const DataTypePtr& from_type) {
+    std::shared_ptr<CastToBase> cast_impl;
+
+    auto make_cast_wrapper = [&](const auto& types) -> bool {
+        using Types = std::decay_t<decltype(types)>;
+        using FromDataType = typename Types::LeftType;
+        if constexpr (type_allow_cast_to_basic_number<FromDataType>) {
+            if (context->enable_strict_mode()) {
+                cast_impl = std::make_shared<
+                        CastToImpl<CastModeType::StrictMode, FromDataType, ToDataType>>();
+            } else {
+                cast_impl = std::make_shared<
+                        CastToImpl<CastModeType::NonStrictMode, FromDataType, ToDataType>>();
+            }
+            return true;
+        } else {
+            return false;
+        }
+    };
+
+    if (!call_on_index_and_data_type<void>(from_type->get_primitive_type(), make_cast_wrapper)) {
+        return create_unsupport_wrapper(
+                fmt::format("CAST AS number not supported {}", from_type->get_name()));
+    }
+
+    return [cast_impl](FunctionContext* context, Block& block, const ColumnNumbers& arguments,
+                       uint32_t result, size_t input_rows_count,
+                       const NullMap::value_type* null_map = nullptr) {
+        return cast_impl->execute_impl(context, block, arguments, result, input_rows_count,
+                                       null_map);
+    };
+}
+
+WrapperType create_int_wrapper(FunctionContext* context, const DataTypePtr& from_type,
+                               PrimitiveType to_type) {
+    switch (to_type) {
+    case TYPE_TINYINT:
+        return create_int_wrapper<DataTypeInt8>(context, from_type);
+    case TYPE_SMALLINT:
+        return create_int_wrapper<DataTypeInt16>(context, from_type);
+    case TYPE_INT:
+        return create_int_wrapper<DataTypeInt32>(context, from_type);
+    case TYPE_BIGINT:
+        return create_int_wrapper<DataTypeInt64>(context, from_type);
+    case TYPE_LARGEINT:
+        return create_int_wrapper<DataTypeInt128>(context, from_type);
+    default:
+        return create_unsupport_wrapper(
+                fmt::format("CAST AS int: unsupported to_type {}", type_to_string(to_type)));
+    }
+}
+
+} // namespace doris::CastWrapper

--- a/be/src/exprs/function/cast/function_cast_int.cpp
+++ b/be/src/exprs/function/cast/function_cast_int.cpp
@@ -16,7 +16,7 @@
 // under the License.
 
 #include "core/data_type/data_type_number.h"
-#include "exprs/function/cast/cast_to_basic_number_common.h"
+#include "exprs/function/cast/cast_to_int.h"
 
 namespace doris::CastWrapper {
 

--- a/be/src/exprs/function/cast/function_cast_ip.cpp
+++ b/be/src/exprs/function/cast/function_cast_ip.cpp
@@ -76,4 +76,3 @@ WrapperType create_ip_wrapper(FunctionContext* context, const DataTypePtr& from_
 }
 
 } // namespace doris::CastWrapper
-

--- a/be/src/exprs/function/cast/function_cast_ip.cpp
+++ b/be/src/exprs/function/cast/function_cast_ip.cpp
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// This translation unit is the ONLY place that includes cast_to_ip.h.
+// All CastToImpl<CastMode, From, ToIpType> template instantiations are
+// confined here, keeping them out of function_cast.cpp.
+
+#include "core/data_type/data_type_ipv4.h"
+#include "core/data_type/data_type_ipv6.h"
+#include "exprs/function/cast/cast_base.h"
+#include "exprs/function/cast/cast_to_ip.h"
+
+namespace doris::CastWrapper {
+
+template <typename IpType>
+    requires(std::is_same_v<IpType, DataTypeIPv4> || std::is_same_v<IpType, DataTypeIPv6>)
+WrapperType create_ip_wrapper(FunctionContext* context, const DataTypePtr& from_type) {
+    std::shared_ptr<CastToBase> cast_to_ip;
+
+    auto make_ip_wrapper = [&](const auto& types) -> bool {
+        using Types = std::decay_t<decltype(types)>;
+        using FromDataType = typename Types::LeftType;
+        if constexpr (IsDataTypeNumber<FromDataType> || IsStringType<FromDataType> ||
+                      IsIPType<FromDataType>) {
+            if (context->enable_strict_mode()) {
+                cast_to_ip = std::make_shared<
+                        CastToImpl<CastModeType::StrictMode, FromDataType, IpType>>();
+            } else {
+                cast_to_ip = std::make_shared<
+                        CastToImpl<CastModeType::NonStrictMode, FromDataType, IpType>>();
+            }
+            return true;
+        } else {
+            return false;
+        }
+    };
+
+    if (!call_on_index_and_data_type<void>(from_type->get_primitive_type(), make_ip_wrapper)) {
+        return create_unsupport_wrapper(
+                fmt::format("CAST AS ip not supported {}", from_type->get_name()));
+    }
+
+    return [cast_to_ip](FunctionContext* context, Block& block, const ColumnNumbers& arguments,
+                        uint32_t result, size_t input_rows_count,
+                        const NullMap::value_type* null_map = nullptr) {
+        return cast_to_ip->execute_impl(context, block, arguments, result, input_rows_count,
+                                        null_map);
+    };
+}
+
+WrapperType create_ip_wrapper(FunctionContext* context, const DataTypePtr& from_type,
+                              PrimitiveType to_type) {
+    switch (to_type) {
+    case TYPE_IPV4:
+        return create_ip_wrapper<DataTypeIPv4>(context, from_type);
+    case TYPE_IPV6:
+        return create_ip_wrapper<DataTypeIPv6>(context, from_type);
+    default:
+        return create_unsupport_wrapper(
+                fmt::format("CAST AS ip: unsupported to_type {}", type_to_string(to_type)));
+    }
+}
+
+} // namespace doris::CastWrapper
+

--- a/be/src/exprs/function/cast/function_cast_timestamptz.cpp
+++ b/be/src/exprs/function/cast/function_cast_timestamptz.cpp
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "exprs/function/cast/cast_to_timestamptz.h"
+
+namespace doris::CastWrapper {
+WrapperType create_timestamptz_wrapper(FunctionContext* context, const DataTypePtr& from_type) {
+    std::shared_ptr<CastToBase> cast_to_timestamptz;
+
+    auto make_timestamptz_wrapper = [&](const auto& types) -> bool {
+        using Types = std::decay_t<decltype(types)>;
+        using FromDataType = typename Types::LeftType;
+        if constexpr (CastUtil::IsBaseCastFromType<FromDataType> ||
+                      IsTimeStampTzType<FromDataType>) {
+            if (context->enable_strict_mode()) {
+                cast_to_timestamptz = std::make_shared<
+                        CastToImpl<CastModeType::StrictMode, FromDataType, DataTypeTimeStampTz>>();
+            } else {
+                cast_to_timestamptz =
+                        std::make_shared<CastToImpl<CastModeType::NonStrictMode, FromDataType,
+                                                    DataTypeTimeStampTz>>();
+            }
+            return true;
+        } else {
+            return false;
+        }
+    };
+
+    if (!call_on_index_and_data_type<void>(from_type->get_primitive_type(),
+                                           make_timestamptz_wrapper)) {
+        return create_unsupport_wrapper(
+                fmt::format("CAST AS timestamptz not supported {}", from_type->get_name()));
+    }
+
+    return [cast_to_timestamptz](FunctionContext* context, Block& block,
+                                 const ColumnNumbers& arguments, uint32_t result,
+                                 size_t input_rows_count,
+                                 const NullMap::value_type* null_map = nullptr) {
+        return cast_to_timestamptz->execute_impl(context, block, arguments, result,
+                                                 input_rows_count, null_map);
+    };
+}
+} // namespace doris::CastWrapper


### PR DESCRIPTION
### What problem does this PR solve?


Previously, many cast instantiations were done in .h files, which caused a lot of code to be instantiated whenever other files included them. Here we move those instantiations into .cpp files, and keep only the code for casting a single value in the .h file.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

