### PR TITLE
[opt](memory) Reduce CloudReplica per-instance memory footprint

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
@@ -73,6 +73,18 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
 
     private static final Random rand = new Random();
 
+    // Intern pool for cluster ID strings to avoid millions of duplicate String instances.
+    // Typically only a handful of distinct cluster IDs exist in the system.
+    private static final ConcurrentHashMap<String, String> CLUSTER_ID_POOL = new ConcurrentHashMap<>();
+
+    private static String internClusterId(String clusterId) {
+        if (clusterId == null) {
+            return null;
+        }
+        String existing = CLUSTER_ID_POOL.putIfAbsent(clusterId, clusterId);
+        return existing != null ? existing : clusterId;
+    }
+
     private Map<String, List<Long>> memClusterToBackends = null;
 
     // clusterId, secondaryBe, changeTimestamp
@@ -608,7 +620,7 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
     }
 
     public void updateClusterToPrimaryBe(String cluster, long beId) {
-        getOrCreatePrimaryMap().put(cluster, beId);
+        getOrCreatePrimaryMap().put(internClusterId(cluster), beId);
         Map<String, Pair<Long, Long>> secMap = secondaryClusterToBackends;
         if (secMap != null) {
             secMap.remove(cluster);
@@ -626,7 +638,7 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
             LOG.debug("add to secondary clusterId {}, beId {}, changeTimestamp {}, replica info {}",
                     cluster, beId, changeTimestamp, this);
         }
-        getOrCreateSecondaryMap().put(cluster, Pair.of(beId, changeTimestamp));
+        getOrCreateSecondaryMap().put(internClusterId(cluster), Pair.of(beId, changeTimestamp));
     }
 
     public void clearClusterToBe(String cluster) {
@@ -709,10 +721,19 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
                 String clusterId = entry.getKey();
                 List<Long> beIds = entry.getValue();
                 if (beIds != null && !beIds.isEmpty()) {
-                    map.put(clusterId, beIds.get(0));
+                    map.put(internClusterId(clusterId), beIds.get(0));
                 }
             }
             this.primaryClusterToBackends = null;
+        }
+        // Intern cluster ID keys in deserialized primary map to share String instances
+        // across millions of CloudReplica objects
+        if (primaryClusterToBackend != null) {
+            ConcurrentHashMap<String, Long> interned = new ConcurrentHashMap<>(primaryClusterToBackend.size());
+            for (Map.Entry<String, Long> entry : primaryClusterToBackend.entrySet()) {
+                interned.put(internClusterId(entry.getKey()), entry.getValue());
+            }
+            primaryClusterToBackend = interned;
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
@@ -56,7 +56,7 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
     @SerializedName(value = "bes")
     private ConcurrentHashMap<String, List<Long>> primaryClusterToBackends = null;
     @SerializedName(value = "be")
-    private ConcurrentHashMap<String, Long> primaryClusterToBackend = new ConcurrentHashMap<>();
+    private volatile ConcurrentHashMap<String, Long> primaryClusterToBackend;
     @SerializedName(value = "dbId")
     private long dbId = -1;
     @SerializedName(value = "tableId")
@@ -76,8 +76,7 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
     private Map<String, List<Long>> memClusterToBackends = null;
 
     // clusterId, secondaryBe, changeTimestamp
-    private Map<String, Pair<Long, Long>> secondaryClusterToBackends
-            = new ConcurrentHashMap<String, Pair<Long, Long>>();
+    private volatile Map<String, Pair<Long, Long>> secondaryClusterToBackends;
 
     public CloudReplica() {
     }
@@ -97,6 +96,34 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
         this.partitionId = partitionId;
         this.indexId = indexId;
         this.idx = idx;
+    }
+
+    private ConcurrentHashMap<String, Long> getOrCreatePrimaryMap() {
+        ConcurrentHashMap<String, Long> map = primaryClusterToBackend;
+        if (map == null) {
+            synchronized (this) {
+                map = primaryClusterToBackend;
+                if (map == null) {
+                    map = new ConcurrentHashMap<>(2);
+                    primaryClusterToBackend = map;
+                }
+            }
+        }
+        return map;
+    }
+
+    private Map<String, Pair<Long, Long>> getOrCreateSecondaryMap() {
+        Map<String, Pair<Long, Long>> map = secondaryClusterToBackends;
+        if (map == null) {
+            synchronized (this) {
+                map = secondaryClusterToBackends;
+                if (map == null) {
+                    map = new ConcurrentHashMap<>(2);
+                    secondaryClusterToBackends = map;
+                }
+            }
+        }
+        return map;
     }
 
     private boolean isColocated() {
@@ -206,7 +233,8 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
             }
         }
 
