### PR TITLE
[refactor](nereids) Preserve plan node id across withXxx() copy methods

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
@@ -61,6 +61,15 @@ public abstract class AbstractPlan extends AbstractTreeNode<Plan> implements Pla
 
     private static final ObjectId zeroId = new ObjectId(0);
 
+    /**
+     * When a {@code withXxx} method wants the newly created plan node to reuse the
+     * same {@link ObjectId} as the original node, it calls
+     * {@link #copyWithSameId(AbstractPlan, Supplier)}.  That helper stores the id
+     * here before invoking the constructor, and the constructor reads and clears it.
+     * Using a ThreadLocal makes this thread-safe without any locking.
+     */
+    private static final ThreadLocal<ObjectId> INHERIT_ID = new ThreadLocal<>();
+
     public final int depth;
 
     protected final ObjectId id;
@@ -84,7 +93,14 @@ public abstract class AbstractPlan extends AbstractTreeNode<Plan> implements Pla
                     ? optLogicalProperties::get
                     : LazyCompute.of(this::computeLogicalProperties);
         this.statistics = statistics;
-        this.id = StatementScopeIdGenerator.newObjectId();
+        // Inherit id from the original node when called via copyWithSameId(), otherwise allocate a fresh id.
+        ObjectId inherited = INHERIT_ID.get();
+        if (inherited != null) {
+            this.id = inherited;
+            INHERIT_ID.remove();
+        } else {
+            this.id = StatementScopeIdGenerator.newObjectId();
+        }
         this.hasUnboundChild = buildHasUnboundChildCache();
 
         switch (children.size()) {
@@ -134,6 +150,33 @@ public abstract class AbstractPlan extends AbstractTreeNode<Plan> implements Pla
             default: {
                 this.depth = computeDepth();
             }
+        }
+    }
+
+    /**
+     * Create a new plan node using {@code factory} and assign it the same {@link ObjectId}
+     * as {@code source}.
+     *
+     * <p>Usage in {@code withXxx} methods:
+     * <pre>{@code
+     *   public LogicalProject<Plan> withChildren(List<Plan> children) {
+     *       return AbstractPlan.copyWithSameId(this, () ->
+     *               new LogicalProject<>(projects, isDistinct, children));
+     *   }
+     * }</pre>
+     *
+     * @param source  the original plan whose id should be inherited
+     * @param factory supplier that creates the new plan node (usually a constructor call)
+     * @param <T>     the concrete plan type
+     * @return the new plan node with the same id as {@code source}
+     */
+    public static <T extends AbstractPlan> T copyWithSameId(AbstractPlan source, Supplier<T> factory) {
+        INHERIT_ID.set(source.id);
+        try {
+            return factory.get();
+        } finally {
+            // Guard against constructor throwing before it could clear the ThreadLocal.
+            INHERIT_ID.remove();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
@@ -32,6 +32,7 @@ import org.apache.doris.nereids.trees.expressions.functions.agg.AggregatePhase;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Count;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Ndv;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Aggregate;
@@ -288,9 +289,10 @@ public class LogicalAggregate<CHILD_TYPE extends Plan>
     }
 
     public LogicalAggregate<Plan> withPartitionExpressions(Optional<List<Expression>> newPartitionExpressions) {
-        return new LogicalAggregate<>(groupByExpressions, outputExpressions, normalized, ordinalIsResolved, generated,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalAggregate<>(groupByExpressions, outputExpressions, normalized, ordinalIsResolved, generated,
                 hasPushed, withInProjection, sourceRepeat, Optional.empty(), Optional.empty(), newPartitionExpressions,
-                child());
+                child()));
     }
 
     public boolean isNormalized() {
@@ -330,69 +332,78 @@ public class LogicalAggregate<CHILD_TYPE extends Plan>
     @Override
     public LogicalAggregate<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalAggregate<>(groupByExpressions, outputExpressions, normalized, ordinalIsResolved, generated,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalAggregate<>(groupByExpressions, outputExpressions, normalized, ordinalIsResolved, generated,
                 hasPushed, withInProjection, sourceRepeat, Optional.empty(), Optional.empty(), partitionExpressions,
-                children.get(0));
+                children.get(0)));
     }
 
     @Override
     public LogicalAggregate<Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalAggregate<>(groupByExpressions, outputExpressions, normalized, ordinalIsResolved, generated,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalAggregate<>(groupByExpressions, outputExpressions, normalized, ordinalIsResolved, generated,
                 hasPushed, withInProjection, sourceRepeat, groupExpression, Optional.of(getLogicalProperties()),
-                partitionExpressions, children.get(0));
+                partitionExpressions, children.get(0)));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalAggregate<>(groupByExpressions, outputExpressions, normalized, ordinalIsResolved, generated,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalAggregate<>(groupByExpressions, outputExpressions, normalized, ordinalIsResolved, generated,
                 hasPushed, withInProjection, sourceRepeat, groupExpression, Optional.of(getLogicalProperties()),
-                partitionExpressions, children.get(0));
+                partitionExpressions, children.get(0)));
     }
 
     public LogicalAggregate<Plan> withGroupByAndOutput(List<Expression> groupByExprList,
             List<NamedExpression> outputExpressionList) {
-        return new LogicalAggregate<>(groupByExprList, outputExpressionList, normalized, ordinalIsResolved, generated,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalAggregate<>(groupByExprList, outputExpressionList, normalized, ordinalIsResolved, generated,
                 hasPushed, withInProjection, sourceRepeat, Optional.empty(), Optional.empty(), partitionExpressions,
-                child());
+                child()));
     }
 
     public LogicalAggregate<Plan> withGroupBy(List<Expression> groupByExprList) {
-        return new LogicalAggregate<>(groupByExprList, outputExpressions, normalized, ordinalIsResolved, generated,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalAggregate<>(groupByExprList, outputExpressions, normalized, ordinalIsResolved, generated,
                 hasPushed, withInProjection, sourceRepeat, Optional.empty(), Optional.empty(), partitionExpressions,
-                child());
+                child()));
     }
 
     public LogicalAggregate<Plan> withChildGroupByAndOutput(List<Expression> groupByExprList,
             List<NamedExpression> outputExpressionList, Plan newChild) {
-        return new LogicalAggregate<>(groupByExprList, outputExpressionList, normalized, ordinalIsResolved, generated,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalAggregate<>(groupByExprList, outputExpressionList, normalized, ordinalIsResolved, generated,
                 hasPushed, withInProjection, sourceRepeat, Optional.empty(), Optional.empty(), partitionExpressions,
-                newChild);
+                newChild));
     }
 
     public LogicalAggregate<Plan> withChildGroupByAndOutputAndPartitionExpr(List<Expression> groupByExprList,
             List<NamedExpression> outputExpressionList, Optional<List<Expression>> partitionExpressions,
             Plan newChild) {
-        return new LogicalAggregate<>(groupByExprList, outputExpressionList, normalized, ordinalIsResolved, generated,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalAggregate<>(groupByExprList, outputExpressionList, normalized, ordinalIsResolved, generated,
                 hasPushed, withInProjection, sourceRepeat, Optional.empty(), Optional.empty(),
-                partitionExpressions, newChild);
+                partitionExpressions, newChild));
     }
 
     public LogicalAggregate<Plan> withChildGroupByAndOutputAndSourceRepeatAndPartitionExpr(
             List<Expression> groupByExprList,
             List<NamedExpression> outputExpressionList, Optional<List<Expression>> partitionExpressions, Plan newChild,
             Optional<LogicalRepeat<? extends Plan>> sourceRepeat) {
-        return new LogicalAggregate<>(groupByExprList, outputExpressionList, normalized, ordinalIsResolved, generated,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalAggregate<>(groupByExprList, outputExpressionList, normalized, ordinalIsResolved, generated,
                 hasPushed, withInProjection, sourceRepeat, Optional.empty(), Optional.empty(),
-                partitionExpressions, newChild);
+                partitionExpressions, newChild));
     }
 
     public LogicalAggregate<Plan> withChildAndOutput(CHILD_TYPE child,
                                                        List<NamedExpression> outputExpressionList) {
-        return new LogicalAggregate<>(groupByExpressions, outputExpressionList, normalized, ordinalIsResolved,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalAggregate<>(groupByExpressions, outputExpressionList, normalized, ordinalIsResolved,
                 generated, hasPushed, withInProjection, sourceRepeat, Optional.empty(),
-                Optional.empty(), partitionExpressions, child);
+                Optional.empty(), partitionExpressions, child));
     }
 
     @Override
@@ -402,34 +413,39 @@ public class LogicalAggregate<CHILD_TYPE extends Plan>
 
     @Override
     public LogicalAggregate<CHILD_TYPE> withAggOutput(List<NamedExpression> newOutput) {
-        return new LogicalAggregate<>(groupByExpressions, newOutput, normalized, ordinalIsResolved, generated,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalAggregate<>(groupByExpressions, newOutput, normalized, ordinalIsResolved, generated,
                 hasPushed, withInProjection, sourceRepeat, Optional.empty(), Optional.empty(), partitionExpressions,
-                child());
+                child()));
     }
 
     public LogicalAggregate<Plan> withAggOutputChild(List<NamedExpression> newOutput, Plan newChild) {
-        return new LogicalAggregate<>(groupByExpressions, newOutput, normalized, ordinalIsResolved, generated,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalAggregate<>(groupByExpressions, newOutput, normalized, ordinalIsResolved, generated,
                 hasPushed, withInProjection, sourceRepeat, Optional.empty(), Optional.empty(), partitionExpressions,
-                newChild);
+                newChild));
     }
 
     public LogicalAggregate<Plan> withNormalized(List<Expression> normalizedGroupBy,
             List<NamedExpression> normalizedOutput, Plan normalizedChild) {
-        return new LogicalAggregate<>(normalizedGroupBy, normalizedOutput, true, ordinalIsResolved, generated,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalAggregate<>(normalizedGroupBy, normalizedOutput, true, ordinalIsResolved, generated,
                 hasPushed, withInProjection, sourceRepeat, Optional.empty(), Optional.empty(), partitionExpressions,
-                normalizedChild);
+                normalizedChild));
     }
 
     public LogicalAggregate<Plan> withInProjection(boolean withInProjection) {
-        return new LogicalAggregate<>(groupByExpressions, outputExpressions, normalized, ordinalIsResolved,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalAggregate<>(groupByExpressions, outputExpressions, normalized, ordinalIsResolved,
                 generated, hasPushed, withInProjection,
-                sourceRepeat, Optional.empty(), Optional.empty(), partitionExpressions, child());
+                sourceRepeat, Optional.empty(), Optional.empty(), partitionExpressions, child()));
     }
 
     public LogicalAggregate<Plan> withSourceRepeat(LogicalRepeat<?> sourceRepeat) {
-        return new LogicalAggregate<>(groupByExpressions, outputExpressions, normalized, ordinalIsResolved,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalAggregate<>(groupByExpressions, outputExpressions, normalized, ordinalIsResolved,
                 generated, hasPushed, withInProjection, Optional.ofNullable(sourceRepeat),
-                Optional.empty(), Optional.empty(), partitionExpressions, child());
+                Optional.empty(), Optional.empty(), partitionExpressions, child()));
     }
 
     private boolean isUniqueGroupByUnique(NamedExpression namedExpression) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalApply.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalApply.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.MarkJoinSlotReference;
 import org.apache.doris.nereids.trees.expressions.ScalarSubquery;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -286,25 +287,28 @@ public class LogicalApply<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends
     @Override
     public LogicalApply<Plan, Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new LogicalApply<>(correlationSlot, subqueryType, isNot, compareExpr, typeCoercionExpr,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalApply<>(correlationSlot, subqueryType, isNot, compareExpr, typeCoercionExpr,
                 correlationFilter, markJoinSlotReference, needAddSubOutputToProjects, isMarkJoinSlotNotNull,
-                children.get(0), children.get(1));
+                children.get(0), children.get(1)));
     }
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalApply<>(groupExpression, Optional.of(getLogicalProperties()),
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalApply<>(groupExpression, Optional.of(getLogicalProperties()),
                 correlationSlot, subqueryType, isNot, compareExpr, typeCoercionExpr, correlationFilter,
-                markJoinSlotReference, needAddSubOutputToProjects, isMarkJoinSlotNotNull, left(), right());
+                markJoinSlotReference, needAddSubOutputToProjects, isMarkJoinSlotNotNull, left(), right()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new LogicalApply<>(groupExpression, logicalProperties, correlationSlot, subqueryType, isNot,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalApply<>(groupExpression, logicalProperties, correlationSlot, subqueryType, isNot,
                 compareExpr, typeCoercionExpr, correlationFilter, markJoinSlotReference,
-                needAddSubOutputToProjects, isMarkJoinSlotNotNull, children.get(0), children.get(1));
+                needAddSubOutputToProjects, isMarkJoinSlotNotNull, children.get(0), children.get(1)));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAssertNumRows.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAssertNumRows.java
@@ -25,6 +25,7 @@ import org.apache.doris.nereids.trees.expressions.AssertNumRowsElement;
 import org.apache.doris.nereids.trees.expressions.AssertNumRowsElement.Assertion;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.DiffOutputInAsterisk;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -101,20 +102,23 @@ public class LogicalAssertNumRows<CHILD_TYPE extends Plan> extends LogicalUnary<
     @Override
     public LogicalUnary<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalAssertNumRows<>(assertNumRowsElement, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalAssertNumRows<>(assertNumRowsElement, children.get(0)));
     }
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalAssertNumRows<>(assertNumRowsElement,
-                groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalAssertNumRows<>(assertNumRowsElement,
+                groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalAssertNumRows<>(assertNumRowsElement, groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalAssertNumRows<>(assertNumRowsElement, groupExpression, logicalProperties, children.get(0)));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalBlackholeSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalBlackholeSink.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.plans.logical;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
@@ -55,7 +56,8 @@ public class LogicalBlackholeSink<CHILD_TYPE extends Plan> extends LogicalSink<C
     public LogicalBlackholeSink<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1,
                 "LogicalBlackholeSink's children size must be 1, but real is %s", children.size());
-        return new LogicalBlackholeSink<>(outputExprs, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalBlackholeSink<>(outputExprs, children.get(0)));
     }
 
     @Override
@@ -65,19 +67,22 @@ public class LogicalBlackholeSink<CHILD_TYPE extends Plan> extends LogicalSink<C
 
     @Override
     public LogicalBlackholeSink<Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalBlackholeSink<>(outputExprs, groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalBlackholeSink<>(outputExprs, groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public LogicalBlackholeSink<Plan> withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1, "LogicalBlackholeSink only accepts one child");
-        return new LogicalBlackholeSink<>(outputExprs, groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalBlackholeSink<>(outputExprs, groupExpression, logicalProperties, children.get(0)));
     }
 
     @Override
     public LogicalBlackholeSink<CHILD_TYPE> withOutputExprs(List<NamedExpression> outputExprs) {
-        return new LogicalBlackholeSink<>(outputExprs, child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalBlackholeSink<>(outputExprs, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCTE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCTE.java
@@ -21,6 +21,7 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
@@ -124,7 +125,8 @@ public class LogicalCTE<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TYPE
     @Override
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(aliasQueries.size() > 0);
-        return new LogicalCTE<>(isRecursive, aliasQueries, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalCTE<>(isRecursive, aliasQueries, children.get(0)));
     }
 
     @Override
@@ -139,14 +141,16 @@ public class LogicalCTE<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TYPE
 
     @Override
     public LogicalCTE<CHILD_TYPE> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalCTE<>(isRecursive, aliasQueries, groupExpression,
-                Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalCTE<>(isRecursive, aliasQueries, groupExpression,
+                Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(aliasQueries.size() > 0);
-        return new LogicalCTE<>(isRecursive, aliasQueries, groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalCTE<>(isRecursive, aliasQueries, groupExpression, logicalProperties, children.get(0)));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCTEAnchor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCTEAnchor.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.CTEId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
@@ -55,7 +56,8 @@ public class LogicalCTEAnchor<LEFT_CHILD_TYPE extends Plan,
 
     @Override
     public Plan withChildren(List<Plan> children) {
-        return new LogicalCTEAnchor<>(cteId, children.get(0), children.get(1));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalCTEAnchor<>(cteId, children.get(0), children.get(1)));
     }
 
     @Override
@@ -70,13 +72,15 @@ public class LogicalCTEAnchor<LEFT_CHILD_TYPE extends Plan,
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalCTEAnchor<>(cteId, groupExpression, Optional.of(getLogicalProperties()), left(), right());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalCTEAnchor<>(cteId, groupExpression, Optional.of(getLogicalProperties()), left(), right()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalCTEAnchor<>(cteId, groupExpression, logicalProperties, children.get(0), children.get(1));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalCTEAnchor<>(cteId, groupExpression, logicalProperties, children.get(0), children.get(1)));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCTEConsumer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCTEConsumer.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.BlockFuncDepsPropagation;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -129,23 +130,26 @@ public class LogicalCTEConsumer extends LogicalRelation implements BlockFuncDeps
 
     public Plan withTwoMaps(Map<Slot, Slot> consumerToProducerOutputMap,
             Multimap<Slot, Slot> producerToConsumerOutputMap) {
-        return new LogicalCTEConsumer(relationId, cteId, name,
-                consumerToProducerOutputMap, producerToConsumerOutputMap);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalCTEConsumer(relationId, cteId, name,
+                consumerToProducerOutputMap, producerToConsumerOutputMap));
     }
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalCTEConsumer(relationId, cteId, name,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalCTEConsumer(relationId, cteId, name,
                 consumerToProducerOutputMap, producerToConsumerOutputMap,
-                groupExpression, Optional.of(getLogicalProperties()));
+                groupExpression, Optional.of(getLogicalProperties())));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalCTEConsumer(relationId, cteId, name,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalCTEConsumer(relationId, cteId, name,
                 consumerToProducerOutputMap, producerToConsumerOutputMap,
-                groupExpression, logicalProperties);
+                groupExpression, logicalProperties));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCTEProducer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCTEProducer.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.CTEId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
@@ -61,7 +62,8 @@ public class LogicalCTEProducer<CHILD_TYPE extends Plan> extends LogicalUnary<CH
     @Override
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalCTEProducer<>(cteId, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalCTEProducer<>(cteId, children.get(0)));
     }
 
     @Override
@@ -76,13 +78,15 @@ public class LogicalCTEProducer<CHILD_TYPE extends Plan> extends LogicalUnary<CH
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalCTEProducer<>(cteId, groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalCTEProducer<>(cteId, groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalCTEProducer<>(cteId, groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalCTEProducer<>(cteId, groupExpression, logicalProperties, children.get(0)));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCheckPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCheckPolicy.java
@@ -38,6 +38,7 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
@@ -116,20 +117,23 @@ public class LogicalCheckPolicy<CHILD_TYPE extends Plan> extends LogicalUnary<CH
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalCheckPolicy<>(groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalCheckPolicy<>(groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalCheckPolicy<>(groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalCheckPolicy<>(groupExpression, logicalProperties, children.get(0)));
     }
 
     @Override
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalCheckPolicy<>(children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalCheckPolicy<>(children.get(0)));
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalDeferMaterializeOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalDeferMaterializeOlapScan.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.algebra.OlapScan;
@@ -113,16 +114,18 @@ public class LogicalDeferMaterializeOlapScan extends LogicalCatalogRelation impl
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalDeferMaterializeOlapScan(logicalOlapScan, deferMaterializeSlotIds, columnIdSlot,
-                groupExpression, Optional.of(getLogicalProperties()));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalDeferMaterializeOlapScan(logicalOlapScan, deferMaterializeSlotIds, columnIdSlot,
+                groupExpression, Optional.of(getLogicalProperties())));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.isEmpty(), "LogicalDeferMaterializeOlapScan should have no child");
-        return new LogicalDeferMaterializeOlapScan(logicalOlapScan, deferMaterializeSlotIds, columnIdSlot,
-                groupExpression, logicalProperties);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalDeferMaterializeOlapScan(logicalOlapScan, deferMaterializeSlotIds, columnIdSlot,
+                groupExpression, logicalProperties));
     }
 
     @Override
@@ -140,8 +143,9 @@ public class LogicalDeferMaterializeOlapScan extends LogicalCatalogRelation impl
     public LogicalDeferMaterializeOlapScan withTableAlias(String tableAlias) {
         // Update the wrapped LogicalOlapScan with the new alias
         LogicalOlapScan newOlapScan = logicalOlapScan.withTableAlias(tableAlias);
-        return new LogicalDeferMaterializeOlapScan(newOlapScan, deferMaterializeSlotIds, columnIdSlot,
-                Optional.empty(), Optional.of(getLogicalProperties()));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalDeferMaterializeOlapScan(newOlapScan, deferMaterializeSlotIds, columnIdSlot,
+                Optional.empty(), Optional.of(getLogicalProperties())));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalDeferMaterializeResultSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalDeferMaterializeResultSink.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
 import org.apache.doris.nereids.trees.plans.algebra.Sink;
@@ -78,15 +79,17 @@ public class LogicalDeferMaterializeResultSink<CHILD_TYPE extends Plan>
     public LogicalDeferMaterializeResultSink<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1,
                 "LogicalDeferMaterializeResultSink only accepts one child");
-        return new LogicalDeferMaterializeResultSink<>(
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalDeferMaterializeResultSink<>(
                 logicalResultSink.withChildren(ImmutableList.of(children.get(0))),
-                olapTable, selectedIndexId, Optional.empty(), Optional.empty(), children.get(0));
+                olapTable, selectedIndexId, Optional.empty(), Optional.empty(), children.get(0)));
     }
 
     @Override
     public LogicalDeferMaterializeResultSink<CHILD_TYPE> withOutputExprs(List<NamedExpression> outputExprs) {
-        return new LogicalDeferMaterializeResultSink<>(logicalResultSink, olapTable, selectedIndexId,
-                Optional.empty(), Optional.empty(), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalDeferMaterializeResultSink<>(logicalResultSink, olapTable, selectedIndexId,
+                Optional.empty(), Optional.empty(), child()));
     }
 
     @Override
@@ -101,8 +104,9 @@ public class LogicalDeferMaterializeResultSink<CHILD_TYPE extends Plan>
 
     @Override
     public LogicalDeferMaterializeResultSink<Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalDeferMaterializeResultSink<>(logicalResultSink, olapTable, selectedIndexId,
-                groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalDeferMaterializeResultSink<>(logicalResultSink, olapTable, selectedIndexId,
+                groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
@@ -112,9 +116,10 @@ public class LogicalDeferMaterializeResultSink<CHILD_TYPE extends Plan>
             List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1,
                 "LogicalDeferMaterializeResultSink only accepts one child");
-        return new LogicalDeferMaterializeResultSink<>(
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalDeferMaterializeResultSink<>(
                 logicalResultSink.withChildren(ImmutableList.of(children.get(0))),
-                olapTable, selectedIndexId, groupExpression, logicalProperties, children.get(0));
+                olapTable, selectedIndexId, groupExpression, logicalProperties, children.get(0)));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalDeferMaterializeTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalDeferMaterializeTopN.java
@@ -25,6 +25,7 @@ import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.BlockFuncDepsPropagation;
 import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.Plan;
@@ -122,8 +123,9 @@ public class LogicalDeferMaterializeTopN<CHILD_TYPE extends Plan> extends Logica
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalDeferMaterializeTopN<>(logicalTopN, deferMaterializeSlotIds, columnIdSlot,
-                groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalDeferMaterializeTopN<>(logicalTopN, deferMaterializeSlotIds, columnIdSlot,
+                groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
@@ -131,16 +133,18 @@ public class LogicalDeferMaterializeTopN<CHILD_TYPE extends Plan> extends Logica
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1,
                 "LogicalDeferMaterializeTopN should have 1 child, but input is %s", children.size());
-        return new LogicalDeferMaterializeTopN<>(logicalTopN.withChildren(ImmutableList.of(children.get(0))),
-                deferMaterializeSlotIds, columnIdSlot, groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalDeferMaterializeTopN<>(logicalTopN.withChildren(ImmutableList.of(children.get(0))),
+                deferMaterializeSlotIds, columnIdSlot, groupExpression, logicalProperties, children.get(0)));
     }
 
     @Override
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1,
                 "LogicalDeferMaterializeTopN should have 1 child, but input is %s", children.size());
-        return new LogicalDeferMaterializeTopN<>(logicalTopN.withChildren(ImmutableList.of(children.get(0))),
-                deferMaterializeSlotIds, columnIdSlot, Optional.empty(), Optional.empty(), children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalDeferMaterializeTopN<>(logicalTopN.withChildren(ImmutableList.of(children.get(0))),
+                deferMaterializeSlotIds, columnIdSlot, Optional.empty(), Optional.empty(), children.get(0)));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalDictionarySink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalDictionarySink.java
@@ -24,6 +24,7 @@ import org.apache.doris.dictionary.Dictionary;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
@@ -83,16 +84,18 @@ public class LogicalDictionarySink<CHILD_TYPE extends Plan> extends LogicalTable
     @Override
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1, "LogicalDictionarySink only accepts one child");
-        return new LogicalDictionarySink<>(database, dictionary, allowAdaptiveLoad, cols, outputExprs, Optional.empty(),
-                Optional.empty(), children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalDictionarySink<>(database, dictionary, allowAdaptiveLoad, cols, outputExprs,
+                        Optional.empty(), Optional.empty(), children.get(0)));
     }
 
     // This function will really set outputExprs in base class
     public Plan withChildAndUpdateOutput(Plan child) {
         List<NamedExpression> output = child.getOutput().stream().map(NamedExpression.class::cast)
                 .collect(ImmutableList.toImmutableList());
-        return new LogicalDictionarySink<>(database, dictionary, allowAdaptiveLoad, cols, output, Optional.empty(),
-                Optional.empty(), child);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalDictionarySink<>(database, dictionary, allowAdaptiveLoad, cols, output, Optional.empty(),
+                Optional.empty(), child));
     }
 
     @Override
