### PR TITLE
branch-4.1: [chore](thirdparty) Upgrade snappy and xxhash #60519

### DIFF
--- a/thirdparty/CHANGELOG.md
+++ b/thirdparty/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file contains version of the third-party dependency libraries in the build-env image. The docker build-env image is apache/doris, and the tag is `build-env-${version}`
 
+## 20260202
+
+- Modified: snappy 1.1.8 -> 1.1.10
+- Modified: xxhash 0.8.1 -> 0.8.3
+
 ## 20251127
 
 - Added: crc32c-1.1.2

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -551,6 +551,13 @@ build_snappy() {
     check_if_source_exist "${SNAPPY_SOURCE}"
     cd "${TP_SOURCE_DIR}/${SNAPPY_SOURCE}"
 
+    # Enable RTTI for snappy (required by Doris BE for SnappySlicesSource inheritance)
+    if [[ "${KERNEL}" == 'Darwin' ]]; then
+        sed -i '' 's/-fno-rtti/-frtti/g' CMakeLists.txt
+    else
+        sed -i 's/-fno-rtti/-frtti/g' CMakeLists.txt
+    fi
+
     mkdir -p "${BUILD_DIR}"
     cd "${BUILD_DIR}"
 
@@ -560,7 +567,8 @@ build_snappy() {
         -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
         -DCMAKE_INSTALL_INCLUDEDIR="${TP_INCLUDE_DIR}"/snappy \
-        -DSNAPPY_BUILD_TESTS=0 ../
+        -DSNAPPY_BUILD_TESTS=OFF \
+        -DSNAPPY_BUILD_BENCHMARKS=OFF ../
 
     "${BUILD_SYSTEM}" -j "${PARALLEL}"
     "${BUILD_SYSTEM}" install

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -269,6 +269,17 @@ if [[ " ${TP_ARCHIVES[*]} " =~ " GLOG " ]]; then
     echo "Finished patching ${GLOG_SOURCE}"
 fi
 
+# snappy patch to fix sign-compare warning
+if [[ " ${TP_ARCHIVES[*]} " =~ " SNAPPY " ]]; then
+    cd "${TP_SOURCE_DIR}/${SNAPPY_SOURCE}"
+    if [[ ! -f "${PATCHED_MARK}" ]]; then
+        patch -p1 <"${TP_PATCH_DIR}/snappy-1.1.10-sign-compare.patch"
+        touch "${PATCHED_MARK}"
+    fi
+    cd -
+    echo "Finished patching ${SNAPPY_SOURCE}"
+fi
+
 # mysql patch
 if [[ " ${TP_ARCHIVES[*]} " =~ " MYSQL " ]]; then
     cd "${TP_SOURCE_DIR}/${MYSQL_SOURCE}"

--- a/thirdparty/patches/snappy-1.1.10-sign-compare.patch
+++ b/thirdparty/patches/snappy-1.1.10-sign-compare.patch
@@ -1,0 +1,11 @@
+--- a/snappy.cc
++++ b/snappy.cc
+@@ -1290,7 +1290,7 @@ inline bool Copy64BytesWithPatternExtension(ptrdiff_t dst, size_t offset) {
+         DeferMemCopy(&deferred_src, &deferred_length, from, len);
+       }
+     } while (ip < ip_limit_min_slop &&
+-             (op + deferred_length) < op_limit_min_slop);
++             static_cast<ptrdiff_t>(op + deferred_length) < op_limit_min_slop);
+   exit:
+     ip--;
+     assert(ip <= ip_limit);

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -98,10 +98,10 @@ GTEST_SOURCE=googletest-release-1.12.1
 GTEST_MD5SUM="e82199374acdfda3f425331028eb4e2a"
 
 # snappy
-SNAPPY_DOWNLOAD="https://github.com/google/snappy/archive/1.1.8.tar.gz"
-SNAPPY_NAME=snappy-1.1.8.tar.gz
-SNAPPY_SOURCE=snappy-1.1.8
-SNAPPY_MD5SUM="70e48cba7fecf289153d009791c9977f"
+SNAPPY_DOWNLOAD="https://github.com/google/snappy/archive/1.1.10.tar.gz"
+SNAPPY_NAME=snappy-1.1.10.tar.gz
+SNAPPY_SOURCE=snappy-1.1.10
+SNAPPY_MD5SUM="70153395ebe6d72febe2cf2e40026a44"
 
 # gperftools
 GPERFTOOLS_DOWNLOAD="https://github.com/gperftools/gperftools/releases/download/gperftools-2.10/gperftools-2.10.tar.gz"
@@ -451,10 +451,10 @@ SSE2NEON_SOURCE=sse2neon-1.6.0
 SSE2NEON_MD5SUM="dce28eb6a78f45bf98740d5fad73febb"
 
 # xxhash
-XXHASH_DOWNLOAD="https://github.com/Cyan4973/xxHash/archive/refs/tags/v0.8.1.tar.gz"
-XXHASH_NAME=xxHash-0.8.1.tar.gz
-XXHASH_SOURCE=xxHash-0.8.1
-XXHASH_MD5SUM="b67c587f5ff4894253da0095ba7ea393"
+XXHASH_DOWNLOAD="https://github.com/Cyan4973/xxHash/archive/refs/tags/v0.8.3.tar.gz"
+XXHASH_NAME=xxHash-0.8.3.tar.gz
+XXHASH_SOURCE=xxHash-0.8.3
+XXHASH_MD5SUM="599804eb9555e51c05f1b821f9212a07"
 
 # concurrentqueue
 CONCURRENTQUEUE_DOWNLOAD="https://github.com/cameron314/concurrentqueue/archive/refs/tags/v1.0.3.tar.gz"
@@ -505,7 +505,7 @@ JSONCPP_SOURCE="jsoncpp-1.9.5"
 JSONCPP_MD5SUM="d6c8c609f2162eff373db62b90a051c7"
 
 # libuuid
-LIBUUID_DOWNLOAD="https://nchc.dl.sourceforge.net/project/libuuid/libuuid-1.0.3.tar.gz"
+LIBUUID_DOWNLOAD="https://downloads.sourceforge.net/project/libuuid/libuuid-1.0.3.tar.gz"
 LIBUUID_NAME="libuuid-1.0.3.tar.gz"
 LIBUUID_SOURCE="libuuid-1.0.3"
 LIBUUID_MD5SUM="d44d866d06286c08ba0846aba1086d68"


### PR DESCRIPTION
Cherry-pick #60519 to branch-4.1

### What problem does this PR solve?

- **Related PR**: #60519

Upgrade snappy 1.1.8 -> 1.1.10 and xxhash 0.8.1 -> 0.8.3.

### Cherry-pick commit

- `3afa26723d9` - [chore](thirdparty) Upgrade snappy and xxhash (#60519)