### PR TITLE
[chore](fe) remove redundant test dependencies

### DIFF
--- a/fe/fe-catalog/pom.xml
+++ b/fe/fe-catalog/pom.xml
@@ -45,11 +45,6 @@ under the License.
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/fe/fe-common/pom.xml
+++ b/fe/fe-common/pom.xml
@@ -66,11 +66,6 @@ under the License.
             <artifactId>RoaringBitmap</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -735,10 +735,6 @@ under the License.
             <artifactId>arrow-vector</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>flight-sql</artifactId>
         </dependency>

--- a/fe/fe-extension-loader/pom.xml
+++ b/fe/fe-extension-loader/pom.xml
@@ -35,15 +35,5 @@ under the License.
             <artifactId>fe-extension-spi</artifactId>
             <version>${revision}</version>
         </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/fe/fe-type/pom.xml
+++ b/fe/fe-type/pom.xml
@@ -60,11 +60,6 @@ under the License.
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -1549,11 +1549,6 @@ under the License.
                 <version>${tree-printer.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest</artifactId>
-                <version>${hamcrest.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>${httpclient.version}</version>


### PR DESCRIPTION
## What

This PR removes several redundant FE-side test dependencies.

## Why

A quick dependency audit under `fe/` found a few dependencies that are declared but not actually used:
- `hamcrest` in multiple FE modules
- JUnit 5 test dependencies in `fe-extension-loader`, which currently has no test sources

Keeping these unused dependencies increases dependency surface and maintenance cost without bringing value.