@@ -102,15 +105,17 @@ public class LogicalDictionarySink<CHILD_TYPE extends Plan> extends LogicalTable
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalDictionarySink<>(database, dictionary, allowAdaptiveLoad, cols, outputExprs, groupExpression,
-                Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalDictionarySink<>(database, dictionary, allowAdaptiveLoad, cols, outputExprs, groupExpression,
+                Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalDictionarySink<>(database, dictionary, allowAdaptiveLoad, cols, outputExprs, groupExpression,
-                logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalDictionarySink<>(database, dictionary, allowAdaptiveLoad, cols, outputExprs, groupExpression,
+                logicalProperties, children.get(0)));
     }
 
     @Override
@@ -120,8 +125,9 @@ public class LogicalDictionarySink<CHILD_TYPE extends Plan> extends LogicalTable
 
     @Override
     public LogicalSink<CHILD_TYPE> withOutputExprs(List<NamedExpression> outputExprs) {
-        return new LogicalDictionarySink<>(database, dictionary, allowAdaptiveLoad, cols, outputExprs, Optional.empty(),
-                Optional.empty(), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalDictionarySink<>(database, dictionary, allowAdaptiveLoad, cols, outputExprs,
+                        Optional.empty(), Optional.empty(), child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEmptyRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEmptyRelation.java
@@ -21,6 +21,7 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.BlockFuncDepsPropagation;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -72,14 +73,16 @@ public class LogicalEmptyRelation extends LogicalRelation
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalEmptyRelation(relationId, projects,
-                groupExpression, Optional.of(logicalPropertiesSupplier.get()));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalEmptyRelation(relationId, projects,
+                groupExpression, Optional.of(logicalPropertiesSupplier.get())));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalEmptyRelation(relationId, projects, groupExpression, logicalProperties);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalEmptyRelation(relationId, projects, groupExpression, logicalProperties));
     }
 
     @Override
@@ -88,11 +91,13 @@ public class LogicalEmptyRelation extends LogicalRelation
     }
 
     public LogicalEmptyRelation withProjects(List<NamedExpression> projects) {
-        return new LogicalEmptyRelation(relationId, projects);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalEmptyRelation(relationId, projects));
     }
 
     public LogicalEmptyRelation withRelationIdAndProjects(RelationId relationId, List<NamedExpression> projects) {
-        return new LogicalEmptyRelation(relationId, projects);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalEmptyRelation(relationId, projects));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEsScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEsScan.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.TableIf;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.RelationId;
@@ -69,32 +70,37 @@ public class LogicalEsScan extends LogicalCatalogRelation {
 
     @Override
     public LogicalEsScan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalEsScan(relationId, table, qualifier, virtualColumns,
-                groupExpression, Optional.of(getLogicalProperties()), tableAlias);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalEsScan(relationId, table, qualifier, virtualColumns,
+                groupExpression, Optional.of(getLogicalProperties()), tableAlias));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalEsScan(relationId, table, qualifier, virtualColumns, groupExpression, logicalProperties,
-                tableAlias);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalEsScan(relationId, table, qualifier, virtualColumns, groupExpression, logicalProperties,
+                tableAlias));
     }
 
     @Override
     public LogicalEsScan withRelationId(RelationId relationId) {
-        return new LogicalEsScan(relationId, table, qualifier, virtualColumns, Optional.empty(), Optional.empty(),
-                tableAlias);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalEsScan(relationId, table, qualifier, virtualColumns, Optional.empty(), Optional.empty(),
+                tableAlias));
     }
 
     @Override
     public LogicalEsScan withVirtualColumns(List<NamedExpression> virtualColumns) {
-        return new LogicalEsScan(relationId, table, qualifier, virtualColumns, Optional.empty(), Optional.empty(),
-                tableAlias);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalEsScan(relationId, table, qualifier, virtualColumns, Optional.empty(), Optional.empty(),
+                tableAlias));
     }
 
     public LogicalEsScan withTableAlias(String tableAlias) {
-        return new LogicalEsScan(relationId, table, qualifier, virtualColumns, Optional.empty(),
-                Optional.of(getLogicalProperties()), tableAlias);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalEsScan(relationId, table, qualifier, virtualColumns, Optional.empty(),
+                Optional.of(getLogicalProperties()), tableAlias));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalExcept.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalExcept.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Except;
@@ -84,7 +85,8 @@ public class LogicalExcept extends LogicalSetOperation implements Except {
 
     @Override
     public LogicalExcept withChildren(List<Plan> children) {
-        return new LogicalExcept(qualifier, outputs, regularChildrenOutputs, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalExcept(qualifier, outputs, regularChildrenOutputs, children));
     }
 
     @Override
@@ -93,26 +95,30 @@ public class LogicalExcept extends LogicalSetOperation implements Except {
         Preconditions.checkArgument(children.size() == childrenOutputs.size(),
                 "children size %s is not equals with children outputs size %s",
                 children.size(), childrenOutputs.size());
-        return new LogicalExcept(qualifier, outputs, childrenOutputs, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalExcept(qualifier, outputs, childrenOutputs, children));
     }
 
     @Override
     public LogicalExcept withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalExcept(qualifier, outputs, regularChildrenOutputs, groupExpression,
-                Optional.of(getLogicalProperties()), children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalExcept(qualifier, outputs, regularChildrenOutputs, groupExpression,
+                Optional.of(getLogicalProperties()), children));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalExcept(qualifier, outputs, regularChildrenOutputs,
-                groupExpression, logicalProperties, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalExcept(qualifier, outputs, regularChildrenOutputs,
+                groupExpression, logicalProperties, children));
     }
 
     @Override
     public LogicalExcept withNewOutputs(List<NamedExpression> newOutputs) {
-        return new LogicalExcept(qualifier, newOutputs, regularChildrenOutputs,
-                Optional.empty(), Optional.empty(), children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalExcept(qualifier, newOutputs, regularChildrenOutputs,
+                Optional.empty(), Optional.empty(), children));
     }
 
     private Map<Slot, Slot> constructReplaceMapForChild(int index) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFileScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFileScan.java
@@ -29,6 +29,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.TableSample;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.RelationId;
@@ -136,39 +137,44 @@ public class LogicalFileScan extends LogicalCatalogRelation implements SupportPr
 
     @Override
     public LogicalFileScan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalFileScan(relationId, (ExternalTable) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalFileScan(relationId, (ExternalTable) table, qualifier,
                 selectedPartitions, operativeSlots, virtualColumns, tableSample, tableSnapshot,
                 scanParams, groupExpression, Optional.of(getLogicalProperties()), tableAlias,
-                cachedOutputs);
+                cachedOutputs));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalFileScan(relationId, (ExternalTable) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalFileScan(relationId, (ExternalTable) table, qualifier,
                 selectedPartitions, operativeSlots, virtualColumns, tableSample, tableSnapshot,
-                scanParams, groupExpression, logicalProperties, tableAlias, cachedOutputs);
+                scanParams, groupExpression, logicalProperties, tableAlias, cachedOutputs));
     }
 
     public LogicalFileScan withSelectedPartitions(SelectedPartitions selectedPartitions) {
-        return new LogicalFileScan(relationId, (ExternalTable) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalFileScan(relationId, (ExternalTable) table, qualifier,
                 selectedPartitions, operativeSlots, virtualColumns, tableSample, tableSnapshot,
                 scanParams, Optional.empty(), Optional.of(getLogicalProperties()), tableAlias,
-                cachedOutputs);
+                cachedOutputs));
     }
 
     @Override
     public LogicalFileScan withRelationId(RelationId relationId) {
-        return new LogicalFileScan(relationId, (ExternalTable) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalFileScan(relationId, (ExternalTable) table, qualifier,
                 selectedPartitions, operativeSlots, virtualColumns, tableSample, tableSnapshot,
-                scanParams, Optional.empty(), Optional.empty(), tableAlias, cachedOutputs);
+                scanParams, Optional.empty(), Optional.empty(), tableAlias, cachedOutputs));
     }
 
     public LogicalFileScan withTableAlias(String tableAlias) {
-        return new LogicalFileScan(relationId, (ExternalTable) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalFileScan(relationId, (ExternalTable) table, qualifier,
                 selectedPartitions, operativeSlots, virtualColumns, tableSample, tableSnapshot,
                 scanParams, Optional.empty(), Optional.of(getLogicalProperties()), tableAlias,
-                cachedOutputs);
+                cachedOutputs));
     }
 
     @Override
@@ -279,15 +285,17 @@ public class LogicalFileScan extends LogicalCatalogRelation implements SupportPr
 
     @Override
     public LogicalFileScan withOperativeSlots(Collection<Slot> operativeSlots) {
-        return new LogicalFileScan(relationId, (ExternalTable) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalFileScan(relationId, (ExternalTable) table, qualifier,
                 selectedPartitions, operativeSlots, virtualColumns, tableSample, tableSnapshot,
-                scanParams, groupExpression, Optional.of(getLogicalProperties()), tableAlias, cachedOutputs);
+                scanParams, groupExpression, Optional.of(getLogicalProperties()), tableAlias, cachedOutputs));
     }
 
     public LogicalFileScan withCachedOutput(List<Slot> cachedOutputs) {
-        return new LogicalFileScan(relationId, (ExternalTable) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalFileScan(relationId, (ExternalTable) table, qualifier,
                 selectedPartitions, operativeSlots, virtualColumns, tableSample, tableSnapshot,
-                scanParams, groupExpression, Optional.empty(), tableAlias, Optional.of(cachedOutputs));
+                scanParams, groupExpression, Optional.empty(), tableAlias, Optional.of(cachedOutputs)));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFileSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFileSink.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.plans.logical;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
@@ -61,13 +62,15 @@ public class LogicalFileSink<CHILD_TYPE extends Plan> extends LogicalSink<CHILD_
     }
 
     public LogicalFileSink<CHILD_TYPE> withOutputExprs(List<NamedExpression> outputExprs) {
-        return new LogicalFileSink<>(filePath, format, properties, outputExprs, child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalFileSink<>(filePath, format, properties, outputExprs, child()));
     }
 
     @Override
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalFileSink<>(filePath, format, properties, outputExprs, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalFileSink<>(filePath, format, properties, outputExprs, children.get(0)));
     }
 
     @Override
@@ -98,16 +101,18 @@ public class LogicalFileSink<CHILD_TYPE extends Plan> extends LogicalSink<CHILD_
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalFileSink<>(filePath, format, properties, outputExprs,
-                groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalFileSink<>(filePath, format, properties, outputExprs,
+                groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalFileSink<>(filePath, format, properties, outputExprs,
-                groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalFileSink<>(filePath, format, properties, outputExprs,
+                groupExpression, logicalProperties, children.get(0)));
     }
 
     public String getFilePath() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFilter.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SubqueryExpr;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.DiffOutputInAsterisk;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -161,35 +162,42 @@ public class LogicalFilter<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
     }
 
     public LogicalFilter<Plan> withConjuncts(Set<Expression> conjuncts) {
-        return new LogicalFilter<>(conjuncts, null, Optional.empty(), Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalFilter<>(conjuncts, null, Optional.empty(), Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public LogicalFilter<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalFilter<>(conjuncts, predicate, Optional.empty(), Optional.empty(), children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalFilter<>(conjuncts, predicate, Optional.empty(), Optional.empty(), children.get(0)));
     }
 
     @Override
     public LogicalFilter<Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalFilter<>(conjuncts, predicate, groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalFilter<>(conjuncts, predicate, groupExpression,
+                        Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalFilter<>(conjuncts, predicate, groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalFilter<>(conjuncts, predicate, groupExpression, logicalProperties, children.get(0)));
     }
 
     public LogicalFilter<Plan> withConjunctsAndChild(Set<Expression> conjuncts, Plan child) {
-        return new LogicalFilter<>(conjuncts, child);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalFilter<>(conjuncts, child));
     }
 
     public LogicalFilter<Plan> withConjunctsAndProps(Set<Expression> conjuncts,
             Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, Plan child) {
-        return new LogicalFilter<>(conjuncts, null, groupExpression, logicalProperties, child);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalFilter<>(conjuncts, null, groupExpression, logicalProperties, child));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalGenerate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalGenerate.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.functions.Function;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.DiffOutputInAsterisk;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -103,7 +104,8 @@ public class LogicalGenerate<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD
     @Override
     public LogicalGenerate<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalGenerate<>(generators, generatorOutput, expandColumnAlias, conjuncts, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalGenerate<>(generators, generatorOutput, expandColumnAlias, conjuncts, children.get(0)));
     }
 
     @Override
@@ -136,21 +138,24 @@ public class LogicalGenerate<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD
         for (int i = 0; i < generators.size(); i++) {
             newGeneratorOutput.add(generatorOutput.get(i).withNullable(generators.get(i).nullable()));
         }
-        return new LogicalGenerate<>(generators, newGeneratorOutput, expandColumnAlias, conjuncts, child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalGenerate<>(generators, newGeneratorOutput, expandColumnAlias, conjuncts, child()));
     }
 
     @Override
     public LogicalGenerate<Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalGenerate<>(generators, generatorOutput, expandColumnAlias, conjuncts,
-                groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalGenerate<>(generators, generatorOutput, expandColumnAlias, conjuncts,
+                groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalGenerate<>(generators, generatorOutput, expandColumnAlias, conjuncts,
-                groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalGenerate<>(generators, generatorOutput, expandColumnAlias, conjuncts,
+                groupExpression, logicalProperties, children.get(0)));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHaving.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHaving.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.DataTrait.Builder;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Filter;
@@ -72,7 +73,8 @@ public class LogicalHaving<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
     @Override
     public LogicalHaving<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalHaving<>(conjuncts, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalHaving<>(conjuncts, children.get(0)));
     }
 
     @Override
@@ -82,23 +84,27 @@ public class LogicalHaving<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalHaving<>(conjuncts, groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalHaving<>(conjuncts, groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalHaving<>(conjuncts, groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalHaving<>(conjuncts, groupExpression, logicalProperties, children.get(0)));
     }
 
     public LogicalHaving<Plan> withConjuncts(Set<Expression> conjuncts) {
-        return new LogicalHaving<>(conjuncts, Optional.empty(),
-                Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalHaving<>(conjuncts, Optional.empty(),
+                Optional.of(getLogicalProperties()), child()));
     }
 
     public LogicalHaving<Plan> withConjunctsAndChild(Set<Expression> conjuncts, Plan child) {
-        return new LogicalHaving<>(conjuncts, child);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalHaving<>(conjuncts, child));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHiveTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHiveTableSink.java
@@ -23,6 +23,7 @@ import org.apache.doris.datasource.hive.HMSExternalTable;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
@@ -65,24 +66,28 @@ public class LogicalHiveTableSink<CHILD_TYPE extends Plan> extends LogicalTableS
         this.dmlCommandType = dmlCommandType;
     }
 
+    /** Update output expressions based on child output and replace child. */
     public Plan withChildAndUpdateOutput(Plan child) {
         List<NamedExpression> output = child.getOutput().stream()
                 .map(NamedExpression.class::cast)
                 .collect(ImmutableList.toImmutableList());
-        return new LogicalHiveTableSink<>(database, targetTable, cols, output,
-                dmlCommandType, Optional.empty(), Optional.empty(), child);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalHiveTableSink<>(database, targetTable, cols, output,
+                dmlCommandType, Optional.empty(), Optional.empty(), child));
     }
 
     @Override
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1, "LogicalHiveTableSink only accepts one child");
-        return new LogicalHiveTableSink<>(database, targetTable, cols, outputExprs,
-                dmlCommandType, Optional.empty(), Optional.empty(), children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalHiveTableSink<>(database, targetTable, cols, outputExprs,
+                dmlCommandType, Optional.empty(), Optional.empty(), children.get(0)));
     }
 
     public LogicalHiveTableSink<CHILD_TYPE> withOutputExprs(List<NamedExpression> outputExprs) {
-        return new LogicalHiveTableSink<>(database, targetTable, cols, outputExprs,
-                dmlCommandType, Optional.empty(), Optional.empty(), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalHiveTableSink<>(database, targetTable, cols, outputExprs,
+                dmlCommandType, Optional.empty(), Optional.empty(), child()));
     }
 
     public HMSExternalDatabase getDatabase() {
@@ -137,14 +142,16 @@ public class LogicalHiveTableSink<CHILD_TYPE extends Plan> extends LogicalTableS
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalHiveTableSink<>(database, targetTable, cols, outputExprs,
-                dmlCommandType, groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalHiveTableSink<>(database, targetTable, cols, outputExprs,
+                dmlCommandType, groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalHiveTableSink<>(database, targetTable, cols, outputExprs,
-                dmlCommandType, groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalHiveTableSink<>(database, targetTable, cols, outputExprs,
+                dmlCommandType, groupExpression, logicalProperties, children.get(0)));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHudiScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalHudiScan.java
@@ -38,6 +38,7 @@ import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -157,34 +158,38 @@ public class LogicalHudiScan extends LogicalFileScan {
 
     @Override
     public LogicalHudiScan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
                 selectedPartitions, tableSample, tableSnapshot, scanParams, incrementalRelation,
                 operativeSlots, virtualColumns, groupExpression, Optional.of(getLogicalProperties()),
-                tableAlias, cachedOutputs);
+                tableAlias, cachedOutputs));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
             selectedPartitions, tableSample, tableSnapshot, scanParams, incrementalRelation,
                 operativeSlots, virtualColumns, groupExpression, logicalProperties,
-                tableAlias, cachedOutputs);
+                tableAlias, cachedOutputs));
     }
 
     public LogicalHudiScan withSelectedPartitions(SelectedPartitions selectedPartitions) {
-        return new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
             selectedPartitions, tableSample, tableSnapshot, scanParams, incrementalRelation,
                 operativeSlots, virtualColumns, groupExpression, Optional.of(getLogicalProperties()),
-                tableAlias, cachedOutputs);
+                tableAlias, cachedOutputs));
     }
 
     @Override
     public LogicalHudiScan withRelationId(RelationId relationId) {
-        return new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
             selectedPartitions, tableSample, tableSnapshot, scanParams, incrementalRelation,
                 operativeSlots, virtualColumns, groupExpression, Optional.empty(),
-                tableAlias, cachedOutputs);
+                tableAlias, cachedOutputs));
     }
 
     @Override
@@ -194,26 +199,29 @@ public class LogicalHudiScan extends LogicalFileScan {
 
     @Override
     public LogicalHudiScan withOperativeSlots(Collection<Slot> operativeSlots) {
-        return new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
                 selectedPartitions, tableSample, tableSnapshot, scanParams, incrementalRelation,
                 operativeSlots, virtualColumns, groupExpression, Optional.of(getLogicalProperties()),
-                tableAlias, cachedOutputs);
+                tableAlias, cachedOutputs));
     }
 
     @Override
     public LogicalHudiScan withTableAlias(String tableAlias) {
-        return new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
                 selectedPartitions, tableSample, tableSnapshot, scanParams, incrementalRelation,
                 operativeSlots, virtualColumns, Optional.empty(), Optional.of(getLogicalProperties()),
-                tableAlias, cachedOutputs);
+                tableAlias, cachedOutputs));
     }
 
     @Override
     public LogicalHudiScan withCachedOutput(List<Slot> cachedOutputs) {
-        return new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
             selectedPartitions, tableSample, tableSnapshot, scanParams, incrementalRelation,
                 operativeSlots, virtualColumns, groupExpression, Optional.empty(),
-                tableAlias, Optional.of(cachedOutputs));
+                tableAlias, Optional.of(cachedOutputs)));
     }
 
     /**
@@ -264,9 +272,11 @@ public class LogicalHudiScan extends LogicalFileScan {
                     "Failed to create incremental relation for table: " + table.getFullQualifiers(), e);
             }
         }
-        return new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
-            selectedPartitions, tableSample, tableSnapshot, scanParams, newIncrementalRelation,
+        Optional<IncrementalRelation> finalIncrementalRelation = newIncrementalRelation;
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalHudiScan(relationId, (ExternalTable) table, qualifier,
+            selectedPartitions, tableSample, tableSnapshot, scanParams, finalIncrementalRelation,
                 operativeSlots, virtualColumns, groupExpression, Optional.of(getLogicalProperties()),
-                tableAlias, cachedOutputs);
+                tableAlias, cachedOutputs));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalIcebergTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalIcebergTableSink.java
@@ -23,6 +23,7 @@ import org.apache.doris.datasource.iceberg.IcebergExternalTable;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
@@ -65,24 +66,28 @@ public class LogicalIcebergTableSink<CHILD_TYPE extends Plan> extends LogicalTab
         this.dmlCommandType = dmlCommandType;
     }
 
+    /** Update output expressions based on child output and replace child. */
     public Plan withChildAndUpdateOutput(Plan child) {
         List<NamedExpression> output = child.getOutput().stream()
                 .map(NamedExpression.class::cast)
                 .collect(ImmutableList.toImmutableList());
-        return new LogicalIcebergTableSink<>(database, targetTable, cols, output,
-                dmlCommandType, Optional.empty(), Optional.empty(), child);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalIcebergTableSink<>(database, targetTable, cols, output,
+                dmlCommandType, Optional.empty(), Optional.empty(), child));
     }
 
     @Override
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1, "LogicalIcebergTableSink only accepts one child");
-        return new LogicalIcebergTableSink<>(database, targetTable, cols, outputExprs,
-                dmlCommandType, Optional.empty(), Optional.empty(), children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalIcebergTableSink<>(database, targetTable, cols, outputExprs,
+                dmlCommandType, Optional.empty(), Optional.empty(), children.get(0)));
     }
 
     public LogicalIcebergTableSink<CHILD_TYPE> withOutputExprs(List<NamedExpression> outputExprs) {
-        return new LogicalIcebergTableSink<>(database, targetTable, cols, outputExprs,
-                dmlCommandType, Optional.empty(), Optional.empty(), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalIcebergTableSink<>(database, targetTable, cols, outputExprs,
+                dmlCommandType, Optional.empty(), Optional.empty(), child()));
     }
 
     public IcebergExternalDatabase getDatabase() {
@@ -137,14 +142,16 @@ public class LogicalIcebergTableSink<CHILD_TYPE extends Plan> extends LogicalTab
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalIcebergTableSink<>(database, targetTable, cols, outputExprs,
-                dmlCommandType, groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalIcebergTableSink<>(database, targetTable, cols, outputExprs,
+                dmlCommandType, groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalIcebergTableSink<>(database, targetTable, cols, outputExprs,
-                dmlCommandType, groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalIcebergTableSink<>(database, targetTable, cols, outputExprs,
+                dmlCommandType, groupExpression, logicalProperties, children.get(0)));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalInlineTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalInlineTable.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.BlockFuncDepsPropagation;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -84,9 +85,10 @@ public class LogicalInlineTable extends LogicalLeaf implements InlineTable, Bloc
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalInlineTable(
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalInlineTable(
                 constantExprsList, groupExpression, Optional.of(getLogicalProperties())
-        );
+        ));
     }
 
     @Override
@@ -95,7 +97,8 @@ public class LogicalInlineTable extends LogicalLeaf implements InlineTable, Bloc
         if (!children.isEmpty()) {
             throw new AnalysisException("children should not be empty");
         }
-        return new LogicalInlineTable(constantExprsList, groupExpression, logicalProperties);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalInlineTable(constantExprsList, groupExpression, logicalProperties));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalIntersect.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalIntersect.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Intersect;
@@ -84,7 +85,8 @@ public class LogicalIntersect extends LogicalSetOperation implements Intersect {
 
     @Override
     public LogicalIntersect withChildren(List<Plan> children) {
-        return new LogicalIntersect(qualifier, outputs, regularChildrenOutputs, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalIntersect(qualifier, outputs, regularChildrenOutputs, children));
     }
 
     @Override
@@ -93,26 +95,30 @@ public class LogicalIntersect extends LogicalSetOperation implements Intersect {
         Preconditions.checkArgument(children.size() == childrenOutputs.size(),
                 "children size %s is not equals with children outputs size %s",
                 children.size(), childrenOutputs.size());
-        return new LogicalIntersect(qualifier, outputs, childrenOutputs, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalIntersect(qualifier, outputs, childrenOutputs, children));
     }
 
     @Override
     public LogicalIntersect withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalIntersect(qualifier, outputs, regularChildrenOutputs, groupExpression,
-                Optional.of(getLogicalProperties()), children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalIntersect(qualifier, outputs, regularChildrenOutputs, groupExpression,
+                Optional.of(getLogicalProperties()), children));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalIntersect(qualifier, outputs, regularChildrenOutputs,
-                groupExpression, logicalProperties, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalIntersect(qualifier, outputs, regularChildrenOutputs,
+                groupExpression, logicalProperties, children));
     }
 
     @Override
     public LogicalIntersect withNewOutputs(List<NamedExpression> newOutputs) {
-        return new LogicalIntersect(qualifier, newOutputs, regularChildrenOutputs,
-                Optional.empty(), Optional.empty(), children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalIntersect(qualifier, newOutputs, regularChildrenOutputs,
+                Optional.empty(), Optional.empty(), children));
     }
 
     Map<Slot, Slot> constructReplaceMap() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJdbcScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJdbcScan.java
