### PR TITLE
[Enhancement](file-cache) Add fine-grained control for compaction file cache

### DIFF
--- a/be/src/cloud/config.cpp
+++ b/be/src/cloud/config.cpp
@@ -159,5 +159,8 @@ DEFINE_mInt64(file_cache_warmup_download_rate_limit_bytes_per_second, "104857600
 // If the value is -1, use the `rehash_tablet_after_be_dead_seconds` setting in the `fe` configuration as the expiration time.
 DEFINE_mInt64(cache_read_from_peer_expired_seconds, "-1");
 
+DEFINE_mBool(enable_file_cache_write_base_compaction_index_only, "false");
+DEFINE_mBool(enable_file_cache_write_cumu_compaction_index_only, "false");
+
 #include "common/compile_check_end.h"
 } // namespace doris::config

--- a/be/src/cloud/config.h
+++ b/be/src/cloud/config.h
@@ -199,5 +199,11 @@ DECLARE_mInt64(file_cache_warmup_download_rate_limit_bytes_per_second);
 
 DECLARE_mInt64(cache_read_from_peer_expired_seconds);
 
+// Base compaction output: only write index files to file cache, not data files
+DECLARE_mBool(enable_file_cache_write_base_compaction_index_only);
+
+// Cumulative compaction output: only write index files to file cache, not data files
+DECLARE_mBool(enable_file_cache_write_cumu_compaction_index_only);
+
 #include "common/compile_check_end.h"
 } // namespace doris::config

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -87,6 +87,32 @@ using std::vector;
 
 namespace doris {
 using namespace ErrorCode;
+
+// Determine whether to enable index-only file cache mode for compaction output.
+// This function decides if only index files should be written to cache, based on:
+// - write_file_cache: whether file cache is enabled
+// - compaction_type: type of compaction (base or cumulative)
+// - enable_base_index_only: config flag for base compaction
+// - enable_cumu_index_only: config flag for cumulative compaction
+// Returns true if index-only mode should be enabled, false otherwise.
+bool should_enable_compaction_cache_index_only(bool write_file_cache, ReaderType compaction_type,
+                                               bool enable_base_index_only,
+                                               bool enable_cumu_index_only) {
+    if (!write_file_cache) {
+        return false;
+    }
+
+    if (compaction_type == ReaderType::READER_BASE_COMPACTION && enable_base_index_only) {
+        return true;
+    }
+
+    if (compaction_type == ReaderType::READER_CUMULATIVE_COMPACTION && enable_cumu_index_only) {
+        return true;
+    }
+
+    return false;
+}
+
 namespace {
 #include "common/compile_check_begin.h"
 
@@ -1724,6 +1750,13 @@ Status CloudCompactionMixin::construct_output_rowset_writer(RowsetWriterContext&
     ctx.write_file_cache = should_cache_compaction_output();
     ctx.file_cache_ttl_sec = _tablet->ttl_seconds();
     ctx.approximate_bytes_to_write = _input_rowsets_total_size;
+
+    // Set fine-grained control: only write index files to cache if configured
+    ctx.compaction_output_write_index_only = should_enable_compaction_cache_index_only(
+            ctx.write_file_cache, compaction_type(),
+            config::enable_file_cache_write_base_compaction_index_only,
+            config::enable_file_cache_write_cumu_compaction_index_only);
+
     ctx.tablet = _tablet;
     ctx.job_id = _uuid;
 

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -1051,8 +1051,9 @@ Status BaseBetaRowsetWriter::_build_tmp(RowsetSharedPtr& rowset_ptr) {
 }
 
 Status BaseBetaRowsetWriter::_create_file_writer(const std::string& path,
-                                                 io::FileWriterPtr& file_writer) {
-    io::FileWriterOptions opts = _context.get_file_writer_options();
+                                                 io::FileWriterPtr& file_writer,
+                                                 bool is_index_file) {
+    io::FileWriterOptions opts = _context.get_file_writer_options(is_index_file);
     Status st = _context.fs()->create_file(path, &file_writer, &opts);
     if (!st.ok()) {
         LOG(WARNING) << "failed to create writable file. path=" << path << ", err: " << st;
@@ -1070,9 +1071,9 @@ Status BaseBetaRowsetWriter::create_file_writer(uint32_t segment_id, io::FileWri
         std::string prefix =
                 std::string {InvertedIndexDescriptor::get_index_file_path_prefix(segment_path)};
         std::string index_path = InvertedIndexDescriptor::get_index_file_path_v2(prefix);
-        return _create_file_writer(index_path, file_writer);
+        return _create_file_writer(index_path, file_writer, true /* is_index_file */);
     } else if (file_type == FileType::SEGMENT_FILE) {
-        return _create_file_writer(segment_path, file_writer);
+        return _create_file_writer(segment_path, file_writer, false /* is_index_file */);
     }
     return Status::Error<ErrorCode::INTERNAL_ERROR>(
             fmt::format("failed to create file = {}, file type = {}", segment_path, file_type));
@@ -1082,7 +1083,8 @@ Status BaseBetaRowsetWriter::create_index_file_writer(uint32_t segment_id,
                                                       IndexFileWriterPtr* index_file_writer) {
     RETURN_IF_ERROR(RowsetWriter::create_index_file_writer(segment_id, index_file_writer));
     // used for inverted index format v1
-    (*index_file_writer)->set_file_writer_opts(_context.get_file_writer_options());
+    (*index_file_writer)
+            ->set_file_writer_opts(_context.get_file_writer_options(true /* is_index_file */));
     return Status::OK();
 }
 
@@ -1092,7 +1094,7 @@ Status BetaRowsetWriter::create_segment_writer_for_segcompaction(
     std::string path = BetaRowset::local_segment_path_segcompacted(_context.tablet_path,
                                                                    _context.rowset_id, begin, end);
     io::FileWriterPtr file_writer;
-    RETURN_IF_ERROR(_create_file_writer(path, file_writer));
+    RETURN_IF_ERROR(_create_file_writer(path, file_writer, false /* is_index_file */));
 
     IndexFileWriterPtr index_file_writer;
     if (_context.tablet_schema->has_inverted_index() || _context.tablet_schema->has_ann_index()) {
@@ -1101,7 +1103,8 @@ Status BetaRowsetWriter::create_segment_writer_for_segcompaction(
         if (_context.tablet_schema->get_inverted_index_storage_format() !=
             InvertedIndexStorageFormatPB::V1) {
             std::string index_path = InvertedIndexDescriptor::get_index_file_path_v2(prefix);
-            RETURN_IF_ERROR(_create_file_writer(index_path, idx_file_writer));
+            RETURN_IF_ERROR(
+                    _create_file_writer(index_path, idx_file_writer, true /* is_index_file */));
         }
         index_file_writer = std::make_unique<IndexFileWriter>(
                 _context.fs(), prefix, _context.rowset_id.to_string(), _num_segcompacted,

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -202,7 +202,8 @@ private:
 protected:
     Status _generate_delete_bitmap(int32_t segment_id);
     virtual Status _build_rowset_meta(RowsetMeta* rowset_meta, bool check_segment_num = false);
-    Status _create_file_writer(const std::string& path, io::FileWriterPtr& file_writer);
+    Status _create_file_writer(const std::string& path, io::FileWriterPtr& file_writer,
+                              bool is_index_file);
     virtual Status _close_file_writers();
     virtual Status _check_segment_number_limit(size_t segnum);
     virtual int64_t _num_seg() const;

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -203,7 +203,7 @@ protected:
     Status _generate_delete_bitmap(int32_t segment_id);
     virtual Status _build_rowset_meta(RowsetMeta* rowset_meta, bool check_segment_num = false);
     Status _create_file_writer(const std::string& path, io::FileWriterPtr& file_writer,
-                              bool is_index_file);
+                               bool is_index_file);
     virtual Status _close_file_writers();
     virtual Status _check_segment_number_limit(size_t segnum);
     virtual int64_t _num_seg() const;

--- a/be/src/olap/rowset/rowset_writer_context.h
+++ b/be/src/olap/rowset/rowset_writer_context.h
@@ -109,6 +109,8 @@ struct RowsetWriterContext {
     bool is_hot_data = false;
     uint64_t file_cache_ttl_sec = 0;
     uint64_t approximate_bytes_to_write = 0;
+    // If true, compaction output only writes index files to file cache, not data files
+    bool compaction_output_write_index_only = false;
     /// end file cache opts
 
     // segcompaction for this RowsetWriter, only enabled when importing data
@@ -237,16 +239,19 @@ struct RowsetWriterContext {
 
     io::FileSystem& fs_ref() const { return *fs(); }
 
-    io::FileWriterOptions get_file_writer_options() {
-        io::FileWriterOptions opts {
-                .write_file_cache = write_file_cache,
-                .is_cold_data = is_hot_data,
-                .file_cache_expiration = file_cache_ttl_sec > 0 && newest_write_timestamp > 0
-                                                 ? newest_write_timestamp + file_cache_ttl_sec
-                                                 : 0,
-                .approximate_bytes_to_write = approximate_bytes_to_write};
+    io::FileWriterOptions get_file_writer_options(bool is_index_file = false) {
+        bool should_write_cache = write_file_cache;
+        // If configured to only write index files to cache, skip cache for data files
+        if (compaction_output_write_index_only && !is_index_file) {
+            should_write_cache = false;
+        }
 
-        return opts;
+        return io::FileWriterOptions {.write_file_cache = should_write_cache,
+                                      .is_cold_data = is_hot_data,
+                                      .file_cache_expiration = file_cache_ttl_sec > 0 && newest_write_timestamp > 0
+                                                                       ? newest_write_timestamp + file_cache_ttl_sec
+                                                                       : 0,
+                                      .approximate_bytes_to_write = approximate_bytes_to_write};
     }
 };
 

--- a/be/src/olap/rowset/rowset_writer_context.h
+++ b/be/src/olap/rowset/rowset_writer_context.h
@@ -246,12 +246,13 @@ struct RowsetWriterContext {
             should_write_cache = false;
         }
 
-        return io::FileWriterOptions {.write_file_cache = should_write_cache,
-                                      .is_cold_data = is_hot_data,
-                                      .file_cache_expiration = file_cache_ttl_sec > 0 && newest_write_timestamp > 0
-                                                                       ? newest_write_timestamp + file_cache_ttl_sec
-                                                                       : 0,
-                                      .approximate_bytes_to_write = approximate_bytes_to_write};
+        return io::FileWriterOptions {
+                .write_file_cache = should_write_cache,
+                .is_cold_data = is_hot_data,
+                .file_cache_expiration = file_cache_ttl_sec > 0 && newest_write_timestamp > 0
+                                                 ? newest_write_timestamp + file_cache_ttl_sec
+                                                 : 0,
+                .approximate_bytes_to_write = approximate_bytes_to_write};
     }
 };
 

--- a/be/test/olap/compaction_file_cache_test.cpp
+++ b/be/test/olap/compaction_file_cache_test.cpp
@@ -1,0 +1,403 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "cloud/config.h"
+#include "io/fs/file_writer.h"
+#include "olap/olap_common.h"
+#include "olap/rowset/rowset_writer_context.h"
+
+namespace doris {
+
+// Extern declaration for the free function in compaction.cpp
+extern bool should_enable_compaction_cache_index_only(bool write_file_cache,
+                                                      ReaderType compaction_type,
+                                                      bool enable_base_index_only,
+                                                      bool enable_cumu_index_only);
+
+class CompactionFileCacheTest : public testing::Test {
+public:
+    void SetUp() override {
+        // Save original configuration
+        _orig_base_config = config::enable_file_cache_write_base_compaction_index_only;
+        _orig_cumu_config = config::enable_file_cache_write_cumu_compaction_index_only;
+    }
+
+    void TearDown() override {
+        // Restore original configuration
+        config::enable_file_cache_write_base_compaction_index_only = _orig_base_config;
+        config::enable_file_cache_write_cumu_compaction_index_only = _orig_cumu_config;
+    }
+
+private:
+    bool _orig_base_config;
+    bool _orig_cumu_config;
+};
+
+// ============================================================================
+// Base Compaction Tests
+// ============================================================================
+
+TEST_F(CompactionFileCacheTest, BaseCompaction_IndexOnly_False_IndexFile) {
+    // Setup: Disable index-only mode for base compaction
+    config::enable_file_cache_write_base_compaction_index_only = false;
+
+    // Create context
+    RowsetWriterContext ctx;
+    ctx.write_file_cache = true;
+    ctx.compaction_output_write_index_only = false;
+
+    // Test: Get file writer options for index file
+    auto opts = ctx.get_file_writer_options(true);
+
+    // Verify: write_file_cache should be true
+    EXPECT_TRUE(opts.write_file_cache);
+}
+
+TEST_F(CompactionFileCacheTest, BaseCompaction_IndexOnly_False_DataFile) {
+    // Setup: Disable index-only mode for base compaction
+    config::enable_file_cache_write_base_compaction_index_only = false;
+
+    // Create context
+    RowsetWriterContext ctx;
+    ctx.write_file_cache = true;
+    ctx.compaction_output_write_index_only = false;
+
+    // Test: Get file writer options for data file
+    auto opts = ctx.get_file_writer_options(false);
+
+    // Verify: write_file_cache should be true
+    EXPECT_TRUE(opts.write_file_cache);
+}
+
+TEST_F(CompactionFileCacheTest, BaseCompaction_IndexOnly_True_IndexFile) {
+    // Setup: Enable index-only mode for base compaction
+    config::enable_file_cache_write_base_compaction_index_only = true;
+
+    // Create context
+    RowsetWriterContext ctx;
+    ctx.write_file_cache = true;
+    ctx.compaction_output_write_index_only = true;
+
+    // Test: Get file writer options for index file
+    auto opts = ctx.get_file_writer_options(true);
+
+    // Verify: write_file_cache should be true (index files are always cached)
+    EXPECT_TRUE(opts.write_file_cache);
+}
+
+TEST_F(CompactionFileCacheTest, BaseCompaction_IndexOnly_True_DataFile) {
+    // Setup: Enable index-only mode for base compaction
+    config::enable_file_cache_write_base_compaction_index_only = true;
+
+    // Create context
+    RowsetWriterContext ctx;
+    ctx.write_file_cache = true;
+    ctx.compaction_output_write_index_only = true;
+
+    // Test: Get file writer options for data file
+    auto opts = ctx.get_file_writer_options(false);
+
+    // Verify: write_file_cache should be false (data files are NOT cached when index-only is enabled)
+    EXPECT_FALSE(opts.write_file_cache);
+}
+
+// ============================================================================
+// Cumulative Compaction Tests
+// ============================================================================
+
+TEST_F(CompactionFileCacheTest, CumuCompaction_IndexOnly_False_IndexFile) {
+    // Setup: Disable index-only mode for cumulative compaction
+    config::enable_file_cache_write_cumu_compaction_index_only = false;
+
+    // Create context
+    RowsetWriterContext ctx;
+    ctx.write_file_cache = true;
+    ctx.compaction_output_write_index_only = false;
+
+    // Test: Get file writer options for index file
+    auto opts = ctx.get_file_writer_options(true);
+
+    // Verify: write_file_cache should be true
+    EXPECT_TRUE(opts.write_file_cache);
+}
+
+TEST_F(CompactionFileCacheTest, CumuCompaction_IndexOnly_False_DataFile) {
+    // Setup: Disable index-only mode for cumulative compaction
+    config::enable_file_cache_write_cumu_compaction_index_only = false;
+
+    // Create context
+    RowsetWriterContext ctx;
+    ctx.write_file_cache = true;
+    ctx.compaction_output_write_index_only = false;
+
+    // Test: Get file writer options for data file
+    auto opts = ctx.get_file_writer_options(false);
+
+    // Verify: write_file_cache should be true
+    EXPECT_TRUE(opts.write_file_cache);
+}
+
+TEST_F(CompactionFileCacheTest, CumuCompaction_IndexOnly_True_IndexFile) {
+    // Setup: Enable index-only mode for cumulative compaction
+    config::enable_file_cache_write_cumu_compaction_index_only = true;
+
+    // Create context
+    RowsetWriterContext ctx;
+    ctx.write_file_cache = true;
+    ctx.compaction_output_write_index_only = true;
+
+    // Test: Get file writer options for index file
+    auto opts = ctx.get_file_writer_options(true);
+
+    // Verify: write_file_cache should be true (index files are always cached)
+    EXPECT_TRUE(opts.write_file_cache);
+}
+
+TEST_F(CompactionFileCacheTest, CumuCompaction_IndexOnly_True_DataFile) {
+    // Setup: Enable index-only mode for cumulative compaction
+    config::enable_file_cache_write_cumu_compaction_index_only = true;
+
+    // Create context
+    RowsetWriterContext ctx;
+    ctx.write_file_cache = true;
+    ctx.compaction_output_write_index_only = true;
+
+    // Test: Get file writer options for data file
+    auto opts = ctx.get_file_writer_options(false);
+
+    // Verify: write_file_cache should be false (data files are NOT cached when index-only is enabled)
+    EXPECT_FALSE(opts.write_file_cache);
+}
+
+// ============================================================================
+// Base Compaction Tests with write_file_cache = false
+// ============================================================================
+
+TEST_F(CompactionFileCacheTest, BaseCompaction_WriteCacheFalse_IndexOnly_False_IndexFile) {
+    // Setup: Disable index-only mode for base compaction
+    config::enable_file_cache_write_base_compaction_index_only = false;
+
+    // Create context with write_file_cache = false
+    RowsetWriterContext ctx;
+    ctx.write_file_cache = false;
+    ctx.compaction_output_write_index_only = false;
+
+    // Test: Get file writer options for index file
+    auto opts = ctx.get_file_writer_options(true);
+
+    // Verify: write_file_cache should remain false
+    EXPECT_FALSE(opts.write_file_cache);
+}
+
+TEST_F(CompactionFileCacheTest, BaseCompaction_WriteCacheFalse_IndexOnly_False_DataFile) {
+    // Setup: Disable index-only mode for base compaction
+    config::enable_file_cache_write_base_compaction_index_only = false;
+
+    // Create context with write_file_cache = false
+    RowsetWriterContext ctx;
+    ctx.write_file_cache = false;
+    ctx.compaction_output_write_index_only = false;
+
+    // Test: Get file writer options for data file
+    auto opts = ctx.get_file_writer_options(false);
+
+    // Verify: write_file_cache should remain false
+    EXPECT_FALSE(opts.write_file_cache);
+}
+
+TEST_F(CompactionFileCacheTest, BaseCompaction_WriteCacheFalse_IndexOnly_True_IndexFile) {
+    // Setup: Enable index-only mode for base compaction
+    config::enable_file_cache_write_base_compaction_index_only = true;
+
+    // Create context with write_file_cache = false
+    RowsetWriterContext ctx;
+    ctx.write_file_cache = false;
+    ctx.compaction_output_write_index_only = true;
+
+    // Test: Get file writer options for index file
+    auto opts = ctx.get_file_writer_options(true);
+
+    // Verify: write_file_cache should remain false (base cache setting takes precedence)
+    EXPECT_FALSE(opts.write_file_cache);
+}
+
+TEST_F(CompactionFileCacheTest, BaseCompaction_WriteCacheFalse_IndexOnly_True_DataFile) {
+    // Setup: Enable index-only mode for base compaction
+    config::enable_file_cache_write_base_compaction_index_only = true;
+
+    // Create context with write_file_cache = false
+    RowsetWriterContext ctx;
+    ctx.write_file_cache = false;
+    ctx.compaction_output_write_index_only = true;
+
+    // Test: Get file writer options for data file
+    auto opts = ctx.get_file_writer_options(false);
+
+    // Verify: write_file_cache should remain false
+    EXPECT_FALSE(opts.write_file_cache);
+}
+
+// ============================================================================
+// Cumulative Compaction Tests with write_file_cache = false
+// ============================================================================
+
+TEST_F(CompactionFileCacheTest, CumuCompaction_WriteCacheFalse_IndexOnly_False_IndexFile) {
+    // Setup: Disable index-only mode for cumulative compaction
+    config::enable_file_cache_write_cumu_compaction_index_only = false;
+
+    // Create context with write_file_cache = false
+    RowsetWriterContext ctx;
+    ctx.write_file_cache = false;
+    ctx.compaction_output_write_index_only = false;
+
+    // Test: Get file writer options for index file
+    auto opts = ctx.get_file_writer_options(true);
+
+    // Verify: write_file_cache should remain false
+    EXPECT_FALSE(opts.write_file_cache);
+}
+
+TEST_F(CompactionFileCacheTest, CumuCompaction_WriteCacheFalse_IndexOnly_False_DataFile) {
+    // Setup: Disable index-only mode for cumulative compaction
+    config::enable_file_cache_write_cumu_compaction_index_only = false;
+
+    // Create context with write_file_cache = false
+    RowsetWriterContext ctx;
+    ctx.write_file_cache = false;
+    ctx.compaction_output_write_index_only = false;
+
+    // Test: Get file writer options for data file
+    auto opts = ctx.get_file_writer_options(false);
+
+    // Verify: write_file_cache should remain false
+    EXPECT_FALSE(opts.write_file_cache);
+}
+
+TEST_F(CompactionFileCacheTest, CumuCompaction_WriteCacheFalse_IndexOnly_True_IndexFile) {
+    // Setup: Enable index-only mode for cumulative compaction
+    config::enable_file_cache_write_cumu_compaction_index_only = true;
+
+    // Create context with write_file_cache = false
+    RowsetWriterContext ctx;
+    ctx.write_file_cache = false;
+    ctx.compaction_output_write_index_only = true;
+
+    // Test: Get file writer options for index file
+    auto opts = ctx.get_file_writer_options(true);
+
+    // Verify: write_file_cache should remain false (base cache setting takes precedence)
+    EXPECT_FALSE(opts.write_file_cache);
+}
+
+TEST_F(CompactionFileCacheTest, CumuCompaction_WriteCacheFalse_IndexOnly_True_DataFile) {
+    // Setup: Enable index-only mode for cumulative compaction
+    config::enable_file_cache_write_cumu_compaction_index_only = true;
+
+    // Create context with write_file_cache = false
+    RowsetWriterContext ctx;
+    ctx.write_file_cache = false;
+    ctx.compaction_output_write_index_only = true;
+
+    // Test: Get file writer options for data file
+    auto opts = ctx.get_file_writer_options(false);
+
+    // Verify: write_file_cache should remain false
+    EXPECT_FALSE(opts.write_file_cache);
+}
+
+// ============================================================================
+// Tests for should_enable_compaction_cache_index_only function
+// ============================================================================
+
+TEST_F(CompactionFileCacheTest, FreeFunction_WriteCacheFalse_AlwaysReturnsFalse) {
+    // When write_file_cache is false, the function should always return false
+    // regardless of other parameters
+    EXPECT_FALSE(should_enable_compaction_cache_index_only(
+            false, ReaderType::READER_BASE_COMPACTION, false, false));
+    EXPECT_FALSE(should_enable_compaction_cache_index_only(
+            false, ReaderType::READER_BASE_COMPACTION, true, false));
+    EXPECT_FALSE(should_enable_compaction_cache_index_only(
+            false, ReaderType::READER_CUMULATIVE_COMPACTION, false, false));
+    EXPECT_FALSE(should_enable_compaction_cache_index_only(
+            false, ReaderType::READER_CUMULATIVE_COMPACTION, false, true));
+    EXPECT_FALSE(should_enable_compaction_cache_index_only(
+            false, ReaderType::READER_BASE_COMPACTION, true, true));
+    EXPECT_FALSE(should_enable_compaction_cache_index_only(
+            false, ReaderType::READER_CUMULATIVE_COMPACTION, true, true));
+}
+
+TEST_F(CompactionFileCacheTest, FreeFunction_BaseCompaction_ConfigDisabled) {
+    // Base compaction with config disabled should return false
+    bool result = should_enable_compaction_cache_index_only(
+            true, ReaderType::READER_BASE_COMPACTION, false, false);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(CompactionFileCacheTest, FreeFunction_BaseCompaction_ConfigEnabled) {
+    // Base compaction with config enabled should return true
+    bool result = should_enable_compaction_cache_index_only(
+            true, ReaderType::READER_BASE_COMPACTION, true, false);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(CompactionFileCacheTest, FreeFunction_CumuCompaction_ConfigDisabled) {
+    // Cumulative compaction with config disabled should return false
+    bool result = should_enable_compaction_cache_index_only(
+            true, ReaderType::READER_CUMULATIVE_COMPACTION, false, false);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(CompactionFileCacheTest, FreeFunction_CumuCompaction_ConfigEnabled) {
+    // Cumulative compaction with config enabled should return true
+    bool result = should_enable_compaction_cache_index_only(
+            true, ReaderType::READER_CUMULATIVE_COMPACTION, false, true);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(CompactionFileCacheTest, FreeFunction_BaseCompaction_WrongConfigEnabled) {
+    // Base compaction with cumulative config enabled (but base disabled) should return false
+    bool result = should_enable_compaction_cache_index_only(
+            true, ReaderType::READER_BASE_COMPACTION, false, true);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(CompactionFileCacheTest, FreeFunction_CumuCompaction_WrongConfigEnabled) {
+    // Cumulative compaction with base config enabled (but cumu disabled) should return false
+    bool result = should_enable_compaction_cache_index_only(
+            true, ReaderType::READER_CUMULATIVE_COMPACTION, true, false);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(CompactionFileCacheTest, FreeFunction_BothConfigsEnabled) {
+    // When both configs are enabled, each compaction type should return true
+    EXPECT_TRUE(should_enable_compaction_cache_index_only(true, ReaderType::READER_BASE_COMPACTION,
+                                                          true, true));
+    EXPECT_TRUE(should_enable_compaction_cache_index_only(
+            true, ReaderType::READER_CUMULATIVE_COMPACTION, true, true));
+}
+
+TEST_F(CompactionFileCacheTest, FreeFunction_OtherCompactionTypes) {
+    // Other compaction types should return false
+    EXPECT_FALSE(
+            should_enable_compaction_cache_index_only(true, ReaderType::READER_QUERY, true, true));
+    EXPECT_FALSE(should_enable_compaction_cache_index_only(true, ReaderType::READER_ALTER_TABLE,
+                                                           true, true));
+}
+
+} // namespace doris


### PR DESCRIPTION
Support selective caching of index files only during compaction in cloud mode.

Cherry-picked from #60609

Changes:
- Add two mBool configs to control index-only caching for base and cumulative compaction:
  * enable_file_cache_write_base_compaction_index_only (default: false)
  * enable_file_cache_write_cumu_compaction_index_only (default: false)

- Extend RowsetWriterContext with compaction_output_write_index_only field
  to mark whether only index files should be cached

- Modify get_file_writer_options() to accept is_index_file parameter:
  * When compaction_output_write_index_only=true and is_index_file=false,
    set write_file_cache=false to skip caching data files
  * Index files continue to be cached normally

- Update file writer creation call sites to pass is_index_file parameter:
  * Index file writers: pass true
  * Segment (data) file writers: pass false

Benefits:
- Reduces cache pressure by avoiding caching large data files during compaction
- Preserves index file caching for query performance
- Provides separate control for base and cumulative compaction strategies
- Maintains backward compatibility with default settings