### PR TITLE
[env](compiler)Reduce hash join build template instantiations

### DIFF
--- a/be/src/exec/operator/hashjoin_build_sink.cpp
+++ b/be/src/exec/operator/hashjoin_build_sink.cpp
@@ -590,22 +590,19 @@ Status HashJoinBuildSinkLocalState::process_build_block(RuntimeState* state, Blo
     RETURN_IF_ERROR(_hash_table_init(state, raw_ptrs));
 
     Status st = std::visit(
-            Overload {[&](std::monostate& arg, auto join_op,
-                          auto short_circuit_for_null_in_build_side,
-                          auto with_other_conjuncts) -> Status {
+            Overload {[&](std::monostate& arg, auto join_op) -> Status {
                           throw Exception(Status::FatalError("FATAL: uninited hash table"));
                       },
-                      [&](auto&& arg, auto&& join_op, auto short_circuit_for_null_in_build_side,
-                          auto with_other_conjuncts) -> Status {
+                      [&](auto&& arg, auto&& join_op) -> Status {
                           using HashTableCtxType = std::decay_t<decltype(arg)>;
                           using JoinOpType = std::decay_t<decltype(join_op)>;
                           ProcessHashTableBuild<HashTableCtxType> hash_table_build_process(
                                   rows, raw_ptrs, this, state->batch_size(), state);
-                          auto st = hash_table_build_process.template run<
-                                  JoinOpType::value, short_circuit_for_null_in_build_side,
-                                  with_other_conjuncts>(
+                          auto st = hash_table_build_process.template run<JoinOpType::value>(
                                   arg, null_map_val ? &null_map_val->get_data() : nullptr,
-                                  &_shared_state->_has_null_in_build_side);
+                                  &_shared_state->_has_null_in_build_side,
+                                  p._short_circuit_for_null_in_build_side,
+                                  p._have_other_join_conjunct);
                           COUNTER_SET(_memory_used_counter,
                                       _build_blocks_memory_usage->value() +
                                               (int64_t)(arg.hash_table->get_byte_size() +
@@ -613,9 +610,7 @@ Status HashJoinBuildSinkLocalState::process_build_block(RuntimeState* state, Blo
                           return st;
                       }},
             _shared_state->hash_table_variant_vector.front()->method_variant,
-            _shared_state->join_op_variants,
-            make_bool_variant(p._short_circuit_for_null_in_build_side),
-            make_bool_variant((p._have_other_join_conjunct)));
+            _shared_state->join_op_variants);
     return st;
 }
 

--- a/be/src/exec/operator/hashjoin_build_sink.h
+++ b/be/src/exec/operator/hashjoin_build_sink.h
@@ -212,8 +212,9 @@ struct ProcessHashTableBuild {
               _batch_size(batch_size),
               _state(state) {}
 
-    template <int JoinOpType, bool short_circuit_for_null, bool with_other_conjuncts>
-    Status run(HashTableContext& hash_table_ctx, ConstNullMapPtr null_map, bool* has_null_key) {
+    template <int JoinOpType>
+    Status run(HashTableContext& hash_table_ctx, ConstNullMapPtr null_map, bool* has_null_key,
+               bool short_circuit_for_null, bool with_other_conjuncts) {
         if (null_map) {
             // first row is mocked and is null
             if (simd::contain_one(null_map->data() + 1, _rows - 1)) {


### PR DESCRIPTION
### What problem does this PR solve?

before
```
[1/1] Compiling: be/src/exec/operator/hashjoin_build_sink.cpp
  → 69.6s
```

now
```
[1/1] Compiling: be/src/exec/operator/hashjoin_build_sink.cpp
  → 48.9s
```

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