@@ -23,6 +23,7 @@ import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.RelationId;
@@ -76,26 +77,30 @@ public class LogicalJdbcScan extends LogicalCatalogRelation {
 
     @Override
     public LogicalJdbcScan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalJdbcScan(relationId, table, qualifier, virtualColumns,
-                groupExpression, Optional.of(getLogicalProperties()), tableAlias);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJdbcScan(relationId, table, qualifier, virtualColumns,
+                groupExpression, Optional.of(getLogicalProperties()), tableAlias));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalJdbcScan(relationId, table, qualifier, virtualColumns,
-                groupExpression, logicalProperties, tableAlias);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJdbcScan(relationId, table, qualifier, virtualColumns,
+                groupExpression, logicalProperties, tableAlias));
     }
 
     @Override
     public LogicalJdbcScan withRelationId(RelationId relationId) {
-        return new LogicalJdbcScan(relationId, table, qualifier, virtualColumns,
-                Optional.empty(), Optional.empty(), tableAlias);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJdbcScan(relationId, table, qualifier, virtualColumns,
+                Optional.empty(), Optional.empty(), tableAlias));
     }
 
     public LogicalJdbcScan withTableAlias(String tableAlias) {
-        return new LogicalJdbcScan(relationId, table, qualifier, virtualColumns, Optional.empty(),
-                Optional.of(getLogicalProperties()), tableAlias);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJdbcScan(relationId, table, qualifier, virtualColumns, Optional.empty(),
+                Optional.of(getLogicalProperties()), tableAlias));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJdbcTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJdbcTableSink.java
@@ -23,6 +23,7 @@ import org.apache.doris.datasource.jdbc.JdbcExternalTable;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
@@ -65,25 +66,29 @@ public class LogicalJdbcTableSink<CHILD_TYPE extends Plan> extends LogicalTableS
         this.dmlCommandType = dmlCommandType;
     }
 
+    /** Update output expressions based on child output and replace child. */
     public Plan withChildAndUpdateOutput(Plan child) {
         List<NamedExpression> output = child.getOutput().stream()
                 .map(NamedExpression.class::cast)
                 .collect(ImmutableList.toImmutableList());
-        return new LogicalJdbcTableSink<>(database, targetTable, cols, output,
-                dmlCommandType, Optional.empty(), Optional.empty(), child);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJdbcTableSink<>(database, targetTable, cols, output,
+                dmlCommandType, Optional.empty(), Optional.empty(), child));
     }
 
     @Override
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1, "LogicalJdbcTableSink only accepts one child");
-        return new LogicalJdbcTableSink<>(database, targetTable, cols, outputExprs,
-                dmlCommandType, Optional.empty(), Optional.empty(), children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJdbcTableSink<>(database, targetTable, cols, outputExprs,
+                dmlCommandType, Optional.empty(), Optional.empty(), children.get(0)));
     }
 
     @Override
     public LogicalSink<CHILD_TYPE> withOutputExprs(List<NamedExpression> outputExprs) {
-        return new LogicalJdbcTableSink<>(database, targetTable, cols, outputExprs,
-                dmlCommandType, Optional.empty(), Optional.empty(), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJdbcTableSink<>(database, targetTable, cols, outputExprs,
+                dmlCommandType, Optional.empty(), Optional.empty(), child()));
     }
 
     public JdbcExternalDatabase getDatabase() {
@@ -138,14 +143,16 @@ public class LogicalJdbcTableSink<CHILD_TYPE extends Plan> extends LogicalTableS
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalJdbcTableSink<>(database, targetTable, cols, outputExprs,
-                dmlCommandType, groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJdbcTableSink<>(database, targetTable, cols, outputExprs,
+                dmlCommandType, groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalJdbcTableSink<>(database, targetTable, cols, outputExprs,
-                dmlCommandType, groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJdbcTableSink<>(database, targetTable, cols, outputExprs,
+                dmlCommandType, groupExpression, logicalProperties, children.get(0)));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
@@ -31,6 +31,7 @@ import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.MarkJoinSlotReference;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.DiffOutputInAsterisk;
 import org.apache.doris.nereids.trees.plans.DistributeType;
 import org.apache.doris.nereids.trees.plans.JoinType;
@@ -423,32 +424,36 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
     @Override
     public LogicalJoin<Plan, Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
                 hint, markJoinSlotReference, exceptAsteriskOutputs,
-                Optional.empty(), Optional.empty(), children, joinReorderContext);
+                Optional.empty(), Optional.empty(), children, joinReorderContext));
     }
 
     @Override
     public LogicalJoin<Plan, Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
                 hint, markJoinSlotReference, exceptAsteriskOutputs,
-                groupExpression, Optional.of(getLogicalProperties()), children, joinReorderContext);
+                groupExpression, Optional.of(getLogicalProperties()), children, joinReorderContext));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
                 hint, markJoinSlotReference, exceptAsteriskOutputs,
-                groupExpression, logicalProperties, children, joinReorderContext);
+                groupExpression, logicalProperties, children, joinReorderContext));
     }
 
     public LogicalJoin<Plan, Plan> withChildrenNoContext(Plan left, Plan right,
                                                          JoinReorderContext otherJoinReorderContext) {
-        return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
                 hint, markJoinSlotReference, exceptAsteriskOutputs,
-                Optional.empty(), Optional.empty(), ImmutableList.of(left, right), otherJoinReorderContext);
+                Optional.empty(), Optional.empty(), ImmutableList.of(left, right), otherJoinReorderContext));
     }
 
     /**
@@ -456,17 +461,19 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
      */
     public LogicalJoin<Plan, Plan> withJoinConjuncts(List<Expression> hashJoinConjuncts,
             List<Expression> otherJoinConjuncts, JoinReorderContext otherJoinReorderContext) {
-        return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
                 hint, markJoinSlotReference, exceptAsteriskOutputs,
-                Optional.empty(), Optional.empty(), children, otherJoinReorderContext);
+                Optional.empty(), Optional.empty(), children, otherJoinReorderContext));
     }
 
     public LogicalJoin<Plan, Plan> withJoinConjuncts(List<Expression> hashJoinConjuncts,
             List<Expression> otherJoinConjuncts, List<Expression> markJoinConjuncts,
             JoinReorderContext otherJoinReorderContext) {
-        return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
                 hint, markJoinSlotReference, exceptAsteriskOutputs,
-                Optional.empty(), Optional.of(getLogicalProperties()), children, otherJoinReorderContext);
+                Optional.empty(), Optional.of(getLogicalProperties()), children, otherJoinReorderContext));
     }
 
     /**
@@ -485,65 +492,74 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
             List<Expression> hashJoinConjuncts, List<Expression> markJoinConjuncts,
             Plan left, Plan right, JoinReorderContext otherJoinReorderContext) {
         Preconditions.checkArgument(children.size() == 2);
-        return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
                 hint, markJoinSlotReference, exceptAsteriskOutputs,
-                Optional.empty(), Optional.empty(), ImmutableList.of(left, right), otherJoinReorderContext);
+                Optional.empty(), Optional.empty(), ImmutableList.of(left, right), otherJoinReorderContext));
     }
 
     public LogicalJoin<Plan, Plan> withHashJoinConjuncts(List<Expression> hashJoinConjuncts) {
-        return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
                 hint, markJoinSlotReference, exceptAsteriskOutputs,
                 Optional.empty(), Optional.empty(),
-                ImmutableList.of(left(), right()), joinReorderContext);
+                ImmutableList.of(left(), right()), joinReorderContext));
     }
 
     public LogicalJoin<Plan, Plan> withConjunctsChildren(List<Expression> hashJoinConjuncts,
             List<Expression> otherJoinConjuncts, Plan left, Plan right, JoinReorderContext otherJoinReorderContext) {
-        return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
                 hint, markJoinSlotReference, exceptAsteriskOutputs,
-                Optional.empty(), Optional.empty(), ImmutableList.of(left, right), otherJoinReorderContext);
+                Optional.empty(), Optional.empty(), ImmutableList.of(left, right), otherJoinReorderContext));
     }
 
     public LogicalJoin<Plan, Plan> withConjunctsChildren(List<Expression> hashJoinConjuncts,
             List<Expression> otherJoinConjuncts, List<Expression> markJoinConjuncts, Plan left, Plan right,
             JoinReorderContext otherJoinReorderContext) {
-        return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
                 hint, markJoinSlotReference, exceptAsteriskOutputs,
-                Optional.empty(), Optional.empty(), ImmutableList.of(left, right), otherJoinReorderContext);
+                Optional.empty(), Optional.empty(), ImmutableList.of(left, right), otherJoinReorderContext));
     }
 
     public LogicalJoin<Plan, Plan> withJoinType(JoinType joinType) {
-        return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
                 hint, markJoinSlotReference, exceptAsteriskOutputs,
-                groupExpression, Optional.empty(), children, joinReorderContext);
+                groupExpression, Optional.empty(), children, joinReorderContext));
     }
 
     public LogicalJoin<Plan, Plan> withJoinTypeAndContext(JoinType joinType,
             JoinReorderContext otherJoinReorderContext) {
-        return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
                 hint, markJoinSlotReference, exceptAsteriskOutputs,
-                Optional.empty(), Optional.empty(), children, otherJoinReorderContext);
+                Optional.empty(), Optional.empty(), children, otherJoinReorderContext));
     }
 
     public LogicalJoin<Plan, Plan> withTypeChildren(JoinType joinType, Plan left, Plan right,
             JoinReorderContext otherJoinReorderContext) {
-        return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
                 hint, markJoinSlotReference, exceptAsteriskOutputs,
-                Optional.empty(), Optional.empty(), ImmutableList.of(left, right), otherJoinReorderContext);
+                Optional.empty(), Optional.empty(), ImmutableList.of(left, right), otherJoinReorderContext));
     }
 
     public LogicalJoin<Plan, Plan> withTypeChildrenAndOtherConjuncts(JoinType joinType, Plan left, Plan right,
             List<Expression> otherJoinConjuncts,
             JoinReorderContext otherJoinReorderContext) {
-        return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
                 hint, markJoinSlotReference, exceptAsteriskOutputs,
-                Optional.empty(), Optional.empty(), ImmutableList.of(left, right), otherJoinReorderContext);
+                Optional.empty(), Optional.empty(), ImmutableList.of(left, right), otherJoinReorderContext));
     }
 
     public LogicalJoin<Plan, Plan> withDistributeHintChildren(DistributeHint hint, Plan left, Plan right) {
-        return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts,
                 hint, markJoinSlotReference, exceptAsteriskOutputs,
-                Optional.empty(), Optional.empty(), ImmutableList.of(left, right), joinReorderContext);
+                Optional.empty(), Optional.empty(), ImmutableList.of(left, right), joinReorderContext));
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalLimit.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalLimit.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.LimitPhase;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -133,25 +134,30 @@ public class LogicalLimit<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TY
     public LogicalLimit<Plan> withLimitChild(long limit, long offset, Plan child) {
         Preconditions.checkArgument(children.size() == 1,
                 "LogicalTopN should have 1 child, but input is %s", children.size());
-        return new LogicalLimit<>(limit, offset, phase, child);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalLimit<>(limit, offset, phase, child));
     }
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalLimit<>(limit, offset, phase, groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalLimit<>(limit, offset, phase, groupExpression,
+                        Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalLimit<>(limit, offset, phase, groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalLimit<>(limit, offset, phase, groupExpression, logicalProperties, children.get(0)));
     }
 
     @Override
     public LogicalLimit<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalLimit<>(limit, offset, phase, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalLimit<>(limit, offset, phase, children.get(0)));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalLoadProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalLoadProject.java
@@ -30,6 +30,7 @@ import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.functions.NoneMovableFunction;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Uuid;
 import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Project;
@@ -154,33 +155,39 @@ public class LogicalLoadProject<CHILD_TYPE extends Plan> extends LogicalUnary<CH
     @Override
     public LogicalLoadProject<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalLoadProject<>(projects, isDistinct, Utils.fastToImmutableList(children));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalLoadProject<>(projects, isDistinct, Utils.fastToImmutableList(children)));
     }
 
     @Override
     public LogicalLoadProject<Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalLoadProject<>(projects, isDistinct,
-                groupExpression, Optional.of(getLogicalProperties()), children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalLoadProject<>(projects, isDistinct,
+                groupExpression, Optional.of(getLogicalProperties()), children));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalLoadProject<>(projects, isDistinct,
-                groupExpression, logicalProperties, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalLoadProject<>(projects, isDistinct,
+                groupExpression, logicalProperties, children));
     }
 
     public LogicalLoadProject<Plan> withProjects(List<NamedExpression> projects) {
-        return new LogicalLoadProject<>(projects, isDistinct, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalLoadProject<>(projects, isDistinct, children));
     }
 
     public LogicalLoadProject<Plan> withProjectsAndChild(List<NamedExpression> projects, Plan child) {
-        return new LogicalLoadProject<>(projects, isDistinct, ImmutableList.of(child));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalLoadProject<>(projects, isDistinct, ImmutableList.of(child)));
     }
 
     public LogicalLoadProject<Plan> withDistinct(boolean isDistinct) {
-        return new LogicalLoadProject<>(projects, isDistinct, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalLoadProject<>(projects, isDistinct, children));
     }
 
     public boolean isDistinct() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalMaxComputeTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalMaxComputeTableSink.java
@@ -23,6 +23,7 @@ import org.apache.doris.datasource.maxcompute.MaxComputeExternalTable;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
@@ -64,24 +65,28 @@ public class LogicalMaxComputeTableSink<CHILD_TYPE extends Plan> extends Logical
         this.dmlCommandType = dmlCommandType;
     }
 
+    /** Update output expressions based on child output and replace child. */
     public Plan withChildAndUpdateOutput(Plan child) {
         List<NamedExpression> output = child.getOutput().stream()
                 .map(NamedExpression.class::cast)
                 .collect(ImmutableList.toImmutableList());
-        return new LogicalMaxComputeTableSink<>(database, targetTable, cols, output,
-                dmlCommandType, Optional.empty(), Optional.empty(), child);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalMaxComputeTableSink<>(database, targetTable, cols, output,
+                dmlCommandType, Optional.empty(), Optional.empty(), child));
     }
 
     @Override
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1, "LogicalMaxComputeTableSink only accepts one child");
-        return new LogicalMaxComputeTableSink<>(database, targetTable, cols, outputExprs,
-                dmlCommandType, Optional.empty(), Optional.empty(), children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalMaxComputeTableSink<>(database, targetTable, cols, outputExprs,
+                dmlCommandType, Optional.empty(), Optional.empty(), children.get(0)));
     }
 
     public LogicalMaxComputeTableSink<CHILD_TYPE> withOutputExprs(List<NamedExpression> outputExprs) {
-        return new LogicalMaxComputeTableSink<>(database, targetTable, cols, outputExprs,
-                dmlCommandType, Optional.empty(), Optional.empty(), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalMaxComputeTableSink<>(database, targetTable, cols, outputExprs,
+                dmlCommandType, Optional.empty(), Optional.empty(), child()));
     }
 
     public MaxComputeExternalDatabase getDatabase() {
@@ -136,14 +141,16 @@ public class LogicalMaxComputeTableSink<CHILD_TYPE extends Plan> extends Logical
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalMaxComputeTableSink<>(database, targetTable, cols, outputExprs,
-                dmlCommandType, groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalMaxComputeTableSink<>(database, targetTable, cols, outputExprs,
+                dmlCommandType, groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalMaxComputeTableSink<>(database, targetTable, cols, outputExprs,
-                dmlCommandType, groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalMaxComputeTableSink<>(database, targetTable, cols, outputExprs,
+                dmlCommandType, groupExpression, logicalProperties, children.get(0)));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOdbcScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOdbcScan.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.OdbcTable;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.RelationId;
@@ -70,24 +71,28 @@ public class LogicalOdbcScan extends LogicalCatalogRelation {
 
     @Override
     public LogicalOdbcScan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalOdbcScan(relationId, table, qualifier, groupExpression,
-                Optional.of(getLogicalProperties()), tableAlias);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOdbcScan(relationId, table, qualifier, groupExpression,
+                Optional.of(getLogicalProperties()), tableAlias));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalOdbcScan(relationId, table, qualifier, groupExpression, logicalProperties, tableAlias);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOdbcScan(relationId, table, qualifier, groupExpression, logicalProperties, tableAlias));
     }
 
     @Override
     public LogicalOdbcScan withRelationId(RelationId relationId) {
-        return new LogicalOdbcScan(relationId, table, qualifier, Optional.empty(), Optional.empty(), tableAlias);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOdbcScan(relationId, table, qualifier, Optional.empty(), Optional.empty(), tableAlias));
     }
 
     public LogicalOdbcScan withTableAlias(String tableAlias) {
-        return new LogicalOdbcScan(relationId, table, qualifier, Optional.empty(),
-                Optional.of(getLogicalProperties()), tableAlias);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOdbcScan(relationId, table, qualifier, Optional.empty(),
+                Optional.of(getLogicalProperties()), tableAlias));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
@@ -34,6 +34,7 @@ import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PreAggStatus;
@@ -349,37 +350,40 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan,
 
     @Override
     public LogicalOlapScan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalOlapScan(relationId, (Table) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOlapScan(relationId, (Table) table, qualifier,
                 groupExpression, Optional.of(getLogicalProperties()),
                 selectedPartitionIds, partitionPruned, selectedTabletIds,
                 selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions,
                 hints, cacheSlotWithSlotName, cachedOutput, tableSample, directMvScan,
                 colToSubPathsMap, manuallySpecifiedTabletIds, operativeSlots, virtualColumns,
-                scoreOrderKeys, scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias);
+                scoreOrderKeys, scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalOlapScan(relationId, (Table) table, qualifier, groupExpression, logicalProperties,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOlapScan(relationId, (Table) table, qualifier, groupExpression, logicalProperties,
                 selectedPartitionIds, partitionPruned, selectedTabletIds,
                 selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions,
                 hints, cacheSlotWithSlotName, cachedOutput, tableSample, directMvScan,
                 colToSubPathsMap, manuallySpecifiedTabletIds, operativeSlots, virtualColumns,
-                scoreOrderKeys, scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias);
+                scoreOrderKeys, scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias));
     }
 
     /**
      * withSelectedPartitionIds
      */
     public LogicalOlapScan withSelectedPartitionIds(List<Long> selectedPartitionIds) {
-        return new LogicalOlapScan(relationId, (Table) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOlapScan(relationId, (Table) table, qualifier,
                 Optional.empty(), Optional.of(getLogicalProperties()),
                 selectedPartitionIds, true, selectedTabletIds,
                 selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions,
                 hints, cacheSlotWithSlotName, cachedOutput, tableSample, directMvScan,
                 colToSubPathsMap, manuallySpecifiedTabletIds, operativeSlots, virtualColumns,
-                scoreOrderKeys, scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias);
+                scoreOrderKeys, scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias));
     }
 
     /**
@@ -388,88 +392,95 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan,
      * @return scan with materialized index id
      */
     public LogicalOlapScan withMaterializedIndexSelected(long indexId) {
-        return new LogicalOlapScan(relationId, (Table) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOlapScan(relationId, (Table) table, qualifier,
                 Optional.empty(), Optional.of(getLogicalProperties()),
                 selectedPartitionIds, partitionPruned, selectedTabletIds,
                 indexId, true, PreAggStatus.unset(), manuallySpecifiedPartitions, hints, cacheSlotWithSlotName,
                 cachedOutput, tableSample, directMvScan, colToSubPathsMap, manuallySpecifiedTabletIds,
                 operativeSlots, virtualColumns, scoreOrderKeys, scoreLimit, scoreRangeInfo,
-                annOrderKeys, annLimit, tableAlias);
+                annOrderKeys, annLimit, tableAlias));
     }
 
     /**
      * withSelectedTabletIds
      */
     public LogicalOlapScan withSelectedTabletIds(List<Long> selectedTabletIds) {
-        return new LogicalOlapScan(relationId, (Table) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOlapScan(relationId, (Table) table, qualifier,
                 Optional.empty(), Optional.of(getLogicalProperties()),
                 selectedPartitionIds, partitionPruned, selectedTabletIds,
                 selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions,
                 hints, cacheSlotWithSlotName, cachedOutput, tableSample, directMvScan,
                 colToSubPathsMap, manuallySpecifiedTabletIds, operativeSlots, virtualColumns, scoreOrderKeys,
-                scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias);
+                scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias));
     }
 
     /**
      * withPreAggStatus
      */
     public LogicalOlapScan withPreAggStatus(PreAggStatus preAggStatus) {
-        return new LogicalOlapScan(relationId, (Table) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOlapScan(relationId, (Table) table, qualifier,
                 Optional.empty(), Optional.of(getLogicalProperties()),
                 selectedPartitionIds, partitionPruned, selectedTabletIds,
                 selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions,
                 hints, cacheSlotWithSlotName, cachedOutput, tableSample, directMvScan,
                 colToSubPathsMap, manuallySpecifiedTabletIds, operativeSlots, virtualColumns,
-                scoreOrderKeys, scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias);
+                scoreOrderKeys, scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias));
     }
 
     /**
      * constructor
      */
     public LogicalOlapScan withColToSubPathsMap(Map<String, Set<List<String>>> colToSubPathsMap) {
-        return new LogicalOlapScan(relationId, (Table) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOlapScan(relationId, (Table) table, qualifier,
                 Optional.empty(), Optional.empty(),
                 selectedPartitionIds, partitionPruned, selectedTabletIds,
                 selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions,
                 hints, cacheSlotWithSlotName, cachedOutput, tableSample, directMvScan,
                 colToSubPathsMap, manuallySpecifiedTabletIds, operativeSlots, virtualColumns,
-                scoreOrderKeys, scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias);
+                scoreOrderKeys, scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias));
     }
 
     /**
      * constructor
      */
     public LogicalOlapScan withManuallySpecifiedTabletIds(List<Long> manuallySpecifiedTabletIds) {
-        return new LogicalOlapScan(relationId, (Table) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOlapScan(relationId, (Table) table, qualifier,
                 Optional.empty(), Optional.of(getLogicalProperties()),
                 selectedPartitionIds, partitionPruned, selectedTabletIds,
                 selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions,
                 hints, cacheSlotWithSlotName, cachedOutput, tableSample, directMvScan,
                 colToSubPathsMap, manuallySpecifiedTabletIds, operativeSlots, virtualColumns,
-                scoreOrderKeys, scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias);
+                scoreOrderKeys, scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias));
     }
 
     @Override
     public LogicalOlapScan withRelationId(RelationId relationId) {
         // we have to set partitionPruned to false, so that mtmv rewrite can prevent deadlock when rewriting union
-        return new LogicalOlapScan(relationId, (Table) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOlapScan(relationId, (Table) table, qualifier,
                 Optional.empty(), Optional.empty(),
                 selectedPartitionIds, false, selectedTabletIds,
                 selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions,
                 hints, Maps.newHashMap(), Optional.empty(), tableSample, directMvScan,
                 colToSubPathsMap, selectedTabletIds, operativeSlots, virtualColumns, scoreOrderKeys,
-                scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias);
+                scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias));
     }
 
     @Override
     public LogicalOlapScan withTableAlias(String tableAlias) {
-        return new LogicalOlapScan(relationId, (Table) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOlapScan(relationId, (Table) table, qualifier,
                 Optional.empty(), Optional.of(getLogicalProperties()),
                 selectedPartitionIds, partitionPruned, selectedTabletIds,
                 selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions,
                 hints, cacheSlotWithSlotName, cachedOutput, tableSample, directMvScan,
                 colToSubPathsMap, manuallySpecifiedTabletIds, operativeSlots, virtualColumns,
-                scoreOrderKeys, scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias);
+                scoreOrderKeys, scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias));
     }
 
     /**
@@ -482,14 +493,15 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan,
         LogicalProperties logicalProperties = getLogicalProperties();
         List<Slot> output = Lists.newArrayList(logicalProperties.getOutput());
         output.addAll(virtualColumns.stream().map(NamedExpression::toSlot).collect(Collectors.toList()));
-        logicalProperties = new LogicalProperties(() -> output, this::computeDataTrait);
-        return new LogicalOlapScan(relationId, (Table) table, qualifier,
-                groupExpression, Optional.of(logicalProperties),
+        LogicalProperties finalLogicalProperties = new LogicalProperties(() -> output, this::computeDataTrait);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOlapScan(relationId, (Table) table, qualifier,
+                groupExpression, Optional.of(finalLogicalProperties),
                 selectedPartitionIds, partitionPruned, selectedTabletIds,
                 selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions,
                 hints, cacheSlotWithSlotName, cachedOutput, tableSample, directMvScan, colToSubPathsMap,
                 manuallySpecifiedTabletIds, operativeSlots, virtualColumns, scoreOrderKeys, scoreLimit,
-                scoreRangeInfo, annOrderKeys, annLimit, tableAlias);
+                scoreRangeInfo, annOrderKeys, annLimit, tableAlias));
     }
 
     /**
@@ -874,13 +886,14 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan,
 
     @Override
     public CatalogRelation withOperativeSlots(Collection<Slot> operativeSlots) {
-        return new LogicalOlapScan(relationId, (Table) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOlapScan(relationId, (Table) table, qualifier,
                 groupExpression, Optional.of(getLogicalProperties()),
                 selectedPartitionIds, partitionPruned, selectedTabletIds,
                 selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions,
                 hints, cacheSlotWithSlotName, cachedOutput, tableSample, directMvScan, colToSubPathsMap,
                 manuallySpecifiedTabletIds, operativeSlots, virtualColumns, scoreOrderKeys, scoreLimit,
-                scoreRangeInfo, annOrderKeys, annLimit, tableAlias);
+                scoreRangeInfo, annOrderKeys, annLimit, tableAlias));
     }
 
     private Map<Slot, Slot> constructReplaceMap(MTMV mtmv) {
@@ -915,13 +928,14 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan,
 
     /** withCachedOutput */
     public LogicalOlapScan withCachedOutput(List<Slot> outputSlots) {
-        return new LogicalOlapScan(relationId, (Table) table, qualifier,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOlapScan(relationId, (Table) table, qualifier,
                 groupExpression, Optional.empty(),
                 selectedPartitionIds, partitionPruned, selectedTabletIds,
                 selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions,
                 hints, cacheSlotWithSlotName, Optional.of(outputSlots), tableSample, directMvScan, colToSubPathsMap,
                 manuallySpecifiedTabletIds, operativeSlots, virtualColumns, scoreOrderKeys, scoreLimit,
-                scoreRangeInfo, annOrderKeys, annLimit, tableAlias);
+                scoreRangeInfo, annOrderKeys, annLimit, tableAlias));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapTableSink.java
@@ -25,6 +25,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
@@ -106,17 +107,19 @@ public class LogicalOlapTableSink<CHILD_TYPE extends Plan> extends LogicalTableS
             Map<Long, Expression> syncMvWhereClauses, List<Slot> targetTableSlots) {
         List<NamedExpression> output = child.getOutput().stream().map(NamedExpression.class::cast)
                 .collect(ImmutableList.toImmutableList());
-        return new LogicalOlapTableSink<>(database, targetTable, cols, partitionIds, output,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOlapTableSink<>(database, targetTable, cols, partitionIds, output,
                 isPartialUpdate, partialUpdateNewKeyPolicy, dmlCommandType, partitionExprList, syncMvWhereClauses,
-                targetTableSlots, Optional.empty(), Optional.empty(), child);
+                targetTableSlots, Optional.empty(), Optional.empty(), child));
     }
 
     @Override
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1, "LogicalOlapTableSink only accepts one child");
-        return new LogicalOlapTableSink<>(database, targetTable, cols, partitionIds, outputExprs,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOlapTableSink<>(database, targetTable, cols, partitionIds, outputExprs,
                 isPartialUpdate, partialUpdateNewKeyPolicy, dmlCommandType, partitionExprList, syncMvWhereClauses,
-                targetTableSlots, Optional.empty(), Optional.empty(), children.get(0));
+                targetTableSlots, Optional.empty(), Optional.empty(), children.get(0)));
     }
 
     public DatabaseIf getDatabase() {
@@ -156,9 +159,10 @@ public class LogicalOlapTableSink<CHILD_TYPE extends Plan> extends LogicalTableS
     }
 
     public LogicalOlapTableSink<CHILD_TYPE> withOutputExprs(List<NamedExpression> outputExprs) {
-        return new LogicalOlapTableSink<>(database, targetTable, cols, partitionIds, outputExprs,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOlapTableSink<>(database, targetTable, cols, partitionIds, outputExprs,
                 isPartialUpdate, partialUpdateNewKeyPolicy, dmlCommandType, partitionExprList, syncMvWhereClauses,
-                targetTableSlots, Optional.empty(), Optional.empty(), child());
+                targetTableSlots, Optional.empty(), Optional.empty(), child()));
     }
 
     @Override
