### PR TITLE
[exec](feat) Dynamic streaming hash table min reduction based on CPU cache

### DIFF
--- a/be/src/exec/operator/distinct_streaming_aggregation_operator.cpp
+++ b/be/src/exec/operator/distinct_streaming_aggregation_operator.cpp
@@ -23,8 +23,9 @@
 #include <utility>
 
 #include "common/compiler_util.h" // IWYU pragma: keep
+#include "exec/operator/streaming_agg_min_reduction.h"
+#include "exprs/vectorized_agg_fn.h"
 #include "util/cpu_info.h"
-#include "vec/exprs/vectorized_agg_fn.h"
 
 namespace doris {
 class ExecNode;
@@ -33,11 +34,6 @@ class RuntimeState;
 
 namespace doris {
 #include "common/compile_check_begin.h"
-
-using StreamingHtMinReductionEntry = doris::CpuInfo::StreamingHtMinReductionEntry;
-static const std::vector<StreamingHtMinReductionEntry>& STREAMING_HT_MIN_REDUCTION =
-        doris::CpuInfo::get_streaming_ht_min_reduction();
-static const size_t STREAMING_HT_MIN_REDUCTION_SIZE = STREAMING_HT_MIN_REDUCTION.size();
 
 DistinctStreamingAggLocalState::DistinctStreamingAggLocalState(RuntimeState* state,
                                                                OperatorXBase* parent)
@@ -82,64 +78,65 @@ bool DistinctStreamingAggLocalState::_should_expand_preagg_hash_tables() {
     }
 
     return std::visit(
-            Overload {[&](std::monostate& arg) -> bool {
-                          throw doris::Exception(ErrorCode::INTERNAL_ERROR, "uninited hash table");
-                          return false;
-                      },
-                      [&](auto& agg_method) -> bool {
-                          auto& hash_tbl = *agg_method.hash_table;
-                          auto [ht_mem, ht_rows] =
-                                  std::pair {hash_tbl.get_buffer_size_in_bytes(), hash_tbl.size()};
+            Overload {
+                    [&](std::monostate& arg) -> bool {
+                        throw doris::Exception(ErrorCode::INTERNAL_ERROR, "uninited hash table");
+                        return false;
+                    },
+                    [&](auto& agg_method) -> bool {
+                        auto& hash_tbl = *agg_method.hash_table;
+                        auto [ht_mem, ht_rows] =
+                                std::pair {hash_tbl.get_buffer_size_in_bytes(), hash_tbl.size()};
 
-                          // Need some rows in tables to have valid statistics.
-                          if (ht_rows == 0) {
-                              return true;
-                          }
+                        // Need some rows in tables to have valid statistics.
+                        if (ht_rows == 0) {
+                            return true;
+                        }
 
-                          const auto* reduction = _is_single_backend
-                                                          ? SINGLE_BE_STREAMING_HT_MIN_REDUCTION
-                                                          : STREAMING_HT_MIN_REDUCTION;
+                        const auto* reduction = _is_single_backend
+                                                        ? SINGLE_BE_STREAMING_HT_MIN_REDUCTION
+                                                        : STREAMING_HT_MIN_REDUCTION;
 
-                          // Find the appropriate reduction factor in our table for the current hash table sizes.
-                          int cache_level = 0;
-                          while (cache_level + 1 < STREAMING_HT_MIN_REDUCTION_SIZE &&
-                                 ht_mem >= reduction[cache_level + 1].min_ht_mem) {
-                              ++cache_level;
-                          }
+                        // Find the appropriate reduction factor in our table for the current hash table sizes.
+                        int cache_level = 0;
+                        while (cache_level + 1 < STREAMING_HT_MIN_REDUCTION_SIZE &&
+                               ht_mem >= reduction[cache_level + 1].min_ht_mem) {
+                            ++cache_level;
+                        }
 
-                          // Compare the number of rows in the hash table with the number of input rows that
-                          // were aggregated into it. Exclude passed through rows from this calculation since
-                          // they were not in hash tables.
-                          const int64_t input_rows = _input_num_rows;
-                          const int64_t aggregated_input_rows = input_rows - _num_rows_returned;
-                          // TODO chenhao
-                          //  const int64_t expected_input_rows = estimated_input_cardinality_ - num_rows_returned_;
-                          double current_reduction = static_cast<double>(aggregated_input_rows) /
-                                                     static_cast<double>(ht_rows);
+                        // Compare the number of rows in the hash table with the number of input rows that
+                        // were aggregated into it. Exclude passed through rows from this calculation since
+                        // they were not in hash tables.
+                        const int64_t input_rows = _input_num_rows;
+                        const int64_t aggregated_input_rows = input_rows - _num_rows_returned;
+                        // TODO chenhao
+                        //  const int64_t expected_input_rows = estimated_input_cardinality_ - num_rows_returned_;
+                        double current_reduction = static_cast<double>(aggregated_input_rows) /
+                                                   static_cast<double>(ht_rows);
 
-                          // TODO: workaround for IMPALA-2490: subplan node rows_returned counter may be
-                          // inaccurate, which could lead to a divide by zero below.
-                          if (aggregated_input_rows <= 0) {
-                              return true;
-                          }
+                        // TODO: workaround for IMPALA-2490: subplan node rows_returned counter may be
+                        // inaccurate, which could lead to a divide by zero below.
+                        if (aggregated_input_rows <= 0) {
+                            return true;
+                        }
 
-                          // Extrapolate the current reduction factor (r) using the formula
-                          // R = 1 + (N / n) * (r - 1), where R is the reduction factor over the full input data
-                          // set, N is the number of input rows, excluding passed-through rows, and n is the
-                          // number of rows inserted or merged into the hash tables. This is a very rough
-                          // approximation but is good enough to be useful.
-                          // TODO: consider collecting more statistics to better estimate reduction.
-                          //  double estimated_reduction = aggregated_input_rows >= expected_input_rows
-                          //      ? current_reduction
-                          //      : 1 + (expected_input_rows / aggregated_input_rows) * (current_reduction - 1);
-                          double min_reduction = reduction[cache_level].streaming_ht_min_reduction;
+                        // Extrapolate the current reduction factor (r) using the formula
+                        // R = 1 + (N / n) * (r - 1), where R is the reduction factor over the full input data
+                        // set, N is the number of input rows, excluding passed-through rows, and n is the
+                        // number of rows inserted or merged into the hash tables. This is a very rough
+                        // approximation but is good enough to be useful.
+                        // TODO: consider collecting more statistics to better estimate reduction.
+                        //  double estimated_reduction = aggregated_input_rows >= expected_input_rows
+                        //      ? current_reduction
+                        //      : 1 + (expected_input_rows / aggregated_input_rows) * (current_reduction - 1);
+                        double min_reduction = reduction[cache_level].streaming_ht_min_reduction;
 
-                          //  COUNTER_SET(preagg_estimated_reduction_, estimated_reduction);
-                          //    COUNTER_SET(preagg_streaming_ht_min_reduction_, min_reduction);
-                          //  return estimated_reduction > min_reduction;
-                          _should_expand_hash_table = current_reduction > min_reduction;
-                          return _should_expand_hash_table;
-                      }},
+                        //  COUNTER_SET(preagg_estimated_reduction_, estimated_reduction);
+                        //    COUNTER_SET(preagg_streaming_ht_min_reduction_, min_reduction);
+                        //  return estimated_reduction > min_reduction;
+                        _should_expand_hash_table = current_reduction > min_reduction;
+                        return _should_expand_hash_table;
+                    }},
             _agg_data->method_variant);
 }
 

--- a/be/src/exec/operator/distinct_streaming_aggregation_operator.cpp
+++ b/be/src/exec/operator/distinct_streaming_aggregation_operator.cpp
@@ -23,8 +23,8 @@
 #include <utility>
 
 #include "common/compiler_util.h" // IWYU pragma: keep
-#include "exec/operator/streaming_agg_min_reduction.h"
-#include "exprs/vectorized_agg_fn.h"
+#include "util/cpu_info.h"
+#include "vec/exprs/vectorized_agg_fn.h"
 
 namespace doris {
 class ExecNode;
@@ -33,6 +33,11 @@ class RuntimeState;
 
 namespace doris {
 #include "common/compile_check_begin.h"
+
+using StreamingHtMinReductionEntry = doris::CpuInfo::StreamingHtMinReductionEntry;
+static const std::vector<StreamingHtMinReductionEntry>& STREAMING_HT_MIN_REDUCTION =
+        doris::CpuInfo::get_streaming_ht_min_reduction();
+static const size_t STREAMING_HT_MIN_REDUCTION_SIZE = STREAMING_HT_MIN_REDUCTION.size();
 
 DistinctStreamingAggLocalState::DistinctStreamingAggLocalState(RuntimeState* state,
                                                                OperatorXBase* parent)
@@ -77,65 +82,64 @@ bool DistinctStreamingAggLocalState::_should_expand_preagg_hash_tables() {
     }
 
     return std::visit(
-            Overload {
-                    [&](std::monostate& arg) -> bool {
-                        throw doris::Exception(ErrorCode::INTERNAL_ERROR, "uninited hash table");
-                        return false;
-                    },
-                    [&](auto& agg_method) -> bool {
-                        auto& hash_tbl = *agg_method.hash_table;
-                        auto [ht_mem, ht_rows] =
-                                std::pair {hash_tbl.get_buffer_size_in_bytes(), hash_tbl.size()};
+            Overload {[&](std::monostate& arg) -> bool {
+                          throw doris::Exception(ErrorCode::INTERNAL_ERROR, "uninited hash table");
+                          return false;
+                      },
+                      [&](auto& agg_method) -> bool {
+                          auto& hash_tbl = *agg_method.hash_table;
+                          auto [ht_mem, ht_rows] =
+                                  std::pair {hash_tbl.get_buffer_size_in_bytes(), hash_tbl.size()};
 
-                        // Need some rows in tables to have valid statistics.
-                        if (ht_rows == 0) {
-                            return true;
-                        }
+                          // Need some rows in tables to have valid statistics.
+                          if (ht_rows == 0) {
+                              return true;
+                          }
 
-                        const auto* reduction = _is_single_backend
-                                                        ? SINGLE_BE_STREAMING_HT_MIN_REDUCTION
-                                                        : STREAMING_HT_MIN_REDUCTION;
+                          const auto* reduction = _is_single_backend
+                                                          ? SINGLE_BE_STREAMING_HT_MIN_REDUCTION
+                                                          : STREAMING_HT_MIN_REDUCTION;
 
-                        // Find the appropriate reduction factor in our table for the current hash table sizes.
-                        int cache_level = 0;
-                        while (cache_level + 1 < STREAMING_HT_MIN_REDUCTION_SIZE &&
-                               ht_mem >= reduction[cache_level + 1].min_ht_mem) {
-                            ++cache_level;
-                        }
+                          // Find the appropriate reduction factor in our table for the current hash table sizes.
+                          int cache_level = 0;
+                          while (cache_level + 1 < STREAMING_HT_MIN_REDUCTION_SIZE &&
+                                 ht_mem >= reduction[cache_level + 1].min_ht_mem) {
+                              ++cache_level;
+                          }
 
-                        // Compare the number of rows in the hash table with the number of input rows that
-                        // were aggregated into it. Exclude passed through rows from this calculation since
-                        // they were not in hash tables.
-                        const int64_t input_rows = _input_num_rows;
-                        const int64_t aggregated_input_rows = input_rows - _num_rows_returned;
-                        // TODO chenhao
-                        //  const int64_t expected_input_rows = estimated_input_cardinality_ - num_rows_returned_;
-                        double current_reduction = static_cast<double>(aggregated_input_rows) /
-                                                   static_cast<double>(ht_rows);
+                          // Compare the number of rows in the hash table with the number of input rows that
+                          // were aggregated into it. Exclude passed through rows from this calculation since
+                          // they were not in hash tables.
+                          const int64_t input_rows = _input_num_rows;
+                          const int64_t aggregated_input_rows = input_rows - _num_rows_returned;
+                          // TODO chenhao
+                          //  const int64_t expected_input_rows = estimated_input_cardinality_ - num_rows_returned_;
+                          double current_reduction = static_cast<double>(aggregated_input_rows) /
+                                                     static_cast<double>(ht_rows);
 
-                        // TODO: workaround for IMPALA-2490: subplan node rows_returned counter may be
-                        // inaccurate, which could lead to a divide by zero below.
-                        if (aggregated_input_rows <= 0) {
-                            return true;
-                        }
+                          // TODO: workaround for IMPALA-2490: subplan node rows_returned counter may be
+                          // inaccurate, which could lead to a divide by zero below.
+                          if (aggregated_input_rows <= 0) {
+                              return true;
+                          }
 
-                        // Extrapolate the current reduction factor (r) using the formula
-                        // R = 1 + (N / n) * (r - 1), where R is the reduction factor over the full input data
-                        // set, N is the number of input rows, excluding passed-through rows, and n is the
-                        // number of rows inserted or merged into the hash tables. This is a very rough
-                        // approximation but is good enough to be useful.
-                        // TODO: consider collecting more statistics to better estimate reduction.
-                        //  double estimated_reduction = aggregated_input_rows >= expected_input_rows
-                        //      ? current_reduction
-                        //      : 1 + (expected_input_rows / aggregated_input_rows) * (current_reduction - 1);
-                        double min_reduction = reduction[cache_level].streaming_ht_min_reduction;
+                          // Extrapolate the current reduction factor (r) using the formula
+                          // R = 1 + (N / n) * (r - 1), where R is the reduction factor over the full input data
+                          // set, N is the number of input rows, excluding passed-through rows, and n is the
+                          // number of rows inserted or merged into the hash tables. This is a very rough
+                          // approximation but is good enough to be useful.
+                          // TODO: consider collecting more statistics to better estimate reduction.
+                          //  double estimated_reduction = aggregated_input_rows >= expected_input_rows
+                          //      ? current_reduction
+                          //      : 1 + (expected_input_rows / aggregated_input_rows) * (current_reduction - 1);
+                          double min_reduction = reduction[cache_level].streaming_ht_min_reduction;
 
-                        //  COUNTER_SET(preagg_estimated_reduction_, estimated_reduction);
-                        //    COUNTER_SET(preagg_streaming_ht_min_reduction_, min_reduction);
-                        //  return estimated_reduction > min_reduction;
-                        _should_expand_hash_table = current_reduction > min_reduction;
-                        return _should_expand_hash_table;
-                    }},
+                          //  COUNTER_SET(preagg_estimated_reduction_, estimated_reduction);
+                          //    COUNTER_SET(preagg_streaming_ht_min_reduction_, min_reduction);
+                          //  return estimated_reduction > min_reduction;
+                          _should_expand_hash_table = current_reduction > min_reduction;
+                          return _should_expand_hash_table;
+                      }},
             _agg_data->method_variant);
 }
 

--- a/be/src/exec/operator/distinct_streaming_aggregation_operator.cpp
+++ b/be/src/exec/operator/distinct_streaming_aggregation_operator.cpp
@@ -25,7 +25,6 @@
 #include "common/compiler_util.h" // IWYU pragma: keep
 #include "exec/operator/streaming_agg_min_reduction.h"
 #include "exprs/vectorized_agg_fn.h"
-#include "util/cpu_info.h"
 
 namespace doris {
 class ExecNode;

--- a/be/src/exec/operator/streaming_aggregation_operator.cpp
+++ b/be/src/exec/operator/streaming_aggregation_operator.cpp
@@ -31,13 +31,23 @@
 #include "exprs/aggregate/aggregate_function_simple_factory.h"
 #include "exprs/vectorized_agg_fn.h"
 #include "exprs/vslot_ref.h"
+#include "pipeline/exec/operator.h"
+#include "util/cpu_info.h"
+#include "vec/aggregate_functions/aggregate_function_simple_factory.h"
+#include "vec/exprs/vectorized_agg_fn.h"
+#include "vec/exprs/vslot_ref.h"
 
 namespace doris {
 #include "common/compile_check_begin.h"
 class RuntimeState;
 } // namespace doris
 
-namespace doris {
+namespace doris::pipeline {
+
+using StreamingHtMinReductionEntry = doris::CpuInfo::StreamingHtMinReductionEntry;
+static const std::vector<StreamingHtMinReductionEntry>& STREAMING_HT_MIN_REDUCTION =
+        doris::CpuInfo::get_streaming_ht_min_reduction();
+static const size_t STREAMING_HT_MIN_REDUCTION_SIZE = STREAMING_HT_MIN_REDUCTION.size();
 
 StreamingAggLocalState::StreamingAggLocalState(RuntimeState* state, OperatorXBase* parent)
         : Base(state, parent),
@@ -1128,4 +1138,4 @@ bool StreamingAggOperatorX::need_more_input_data(RuntimeState* state) const {
 }
 
 #include "common/compile_check_end.h"
-} // namespace doris
+} // namespace doris::pipeline

--- a/be/src/exec/operator/streaming_aggregation_operator.cpp
+++ b/be/src/exec/operator/streaming_aggregation_operator.cpp
@@ -31,23 +31,10 @@
 #include "exprs/aggregate/aggregate_function_simple_factory.h"
 #include "exprs/vectorized_agg_fn.h"
 #include "exprs/vslot_ref.h"
-#include "pipeline/exec/operator.h"
 #include "util/cpu_info.h"
-#include "vec/aggregate_functions/aggregate_function_simple_factory.h"
-#include "vec/exprs/vectorized_agg_fn.h"
-#include "vec/exprs/vslot_ref.h"
 
 namespace doris {
 #include "common/compile_check_begin.h"
-class RuntimeState;
-} // namespace doris
-
-namespace doris::pipeline {
-
-using StreamingHtMinReductionEntry = doris::CpuInfo::StreamingHtMinReductionEntry;
-static const std::vector<StreamingHtMinReductionEntry>& STREAMING_HT_MIN_REDUCTION =
-        doris::CpuInfo::get_streaming_ht_min_reduction();
-static const size_t STREAMING_HT_MIN_REDUCTION_SIZE = STREAMING_HT_MIN_REDUCTION.size();
 
 StreamingAggLocalState::StreamingAggLocalState(RuntimeState* state, OperatorXBase* parent)
         : Base(state, parent),
@@ -1138,4 +1125,4 @@ bool StreamingAggOperatorX::need_more_input_data(RuntimeState* state) const {
 }
 
 #include "common/compile_check_end.h"
-} // namespace doris::pipeline
+} // namespace doris

--- a/be/src/exec/operator/streaming_aggregation_operator.cpp
+++ b/be/src/exec/operator/streaming_aggregation_operator.cpp
@@ -31,7 +31,6 @@
 #include "exprs/aggregate/aggregate_function_simple_factory.h"
 #include "exprs/vectorized_agg_fn.h"
 #include "exprs/vslot_ref.h"
-#include "util/cpu_info.h"
 
 namespace doris {
 #include "common/compile_check_begin.h"

--- a/be/src/util/cpu_info.cpp
+++ b/be/src/util/cpu_info.cpp
@@ -381,9 +381,7 @@ void CpuInfo::_get_cache_info(long cache_sizes[NUM_CACHE_LEVELS],
 
 std::string CpuInfo::debug_string() {
     std::stringstream stream;
-    if (!initialized_) {
-        return stream.str();
-    }
+    DCHECK(initialized_);
 
     std::string L1 = absl::Substitute(
             "L1 Cache: $0 (Line: $1)",

--- a/be/src/util/cpu_info.cpp
+++ b/be/src/util/cpu_info.cpp
@@ -101,6 +101,8 @@ int CpuInfo::max_num_numa_nodes_;
 std::unique_ptr<int[]> CpuInfo::core_to_numa_node_;
 std::vector<std::vector<int>> CpuInfo::numa_node_to_cores_;
 std::vector<int> CpuInfo::numa_node_core_idx_;
+long CpuInfo::cache_sizes_[CpuInfo::NUM_CACHE_LEVELS];
+long CpuInfo::cache_line_sizes_[CpuInfo::NUM_CACHE_LEVELS];
 
 static struct {
     std::string name;
@@ -203,6 +205,7 @@ void CpuInfo::init() {
 #endif
 
     _init_numa();
+    _get_cache_info(cache_sizes_, cache_line_sizes_);
     initialized_ = true;
 }
 
@@ -377,28 +380,28 @@ void CpuInfo::_get_cache_info(long cache_sizes[NUM_CACHE_LEVELS],
 }
 
 std::string CpuInfo::debug_string() {
-    DCHECK(initialized_);
     std::stringstream stream;
-    long cache_sizes[NUM_CACHE_LEVELS];
-    long cache_line_sizes[NUM_CACHE_LEVELS];
-    _get_cache_info(cache_sizes, cache_line_sizes);
+    if (!initialized_) {
+        return stream.str();
+    }
 
     std::string L1 = absl::Substitute(
             "L1 Cache: $0 (Line: $1)",
-            PrettyPrinter::print(static_cast<int64_t>(cache_sizes[L1_CACHE]), TUnit::BYTES),
-            PrettyPrinter::print(static_cast<int64_t>(cache_line_sizes[L1_CACHE]), TUnit::BYTES));
+            PrettyPrinter::print(static_cast<int64_t>(cache_sizes_[L1_CACHE]), TUnit::BYTES),
+            PrettyPrinter::print(static_cast<int64_t>(cache_line_sizes_[L1_CACHE]), TUnit::BYTES));
     std::string L2 = absl::Substitute(
             "L2 Cache: $0 (Line: $1)",
-            PrettyPrinter::print(static_cast<int64_t>(cache_sizes[L2_CACHE]), TUnit::BYTES),
-            PrettyPrinter::print(static_cast<int64_t>(cache_line_sizes[L2_CACHE]), TUnit::BYTES));
+            PrettyPrinter::print(static_cast<int64_t>(cache_sizes_[L2_CACHE]), TUnit::BYTES),
+            PrettyPrinter::print(static_cast<int64_t>(cache_line_sizes_[L2_CACHE]), TUnit::BYTES));
     std::string L3 =
-            cache_sizes[L3_CACHE]
+            cache_sizes_[L3_CACHE]
                     ? absl::Substitute(
                               "L3 Cache: $0 (Line: $1)",
-                              PrettyPrinter::print(static_cast<int64_t>(cache_sizes[L3_CACHE]),
+                              PrettyPrinter::print(static_cast<int64_t>(cache_sizes_[L3_CACHE]),
                                                    TUnit::BYTES),
-                              PrettyPrinter::print(static_cast<int64_t>(cache_line_sizes[L3_CACHE]),
-                                                   TUnit::BYTES))
+                              PrettyPrinter::print(
+                                      static_cast<int64_t>(cache_line_sizes_[L3_CACHE]),
+                                      TUnit::BYTES))
                     : "";
     stream << "Cpu Info:" << std::endl
            << "  Model: " << model_name_ << std::endl

--- a/be/src/util/cpu_info.h
+++ b/be/src/util/cpu_info.h
@@ -148,6 +148,56 @@ public:
 
     static std::string debug_string();
 
+    static long get_cache_size(CacheLevel level) {
+        long cache_sizes[NUM_CACHE_LEVELS];
+        long cache_line_sizes[NUM_CACHE_LEVELS];
+        _get_cache_info(cache_sizes, cache_line_sizes);
+        return cache_sizes[level];
+    }
+
+    static long get_cache_line_size(CacheLevel level) {
+        long cache_sizes[NUM_CACHE_LEVELS];
+        long cache_line_sizes[NUM_CACHE_LEVELS];
+        _get_cache_info(cache_sizes, cache_line_sizes);
+        return cache_line_sizes[level];
+    }
+
+    struct StreamingHtMinReductionEntry {
+        long min_ht_mem;
+        double streaming_ht_min_reduction;
+    };
+
+    static const std::vector<StreamingHtMinReductionEntry>& get_streaming_ht_min_reduction() {
+        static std::vector<StreamingHtMinReductionEntry> entries;
+        static bool initialized = false;
+
+        if (!initialized) {
+            long l2_cache_size = CpuInfo::get_cache_size(CpuInfo::L2_CACHE);
+            long l3_cache_size = CpuInfo::get_cache_size(CpuInfo::L3_CACHE);
+
+            entries.push_back({.min_ht_mem = 0, .streaming_ht_min_reduction = 0.0});
+
+            if (l2_cache_size > 256 * 1024) {
+                entries.push_back(
+                        {.min_ht_mem = l2_cache_size / 4, .streaming_ht_min_reduction = 1.1});
+            } else {
+                entries.push_back({.min_ht_mem = 256 * 1024, .streaming_ht_min_reduction = 1.1});
+            }
+
+            if (l3_cache_size > 4 * 1024 * 1024) {
+                entries.push_back(
+                        {.min_ht_mem = l3_cache_size / 2, .streaming_ht_min_reduction = 2.0});
+            } else {
+                entries.push_back(
+                        {.min_ht_mem = 16 * 1024 * 1024, .streaming_ht_min_reduction = 2.0});
+            }
+
+            initialized = true;
+        }
+
+        return entries;
+    }
+
     /// A utility class for temporarily disabling CPU features. Usage:
     ///
     /// {

--- a/be/src/util/cpu_info.h
+++ b/be/src/util/cpu_info.h
@@ -148,9 +148,15 @@ public:
 
     static std::string debug_string();
 
-    static long get_cache_size(CacheLevel level) { return cache_sizes_[level]; }
+    static long get_cache_size(CacheLevel level) {
+        DCHECK(initialized_);
+        return cache_sizes_[level];
+    }
 
-    static long get_cache_line_size(CacheLevel level) { return cache_line_sizes_[level]; }
+    static long get_cache_line_size(CacheLevel level) {
+        DCHECK(initialized_);
+        return cache_line_sizes_[level];
+    }
 
     /// A utility class for temporarily disabling CPU features. Usage:
     ///

--- a/be/src/util/cpu_info.h
+++ b/be/src/util/cpu_info.h
@@ -148,55 +148,9 @@ public:
 
     static std::string debug_string();
 
-    static long get_cache_size(CacheLevel level) {
-        long cache_sizes[NUM_CACHE_LEVELS];
-        long cache_line_sizes[NUM_CACHE_LEVELS];
-        _get_cache_info(cache_sizes, cache_line_sizes);
-        return cache_sizes[level];
-    }
+    static long get_cache_size(CacheLevel level) { return cache_sizes_[level]; }
 
-    static long get_cache_line_size(CacheLevel level) {
-        long cache_sizes[NUM_CACHE_LEVELS];
-        long cache_line_sizes[NUM_CACHE_LEVELS];
-        _get_cache_info(cache_sizes, cache_line_sizes);
-        return cache_line_sizes[level];
-    }
-
-    struct StreamingHtMinReductionEntry {
-        long min_ht_mem;
-        double streaming_ht_min_reduction;
-    };
-
-    static const std::vector<StreamingHtMinReductionEntry>& get_streaming_ht_min_reduction() {
-        static std::vector<StreamingHtMinReductionEntry> entries;
-        static bool initialized = false;
-
-        if (!initialized) {
-            long l2_cache_size = CpuInfo::get_cache_size(CpuInfo::L2_CACHE);
-            long l3_cache_size = CpuInfo::get_cache_size(CpuInfo::L3_CACHE);
-
-            entries.push_back({.min_ht_mem = 0, .streaming_ht_min_reduction = 0.0});
-
-            if (l2_cache_size > 256 * 1024) {
-                entries.push_back(
-                        {.min_ht_mem = l2_cache_size / 4, .streaming_ht_min_reduction = 1.1});
-            } else {
-                entries.push_back({.min_ht_mem = 256 * 1024, .streaming_ht_min_reduction = 1.1});
-            }
-
-            if (l3_cache_size > 4 * 1024 * 1024) {
-                entries.push_back(
-                        {.min_ht_mem = l3_cache_size / 2, .streaming_ht_min_reduction = 2.0});
-            } else {
-                entries.push_back(
-                        {.min_ht_mem = 16 * 1024 * 1024, .streaming_ht_min_reduction = 2.0});
-            }
-
-            initialized = true;
-        }
-
-        return entries;
-    }
+    static long get_cache_line_size(CacheLevel level) { return cache_line_sizes_[level]; }
 
     /// A utility class for temporarily disabling CPU features. Usage:
     ///
@@ -271,5 +225,8 @@ private:
     /// Array with 'max_num_cores_' entries, each of which is the index of that core in its
     /// NUMA node.
     static std::vector<int> numa_node_core_idx_;
+
+    static long cache_sizes_[NUM_CACHE_LEVELS];
+    static long cache_line_sizes_[NUM_CACHE_LEVELS];
 };
 } // namespace doris


### PR DESCRIPTION
- Add get_cache_size() and get_cache_line_size() methods to CpuInfo
- Add StreamingHtMinReductionEntry struct and get_streaming_ht_min_reduction() method
- Replace static STREAMING_HT_MIN_REDUCTION config with dynamic calculation based on L2/L3 cache size
- Update include paths in streaming_aggregation_operator.cpp and distinct_streaming_aggregation_operator.cpp
- Change namespace from doris to doris::pipeline in streaming_aggregation_operator.cpp

This change enables better adaptation to different hardware environments by dynamically calculating hash table expansion thresholds based on actual CPU cache sizes.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