-        return primaryClusterToBackend.getOrDefault(clusterId, -1L);
+        ConcurrentHashMap<String, Long> map = primaryClusterToBackend;
+        return map != null ? map.getOrDefault(clusterId, -1L) : -1L;
     }
 
     private String getCurrentClusterId() throws ComputeGroupException {
@@ -316,8 +344,9 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
                 backendId = memClusterToBackends.get(clusterId).get(indexRand);
             }
 
-            if (!replicaEnough && !allowColdRead && primaryClusterToBackend.containsKey(clusterId)) {
-                backendId = primaryClusterToBackend.get(clusterId);
+            ConcurrentHashMap<String, Long> priMap = primaryClusterToBackend;
+            if (!replicaEnough && !allowColdRead && priMap != null && priMap.containsKey(clusterId)) {
+                backendId = priMap.get(clusterId);
             }
 
             if (backendId > 0) {
@@ -393,7 +422,11 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
     }
 
     public Backend getSecondaryBackend(String clusterId) {
-        Pair<Long, Long> secondBeAndChangeTimestamp = secondaryClusterToBackends.get(clusterId);
+        Map<String, Pair<Long, Long>> secMap = secondaryClusterToBackends;
+        if (secMap == null) {
+            return null;
+        }
+        Pair<Long, Long> secondBeAndChangeTimestamp = secMap.get(clusterId);
         if (secondBeAndChangeTimestamp == null) {
             return null;
         }
@@ -575,8 +608,11 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
     }
 
     public void updateClusterToPrimaryBe(String cluster, long beId) {
-        primaryClusterToBackend.put(cluster, beId);
-        secondaryClusterToBackends.remove(cluster);
+        getOrCreatePrimaryMap().put(cluster, beId);
+        Map<String, Pair<Long, Long>> secMap = secondaryClusterToBackends;
+        if (secMap != null) {
+            secMap.remove(cluster);
+        }
     }
 
     /**
@@ -590,19 +626,29 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
             LOG.debug("add to secondary clusterId {}, beId {}, changeTimestamp {}, replica info {}",
                     cluster, beId, changeTimestamp, this);
         }
-        secondaryClusterToBackends.put(cluster, Pair.of(beId, changeTimestamp));
+        getOrCreateSecondaryMap().put(cluster, Pair.of(beId, changeTimestamp));
     }
 
     public void clearClusterToBe(String cluster) {
-        primaryClusterToBackend.remove(cluster);
-        secondaryClusterToBackends.remove(cluster);
+        ConcurrentHashMap<String, Long> priMap = primaryClusterToBackend;
+        if (priMap != null) {
+            priMap.remove(cluster);
+        }
+        Map<String, Pair<Long, Long>> secMap = secondaryClusterToBackends;
+        if (secMap != null) {
+            secMap.remove(cluster);
+        }
     }
 
     // ATTN: This func is only used by redundant tablet report clean in bes.
     // Only the master node will do the diff logic,
     // so just only need to clean up secondaryClusterToBackends on the master node.
     public void checkAndClearSecondaryClusterToBe(String clusterId, long expireTimestamp) {
-        Pair<Long, Long> secondBeAndChangeTimestamp = secondaryClusterToBackends.get(clusterId);
+        Map<String, Pair<Long, Long>> secMap = secondaryClusterToBackends;
+        if (secMap == null) {
+            return;
+        }
+        Pair<Long, Long> secondBeAndChangeTimestamp = secMap.get(clusterId);
         if (secondBeAndChangeTimestamp == null) {
             return;
         }
@@ -612,19 +658,22 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
         if (changeTimestamp < expireTimestamp) {
             LOG.debug("remove clusterId {} secondary beId {} changeTimestamp {} expireTimestamp {} replica info {}",
                     clusterId, beId, changeTimestamp, expireTimestamp, this);
-            secondaryClusterToBackends.remove(clusterId);
+            secMap.remove(clusterId);
             return;
         }
     }
 
     public List<Backend> getAllPrimaryBes() {
         List<Backend> result = new ArrayList<Backend>();
-        primaryClusterToBackend.forEach((clusterId, beId) -> {
-            if (beId != -1) {
-                Backend backend = Env.getCurrentSystemInfo().getBackend(beId);
-                result.add(backend);
-            }
-        });
+        ConcurrentHashMap<String, Long> map = primaryClusterToBackend;
+        if (map != null) {
+            map.forEach((clusterId, beId) -> {
+                if (beId != -1) {
+                    Backend backend = Env.getCurrentSystemInfo().getBackend(beId);
+                    result.add(backend);
+                }
+            });
+        }
         return result;
     }
 
@@ -655,11 +704,12 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
                     this.getId(), this.primaryClusterToBackends, this.primaryClusterToBackend);
         }
         if (primaryClusterToBackends != null) {
+            ConcurrentHashMap<String, Long> map = getOrCreatePrimaryMap();
             for (Map.Entry<String, List<Long>> entry : primaryClusterToBackends.entrySet()) {
                 String clusterId = entry.getKey();
                 List<Long> beIds = entry.getValue();
                 if (beIds != null && !beIds.isEmpty()) {
-                    primaryClusterToBackend.put(clusterId, beIds.get(0));
+                    map.put(clusterId, beIds.get(0));
                 }
             }
             this.primaryClusterToBackends = null;


### PR DESCRIPTION
## Summary
- **Lazy-init ConcurrentHashMaps**: Replace eager `new ConcurrentHashMap<>()` initialization with null defaults and lazy allocation via double-checked locking. For millions of CloudReplica instances, this saves ~120 bytes per replica when maps are empty (most replicas never use `secondaryClusterToBackends`).
- **Intern cluster ID strings**: Add a static intern pool for cluster ID strings to eliminate duplicate String instances across CloudReplica objects. During Gson deserialization, each replica gets its own String copy of the same cluster ID (~40-70 bytes each). Interning shares a single instance.

### Memory savings estimate (1M tablets):
| Optimization | Per-replica savings | Total (1M) |
|---|---|---|
| Lazy-init secondaryClusterToBackends | ~56 bytes | ~53 MB |
| Lazy-init primaryClusterToBackend (unassigned) | ~56 bytes | varies |
| Smaller ConcurrentHashMap capacity (2 vs 16) | ~112 bytes | ~107 MB |
| Cluster ID string interning | ~40-70 bytes | ~40-70 MB |
| **Total** | **~160-230 bytes** | **~150-230 MB** |

### Changes:
- `primaryClusterToBackend`: `volatile`, null by default, lazy-allocated with `new ConcurrentHashMap<>(2)`
- `secondaryClusterToBackends`: `volatile`, null by default, lazy-allocated with `new ConcurrentHashMap<>(2)`
- `getOrCreatePrimaryMap()` / `getOrCreateSecondaryMap()`: double-checked locking helpers
- `internClusterId()`: heap-based intern pool using static ConcurrentHashMap
- All access sites updated with null-safe patterns
- `gsonPostProcess()`: interns keys from deserialized maps

## Test plan
- [ ] Verify FE compilation passes
- [ ] Run existing CloudReplica-related tests
- [ ] Verify backward compatibility: old checkpoint/editlog with eager-initialized maps deserializes correctly
- [ ] Verify `updateClusterToPrimaryBe` / `updateClusterToSecondaryBe` work correctly with lazy init
- [ ] Verify `clearClusterToBe` handles null maps gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)