@@ -207,23 +211,26 @@ public class LogicalOlapTableSink<CHILD_TYPE extends Plan> extends LogicalTableS
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalOlapTableSink<>(database, targetTable, cols, partitionIds, outputExprs,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOlapTableSink<>(database, targetTable, cols, partitionIds, outputExprs,
                 isPartialUpdate, partialUpdateNewKeyPolicy, dmlCommandType, partitionExprList, syncMvWhereClauses,
-                targetTableSlots, groupExpression, Optional.of(getLogicalProperties()), child());
+                targetTableSlots, groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalOlapTableSink<>(database, targetTable, cols, partitionIds, outputExprs,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOlapTableSink<>(database, targetTable, cols, partitionIds, outputExprs,
                 isPartialUpdate, partialUpdateNewKeyPolicy, dmlCommandType, partitionExprList, syncMvWhereClauses,
-                targetTableSlots, groupExpression, logicalProperties, children.get(0));
+                targetTableSlots, groupExpression, logicalProperties, children.get(0)));
     }
 
     public Plan withPartitionExprAndMvWhereClause(List<Expression> partitionExprList,
                                                   Map<Long, Expression> syncMvWhereClauses) {
-        return new LogicalOlapTableSink<>(database, targetTable, cols, partitionIds, outputExprs,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOlapTableSink<>(database, targetTable, cols, partitionIds, outputExprs,
                 isPartialUpdate, partialUpdateNewKeyPolicy, dmlCommandType, partitionExprList, syncMvWhereClauses,
-                targetTableSlots, Optional.empty(), Optional.empty(), child());
+                targetTableSlots, Optional.empty(), Optional.empty(), child()));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOneRowRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOneRowRelation.java
@@ -27,6 +27,7 @@ import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.WindowExpression;
 import org.apache.doris.nereids.trees.expressions.functions.generator.TableGeneratingFunction;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.GroupingScalarFunction;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.RelationId;
@@ -96,13 +97,15 @@ public class LogicalOneRowRelation extends LogicalRelation implements OneRowRela
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalOneRowRelation(relationId, projects, groupExpression, Optional.of(getLogicalProperties()));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOneRowRelation(relationId, projects, groupExpression, Optional.of(getLogicalProperties())));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalOneRowRelation(relationId, projects, groupExpression, logicalProperties);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOneRowRelation(relationId, projects, groupExpression, logicalProperties));
     }
 
     @Override
@@ -111,7 +114,8 @@ public class LogicalOneRowRelation extends LogicalRelation implements OneRowRela
     }
 
     public LogicalOneRowRelation withRelationIdAndProjects(RelationId relationId, List<NamedExpression> projects) {
-        return new LogicalOneRowRelation(relationId, projects);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOneRowRelation(relationId, projects));
     }
 
     @Override
@@ -149,7 +153,8 @@ public class LogicalOneRowRelation extends LogicalRelation implements OneRowRela
     }
 
     public LogicalOneRowRelation withProjects(List<NamedExpression> namedExpressions) {
-        return new LogicalOneRowRelation(relationId, namedExpressions, Optional.empty(), Optional.empty());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalOneRowRelation(relationId, namedExpressions, Optional.empty(), Optional.empty()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalPartitionTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalPartitionTopN.java
@@ -26,6 +26,7 @@ import org.apache.doris.nereids.trees.expressions.WindowExpression;
 import org.apache.doris.nereids.trees.expressions.functions.window.DenseRank;
 import org.apache.doris.nereids.trees.expressions.functions.window.Rank;
 import org.apache.doris.nereids.trees.expressions.functions.window.RowNumber;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
@@ -179,28 +180,32 @@ public class LogicalPartitionTopN<CHILD_TYPE extends Plan> extends LogicalUnary<
 
     public LogicalPartitionTopN<Plan> withPartitionKeysAndOrderKeys(
             List<Expression> partitionKeys, List<OrderExpression> orderKeys) {
-        return new LogicalPartitionTopN<>(function, partitionKeys, orderKeys, hasGlobalLimit, partitionLimit,
-                Optional.empty(), Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalPartitionTopN<>(function, partitionKeys, orderKeys, hasGlobalLimit, partitionLimit,
+                Optional.empty(), Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public LogicalPartitionTopN<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalPartitionTopN<>(function, partitionKeys, orderKeys, hasGlobalLimit, partitionLimit,
-            children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalPartitionTopN<>(function, partitionKeys, orderKeys, hasGlobalLimit, partitionLimit,
+            children.get(0)));
     }
 
     @Override
     public LogicalPartitionTopN<Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalPartitionTopN<>(function, partitionKeys, orderKeys, hasGlobalLimit, partitionLimit,
-            groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalPartitionTopN<>(function, partitionKeys, orderKeys, hasGlobalLimit, partitionLimit,
+            groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalPartitionTopN<>(function, partitionKeys, orderKeys, hasGlobalLimit, partitionLimit,
-                groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalPartitionTopN<>(function, partitionKeys, orderKeys, hasGlobalLimit, partitionLimit,
+                groupExpression, logicalProperties, children.get(0)));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalPostProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalPostProject.java
@@ -29,6 +29,7 @@ import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.functions.NoneMovableFunction;
 import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Project;
@@ -150,33 +151,39 @@ public class LogicalPostProject<CHILD_TYPE extends Plan> extends LogicalUnary<CH
     @Override
     public LogicalPostProject<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalPostProject<>(projects, isDistinct, Utils.fastToImmutableList(children));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalPostProject<>(projects, isDistinct, Utils.fastToImmutableList(children)));
     }
 
     @Override
     public LogicalPostProject<Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalPostProject<>(projects, isDistinct,
-                groupExpression, Optional.of(getLogicalProperties()), children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalPostProject<>(projects, isDistinct,
+                groupExpression, Optional.of(getLogicalProperties()), children));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalPostProject<>(projects, isDistinct,
-                groupExpression, logicalProperties, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalPostProject<>(projects, isDistinct,
+                groupExpression, logicalProperties, children));
     }
 
     public LogicalPostProject<Plan> withProjects(List<NamedExpression> projects) {
-        return new LogicalPostProject<>(projects, isDistinct, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalPostProject<>(projects, isDistinct, children));
     }
 
     public LogicalPostProject<Plan> withProjectsAndChild(List<NamedExpression> projects, Plan child) {
-        return new LogicalPostProject<>(projects, isDistinct, ImmutableList.of(child));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalPostProject<>(projects, isDistinct, ImmutableList.of(child)));
     }
 
     public LogicalPostProject<Plan> withDistinct(boolean isDistinct) {
-        return new LogicalPostProject<>(projects, isDistinct, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalPostProject<>(projects, isDistinct, children));
     }
 
     public boolean isDistinct() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalPreAggOnHint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalPreAggOnHint.java
@@ -21,6 +21,7 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.BlockFuncDepsPropagation;
 import org.apache.doris.nereids.trees.plans.DiffOutputInAsterisk;
 import org.apache.doris.nereids.trees.plans.Plan;
@@ -57,7 +58,8 @@ public class LogicalPreAggOnHint<CHILD_TYPE extends Plan> extends LogicalUnary<C
     @Override
     public LogicalPreAggOnHint<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalPreAggOnHint<>(children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalPreAggOnHint<>(children.get(0)));
     }
 
     @Override
@@ -72,14 +74,16 @@ public class LogicalPreAggOnHint<CHILD_TYPE extends Plan> extends LogicalUnary<C
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalPreAggOnHint<>(groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalPreAggOnHint<>(groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalPreAggOnHint<>(groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalPreAggOnHint<>(groupExpression, logicalProperties, children.get(0)));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalPreFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalPreFilter.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SubqueryExpr;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.DiffOutputInAsterisk;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -122,35 +123,41 @@ public class LogicalPreFilter<CHILD_TYPE extends Plan> extends LogicalUnary<CHIL
     }
 
     public LogicalPreFilter<Plan> withConjuncts(Set<Expression> conjuncts) {
-        return new LogicalPreFilter<>(conjuncts, Optional.empty(), Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalPreFilter<>(conjuncts, Optional.empty(), Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public LogicalPreFilter<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalPreFilter<>(conjuncts, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalPreFilter<>(conjuncts, children.get(0)));
     }
 
     @Override
     public LogicalPreFilter<Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalPreFilter<>(conjuncts, groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalPreFilter<>(conjuncts, groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalPreFilter<>(conjuncts, groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalPreFilter<>(conjuncts, groupExpression, logicalProperties, children.get(0)));
     }
 
     public LogicalPreFilter<Plan> withConjunctsAndChild(Set<Expression> conjuncts, Plan child) {
-        return new LogicalPreFilter<>(conjuncts, child);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalPreFilter<>(conjuncts, child));
     }
 
     public LogicalPreFilter<Plan> withConjunctsAndProps(Set<Expression> conjuncts,
             Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, Plan child) {
-        return new LogicalPreFilter<>(conjuncts, groupExpression, logicalProperties, child);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalPreFilter<>(conjuncts, groupExpression, logicalProperties, child));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
@@ -28,6 +28,7 @@ import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.functions.NoneMovableFunction;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Uuid;
 import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Project;
@@ -186,33 +187,39 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
     @Override
     public LogicalProject<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalProject<>(projects, isDistinct, Utils.fastToImmutableList(children));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalProject<>(projects, isDistinct, Utils.fastToImmutableList(children)));
     }
 
     @Override
     public LogicalProject<Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalProject<>(projects, isDistinct,
-                groupExpression, Optional.of(getLogicalProperties()), children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalProject<>(projects, isDistinct,
+                groupExpression, Optional.of(getLogicalProperties()), children));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalProject<>(projects, isDistinct,
-                groupExpression, logicalProperties, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalProject<>(projects, isDistinct,
+                groupExpression, logicalProperties, children));
     }
 
     public LogicalProject<Plan> withProjects(List<NamedExpression> projects) {
-        return new LogicalProject<>(projects, isDistinct, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalProject<>(projects, isDistinct, children));
     }
 
     public LogicalProject<Plan> withProjectsAndChild(List<NamedExpression> projects, Plan child) {
-        return new LogicalProject<>(projects, isDistinct, ImmutableList.of(child));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalProject<>(projects, isDistinct, ImmutableList.of(child)));
     }
 
     public LogicalProject<Plan> withDistinct(boolean isDistinct) {
-        return new LogicalProject<>(projects, isDistinct, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalProject<>(projects, isDistinct, children));
     }
 
     public boolean isDistinct() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalQualify.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalQualify.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.DataTrait.Builder;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Filter;
@@ -70,18 +71,21 @@ public class LogicalQualify<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalQualify<>(conjuncts, groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalQualify<>(conjuncts, groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
                                                  Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalQualify<>(conjuncts, groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalQualify<>(conjuncts, groupExpression, logicalProperties, children.get(0)));
     }
 
     public LogicalQualify<Plan> withConjuncts(Set<Expression> conjuncts) {
-        return new LogicalQualify<>(conjuncts, Optional.empty(), Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalQualify<>(conjuncts, Optional.empty(), Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
@@ -130,7 +134,8 @@ public class LogicalQualify<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
     @Override
     public LogicalQualify<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalQualify<>(conjuncts, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalQualify<>(conjuncts, children.get(0)));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRecursiveUnion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRecursiveUnion.java
@@ -33,6 +33,7 @@ import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.RecursiveCte;
@@ -241,7 +242,8 @@ public class LogicalRecursiveUnion<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYP
 
     @Override
     public LogicalRecursiveUnion<Plan, Plan> withChildren(List<Plan> children) {
-        return new LogicalRecursiveUnion<>(cteName, qualifier, outputs, regularChildrenOutputs, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRecursiveUnion<>(cteName, qualifier, outputs, regularChildrenOutputs, children));
     }
 
     public LogicalRecursiveUnion<Plan, Plan> withChildrenAndTheirOutputs(List<Plan> children,
@@ -249,32 +251,37 @@ public class LogicalRecursiveUnion<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYP
         Preconditions.checkArgument(children.size() == childrenOutputs.size(),
                 "children size %s is not equals with children outputs size %s",
                 children.size(), childrenOutputs.size());
-        return new LogicalRecursiveUnion<>(cteName, qualifier, outputs, childrenOutputs, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRecursiveUnion<>(cteName, qualifier, outputs, childrenOutputs, children));
     }
 
     @Override
     public LogicalRecursiveUnion<Plan, Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalRecursiveUnion<>(cteName, qualifier, outputs, regularChildrenOutputs,
-                groupExpression, Optional.of(getLogicalProperties()), children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRecursiveUnion<>(cteName, qualifier, outputs, regularChildrenOutputs,
+                groupExpression, Optional.of(getLogicalProperties()), children));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalRecursiveUnion<>(cteName, qualifier, outputs, regularChildrenOutputs,
-                groupExpression, logicalProperties, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRecursiveUnion<>(cteName, qualifier, outputs, regularChildrenOutputs,
+                groupExpression, logicalProperties, children));
     }
 
     public LogicalRecursiveUnion<Plan, Plan> withNewOutputs(List<NamedExpression> newOutputs) {
-        return new LogicalRecursiveUnion<>(cteName, qualifier, newOutputs, regularChildrenOutputs,
-                Optional.empty(), Optional.empty(), children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRecursiveUnion<>(cteName, qualifier, newOutputs, regularChildrenOutputs,
+                Optional.empty(), Optional.empty(), children));
     }
 
     public LogicalRecursiveUnion<Plan, Plan> withNewOutputsAndChildren(List<NamedExpression> newOutputs,
             List<Plan> children,
             List<List<SlotReference>> childrenOutputs) {
-        return new LogicalRecursiveUnion<>(cteName, qualifier, newOutputs, childrenOutputs,
-                Optional.empty(), Optional.empty(), children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRecursiveUnion<>(cteName, qualifier, newOutputs, childrenOutputs,
+                Optional.empty(), Optional.empty(), children));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRecursiveUnionAnchor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRecursiveUnionAnchor.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.CTEId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -61,7 +62,8 @@ public class LogicalRecursiveUnionAnchor<CHILD_TYPE extends Plan> extends Logica
 
     @Override
     public Plan withChildren(List<Plan> children) {
-        return new LogicalRecursiveUnionAnchor<>(cteId, Optional.empty(), Optional.empty(), children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRecursiveUnionAnchor<>(cteId, Optional.empty(), Optional.empty(), children));
     }
 
     @Override
@@ -76,14 +78,16 @@ public class LogicalRecursiveUnionAnchor<CHILD_TYPE extends Plan> extends Logica
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalRecursiveUnionAnchor<>(cteId, groupExpression,
-                Optional.of(getLogicalProperties()), children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRecursiveUnionAnchor<>(cteId, groupExpression,
+                Optional.of(getLogicalProperties()), children));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalRecursiveUnionAnchor<>(cteId, groupExpression, logicalProperties, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRecursiveUnionAnchor<>(cteId, groupExpression, logicalProperties, children));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRecursiveUnionProducer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRecursiveUnionProducer.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -60,7 +61,8 @@ public class LogicalRecursiveUnionProducer<CHILD_TYPE extends Plan> extends Logi
 
     @Override
     public Plan withChildren(List<Plan> children) {
-        return new LogicalRecursiveUnionProducer<>(cteName, Optional.empty(), Optional.empty(), children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRecursiveUnionProducer<>(cteName, Optional.empty(), Optional.empty(), children));
     }
 
     @Override
@@ -75,14 +77,16 @@ public class LogicalRecursiveUnionProducer<CHILD_TYPE extends Plan> extends Logi
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalRecursiveUnionProducer<>(cteName, groupExpression,
-                Optional.of(getLogicalProperties()), children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRecursiveUnionProducer<>(cteName, groupExpression,
+                Optional.of(getLogicalProperties()), children));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalRecursiveUnionProducer<>(cteName, groupExpression, logicalProperties, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRecursiveUnionProducer<>(cteName, groupExpression, logicalProperties, children));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRepeat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRepeat.java
@@ -25,6 +25,7 @@ import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.GroupingScalarFunction;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Repeat;
@@ -226,49 +227,58 @@ public class LogicalRepeat<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
     @Override
     public LogicalRepeat<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalRepeat<>(groupingSets, outputExpressions, groupingId, type, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRepeat<>(groupingSets, outputExpressions, groupingId, type, children.get(0)));
     }
 
     @Override
     public LogicalRepeat<CHILD_TYPE> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalRepeat<>(groupingSets, outputExpressions, groupExpression,
-                Optional.of(getLogicalProperties()), groupingId, withInProjection, type, child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRepeat<>(groupingSets, outputExpressions, groupExpression,
+                Optional.of(getLogicalProperties()), groupingId, withInProjection, type, child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalRepeat<>(groupingSets, outputExpressions, groupExpression, logicalProperties,
-                groupingId, withInProjection, type, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRepeat<>(groupingSets, outputExpressions, groupExpression, logicalProperties,
+                groupingId, withInProjection, type, children.get(0)));
     }
 
     public LogicalRepeat<CHILD_TYPE> withGroupSets(List<List<Expression>> groupingSets) {
-        return new LogicalRepeat<>(groupingSets, outputExpressions, groupingId, type, child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRepeat<>(groupingSets, outputExpressions, groupingId, type, child()));
     }
 
     public LogicalRepeat<CHILD_TYPE> withGroupSetsAndOutput(List<List<Expression>> groupingSets,
             List<NamedExpression> outputExpressionList) {
-        return new LogicalRepeat<>(groupingSets, outputExpressionList, groupingId, type, child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRepeat<>(groupingSets, outputExpressionList, groupingId, type, child()));
     }
 
     @Override
     public LogicalRepeat<CHILD_TYPE> withAggOutput(List<NamedExpression> newOutput) {
-        return new LogicalRepeat<>(groupingSets, newOutput, groupingId, type, child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRepeat<>(groupingSets, newOutput, groupingId, type, child()));
     }
 
     public LogicalRepeat<Plan> withNormalizedExpr(List<List<Expression>> groupingSets,
             List<NamedExpression> outputExpressionList, SlotReference groupingId, Plan child) {
-        return new LogicalRepeat<>(groupingSets, outputExpressionList, groupingId, type, child);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRepeat<>(groupingSets, outputExpressionList, groupingId, type, child));
     }
 
     public LogicalRepeat<Plan> withAggOutputAndChild(List<NamedExpression> newOutput, Plan child) {
-        return new LogicalRepeat<>(groupingSets, newOutput, groupingId, type, child);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRepeat<>(groupingSets, newOutput, groupingId, type, child));
     }
 
     public LogicalRepeat<CHILD_TYPE> withInProjection(boolean withInProjection) {
-        return new LogicalRepeat<>(groupingSets, outputExpressions,
-                Optional.empty(), Optional.empty(), groupingId, withInProjection, type, child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalRepeat<>(groupingSets, outputExpressions,
+                Optional.empty(), Optional.empty(), groupingId, withInProjection, type, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalResultSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalResultSink.java
@@ -21,6 +21,7 @@ import org.apache.doris.analysis.StmtType;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
@@ -53,7 +54,8 @@ public class LogicalResultSink<CHILD_TYPE extends Plan> extends LogicalSink<CHIL
     public LogicalResultSink<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1,
                 "LogicalResultSink's children size must be 1, but real is %s", children.size());
-        return new LogicalResultSink<>(outputExprs, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalResultSink<>(outputExprs, children.get(0)));
     }
 
     @Override
@@ -63,19 +65,22 @@ public class LogicalResultSink<CHILD_TYPE extends Plan> extends LogicalSink<CHIL
 
     @Override
     public LogicalResultSink<Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalResultSink<>(outputExprs, groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalResultSink<>(outputExprs, groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public LogicalResultSink<Plan> withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1, "LogicalResultSink only accepts one child");
-        return new LogicalResultSink<>(outputExprs, groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalResultSink<>(outputExprs, groupExpression, logicalProperties, children.get(0)));
     }
 
     @Override
     public LogicalResultSink<CHILD_TYPE> withOutputExprs(List<NamedExpression> outputExprs) {
-        return new LogicalResultSink<>(outputExprs, child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalResultSink<>(outputExprs, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSchemaScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSchemaScan.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.RelationId;
@@ -119,36 +120,41 @@ public class LogicalSchemaScan extends LogicalCatalogRelation {
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalSchemaScan(relationId, table, qualifier, filterPushed,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalSchemaScan(relationId, table, qualifier, filterPushed,
                 schemaCatalog, schemaDatabase, schemaTable, virtualColumns,
-                frontendConjuncts, groupExpression, Optional.of(getLogicalProperties()), tableAlias);
+                frontendConjuncts, groupExpression, Optional.of(getLogicalProperties()), tableAlias));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalSchemaScan(relationId, table, qualifier, filterPushed,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalSchemaScan(relationId, table, qualifier, filterPushed,
                 schemaCatalog, schemaDatabase, schemaTable, virtualColumns, frontendConjuncts, groupExpression,
-                logicalProperties, tableAlias);
+                logicalProperties, tableAlias));
     }
 
     @Override
     public LogicalSchemaScan withRelationId(RelationId relationId) {
-        return new LogicalSchemaScan(relationId, table, qualifier, filterPushed,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalSchemaScan(relationId, table, qualifier, filterPushed,
                 schemaCatalog, schemaDatabase, schemaTable, virtualColumns, frontendConjuncts, Optional.empty(),
-                Optional.empty(), tableAlias);
+                Optional.empty(), tableAlias));
     }
 
     public LogicalSchemaScan withFrontendConjuncts(Optional<String> schemaCatalog, Optional<String> schemaDatabase,
             Optional<String> schemaTable, List<Expression> frontendConjuncts) {
-        return new LogicalSchemaScan(relationId, table, qualifier, true, schemaCatalog, schemaDatabase, schemaTable,
-                virtualColumns, frontendConjuncts, Optional.empty(), Optional.of(getLogicalProperties()), tableAlias);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalSchemaScan(relationId, table, qualifier, true, schemaCatalog, schemaDatabase, schemaTable,
+                virtualColumns, frontendConjuncts, Optional.empty(), Optional.of(getLogicalProperties()), tableAlias));
     }
 
     public LogicalSchemaScan withTableAlias(String tableAlias) {
-        return new LogicalSchemaScan(relationId, table, qualifier, filterPushed, schemaCatalog, schemaDatabase,
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalSchemaScan(relationId, table, qualifier, filterPushed, schemaCatalog, schemaDatabase,
                 schemaTable, virtualColumns, frontendConjuncts, Optional.empty(),
-                Optional.of(getLogicalProperties()), tableAlias);
+                Optional.of(getLogicalProperties()), tableAlias));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSelectHint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSelectHint.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.SelectHint;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.BlockFuncDepsPropagation;
 import org.apache.doris.nereids.trees.plans.DiffOutputInAsterisk;
 import org.apache.doris.nereids.trees.plans.Plan;
@@ -84,7 +85,8 @@ public class LogicalSelectHint<CHILD_TYPE extends Plan> extends LogicalUnary<CHI
     @Override
     public LogicalSelectHint<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalSelectHint<>(hints, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalSelectHint<>(hints, children.get(0)));
     }
 
     @Override
@@ -99,14 +101,16 @@ public class LogicalSelectHint<CHILD_TYPE extends Plan> extends LogicalUnary<CHI
 
     @Override
     public LogicalSelectHint<CHILD_TYPE> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalSelectHint<>(hints, groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalSelectHint<>(hints, groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalSelectHint<>(hints, groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalSelectHint<>(hints, groupExpression, logicalProperties, children.get(0)));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSort.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSort.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.OrderKey;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
@@ -131,27 +132,32 @@ public class LogicalSort<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TYP
     @Override
     public LogicalSort<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalSort<>(orderKeys, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalSort<>(orderKeys, children.get(0)));
     }
 
     @Override
     public LogicalSort<Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalSort<>(orderKeys, groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalSort<>(orderKeys, groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public LogicalSort<Plan> withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalSort<>(orderKeys, groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalSort<>(orderKeys, groupExpression, logicalProperties, children.get(0)));
     }
 
     public LogicalSort<Plan> withOrderKeys(List<OrderKey> orderKeys) {
-        return new LogicalSort<>(orderKeys, Optional.empty(),
-                Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalSort<>(orderKeys, Optional.empty(),
+                Optional.of(getLogicalProperties()), child()));
     }
 
     public LogicalSort<Plan> withOrderKeysAndChild(List<OrderKey> orderKeys, Plan child) {
-        return new LogicalSort<>(orderKeys, child);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalSort<>(orderKeys, child));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSubQueryAlias.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSubQueryAlias.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.DiffOutputInAsterisk;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -224,7 +225,8 @@ public class LogicalSubQueryAlias<CHILD_TYPE extends Plan> extends LogicalUnary<
     @Override
     public LogicalSubQueryAlias<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalSubQueryAlias<>(qualifier, columnAliases, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalSubQueryAlias<>(qualifier, columnAliases, children.get(0)));
     }
 
     @Override
@@ -239,16 +241,18 @@ public class LogicalSubQueryAlias<CHILD_TYPE extends Plan> extends LogicalUnary<
 
     @Override
     public LogicalSubQueryAlias<CHILD_TYPE> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalSubQueryAlias<>(qualifier, columnAliases, groupExpression,
-                Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalSubQueryAlias<>(qualifier, columnAliases, groupExpression,
+                Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalSubQueryAlias<>(qualifier, columnAliases, groupExpression, logicalProperties,
-                children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalSubQueryAlias<>(qualifier, columnAliases, groupExpression, logicalProperties,
+                children.get(0)));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalTVFRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalTVFRelation.java
@@ -25,6 +25,7 @@ import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.trees.expressions.functions.table.TableValuedFunction;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.BlockFuncDepsPropagation;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -76,25 +77,29 @@ public class LogicalTVFRelation extends LogicalRelation implements TVFRelation, 
 
     @Override
     public LogicalTVFRelation withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalTVFRelation(relationId, function, operativeSlots,
-                groupExpression, Optional.of(getLogicalProperties()));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalTVFRelation(relationId, function, operativeSlots,
+                groupExpression, Optional.of(getLogicalProperties())));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalTVFRelation(relationId, function, operativeSlots, groupExpression, logicalProperties);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalTVFRelation(relationId, function, operativeSlots, groupExpression, logicalProperties));
     }
 
     @Override
     public LogicalTVFRelation withRelationId(RelationId relationId) {
-        return new LogicalTVFRelation(relationId, function, operativeSlots, Optional.empty(),
-                Optional.of(getLogicalProperties()));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalTVFRelation(relationId, function, operativeSlots, Optional.empty(),
+                Optional.of(getLogicalProperties())));
     }
 
     public LogicalTVFRelation withOperativeSlots(Collection<Slot> operativeSlots) {
-        return new LogicalTVFRelation(relationId, function, Utils.fastToImmutableList(operativeSlots),
-                Optional.empty(), Optional.of(getLogicalProperties()));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalTVFRelation(relationId, function, Utils.fastToImmutableList(operativeSlots),
+                Optional.empty(), Optional.of(getLogicalProperties())));
     }
 
     public List<Slot> getOperativeSlots() {
@@ -154,7 +159,8 @@ public class LogicalTVFRelation extends LogicalRelation implements TVFRelation, 
     }
 
     public LogicalTVFRelation withCachedOutputs(List<Slot> replaceSlots) {
-        return new LogicalTVFRelation(relationId, function, Utils.fastToImmutableList(operativeSlots),
-                Optional.of(replaceSlots), Optional.empty(), Optional.empty());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalTVFRelation(relationId, function, Utils.fastToImmutableList(operativeSlots),
+                Optional.of(replaceSlots), Optional.empty(), Optional.empty()));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalTVFTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalTVFTableSink.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
@@ -79,7 +80,8 @@ public class LogicalTVFTableSink<CHILD_TYPE extends Plan> extends LogicalSink<CH
     public LogicalTVFTableSink<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1,
                 "LogicalTVFTableSink's children size must be 1, but real is %s", children.size());
