### PR TITLE
[fix](build) Fix Boost sigtimedwait compile error on macOS

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -723,4 +723,17 @@ if [[ " ${TP_ARCHIVES[*]} " =~ " CCTZ " ]] ; then
     echo "Finished patching ${CCTZ_SOURCE}"
 fi
 
+# boost patch to fix sigtimedwait not available on macOS
+if [[ " ${TP_ARCHIVES[*]} " =~ " BOOST " ]]; then
+    cd "${TP_SOURCE_DIR}/${BOOST_SOURCE}"
+    if [[ ! -f "${PATCHED_MARK}" ]]; then
+        if [[ "$(uname -s)" == "Darwin" ]]; then
+            patch -p1 <"${TP_PATCH_DIR}/boost-1.81.0-mac-sigtimedwait.patch"
+        fi
+        touch "${PATCHED_MARK}"
+    fi
+    cd -
+    echo "Finished patching ${BOOST_SOURCE}"
+fi
+
 # vim: ts=4 sw=4 ts=4 tw=100:

--- a/thirdparty/patches/boost-1.81.0-mac-sigtimedwait.patch
+++ b/thirdparty/patches/boost-1.81.0-mac-sigtimedwait.patch
@@ -1,0 +1,11 @@
+--- a/boost/process/detail/config.hpp
++++ b/boost/process/detail/config.hpp
+@@ -57,7 +57,7 @@
+ #define BOOST_POSIX_HAS_VFORK 1
+ #endif
+
+-#if (_POSIX_C_SOURCE >= 199309L)
++#if (_POSIX_C_SOURCE >= 199309L) && !defined(__APPLE__)
+ #define BOOST_POSIX_HAS_SIGTIMEDWAIT 1
+ #endif
+


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

macOS does not implement `sigtimedwait` despite declaring `_POSIX_C_SOURCE >= 199309L`. Boost 1.81's `config.hpp` incorrectly enables `BOOST_POSIX_HAS_SIGTIMEDWAIT` on macOS, causing compile failures in `boost/process/detail/posix/wait_for_exit.hpp`.

This issue was newly exposed by the Python UDF feature (#59543), which introduced the first usage of `boost/process.hpp` in the BE codebase via the include chain:
`aggregate_function_python_udaf.cpp → python_udaf_client.h → python_client.h → python_udf_runtime.h → boost/process.hpp`

This PR adds a thirdparty patch to exclude `__APPLE__` from the sigtimedwait detection macro, so Boost falls back to its fork-based `wait_for_exit` implementation. The patch is only applied on Darwin and does not affect Linux builds.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - Verified BE compiles successfully on macOS (Apple Silicon) after applying the patch.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label