### PR TITLE
[chore](github)Update .asf.yaml to remove inactive contributors

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -175,8 +175,8 @@ github:
     - shuke987
     - wm1581066
     - doris-robot
-    - echo-hhj
     - ixzc
     - deardeng
+    - wyxxxcat
 notifications:
   pullrequests_status:  commits@doris.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -176,10 +176,7 @@ github:
     - wm1581066
     - doris-robot
     - echo-hhj
-    - yuanyuan8983
-    - yz-jayhua
     - ixzc
     - deardeng
-    - wyxxxcat
 notifications:
   pullrequests_status:  commits@doris.apache.org


### PR DESCRIPTION
only have a maximum of 10 external triage collaborators