-        return new LogicalTVFTableSink<>(tvfName, properties, cols, outputExprs, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalTVFTableSink<>(tvfName, properties, cols, outputExprs, children.get(0)));
     }
 
     @Override
@@ -89,21 +91,24 @@ public class LogicalTVFTableSink<CHILD_TYPE extends Plan> extends LogicalSink<CH
 
     @Override
     public LogicalTVFTableSink<Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalTVFTableSink<>(tvfName, properties, cols, outputExprs,
-                groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalTVFTableSink<>(tvfName, properties, cols, outputExprs,
+                groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public LogicalTVFTableSink<Plan> withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1, "LogicalTVFTableSink only accepts one child");
-        return new LogicalTVFTableSink<>(tvfName, properties, cols, outputExprs,
-                groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalTVFTableSink<>(tvfName, properties, cols, outputExprs,
+                groupExpression, logicalProperties, children.get(0)));
     }
 
     @Override
     public LogicalTVFTableSink<CHILD_TYPE> withOutputExprs(List<NamedExpression> outputExprs) {
-        return new LogicalTVFTableSink<>(tvfName, properties, cols, outputExprs, child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalTVFTableSink<>(tvfName, properties, cols, outputExprs, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalTestScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalTestScan.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.plans.logical;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.RelationId;
@@ -66,19 +67,22 @@ public class LogicalTestScan extends LogicalCatalogRelation {
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalTestScan(relationId, table, qualifier,
-                groupExpression, Optional.ofNullable(getLogicalProperties()), tableAlias);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalTestScan(relationId, table, qualifier,
+                groupExpression, Optional.ofNullable(getLogicalProperties()), tableAlias));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalTestScan(relationId, table, qualifier, groupExpression, logicalProperties, tableAlias);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalTestScan(relationId, table, qualifier, groupExpression, logicalProperties, tableAlias));
     }
 
     public LogicalTestScan withTableAlias(String tableAlias) {
-        return new LogicalTestScan(relationId, table, qualifier, Optional.empty(),
-                Optional.of(getLogicalProperties()), tableAlias);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalTestScan(relationId, table, qualifier, Optional.empty(),
+                Optional.of(getLogicalProperties()), tableAlias));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalTopN.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.OrderKey;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -128,36 +129,42 @@ public class LogicalTopN<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TYP
     }
 
     public LogicalTopN<Plan> withOrderKeys(List<OrderKey> orderKeys) {
-        return new LogicalTopN<>(orderKeys, limit, offset,
-                Optional.empty(), Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalTopN<>(orderKeys, limit, offset,
+                Optional.empty(), Optional.of(getLogicalProperties()), child()));
     }
 
     public LogicalTopN<Plan> withLimitChild(long limit, long offset, Plan child) {
-        return new LogicalTopN<>(orderKeys, limit, offset, child);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalTopN<>(orderKeys, limit, offset, child));
     }
 
     public LogicalTopN<Plan> withLimitOrderKeyAndChild(long limit, long offset, List<OrderKey> orderKeys, Plan child) {
-        return new LogicalTopN<>(orderKeys, limit, offset, child);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalTopN<>(orderKeys, limit, offset, child));
     }
 
     @Override
     public LogicalTopN<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1,
                 "LogicalTopN should have 1 child, but input is %s", children.size());
-        return new LogicalTopN<>(orderKeys, limit, offset, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalTopN<>(orderKeys, limit, offset, children.get(0)));
     }
 
     @Override
     public LogicalTopN<Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalTopN<>(orderKeys, limit, offset, groupExpression, Optional.of(getLogicalProperties()),
-                child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalTopN<>(orderKeys, limit, offset, groupExpression, Optional.of(getLogicalProperties()),
+                child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalTopN<>(orderKeys, limit, offset, groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalTopN<>(orderKeys, limit, offset, groupExpression, logicalProperties, children.get(0)));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalUnion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalUnion.java
@@ -29,6 +29,7 @@ import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Union;
@@ -157,8 +158,9 @@ public class LogicalUnion extends LogicalSetOperation implements Union, OutputPr
 
     @Override
     public LogicalUnion withChildren(List<Plan> children) {
-        return new LogicalUnion(qualifier, outputs, regularChildrenOutputs,
-                constantExprsList, hasPushedFilter, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalUnion(qualifier, outputs, regularChildrenOutputs,
+                constantExprsList, hasPushedFilter, children));
     }
 
     @Override
@@ -167,49 +169,57 @@ public class LogicalUnion extends LogicalSetOperation implements Union, OutputPr
         Preconditions.checkArgument(children.size() == childrenOutputs.size(),
                 "children size %s is not equals with children outputs size %s",
                 children.size(), childrenOutputs.size());
-        return new LogicalUnion(qualifier, outputs, childrenOutputs, constantExprsList, hasPushedFilter, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalUnion(qualifier, outputs, childrenOutputs, constantExprsList, hasPushedFilter, children));
     }
 
     @Override
     public LogicalUnion withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalUnion(qualifier, outputs, regularChildrenOutputs, constantExprsList, hasPushedFilter,
-                groupExpression, Optional.of(getLogicalProperties()), children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalUnion(qualifier, outputs, regularChildrenOutputs, constantExprsList, hasPushedFilter,
+                groupExpression, Optional.of(getLogicalProperties()), children));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalUnion(qualifier, outputs, regularChildrenOutputs, constantExprsList, hasPushedFilter,
-                groupExpression, logicalProperties, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalUnion(qualifier, outputs, regularChildrenOutputs, constantExprsList, hasPushedFilter,
+                groupExpression, logicalProperties, children));
     }
 
     @Override
     public LogicalUnion withNewOutputs(List<NamedExpression> newOutputs) {
-        return new LogicalUnion(qualifier, newOutputs, regularChildrenOutputs, constantExprsList,
-                hasPushedFilter, Optional.empty(), Optional.empty(), children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalUnion(qualifier, newOutputs, regularChildrenOutputs, constantExprsList,
+                hasPushedFilter, Optional.empty(), Optional.empty(), children));
     }
 
     public LogicalUnion withNewOutputsAndConstExprsList(List<NamedExpression> newOutputs,
             List<List<NamedExpression>> constantExprsList) {
-        return new LogicalUnion(qualifier, newOutputs, regularChildrenOutputs, constantExprsList,
-                hasPushedFilter, Optional.empty(), Optional.empty(), children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalUnion(qualifier, newOutputs, regularChildrenOutputs, constantExprsList,
+                hasPushedFilter, Optional.empty(), Optional.empty(), children));
     }
 
     public LogicalUnion withChildrenAndConstExprsList(List<Plan> children,
             List<List<SlotReference>> childrenOutputs, List<List<NamedExpression>> constantExprsList) {
-        return new LogicalUnion(qualifier, outputs, childrenOutputs, constantExprsList, hasPushedFilter, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalUnion(qualifier, outputs, childrenOutputs, constantExprsList, hasPushedFilter, children));
     }
 
     public LogicalUnion withNewOutputsChildrenAndConstExprsList(List<NamedExpression> newOutputs, List<Plan> children,
                                                                 List<List<SlotReference>> childrenOutputs,
                                                                 List<List<NamedExpression>> constantExprsList) {
-        return new LogicalUnion(qualifier, newOutputs, childrenOutputs, constantExprsList,
-                hasPushedFilter, Optional.empty(), Optional.empty(), children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalUnion(qualifier, newOutputs, childrenOutputs, constantExprsList,
+                hasPushedFilter, Optional.empty(), Optional.empty(), children));
     }
 
     public LogicalUnion withAllQualifier() {
-        return new LogicalUnion(Qualifier.ALL, outputs, regularChildrenOutputs, constantExprsList, hasPushedFilter,
-                Optional.empty(), Optional.empty(), children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalUnion(Qualifier.ALL, outputs, regularChildrenOutputs, constantExprsList, hasPushedFilter,
+                Optional.empty(), Optional.empty(), children));
     }
 
     @Override
@@ -430,6 +440,7 @@ public class LogicalUnion extends LogicalSetOperation implements Union, OutputPr
         Preconditions.checkArgument(children.size() == childrenOutputs.size(),
                 "children size %s is not equals with children outputs size %s",
                 children.size(), childrenOutputs.size());
-        return new LogicalUnion(qualifier, newOuptuts, childrenOutputs, constantExprsList, hasPushedFilter, children);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalUnion(qualifier, newOuptuts, childrenOutputs, constantExprsList, hasPushedFilter, children));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalUsingJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalUsingJoin.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.BlockFuncDepsPropagation;
 import org.apache.doris.nereids.trees.plans.DistributeType;
 import org.apache.doris.nereids.trees.plans.JoinType;
@@ -76,21 +77,24 @@ public class LogicalUsingJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE ext
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalUsingJoin<>(joinType, child(0), child(1),
-                usingSlots, matchCondition, groupExpression, Optional.of(getLogicalProperties()), hint);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalUsingJoin<>(joinType, child(0), child(1),
+                usingSlots, matchCondition, groupExpression, Optional.of(getLogicalProperties()), hint));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalUsingJoin<>(joinType, children.get(0), children.get(1),
-                usingSlots, matchCondition, groupExpression, logicalProperties, hint);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalUsingJoin<>(joinType, children.get(0), children.get(1),
+                usingSlots, matchCondition, groupExpression, logicalProperties, hint));
     }
 
     @Override
     public Plan withChildren(List<Plan> children) {
-        return new LogicalUsingJoin<>(joinType, children.get(0), children.get(1),
-                usingSlots, matchCondition, groupExpression, Optional.of(getLogicalProperties()), hint);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalUsingJoin<>(joinType, children.get(0), children.get(1),
+                usingSlots, matchCondition, groupExpression, Optional.of(getLogicalProperties()), hint));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalView.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalView.java
@@ -25,6 +25,7 @@ import org.apache.doris.nereids.properties.DataTrait.Builder;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -78,13 +79,15 @@ public class LogicalView<BODY extends Plan> extends LogicalUnary<BODY> {
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalView<>(view, child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalView<>(view, child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalView<>(view, child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalView<>(view, child()));
     }
 
     @Override
@@ -136,7 +139,8 @@ public class LogicalView<BODY extends Plan> extends LogicalUnary<BODY> {
 
     @Override
     public Plan withChildren(List<Plan> children) {
-        return new LogicalView<>(view, (LogicalPlan) children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalView<>(view, (LogicalPlan) children.get(0)));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalWindow.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalWindow.java
@@ -39,6 +39,7 @@ import org.apache.doris.nereids.trees.expressions.functions.window.DenseRank;
 import org.apache.doris.nereids.trees.expressions.functions.window.Rank;
 import org.apache.doris.nereids.trees.expressions.functions.window.RowNumber;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLikeLiteral;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Window;
@@ -107,18 +108,21 @@ public class LogicalWindow<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
     }
 
     public LogicalWindow<Plan> withExpressionsAndChild(List<NamedExpression> windowExpressions, Plan child) {
-        return new LogicalWindow<>(windowExpressions, isChecked, child);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalWindow<>(windowExpressions, isChecked, child));
     }
 
     public LogicalWindow<Plan> withChecked(List<NamedExpression> windowExpressions, Plan child) {
-        return new LogicalWindow<>(windowExpressions, true, Optional.empty(),
-                Optional.of(getLogicalProperties()), child);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalWindow<>(windowExpressions, true, Optional.empty(),
+                Optional.of(getLogicalProperties()), child));
     }
 
     @Override
     public LogicalUnary<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalWindow<>(windowExpressions, isChecked, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalWindow<>(windowExpressions, isChecked, children.get(0)));
     }
 
     @Override
@@ -128,15 +132,17 @@ public class LogicalWindow<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalWindow<>(windowExpressions, isChecked,
-                groupExpression, Optional.of(getLogicalProperties()), child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalWindow<>(windowExpressions, isChecked,
+                groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalWindow<>(windowExpressions, isChecked, groupExpression, logicalProperties, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalWindow<>(windowExpressions, isChecked, groupExpression, logicalProperties, children.get(0)));
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalWorkTableReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalWorkTableReference.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.CTEId;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.RelationId;
@@ -97,14 +98,17 @@ public class LogicalWorkTableReference extends LogicalRelation {
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalWorkTableReference(relationId, cteId, outputs, nameParts,
-                groupExpression, Optional.ofNullable(getLogicalProperties()));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalWorkTableReference(relationId, cteId, outputs, nameParts,
+                groupExpression, Optional.ofNullable(getLogicalProperties())));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new LogicalWorkTableReference(relationId, cteId, outputs, nameParts, groupExpression, logicalProperties);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalWorkTableReference(relationId, cteId, outputs, nameParts,
+                        groupExpression, logicalProperties));
     }
 
     @Override
