### PR TITLE
[fix](constraint) Fix NPE in PrimaryKeyConstraint when loading old metadata

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/constraint/PrimaryKeyConstraint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/constraint/PrimaryKeyConstraint.java
@@ -40,14 +40,14 @@ public class PrimaryKeyConstraint extends Constraint implements GsonPostProcessa
 
     // record the foreign table which references the primary key
     @SerializedName(value = "ft")
-    private final Set<TableIdentifier> foreignTables = new HashSet<>();
+    private Set<TableIdentifier> foreignTables = new HashSet<>();
 
     // qualified name strings kept for backward-compatible deserialization
     @SerializedName(value = "ftn")
-    private final Set<String> foreignTableNameStrs = new HashSet<>();
+    private Set<String> foreignTableNameStrs = new HashSet<>();
 
     @SerializedName(value = "ftni")
-    private final List<TableNameInfo> foreignTableInfos = new ArrayList<>();
+    private List<TableNameInfo> foreignTableInfos = new ArrayList<>();
 
     public PrimaryKeyConstraint(String name, Set<String> columns) {
         super(ConstraintType.PRIMARY_KEY, name);
@@ -116,6 +116,15 @@ public class PrimaryKeyConstraint extends Constraint implements GsonPostProcessa
 
     @Override
     public void gsonPostProcess() throws IOException {
+        if (foreignTables == null) {
+            foreignTables = new HashSet<>();
+        }
+        if (foreignTableNameStrs == null) {
+            foreignTableNameStrs = new HashSet<>();
+        }
+        if (foreignTableInfos == null) {
+            foreignTableInfos = new ArrayList<>();
+        }
         if (foreignTableInfos.isEmpty() && !foreignTableNameStrs.isEmpty()) {
             for (String qualifiedName : foreignTableNameStrs) {
                 foreignTableInfos.add(new TableNameInfo(qualifiedName));


### PR DESCRIPTION
### What problem does this PR solve?


When FE starts with -r (metadata_failure_recovery) or without a checkpoint image, it replays all journal logs from the beginning. Old journal entries may contain PrimaryKeyConstraint objects that were serialized before the fields foreignTables, foreignTableNameStrs, or foreignTableInfos were added to the class.

Gson uses Unsafe to instantiate objects during deserialization, bypassing the constructor and its field initializers. If a field is absent from the JSON, Gson leaves it as null rather than using the declared initializer (e.g. `= new HashSet<>()`). Calling .isEmpty() or any method on a null collection then throws a NullPointerException.

Fix: remove `final` from the three collection fields (so they can be reassigned in gsonPostProcess) and add null-guards at the top of gsonPostProcess() to initialize them to empty collections when absent.

Impact on -r mode: when FE is started with --metadata_failure_recovery it replays every journal from journal #1, encountering the oldest serialized PrimaryKeyConstraint objects. Without this fix, FE always crashes during -r recovery if any PrimaryKeyConstraint was persisted before these fields existed.



Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

