### PR TITLE
[fix](build) Fix --whole-archive linker error on macOS

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -663,10 +663,17 @@ set(DORIS_DEPENDENCIES ${DORIS_DEPENDENCIES} clucene-contribs-lib)
 
 if (ENABLE_PAIMON_CPP)
     if (PAIMON_FACTORY_REGISTRY_LIBS)
-        set(DORIS_DEPENDENCIES ${DORIS_DEPENDENCIES}
-            -Wl,--whole-archive
-            ${PAIMON_FACTORY_REGISTRY_LIBS}
-            -Wl,--no-whole-archive)
+        if (APPLE)
+            foreach(lib ${PAIMON_FACTORY_REGISTRY_LIBS})
+                set(DORIS_DEPENDENCIES ${DORIS_DEPENDENCIES}
+                    -Wl,-force_load,$<TARGET_FILE:${lib}>)
+            endforeach()
+        else()
+            set(DORIS_DEPENDENCIES ${DORIS_DEPENDENCIES}
+                -Wl,--whole-archive
+                ${PAIMON_FACTORY_REGISTRY_LIBS}
+                -Wl,--no-whole-archive)
+        endif()
     endif()
 
     # paimon-cpp internal dependencies (renamed with _paimon suffix)

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -110,8 +110,13 @@ add_subdirectory(storage/index/ann)
 
 add_executable(doris_be_test ${UT_FILES})
 
-target_link_libraries(doris_be_test ${TEST_LINK_LIBS} 
-    -Wl,--whole-archive vector_search_test -Wl,--no-whole-archive)
+if (APPLE)
+    target_link_libraries(doris_be_test ${TEST_LINK_LIBS}
+        -Wl,-force_load,$<TARGET_FILE:vector_search_test>)
+else()
+    target_link_libraries(doris_be_test ${TEST_LINK_LIBS}
+        -Wl,--whole-archive vector_search_test -Wl,--no-whole-archive)
+endif()
 set_target_properties(doris_be_test PROPERTIES COMPILE_FLAGS "-fno-access-control")
 target_compile_options(doris_be_test PRIVATE -include gtest/gtest.h -Wno-shadow -Wno-shadow-field)
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #61285

Problem Summary:

macOS `ld64` does not support GNU ld's `--whole-archive` / `--no-whole-archive` linker options, causing link failure when building BE on macOS:

```
ld: unknown options: --whole-archive --no-whole-archive
```

This PR uses macOS-native `-force_load` with CMake's `$<TARGET_FILE:lib>` generator expression on Apple platforms instead. Fixes both `doris_be` (paimon factory registry libs) and `doris_be_test` (vector_search_test) link targets.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - BE compiles and links successfully on macOS (Apple Silicon).
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label