@@ -129,8 +133,9 @@ public class LogicalWorkTableReference extends LogicalRelation {
 
     @Override
     public LogicalWorkTableReference withRelationId(RelationId relationId) {
-        return new LogicalWorkTableReference(relationId, cteId, outputs, nameParts,
-                groupExpression, Optional.ofNullable(getLogicalProperties()));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new LogicalWorkTableReference(relationId, cteId, outputs, nameParts,
+                groupExpression, Optional.ofNullable(getLogicalProperties())));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalAssertNumRows.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalAssertNumRows.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.AssertNumRowsElement;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -105,29 +106,33 @@ public class PhysicalAssertNumRows<CHILD_TYPE extends Plan> extends PhysicalUnar
     @Override
     public PhysicalAssertNumRows<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalAssertNumRows<>(assertNumRowsElement, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new PhysicalAssertNumRows<>(assertNumRowsElement, groupExpression,
+                        getLogicalProperties(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
     public PhysicalAssertNumRows<CHILD_TYPE> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalAssertNumRows<>(assertNumRowsElement, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new PhysicalAssertNumRows<>(assertNumRowsElement, groupExpression,
+                        getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalAssertNumRows<>(assertNumRowsElement, groupExpression,
-                logicalProperties.get(), physicalProperties, statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () ->
+                new PhysicalAssertNumRows<>(assertNumRowsElement, groupExpression,
+                        logicalProperties.get(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
     public PhysicalAssertNumRows<CHILD_TYPE> withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalAssertNumRows<>(assertNumRowsElement, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () ->
+                new PhysicalAssertNumRows<>(assertNumRowsElement, groupExpression,
+                        getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalBlackholeSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalBlackholeSink.java
@@ -25,6 +25,7 @@ import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.ComputeResultSet;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -66,8 +67,8 @@ public class PhysicalBlackholeSink<CHILD_TYPE extends Plan> extends PhysicalSink
     public PhysicalBlackholeSink<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1,
                 "PhysicalBlackholeSink's children size must be 1, but real is %s", children.size());
-        return new PhysicalBlackholeSink<>(outputExprs, groupExpression, getLogicalProperties(),
-                physicalProperties, statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalBlackholeSink<>(outputExprs, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
@@ -82,8 +83,8 @@ public class PhysicalBlackholeSink<CHILD_TYPE extends Plan> extends PhysicalSink
 
     @Override
     public PhysicalBlackholeSink<Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalBlackholeSink<>(outputExprs, groupExpression, getLogicalProperties(),
-                physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalBlackholeSink<>(outputExprs, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override
@@ -91,15 +92,15 @@ public class PhysicalBlackholeSink<CHILD_TYPE extends Plan> extends PhysicalSink
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1,
                 "PhysicalBlackholeSink's children size must be 1, but real is %s", children.size());
-        return new PhysicalBlackholeSink<>(outputExprs, groupExpression, logicalProperties.get(),
-                physicalProperties, statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalBlackholeSink<>(outputExprs, groupExpression,
+                logicalProperties.get(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
     public PhysicalBlackholeSink<Plan> withPhysicalPropertiesAndStats(
             PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalBlackholeSink<>(outputExprs, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalBlackholeSink<>(outputExprs, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalCTEAnchor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalCTEAnchor.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.CTEId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
@@ -104,28 +105,29 @@ public class PhysicalCTEAnchor<
     @Override
     public PhysicalCTEAnchor<Plan, Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new PhysicalCTEAnchor<>(cteId, groupExpression, getLogicalProperties(), physicalProperties,
-                statistics, children.get(0), children.get(1));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalCTEAnchor<>(cteId, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, children.get(0), children.get(1)));
     }
 
     @Override
     public PhysicalCTEAnchor<Plan, Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalCTEAnchor<>(cteId, groupExpression, getLogicalProperties(), child(0), child(1));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalCTEAnchor<>(cteId, groupExpression,
+                getLogicalProperties(), child(0), child(1)));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new PhysicalCTEAnchor<>(cteId, groupExpression, logicalProperties.get(), children.get(0),
-                children.get(1));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalCTEAnchor<>(cteId, groupExpression,
+                logicalProperties.get(), children.get(0), children.get(1)));
     }
 
     @Override
     public PhysicalCTEAnchor<Plan, Plan> withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalCTEAnchor<>(cteId, groupExpression, getLogicalProperties(), physicalProperties,
-                statistics, child(0), child(1));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalCTEAnchor<>(cteId, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, child(0), child(1)));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalCTEConsumer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalCTEConsumer.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.CTEId;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.BlockFuncDepsPropagation;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -115,25 +116,25 @@ public class PhysicalCTEConsumer extends PhysicalRelation implements BlockFuncDe
 
     @Override
     public PhysicalCTEConsumer withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalCTEConsumer(relationId, cteId,
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalCTEConsumer(relationId, cteId,
                 consumerToProducerSlotMap, producerToConsumerSlotMap,
-                groupExpression, getLogicalProperties());
+                groupExpression, getLogicalProperties()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalCTEConsumer(relationId, cteId,
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalCTEConsumer(relationId, cteId,
                 consumerToProducerSlotMap, producerToConsumerSlotMap,
-                groupExpression, logicalProperties.get());
+                groupExpression, logicalProperties.get()));
     }
 
     @Override
     public PhysicalCTEConsumer withPhysicalPropertiesAndStats(
             PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalCTEConsumer(relationId, cteId,
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalCTEConsumer(relationId, cteId,
                 consumerToProducerSlotMap, producerToConsumerSlotMap,
-                groupExpression, getLogicalProperties(), physicalProperties, statistics);
+                groupExpression, getLogicalProperties(), physicalProperties, statistics));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalCTEProducer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalCTEProducer.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.CTEId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
@@ -103,26 +104,28 @@ public class PhysicalCTEProducer<CHILD_TYPE extends Plan> extends PhysicalUnary<
     @Override
     public PhysicalCTEProducer<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalCTEProducer<>(cteId, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalCTEProducer<>(cteId, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
     public PhysicalCTEProducer<CHILD_TYPE> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalCTEProducer<>(cteId, groupExpression, getLogicalProperties(), child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalCTEProducer<>(cteId, groupExpression,
+                getLogicalProperties(), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalCTEProducer<>(cteId, groupExpression, logicalProperties.get(), children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalCTEProducer<>(cteId, groupExpression,
+                logicalProperties.get(), children.get(0)));
     }
 
     @Override
     public PhysicalCTEProducer<CHILD_TYPE> withPhysicalPropertiesAndStats(
             PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalCTEProducer<>(cteId, groupExpression, getLogicalProperties(), physicalProperties,
-            statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalCTEProducer<>(cteId, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDeferMaterializeOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDeferMaterializeOlapScan.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.algebra.OlapScan;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -110,21 +111,24 @@ public class PhysicalDeferMaterializeOlapScan extends PhysicalCatalogRelation im
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalDeferMaterializeOlapScan(physicalOlapScan, deferMaterializeSlotIds, columnIdSlot,
-                groupExpression, getLogicalProperties(), physicalProperties, statistics);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalDeferMaterializeOlapScan(physicalOlapScan,
+                deferMaterializeSlotIds, columnIdSlot, groupExpression, getLogicalProperties(),
+                physicalProperties, statistics));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalDeferMaterializeOlapScan(physicalOlapScan, deferMaterializeSlotIds, columnIdSlot,
-                groupExpression, logicalProperties.get(), physicalProperties, statistics);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalDeferMaterializeOlapScan(physicalOlapScan,
+                deferMaterializeSlotIds, columnIdSlot, groupExpression, logicalProperties.get(),
+                physicalProperties, statistics));
     }
 
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalDeferMaterializeOlapScan(physicalOlapScan, deferMaterializeSlotIds, columnIdSlot,
-                groupExpression, getLogicalProperties(), physicalProperties, statistics);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalDeferMaterializeOlapScan(physicalOlapScan,
+                deferMaterializeSlotIds, columnIdSlot, groupExpression, getLogicalProperties(),
+                physicalProperties, statistics));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDeferMaterializeResultSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDeferMaterializeResultSink.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.algebra.Sink;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -82,10 +83,10 @@ public class PhysicalDeferMaterializeResultSink<CHILD_TYPE extends Plan>
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1,
                 "PhysicalDeferMaterializeResultSink's children size must be 1, but real is %s", children.size());
-        return new PhysicalDeferMaterializeResultSink<>(
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalDeferMaterializeResultSink<>(
                 physicalResultSink.withChildren(ImmutableList.of(children.get(0))),
                 olapTable, selectedIndexId, groupExpression, getLogicalProperties(),
-                physicalProperties, statistics, children.get(0));
+                physicalProperties, statistics, children.get(0)));
     }
 
     @Override
@@ -100,8 +101,9 @@ public class PhysicalDeferMaterializeResultSink<CHILD_TYPE extends Plan>
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalDeferMaterializeResultSink<>(physicalResultSink, olapTable, selectedIndexId,
-                groupExpression, getLogicalProperties(), physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalDeferMaterializeResultSink<>(physicalResultSink,
+                olapTable, selectedIndexId, groupExpression, getLogicalProperties(),
+                physicalProperties, statistics, child()));
     }
 
     @Override
@@ -109,16 +111,17 @@ public class PhysicalDeferMaterializeResultSink<CHILD_TYPE extends Plan>
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1,
                 "PhysicalDeferMaterializeResultSink's children size must be 1, but real is %s", children.size());
-        return new PhysicalDeferMaterializeResultSink<>(
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalDeferMaterializeResultSink<>(
                 physicalResultSink.withChildren(ImmutableList.of(children.get(0))),
                 olapTable, selectedIndexId, groupExpression, logicalProperties.get(),
-                physicalProperties, statistics, children.get(0));
+                physicalProperties, statistics, children.get(0)));
     }
 
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalDeferMaterializeResultSink<>(physicalResultSink, olapTable, selectedIndexId,
-                groupExpression, getLogicalProperties(), physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalDeferMaterializeResultSink<>(physicalResultSink,
+                olapTable, selectedIndexId, groupExpression, getLogicalProperties(),
+                physicalProperties, statistics, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDeferMaterializeTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDeferMaterializeTopN.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.algebra.TopN;
@@ -94,17 +95,19 @@ public class PhysicalDeferMaterializeTopN<CHILD_TYPE extends Plan>
     }
 
     public PhysicalDeferMaterializeTopN<? extends Plan> withPhysicalTopN(PhysicalTopN<? extends Plan> physicalTopN) {
-        return new PhysicalDeferMaterializeTopN<>(physicalTopN, deferMaterializeSlotIds, columnIdSlot, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, physicalTopN.child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalDeferMaterializeTopN<>(physicalTopN,
+                deferMaterializeSlotIds, columnIdSlot, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, physicalTopN.child()));
     }
 
     @Override
     public PhysicalDeferMaterializeTopN<? extends Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1,
                 "PhysicalDeferMaterializeTopN's children size must be 1, but real is %s", children.size());
-        return new PhysicalDeferMaterializeTopN<>(physicalTopN.withChildren(ImmutableList.of(children.get(0))),
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalDeferMaterializeTopN<>(
+                physicalTopN.withChildren(ImmutableList.of(children.get(0))),
                 deferMaterializeSlotIds, columnIdSlot, groupExpression, getLogicalProperties(),
-                physicalProperties, statistics, children.get(0));
+                physicalProperties, statistics, children.get(0)));
     }
 
     @Override
@@ -114,8 +117,9 @@ public class PhysicalDeferMaterializeTopN<CHILD_TYPE extends Plan>
 
     @Override
     public PhysicalDeferMaterializeTopN<? extends Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalDeferMaterializeTopN<>(physicalTopN, deferMaterializeSlotIds, columnIdSlot,
-                groupExpression, getLogicalProperties(), physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalDeferMaterializeTopN<>(physicalTopN,
+                deferMaterializeSlotIds, columnIdSlot, groupExpression, getLogicalProperties(),
+                physicalProperties, statistics, child()));
     }
 
     @Override
@@ -124,16 +128,18 @@ public class PhysicalDeferMaterializeTopN<CHILD_TYPE extends Plan>
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1,
                 "PhysicalDeferMaterializeTopN's children size must be 1, but real is %s", children.size());
-        return new PhysicalDeferMaterializeTopN<>(physicalTopN.withChildren(ImmutableList.of(children.get(0))),
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalDeferMaterializeTopN<>(
+                physicalTopN.withChildren(ImmutableList.of(children.get(0))),
                 deferMaterializeSlotIds, columnIdSlot, groupExpression, logicalProperties.get(),
-                physicalProperties, statistics, children.get(0));
+                physicalProperties, statistics, children.get(0)));
     }
 
     @Override
     public PhysicalDeferMaterializeTopN<? extends Plan> withPhysicalPropertiesAndStats(
             PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalDeferMaterializeTopN<>(physicalTopN, deferMaterializeSlotIds, columnIdSlot,
-                groupExpression, getLogicalProperties(), physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalDeferMaterializeTopN<>(physicalTopN,
+                deferMaterializeSlotIds, columnIdSlot, groupExpression, getLogicalProperties(),
+                physicalProperties, statistics, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDictionarySink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDictionarySink.java
@@ -27,6 +27,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Sink;
@@ -101,27 +102,31 @@ public class PhysicalDictionarySink<CHILD_TYPE extends Plan> extends PhysicalTab
 
     @Override
     public Plan withChildren(List<Plan> children) {
-        return new PhysicalDictionarySink<>(database, dictionary, allowAdaptiveLoad, cols, outputExprs, groupExpression,
-                getLogicalProperties(), statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalDictionarySink<>(database, dictionary,
+                allowAdaptiveLoad, cols, outputExprs, groupExpression,
+                getLogicalProperties(), statistics, children.get(0)));
     }
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalDictionarySink<>(database, dictionary, allowAdaptiveLoad, cols, outputExprs, groupExpression,
-                getLogicalProperties(), statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalDictionarySink<>(database, dictionary,
+                allowAdaptiveLoad, cols, outputExprs, groupExpression,
+                getLogicalProperties(), statistics, child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalDictionarySink<>(database, dictionary, allowAdaptiveLoad, cols, outputExprs, groupExpression,
-                logicalProperties.get(), statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalDictionarySink<>(database, dictionary,
+                allowAdaptiveLoad, cols, outputExprs, groupExpression,
+                logicalProperties.get(), statistics, children.get(0)));
     }
 
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalDictionarySink<>(database, dictionary, allowAdaptiveLoad, cols, outputExprs, groupExpression,
-                getLogicalProperties(), statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalDictionarySink<>(database, dictionary,
+                allowAdaptiveLoad, cols, outputExprs, groupExpression,
+                getLogicalProperties(), statistics, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDistribute.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDistribute.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
@@ -98,29 +99,29 @@ public class PhysicalDistribute<CHILD_TYPE extends Plan> extends PhysicalUnary<C
     @Override
     public PhysicalDistribute<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalDistribute<>(distributionSpec, Optional.empty(),
-                getLogicalProperties(), physicalProperties, statistics, children.get(0));
-
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalDistribute<>(distributionSpec, Optional.empty(),
+                getLogicalProperties(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
     public PhysicalDistribute<CHILD_TYPE> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalDistribute<>(distributionSpec, groupExpression, getLogicalProperties(), child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalDistribute<>(distributionSpec, groupExpression,
+                getLogicalProperties(), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalDistribute<>(distributionSpec, groupExpression,
-                logicalProperties.get(), children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalDistribute<>(distributionSpec, groupExpression,
+                logicalProperties.get(), children.get(0)));
     }
 
     @Override
     public PhysicalDistribute<CHILD_TYPE> withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalDistribute<>(distributionSpec, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalDistribute<>(distributionSpec, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalEmptyRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalEmptyRelation.java
@@ -27,6 +27,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.BlockFuncDepsPropagation;
 import org.apache.doris.nereids.trees.plans.ComputeResultSet;
 import org.apache.doris.nereids.trees.plans.Plan;
@@ -79,15 +80,15 @@ public class PhysicalEmptyRelation extends PhysicalRelation
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalEmptyRelation(relationId, projects, groupExpression,
-                logicalPropertiesSupplier.get(), physicalProperties, statistics);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalEmptyRelation(relationId, projects, groupExpression,
+                logicalPropertiesSupplier.get(), physicalProperties, statistics));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalEmptyRelation(relationId, projects, groupExpression,
-                logicalProperties.get(), physicalProperties, statistics);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalEmptyRelation(relationId, projects, groupExpression,
+                logicalProperties.get(), physicalProperties, statistics));
     }
 
     @Override
@@ -112,8 +113,8 @@ public class PhysicalEmptyRelation extends PhysicalRelation
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalEmptyRelation(relationId, projects, Optional.empty(),
-                logicalPropertiesSupplier.get(), physicalProperties, statistics);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalEmptyRelation(relationId, projects, Optional.empty(),
+                logicalPropertiesSupplier.get(), physicalProperties, statistics));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalEsScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalEsScan.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.DistributionSpec;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.RelationId;
@@ -89,21 +90,22 @@ public class PhysicalEsScan extends PhysicalCatalogRelation {
 
     @Override
     public PhysicalEsScan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalEsScan(relationId, getTable(), qualifier, distributionSpec,
-                groupExpression, getLogicalProperties(), null, null, tableAlias);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalEsScan(relationId, getTable(), qualifier,
+                distributionSpec, groupExpression, getLogicalProperties(), null, null, tableAlias));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalEsScan(relationId, getTable(), qualifier, distributionSpec,
-                groupExpression, logicalProperties.get(), null, null, tableAlias);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalEsScan(relationId, getTable(), qualifier,
+                distributionSpec, groupExpression, logicalProperties.get(), null, null, tableAlias));
     }
 
     @Override
     public PhysicalEsScan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statsDeriveResult) {
-        return new PhysicalEsScan(relationId, getTable(), qualifier, distributionSpec,
-                groupExpression, getLogicalProperties(), physicalProperties, statsDeriveResult, tableAlias);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalEsScan(relationId, getTable(), qualifier,
+                distributionSpec, groupExpression, getLogicalProperties(), physicalProperties, statsDeriveResult,
+                tableAlias));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalExcept.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalExcept.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Except;
@@ -87,28 +88,29 @@ public class PhysicalExcept extends PhysicalSetOperation implements Except {
 
     @Override
     public PhysicalExcept withChildren(List<Plan> children) {
-        return new PhysicalExcept(qualifier, outputs, regularChildrenOutputs, getLogicalProperties(), children);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalExcept(qualifier, outputs,
+                regularChildrenOutputs, getLogicalProperties(), children));
     }
 
     @Override
     public PhysicalExcept withGroupExpression(
             Optional<GroupExpression> groupExpression) {
-        return new PhysicalExcept(qualifier, outputs, regularChildrenOutputs,
-                groupExpression, getLogicalProperties(), children);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalExcept(qualifier, outputs, regularChildrenOutputs,
+                groupExpression, getLogicalProperties(), children));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalExcept(qualifier, outputs, regularChildrenOutputs,
-                groupExpression, logicalProperties.get(), children);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalExcept(qualifier, outputs, regularChildrenOutputs,
+                groupExpression, logicalProperties.get(), children));
     }
 
     @Override
     public PhysicalExcept withPhysicalPropertiesAndStats(
             PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalExcept(qualifier, outputs, regularChildrenOutputs, Optional.empty(),
-                getLogicalProperties(), physicalProperties, statistics, children);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalExcept(qualifier, outputs, regularChildrenOutputs,
+                Optional.empty(), getLogicalProperties(), physicalProperties, statistics, children));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFileScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFileScan.java
@@ -26,6 +26,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.TableSample;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.RelationId;
@@ -152,17 +153,17 @@ public class PhysicalFileScan extends PhysicalCatalogRelation {
 
     @Override
     public PhysicalFileScan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalFileScan(relationId, getTable(), qualifier, distributionSpec,
-                groupExpression, getLogicalProperties(), selectedPartitions, tableSample, tableSnapshot,
-                operativeSlots, scanParams);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalFileScan(relationId, getTable(), qualifier,
+                distributionSpec, groupExpression, getLogicalProperties(), selectedPartitions, tableSample,
+                tableSnapshot, operativeSlots, scanParams));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalFileScan(relationId, getTable(), qualifier, distributionSpec,
-                groupExpression, logicalProperties.get(), selectedPartitions, tableSample, tableSnapshot,
-                operativeSlots, scanParams);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalFileScan(relationId, getTable(), qualifier,
+                distributionSpec, groupExpression, logicalProperties.get(), selectedPartitions, tableSample,
+                tableSnapshot, operativeSlots, scanParams));
     }
 
     @Override
@@ -173,10 +174,9 @@ public class PhysicalFileScan extends PhysicalCatalogRelation {
     @Override
     public PhysicalFileScan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
                                                        Statistics statistics) {
-        return new PhysicalFileScan(relationId, getTable(), qualifier, distributionSpec,
-                groupExpression, getLogicalProperties(), physicalProperties, statistics,
-                selectedPartitions, tableSample, tableSnapshot,
-                operativeSlots, scanParams);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalFileScan(relationId, getTable(), qualifier,
+                distributionSpec, groupExpression, getLogicalProperties(), physicalProperties, statistics,
+                selectedPartitions, tableSample, tableSnapshot, operativeSlots, scanParams));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFileSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFileSink.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Sink;
@@ -95,8 +96,8 @@ public class PhysicalFileSink<CHILD_TYPE extends Plan> extends PhysicalSink<CHIL
     @Override
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1, "PhysicalFileSink only accepts one child");
-        return new PhysicalFileSink<>(outputExprs, filePath, format, properties,
-                getLogicalProperties(), children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalFileSink<>(outputExprs, filePath, format,
+                properties, getLogicalProperties(), children.get(0)));
     }
 
     @Override
