### PR TITLE
[fix](iceberg) Fix execute action validation gaps

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergRewriteDataFilesAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergRewriteDataFilesAction.java
@@ -161,6 +161,9 @@ public class IcebergRewriteDataFilesAction extends BaseIcebergAction {
         if (this.maxFileSizeBytes == 0) {
             this.maxFileSizeBytes = (long) (targetFileSizeBytes * 1.8);
         }
+        if (this.minFileSizeBytes > this.maxFileSizeBytes) {
+            throw new UserException("min-file-size-bytes must be less than or equal to max-file-size-bytes");
+        }
         validateNoPartitions();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergRollbackToTimestampAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/action/IcebergRollbackToTimestampAction.java
@@ -36,6 +36,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TimeZone;
 
 /**
  * Iceberg rollback to timestamp action implementation.
@@ -103,7 +104,7 @@ public class IcebergRollbackToTimestampAction extends BaseIcebergAction {
         Long previousSnapshotId = previousSnapshot != null ? previousSnapshot.snapshotId() : null;
 
         try {
-            long targetTimestamp = TimeUtils.msTimeStringToLong(timestampStr, TimeUtils.getTimeZone());
+            long targetTimestamp = parseTimestampMillis(timestampStr, TimeUtils.getTimeZone());
             icebergTable.manageSnapshots().rollbackToTime(targetTimestamp).commit();
 
             Snapshot currentSnapshot = icebergTable.currentSnapshot();
@@ -132,5 +133,23 @@ public class IcebergRollbackToTimestampAction extends BaseIcebergAction {
     @Override
     public String getDescription() {
         return "Rollback Iceberg table to the snapshot that was current at a specific timestamp";
+    }
+
+    static long parseTimestampMillis(String timestampStr, TimeZone timeZone) {
+        String trimmed = timestampStr.trim();
+        try {
+            long timestampMs = Long.parseLong(trimmed);
+            if (timestampMs < 0) {
+                throw new IllegalArgumentException("Timestamp must be non-negative: " + timestampMs);
+            }
+            return timestampMs;
+        } catch (NumberFormatException e) {
+            long parsedTimestamp = TimeUtils.msTimeStringToLong(trimmed, timeZone);
+            if (parsedTimestamp < 0) {
+                throw new IllegalArgumentException("Invalid timestamp format. Expected ISO datetime "
+                        + "(yyyy-MM-dd HH:mm:ss.SSS) or timestamp in milliseconds: " + trimmed, e);
+            }
+            return parsedTimestamp;
+        }
     }
 }

--- a/regression-test/suites/external_table_p0/iceberg/action/test_iceberg_execute_actions.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/action/test_iceberg_execute_actions.groovy
@@ -264,6 +264,25 @@ suite("test_iceberg_optimize_actions_ddl", "p0,external") {
     logger.info("Rollback timestamp result: ${rollbackTimestampResult}")
     qt_after_rollback_to_timestamp """SELECT * FROM test_rollback_timestamp ORDER BY id"""
 
+    String middleCommittedTime = timestampSnapshotList[1][0]
+    LocalDateTime middleDateTime = LocalDateTime.parse(middleCommittedTime, unifiedFormatter)
+    String epochMillisSnapshotTime = String.valueOf(
+            middleDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli())
+
+    List<List<Object>> rollbackTimestampEpochResult = sql """
+        ALTER TABLE ${catalog_name}.${db_name}.test_rollback_timestamp
+        EXECUTE rollback_to_timestamp("timestamp" = "${epochMillisSnapshotTime}")
+    """
+    logger.info("Rollback epoch millis result: ${rollbackTimestampEpochResult}")
+
+    List<List<Object>> rowsAfterEpochRollback = sql """
+        SELECT id, version FROM test_rollback_timestamp ORDER BY id
+    """
+    assertTrue(rowsAfterEpochRollback.size() == 2,
+            "Expected rollback_to_timestamp with epoch millis to keep exactly 2 rows")
+    assertTrue(rowsAfterEpochRollback[0][0] == 1 && rowsAfterEpochRollback[1][0] == 2,
+            "Expected rollback_to_timestamp with epoch millis to restore the first two snapshots")
+
 
     // =====================================================================================
     // Test Case 3: set_current_snapshot action
@@ -482,6 +501,19 @@ suite("test_iceberg_optimize_actions_ddl", "p0,external") {
             ("target-file-size-bytes" = "not-a-number")
         """
         exception "Invalid target-file-size-bytes format: not-a-number"
+    }
+
+    // Test rewrite_data_files with invalid min/max file size relationship
+    test {
+        sql """
+            ALTER TABLE ${catalog_name}.${db_name}.${table_name} EXECUTE rewrite_data_files
+            (
+                "target-file-size-bytes" = "536870912",
+                "min-file-size-bytes" = "1073741824",
+                "max-file-size-bytes" = "536870912"
+            )
+        """
+        exception "min-file-size-bytes must be less than or equal to max-file-size-bytes"
     }
 
     // Test set_current_snapshot with both snapshot_id and ref

--- a/regression-test/suites/external_table_p0/iceberg/action/test_iceberg_execute_actions.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/action/test_iceberg_execute_actions.groovy
@@ -264,10 +264,8 @@ suite("test_iceberg_optimize_actions_ddl", "p0,external") {
     logger.info("Rollback timestamp result: ${rollbackTimestampResult}")
     qt_after_rollback_to_timestamp """SELECT * FROM test_rollback_timestamp ORDER BY id"""
 
-    String middleCommittedTime = timestampSnapshotList[1][0]
-    LocalDateTime middleDateTime = LocalDateTime.parse(middleCommittedTime, unifiedFormatter)
     String epochMillisSnapshotTime = String.valueOf(
-            middleDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli())
+            dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli())
 
     List<List<Object>> rollbackTimestampEpochResult = sql """
         ALTER TABLE ${catalog_name}.${db_name}.test_rollback_timestamp


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:
- Fix `rollback_to_timestamp` so epoch millis input is parsed correctly instead of falling through to `rollbackToTime(-1)`.
- Reject invalid `rewrite_data_files` input when `min-file-size-bytes > max-file-size-bytes` during FE validation.
- Add Iceberg regression coverage for the epoch-millis rollback path and invalid rewrite_data_files file-size bounds.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

Regression test:
- `bash run-regression-test.sh --run -d external_table_p0/iceberg/action -s test_iceberg_optimize_actions_ddl`
- In the current local environment, the regression framework ran successfully but the Iceberg suite was skipped because `enableIcebergTest` is disabled, so the new Iceberg cases were not executed locally.

- Behavior changed:
    - [ ] No.
    - [x] Yes. Buggy Iceberg execute action inputs are now rejected or interpreted correctly instead of silently succeeding or executing with `-1`.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