@@ -139,21 +140,21 @@ public class PhysicalFileSink<CHILD_TYPE extends Plan> extends PhysicalSink<CHIL
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalFileSink<>(outputExprs, filePath, format, properties,
-                groupExpression, getLogicalProperties(), child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalFileSink<>(outputExprs, filePath, format,
+                properties, groupExpression, getLogicalProperties(), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalFileSink<>(outputExprs, filePath, format, properties,
-                groupExpression, logicalProperties.get(), children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalFileSink<>(outputExprs, filePath, format,
+                properties, groupExpression, logicalProperties.get(), children.get(0)));
     }
 
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalFileSink<>(outputExprs, filePath, format, properties, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalFileSink<>(outputExprs, filePath, format,
+                properties, groupExpression, getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFilter.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Filter;
@@ -117,32 +118,34 @@ public class PhysicalFilter<CHILD_TYPE extends Plan> extends PhysicalUnary<CHILD
     @Override
     public PhysicalFilter<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalFilter<>(conjuncts, groupExpression, getLogicalProperties(), physicalProperties,
-                statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalFilter<>(conjuncts, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
     public PhysicalFilter<CHILD_TYPE> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalFilter<>(conjuncts, groupExpression, getLogicalProperties(), child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalFilter<>(conjuncts, groupExpression,
+                getLogicalProperties(), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalFilter<>(conjuncts, groupExpression, logicalProperties.get(), children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalFilter<>(conjuncts, groupExpression,
+                logicalProperties.get(), children.get(0)));
     }
 
     @Override
     public PhysicalFilter<CHILD_TYPE> withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalFilter<>(conjuncts, groupExpression, getLogicalProperties(), physicalProperties,
-                statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalFilter<>(conjuncts, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     public PhysicalFilter<Plan> withConjunctsAndChild(Set<Expression> conjuncts, Plan child) {
-        return new PhysicalFilter<>(conjuncts, groupExpression, getLogicalProperties(), physicalProperties,
-                statistics, child);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalFilter<>(conjuncts, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, child));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalGenerate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalGenerate.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.functions.Function;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Generate;
@@ -124,30 +125,29 @@ public class PhysicalGenerate<CHILD_TYPE extends Plan> extends PhysicalUnary<CHI
     @Override
     public PhysicalGenerate<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalGenerate<>(generators, generatorOutput, conjuncts, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalGenerate<>(generators, generatorOutput, conjuncts,
+                groupExpression, getLogicalProperties(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
     public PhysicalGenerate<CHILD_TYPE> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalGenerate<>(generators, generatorOutput, conjuncts,
-                groupExpression, getLogicalProperties(), PhysicalProperties.ANY, null, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalGenerate<>(generators, generatorOutput, conjuncts,
+                groupExpression, getLogicalProperties(), PhysicalProperties.ANY, null, child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalGenerate<>(generators, generatorOutput, conjuncts,
-                groupExpression, logicalProperties.get(), PhysicalProperties.ANY, null, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalGenerate<>(generators, generatorOutput, conjuncts,
+                groupExpression, logicalProperties.get(), PhysicalProperties.ANY, null, children.get(0)));
     }
 
     @Override
     public PhysicalGenerate<CHILD_TYPE> withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalGenerate<>(generators, generatorOutput, conjuncts,
-                Optional.empty(), getLogicalProperties(), physicalProperties,
-                statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalGenerate<>(generators, generatorOutput, conjuncts,
+                Optional.empty(), getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashAggregate.java
@@ -32,6 +32,7 @@ import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateParam;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Count;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Ndv;
 import org.apache.doris.nereids.trees.expressions.functions.agg.NullableAggregateFunction;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.AggMode;
 import org.apache.doris.nereids.trees.plans.AggPhase;
 import org.apache.doris.nereids.trees.plans.Plan;
@@ -252,38 +253,40 @@ public class PhysicalHashAggregate<CHILD_TYPE extends Plan> extends PhysicalUnar
     @Override
     public PhysicalHashAggregate<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalHashAggregate<>(groupByExpressions, outputExpressions, partitionExpressions,
-                aggregateParam, maybeUsingStream, groupExpression, getLogicalProperties(),
-                physicalProperties, statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalHashAggregate<>(groupByExpressions,
+                outputExpressions, partitionExpressions, aggregateParam, maybeUsingStream, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
     public PhysicalHashAggregate<CHILD_TYPE> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalHashAggregate<>(groupByExpressions, outputExpressions, partitionExpressions,
-                aggregateParam, maybeUsingStream, groupExpression, getLogicalProperties(), child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalHashAggregate<>(groupByExpressions,
+                outputExpressions, partitionExpressions, aggregateParam, maybeUsingStream, groupExpression,
+                getLogicalProperties(), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalHashAggregate<>(groupByExpressions, outputExpressions, partitionExpressions,
-                aggregateParam, maybeUsingStream, groupExpression, logicalProperties.get(), children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalHashAggregate<>(groupByExpressions,
+                outputExpressions, partitionExpressions, aggregateParam, maybeUsingStream, groupExpression,
+                logicalProperties.get(), children.get(0)));
     }
 
     @Override
     public PhysicalHashAggregate<CHILD_TYPE> withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalHashAggregate<>(groupByExpressions, outputExpressions, partitionExpressions,
-                aggregateParam, maybeUsingStream, groupExpression, getLogicalProperties(),
-                physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalHashAggregate<>(groupByExpressions,
+                outputExpressions, partitionExpressions, aggregateParam, maybeUsingStream, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override
     public PhysicalHashAggregate<CHILD_TYPE> withAggOutput(List<NamedExpression> newOutput) {
-        return new PhysicalHashAggregate<>(groupByExpressions, newOutput, partitionExpressions,
-                aggregateParam, maybeUsingStream, Optional.empty(), getLogicalProperties(),
-                physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalHashAggregate<>(groupByExpressions, newOutput,
+                partitionExpressions, aggregateParam, maybeUsingStream, Optional.empty(), getLogicalProperties(),
+                physicalProperties, statistics, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
@@ -28,6 +28,7 @@ import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.MarkJoinSlotReference;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -173,25 +174,25 @@ public class PhysicalHashJoin<
     @Override
     public PhysicalHashJoin<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> withGroupExpression(
             Optional<GroupExpression> groupExpression) {
-        return new PhysicalHashJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts,
-                markJoinConjuncts, hint, markJoinSlotReference, groupExpression,
-                getLogicalProperties(), null, null, left(), right());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalHashJoin<>(joinType, hashJoinConjuncts,
+                otherJoinConjuncts, markJoinConjuncts, hint, markJoinSlotReference, groupExpression,
+                getLogicalProperties(), null, null, left(), right()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new PhysicalHashJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts,
-                markJoinConjuncts, hint, markJoinSlotReference, groupExpression,
-                logicalProperties.get(), null, null, children.get(0), children.get(1));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalHashJoin<>(joinType, hashJoinConjuncts,
+                otherJoinConjuncts, markJoinConjuncts, hint, markJoinSlotReference, groupExpression,
+                logicalProperties.get(), null, null, children.get(0), children.get(1)));
     }
 
     public PhysicalHashJoin<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> withPhysicalPropertiesAndStats(
             PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalHashJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts,
-                markJoinConjuncts, hint, markJoinSlotReference, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, left(), right());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalHashJoin<>(joinType, hashJoinConjuncts,
+                otherJoinConjuncts, markJoinConjuncts, hint, markJoinSlotReference, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, left(), right()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
@@ -161,10 +161,10 @@ public class PhysicalHashJoin<
     @Override
     public PhysicalHashJoin<Plan, Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 2);
-        PhysicalHashJoin newJoin = new PhysicalHashJoin<>(joinType, hashJoinConjuncts,
-                otherJoinConjuncts, markJoinConjuncts, hint, markJoinSlotReference,
+        PhysicalHashJoin newJoin = AbstractPlan.copyWithSameId(this, () -> new PhysicalHashJoin<>(joinType,
+                hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts, hint, markJoinSlotReference,
                 Optional.empty(), getLogicalProperties(), physicalProperties, statistics,
-                children.get(0), children.get(1));
+                children.get(0), children.get(1)));
         if (groupExpression.isPresent()) {
             newJoin.setMutableState(MutableState.KEY_GROUP, groupExpression.get().getOwnerGroup().getGroupId().asInt());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHiveTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHiveTableSink.java
@@ -26,6 +26,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -72,9 +73,9 @@ public class PhysicalHiveTableSink<CHILD_TYPE extends Plan> extends PhysicalBase
 
     @Override
     public Plan withChildren(List<Plan> children) {
-        return new PhysicalHiveTableSink<>(
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalHiveTableSink<>(
                 (HMSExternalDatabase) database, (HMSExternalTable) targetTable, cols, outputExprs, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, children.get(0));
+                getLogicalProperties(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
@@ -84,24 +85,24 @@ public class PhysicalHiveTableSink<CHILD_TYPE extends Plan> extends PhysicalBase
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalHiveTableSink<>(
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalHiveTableSink<>(
                 (HMSExternalDatabase) database, (HMSExternalTable) targetTable, cols, outputExprs,
-                groupExpression, getLogicalProperties(), child());
+                groupExpression, getLogicalProperties(), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
                                                  Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalHiveTableSink<>(
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalHiveTableSink<>(
                 (HMSExternalDatabase) database, (HMSExternalTable) targetTable, cols, outputExprs,
-                groupExpression, logicalProperties.get(), children.get(0));
+                groupExpression, logicalProperties.get(), children.get(0)));
     }
 
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalHiveTableSink<>(
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalHiveTableSink<>(
                 (HMSExternalDatabase) database, (HMSExternalTable) targetTable, cols, outputExprs,
-                groupExpression, getLogicalProperties(), physicalProperties, statistics, child());
+                groupExpression, getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHudiScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHudiScan.java
@@ -27,6 +27,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.TableSample;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.RelationId;
@@ -91,26 +92,25 @@ public class PhysicalHudiScan extends PhysicalFileScan {
 
     @Override
     public PhysicalHudiScan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalHudiScan(relationId, getTable(), qualifier, distributionSpec,
-                groupExpression, getLogicalProperties(), selectedPartitions, tableSample, tableSnapshot,
-                scanParams, incrementalRelation, operativeSlots);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalHudiScan(relationId, getTable(), qualifier,
+                distributionSpec, groupExpression, getLogicalProperties(), selectedPartitions, tableSample,
+                tableSnapshot, scanParams, incrementalRelation, operativeSlots));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalHudiScan(relationId, getTable(), qualifier, distributionSpec,
-                groupExpression, logicalProperties.get(), selectedPartitions, tableSample, tableSnapshot,
-                scanParams, incrementalRelation, operativeSlots);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalHudiScan(relationId, getTable(), qualifier,
+                distributionSpec, groupExpression, logicalProperties.get(), selectedPartitions, tableSample,
+                tableSnapshot, scanParams, incrementalRelation, operativeSlots));
     }
 
     @Override
     public PhysicalHudiScan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalHudiScan(relationId, getTable(), qualifier, distributionSpec,
-                groupExpression, getLogicalProperties(), physicalProperties, statistics,
-                selectedPartitions, tableSample, tableSnapshot,
-                scanParams, incrementalRelation, operativeSlots);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalHudiScan(relationId, getTable(), qualifier,
+                distributionSpec, groupExpression, getLogicalProperties(), physicalProperties, statistics,
+                selectedPartitions, tableSample, tableSnapshot, scanParams, incrementalRelation, operativeSlots));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalIcebergTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalIcebergTableSink.java
@@ -26,6 +26,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -73,10 +74,10 @@ public class PhysicalIcebergTableSink<CHILD_TYPE extends Plan> extends PhysicalB
 
     @Override
     public Plan withChildren(List<Plan> children) {
-        return new PhysicalIcebergTableSink<>(
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalIcebergTableSink<>(
                 (IcebergExternalDatabase) database, (IcebergExternalTable) targetTable,
                 cols, outputExprs, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, children.get(0));
+                getLogicalProperties(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
@@ -86,24 +87,24 @@ public class PhysicalIcebergTableSink<CHILD_TYPE extends Plan> extends PhysicalB
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalIcebergTableSink<>(
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalIcebergTableSink<>(
                 (IcebergExternalDatabase) database, (IcebergExternalTable) targetTable, cols, outputExprs,
-                groupExpression, getLogicalProperties(), child());
+                groupExpression, getLogicalProperties(), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
                                                  Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalIcebergTableSink<>(
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalIcebergTableSink<>(
                 (IcebergExternalDatabase) database, (IcebergExternalTable) targetTable, cols, outputExprs,
-                groupExpression, logicalProperties.get(), children.get(0));
+                groupExpression, logicalProperties.get(), children.get(0)));
     }
 
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalIcebergTableSink<>(
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalIcebergTableSink<>(
                 (IcebergExternalDatabase) database, (IcebergExternalTable) targetTable, cols, outputExprs,
-                groupExpression, getLogicalProperties(), physicalProperties, statistics, child());
+                groupExpression, getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalIntersect.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalIntersect.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Intersect;
@@ -88,28 +89,30 @@ public class PhysicalIntersect extends PhysicalSetOperation implements Intersect
 
     @Override
     public PhysicalIntersect withChildren(List<Plan> children) {
-        return new PhysicalIntersect(qualifier, outputs, regularChildrenOutputs, getLogicalProperties(), children);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalIntersect(qualifier, outputs,
+                regularChildrenOutputs, getLogicalProperties(), children));
     }
 
     @Override
     public PhysicalIntersect withGroupExpression(
             Optional<GroupExpression> groupExpression) {
-        return new PhysicalIntersect(qualifier, outputs, regularChildrenOutputs,
-                groupExpression, getLogicalProperties(), children);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalIntersect(qualifier, outputs,
+                regularChildrenOutputs, groupExpression, getLogicalProperties(), children));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalIntersect(qualifier, outputs, regularChildrenOutputs,
-                groupExpression, logicalProperties.get(), children);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalIntersect(qualifier, outputs,
+                regularChildrenOutputs, groupExpression, logicalProperties.get(), children));
     }
 
     @Override
     public PhysicalIntersect withPhysicalPropertiesAndStats(
             PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalIntersect(qualifier, outputs, regularChildrenOutputs,
-                Optional.empty(), getLogicalProperties(), physicalProperties, statistics, children);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalIntersect(qualifier, outputs,
+                regularChildrenOutputs, Optional.empty(), getLogicalProperties(), physicalProperties,
+                statistics, children));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalJdbcScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalJdbcScan.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.RelationId;
@@ -92,21 +93,21 @@ public class PhysicalJdbcScan extends PhysicalCatalogRelation {
 
     @Override
     public PhysicalJdbcScan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalJdbcScan(relationId, table, qualifier, groupExpression, getLogicalProperties(),
-                null, null, operativeSlots, tableAlias);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalJdbcScan(relationId, table, qualifier,
+                groupExpression, getLogicalProperties(), null, null, operativeSlots, tableAlias));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalJdbcScan(relationId, table, qualifier, groupExpression, logicalProperties.get(),
-                null, null, operativeSlots, tableAlias);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalJdbcScan(relationId, table, qualifier,
+                groupExpression, logicalProperties.get(), null, null, operativeSlots, tableAlias));
     }
 
     @Override
     public PhysicalJdbcScan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalJdbcScan(relationId, table, qualifier, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, operativeSlots, tableAlias);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalJdbcScan(relationId, table, qualifier,
+                groupExpression, getLogicalProperties(), physicalProperties, statistics, operativeSlots, tableAlias));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalJdbcTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalJdbcTableSink.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -67,10 +68,10 @@ public class PhysicalJdbcTableSink<CHILD_TYPE extends Plan> extends PhysicalBase
 
     @Override
     public Plan withChildren(List<Plan> children) {
-        return new PhysicalJdbcTableSink<>(
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalJdbcTableSink<>(
                 (JdbcExternalDatabase) database, (JdbcExternalTable) targetTable,
                 cols, outputExprs, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, children.get(0));
+                getLogicalProperties(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
@@ -80,24 +81,24 @@ public class PhysicalJdbcTableSink<CHILD_TYPE extends Plan> extends PhysicalBase
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalJdbcTableSink<>(
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalJdbcTableSink<>(
                 (JdbcExternalDatabase) database, (JdbcExternalTable) targetTable, cols, outputExprs,
-                groupExpression, getLogicalProperties(), child());
+                groupExpression, getLogicalProperties(), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalJdbcTableSink<>(
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalJdbcTableSink<>(
                 (JdbcExternalDatabase) database, (JdbcExternalTable) targetTable, cols, outputExprs,
-                groupExpression, logicalProperties.get(), children.get(0));
+                groupExpression, logicalProperties.get(), children.get(0)));
     }
 
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalJdbcTableSink<>(
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalJdbcTableSink<>(
                 (JdbcExternalDatabase) database, (JdbcExternalTable) targetTable, cols, outputExprs,
-                groupExpression, getLogicalProperties(), physicalProperties, statistics, child());
+                groupExpression, getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalLazyMaterialize.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalLazyMaterialize.java
@@ -28,6 +28,7 @@ import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.CatalogRelation;
@@ -191,9 +192,9 @@ public class PhysicalLazyMaterialize<CHILD_TYPE extends Plan> extends PhysicalUn
 
     @Override
     public Plan withChildren(List<Plan> children) {
-        return new PhysicalLazyMaterialize<>(children.get(0),
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalLazyMaterialize<>(children.get(0),
                 materializeInput, materializedSlots, relationToLazySlotMap,
-                relationToRowId, materializeMap, null, null);
+                relationToRowId, materializeMap, null, null));
     }
 
     @Override
@@ -210,8 +211,9 @@ public class PhysicalLazyMaterialize<CHILD_TYPE extends Plan> extends PhysicalUn
 
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalLazyMaterialize(children.get(0), materializeInput, materializedSlots, relationToLazySlotMap,
-                relationToRowId, materializeMap, physicalProperties, statistics);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalLazyMaterialize(children.get(0),
+                materializeInput, materializedSlots, relationToLazySlotMap,
+                relationToRowId, materializeMap, physicalProperties, statistics));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalLazyMaterializeOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalLazyMaterializeOlapScan.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.plans.physical;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.statistics.Statistics;
@@ -114,7 +115,7 @@ public class PhysicalLazyMaterializeOlapScan extends PhysicalOlapScan {
     @Override
     public PhysicalLazyMaterializeOlapScan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalLazyMaterializeOlapScan(scan, rowId, lazySlots);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalLazyMaterializeOlapScan(scan, rowId, lazySlots));
     }
 
     public SlotReference getRowId() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalLazyMaterializeTVFScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalLazyMaterializeTVFScan.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.statistics.Statistics;
@@ -88,14 +89,16 @@ public class PhysicalLazyMaterializeTVFScan extends PhysicalTVFRelation {
             Statistics statistics) {
         PhysicalTVFRelation tvfRelation = new PhysicalTVFRelation(relationId, function, operativeSlots,
                 Optional.empty(), getLogicalProperties(), physicalProperties, statistics);
-        return new PhysicalLazyMaterializeTVFScan(tvfRelation, rowId, lazySlots);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new PhysicalLazyMaterializeTVFScan(tvfRelation, rowId, lazySlots));
     }
 
     @Override
     public PhysicalLazyMaterializeTVFScan withGroupExpression(Optional<GroupExpression> groupExpression) {
         PhysicalTVFRelation tvfRelation = new PhysicalTVFRelation(relationId, function, operativeSlots,
                 groupExpression, getLogicalProperties(), physicalProperties, statistics);
-        return new PhysicalLazyMaterializeTVFScan(tvfRelation, rowId, lazySlots);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new PhysicalLazyMaterializeTVFScan(tvfRelation, rowId, lazySlots));
     }
 
     @Override
@@ -103,6 +106,7 @@ public class PhysicalLazyMaterializeTVFScan extends PhysicalTVFRelation {
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         PhysicalTVFRelation tvfRelation = new PhysicalTVFRelation(relationId, function, operativeSlots,
                 groupExpression, logicalProperties.get(), physicalProperties, statistics);
-        return new PhysicalLazyMaterializeTVFScan(tvfRelation, rowId, lazySlots);
+        return AbstractPlan.copyWithSameId(this, () ->
+                new PhysicalLazyMaterializeTVFScan(tvfRelation, rowId, lazySlots));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalLimit.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalLimit.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.LimitPhase;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -103,15 +104,15 @@ public class PhysicalLimit<CHILD_TYPE extends Plan> extends PhysicalUnary<CHILD_
     }
 
     public Plan withLimit(long limit) {
-        return new PhysicalLimit<>(limit, offset, phase, groupExpression, getLogicalProperties(),
-                physicalProperties, statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalLimit<>(limit, offset, phase, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalLimit<>(limit, offset, phase, groupExpression, getLogicalProperties(),
-                physicalProperties, statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalLimit<>(limit, offset, phase, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
@@ -121,21 +122,23 @@ public class PhysicalLimit<CHILD_TYPE extends Plan> extends PhysicalUnary<CHILD_
 
     @Override
     public PhysicalLimit<CHILD_TYPE> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalLimit<>(limit, offset, phase, groupExpression, getLogicalProperties(), child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalLimit<>(limit, offset, phase, groupExpression,
+                getLogicalProperties(), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalLimit<>(limit, offset, phase, groupExpression, logicalProperties.get(), children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalLimit<>(limit, offset, phase, groupExpression,
+                logicalProperties.get(), children.get(0)));
     }
 
     @Override
     public PhysicalLimit<CHILD_TYPE> withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalLimit<>(limit, offset, phase, groupExpression, getLogicalProperties(), physicalProperties,
-                statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalLimit<>(limit, offset, phase, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalMaxComputeTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalMaxComputeTableSink.java
@@ -28,6 +28,7 @@ import org.apache.doris.nereids.properties.OrderKey;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -74,10 +75,10 @@ public class PhysicalMaxComputeTableSink<CHILD_TYPE extends Plan> extends Physic
 
     @Override
     public Plan withChildren(List<Plan> children) {
-        return new PhysicalMaxComputeTableSink<>(
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalMaxComputeTableSink<>(
                 (MaxComputeExternalDatabase) database, (MaxComputeExternalTable) targetTable,
                 cols, outputExprs, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, children.get(0));
+                getLogicalProperties(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
@@ -87,24 +88,24 @@ public class PhysicalMaxComputeTableSink<CHILD_TYPE extends Plan> extends Physic
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalMaxComputeTableSink<>(
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalMaxComputeTableSink<>(
                 (MaxComputeExternalDatabase) database, (MaxComputeExternalTable) targetTable, cols, outputExprs,
-                groupExpression, getLogicalProperties(), child());
+                groupExpression, getLogicalProperties(), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
                                                  Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalMaxComputeTableSink<>(
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalMaxComputeTableSink<>(
                 (MaxComputeExternalDatabase) database, (MaxComputeExternalTable) targetTable, cols, outputExprs,
-                groupExpression, logicalProperties.get(), children.get(0));
+                groupExpression, logicalProperties.get(), children.get(0)));
     }
 
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalMaxComputeTableSink<>(
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalMaxComputeTableSink<>(
                 (MaxComputeExternalDatabase) database, (MaxComputeExternalTable) targetTable, cols, outputExprs,
-                groupExpression, getLogicalProperties(), physicalProperties, statistics, child());
+                groupExpression, getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalNestedLoopJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalNestedLoopJoin.java
@@ -163,9 +163,9 @@ public class PhysicalNestedLoopJoin<
     @Override
     public PhysicalNestedLoopJoin<Plan, Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 2);
-        PhysicalNestedLoopJoin newJoin = new PhysicalNestedLoopJoin<>(joinType,
+        PhysicalNestedLoopJoin newJoin = AbstractPlan.copyWithSameId(this, () -> new PhysicalNestedLoopJoin<>(joinType,
                 hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts, markJoinSlotReference, Optional.empty(),
-                getLogicalProperties(), physicalProperties, statistics, children.get(0), children.get(1));
+                getLogicalProperties(), physicalProperties, statistics, children.get(0), children.get(1)));
         if (groupExpression.isPresent()) {
             newJoin.setMutableState(MutableState.KEY_GROUP, groupExpression.get().getOwnerGroup().getGroupId().asInt());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalNestedLoopJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalNestedLoopJoin.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.MarkJoinSlotReference;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.BlockFuncDepsPropagation;
 import org.apache.doris.nereids.trees.plans.DistributeType;
 import org.apache.doris.nereids.trees.plans.JoinType;
@@ -174,26 +175,26 @@ public class PhysicalNestedLoopJoin<
     @Override
     public PhysicalNestedLoopJoin<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> withGroupExpression(
             Optional<GroupExpression> groupExpression) {
-        return new PhysicalNestedLoopJoin<>(joinType,
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalNestedLoopJoin<>(joinType,
                 hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts, markJoinSlotReference,
-                groupExpression, getLogicalProperties(), null, null, left(), right());
+                groupExpression, getLogicalProperties(), null, null, left(), right()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new PhysicalNestedLoopJoin<>(joinType,
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalNestedLoopJoin<>(joinType,
                 hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts, markJoinSlotReference, groupExpression,
-                logicalProperties.get(), null, null, children.get(0), children.get(1));
+                logicalProperties.get(), null, null, children.get(0), children.get(1)));
     }
 
     @Override
     public PhysicalNestedLoopJoin<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> withPhysicalPropertiesAndStats(
             PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalNestedLoopJoin<>(joinType,
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalNestedLoopJoin<>(joinType,
                 hashJoinConjuncts, otherJoinConjuncts, markJoinConjuncts, markJoinSlotReference, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, left(), right());
+                getLogicalProperties(), physicalProperties, statistics, left(), right()));
     }
 
     public void addBitmapRuntimeFilterCondition(Expression expr) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOdbcScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOdbcScan.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.RelationId;
@@ -86,21 +87,21 @@ public class PhysicalOdbcScan extends PhysicalCatalogRelation {
 
     @Override
     public PhysicalOdbcScan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalOdbcScan(relationId, table, qualifier, groupExpression, getLogicalProperties(),
-                null, null, operativeSlots, tableAlias);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalOdbcScan(relationId, table, qualifier,
+                groupExpression, getLogicalProperties(), null, null, operativeSlots, tableAlias));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalOdbcScan(relationId, table, qualifier, groupExpression, logicalProperties.get(),
-                null, null, operativeSlots, tableAlias);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalOdbcScan(relationId, table, qualifier,
+                groupExpression, logicalProperties.get(), null, null, operativeSlots, tableAlias));
     }
 
     @Override
     public PhysicalOdbcScan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalOdbcScan(relationId, table, qualifier, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, operativeSlots, tableAlias);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalOdbcScan(relationId, table, qualifier,
+                groupExpression, getLogicalProperties(), physicalProperties, statistics, operativeSlots, tableAlias));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOlapScan.java
@@ -28,6 +28,7 @@ import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PreAggStatus;
@@ -300,28 +301,28 @@ public class PhysicalOlapScan extends PhysicalCatalogRelation implements OlapSca
 
     @Override
     public PhysicalOlapScan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalOlapScan(relationId, getTable(), qualifier, selectedIndexId, selectedTabletIds,
-                selectedPartitionIds, distributionSpec, preAggStatus, baseOutputs,
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalOlapScan(relationId, getTable(), qualifier,
+                selectedIndexId, selectedTabletIds, selectedPartitionIds, distributionSpec, preAggStatus, baseOutputs,
                 groupExpression, getLogicalProperties(), null, null, tableSample, operativeSlots, virtualColumns,
-                scoreOrderKeys, scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias);
+                scoreOrderKeys, scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalOlapScan(relationId, getTable(), qualifier, selectedIndexId, selectedTabletIds,
-                selectedPartitionIds, distributionSpec, preAggStatus, baseOutputs, groupExpression,
-                logicalProperties.get(), null, null, tableSample, operativeSlots, virtualColumns,
-                scoreOrderKeys, scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalOlapScan(relationId, getTable(), qualifier,
+                selectedIndexId, selectedTabletIds, selectedPartitionIds, distributionSpec, preAggStatus, baseOutputs,
+                groupExpression, logicalProperties.get(), null, null, tableSample, operativeSlots, virtualColumns,
+                scoreOrderKeys, scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias));
     }
 
     @Override
     public PhysicalOlapScan withPhysicalPropertiesAndStats(
             PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalOlapScan(relationId, getTable(), qualifier, selectedIndexId, selectedTabletIds,
-                selectedPartitionIds, distributionSpec, preAggStatus, baseOutputs, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, tableSample, operativeSlots,
-                virtualColumns, scoreOrderKeys, scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalOlapScan(relationId, getTable(), qualifier,
+                selectedIndexId, selectedTabletIds, selectedPartitionIds, distributionSpec, preAggStatus, baseOutputs,
+                groupExpression, getLogicalProperties(), physicalProperties, statistics, tableSample, operativeSlots,
+                virtualColumns, scoreOrderKeys, scoreLimit, scoreRangeInfo, annOrderKeys, annLimit, tableAlias));
     }
 
     @Override
@@ -344,11 +345,11 @@ public class PhysicalOlapScan extends PhysicalCatalogRelation implements OlapSca
 
     @Override
     public CatalogRelation withOperativeSlots(Collection<Slot> operativeSlots) {
-        return new PhysicalOlapScan(relationId, (OlapTable) table, qualifier, selectedIndexId, selectedTabletIds,
-                selectedPartitionIds, distributionSpec, preAggStatus, baseOutputs,
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalOlapScan(relationId, (OlapTable) table, qualifier,
+                selectedIndexId, selectedTabletIds, selectedPartitionIds, distributionSpec, preAggStatus, baseOutputs,
                 groupExpression, getLogicalProperties(), getPhysicalProperties(), statistics,
                 tableSample, operativeSlots, virtualColumns, scoreOrderKeys, scoreLimit,
-                scoreRangeInfo, annOrderKeys, annLimit, tableAlias);
+                scoreRangeInfo, annOrderKeys, annLimit, tableAlias));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOlapTableSink.java
@@ -32,6 +32,7 @@ import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Sink;
@@ -155,10 +156,10 @@ public class PhysicalOlapTableSink<CHILD_TYPE extends Plan> extends PhysicalTabl
     @Override
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1, "PhysicalOlapTableSink only accepts one child");
-        return new PhysicalOlapTableSink<>(database, targetTable, cols, partitionIds, outputExprs,
-                singleReplicaLoad, isPartialUpdate, partialUpdateNewKeyPolicy, dmlCommandType, partitionExprList,
-                syncMvWhereClauses, targetTableSlots, groupExpression, getLogicalProperties(),
-                physicalProperties, statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalOlapTableSink<>(database, targetTable, cols,
+                partitionIds, outputExprs, singleReplicaLoad, isPartialUpdate, partialUpdateNewKeyPolicy,
+                dmlCommandType, partitionExprList, syncMvWhereClauses, targetTableSlots, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
@@ -213,28 +214,28 @@ public class PhysicalOlapTableSink<CHILD_TYPE extends Plan> extends PhysicalTabl
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalOlapTableSink<>(database, targetTable, cols, partitionIds, outputExprs,
-                singleReplicaLoad, isPartialUpdate, partialUpdateNewKeyPolicy, dmlCommandType, partitionExprList,
-                syncMvWhereClauses, targetTableSlots, groupExpression, getLogicalProperties(),
-                child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalOlapTableSink<>(database, targetTable, cols,
+                partitionIds, outputExprs, singleReplicaLoad, isPartialUpdate, partialUpdateNewKeyPolicy,
+                dmlCommandType, partitionExprList, syncMvWhereClauses, targetTableSlots, groupExpression,
+                getLogicalProperties(), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalOlapTableSink<>(database, targetTable, cols, partitionIds, outputExprs,
-                singleReplicaLoad, isPartialUpdate, partialUpdateNewKeyPolicy, dmlCommandType, partitionExprList,
-                syncMvWhereClauses, targetTableSlots, groupExpression, logicalProperties.get(),
-                children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalOlapTableSink<>(database, targetTable, cols,
+                partitionIds, outputExprs, singleReplicaLoad, isPartialUpdate, partialUpdateNewKeyPolicy,
+                dmlCommandType, partitionExprList, syncMvWhereClauses, targetTableSlots, groupExpression,
+                logicalProperties.get(), children.get(0)));
     }
 
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalOlapTableSink<>(database, targetTable, cols, partitionIds, outputExprs,
-                singleReplicaLoad, isPartialUpdate, partialUpdateNewKeyPolicy, dmlCommandType, partitionExprList,
-                syncMvWhereClauses, targetTableSlots, groupExpression, getLogicalProperties(),
-                physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalOlapTableSink<>(database, targetTable, cols,
+                partitionIds, outputExprs, singleReplicaLoad, isPartialUpdate, partialUpdateNewKeyPolicy,
+                dmlCommandType, partitionExprList, syncMvWhereClauses, targetTableSlots, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOneRowRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOneRowRelation.java
@@ -32,6 +32,7 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.ComputeResultSet;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -96,15 +97,15 @@ public class PhysicalOneRowRelation extends PhysicalRelation implements OneRowRe
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalOneRowRelation(relationId, projects, groupExpression,
-                logicalPropertiesSupplier.get(), physicalProperties, statistics);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalOneRowRelation(relationId, projects,
+                groupExpression, logicalPropertiesSupplier.get(), physicalProperties, statistics));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalOneRowRelation(relationId, projects, groupExpression,
-                logicalProperties.get(), physicalProperties, statistics);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalOneRowRelation(relationId, projects,
+                groupExpression, logicalProperties.get(), physicalProperties, statistics));
     }
 
     @Override
@@ -154,8 +155,8 @@ public class PhysicalOneRowRelation extends PhysicalRelation implements OneRowRe
     @Override
     public PhysicalOneRowRelation withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalOneRowRelation(relationId, projects, groupExpression,
-                logicalPropertiesSupplier.get(), physicalProperties, statistics);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalOneRowRelation(relationId, projects,
+                groupExpression, logicalPropertiesSupplier.get(), physicalProperties, statistics));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalPartitionTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalPartitionTopN.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.OrderKey;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.PartitionTopnPhase;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -163,29 +164,31 @@ public class PhysicalPartitionTopN<CHILD_TYPE extends Plan> extends PhysicalUnar
     @Override
     public PhysicalPartitionTopN<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalPartitionTopN<>(function, partitionKeys, orderKeys, hasGlobalLimit,
-                partitionLimit, phase, groupExpression, getLogicalProperties(), physicalProperties,
-                statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalPartitionTopN<>(function, partitionKeys,
+                orderKeys, hasGlobalLimit, partitionLimit, phase, groupExpression, getLogicalProperties(),
+                physicalProperties, statistics, children.get(0)));
     }
 
     @Override
     public PhysicalPartitionTopN<CHILD_TYPE> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalPartitionTopN<>(function, partitionKeys, orderKeys, hasGlobalLimit, partitionLimit, phase,
-                groupExpression, getLogicalProperties(), child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalPartitionTopN<>(function, partitionKeys,
+                orderKeys, hasGlobalLimit, partitionLimit, phase, groupExpression, getLogicalProperties(), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalPartitionTopN<>(function, partitionKeys, orderKeys, hasGlobalLimit, partitionLimit, phase,
-                groupExpression, logicalProperties.get(), children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalPartitionTopN<>(function, partitionKeys,
+                orderKeys, hasGlobalLimit, partitionLimit, phase, groupExpression, logicalProperties.get(),
+                children.get(0)));
     }
 
     @Override
     public PhysicalPartitionTopN<CHILD_TYPE> withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
                                                                             Statistics statistics) {
-        return new PhysicalPartitionTopN<>(function, partitionKeys, orderKeys, hasGlobalLimit, partitionLimit, phase,
-                groupExpression, getLogicalProperties(), physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalPartitionTopN<>(function, partitionKeys,
+                orderKeys, hasGlobalLimit, partitionLimit, phase, groupExpression, getLogicalProperties(),
+                physicalProperties, statistics, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalProject.java
@@ -29,6 +29,7 @@ import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.functions.NoneMovableFunction;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Uuid;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Project;
@@ -161,32 +162,29 @@ public class PhysicalProject<CHILD_TYPE extends Plan> extends PhysicalUnary<CHIL
     @Override
     public PhysicalProject<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalProject<>(projects,
-                groupExpression,
-                getLogicalProperties(),
-                physicalProperties,
-                statistics,
-                children.get(0)
-        );
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalProject<>(projects,
+                groupExpression, getLogicalProperties(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
     public PhysicalProject<CHILD_TYPE> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalProject<>(projects, groupExpression, getLogicalProperties(), child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalProject<>(projects, groupExpression,
+                getLogicalProperties(), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalProject<>(projects, groupExpression, logicalProperties.get(), children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalProject<>(projects, groupExpression,
+                logicalProperties.get(), children.get(0)));
     }
 
     @Override
     public PhysicalProject<CHILD_TYPE> withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalProject<>(projects, groupExpression, getLogicalProperties(), physicalProperties,
-                statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalProject<>(projects, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     /**
@@ -196,13 +194,8 @@ public class PhysicalProject<CHILD_TYPE extends Plan> extends PhysicalUnary<CHIL
      * @return new project
      */
     public PhysicalProject<Plan> withProjectionsAndChild(List<NamedExpression> projections, Plan child) {
-        return new PhysicalProject<>(Utils.fastToImmutableList(projections),
-                groupExpression,
-                getLogicalProperties(),
-                physicalProperties,
-                statistics,
-                child
-        );
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalProject<>(Utils.fastToImmutableList(projections),
+                groupExpression, getLogicalProperties(), physicalProperties, statistics, child));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalQuickSort.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalQuickSort.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.OrderKey;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PropagateFuncDeps;
@@ -80,27 +81,29 @@ public class PhysicalQuickSort<CHILD_TYPE extends Plan> extends AbstractPhysical
     @Override
     public PhysicalQuickSort<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalQuickSort<>(orderKeys, phase, groupExpression, getLogicalProperties(), physicalProperties,
-                statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalQuickSort<>(orderKeys, phase, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
     public PhysicalQuickSort<CHILD_TYPE> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalQuickSort<>(orderKeys, phase, groupExpression, getLogicalProperties(), child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalQuickSort<>(orderKeys, phase, groupExpression,
+                getLogicalProperties(), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalQuickSort<>(orderKeys, phase, groupExpression, logicalProperties.get(), children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalQuickSort<>(orderKeys, phase, groupExpression,
+                logicalProperties.get(), children.get(0)));
     }
 
     @Override
     public PhysicalQuickSort<CHILD_TYPE> withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalQuickSort<>(orderKeys, phase, groupExpression, getLogicalProperties(), physicalProperties,
-                statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalQuickSort<>(orderKeys, phase, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalRecursiveUnion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalRecursiveUnion.java
@@ -25,6 +25,7 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.RecursiveCte;
@@ -177,29 +178,30 @@ public class PhysicalRecursiveUnion<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TY
 
     @Override
     public PhysicalRecursiveUnion<Plan, Plan> withChildren(List<Plan> children) {
-        return new PhysicalRecursiveUnion<>(cteName, qualifier, outputs, regularChildrenOutputs, groupExpression,
-                getLogicalProperties(), children.get(0), children.get(1));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalRecursiveUnion<>(cteName, qualifier, outputs,
+                regularChildrenOutputs, groupExpression, getLogicalProperties(), children.get(0), children.get(1)));
     }
 
     @Override
     public PhysicalRecursiveUnion<Plan, Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalRecursiveUnion<>(cteName, qualifier, outputs, regularChildrenOutputs,
-                groupExpression, getLogicalProperties(), left(), right());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalRecursiveUnion<>(cteName, qualifier, outputs,
+                regularChildrenOutputs, groupExpression, getLogicalProperties(), left(), right()));
     }
 
     @Override
     public PhysicalRecursiveUnion<Plan, Plan> withGroupExprLogicalPropChildren(
             Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalRecursiveUnion<>(cteName, qualifier, outputs, regularChildrenOutputs,
-                groupExpression, logicalProperties.get(), left(), right());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalRecursiveUnion<>(cteName, qualifier, outputs,
+                regularChildrenOutputs, groupExpression, logicalProperties.get(), left(), right()));
     }
 
     @Override
     public PhysicalRecursiveUnion<Plan, Plan> withPhysicalPropertiesAndStats(
             PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalRecursiveUnion<>(cteName, qualifier, outputs, regularChildrenOutputs,
-                groupExpression, getLogicalProperties(), physicalProperties, statistics, left(), right());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalRecursiveUnion<>(cteName, qualifier, outputs,
+                regularChildrenOutputs, groupExpression, getLogicalProperties(), physicalProperties, statistics,
+                left(), right()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalRecursiveUnionAnchor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalRecursiveUnionAnchor.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.CTEId;
 import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -90,8 +91,8 @@ public class PhysicalRecursiveUnionAnchor<CHILD_TYPE extends Plan> extends Physi
     @Override
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalRecursiveUnionAnchor<>(cteId, groupExpression, getLogicalProperties(),
-                children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalRecursiveUnionAnchor<>(cteId, groupExpression,
+                getLogicalProperties(), children.get(0)));
     }
 
     @Override
@@ -106,14 +107,16 @@ public class PhysicalRecursiveUnionAnchor<CHILD_TYPE extends Plan> extends Physi
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalRecursiveUnionAnchor<>(cteId, groupExpression, getLogicalProperties(), child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalRecursiveUnionAnchor<>(cteId, groupExpression,
+                getLogicalProperties(), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalRecursiveUnionAnchor<>(cteId, groupExpression, logicalProperties.get(), child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalRecursiveUnionAnchor<>(cteId, groupExpression,
+                logicalProperties.get(), child()));
     }
 
     @Override
@@ -138,7 +141,7 @@ public class PhysicalRecursiveUnionAnchor<CHILD_TYPE extends Plan> extends Physi
 
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalRecursiveUnionAnchor<>(cteId, groupExpression, getLogicalProperties(),
-                physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalRecursiveUnionAnchor<>(cteId, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, child()));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalRecursiveUnionProducer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalRecursiveUnionProducer.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -85,8 +86,8 @@ public class PhysicalRecursiveUnionProducer<CHILD_TYPE extends Plan> extends Phy
     @Override
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalRecursiveUnionProducer<>(cteName, groupExpression, getLogicalProperties(),
-                children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalRecursiveUnionProducer<>(cteName, groupExpression,
+                getLogicalProperties(), children.get(0)));
     }
 
     @Override
@@ -101,14 +102,16 @@ public class PhysicalRecursiveUnionProducer<CHILD_TYPE extends Plan> extends Phy
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalRecursiveUnionProducer<>(cteName, groupExpression, getLogicalProperties(), child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalRecursiveUnionProducer<>(cteName, groupExpression,
+                getLogicalProperties(), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalRecursiveUnionProducer<>(cteName, groupExpression, logicalProperties.get(), child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalRecursiveUnionProducer<>(cteName, groupExpression,
+                logicalProperties.get(), child()));
     }
 
     @Override
@@ -133,7 +136,7 @@ public class PhysicalRecursiveUnionProducer<CHILD_TYPE extends Plan> extends Phy
 
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalRecursiveUnionProducer<>(cteName, groupExpression, getLogicalProperties(),
-                physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalRecursiveUnionProducer<>(cteName, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, child()));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalRepeat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalRepeat.java
@@ -25,6 +25,7 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Repeat;
@@ -159,42 +160,48 @@ public class PhysicalRepeat<CHILD_TYPE extends Plan> extends PhysicalUnary<CHILD
     @Override
     public PhysicalRepeat<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalRepeat<>(groupingSets, outputExpressions, groupingId, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalRepeat<>(groupingSets, outputExpressions,
+                groupingId, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
     public PhysicalRepeat<CHILD_TYPE> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalRepeat<>(groupingSets, outputExpressions, groupingId, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalRepeat<>(groupingSets, outputExpressions,
+                groupingId, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalRepeat<>(groupingSets, outputExpressions, groupingId, groupExpression,
-                logicalProperties.get(), physicalProperties, statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalRepeat<>(groupingSets, outputExpressions,
+                groupingId, groupExpression,
+                logicalProperties.get(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
     public PhysicalRepeat<CHILD_TYPE> withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalRepeat<>(groupingSets, outputExpressions, groupingId, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalRepeat<>(groupingSets, outputExpressions,
+                groupingId, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override
     public PhysicalRepeat<CHILD_TYPE> withAggOutput(List<NamedExpression> newOutput) {
-        return new PhysicalRepeat<>(groupingSets, newOutput, groupingId, Optional.empty(),
-                getLogicalProperties(), physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalRepeat<>(groupingSets, newOutput, groupingId,
+                Optional.empty(),
+                getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override
     public PhysicalRepeat<CHILD_TYPE> withGroupSetsAndOutput(List<List<Expression>> groupingSets,
             List<NamedExpression> outputExpressionList) {
-        return new PhysicalRepeat<>(groupingSets, outputExpressionList, groupingId, Optional.empty(),
-                getLogicalProperties(), physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalRepeat<>(groupingSets, outputExpressionList,
+                groupingId, Optional.empty(),
+                getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalResultSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalResultSink.java
@@ -25,6 +25,7 @@ import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.ComputeResultSet;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -63,8 +64,8 @@ public class PhysicalResultSink<CHILD_TYPE extends Plan> extends PhysicalSink<CH
     public PhysicalResultSink<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1,
                 "PhysicalResultSink's children size must be 1, but real is %s", children.size());
-        return new PhysicalResultSink<>(outputExprs, groupExpression, getLogicalProperties(),
-                physicalProperties, statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalResultSink<>(outputExprs, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
@@ -79,8 +80,8 @@ public class PhysicalResultSink<CHILD_TYPE extends Plan> extends PhysicalSink<CH
 
     @Override
     public PhysicalResultSink<Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalResultSink<>(outputExprs, groupExpression, getLogicalProperties(),
-                physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalResultSink<>(outputExprs, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override
@@ -88,15 +89,15 @@ public class PhysicalResultSink<CHILD_TYPE extends Plan> extends PhysicalSink<CH
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1,
                 "PhysicalResultSink's children size must be 1, but real is %s", children.size());
-        return new PhysicalResultSink<>(outputExprs, groupExpression, logicalProperties.get(),
-                physicalProperties, statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalResultSink<>(outputExprs, groupExpression,
+                logicalProperties.get(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
     public PhysicalResultSink<Plan> withPhysicalPropertiesAndStats(
             PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalResultSink<>(outputExprs, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalResultSink<>(outputExprs, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalSchemaScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalSchemaScan.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.RelationId;
@@ -100,25 +101,25 @@ public class PhysicalSchemaScan extends PhysicalCatalogRelation {
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalSchemaScan(relationId, getTable(), qualifier,
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalSchemaScan(relationId, getTable(), qualifier,
                 groupExpression, getLogicalProperties(), physicalProperties, statistics,
-                schemaCatalog, schemaDatabase, schemaTable, frontendConjuncts);
+                schemaCatalog, schemaDatabase, schemaTable, frontendConjuncts));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalSchemaScan(relationId, getTable(), qualifier,
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalSchemaScan(relationId, getTable(), qualifier,
                 groupExpression, logicalProperties.get(), physicalProperties, statistics,
-                schemaCatalog, schemaDatabase, schemaTable, frontendConjuncts);
+                schemaCatalog, schemaDatabase, schemaTable, frontendConjuncts));
     }
 
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalSchemaScan(relationId, getTable(), qualifier,
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalSchemaScan(relationId, getTable(), qualifier,
                 groupExpression, getLogicalProperties(), physicalProperties, statistics,
-                schemaCatalog, schemaDatabase, schemaTable, frontendConjuncts);
+                schemaCatalog, schemaDatabase, schemaTable, frontendConjuncts));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalStorageLayerAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalStorageLayerAggregate.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunctio
 import org.apache.doris.nereids.trees.expressions.functions.agg.Count;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Max;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Min;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
@@ -82,29 +83,29 @@ public class PhysicalStorageLayerAggregate extends PhysicalCatalogRelation {
     }
 
     public PhysicalStorageLayerAggregate withPhysicalOlapScan(PhysicalOlapScan physicalOlapScan) {
-        return new PhysicalStorageLayerAggregate(physicalOlapScan, aggOp);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalStorageLayerAggregate(physicalOlapScan, aggOp));
     }
 
     @Override
     public PhysicalStorageLayerAggregate withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalStorageLayerAggregate(relation, aggOp, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalStorageLayerAggregate(relation, aggOp,
+                groupExpression, getLogicalProperties(), physicalProperties, statistics));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalStorageLayerAggregate(relation, aggOp, groupExpression,
-                logicalProperties.get(), physicalProperties, statistics);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalStorageLayerAggregate(relation, aggOp,
+                groupExpression, logicalProperties.get(), physicalProperties, statistics));
     }
 
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalStorageLayerAggregate(
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalStorageLayerAggregate(
                 (PhysicalCatalogRelation) relation.withPhysicalPropertiesAndStats(null, statistics),
                 aggOp, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics);
+                getLogicalProperties(), physicalProperties, statistics));
     }
 
     /** PushAggOp */

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalTVFRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalTVFRelation.java
@@ -26,6 +26,7 @@ import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.trees.expressions.functions.table.TableValuedFunction;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.BlockFuncDepsPropagation;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -66,22 +67,22 @@ public class PhysicalTVFRelation extends PhysicalRelation implements TVFRelation
 
     @Override
     public PhysicalTVFRelation withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalTVFRelation(relationId, function, operativeSlots, groupExpression, getLogicalProperties(),
-                physicalProperties, statistics);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalTVFRelation(relationId, function, operativeSlots,
+                groupExpression, getLogicalProperties(), physicalProperties, statistics));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalTVFRelation(relationId, function, operativeSlots, groupExpression,
-                logicalProperties.get(), physicalProperties, statistics);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalTVFRelation(relationId, function, operativeSlots,
+                groupExpression, logicalProperties.get(), physicalProperties, statistics));
     }
 
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalTVFRelation(relationId, function, operativeSlots, Optional.empty(),
-                getLogicalProperties(), physicalProperties, statistics);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalTVFRelation(relationId, function, operativeSlots,
+                Optional.empty(), getLogicalProperties(), physicalProperties, statistics));
     }
 
     public List<Slot> getOperativeSlots() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalTVFTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalTVFTableSink.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Sink;
@@ -86,8 +87,9 @@ public class PhysicalTVFTableSink<CHILD_TYPE extends Plan> extends PhysicalSink<
     public PhysicalTVFTableSink<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1,
                 "PhysicalTVFTableSink's children size must be 1, but real is %s", children.size());
-        return new PhysicalTVFTableSink<>(tvfName, properties, cols, outputExprs,
-                groupExpression, getLogicalProperties(), physicalProperties, statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalTVFTableSink<>(tvfName, properties, cols,
+                outputExprs, groupExpression, getLogicalProperties(), physicalProperties, statistics,
+                children.get(0)));
     }
 
     @Override
@@ -102,8 +104,8 @@ public class PhysicalTVFTableSink<CHILD_TYPE extends Plan> extends PhysicalSink<
 
     @Override
     public PhysicalTVFTableSink<Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalTVFTableSink<>(tvfName, properties, cols, outputExprs,
-                groupExpression, getLogicalProperties(), physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalTVFTableSink<>(tvfName, properties, cols,
+                outputExprs, groupExpression, getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override
@@ -111,15 +113,16 @@ public class PhysicalTVFTableSink<CHILD_TYPE extends Plan> extends PhysicalSink<
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1,
                 "PhysicalTVFTableSink's children size must be 1, but real is %s", children.size());
-        return new PhysicalTVFTableSink<>(tvfName, properties, cols, outputExprs,
-                groupExpression, logicalProperties.get(), physicalProperties, statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalTVFTableSink<>(tvfName, properties, cols,
+                outputExprs, groupExpression, logicalProperties.get(), physicalProperties, statistics,
+                children.get(0)));
     }
 
     @Override
     public PhysicalTVFTableSink<Plan> withPhysicalPropertiesAndStats(
             PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalTVFTableSink<>(tvfName, properties, cols, outputExprs,
-                groupExpression, getLogicalProperties(), physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalTVFTableSink<>(tvfName, properties, cols,
+                outputExprs, groupExpression, getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalTopN.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.OrderKey;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -113,14 +114,14 @@ public class PhysicalTopN<CHILD_TYPE extends Plan> extends AbstractPhysicalSort<
     public PhysicalTopN<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1,
                 "PhysicalTopN's children size must be 1, but real is %s", children.size());
-        return new PhysicalTopN<>(orderKeys, limit, offset, phase, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalTopN<>(orderKeys, limit, offset, phase,
+                groupExpression, getLogicalProperties(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
     public PhysicalTopN<CHILD_TYPE> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalTopN<>(orderKeys, limit, offset, phase,
-                groupExpression, getLogicalProperties(), child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalTopN<>(orderKeys, limit, offset, phase,
+                groupExpression, getLogicalProperties(), child()));
     }
 
     @Override
@@ -128,15 +129,15 @@ public class PhysicalTopN<CHILD_TYPE extends Plan> extends AbstractPhysicalSort<
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1,
                 "PhysicalTopN's children size must be 1, but real is %s", children.size());
-        return new PhysicalTopN<>(orderKeys, limit, offset, phase,
-                groupExpression, logicalProperties.get(), children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalTopN<>(orderKeys, limit, offset, phase,
+                groupExpression, logicalProperties.get(), children.get(0)));
     }
 
     @Override
     public PhysicalTopN<CHILD_TYPE> withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalTopN<>(orderKeys, limit, offset, phase,
-                groupExpression, getLogicalProperties(), physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalTopN<>(orderKeys, limit, offset, phase,
+                groupExpression, getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalUnion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalUnion.java
@@ -25,6 +25,7 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.ShuffleType;
@@ -142,28 +143,32 @@ public class PhysicalUnion extends PhysicalSetOperation implements Union {
 
     @Override
     public PhysicalUnion withChildren(List<Plan> children) {
-        return new PhysicalUnion(qualifier, outputs, regularChildrenOutputs, constantExprsList, groupExpression,
-                getLogicalProperties(), children);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalUnion(qualifier, outputs,
+                regularChildrenOutputs, constantExprsList, groupExpression,
+                getLogicalProperties(), children));
     }
 
     @Override
     public PhysicalUnion withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalUnion(qualifier, outputs, regularChildrenOutputs, constantExprsList,
-                groupExpression, getLogicalProperties(), children);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalUnion(qualifier, outputs,
+                regularChildrenOutputs, constantExprsList,
+                groupExpression, getLogicalProperties(), children));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalUnion(qualifier, outputs, regularChildrenOutputs, constantExprsList,
-                groupExpression, logicalProperties.get(), children);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalUnion(qualifier, outputs,
+                regularChildrenOutputs, constantExprsList,
+                groupExpression, logicalProperties.get(), children));
     }
 
     @Override
     public PhysicalUnion withPhysicalPropertiesAndStats(
             PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalUnion(qualifier, outputs, regularChildrenOutputs, constantExprsList,
-                groupExpression, getLogicalProperties(), physicalProperties, statistics, children);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalUnion(qualifier, outputs,
+                regularChildrenOutputs, constantExprsList,
+                groupExpression, getLogicalProperties(), physicalProperties, statistics, children));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalWindow.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalWindow.java
@@ -30,6 +30,7 @@ import org.apache.doris.nereids.trees.expressions.WindowExpression;
 import org.apache.doris.nereids.trees.expressions.functions.window.DenseRank;
 import org.apache.doris.nereids.trees.expressions.functions.window.Rank;
 import org.apache.doris.nereids.trees.expressions.functions.window.RowNumber;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.algebra.Window;
@@ -140,35 +141,40 @@ public class PhysicalWindow<CHILD_TYPE extends Plan> extends PhysicalUnary<CHILD
     @Override
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkState(children.size() == 1);
-        return new PhysicalWindow<>(windowFrameGroup, requireProperties, windowExpressions, isSkew, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalWindow<>(windowFrameGroup, requireProperties,
+                windowExpressions, isSkew, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, children.get(0)));
     }
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalWindow<>(windowFrameGroup, requireProperties, windowExpressions, isSkew, groupExpression,
-                getLogicalProperties(), child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalWindow<>(windowFrameGroup, requireProperties,
+                windowExpressions, isSkew, groupExpression,
+                getLogicalProperties(), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkState(children.size() == 1);
-        return new PhysicalWindow<>(windowFrameGroup, requireProperties, windowExpressions, isSkew, groupExpression,
-                logicalProperties.get(), children.get(0));
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalWindow<>(windowFrameGroup, requireProperties,
+                windowExpressions, isSkew, groupExpression,
+                logicalProperties.get(), children.get(0)));
     }
 
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
                                                        Statistics statistics) {
-        return new PhysicalWindow<>(windowFrameGroup, requireProperties, windowExpressions, isSkew, groupExpression,
-                getLogicalProperties(), physicalProperties, statistics, child());
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalWindow<>(windowFrameGroup, requireProperties,
+                windowExpressions, isSkew, groupExpression,
+                getLogicalProperties(), physicalProperties, statistics, child()));
     }
 
     public <C extends Plan> PhysicalWindow<C> withRequirePropertiesAndChild(RequireProperties requireProperties,
                                                                             C newChild) {
-        return new PhysicalWindow<>(windowFrameGroup, requireProperties, windowExpressions, isSkew, Optional.empty(),
-                getLogicalProperties(), physicalProperties, statistics, newChild);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalWindow<>(windowFrameGroup, requireProperties,
+                windowExpressions, isSkew, Optional.empty(),
+                getLogicalProperties(), physicalProperties, statistics, newChild));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalWorkTableReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalWorkTableReference.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.CTEId;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.RelationId;
@@ -77,17 +78,15 @@ public class PhysicalWorkTableReference extends PhysicalRelation {
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new PhysicalWorkTableReference(relationId, cteId, outputs, nameParts, groupExpression,
-                getLogicalProperties(),
-                physicalProperties, statistics);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalWorkTableReference(relationId, cteId, outputs,
+                nameParts, groupExpression, getLogicalProperties(), physicalProperties, statistics));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
-        return new PhysicalWorkTableReference(relationId, cteId, outputs, nameParts, groupExpression,
-                getLogicalProperties(),
-                physicalProperties, statistics);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalWorkTableReference(relationId, cteId, outputs,
+                nameParts, groupExpression, getLogicalProperties(), physicalProperties, statistics));
     }
 
     @Override
@@ -112,9 +111,8 @@ public class PhysicalWorkTableReference extends PhysicalRelation {
 
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties, Statistics statistics) {
-        return new PhysicalWorkTableReference(relationId, cteId, outputs, nameParts, groupExpression,
-                getLogicalProperties(),
-                physicalProperties, statistics);
+        return AbstractPlan.copyWithSameId(this, () -> new PhysicalWorkTableReference(relationId, cteId, outputs,
+                nameParts, groupExpression, getLogicalProperties(), physicalProperties, statistics));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanNodeIdPreservationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanNodeIdPreservationTest.java
@@ -1,0 +1,131 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans;
+
+import org.apache.doris.nereids.rules.exploration.join.JoinReorderContext;
+import org.apache.doris.nereids.trees.expressions.Alias;
+import org.apache.doris.nereids.trees.expressions.EqualTo;
+import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
+import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
+import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
+import org.apache.doris.nereids.trees.plans.logical.LogicalOneRowRelation;
+import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Verifies that withXxx() copy methods on plan nodes preserve the original node's ObjectId.
+ */
+class PlanNodeIdPreservationTest {
+
+    private LogicalOneRowRelation oneRow(int relationId) {
+        return new LogicalOneRowRelation(
+                new RelationId(relationId),
+                ImmutableList.of(new Alias(Literal.of(1L), "a"))
+        );
+    }
+
+    @Test
+    void testLogicalProjectWithChildrenPreservesId() {
+        LogicalOneRowRelation child = oneRow(1);
+        List<NamedExpression> projects = ImmutableList.of(new Alias(Literal.of(1L), "x"));
+        LogicalProject<Plan> original = new LogicalProject<>(projects, child);
+
+        LogicalOneRowRelation newChild = oneRow(2);
+        LogicalProject<Plan> copy = original.withChildren(ImmutableList.of(newChild));
+
+        Assertions.assertEquals(original.getId(), copy.getId(),
+                "withChildren should preserve the node id");
+    }
+
+    @Test
+    void testLogicalProjectWithProjectsPreservesId() {
+        LogicalOneRowRelation child = oneRow(1);
+        List<NamedExpression> projects = ImmutableList.of(new Alias(Literal.of(1L), "x"));
+        LogicalProject<Plan> original = new LogicalProject<>(projects, child);
+
+        List<NamedExpression> newProjects = ImmutableList.of(new Alias(Literal.of(2L), "y"));
+        LogicalProject<Plan> copy = original.withProjects(newProjects);
+
+        Assertions.assertEquals(original.getId(), copy.getId(),
+                "withProjects should preserve the node id");
+    }
+
+    @Test
+    void testLogicalFilterWithChildrenPreservesId() {
+        LogicalOneRowRelation child = oneRow(1);
+        LogicalFilter<Plan> original = new LogicalFilter<>(
+                ImmutableSet.of(new EqualTo(Literal.of(1), Literal.of(1))), child);
+
+        LogicalOneRowRelation newChild = oneRow(2);
+        LogicalFilter<Plan> copy = original.withChildren(ImmutableList.of(newChild));
+
+        Assertions.assertEquals(original.getId(), copy.getId(),
+                "withChildren on LogicalFilter should preserve the node id");
+    }
+
+    @Test
+    void testLogicalJoinWithChildrenPreservesId() {
+        LogicalOneRowRelation left = oneRow(1);
+        LogicalOneRowRelation right = oneRow(2);
+        LogicalJoin<Plan, Plan> original = new LogicalJoin<>(
+                JoinType.INNER_JOIN,
+                left,
+                right,
+                new JoinReorderContext()
+        );
+
+        LogicalOneRowRelation newLeft = oneRow(3);
+        LogicalOneRowRelation newRight = oneRow(4);
+        LogicalJoin<Plan, Plan> copy = (LogicalJoin<Plan, Plan>) original.withChildren(
+                ImmutableList.of(newLeft, newRight));
+
+        Assertions.assertEquals(original.getId(), copy.getId(),
+                "withChildren on LogicalJoin should preserve the node id");
+    }
+
+    @Test
+    void testWithGroupExpressionPreservesId() {
+        LogicalOneRowRelation child = oneRow(1);
+        List<NamedExpression> projects = ImmutableList.of(new Alias(Literal.of(1L), "x"));
+        LogicalProject<Plan> original = new LogicalProject<>(projects, child);
+
+        LogicalProject<Plan> copy = original.withGroupExpression(Optional.empty());
+
+        Assertions.assertEquals(original.getId(), copy.getId(),
+                "withGroupExpression should preserve the node id");
+    }
+
+    @Test
+    void testDistinctNodesHaveDifferentIds() {
+        LogicalOneRowRelation child = oneRow(1);
+        List<NamedExpression> projects = ImmutableList.of(new Alias(Literal.of(1L), "x"));
+        LogicalProject<Plan> node1 = new LogicalProject<>(projects, child);
+        LogicalProject<Plan> node2 = new LogicalProject<>(projects, child);
+
+        Assertions.assertNotEquals(node1.getId(), node2.getId(),
+                "independently constructed nodes must have different ids");
+    }
+}


### PR DESCRIPTION
## Problem

In the Nereids optimizer, every plan node (both logical and physical) carries a unique ObjectId (`AbstractPlan.id`). Previously, every call to a `withXxx()` method (e.g. `withChildren`, `withGroupExpression`, `withGroupExprLogicalPropChildren`, `withPhysicalPropertiesAndStats`) constructed a brand-new node that was allocated a fresh id via `StatementScopeIdGenerator.newObjectId()`. This means a node and its "copy" had different ids even though they represent the same operator, which can confuse plan identification, caching, and debugging.

## Solution

Introduce a thread-local id-inheritance mechanism in `AbstractPlan`:

1. Add `private static final ThreadLocal<ObjectId> INHERIT_ID` to `AbstractPlan`.
2. Add a static helper `AbstractPlan.copyWithSameId(source, factory)`: it stores `source.id` in the ThreadLocal, calls the constructor through the supplied lambda, and clears the ThreadLocal in a `finally` block.
3. Modify the constructor to read and clear `INHERIT_ID` when present; otherwise allocate a fresh id as before.
4. Rewrite all `withXxx()` methods in every logical and physical plan node (60 logical + 51 physical, ~490 call sites) to use `AbstractPlan.copyWithSameId(this, () -> new ...)`.

This approach keeps `id` final-by-contract (only set once in the constructor), is thread-safe without locking, and requires no changes to callers outside the plan-node classes themselves.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

