### PR TITLE
[Improve](variant) Implement NestedGroup streaming compaction path

### DIFF
--- a/be/src/exec/common/variant_util.cpp
+++ b/be/src/exec/common/variant_util.cpp
@@ -42,6 +42,7 @@
 #include <mutex>
 #include <optional>
 #include <ostream>
+#include <ranges>
 #include <set>
 #include <stack>
 #include <string>
@@ -377,6 +378,11 @@ void get_column_by_type(const DataTypePtr& data_type, const std::string& name, T
                            "", child, {});
         column.set_length(TabletColumn::get_field_length_by_type(TPrimitiveType::ARRAY, 0));
         column.add_sub_column(child);
+        return;
+    }
+    if (data_type->get_primitive_type() == PrimitiveType::TYPE_VARIANT) {
+        column.set_variant_max_subcolumns_count(assert_cast<const DataTypeVariant*>(data_type.get())
+                                                        ->variant_max_subcolumns_count());
         return;
     }
     // size is not fixed when type is string or json
@@ -806,7 +812,9 @@ Status VariantCompactionUtil::aggregate_path_to_stats(
         if (!column->is_variant_type() || column->unique_id() < 0) {
             continue;
         }
-
+        if (!should_check_variant_path_stats(*column)) {
+            continue;
+        }
         for (const auto& segment : segment_cache.get_segments()) {
             std::shared_ptr<ColumnReader> column_reader;
             OlapReaderStatistics stats;
@@ -846,6 +854,10 @@ Status VariantCompactionUtil::aggregate_variant_extended_info(
 
     for (const auto& column : rs->tablet_schema()->columns()) {
         if (!column->is_variant_type()) {
+            continue;
+        }
+        if (column->variant_enable_nested_group()) {
+            (*uid_to_variant_extended_info)[column->unique_id()].has_nested_group = true;
             continue;
         }
         for (const auto& segment : segment_cache.get_segments()) {
@@ -889,11 +901,6 @@ Status VariantCompactionUtil::aggregate_variant_extended_info(
             // 4. extract nested paths
             auto& nested_paths = (*uid_to_variant_extended_info)[column->unique_id()].nested_paths;
             variant_column_reader->get_nested_paths(&nested_paths);
-
-            // 5. check if has nested group from stats
-            if (source_stats->has_nested_group) {
-                (*uid_to_variant_extended_info)[column->unique_id()].has_nested_group = true;
-            }
         }
     }
     return Status::OK();
@@ -936,6 +943,13 @@ Status VariantCompactionUtil::check_path_stats(const std::vector<RowsetSharedPtr
     if (output->tablet_schema()->num_variant_columns() == 0) {
         return Status::OK();
     }
+    for (const auto& rowset : intputs) {
+        for (const auto& column : rowset->tablet_schema()->columns()) {
+            if (column->is_variant_type() && !should_check_variant_path_stats(*column)) {
+                return Status::OK();
+            }
+        }
+    }
     // check no extended schema in input rowsets
     for (const auto& rowset : intputs) {
         for (const auto& column : rowset->tablet_schema()->columns()) {
@@ -967,6 +981,16 @@ Status VariantCompactionUtil::check_path_stats(const std::vector<RowsetSharedPtr
     for (auto& rowset : intputs) {
         if (rowset->rowset_meta()->has_delete_predicate()) {
             return Status::OK();
+        }
+    }
+    for (const auto& column : output->tablet_schema()->columns()) {
+        if (column->is_variant_type() && !should_check_variant_path_stats(*column)) {
+            return Status::OK();
+        }
+    }
+    for (const auto& column : output->tablet_schema()->columns()) {
+        if (!column->is_variant_type()) {
+            continue;
         }
     }
     std::unordered_map<int32_t, PathToNoneNullValues> original_uid_to_path_stats;
@@ -1188,18 +1212,14 @@ void VariantCompactionUtil::get_compaction_subcolumns_from_data_types(
 Status VariantCompactionUtil::get_extended_compaction_schema(
         const std::vector<RowsetSharedPtr>& rowsets, TabletSchemaSPtr& target) {
     std::unordered_map<int32_t, VariantExtendedInfo> uid_to_variant_extended_info;
-    // collect path stats from all rowsets and segments
-    for (const auto& rs : rowsets) {
-        RETURN_IF_ERROR(aggregate_variant_extended_info(rs, &uid_to_variant_extended_info));
-    }
-
-    // If any variant column has nested group, skip extended schema and use normal compaction.
-    // Nested groups require special handling that is not yet supported in extended schema compaction.
-    for (const auto& [uid, info] : uid_to_variant_extended_info) {
-        if (info.has_nested_group) {
-            LOG(INFO) << "Variant column uid=" << uid
-                      << " has nested group, skip extended schema compaction";
-            return Status::OK();
+    const bool has_extendable_variant =
+            std::ranges::any_of(target->columns(), [](const TabletColumnPtr& column) {
+                return column->is_variant_type() && should_check_variant_path_stats(*column);
+            });
+    if (has_extendable_variant) {
+        // collect path stats from all rowsets and segments
+        for (const auto& rs : rowsets) {
+            RETURN_IF_ERROR(aggregate_variant_extended_info(rs, &uid_to_variant_extended_info));
         }
     }
 
@@ -1216,6 +1236,22 @@ Status VariantCompactionUtil::get_extended_compaction_schema(
         }
         VLOG_DEBUG << "column " << column->name() << " unique id " << column->unique_id();
 
+        const auto info_it = uid_to_variant_extended_info.find(column->unique_id());
+        const VariantExtendedInfo empty_extended_info;
+        const VariantExtendedInfo& extended_info = info_it == uid_to_variant_extended_info.end()
+                                                           ? empty_extended_info
+                                                           : info_it->second;
+        if (!should_check_variant_path_stats(*column)) {
+            VLOG_DEBUG << "skip extended schema compaction for variant uid=" << column->unique_id()
+                       << " because the column disables variant path stats";
+            continue;
+        }
+        if (extended_info.has_nested_group) {
+            LOG(INFO) << "Variant column uid=" << column->unique_id()
+                      << " has nested group, keep original column in compaction schema";
+            continue;
+        }
+
         if (column->variant_enable_doc_mode()) {
             const int bucket_num = std::max(1, column->variant_doc_hash_shard_count());
             for (int b = 0; b < bucket_num; ++b) {
@@ -1228,34 +1264,30 @@ Status VariantCompactionUtil::get_extended_compaction_schema(
         }
 
         // 1. append typed columns
-        RETURN_IF_ERROR(get_compaction_typed_columns(
-                target, uid_to_variant_extended_info[column->unique_id()].typed_paths, column,
-                output_schema, uid_to_paths_set_info[column->unique_id()]));
+        RETURN_IF_ERROR(get_compaction_typed_columns(target, extended_info.typed_paths, column,
+                                                     output_schema,
+                                                     uid_to_paths_set_info[column->unique_id()]));
         // 2. append nested columns
         RETURN_IF_ERROR(get_compaction_nested_columns(
-                uid_to_variant_extended_info[column->unique_id()].nested_paths,
-                uid_to_variant_extended_info[column->unique_id()].path_to_data_types, column,
-                output_schema, uid_to_paths_set_info[column->unique_id()]));
+                extended_info.nested_paths, extended_info.path_to_data_types, column, output_schema,
+                uid_to_paths_set_info[column->unique_id()]));
 
         // 3. get the subpaths
-        get_subpaths(column->variant_max_subcolumns_count(),
-                     uid_to_variant_extended_info[column->unique_id()].path_to_none_null_values,
+        get_subpaths(column->variant_max_subcolumns_count(), extended_info.path_to_none_null_values,
                      uid_to_paths_set_info[column->unique_id()]);
 
         // 4. append subcolumns
         if (column->variant_max_subcolumns_count() > 0 || !column->get_sub_columns().empty()) {
             get_compaction_subcolumns_from_subpaths(
                     uid_to_paths_set_info[column->unique_id()], column, target,
-                    uid_to_variant_extended_info[column->unique_id()].path_to_data_types,
-                    uid_to_variant_extended_info[column->unique_id()].sparse_paths, output_schema);
+                    extended_info.path_to_data_types, extended_info.sparse_paths, output_schema);
         }
         // variant_max_subcolumns_count == 0 and no typed paths materialized
         // it means that all subcolumns are materialized, may be from old data
         else {
             get_compaction_subcolumns_from_data_types(
                     uid_to_paths_set_info[column->unique_id()], column, target,
-                    uid_to_variant_extended_info[column->unique_id()].path_to_data_types,
-                    output_schema);
+                    extended_info.path_to_data_types, output_schema);
         }
 
         // append sparse column(s)

--- a/be/src/exec/common/variant_util.h
+++ b/be/src/exec/common/variant_util.h
@@ -72,6 +72,18 @@ bool glob_match_re2(const std::string& glob_pattern, const std::string& candidat
 using PathToNoneNullValues = std::unordered_map<std::string, int64_t>;
 using PathToDataTypes = std::unordered_map<PathInData, std::vector<DataTypePtr>, PathInData::Hash>;
 
+inline bool should_record_variant_path_stats(const TabletColumn& column) {
+    return !column.variant_enable_nested_group();
+}
+
+inline bool should_write_variant_binary_columns(const TabletColumn& column) {
+    return !column.variant_enable_nested_group();
+}
+
+inline bool should_check_variant_path_stats(const TabletColumn& column) {
+    return !column.variant_enable_nested_group();
+}
+
 struct VariantExtendedInfo {
     PathToNoneNullValues path_to_none_null_values; // key: path, value: number of none null values
     std::unordered_set<std::string> sparse_paths;  // sparse paths in this variant column

--- a/be/src/storage/segment/column_writer.h
+++ b/be/src/storage/segment/column_writer.h
@@ -679,6 +679,8 @@ public:
         return Status::NotSupported("variant writer has no data, can not finish_current_page");
     }
 
+    VariantColumnWriterImpl* impl_for_test() const { return _impl.get(); }
+
 private:
     std::unique_ptr<VariantColumnWriterImpl> _impl;
     ordinal_t _next_rowid = 0;

--- a/be/src/storage/segment/variant/nested_group_builder.h
+++ b/be/src/storage/segment/variant/nested_group_builder.h
@@ -1,0 +1,165 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <parallel_hashmap/phmap.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "common/status.h"
+#include "core/column/column.h"
+#include "core/column/column_variant.h"
+#include "storage/segment/variant/nested_group_path.h"
+#include "util/json/path_in_data.h"
+
+namespace doris {
+struct JsonbValue;
+} // namespace doris
+
+namespace doris::segment_v2 {
+
+/**
+ * English comment: NestedGroup is a storage-layer structure used to persist array<object>
+ * with shared offsets to preserve per-element field associations.
+ *
+ * This is intentionally independent from ColumnVariant's in-memory nested structures.
+ */
+struct NestedGroup {
+    // Full array path for top-level group (e.g. "voltage.list"),
+    // and relative path for nested groups within another NestedGroup (e.g. "cells").
+    PathInData path;
+
+    // Offsets per parent row (or per parent element for nested groups).
+    MutableColumnPtr offsets;
+
+    // Scalar (or flattened object) children under this array path.
+    phmap::flat_hash_map<PathInData, ColumnVariant::Subcolumn, PathInData::Hash> children;
+    // Sparse row positions for each child subcolumn value in flattened element space.
+    // When present for a child path, children[path] stores only non-missing values and
+    // child_rowids[path][i] is the logical row index for children[path][i].
+    phmap::flat_hash_map<PathInData, std::vector<uint32_t>, PathInData::Hash> child_rowids;
+
+    // Nested array<object> groups under this array path.
+    phmap::flat_hash_map<PathInData, std::shared_ptr<NestedGroup>, PathInData::Hash> nested_groups;
+
+    size_t current_flat_size = 0;
+    bool is_disabled = false;
+
+    enum struct StructureType { UNKNOWN, SCALAR, ARRAY, OBJECT };
+    StructureType expected_type = StructureType::UNKNOWN;
+
+    void ensure_offsets();
+};
+
+using NestedGroupsMap =
+        phmap::flat_hash_map<PathInData, std::shared_ptr<NestedGroup>, PathInData::Hash>;
+
+// NestedGroup marker/path constants are defined in nested_group_path.h
+
+/**
+ * English comment: Build NestedGroup(s) from JSONB columns at storage finalize stage.
+ * The builder scans JSONB values and only expands array<object>.
+ */
+class NestedGroupBuilder {
+public:
+    NestedGroupBuilder() = default;
+
+    // Build NestedGroups from a JSONB column. base_path is the path of this JSONB column
+    // in ColumnVariant (empty for root JSONB).
+    Status build_from_jsonb(const ColumnPtr& jsonb_column, const PathInData& base_path,
+                            NestedGroupsMap& nested_groups, size_t num_rows);
+
+    // Convenience overload for root JSONB.
+    Status build_from_jsonb(const ColumnPtr& jsonb_column, NestedGroupsMap& nested_groups,
+                            size_t num_rows) {
+        return build_from_jsonb(jsonb_column, PathInData {}, nested_groups, num_rows);
+    }
+
+    // Collect paths that have ARRAY<OBJECT> vs non-array structural conflicts.
+    // Returned paths are de-duplicated and sorted.
+    void collect_conflict_paths(std::vector<std::string>* out_paths) const;
+
+    void set_max_depth(size_t max_depth) { _max_depth = max_depth; }
+
+private:
+    using AppendedPathCache =
+            phmap::flat_hash_map<std::string, PathInData, phmap::priv::StringHashEqT<char>::Hash,
+                                 phmap::priv::StringHashEqT<char>::Eq>;
+
+    enum class PathShape { ARRAY_OBJECT, NON_ARRAY };
+
+    struct PathShapeState {
+        bool has_array_object = false;
+        bool has_non_array = false;
+    };
+
+    const PathInData& _normalize_group_path(const PathInData& path) const;
+    void _record_path_shape(const PathInData& path, PathShape shape);
+    PathInData _append_path_cached(const PathInData& base, std::string_view suffix);
+
+    Status _process_jsonb_value(const doris::JsonbValue* value, const PathInData& current_path,
+                                NestedGroupsMap& nested_groups, size_t row_idx, size_t depth);
+
+    Status _process_object_as_paths(const doris::JsonbValue* obj_value,
+                                    const PathInData& current_prefix, NestedGroup& group,
+                                    size_t element_flat_idx, size_t depth,
+                                    const PathInData& group_absolute_path);
+
+    Status _process_array_of_objects(const doris::JsonbValue* arr_value, NestedGroup& group,
+                                     size_t parent_row_idx, size_t depth,
+                                     const PathInData& group_absolute_path);
+    Status _finalize_group(NestedGroup& group);
+
+    // Process nested object field by recursively flattening into dotted paths.
+    Status _process_object_field(const doris::JsonbValue* obj_value, const PathInData& next_prefix,
+                                 NestedGroup& group, size_t element_flat_idx, size_t depth,
+                                 const PathInData& group_absolute_path);
+
+    // Process nested array<object> field within a NestedGroup.
+    Status _process_nested_array_field(const doris::JsonbValue* arr_value,
+                                       const PathInData& next_prefix, NestedGroup& group,
+                                       size_t element_flat_idx, size_t depth,
+                                       const PathInData& group_absolute_path);
+
+    // Process scalar field and insert into subcolumn.
+    Status _process_scalar_field(const doris::JsonbValue* value, const PathInData& next_prefix,
+                                 NestedGroup& group, size_t element_flat_idx);
+
+    // Return true if this array can be treated as array<object> (nulls allowed).
+    bool _is_array_of_objects(const doris::JsonbValue* arr_value) const;
+
+    // Convert a JsonbValue to a scalar Field (or NULL Field). Container types are not supported.
+    Status _jsonb_to_field(const doris::JsonbValue* value, Field& out) const;
+
+    // Conflict policy placeholder. Returns true if the current value should be discarded.
+    bool _handle_conflict(NestedGroup& group, bool is_array_object) const;
+
+private:
+    size_t _max_depth = 0; // 0 = unlimited
+    phmap::flat_hash_map<PathInData, PathShapeState, PathInData::Hash> _path_shape_states;
+    phmap::flat_hash_set<std::string> _conflict_paths;
+    phmap::flat_hash_map<PathInData, AppendedPathCache, PathInData::Hash> _appended_path_cache;
+};
+
+} // namespace doris::segment_v2

--- a/be/src/storage/segment/variant/nested_group_path.h
+++ b/be/src/storage/segment/variant/nested_group_path.h
@@ -39,6 +39,15 @@ inline bool contains_nested_group_marker(std::string_view path) {
     return path.find(kNestedGroupMarker) != std::string_view::npos;
 }
 
+inline bool nested_group_path_has_prefix(std::string_view path, std::string_view prefix) {
+    return path == prefix ||
+           (path.size() > prefix.size() && path.starts_with(prefix) && path[prefix.size()] == '.');
+}
+
+inline bool nested_group_paths_overlap(std::string_view lhs, std::string_view rhs) {
+    return nested_group_path_has_prefix(lhs, rhs) || nested_group_path_has_prefix(rhs, lhs);
+}
+
 inline std::string nested_group_marker_token() {
     return "." + std::string(kNestedGroupMarker) + ".";
 }

--- a/be/src/storage/segment/variant/nested_group_provider.cpp
+++ b/be/src/storage/segment/variant/nested_group_provider.cpp
@@ -169,8 +169,8 @@ public:
     Status init_readers(const ColumnReaderOptions& /*opts*/,
                         const std::shared_ptr<SegmentFooterPB>& /*footer*/,
                         const std::shared_ptr<io::FileReader>& /*file_reader*/,
-                        ColumnMetaAccessor* /*accessor*/, uint64_t /*num_rows*/,
-                        NestedGroupReaders& /*out_readers*/) override {
+                        ColumnMetaAccessor* /*accessor*/, int32_t /*root_unique_id*/,
+                        uint64_t /*num_rows*/, NestedGroupReaders& /*out_readers*/) override {
         return Status::OK();
     }
 

--- a/be/src/storage/segment/variant/nested_group_provider.cpp
+++ b/be/src/storage/segment/variant/nested_group_provider.cpp
@@ -17,26 +17,138 @@
 
 #include "storage/segment/variant/nested_group_provider.h"
 
-#include <string>
-
-#include "storage/segment/variant/nested_group_routing_plan.h"
-
 namespace doris::segment_v2 {
 
 namespace {
 
-// --------------------------------------------------------------------------
-// Default write provider — no-op placeholder.
-// TODO: provide a full implementation that expands JSONB into NestedGroup
-//       columns with auxiliary indexes.
-// --------------------------------------------------------------------------
+NestedGroupPathMatch build_path_match(const NestedGroupReader* reader, std::string child_path,
+                                      bool collect_chain) {
+    NestedGroupPathMatch result;
+    result.reader = reader;
+    result.child_path = std::move(child_path);
+    result.found = true;
+    if (collect_chain) {
+        result.chain.push_back(reader);
+    }
+    return result;
+}
+
+void maybe_prepend_chain(NestedGroupPathMatch* result, const NestedGroupReader* reader,
+                         bool collect_chain) {
+    if (result == nullptr || !result->found || !collect_chain) {
+        return;
+    }
+    result->chain.insert(result->chain.begin(), reader);
+}
+
+bool has_child_or_nested_prefix(const NestedGroupReader& reader, const std::string& remaining) {
+    const std::string remaining_dot = remaining + ".";
+    const bool has_child_prefix =
+            std::any_of(reader.child_readers.begin(), reader.child_readers.end(),
+                        [&](const auto& e) { return e.first.starts_with(remaining_dot); });
+    if (has_child_prefix) {
+        return true;
+    }
+    return std::any_of(reader.nested_group_readers.begin(), reader.nested_group_readers.end(),
+                       [&](const auto& e) { return e.first.starts_with(remaining_dot); });
+}
+
+NestedGroupPathMatch find_in_nested_groups_impl(const NestedGroupReaders& readers,
+                                                const std::string& path, bool collect_chain) {
+    if (path.empty()) {
+        return {};
+    }
+
+    const std::string root_path(kRootNestedGroupPath);
+    if (auto it = readers.find(root_path); it != readers.end()) {
+        const auto& root_reader = it->second;
+        if (root_reader && root_reader->is_valid()) {
+            if (path == root_path) {
+                return build_path_match(root_reader.get(), {}, collect_chain);
+            }
+            if (root_reader->child_readers.contains(path)) {
+                return build_path_match(root_reader.get(), path, collect_chain);
+            }
+            auto nested = find_in_nested_groups_impl(root_reader->nested_group_readers, path,
+                                                     collect_chain);
+            if (nested.found) {
+                maybe_prepend_chain(&nested, root_reader.get(), collect_chain);
+                return nested;
+            }
+        }
+    }
+
+    for (const auto& [ng_path, reader] : readers) {
+        if (ng_path == root_path) {
+            continue;
+        }
+        if (!reader || !reader->is_valid()) {
+            continue;
+        }
+
+        if (path == ng_path) {
+            return build_path_match(reader.get(), {}, collect_chain);
+        }
+
+        const std::string prefix = ng_path + ".";
+        if (path.size() <= prefix.size() || !path.starts_with(prefix)) {
+            continue;
+        }
+
+        std::string remaining = path.substr(prefix.size());
+        if (reader->child_readers.contains(remaining)) {
+            return build_path_match(reader.get(), std::move(remaining), collect_chain);
+        }
+
+        auto nested =
+                find_in_nested_groups_impl(reader->nested_group_readers, remaining, collect_chain);
+        if (nested.found) {
+            maybe_prepend_chain(&nested, reader.get(), collect_chain);
+            return nested;
+        }
+
+        if (has_child_or_nested_prefix(*reader, remaining)) {
+            return build_path_match(reader.get(), std::move(remaining), collect_chain);
+        }
+    }
+    return {};
+}
+
 class DefaultNestedGroupWriteProvider final : public NestedGroupWriteProvider {
 public:
-    Status prepare(const ColumnVariant& /*variant*/, bool /*include_jsonb_subcolumns*/,
-                   const TabletColumn* /*tablet_column*/, const ColumnWriterOptions& /*opts*/,
-                   OlapBlockDataConvertor* /*converter*/, size_t /*num_rows*/, int* /*column_id*/,
-                   VariantStatistics* /*statistics*/) override {
-        // No-op: NestedGroup write is not available in this build.
+    Status prepare(const ColumnVariant& /*variant*/, const TabletColumn* tablet_column,
+                   const ColumnWriterOptions& /*opts*/, OlapBlockDataConvertor* converter,
+                   int* column_id, VariantStatistics* statistics) override {
+        if (tablet_column == nullptr || converter == nullptr || column_id == nullptr ||
+            statistics == nullptr) {
+            return Status::InvalidArgument("NestedGroup provider input is null");
+        }
+        return Status::OK();
+    }
+
+    Status prepare_with_built_groups(const NestedGroupsMap& /*nested_groups*/,
+                                     const TabletColumn* tablet_column,
+                                     const ColumnWriterOptions& /*opts*/,
+                                     OlapBlockDataConvertor* converter, int* column_id,
+                                     VariantStatistics* statistics) override {
+        if (tablet_column == nullptr || converter == nullptr || column_id == nullptr ||
+            statistics == nullptr) {
+            return Status::InvalidArgument("NestedGroup provider input is null");
+        }
+        return Status::OK();
+    }
+
+    Status init_with_plan(const NestedGroupStreamingWritePlan& /*plan*/,
+                          const TabletColumn* tablet_column, const ColumnWriterOptions& /*opts*/,
+                          int* column_id, VariantStatistics* statistics) override {
+        if (tablet_column == nullptr || column_id == nullptr || statistics == nullptr) {
+            return Status::InvalidArgument("NestedGroup streaming init input is null");
+        }
+        return Status::OK();
+    }
+
+    Status append_chunk(const NestedGroupStreamingWritePlan& /*plan*/,
+                        const ColumnVariant& /*variant*/) override {
         return Status::OK();
     }
 
@@ -50,16 +162,9 @@ public:
     Status write_bloom_filter_index() override { return Status::OK(); }
 };
 
-// --------------------------------------------------------------------------
-// Default read provider — disabled placeholder.
-// TODO: provide a full implementation for nested array<object> access.
-// --------------------------------------------------------------------------
 class DefaultNestedGroupReadProvider final : public NestedGroupReadProvider {
 public:
-    bool should_enable_nested_group_read_path() const override {
-        // Disabled: NestedGroup read path is not available in this build.
-        return false;
-    }
+    bool should_enable_nested_group_read_path() const override { return false; }
 
     Status init_readers(const ColumnReaderOptions& /*opts*/,
                         const std::shared_ptr<SegmentFooterPB>& /*footer*/,
@@ -72,13 +177,11 @@ public:
     bool try_build_read_plan(
             const TabletSchema* /*tablet_schema*/, const NestedGroupReaders& /*readers*/,
             const TabletColumn& /*target_col*/, const StorageReadOptions* /*opt*/,
-            int32_t /*col_uid*/, const PathInData& /*relative_path*/,
-            // outputs:
-            bool* /*out_is_whole*/, DataTypePtr* /*out_type*/, PathInData* /*out_relative_path*/,
+            int32_t /*col_uid*/, const PathInData& /*relative_path*/, bool* /*out_is_whole*/,
+            DataTypePtr* /*out_type*/, PathInData* /*out_relative_path*/,
             std::string* /*out_child_path*/, std::string* /*out_pruned_path*/,
             std::vector<const NestedGroupReader*>* /*out_chain*/,
             std::optional<NestedGroupPathFilter>* /*out_path_filter*/) const override {
-        // Always returns false: NestedGroup read planning is not available.
         return false;
     }
 
@@ -122,19 +225,35 @@ public:
 
 NestedGroupPathMatch find_in_nested_groups(const NestedGroupReaders& readers,
                                            const std::string& path, bool collect_chain) {
-    // Default implementation: no nested groups are populated, so nothing matches.
-    return {};
+    return find_in_nested_groups_impl(readers, path, collect_chain);
+}
+
+Status build_nested_groups_from_variant_jsonb(const ColumnVariant& /*variant*/,
+                                              NestedGroupsMap* nested_groups,
+                                              std::vector<std::string>* out_ng_paths,
+                                              std::vector<std::string>* out_conflict_paths) {
+    if (nested_groups == nullptr) {
+        return Status::InvalidArgument("nested_groups is null");
+    }
+    nested_groups->clear();
+    if (out_ng_paths != nullptr) {
+        out_ng_paths->clear();
+    }
+    if (out_conflict_paths != nullptr) {
+        out_conflict_paths->clear();
+    }
+    return Status::OK();
 }
 
 Status collect_nested_group_routing_paths_from_variant_jsonb(
-        const ColumnVariant& /*variant*/, std::vector<std::string>* out_ng_paths,
+        const ColumnVariant& variant, std::vector<std::string>* out_ng_paths,
         std::vector<std::string>* out_conflict_paths) {
     if (out_ng_paths == nullptr || out_conflict_paths == nullptr) {
         return Status::InvalidArgument("out_ng_paths or out_conflict_paths is null");
     }
-    out_ng_paths->clear();
-    out_conflict_paths->clear();
-    return Status::OK();
+    NestedGroupsMap nested_groups;
+    return build_nested_groups_from_variant_jsonb(variant, &nested_groups, out_ng_paths,
+                                                  out_conflict_paths);
 }
 
 std::unique_ptr<NestedGroupWriteProvider> create_nested_group_write_provider() {

--- a/be/src/storage/segment/variant/nested_group_provider.h
+++ b/be/src/storage/segment/variant/nested_group_provider.h
@@ -193,8 +193,8 @@ public:
     virtual Status init_readers(const ColumnReaderOptions& opts,
                                 const std::shared_ptr<SegmentFooterPB>& footer,
                                 const std::shared_ptr<io::FileReader>& file_reader,
-                                ColumnMetaAccessor* accessor, uint64_t num_rows,
-                                NestedGroupReaders& out_readers) = 0;
+                                ColumnMetaAccessor* accessor, int32_t root_unique_id,
+                                uint64_t num_rows, NestedGroupReaders& out_readers) = 0;
 
     // --- Read planning ---
     // Determines if |relative_path| should be read via the NestedGroup path and if so

--- a/be/src/storage/segment/variant/nested_group_provider.h
+++ b/be/src/storage/segment/variant/nested_group_provider.h
@@ -31,7 +31,11 @@
 #include "core/column/column.h"
 #include "core/data_type/data_type.h"
 #include "storage/segment/column_reader.h"
+#include "storage/segment/variant/nested_group_builder.h"
+#include "storage/segment/variant/nested_group_path.h"
 #include "storage/segment/variant/nested_group_reader.h"
+#include "storage/segment/variant/nested_group_routing_plan.h"
+#include "storage/segment/variant/nested_group_streaming_write_plan.h"
 #include "util/json/path_in_data.h"
 
 namespace roaring {
@@ -81,12 +85,8 @@ struct NestedGroupPathFilter {
         if (allow_all) {
             return true;
         }
-        if (allowed_paths.contains(name)) {
-            return true;
-        }
-        std::string prefix = name + ".";
         return std::ranges::any_of(allowed_paths, [&](const auto& path) {
-            return path.starts_with(prefix) || name.starts_with(path + ".");
+            return nested_group_paths_overlap(path, name);
         });
     }
 
@@ -134,14 +134,32 @@ NestedGroupPathMatch find_in_nested_groups(const NestedGroupReaders& readers,
 // The default provider is a no-op placeholder.
 // Downstream integrations may provide a full implementation that expands JSONB
 // into NestedGroup columns with auxiliary indexes.
+Status build_nested_groups_from_variant_jsonb(
+        const ColumnVariant& variant, NestedGroupsMap* nested_groups,
+        std::vector<std::string>* out_ng_paths = nullptr,
+        std::vector<std::string>* out_conflict_paths = nullptr);
+
 class NestedGroupWriteProvider {
 public:
     virtual ~NestedGroupWriteProvider() = default;
 
-    virtual Status prepare(const ColumnVariant& variant, bool include_jsonb_subcolumns,
-                           const TabletColumn* tablet_column, const ColumnWriterOptions& opts,
-                           OlapBlockDataConvertor* converter, size_t num_rows, int* column_id,
-                           VariantStatistics* statistics) = 0;
+    virtual Status prepare(const ColumnVariant& variant, const TabletColumn* tablet_column,
+                           const ColumnWriterOptions& opts, OlapBlockDataConvertor* converter,
+                           int* column_id, VariantStatistics* statistics) = 0;
+
+    virtual Status prepare_with_built_groups(const NestedGroupsMap& nested_groups,
+                                             const TabletColumn* tablet_column,
+                                             const ColumnWriterOptions& opts,
+                                             OlapBlockDataConvertor* converter, int* column_id,
+                                             VariantStatistics* statistics) = 0;
+
+    virtual Status init_with_plan(const NestedGroupStreamingWritePlan& plan,
+                                  const TabletColumn* tablet_column,
+                                  const ColumnWriterOptions& opts, int* column_id,
+                                  VariantStatistics* statistics) = 0;
+
+    virtual Status append_chunk(const NestedGroupStreamingWritePlan& plan,
+                                const ColumnVariant& variant) = 0;
 
     virtual uint64_t estimate_buffer_size() const = 0;
 

--- a/be/src/storage/segment/variant/nested_group_routing_plan.cpp
+++ b/be/src/storage/segment/variant/nested_group_routing_plan.cpp
@@ -35,11 +35,6 @@ namespace doris::segment_v2 {
 // Path prefix utilities
 // --------------------------------------------------------------------------
 
-static bool _path_has_prefix(std::string_view path, std::string_view prefix) {
-    return path == prefix ||
-           (path.size() > prefix.size() && path.starts_with(prefix) && path[prefix.size()] == '.');
-}
-
 static bool _is_excluded_by_prefixes(std::string_view path,
                                      const std::vector<std::string>& excluded_prefixes,
                                      bool exclude_all_paths) {
@@ -47,7 +42,7 @@ static bool _is_excluded_by_prefixes(std::string_view path,
         return true;
     }
     for (const auto& prefix : excluded_prefixes) {
-        if (_path_has_prefix(path, prefix)) {
+        if (nested_group_path_has_prefix(path, prefix)) {
             return true;
         }
     }
@@ -72,7 +67,7 @@ static std::vector<std::string> _compact_prefixes(std::vector<std::string> prefi
     for (auto& p : prefixes) {
         bool redundant = false;
         for (const auto& c : compacted) {
-            if (_path_has_prefix(p, c)) {
+            if (nested_group_path_has_prefix(p, c)) {
                 redundant = true;
                 break;
             }
@@ -90,6 +85,27 @@ static bool _is_array_variant_type(const DataTypePtr& type) {
     return base_type != nullptr &&
            remove_nullable(base_type)->get_primitive_type() == PrimitiveType::TYPE_VARIANT;
 }
+
+std::string format_nested_group_conflict_paths(const std::vector<std::string>& conflict_paths) {
+    std::string paths_str;
+    for (const auto& path : conflict_paths) {
+        if (!paths_str.empty()) {
+            paths_str += ", ";
+        }
+        paths_str += path;
+    }
+    return paths_str;
+}
+
+Status validate_nested_group_conflicts(const std::vector<std::string>& conflict_paths,
+                                       NestedGroupConflictPolicy policy) {
+    if (policy == NestedGroupConflictPolicy::ERROR && !conflict_paths.empty()) {
+        return Status::InvalidArgument("NestedGroup conflict detected (policy=ERROR) at paths: {}",
+                                       format_nested_group_conflict_paths(conflict_paths));
+    }
+    return Status::OK();
+}
+
 // Routing builder: only NON-conflict NG paths go into ng_only_prefixes.
 // Conflict paths are NOT excluded from subcolumn writes so compaction/write
 // can still preserve conflict-path payload in regular subcolumns.
@@ -112,16 +128,7 @@ static Status _build_ng_routing_from_columns(
         return Status::OK();
     }
 
-    // Under ERROR policy, reject any conflicts immediately.
-    if (*conflict_policy == NestedGroupConflictPolicy::ERROR && !conflict_candidate_paths.empty()) {
-        std::string paths_str;
-        for (const auto& p : conflict_candidate_paths) {
-            if (!paths_str.empty()) paths_str += ", ";
-            paths_str += p;
-        }
-        return Status::InvalidArgument("NestedGroup conflict detected (policy=ERROR) at paths: {}",
-                                       paths_str);
-    }
+    RETURN_IF_ERROR(validate_nested_group_conflicts(conflict_candidate_paths, *conflict_policy));
 
     // Build the conflict set for quick lookup.
     std::unordered_set<std::string> conflict_set(conflict_candidate_paths.begin(),
@@ -159,15 +166,22 @@ static Status _build_ng_routing_from_columns(
 // --------------------------------------------------------------------------
 
 Status build_nested_group_routing_plan(const ColumnVariant& variant, NestedGroupRoutingPlan* plan) {
+    std::vector<std::string> ng_candidate_paths;
+    std::vector<std::string> conflict_candidate_paths;
+    RETURN_IF_ERROR(collect_nested_group_routing_paths_from_variant_jsonb(
+            variant, &ng_candidate_paths, &conflict_candidate_paths));
+    return build_nested_group_routing_plan_from_candidates(variant, ng_candidate_paths,
+                                                           conflict_candidate_paths, plan);
+}
+
+Status build_nested_group_routing_plan_from_candidates(
+        const ColumnVariant& variant, const std::vector<std::string>& ng_candidate_paths,
+        const std::vector<std::string>& conflict_candidate_paths, NestedGroupRoutingPlan* plan) {
     if (plan == nullptr) {
         return Status::InvalidArgument("plan is null");
     }
     *plan = NestedGroupRoutingPlan {};
 
-    std::vector<std::string> ng_candidate_paths;
-    std::vector<std::string> conflict_candidate_paths;
-    RETURN_IF_ERROR(collect_nested_group_routing_paths_from_variant_jsonb(
-            variant, &ng_candidate_paths, &conflict_candidate_paths));
     RETURN_IF_ERROR(_build_ng_routing_from_columns(
             variant, ng_candidate_paths, conflict_candidate_paths, &plan->ng_only_prefixes,
             &plan->exclude_all_subcolumns, &plan->conflict_policy, &plan->has_conflict_paths));

--- a/be/src/storage/segment/variant/nested_group_routing_plan.h
+++ b/be/src/storage/segment/variant/nested_group_routing_plan.h
@@ -67,6 +67,11 @@ struct NestedGroupRoutingPlan {
 // array<object> paths, detects conflicts, and populates the plan.
 Status build_nested_group_routing_plan(const ColumnVariant& variant, NestedGroupRoutingPlan* plan);
 
+// Build NG routing plan from pre-collected NG and conflict paths.
+Status build_nested_group_routing_plan_from_candidates(
+        const ColumnVariant& variant, const std::vector<std::string>& ng_candidate_paths,
+        const std::vector<std::string>& conflict_candidate_paths, NestedGroupRoutingPlan* plan);
+
 // Collect NG routing metadata from variant content:
 // - out_ng_paths: all NG candidate paths
 // - out_conflict_paths: NG paths that have ARRAY<OBJECT> vs non-array structural conflicts
@@ -77,5 +82,10 @@ Status collect_nested_group_routing_paths_from_variant_jsonb(
 
 // Get the current global conflict policy (driven by config).
 NestedGroupConflictPolicy get_nested_group_conflict_policy();
+
+// Shared helpers for conflict reporting / validation across write and compaction planners.
+std::string format_nested_group_conflict_paths(const std::vector<std::string>& conflict_paths);
+Status validate_nested_group_conflicts(const std::vector<std::string>& conflict_paths,
+                                       NestedGroupConflictPolicy policy);
 
 } // namespace doris::segment_v2

--- a/be/src/storage/segment/variant/nested_group_streaming_write_plan.cpp
+++ b/be/src/storage/segment/variant/nested_group_streaming_write_plan.cpp
@@ -1,0 +1,241 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "storage/segment/variant/nested_group_streaming_write_plan.h"
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+#include "core/data_type/get_least_supertype.h"
+#include "storage/rowset/beta_rowset.h"
+#include "storage/segment/column_reader.h"
+#include "storage/segment/segment.h"
+#include "storage/segment/segment_loader.h"
+#include "storage/segment/variant/nested_group_path.h"
+#include "storage/segment/variant/nested_group_provider.h"
+#include "storage/segment/variant/variant_column_reader.h"
+#include "storage/tablet/tablet_schema.h"
+
+namespace doris::segment_v2 {
+namespace {
+
+using MutableGroupMap = std::map<std::string, std::unique_ptr<struct MutableGroup>>;
+using PathToDataTypes = std::unordered_map<PathInData, DataTypes, PathInData::Hash>;
+
+struct MutableGroup {
+    std::string group_name;
+    std::string physical_path;
+    std::string logical_path;
+    size_t depth = 1;
+    std::map<std::string, DataTypes> child_types_by_rel_path;
+    MutableGroupMap nested_groups;
+};
+
+void collect_group_paths(const NestedGroupReaders& readers, const std::string& physical_prefix,
+                         const std::string& logical_prefix, MutableGroupMap* groups,
+                         std::unordered_set<std::string>* ng_owned_paths) {
+    for (const auto& [group_name, reader] : readers) {
+        std::string physical_path =
+                physical_prefix.empty()
+                        ? group_name
+                        : physical_prefix + nested_group_marker_token() + group_name;
+        std::string logical_path =
+                logical_prefix.empty() ? group_name : logical_prefix + "." + group_name;
+
+        auto& group_holder = (*groups)[group_name];
+        if (group_holder == nullptr) {
+            group_holder = std::make_unique<MutableGroup>();
+        }
+        auto& group = *group_holder;
+        group.group_name = group_name;
+        group.physical_path = physical_path;
+        group.logical_path = logical_path;
+        group.depth = reader->depth;
+
+        ng_owned_paths->insert(logical_path);
+        for (const auto& [relative_path, child_reader] : reader->child_readers) {
+            group.child_types_by_rel_path[relative_path].push_back(
+                    child_reader->get_vec_data_type());
+            ng_owned_paths->insert(logical_path + "." + relative_path);
+        }
+
+        collect_group_paths(reader->nested_group_readers, physical_path, logical_path,
+                            &group.nested_groups, ng_owned_paths);
+    }
+}
+
+void append_types_from_segment_reader(const VariantColumnReader& variant_reader,
+                                      PathToDataTypes* regular_path_types, MutableGroupMap* groups,
+                                      std::unordered_set<std::string>* ng_owned_paths) {
+    PathToDataTypes current_types;
+    variant_reader.get_subcolumns_types(&current_types);
+    for (auto& [path, types] : current_types) {
+        const std::string& path_str = path.get_path();
+        if (path_str.empty() || contains_nested_group_marker(path_str) ||
+            is_root_nested_group_path(path_str)) {
+            continue;
+        }
+        auto& out_types = (*regular_path_types)[path];
+        out_types.insert(out_types.end(), types.begin(), types.end());
+    }
+    collect_group_paths(variant_reader.get_nested_group_readers(), "", "", groups, ng_owned_paths);
+}
+
+void build_final_group_plan(const MutableGroupMap& groups,
+                            std::vector<NestedGroupStreamingGroupWritePlan>* out_groups) {
+    out_groups->clear();
+    out_groups->reserve(groups.size());
+    for (const auto& [_, group_ptr] : groups) {
+        DCHECK(group_ptr != nullptr);
+        NestedGroupStreamingGroupWritePlan group_plan;
+        group_plan.group_name = group_ptr->group_name;
+        group_plan.physical_path = group_ptr->physical_path;
+        group_plan.logical_path = group_ptr->logical_path;
+        group_plan.depth = group_ptr->depth;
+
+        for (const auto& [relative_path, data_types] : group_ptr->child_types_by_rel_path) {
+            DataTypePtr final_type;
+            get_least_supertype_jsonb(data_types, &final_type);
+            if (final_type == nullptr) {
+                continue;
+            }
+            NestedGroupStreamingChildWritePlan child_plan;
+            child_plan.relative_path = relative_path;
+            child_plan.logical_path = group_ptr->logical_path + "." + relative_path;
+            child_plan.relative_path_in_data = PathInData(relative_path);
+            child_plan.logical_path_in_data = PathInData(child_plan.logical_path);
+            child_plan.data_type = std::move(final_type);
+            group_plan.children.push_back(std::move(child_plan));
+        }
+
+        build_final_group_plan(group_ptr->nested_groups, &group_plan.nested_groups);
+        out_groups->push_back(std::move(group_plan));
+    }
+}
+
+Status append_plan_from_rowset_reader(const RowsetReaderSharedPtr& input_rs_reader,
+                                      int32_t variant_uid, PathToDataTypes* regular_path_types,
+                                      MutableGroupMap* groups,
+                                      std::unordered_set<std::string>* ng_owned_paths) {
+    if (input_rs_reader == nullptr) {
+        return Status::InvalidArgument("input rowset reader is null");
+    }
+
+    auto rowset = input_rs_reader->rowset();
+    if (rowset == nullptr) {
+        return Status::InvalidArgument("rowset reader returned null rowset");
+    }
+
+    SegmentCacheHandle segment_cache;
+    RETURN_IF_ERROR(SegmentLoader::instance()->load_segments(
+            std::static_pointer_cast<BetaRowset>(rowset), &segment_cache));
+
+    for (const auto& segment : segment_cache.get_segments()) {
+        std::shared_ptr<ColumnReader> column_reader;
+        OlapReaderStatistics stats;
+        Status st = segment->get_column_reader(variant_uid, &column_reader, &stats);
+        if (st.is<ErrorCode::NOT_FOUND>()) {
+            continue;
+        }
+        RETURN_IF_ERROR(st);
+        if (column_reader == nullptr) {
+            continue;
+        }
+        auto* variant_reader = dynamic_cast<VariantColumnReader*>(column_reader.get());
+        if (variant_reader == nullptr) {
+            return Status::InternalError("column uid {} is not a VariantColumnReader", variant_uid);
+        }
+        RETURN_IF_ERROR(variant_reader->load_external_meta_once());
+        append_types_from_segment_reader(*variant_reader, regular_path_types, groups,
+                                         ng_owned_paths);
+    }
+
+    return Status::OK();
+}
+
+} // namespace
+
+Status build_nested_group_streaming_write_plan(
+        const std::vector<RowsetReaderSharedPtr>& input_rs_readers,
+        const TabletColumn& variant_column, NestedGroupStreamingWritePlan* plan) {
+    if (plan == nullptr) {
+        return Status::InvalidArgument("plan is null");
+    }
+
+    *plan = NestedGroupStreamingWritePlan {};
+    plan->conflict_policy = get_nested_group_conflict_policy();
+
+    PathToDataTypes regular_path_types;
+    MutableGroupMap groups;
+    std::unordered_set<std::string> ng_owned_paths;
+
+    for (const auto& input_rs_reader : input_rs_readers) {
+        RETURN_IF_ERROR(append_plan_from_rowset_reader(input_rs_reader, variant_column.unique_id(),
+                                                       &regular_path_types, &groups,
+                                                       &ng_owned_paths));
+    }
+
+    build_final_group_plan(groups, &plan->nested_groups);
+    for (const auto& group : plan->nested_groups) {
+        if (is_root_nested_group_path(group.logical_path)) {
+            plan->has_root_nested_group = true;
+            break;
+        }
+    }
+
+    std::unordered_set<std::string> conflict_path_set;
+    for (const auto& [path, _] : regular_path_types) {
+        const std::string& regular_path = path.get_path();
+        for (const auto& ng_owned_path : ng_owned_paths) {
+            if (nested_group_paths_overlap(regular_path, ng_owned_path)) {
+                conflict_path_set.insert(regular_path);
+                break;
+            }
+        }
+    }
+
+    plan->conflict_paths.assign(conflict_path_set.begin(), conflict_path_set.end());
+    std::sort(plan->conflict_paths.begin(), plan->conflict_paths.end());
+    plan->has_conflict_paths = !plan->conflict_paths.empty();
+    RETURN_IF_ERROR(validate_nested_group_conflicts(plan->conflict_paths, plan->conflict_policy));
+
+    for (const auto& [path, types] : regular_path_types) {
+        if (conflict_path_set.contains(path.get_path())) {
+            continue;
+        }
+        DataTypePtr final_type;
+        get_least_supertype_jsonb(types, &final_type);
+        if (final_type == nullptr) {
+            continue;
+        }
+        NestedGroupStreamingRegularSubcolumnPlan regular_plan;
+        regular_plan.path = path.get_path();
+        regular_plan.path_in_data = path;
+        regular_plan.data_type = std::move(final_type);
+        plan->regular_subcolumns.push_back(std::move(regular_plan));
+    }
+
+    std::sort(plan->regular_subcolumns.begin(), plan->regular_subcolumns.end(),
+              [](const auto& lhs, const auto& rhs) { return lhs.path < rhs.path; });
+    return Status::OK();
+}
+
+} // namespace doris::segment_v2

--- a/be/src/storage/segment/variant/nested_group_streaming_write_plan.h
+++ b/be/src/storage/segment/variant/nested_group_streaming_write_plan.h
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "common/status.h"
+#include "core/data_type/data_type.h"
+#include "storage/rowset/rowset_fwd.h"
+#include "storage/segment/variant/nested_group_routing_plan.h"
+#include "util/json/path_in_data.h"
+
+namespace doris {
+class TabletColumn;
+
+namespace segment_v2 {
+
+struct NestedGroupStreamingChildWritePlan {
+    std::string relative_path;
+    std::string logical_path;
+    PathInData relative_path_in_data;
+    PathInData logical_path_in_data;
+    DataTypePtr data_type;
+};
+
+struct NestedGroupStreamingGroupWritePlan {
+    std::string group_name;
+    std::string physical_path;
+    std::string logical_path;
+    size_t depth = 1;
+    std::vector<NestedGroupStreamingChildWritePlan> children;
+    std::vector<NestedGroupStreamingGroupWritePlan> nested_groups;
+};
+
+struct NestedGroupStreamingRegularSubcolumnPlan {
+    std::string path;
+    PathInData path_in_data;
+    DataTypePtr data_type;
+};
+
+struct NestedGroupStreamingWritePlan {
+    NestedGroupConflictPolicy conflict_policy = NestedGroupConflictPolicy::DISCARD_SCALAR;
+    bool has_conflict_paths = false;
+    bool has_root_nested_group = false;
+    std::vector<std::string> conflict_paths;
+    std::vector<NestedGroupStreamingRegularSubcolumnPlan> regular_subcolumns;
+    std::vector<NestedGroupStreamingGroupWritePlan> nested_groups;
+
+    bool can_remove_root_jsonb() const { return has_root_nested_group && !has_conflict_paths; }
+};
+
+Status build_nested_group_streaming_write_plan(
+        const std::vector<RowsetReaderSharedPtr>& input_rs_readers,
+        const TabletColumn& variant_column, NestedGroupStreamingWritePlan* plan);
+
+} // namespace segment_v2
+} // namespace doris

--- a/be/src/storage/segment/variant/variant_column_reader.cpp
+++ b/be/src/storage/segment/variant/variant_column_reader.cpp
@@ -416,6 +416,7 @@ Status VariantColumnReader::_build_read_plan_flat_leaves(
         plan->kind = ReadKind::ROOT_FLAT;
         plan->type = create_variant_type(target_col);
         plan->relative_path = relative_path;
+        plan->needs_root_merge = _needs_root_nested_group_merge(relative_path);
         return Status::OK();
     }
     VLOG_DEBUG << "new iterator: " << target_col.path_info_ptr()->get_path();
@@ -477,6 +478,11 @@ bool VariantColumnReader::_need_read_flat_leaves(const StorageReadOptions* opts)
 bool VariantColumnReader::_can_use_nested_group_read_path() const {
     return _nested_group_read_provider != nullptr &&
            _nested_group_read_provider->should_enable_nested_group_read_path();
+}
+
+bool VariantColumnReader::_needs_root_nested_group_merge(const PathInData& relative_path) const {
+    return relative_path.empty() && _nested_group_read_provider != nullptr &&
+           !_nested_group_readers.empty();
 }
 
 Status VariantColumnReader::_validate_access_paths_debug(const TabletColumn& target_col,
@@ -752,6 +758,7 @@ Status VariantColumnReader::_build_read_plan(ReadPlan* plan, const TabletColumn&
         plan->type = create_variant_type(target_col);
         plan->relative_path = relative_path;
         plan->root = root;
+        plan->needs_root_merge = _needs_root_nested_group_merge(relative_path);
         return Status::OK();
     }
 
@@ -781,6 +788,7 @@ Status VariantColumnReader::_build_read_plan(ReadPlan* plan, const TabletColumn&
         plan->relative_path = relative_path;
         plan->node = node;
         plan->root = root;
+        plan->needs_root_merge = _needs_root_nested_group_merge(relative_path);
         return Status::OK();
     }
 
@@ -822,6 +830,7 @@ Status VariantColumnReader::_build_read_plan(ReadPlan* plan, const TabletColumn&
             plan->type = create_variant_type(target_col);
             plan->relative_path = relative_path;
             plan->root = root;
+            plan->needs_root_merge = _needs_root_nested_group_merge(relative_path);
             return Status::OK();
         }
 
@@ -847,6 +856,7 @@ Status VariantColumnReader::_build_read_plan(ReadPlan* plan, const TabletColumn&
             plan->relative_path = relative_path;
             plan->node = node;
             plan->root = root;
+            plan->needs_root_merge = _needs_root_nested_group_merge(relative_path);
             return Status::OK();
         }
 
@@ -866,31 +876,23 @@ Status VariantColumnReader::_create_iterator_from_plan(
         PathToBinaryColumnCache* binary_column_cache_ptr) {
     switch (plan.kind) {
     case ReadKind::ROOT_FLAT: {
+        // ROOT_FLAT reads the persisted root column itself. It does not rebuild root `v` from
+        // regular extracted columns such as `v.keep` / `v.owner`; only the optional root-merge
+        // wrapper below may fold NestedGroup data back into the root view.
         *iterator = std::make_unique<VariantRootColumnIterator>(
                 std::make_unique<FileColumnIterator>(_root_column_reader));
-        return Status::OK();
+        return _maybe_wrap_root_merge_iterator(iterator, plan, opt);
     }
     case ReadKind::HIERARCHICAL: {
+        // HIERARCHICAL reconstructs the requested object from extracted subcolumns plus sparse
+        // state. Reading root `v` through this branch may therefore read regular children such as
+        // `v.keep` / `v.owner` and merge them into the final variant result.
         int32_t col_uid = target_col.unique_id() >= 0 ? target_col.unique_id()
                                                       : target_col.parent_unique_id();
-        ColumnIteratorUPtr base_iterator;
         RETURN_IF_ERROR(_create_hierarchical_reader(
-                &base_iterator, col_uid, plan.relative_path, plan.node, plan.root,
-                column_reader_cache, opt->stats,
-                HierarchicalDataIterator::ReadType::SUBCOLUMNS_AND_SPARSE));
-
-        // Root variant reconstruction needs to merge top-level NestedGroup arrays, because NG leaf
-        // columns are not row-aligned and are skipped by the generic hierarchical reader.
-        if (plan.relative_path.empty() && _nested_group_read_provider != nullptr &&
-            !_nested_group_readers.empty()) {
-            ColumnIteratorUPtr merged_iterator;
-            RETURN_IF_ERROR(_nested_group_read_provider->create_root_merge_iterator(
-                    std::move(base_iterator), _nested_group_readers, opt, &merged_iterator));
-            *iterator = std::move(merged_iterator);
-            return Status::OK();
-        }
-        *iterator = std::move(base_iterator);
-        return Status::OK();
+                iterator, col_uid, plan.relative_path, plan.node, plan.root, column_reader_cache,
+                opt->stats, HierarchicalDataIterator::ReadType::SUBCOLUMNS_AND_SPARSE));
+        return _maybe_wrap_root_merge_iterator(iterator, plan, opt);
     }
     case ReadKind::LEAF: {
         DCHECK(plan.leaf_column_reader != nullptr);
@@ -947,7 +949,7 @@ Status VariantColumnReader::_create_iterator_from_plan(
         if (opt && opt->stats) {
             opt->stats->variant_doc_value_column_iter_count++;
         }
-        return Status::OK();
+        return _maybe_wrap_root_merge_iterator(iterator, plan, opt);
     }
     case ReadKind::NESTED_GROUP_WHOLE:
     case ReadKind::NESTED_GROUP_CHILD: {
@@ -971,6 +973,22 @@ Status VariantColumnReader::_create_iterator_from_plan(
     default:
         return Status::InternalError("unknown variant read kind");
     }
+}
+
+Status VariantColumnReader::_maybe_wrap_root_merge_iterator(ColumnIteratorUPtr* iterator,
+                                                            const ReadPlan& plan,
+                                                            const StorageReadOptions* opt) {
+    if (!plan.needs_root_merge) {
+        return Status::OK();
+    }
+
+    // The planner may reach this point through ROOT_FLAT, HIERARCHICAL or HIERARCHICAL_DOC.
+    // Wrapping once here prevents those branches from duplicating the same root merge logic.
+    ColumnIteratorUPtr merged_iterator;
+    RETURN_IF_ERROR(_nested_group_read_provider->create_root_merge_iterator(
+            std::move(*iterator), _nested_group_readers, opt, &merged_iterator));
+    *iterator = std::move(merged_iterator);
+    return Status::OK();
 }
 
 Status VariantColumnReader::new_iterator(ColumnIteratorUPtr* iterator,
@@ -1218,8 +1236,9 @@ Status VariantColumnReader::init(const ColumnReaderOptions& opts, ColumnMetaAcce
     // NestedGroup initialization is provider-driven. Disabled providers keep fallback behavior,
     // while enabled providers populate nested group readers from segment footer.
     if (_can_use_nested_group_read_path()) {
-        RETURN_IF_ERROR(_nested_group_read_provider->init_readers(
-                opts, footer, file_reader, accessor, num_rows, _nested_group_readers));
+        RETURN_IF_ERROR(_nested_group_read_provider->init_readers(opts, footer, file_reader,
+                                                                  accessor, _root_unique_id,
+                                                                  num_rows, _nested_group_readers));
     }
 
     return Status::OK();

--- a/be/src/storage/segment/variant/variant_column_reader.cpp
+++ b/be/src/storage/segment/variant/variant_column_reader.cpp
@@ -669,6 +669,7 @@ Status VariantColumnReader::_try_build_leaf_plan(ReadPlan* plan, int32_t col_uid
 
     DCHECK(node->is_leaf_node());
     const auto* leaf_node = _subcolumns_meta_info->find_leaf(relative_path);
+
     std::shared_ptr<ColumnReader> leaf_column_reader;
     RETURN_IF_ERROR(column_reader_cache->get_path_column_reader(
             col_uid, leaf_node->path, &leaf_column_reader, stats, leaf_node));
@@ -686,6 +687,7 @@ Status VariantColumnReader::_try_build_external_leaf_plan(ReadPlan* plan, int32_
     if (!_ext_meta_reader || !_ext_meta_reader->available()) {
         return Status::OK();
     }
+
     std::shared_ptr<ColumnReader> leaf_column_reader;
     Status st = column_reader_cache->get_path_column_reader(col_uid, relative_path,
                                                             &leaf_column_reader, stats, nullptr);
@@ -750,12 +752,6 @@ Status VariantColumnReader::_build_read_plan(ReadPlan* plan, const TabletColumn&
         plan->type = create_variant_type(target_col);
         plan->relative_path = relative_path;
         plan->root = root;
-        return Status::OK();
-    }
-
-    // NestedGroup path resolution must happen before sparse/hierarchical fallbacks.
-    // Otherwise a valid nested path may be misclassified as generic sparse extraction.
-    if (_try_build_nested_group_plan(plan, target_col, opt, col_uid, relative_path)) {
         return Status::OK();
     }
 
@@ -1032,6 +1028,8 @@ Status VariantColumnReader::init(const ColumnReaderOptions& opts, ColumnMetaAcce
 
     _data_type = DataTypeFactory::instance().create_data_type(self_column_pb);
     _root_unique_id = self_column_pb.unique_id();
+    const bool should_record_path_stats = variant_util::should_record_variant_path_stats(
+            opts.tablet_schema->column_by_uid(self_column_pb.unique_id()));
     const auto& parent_index = opts.tablet_schema->inverted_indexs(self_column_pb.unique_id());
     // record variant_sparse_column_statistics_size from parent column
     _variant_sparse_column_statistics_size =
@@ -1067,10 +1065,12 @@ Status VariantColumnReader::init(const ColumnReaderOptions& opts, ColumnMetaAcce
         std::string rel_str = relative.get_path();
         if (rel_str == SPARSE_COLUMN_PATH) {
             DCHECK(col.has_variant_statistics()) << col.DebugString();
-            // Always load sparse stats from the sparse column's own meta.
-            // This is the authoritative source; root stats may duplicate these
-            // but the sparse column meta is canonical.
-            _statistics->merge_sparse_from_pb(col.variant_statistics());
+            if (should_record_path_stats) {
+                // Always load sparse stats from the sparse column's own meta.
+                // This is the authoritative source; root stats may duplicate these
+                // but the sparse column meta is canonical.
+                _statistics->merge_sparse_from_pb(col.variant_statistics());
+            }
             std::shared_ptr<ColumnReader> single_reader;
             RETURN_IF_ERROR(ColumnReader::create(opts, col, footer->num_rows(), file_reader,
                                                  &single_reader));
@@ -1091,8 +1091,10 @@ Status VariantColumnReader::init(const ColumnReaderOptions& opts, ColumnMetaAcce
             uint32_t idx =
                     static_cast<uint32_t>(atoi(rel_str.substr(bucket_prefix.size()).c_str()));
             DCHECK(col.has_variant_statistics()) << col.DebugString();
-            // Additively merge per-bucket sparse stats into the unified statistics.
-            _statistics->merge_sparse_from_pb(col.variant_statistics());
+            if (should_record_path_stats) {
+                // Additively merge per-bucket sparse stats into the unified statistics.
+                _statistics->merge_sparse_from_pb(col.variant_statistics());
+            }
             std::shared_ptr<ColumnReader> reader;
             RETURN_IF_ERROR(ColumnReader::create(opts, col, num_rows, file_reader, &reader));
             tmp_sparse_readers[idx] = std::move(reader);
@@ -1107,8 +1109,10 @@ Status VariantColumnReader::init(const ColumnReaderOptions& opts, ColumnMetaAcce
             std::shared_ptr<ColumnReader> column_reader;
             RETURN_IF_ERROR(ColumnReader::create(opts, col, num_rows, file_reader, &column_reader));
             tmp_doc_value_readers[bucket_value] = std::move(column_reader);
-            // Additively merge per-bucket doc value stats into the unified statistics.
-            _statistics->merge_doc_value_from_pb(col.variant_statistics());
+            if (should_record_path_stats) {
+                // Additively merge per-bucket doc value stats into the unified statistics.
+                _statistics->merge_doc_value_from_pb(col.variant_statistics());
+            }
             *handled = true;
             return Status::OK();
         }
@@ -1173,7 +1177,7 @@ Status VariantColumnReader::init(const ColumnReaderOptions& opts, ColumnMetaAcce
             continue;
         }
         // check the root is already a leaf node
-        if (column_pb.has_none_null_size()) {
+        if (should_record_path_stats && column_pb.has_none_null_size()) {
             _statistics->subcolumns_non_null_size.emplace(relative_path.get_path(),
                                                           column_pb.none_null_size());
         }
@@ -1280,7 +1284,11 @@ Status VariantColumnReader::load_external_meta_once() {
     // Ensure only one writer can populate `_subcolumns_meta_info` / `_statistics`
     // while readers of these structures hold shared locks.
     std::unique_lock<std::shared_mutex> lock(_subcolumns_meta_mutex);
-    return _ext_meta_reader->load_all_once(_subcolumns_meta_info.get(), _statistics.get());
+    VariantStatistics* stats = variant_util::should_record_variant_path_stats(
+                                       _tablet_schema->column_by_uid(_root_unique_id))
+                                       ? _statistics.get()
+                                       : nullptr;
+    return _ext_meta_reader->load_all_once(_subcolumns_meta_info.get(), stats);
 }
 
 TabletIndexes VariantColumnReader::find_subcolumn_tablet_indexes(const TabletColumn& column,
@@ -1302,13 +1310,20 @@ TabletIndexes VariantColumnReader::find_subcolumn_tablet_indexes(const TabletCol
         PathInData index_path {*column.path_info_ptr()};
         DataTypePtr index_data_type = data_type;
         if (!relative_path.empty()) {
-            // For nested-group materialized columns, the inverted index suffix is built from the
-            // variant-relative path (e.g. "items.msg"), rather than the full logical column path
-            // (e.g. "data.items.msg"). This keeps the suffix consistent with the write path which
-            // does not include the VARIANT root column name.
             auto [nested_reader, _] = find_nested_group_for_path(relative_path.get_path());
+            const std::string root_path(kRootNestedGroupPath);
+
             if (nested_reader != nullptr) {
-                index_path = relative_path;
+                const bool is_root_ng = nested_reader->array_path == root_path;
+                if (!is_root_ng) {
+                    // Named NG — use variant-relative path (consistent with write path)
+                    index_path = relative_path;
+                } else {
+                    // $root NG — prefix path with __D0_root__
+                    index_path = PathInData(root_path + "." + relative_path.get_path());
+                }
+
+                // Unwrap Nullable(Array(...)) → element type for NG subcolumns
                 if (data_type->is_nullable()) {
                     auto base = variant_util::get_base_type_of_array(remove_nullable(data_type));
                     index_data_type = base->is_nullable() ? base : make_nullable(base);
@@ -1316,18 +1331,7 @@ TabletIndexes VariantColumnReader::find_subcolumn_tablet_indexes(const TabletCol
                     index_data_type = variant_util::get_base_type_of_array(data_type);
                 }
             }
-        }
-        const std::string root_path(kRootNestedGroupPath);
-        if (_nested_group_readers.contains(root_path) && !relative_path.empty()) {
-            // If the segment has a top-level "$root" nested group (JSON root is array<object>),
-            // nested paths are stored under the virtual root marker.
-            index_path = PathInData(root_path + "." + relative_path.get_path());
-            if (data_type->is_nullable()) {
-                auto base = variant_util::get_base_type_of_array(remove_nullable(data_type));
-                index_data_type = base->is_nullable() ? base : make_nullable(base);
-            } else {
-                index_data_type = variant_util::get_base_type_of_array(data_type);
-            }
+            // else: non-NG scalar field — keep index_path and index_data_type unchanged
         }
         TabletColumn target_column =
                 variant_util::get_column_by_type(index_data_type, column.name(),

--- a/be/src/storage/segment/variant/variant_column_reader.h
+++ b/be/src/storage/segment/variant/variant_column_reader.h
@@ -315,6 +315,9 @@ private:
     struct ReadPlan {
         ReadKind kind {ReadKind::DEFAULT_FILL};
         DataTypePtr type;
+        // Some root reads still need a final merge with NestedGroup readers even after the actual
+        // source iterator kind has been chosen by the planner.
+        bool needs_root_merge = false;
 
         // path & meta context
         PathInData relative_path;
@@ -352,6 +355,9 @@ private:
 
     static bool _need_read_flat_leaves(const StorageReadOptions* opts);
     bool _can_use_nested_group_read_path() const;
+    // Only root-path reads need the extra merge; child-path reads are already served by the
+    // specific iterator selected in the plan.
+    bool _needs_root_nested_group_merge(const PathInData& relative_path) const;
     Status _validate_access_paths_debug(const TabletColumn& target_col,
                                         const StorageReadOptions* opt, int32_t col_uid,
                                         const PathInData& relative_path) const;
@@ -375,6 +381,10 @@ private:
                                       const TabletColumn& target_col, const StorageReadOptions* opt,
                                       ColumnReaderCache* column_reader_cache,
                                       PathToBinaryColumnCache* binary_column_cache_ptr);
+    // Keep the merge wrapper centralized so each read-kind branch only decides where data comes
+    // from, not how root NestedGroup readers are stitched together.
+    Status _maybe_wrap_root_merge_iterator(ColumnIteratorUPtr* iterator, const ReadPlan& plan,
+                                           const StorageReadOptions* opt);
     // init for compaction read
     Status _new_default_iter_with_same_nested(ColumnIteratorUPtr* iterator, const TabletColumn& col,
                                               const StorageReadOptions* opt,

--- a/be/src/storage/segment/variant/variant_column_reader.h
+++ b/be/src/storage/segment/variant/variant_column_reader.h
@@ -30,13 +30,13 @@
 
 #include "core/column/column_variant.h"
 #include "core/column/subcolumn_tree.h"
+#include "nested_group_provider.h"
+#include "nested_group_reader.h"
 #include "storage/index/indexed_column_reader.h"
 #include "storage/segment/column_reader.h"
 #include "storage/segment/page_handle.h"
 #include "storage/segment/variant/binary_column_reader.h"
 #include "storage/segment/variant/hierarchical_data_iterator.h"
-#include "storage/segment/variant/nested_group_provider.h"
-#include "storage/segment/variant/nested_group_reader.h"
 #include "storage/segment/variant/variant_external_meta_reader.h"
 #include "storage/segment/variant/variant_statistics.h"
 #include "storage/tablet/tablet_schema.h"
@@ -451,10 +451,6 @@ public:
                           MutableColumnPtr& dst) override;
 
     ordinal_t get_current_ordinal() const override { return _inner_iter->get_current_ordinal(); }
-
-    Status read_null_map(size_t* n, NullMap& null_map) override {
-        return _inner_iter->read_null_map(n, null_map);
-    }
 
     Status init_prefetcher(const SegmentPrefetchParams& params) override;
     void collect_prefetchers(

--- a/be/src/storage/segment/variant/variant_column_writer_impl.cpp
+++ b/be/src/storage/segment/variant/variant_column_writer_impl.cpp
@@ -19,7 +19,6 @@
 #include <gen_cpp/segment_v2.pb.h>
 
 #include <algorithm>
-#include <iostream>
 #include <memory>
 #include <string_view>
 #include <unordered_map>
@@ -53,6 +52,7 @@
 #include "storage/segment/column_writer.h"
 #include "storage/segment/variant/nested_group_path.h"
 #include "storage/segment/variant/nested_group_routing_plan.h"
+#include "storage/segment/variant/variant_writer_helpers.h"
 #include "storage/tablet/tablet_schema.h"
 #include "storage/types.h"
 #include "util/json/path_in_data.h"
@@ -151,9 +151,10 @@ Status _create_column_writer(uint32_t cid, const TabletColumn& column,
     return Status::OK();
 }
 
+namespace variant_writer_helpers {
+
 Status convert_and_write_column(OlapBlockDataConvertor* converter, const TabletColumn& column,
                                 DataTypePtr data_type, ColumnWriter* writer,
-
                                 const ColumnPtr& src_column, size_t num_rows, int column_id) {
     converter->add_column_data_convertor(column);
     RETURN_IF_ERROR(converter->set_source_content_with_specifid_column({src_column, data_type, ""},
@@ -167,6 +168,8 @@ Status convert_and_write_column(OlapBlockDataConvertor* converter, const TabletC
     converter->clear_source_content(column_id);
     return Status::OK();
 }
+
+} // namespace variant_writer_helpers
 
 namespace {
 // Per-path sparse materialization result from a VARIANT doc-value column.
@@ -415,8 +418,9 @@ Status write_materialized_subcolumn(const TabletColumn& parent_column, std::stri
                                               current_type, current_column, *rowids, num_rows);
     }
 
-    return convert_and_write_column(subcolumn_converter.get(), tablet_column, current_type, writer,
-                                    current_column, num_rows, 0);
+    return variant_writer_helpers::convert_and_write_column(subcolumn_converter.get(),
+                                                            tablet_column, current_type, writer,
+                                                            current_column, num_rows, 0);
 }
 
 // Convert a sparse (values_column, rowids) pair into storage format and append to writer.
@@ -1032,6 +1036,110 @@ Status VariantDocWriter::write_bloom_filter_index() {
     return Status::OK();
 }
 
+namespace variant_writer_helpers {
+
+void maybe_remove_root_jsonb_with_empty_defaults(MutableColumnPtr* root_column, size_t num_rows,
+                                                 bool remove_root_jsonb) {
+    if (!remove_root_jsonb) {
+        return;
+    }
+    auto bare_jsonb_type = std::make_shared<ColumnVariant::MostCommonType>();
+    auto bare_jsonb_col = bare_jsonb_type->create_column();
+    bare_jsonb_col->insert_many_defaults(num_rows);
+    *root_column = std::move(bare_jsonb_col);
+}
+
+Status prepare_subcolumn_writer_target(
+        const ColumnWriterOptions& base_opts, const TabletColumn& parent_column,
+        int current_column_id, const PathInData& relative_path, const DataTypePtr& current_type,
+        int64_t none_null_value_size, size_t num_rows,
+        const TabletSchema::SubColumnInfo* existing_subcolumn_info, bool check_storage_type,
+        TabletIndexes* out_subcolumn_indexes, ColumnWriterOptions* out_subcolumn_opts,
+        std::unique_ptr<ColumnWriter>* out_writer, TabletColumn* out_tablet_column) {
+    if (out_subcolumn_indexes == nullptr || out_subcolumn_opts == nullptr ||
+        out_writer == nullptr || out_tablet_column == nullptr) {
+        return Status::InvalidArgument("subcolumn writer target output is null");
+    }
+
+    TabletColumn tablet_column;
+    TabletIndexes subcolumn_indexes;
+    bool resolved_from_schema = false;
+    if (existing_subcolumn_info != nullptr) {
+        tablet_column = existing_subcolumn_info->column;
+        subcolumn_indexes = existing_subcolumn_info->indexes;
+        resolved_from_schema = true;
+    } else {
+        TabletSchema::SubColumnInfo sub_column_info;
+        if (variant_util::generate_sub_column_info(*base_opts.rowset_ctx->tablet_schema,
+                                                   parent_column.unique_id(),
+                                                   relative_path.get_path(), &sub_column_info)) {
+            tablet_column = std::move(sub_column_info.column);
+            subcolumn_indexes = std::move(sub_column_info.indexes);
+            resolved_from_schema = true;
+        } else {
+            const std::string column_name =
+                    parent_column.name_lower_case() + "." + relative_path.get_path();
+            PathInData full_path;
+            if (relative_path.has_nested_part()) {
+                PathInDataBuilder full_path_builder;
+                full_path = full_path_builder.append(parent_column.name_lower_case(), false)
+                                    .append(relative_path.get_parts(), false)
+                                    .build();
+            } else {
+                full_path = PathInData(column_name);
+            }
+            tablet_column = variant_util::get_column_by_type(
+                    current_type, column_name,
+                    variant_util::ExtraInfo {.unique_id = -1,
+                                             .parent_unique_id = parent_column.unique_id(),
+                                             .path_info = full_path});
+            const auto& indexes =
+                    base_opts.rowset_ctx->tablet_schema->inverted_indexs(parent_column.unique_id());
+            variant_util::inherit_index(indexes, subcolumn_indexes, tablet_column);
+        }
+    }
+
+    if (resolved_from_schema && check_storage_type) {
+        auto storage_type = DataTypeFactory::instance().create_data_type(tablet_column);
+        if (!storage_type->equals(*current_type)) {
+            return Status::InvalidArgument(
+                    "Storage type {} is not equal to current type {} for path {}",
+                    storage_type->get_name(), current_type->get_name(), relative_path.get_path());
+        }
+    }
+
+    ColumnWriterOptions opts;
+    opts.meta = base_opts.footer->add_columns();
+    opts.index_file_writer = base_opts.index_file_writer;
+    opts.compression_type = base_opts.compression_type;
+    opts.rowset_ctx = base_opts.rowset_ctx;
+    opts.file_writer = base_opts.file_writer;
+    opts.encoding_preference = base_opts.encoding_preference;
+    variant_util::inherit_column_attributes(parent_column, tablet_column);
+
+    bool need_record_none_null_value_size =
+            (!tablet_column.path_info_ptr()->get_is_typed() ||
+             parent_column.variant_enable_typed_paths_to_sparse()) &&
+            !tablet_column.path_info_ptr()->has_nested_part() &&
+            variant_util::should_record_variant_path_stats(parent_column);
+
+    std::unique_ptr<ColumnWriter> writer;
+    RETURN_IF_ERROR(_create_column_writer(
+            current_column_id, tablet_column, base_opts.rowset_ctx->tablet_schema,
+            base_opts.index_file_writer, &writer, subcolumn_indexes, &opts, none_null_value_size,
+            need_record_none_null_value_size));
+    opts.meta->set_num_rows(num_rows);
+    *out_subcolumn_indexes = std::move(subcolumn_indexes);
+    *out_subcolumn_opts = opts;
+    *out_writer = std::move(writer);
+    *out_tablet_column = std::move(tablet_column);
+    return Status::OK();
+}
+
+} // namespace variant_writer_helpers
+
+VariantColumnWriterImpl::~VariantColumnWriterImpl() = default;
+
 VariantColumnWriterImpl::VariantColumnWriterImpl(const ColumnWriterOptions& opts,
                                                  const TabletColumn* column) {
     _opts = opts;
@@ -1040,7 +1148,19 @@ VariantColumnWriterImpl::VariantColumnWriterImpl(const ColumnWriterOptions& opts
     _nested_group_provider = create_nested_group_write_provider();
 }
 
+bool VariantColumnWriterImpl::_can_use_nested_group_streaming_compaction() const {
+    return _opts.rowset_ctx != nullptr &&
+           _opts.rowset_ctx->write_type == DataWriteType::TYPE_COMPACTION &&
+           _tablet_column->variant_enable_nested_group() &&
+           !_tablet_column->variant_enable_doc_mode() && !_opts.input_rs_readers.empty();
+}
+
 Status VariantColumnWriterImpl::init() {
+    if (_can_use_nested_group_streaming_compaction()) {
+        _streaming_compaction_writer = std::make_unique<VariantStreamingCompactionWriter>(
+                _opts, _tablet_column, _nested_group_provider.get(), &_statistics);
+        return _streaming_compaction_writer->init();
+    }
     DCHECK(_tablet_column->variant_max_subcolumns_count() >= 0)
             << "max subcolumns count is: " << _tablet_column->variant_max_subcolumns_count();
     int count = _tablet_column->variant_max_subcolumns_count();
@@ -1049,6 +1169,15 @@ Status VariantColumnWriterImpl::init() {
     }
     _column = ColumnVariant::create(count);
     return Status::OK();
+}
+
+bool VariantColumnWriterImpl::_has_extracted_variant_columns() const {
+    const int current_variant_uid = _tablet_column->unique_id();
+    return std::ranges::any_of(_opts.rowset_ctx->tablet_schema->columns(),
+                               [current_variant_uid](const auto& column) {
+                                   return column->is_extracted_column() &&
+                                          column->parent_unique_id() == current_variant_uid;
+                               });
 }
 
 Status VariantColumnWriterImpl::_process_root_column(ColumnVariant* ptr,
@@ -1070,22 +1199,12 @@ Status VariantColumnWriterImpl::_process_root_column(ColumnVariant* ptr,
     auto& nullable_column = assert_cast<ColumnNullable&>(*ptr->get_root()->assume_mutable());
     auto root_column = nullable_column.get_nested_column_ptr();
 
-    // Simplified dedup logic:
-    // If we have NG paths that cover the root data, replace root JSONB with
-    // empty defaults — the actual data lives in NG columns.
-    // Conflict scalar data is discarded per the conflict policy.
-    if (_nested_group_routing_plan.can_remove_root_jsonb()) {
-        const bool has_root_ng = std::ranges::any_of(
-                _nested_group_routing_plan.ng_only_prefixes,
-                [](const std::string& p) { return is_root_nested_group_path(p); });
-        if (has_root_ng) {
-            // Replace with empty JSONB defaults — the actual data is in NG columns.
-            auto bare_jsonb_type = std::make_shared<ColumnVariant::MostCommonType>();
-            auto bare_jsonb_col = bare_jsonb_type->create_column();
-            bare_jsonb_col->insert_many_defaults(num_rows);
-            root_column = std::move(bare_jsonb_col);
-        }
-    }
+    const bool has_root_ng =
+            std::ranges::any_of(_nested_group_routing_plan.ng_only_prefixes,
+                                [](const std::string& p) { return is_root_nested_group_path(p); });
+    variant_writer_helpers::maybe_remove_root_jsonb_with_empty_defaults(
+            &root_column, num_rows,
+            _nested_group_routing_plan.can_remove_root_jsonb() && has_root_ng);
 
     // If the root variant is nullable, then update the root column null column with the outer null column.
     if (_tablet_column->is_nullable()) {
@@ -1116,25 +1235,6 @@ Status VariantColumnWriterImpl::_process_root_column(ColumnVariant* ptr,
 Status VariantColumnWriterImpl::_process_subcolumns(ColumnVariant* ptr,
                                                     OlapBlockDataConvertor* converter,
                                                     size_t num_rows, int& column_id) {
-    auto generate_column_info = [&](const PathInData& relative_path,
-                                    const DataTypePtr& final_data_type) {
-        const std::string column_name =
-                _tablet_column->name_lower_case() + "." + relative_path.get_path();
-        PathInData full_path;
-        if (relative_path.has_nested_part()) {
-            PathInDataBuilder full_path_builder;
-            full_path = full_path_builder.append(_tablet_column->name_lower_case(), false)
-                                .append(relative_path.get_parts(), false)
-                                .build();
-        } else {
-            full_path = PathInData(column_name);
-        }
-        return variant_util::get_column_by_type(
-                final_data_type, column_name,
-                variant_util::ExtraInfo {.unique_id = -1,
-                                         .parent_unique_id = _tablet_column->unique_id(),
-                                         .path_info = full_path});
-    };
     _subcolumns_indexes.resize(ptr->get_subcolumns().size());
 
     auto write_one_subcolumn = [&](const std::string& current_path, const PathInData& relative_path,
@@ -1146,52 +1246,26 @@ Status VariantColumnWriterImpl::_process_subcolumns(ColumnVariant* ptr,
             _subcolumns_indexes.resize(cast_set<size_t>(current_column_id) + 1);
         }
 
-        TabletColumn tablet_column;
+        const TabletSchema::SubColumnInfo* existing_subcolumn_info = nullptr;
         if (use_existing_subcolumn_info) {
             if (auto it = _subcolumns_info.find(current_path); it != _subcolumns_info.end()) {
-                tablet_column = it->second.column;
-                _subcolumns_indexes[current_column_id] = it->second.indexes;
-                if (check_storage_type) {
-                    auto storage_type = DataTypeFactory::instance().create_data_type(tablet_column);
-                    if (!storage_type->equals(*current_type)) {
-                        return Status::InvalidArgument(
-                                "Storage type {} is not equal to current type {} for path {}",
-                                storage_type->get_name(), current_type->get_name(), current_path);
-                    }
-                }
-            } else {
-                tablet_column = generate_column_info(relative_path, current_type);
+                existing_subcolumn_info = &it->second;
             }
-        } else {
-            tablet_column = generate_column_info(relative_path, current_type);
         }
 
+        TabletColumn tablet_column;
         ColumnWriterOptions opts;
-        opts.meta = _opts.footer->add_columns();
-        opts.index_file_writer = _opts.index_file_writer;
-        opts.compression_type = _opts.compression_type;
-        opts.rowset_ctx = _opts.rowset_ctx;
-        opts.file_writer = _opts.file_writer;
-        opts.encoding_preference = _opts.encoding_preference;
         std::unique_ptr<ColumnWriter> writer;
-        variant_util::inherit_column_attributes(*_tablet_column, tablet_column);
-
-        bool need_record_none_null_value_size =
-                (!tablet_column.path_info_ptr()->get_is_typed() ||
-                 _tablet_column->variant_enable_typed_paths_to_sparse()) &&
-                !tablet_column.path_info_ptr()->has_nested_part();
-
-        RETURN_IF_ERROR(_create_column_writer(
-                current_column_id, tablet_column, _opts.rowset_ctx->tablet_schema,
-                _opts.index_file_writer, &writer, _subcolumns_indexes[current_column_id], &opts,
-                non_null_count, need_record_none_null_value_size));
+        RETURN_IF_ERROR(variant_writer_helpers::prepare_subcolumn_writer_target(
+                _opts, *_tablet_column, current_column_id, relative_path, current_type,
+                non_null_count, num_rows, existing_subcolumn_info, check_storage_type,
+                &_subcolumns_indexes[current_column_id], &opts, &writer, &tablet_column));
         _subcolumn_writers.push_back(std::move(writer));
         _subcolumn_opts.push_back(opts);
-        _subcolumn_opts.back().meta->set_num_rows(num_rows);
 
-        RETURN_IF_ERROR(convert_and_write_column(converter, tablet_column, current_type,
-                                                 _subcolumn_writers.back().get(), current_column,
-                                                 ptr->rows(), current_column_id));
+        RETURN_IF_ERROR(variant_writer_helpers::convert_and_write_column(
+                converter, tablet_column, current_type, _subcolumn_writers.back().get(),
+                current_column, ptr->rows(), current_column_id));
         return Status::OK();
     };
 
@@ -1249,6 +1323,9 @@ Status VariantColumnWriterImpl::_process_binary_column(ColumnVariant* ptr,
 }
 
 Status VariantColumnWriterImpl::finalize() {
+    if (_streaming_compaction_writer != nullptr) {
+        return Status::OK();
+    }
     auto* ptr = _column.get();
     ptr->set_max_subcolumns_count(_tablet_column->variant_max_subcolumns_count());
 
@@ -1277,26 +1354,28 @@ Status VariantColumnWriterImpl::finalize() {
     }
 
     RETURN_IF_ERROR(ptr->convert_typed_path_to_storage_type(_subcolumns_info));
+
+    // Root NG dedup is handled in _process_root_column() — see the
+    // has_root_ng check there. We intentionally do NOT modify the in-memory
+    // root data here because the legacy NestedGroup prepare path still needs it.
+    const bool has_extracted_columns = _has_extracted_variant_columns();
+    NestedGroupsMap prebuilt_nested_groups;
+    bool has_prebuilt_nested_groups = false;
     _nested_group_routing_plan = NestedGroupRoutingPlan {};
-
-    const int current_variant_uid = _tablet_column->unique_id();
-    const bool has_extracted_columns = std::ranges::any_of(
-            _opts.rowset_ctx->tablet_schema->columns(), [current_variant_uid](const auto& column) {
-                return column->is_extracted_column() &&
-                       column->parent_unique_id() == current_variant_uid;
-            });
-    if (!has_extracted_columns) {
-        if (_tablet_column->variant_enable_nested_group()) {
-            RETURN_IF_ERROR(build_nested_group_routing_plan(*ptr, &_nested_group_routing_plan));
-
-            // Root NG dedup is handled in _process_root_column() — see the
-            // has_root_ng check there. We intentionally do NOT modify the in-memory
-            // root data here because _nested_group_provider->prepare() needs it.
-        }
+    if (!has_extracted_columns && _tablet_column->variant_enable_nested_group()) {
+        std::vector<std::string> ng_candidate_paths;
+        std::vector<std::string> conflict_candidate_paths;
+        RETURN_IF_ERROR(build_nested_groups_from_variant_jsonb(
+                *ptr, &prebuilt_nested_groups, &ng_candidate_paths, &conflict_candidate_paths));
+        RETURN_IF_ERROR(build_nested_group_routing_plan_from_candidates(
+                *ptr, ng_candidate_paths, conflict_candidate_paths, &_nested_group_routing_plan));
+        has_prebuilt_nested_groups = true;
     }
 
-    RETURN_IF_ERROR(ptr->pick_subcolumns_to_sparse_column(
-            _subcolumns_info, _tablet_column->variant_enable_typed_paths_to_sparse()));
+    if (variant_util::should_write_variant_binary_columns(*_tablet_column)) {
+        RETURN_IF_ERROR(ptr->pick_subcolumns_to_sparse_column(
+                _subcolumns_info, _tablet_column->variant_enable_typed_paths_to_sparse()));
+    }
 
 #ifndef NDEBUG
     ptr->check_consistency();
@@ -1315,17 +1394,24 @@ Status VariantColumnWriterImpl::finalize() {
                     _process_subcolumns(ptr, olap_data_convertor.get(), num_rows, column_id));
         }
 
-        // process sparse column and append to sparse writer buffer
-        RETURN_IF_ERROR(
-                _process_binary_column(ptr, olap_data_convertor.get(), num_rows, column_id));
+        if (variant_util::should_write_variant_binary_columns(*_tablet_column)) {
+            // process sparse/doc column and append to binary writer buffer
+            RETURN_IF_ERROR(
+                    _process_binary_column(ptr, olap_data_convertor.get(), num_rows, column_id));
+        }
     }
 
-    // NestedGroup write behavior is determined by the injected provider implementation.
-    // Only invoke the provider when nested group writing is enabled.
+    // Legacy non-streaming NestedGroup write behavior stays behind provider->prepare().
     if (_tablet_column->variant_enable_nested_group()) {
-        RETURN_IF_ERROR(_nested_group_provider->prepare(
-                *ptr, /*include_jsonb_subcolumns=*/true, _tablet_column, _opts,
-                olap_data_convertor.get(), num_rows, &column_id, &_statistics));
+        if (has_prebuilt_nested_groups) {
+            RETURN_IF_ERROR(_nested_group_provider->prepare_with_built_groups(
+                    prebuilt_nested_groups, _tablet_column, _opts, olap_data_convertor.get(),
+                    &column_id, &_statistics));
+        } else {
+            RETURN_IF_ERROR(_nested_group_provider->prepare(*ptr, _tablet_column, _opts,
+                                                            olap_data_convertor.get(), &column_id,
+                                                            &_statistics));
+        }
     }
     if (_binary_writer) {
         _binary_writer->merge_stats_to(&_statistics);
@@ -1337,6 +1423,9 @@ Status VariantColumnWriterImpl::finalize() {
 }
 
 bool VariantColumnWriterImpl::is_finalized() const {
+    if (_streaming_compaction_writer != nullptr) {
+        return _streaming_compaction_writer->is_finalized();
+    }
     return _column->is_finalized() && _is_finalized;
 }
 
@@ -1349,19 +1438,36 @@ Status VariantColumnWriterImpl::_for_each_column_writer(
     return Status::OK();
 }
 
+Status VariantColumnWriterImpl::_ensure_materialized_variant_finalized() {
+    if (_streaming_compaction_writer != nullptr || is_finalized()) {
+        return Status::OK();
+    }
+    return finalize();
+}
+
+void VariantColumnWriterImpl::_assert_ready_for_index_writes() const {
+    if (_streaming_compaction_writer == nullptr) {
+        assert(is_finalized());
+    }
+}
+
 Status VariantColumnWriterImpl::append_data(const uint8_t** ptr, size_t num_rows) {
-    DCHECK(!is_finalized());
+    if (_streaming_compaction_writer != nullptr) {
+        return _streaming_compaction_writer->append_data(ptr, num_rows, nullptr);
+    }
     const auto* column = reinterpret_cast<const VariantColumnData*>(*ptr);
     const auto& src = *reinterpret_cast<const ColumnVariant*>(column->column_data);
     RETURN_IF_ERROR(src.sanitize());
-    // TODO: if direct write we could avoid copy
+    DCHECK(!is_finalized());
     _column->insert_range_from(src, column->row_pos, num_rows);
     return Status::OK();
 }
 
 uint64_t VariantColumnWriterImpl::estimate_buffer_size() {
+    if (_streaming_compaction_writer != nullptr) {
+        return _streaming_compaction_writer->estimate_buffer_size();
+    }
     if (!is_finalized()) {
-        // not accurate
         return _column->byte_size();
     }
     uint64_t size = 0;
@@ -1377,9 +1483,10 @@ uint64_t VariantColumnWriterImpl::estimate_buffer_size() {
 }
 
 Status VariantColumnWriterImpl::finish() {
-    if (!is_finalized()) {
-        RETURN_IF_ERROR(finalize());
+    if (_streaming_compaction_writer != nullptr) {
+        return _streaming_compaction_writer->finish();
     }
+    RETURN_IF_ERROR(_ensure_materialized_variant_finalized());
     RETURN_IF_ERROR(_for_each_column_writer([](ColumnWriter* writer) { return writer->finish(); }));
     if (_binary_writer) {
         RETURN_IF_ERROR(_binary_writer->finish());
@@ -1388,9 +1495,10 @@ Status VariantColumnWriterImpl::finish() {
     return Status::OK();
 }
 Status VariantColumnWriterImpl::write_data() {
-    if (!is_finalized()) {
-        RETURN_IF_ERROR(finalize());
+    if (_streaming_compaction_writer != nullptr) {
+        return _streaming_compaction_writer->write_data();
     }
+    RETURN_IF_ERROR(_ensure_materialized_variant_finalized());
     RETURN_IF_ERROR(
             _for_each_column_writer([](ColumnWriter* writer) { return writer->write_data(); }));
     if (_binary_writer) {
@@ -1400,8 +1508,10 @@ Status VariantColumnWriterImpl::write_data() {
     return Status::OK();
 }
 Status VariantColumnWriterImpl::write_ordinal_index() {
-    // write ordinal index after data has been written which should be finalized
-    assert(is_finalized());
+    if (_streaming_compaction_writer != nullptr) {
+        return _streaming_compaction_writer->write_ordinal_index();
+    }
+    _assert_ready_for_index_writes();
     RETURN_IF_ERROR(_for_each_column_writer(
             [](ColumnWriter* writer) { return writer->write_ordinal_index(); }));
     if (_binary_writer) {
@@ -1412,7 +1522,10 @@ Status VariantColumnWriterImpl::write_ordinal_index() {
 }
 
 Status VariantColumnWriterImpl::write_zone_map() {
-    assert(is_finalized());
+    if (_streaming_compaction_writer != nullptr) {
+        return _streaming_compaction_writer->write_zone_map();
+    }
+    _assert_ready_for_index_writes();
     for (size_t i = 0; i < _subcolumn_writers.size(); ++i) {
         if (_subcolumn_opts[i].need_zone_map) {
             RETURN_IF_ERROR(_subcolumn_writers[i]->write_zone_map());
@@ -1426,7 +1539,10 @@ Status VariantColumnWriterImpl::write_zone_map() {
 }
 
 Status VariantColumnWriterImpl::write_inverted_index() {
-    assert(is_finalized());
+    if (_streaming_compaction_writer != nullptr) {
+        return _streaming_compaction_writer->write_inverted_index();
+    }
+    _assert_ready_for_index_writes();
     for (size_t i = 0; i < _subcolumn_writers.size(); ++i) {
         if (_subcolumn_opts[i].need_inverted_index) {
             RETURN_IF_ERROR(_subcolumn_writers[i]->write_inverted_index());
@@ -1439,7 +1555,10 @@ Status VariantColumnWriterImpl::write_inverted_index() {
     return Status::OK();
 }
 Status VariantColumnWriterImpl::write_bloom_filter_index() {
-    assert(is_finalized());
+    if (_streaming_compaction_writer != nullptr) {
+        return _streaming_compaction_writer->write_bloom_filter_index();
+    }
+    _assert_ready_for_index_writes();
     for (size_t i = 0; i < _subcolumn_writers.size(); ++i) {
         if (_subcolumn_opts[i].need_bloom_filter) {
             RETURN_IF_ERROR(_subcolumn_writers[i]->write_bloom_filter_index());
@@ -1454,6 +1573,9 @@ Status VariantColumnWriterImpl::write_bloom_filter_index() {
 
 Status VariantColumnWriterImpl::append_nullable(const uint8_t* null_map, const uint8_t** ptr,
                                                 size_t num_rows) {
+    if (_streaming_compaction_writer != nullptr) {
+        return _streaming_compaction_writer->append_data(ptr, num_rows, null_map);
+    }
     if (null_map != nullptr) {
         _null_column->insert_many_raw_data((const char*)null_map, num_rows);
     }
@@ -1468,7 +1590,6 @@ VariantSubcolumnWriter::VariantSubcolumnWriter(const ColumnWriterOptions& opts,
     _tablet_column = column;
     _opts = opts;
     _column = ColumnVariant::create(0);
-    _nested_group_provider = create_nested_group_write_provider();
 }
 
 Status VariantSubcolumnWriter::init() {
@@ -1487,12 +1608,7 @@ uint64_t VariantSubcolumnWriter::estimate_buffer_size() {
     if (!is_finalized()) {
         return _column->byte_size();
     }
-    uint64_t size = 0;
-    if (_writer) {
-        size += _writer->estimate_buffer_size();
-    }
-    size += _nested_group_provider->estimate_buffer_size();
-    return size;
+    return _writer ? _writer->estimate_buffer_size() : 0;
 }
 
 bool VariantSubcolumnWriter::is_finalized() const {
@@ -1534,18 +1650,13 @@ Status VariantSubcolumnWriter::finalize() {
     _opts = opts;
     auto olap_data_convertor = std::make_unique<OlapBlockDataConvertor>();
     int column_id = 0;
-    RETURN_IF_ERROR(convert_and_write_column(olap_data_convertor.get(), flush_column,
-                                             ptr->get_root_type(), _writer.get(),
-                                             ptr->get_root()->get_ptr(), ptr->rows(), column_id));
+    RETURN_IF_ERROR(variant_writer_helpers::convert_and_write_column(
+            olap_data_convertor.get(), flush_column, ptr->get_root_type(), _writer.get(),
+            ptr->get_root()->get_ptr(), ptr->rows(), column_id));
     _opts.meta->set_num_rows(ptr->rows());
     ++column_id;
 
-    if (parent_column.variant_enable_nested_group()) {
-        RETURN_IF_ERROR(_nested_group_provider->prepare(
-                *ptr, /*include_jsonb_subcolumns=*/false, &flush_column, _opts,
-                olap_data_convertor.get(), ptr->rows(), &column_id, &_statistics));
-    }
-    _statistics.to_pb(_opts.meta->mutable_variant_statistics());
+    DORIS_CHECK(!parent_column.variant_enable_nested_group());
 
     _is_finalized = true;
     return Status::OK();
@@ -1555,48 +1666,39 @@ Status VariantSubcolumnWriter::finish() {
     if (!is_finalized()) {
         RETURN_IF_ERROR(finalize());
     }
-    RETURN_IF_ERROR(_writer->finish());
-    RETURN_IF_ERROR(_nested_group_provider->finish());
-    return Status::OK();
+    return _writer->finish();
 }
 Status VariantSubcolumnWriter::write_data() {
     if (!is_finalized()) {
         RETURN_IF_ERROR(finalize());
     }
-    RETURN_IF_ERROR(_writer->write_data());
-    RETURN_IF_ERROR(_nested_group_provider->write_data());
-    return Status::OK();
+    return _writer->write_data();
 }
 Status VariantSubcolumnWriter::write_ordinal_index() {
     assert(is_finalized());
-    RETURN_IF_ERROR(_writer->write_ordinal_index());
-    RETURN_IF_ERROR(_nested_group_provider->write_ordinal_index());
-    return Status::OK();
+    return _writer->write_ordinal_index();
 }
 
 Status VariantSubcolumnWriter::write_zone_map() {
     assert(is_finalized());
     if (_opts.need_zone_map) {
-        RETURN_IF_ERROR(_writer->write_zone_map());
+        return _writer->write_zone_map();
     }
-    RETURN_IF_ERROR(_nested_group_provider->write_zone_map());
     return Status::OK();
 }
 
 Status VariantSubcolumnWriter::write_inverted_index() {
     assert(is_finalized());
     if (_opts.need_inverted_index) {
-        RETURN_IF_ERROR(_writer->write_inverted_index());
+        return _writer->write_inverted_index();
     }
-    RETURN_IF_ERROR(_nested_group_provider->write_inverted_index());
     return Status::OK();
 }
 Status VariantSubcolumnWriter::write_bloom_filter_index() {
     assert(is_finalized());
     if (_opts.need_bloom_filter) {
-        RETURN_IF_ERROR(_writer->write_bloom_filter_index());
+        return _writer->write_bloom_filter_index();
     }
-    RETURN_IF_ERROR(_nested_group_provider->write_bloom_filter_index());
     return Status::OK();
 }
 

--- a/be/src/storage/segment/variant/variant_column_writer_impl.h
+++ b/be/src/storage/segment/variant/variant_column_writer_impl.h
@@ -26,13 +26,13 @@
 
 #include "common/status.h"
 #include "core/column/column.h"
-#include "core/field.h"
 #include "exec/common/variant_util.h"
 #include "storage/index/indexed_column_writer.h"
 #include "storage/segment/column_writer.h"
 #include "storage/segment/variant/nested_group_provider.h"
 #include "storage/segment/variant/nested_group_routing_plan.h"
 #include "storage/segment/variant/variant_statistics.h"
+#include "storage/segment/variant/variant_streaming_compaction_writer.h"
 #include "storage/tablet/tablet_schema.h"
 
 namespace doris {
@@ -167,9 +167,13 @@ private:
 class VariantColumnWriterImpl {
 public:
     VariantColumnWriterImpl(const ColumnWriterOptions& opts, const TabletColumn* column);
+    ~VariantColumnWriterImpl();
     Status finalize();
     Status init();
     bool is_finalized() const;
+    bool has_streaming_compaction_writer_for_test() const {
+        return _streaming_compaction_writer != nullptr;
+    }
 
     Status append_data(const uint8_t** ptr, size_t num_rows);
 
@@ -184,6 +188,10 @@ public:
 
 private:
     Status _for_each_column_writer(const std::function<Status(ColumnWriter*)>& func);
+    bool _can_use_nested_group_streaming_compaction() const;
+    Status _ensure_materialized_variant_finalized();
+    void _assert_ready_for_index_writes() const;
+    bool _has_extracted_variant_columns() const;
     Status _process_root_column(ColumnVariant* ptr, OlapBlockDataConvertor* converter,
                                 size_t num_rows, int& column_id);
     Status _process_subcolumns(ColumnVariant* ptr, OlapBlockDataConvertor* converter,
@@ -212,6 +220,7 @@ private:
     std::unique_ptr<NestedGroupWriteProvider> _nested_group_provider;
     VariantStatistics _statistics;
     NestedGroupRoutingPlan _nested_group_routing_plan;
+    std::unique_ptr<VariantStreamingCompactionWriter> _streaming_compaction_writer;
 };
 
 class VariantDocCompactWriter : public ColumnWriter {

--- a/be/src/storage/segment/variant/variant_streaming_compaction_writer.cpp
+++ b/be/src/storage/segment/variant/variant_streaming_compaction_writer.cpp
@@ -1,0 +1,313 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "storage/segment/variant/variant_streaming_compaction_writer.h"
+
+#include <memory>
+
+#include "common/cast_set.h"
+#include "core/column/column_nullable.h"
+#include "core/column/column_variant.h"
+#include "exec/common/variant_util.h"
+#include "storage/index/indexed_column_writer.h"
+#include "storage/iterator/olap_data_convertor.h"
+#include "storage/segment/variant/variant_writer_helpers.h"
+#include "storage/types.h"
+
+namespace doris::segment_v2 {
+
+#include "common/compile_check_begin.h"
+
+VariantStreamingCompactionWriter::VariantStreamingCompactionWriter(
+        const ColumnWriterOptions& opts, const TabletColumn* column,
+        NestedGroupWriteProvider* nested_group_provider, VariantStatistics* statistics)
+        : _opts(opts),
+          _tablet_column(column),
+          _nested_group_provider(nested_group_provider),
+          _statistics(statistics) {}
+
+Status VariantStreamingCompactionWriter::init() {
+    RETURN_IF_ERROR(build_nested_group_streaming_write_plan(_opts.input_rs_readers, *_tablet_column,
+                                                            &_streaming_plan));
+    RETURN_IF_ERROR(_init_root_writer());
+    int column_id = 1;
+    RETURN_IF_ERROR(_init_regular_subcolumn_writers(column_id));
+    RETURN_IF_ERROR(_nested_group_provider->init_with_plan(_streaming_plan, _tablet_column, _opts,
+                                                           &column_id, _statistics));
+    _statistics->to_pb(_opts.meta->mutable_variant_statistics());
+    _phase = Phase::INITIALIZED;
+    return Status::OK();
+}
+
+Status VariantStreamingCompactionWriter::_init_root_writer() {
+    _root_writer = std::make_unique<ScalarColumnWriter>(
+            _opts, std::unique_ptr<StorageField>(StorageFieldFactory::create(*_tablet_column)),
+            _opts.file_writer);
+    RETURN_IF_ERROR(_root_writer->init());
+    _opts.meta->set_num_rows(0);
+    return Status::OK();
+}
+
+Status VariantStreamingCompactionWriter::_init_regular_subcolumn_writers(int& column_id) {
+    _streaming_regular_subcolumn_writers.clear();
+    for (const auto& plan_entry : _streaming_plan.regular_subcolumns) {
+        TabletColumn tablet_column;
+        TabletIndexes subcolumn_indexes;
+        ColumnWriterOptions opts;
+        std::unique_ptr<ColumnWriter> writer;
+        RETURN_IF_ERROR(variant_writer_helpers::prepare_subcolumn_writer_target(
+                _opts, *_tablet_column, column_id, plan_entry.path_in_data, plan_entry.data_type, 0,
+                0, nullptr /* existing_subcolumn_info */, false /* check_storage_type */,
+                &subcolumn_indexes, &opts, &writer, &tablet_column));
+        auto converter = std::make_unique<OlapBlockDataConvertor>();
+        converter->add_column_data_convertor(tablet_column);
+        _subcolumns_indexes.push_back(std::move(subcolumn_indexes));
+        _subcolumn_opts.push_back(opts);
+        _subcolumn_writers.push_back(std::move(writer));
+        _streaming_regular_subcolumn_writers.push_back(
+                StreamingRegularSubcolumnWriter {.plan = plan_entry,
+                                                 .tablet_column = std::move(tablet_column),
+                                                 .converter = std::move(converter)});
+        ++column_id;
+    }
+    return Status::OK();
+}
+
+Status VariantStreamingCompactionWriter::append_data(const uint8_t** ptr, size_t num_rows,
+                                                     const uint8_t* outer_null_map) {
+    RETURN_IF_ERROR(_check_initialized("append_data"));
+    RETURN_IF_ERROR(_append_input_from_raw(ptr, num_rows, outer_null_map));
+    if (num_rows > 0 && _phase == Phase::INITIALIZED) {
+        _phase = Phase::APPENDING;
+    }
+    return Status::OK();
+}
+
+Status VariantStreamingCompactionWriter::_append_input_from_raw(const uint8_t** ptr,
+                                                                size_t num_rows,
+                                                                const uint8_t* outer_null_map) {
+    const auto* column = reinterpret_cast<const VariantColumnData*>(*ptr);
+    const auto& src = *reinterpret_cast<const ColumnVariant*>(column->column_data);
+    RETURN_IF_ERROR(src.sanitize());
+    return _append_input(src, column->row_pos, num_rows, outer_null_map);
+}
+
+Status VariantStreamingCompactionWriter::_append_input(const ColumnVariant& src, size_t row_pos,
+                                                       size_t num_rows,
+                                                       const uint8_t* outer_null_map) {
+    auto chunk_variant = ColumnVariant::create(0);
+    chunk_variant->insert_range_from(src, row_pos, num_rows);
+    RETURN_IF_ERROR(chunk_variant->sanitize());
+    chunk_variant->finalize();
+    return _append_chunk(*chunk_variant, outer_null_map);
+}
+
+Status VariantStreamingCompactionWriter::_append_root_column(const ColumnVariant& chunk_variant,
+                                                             const uint8_t* outer_null_map) {
+    auto* variant = const_cast<ColumnVariant*>(&chunk_variant);
+    auto expected_root_type = make_nullable(std::make_shared<ColumnVariant::MostCommonType>());
+    variant->ensure_root_node_type(expected_root_type);
+
+    auto& nullable_column = assert_cast<ColumnNullable&>(*variant->get_root()->assume_mutable());
+    auto root_column = nullable_column.get_nested_column_ptr();
+    const size_t num_rows = chunk_variant.rows();
+    variant_writer_helpers::maybe_remove_root_jsonb_with_empty_defaults(
+            &root_column, num_rows, _streaming_plan.can_remove_root_jsonb());
+
+    const uint8_t* nullmap = nullptr;
+    if (_tablet_column->is_nullable()) {
+        auto null_column = ColumnUInt8::create();
+        if (outer_null_map != nullptr) {
+            null_column->insert_many_raw_data(reinterpret_cast<const char*>(outer_null_map),
+                                              num_rows);
+            nullmap = outer_null_map;
+        } else {
+            null_column->insert_many_defaults(num_rows);
+        }
+        root_column = ColumnNullable::create(root_column->get_ptr(), std::move(null_column));
+    } else {
+        root_column = ColumnNullable::create(root_column->get_ptr(),
+                                             ColumnUInt8::create(root_column->size(), 0));
+    }
+
+    auto converter = std::make_unique<OlapBlockDataConvertor>();
+    converter->add_column_data_convertor(*_tablet_column);
+    RETURN_IF_ERROR(converter->set_source_content_with_specifid_column(
+            {root_column->get_ptr(), nullptr, ""}, 0, num_rows, 0));
+    auto [status, column] = converter->convert_column_data(0);
+    RETURN_IF_ERROR(status);
+    RETURN_IF_ERROR(_root_writer->append(nullmap, column->get_data(), num_rows));
+    converter->clear_source_content(0);
+    _opts.meta->set_num_rows(_root_writer->get_next_rowid());
+    return Status::OK();
+}
+
+Status VariantStreamingCompactionWriter::_append_regular_subcolumns(
+        const ColumnVariant& chunk_variant) {
+    const size_t num_rows = chunk_variant.rows();
+    for (size_t i = 0; i < _streaming_regular_subcolumn_writers.size(); ++i) {
+        auto& state = _streaming_regular_subcolumn_writers[i];
+        auto* subcolumn = chunk_variant.get_subcolumn(state.plan.path_in_data);
+        ColumnWriter* writer = _subcolumn_writers[i].get();
+        if (subcolumn == nullptr || subcolumn->get_least_common_type() == nullptr) {
+            DCHECK(state.tablet_column.is_nullable());
+            RETURN_IF_ERROR(writer->append_nulls(num_rows));
+            _subcolumn_opts[i].meta->set_num_rows(writer->get_next_rowid());
+            continue;
+        }
+        auto base_type = variant_util::get_base_type_of_array(subcolumn->get_least_common_type());
+        if (base_type != nullptr &&
+            base_type->get_primitive_type() == PrimitiveType::INVALID_TYPE) {
+            DCHECK(state.tablet_column.is_nullable());
+            RETURN_IF_ERROR(writer->append_nulls(num_rows));
+            _subcolumn_opts[i].meta->set_num_rows(writer->get_next_rowid());
+            continue;
+        }
+        if (!subcolumn->is_finalized()) {
+            const_cast<ColumnVariant::Subcolumn*>(subcolumn)->finalize();
+        }
+        ColumnPtr current_column = subcolumn->get_finalized_column_ptr()->get_ptr();
+        DataTypePtr current_type = subcolumn->get_least_common_type();
+        if (!state.plan.data_type->equals(*current_type)) {
+            RETURN_IF_ERROR(variant_util::cast_column({current_column, current_type, ""},
+                                                      state.plan.data_type, &current_column));
+            current_type = state.plan.data_type;
+        }
+        DCHECK_EQ(current_column->size(), num_rows);
+        // Keep one converter per writer so array/map offsets stay rebased across streaming chunks.
+        RETURN_IF_ERROR(state.converter->set_source_content_with_specifid_column(
+                {current_column, current_type, ""}, 0, num_rows, 0));
+        auto [status, converted] = state.converter->convert_column_data(0);
+        RETURN_IF_ERROR(status);
+        RETURN_IF_ERROR(writer->append(converted->get_nullmap(), converted->get_data(), num_rows));
+        state.converter->clear_source_content(0);
+        _subcolumn_opts[i].meta->set_num_rows(writer->get_next_rowid());
+    }
+    return Status::OK();
+}
+
+Status VariantStreamingCompactionWriter::_append_chunk(const ColumnVariant& chunk_variant,
+                                                       const uint8_t* outer_null_map) {
+    RETURN_IF_ERROR(_append_root_column(chunk_variant, outer_null_map));
+    RETURN_IF_ERROR(_append_regular_subcolumns(chunk_variant));
+    RETURN_IF_ERROR(_nested_group_provider->append_chunk(_streaming_plan, chunk_variant));
+    return Status::OK();
+}
+
+Status VariantStreamingCompactionWriter::_for_each_column_writer(
+        const std::function<Status(ColumnWriter*)>& func) {
+    RETURN_IF_ERROR(func(_root_writer.get()));
+    for (auto& writer : _subcolumn_writers) {
+        RETURN_IF_ERROR(func(writer.get()));
+    }
+    return Status::OK();
+}
+
+uint64_t VariantStreamingCompactionWriter::estimate_buffer_size() const {
+    uint64_t size = 0;
+    if (_root_writer) {
+        size += _root_writer->estimate_buffer_size();
+    }
+    for (const auto& column_writer : _subcolumn_writers) {
+        size += column_writer->estimate_buffer_size();
+    }
+    size += _nested_group_provider->estimate_buffer_size();
+    return size;
+}
+
+Status VariantStreamingCompactionWriter::_check_initialized(std::string_view action) const {
+    if (!is_initialized()) {
+        return Status::InternalError(
+                "VariantStreamingCompactionWriter must be initialized before "
+                "{}",
+                action);
+    }
+    if (_phase == Phase::CLOSED) {
+        return Status::InternalError("VariantStreamingCompactionWriter is already closed: {}",
+                                     action);
+    }
+    return Status::OK();
+}
+
+Status VariantStreamingCompactionWriter::_check_closed(std::string_view action) const {
+    if (!is_finalized()) {
+        return Status::InternalError("VariantStreamingCompactionWriter must be closed before {}",
+                                     action);
+    }
+    return Status::OK();
+}
+
+Status VariantStreamingCompactionWriter::finish() {
+    RETURN_IF_ERROR(_check_initialized("finish"));
+    RETURN_IF_ERROR(_for_each_column_writer([](ColumnWriter* writer) { return writer->finish(); }));
+    RETURN_IF_ERROR(_nested_group_provider->finish());
+    _phase = Phase::CLOSED;
+    return Status::OK();
+}
+
+Status VariantStreamingCompactionWriter::write_data() {
+    RETURN_IF_ERROR(_check_closed("write_data"));
+    RETURN_IF_ERROR(
+            _for_each_column_writer([](ColumnWriter* writer) { return writer->write_data(); }));
+    RETURN_IF_ERROR(_nested_group_provider->write_data());
+    return Status::OK();
+}
+
+Status VariantStreamingCompactionWriter::write_ordinal_index() {
+    RETURN_IF_ERROR(_check_closed("write_ordinal_index"));
+    RETURN_IF_ERROR(_for_each_column_writer(
+            [](ColumnWriter* writer) { return writer->write_ordinal_index(); }));
+    RETURN_IF_ERROR(_nested_group_provider->write_ordinal_index());
+    return Status::OK();
+}
+
+Status VariantStreamingCompactionWriter::write_zone_map() {
+    RETURN_IF_ERROR(_check_closed("write_zone_map"));
+    for (size_t i = 0; i < _subcolumn_writers.size(); ++i) {
+        if (_subcolumn_opts[i].need_zone_map) {
+            RETURN_IF_ERROR(_subcolumn_writers[i]->write_zone_map());
+        }
+    }
+    RETURN_IF_ERROR(_nested_group_provider->write_zone_map());
+    return Status::OK();
+}
+
+Status VariantStreamingCompactionWriter::write_inverted_index() {
+    RETURN_IF_ERROR(_check_closed("write_inverted_index"));
+    for (size_t i = 0; i < _subcolumn_writers.size(); ++i) {
+        if (_subcolumn_opts[i].need_inverted_index) {
+            RETURN_IF_ERROR(_subcolumn_writers[i]->write_inverted_index());
+        }
+    }
+    RETURN_IF_ERROR(_nested_group_provider->write_inverted_index());
+    return Status::OK();
+}
+
+Status VariantStreamingCompactionWriter::write_bloom_filter_index() {
+    RETURN_IF_ERROR(_check_closed("write_bloom_filter_index"));
+    for (size_t i = 0; i < _subcolumn_writers.size(); ++i) {
+        if (_subcolumn_opts[i].need_bloom_filter) {
+            RETURN_IF_ERROR(_subcolumn_writers[i]->write_bloom_filter_index());
+        }
+    }
+    RETURN_IF_ERROR(_nested_group_provider->write_bloom_filter_index());
+    return Status::OK();
+}
+
+#include "common/compile_check_end.h"
+
+} // namespace doris::segment_v2

--- a/be/src/storage/segment/variant/variant_streaming_compaction_writer.h
+++ b/be/src/storage/segment/variant/variant_streaming_compaction_writer.h
@@ -1,0 +1,105 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string_view>
+#include <vector>
+
+#include "common/status.h"
+#include "core/column/column.h"
+#include "storage/iterator/olap_data_convertor.h"
+#include "storage/segment/column_writer.h"
+#include "storage/segment/variant/nested_group_provider.h"
+#include "storage/segment/variant/nested_group_streaming_write_plan.h"
+#include "storage/segment/variant/variant_statistics.h"
+#include "storage/tablet/tablet_schema.h"
+
+namespace doris {
+
+class ColumnVariant;
+namespace segment_v2 {
+
+#include "common/compile_check_begin.h"
+
+class VariantStreamingCompactionWriter {
+public:
+    enum class Phase : uint8_t {
+        UNINITIALIZED = 0,
+        INITIALIZED = 1,
+        APPENDING = 2,
+        CLOSED = 3,
+    };
+
+    VariantStreamingCompactionWriter(const ColumnWriterOptions& opts, const TabletColumn* column,
+                                     NestedGroupWriteProvider* nested_group_provider,
+                                     VariantStatistics* statistics);
+
+    Status init();
+    Status append_data(const uint8_t** ptr, size_t num_rows, const uint8_t* outer_null_map);
+    bool is_initialized() const { return _phase != Phase::UNINITIALIZED; }
+    bool is_finalized() const { return _phase == Phase::CLOSED; }
+    Phase phase() const { return _phase; }
+
+    uint64_t estimate_buffer_size() const;
+    Status finish();
+    Status write_data();
+    Status write_ordinal_index();
+    Status write_zone_map();
+    Status write_inverted_index();
+    Status write_bloom_filter_index();
+
+private:
+    struct StreamingRegularSubcolumnWriter {
+        NestedGroupStreamingRegularSubcolumnPlan plan;
+        TabletColumn tablet_column;
+        std::unique_ptr<OlapBlockDataConvertor> converter;
+    };
+
+    Status _for_each_column_writer(const std::function<Status(ColumnWriter*)>& func);
+    Status _init_root_writer();
+    Status _init_regular_subcolumn_writers(int& column_id);
+    Status _append_input_from_raw(const uint8_t** ptr, size_t num_rows,
+                                  const uint8_t* outer_null_map);
+    Status _append_input(const ColumnVariant& src, size_t row_pos, size_t num_rows,
+                         const uint8_t* outer_null_map);
+    Status _append_chunk(const ColumnVariant& chunk_variant, const uint8_t* outer_null_map);
+    Status _append_root_column(const ColumnVariant& chunk_variant, const uint8_t* outer_null_map);
+    Status _append_regular_subcolumns(const ColumnVariant& chunk_variant);
+    Status _check_initialized(std::string_view action) const;
+    Status _check_closed(std::string_view action) const;
+
+    ColumnWriterOptions _opts;
+    const TabletColumn* _tablet_column = nullptr;
+    NestedGroupWriteProvider* _nested_group_provider = nullptr;
+    VariantStatistics* _statistics = nullptr;
+    Phase _phase = Phase::UNINITIALIZED;
+
+    std::unique_ptr<ColumnWriter> _root_writer;
+    std::vector<std::unique_ptr<ColumnWriter>> _subcolumn_writers;
+    std::vector<ColumnWriterOptions> _subcolumn_opts;
+    std::vector<TabletIndexes> _subcolumns_indexes;
+    NestedGroupStreamingWritePlan _streaming_plan;
+    std::vector<StreamingRegularSubcolumnWriter> _streaming_regular_subcolumn_writers;
+};
+
+#include "common/compile_check_end.h"
+
+} // namespace segment_v2
+} // namespace doris

--- a/be/src/storage/segment/variant/variant_writer_helpers.h
+++ b/be/src/storage/segment/variant/variant_writer_helpers.h
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "common/status.h"
+#include "core/column/column.h"
+#include "core/data_type/data_type.h"
+#include "storage/segment/column_writer.h"
+#include "storage/tablet/tablet_schema.h"
+#include "util/json/path_in_data.h"
+
+namespace doris {
+
+class OlapBlockDataConvertor;
+
+namespace segment_v2 {
+
+#include "common/compile_check_begin.h"
+
+namespace variant_writer_helpers {
+
+Status convert_and_write_column(OlapBlockDataConvertor* converter, const TabletColumn& column,
+                                DataTypePtr data_type, ColumnWriter* writer,
+                                const ColumnPtr& src_column, size_t num_rows, int column_id);
+
+void maybe_remove_root_jsonb_with_empty_defaults(MutableColumnPtr* root_column, size_t num_rows,
+                                                 bool remove_root_jsonb);
+
+Status prepare_subcolumn_writer_target(
+        const ColumnWriterOptions& base_opts, const TabletColumn& parent_column,
+        int current_column_id, const PathInData& relative_path, const DataTypePtr& current_type,
+        int64_t none_null_value_size, size_t num_rows,
+        const TabletSchema::SubColumnInfo* existing_subcolumn_info, bool check_storage_type,
+        TabletIndexes* out_subcolumn_indexes, ColumnWriterOptions* out_subcolumn_opts,
+        std::unique_ptr<ColumnWriter>* out_writer, TabletColumn* out_tablet_column);
+
+} // namespace variant_writer_helpers
+
+#include "common/compile_check_end.h"
+
+} // namespace segment_v2
+} // namespace doris

--- a/be/test/storage/segment/nested_group_path_filter_test.cpp
+++ b/be/test/storage/segment/nested_group_path_filter_test.cpp
@@ -104,6 +104,13 @@ TEST(NestedGroupPathFilterTest, MatchesChildPrefixMatch) {
     EXPECT_TRUE(filter.matches_child("items"));
 }
 
+TEST(NestedGroupPathFilterTest, MatchesChildDescendantMatch) {
+    NestedGroupPathFilter filter;
+    filter.add_path("items");
+
+    EXPECT_TRUE(filter.matches_child("items.msg"));
+}
+
 TEST(NestedGroupPathFilterTest, MatchesChildNoMatch) {
     NestedGroupPathFilter filter;
     filter.add_path("items.msg");

--- a/be/test/storage/segment/nested_group_path_test.cpp
+++ b/be/test/storage/segment/nested_group_path_test.cpp
@@ -48,6 +48,21 @@ TEST(NestedGroupPathTest, ContainsNestedGroupMarker) {
     EXPECT_FALSE(contains_nested_group_marker("__D0_root__"));
 }
 
+TEST(NestedGroupPathTest, NestedGroupPathHasPrefix) {
+    EXPECT_TRUE(nested_group_path_has_prefix("items.msg", "items"));
+    EXPECT_TRUE(nested_group_path_has_prefix("items", "items"));
+    EXPECT_FALSE(nested_group_path_has_prefix("item", "items"));
+    EXPECT_FALSE(nested_group_path_has_prefix("items_extra", "items"));
+}
+
+TEST(NestedGroupPathTest, NestedGroupPathsOverlap) {
+    EXPECT_TRUE(nested_group_paths_overlap("items", "items.msg"));
+    EXPECT_TRUE(nested_group_paths_overlap("items.msg", "items"));
+    EXPECT_TRUE(nested_group_paths_overlap("items", "items"));
+    EXPECT_FALSE(nested_group_paths_overlap("items", "other.msg"));
+    EXPECT_FALSE(nested_group_paths_overlap("items", "item"));
+}
+
 // ===========================================================================
 // nested_group_marker_token
 // ===========================================================================

--- a/be/test/storage/segment/nested_group_provider_test.cpp
+++ b/be/test/storage/segment/nested_group_provider_test.cpp
@@ -62,10 +62,10 @@ TEST(NestedGroupProviderTest, DefaultWriteProviderIsNoOp) {
     ColumnWriterOptions opts;
     VariantStatistics statistics;
 
-    EXPECT_TRUE(write_provider
-                        ->prepare(*column_variant, false, nullptr, opts, nullptr, 0, nullptr,
-                                  &statistics)
-                        .ok());
+    auto status =
+            write_provider->prepare(*column_variant, nullptr, opts, nullptr, nullptr, &statistics);
+    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.is<ErrorCode::INVALID_ARGUMENT>());
     EXPECT_EQ(0, write_provider->estimate_buffer_size());
     EXPECT_TRUE(write_provider->finish().ok());
     EXPECT_TRUE(write_provider->write_data().ok());

--- a/be/test/storage/segment/nested_group_provider_test.cpp
+++ b/be/test/storage/segment/nested_group_provider_test.cpp
@@ -161,7 +161,7 @@ TEST(DefaultNestedGroupReadProviderTest, InitReadersCEBehavior) {
 
     ColumnReaderOptions opts;
     NestedGroupReaders out_readers;
-    auto status = provider->init_readers(opts, nullptr, nullptr, nullptr, 0, out_readers);
+    auto status = provider->init_readers(opts, nullptr, nullptr, nullptr, 0, 0, out_readers);
     EXPECT_TRUE(status.ok());
     EXPECT_TRUE(out_readers.empty());
 }

--- a/be/test/storage/segment/variant_column_writer_reader_test.cpp
+++ b/be/test/storage/segment/variant_column_writer_reader_test.cpp
@@ -16,16 +16,19 @@
 // under the License.
 
 #include <atomic>
+#include <set>
 #include <thread>
 
 #include "common/config.h"
 #include "core/data_type_serde/data_type_serde.h"
 #include "gtest/gtest.h"
+#include "storage/rowset/rowset_factory.h"
 #include "storage/segment/column_meta_accessor.h"
 #include "storage/segment/column_reader.h"
 #include "storage/segment/column_reader_cache.h"
 #include "storage/segment/variant/binary_column_extract_iterator.h"
 #include "storage/segment/variant/hierarchical_data_iterator.h"
+#include "storage/segment/variant/nested_group_streaming_write_plan.h"
 #include "storage/segment/variant/sparse_column_merge_iterator.h"
 #include "storage/segment/variant/variant_column_reader.h"
 #include "storage/segment/variant/variant_column_writer_impl.h"
@@ -47,7 +50,8 @@ static void construct_column(ColumnPB* column_pb, int32_t col_unique_id,
                              bool is_nullable = false, int variant_sparse_hash_shard_count = 0,
                              bool variant_enable_doc_mode = false,
                              int64_t variant_doc_materialization_min_rows = 0,
-                             int variant_doc_hash_shard_count = 0) {
+                             int variant_doc_hash_shard_count = 0,
+                             bool variant_enable_nested_group = false) {
     column_pb->set_unique_id(col_unique_id);
     column_pb->set_name(column_name);
     column_pb->set_type(column_type);
@@ -63,6 +67,7 @@ static void construct_column(ColumnPB* column_pb, int32_t col_unique_id,
         if (variant_doc_hash_shard_count > 0) {
             column_pb->set_variant_doc_hash_shard_count(variant_doc_hash_shard_count);
         }
+        column_pb->set_variant_enable_nested_group(variant_enable_nested_group);
     }
 }
 
@@ -181,6 +186,154 @@ public:
     ~VariantColumnWriterReaderTest() override = default;
 
 protected:
+    void init_variant_tablet(int64_t tablet_id, int variant_max_subcolumns_count = 10,
+                             bool variant_enable_nested_group = false, bool is_nullable = false) {
+        TabletSchemaPB schema_pb;
+        schema_pb.set_keys_type(KeysType::DUP_KEYS);
+        construct_column(schema_pb.add_column(), 1, "VARIANT", "V1", variant_max_subcolumns_count,
+                         false, is_nullable, 0, false, 0, 0, variant_enable_nested_group);
+        _tablet_schema = std::make_shared<TabletSchema>();
+        _tablet_schema->init_from_pb(schema_pb);
+
+        TabletMetaSharedPtr tablet_meta(new TabletMeta(_tablet_schema));
+        _tablet_schema->set_external_segment_meta_used_default(true);
+        tablet_meta->_tablet_id = tablet_id;
+        _tablet = std::make_shared<Tablet>(*_engine_ref, tablet_meta, _data_dir.get());
+
+        EXPECT_TRUE(_tablet->init().ok());
+        EXPECT_TRUE(io::global_local_filesystem()->delete_directory(_tablet->tablet_path()).ok());
+        EXPECT_TRUE(io::global_local_filesystem()->create_directory(_tablet->tablet_path()).ok());
+    }
+
+    RowsetSharedPtr create_variant_rowset(const std::vector<std::vector<std::string>>& batches,
+                                          int64_t version, int64_t max_rows_per_segment = 200) {
+        RowsetWriterContext ctx;
+        RowsetId rowset_id;
+        rowset_id.init(version + 1000);
+        ctx.rowset_id = rowset_id;
+        ctx.rowset_type = BETA_ROWSET;
+        ctx.data_dir = _data_dir.get();
+        ctx.rowset_state = VISIBLE;
+        ctx.tablet_schema = _tablet_schema;
+        ctx.tablet_path = _tablet->tablet_path();
+        ctx.tablet_id = _tablet->tablet_id();
+        ctx.tablet = _tablet;
+        ctx.version = Version(version, version);
+        ctx.segments_overlap = NONOVERLAPPING;
+        ctx.max_rows_per_segment = max_rows_per_segment;
+        ctx.write_type = DataWriteType::TYPE_DIRECT;
+
+        auto res = RowsetFactory::create_rowset_writer(*_engine_ref, ctx, false);
+        EXPECT_TRUE(res.has_value()) << res.error();
+        auto rowset_writer = std::move(res).value();
+
+        for (const auto& batch : batches) {
+            Block block = _tablet_schema->create_block();
+            auto columns = block.mutate_columns();
+            auto variant_col =
+                    ColumnVariant::create(_tablet_schema->column(0).variant_max_subcolumns_count());
+            auto json_col = ColumnString::create();
+            for (const auto& json : batch) {
+                json_col->insert_data(json.data(), json.size());
+            }
+            ParseConfig config;
+            variant_util::parse_json_to_variant(*variant_col, *json_col, config);
+            columns[0] = std::move(variant_col);
+            block.set_columns(std::move(columns));
+
+            auto st = rowset_writer->add_block(&block);
+            EXPECT_TRUE(st.ok()) << st.to_string();
+            st = rowset_writer->flush();
+            EXPECT_TRUE(st.ok()) << st.to_string();
+        }
+
+        RowsetSharedPtr rowset;
+        EXPECT_TRUE(rowset_writer->build(rowset).ok());
+        return rowset;
+    }
+
+    std::vector<RowsetReaderSharedPtr> create_rowset_readers(
+            const std::vector<RowsetSharedPtr>& rowsets) const {
+        std::vector<RowsetReaderSharedPtr> readers;
+        readers.reserve(rowsets.size());
+        for (const auto& rowset : rowsets) {
+            RowsetReaderSharedPtr reader;
+            EXPECT_TRUE(rowset->create_reader(&reader).ok());
+            readers.push_back(std::move(reader));
+        }
+        return readers;
+    }
+
+    Status append_json_batch(ColumnWriter* writer, const std::vector<std::string>& jsons) {
+        if (writer == nullptr) {
+            return Status::InvalidArgument("writer is null");
+        }
+
+        Block block = _tablet_schema->create_block();
+        auto columns = block.mutate_columns();
+        auto variant_col =
+                ColumnVariant::create(_tablet_schema->column(0).variant_max_subcolumns_count());
+        auto json_col = ColumnString::create();
+        for (const auto& json : jsons) {
+            json_col->insert_data(json.data(), json.size());
+        }
+        ParseConfig config;
+        variant_util::parse_json_to_variant(*variant_col, *json_col, config);
+        columns[0] = std::move(variant_col);
+        block.set_columns(std::move(columns));
+
+        auto converter = std::make_unique<OlapBlockDataConvertor>();
+        converter->add_column_data_convertor(_tablet_schema->column(0));
+        converter->set_source_content(&block, 0, jsons.size());
+        auto [status, accessor] = converter->convert_column_data(0);
+        RETURN_IF_ERROR(status);
+        return writer->append(accessor->get_nullmap(), accessor->get_data(), jsons.size());
+    }
+
+    Status read_root_rows(const SegmentFooterPB& footer, const std::string& file_path,
+                          std::vector<std::string>* out_rows) {
+        io::FileReaderSPtr file_reader;
+        RETURN_IF_ERROR(io::global_local_filesystem()->open_file(file_path, &file_reader));
+
+        std::shared_ptr<ColumnReader> column_reader;
+        RETURN_IF_ERROR(
+                create_variant_root_reader(footer, file_reader, _tablet_schema, &column_reader));
+
+        auto* variant_column_reader = assert_cast<VariantColumnReader*>(column_reader.get());
+        MockColumnReaderCache column_reader_cache(footer, file_reader, _tablet_schema);
+
+        TabletColumn parent_column = _tablet_schema->column(0);
+        StorageReadOptions storage_read_opts;
+        storage_read_opts.io_ctx.reader_type = ReaderType::READER_QUERY;
+        OlapReaderStatistics stats;
+        storage_read_opts.stats = &stats;
+
+        ColumnIteratorUPtr iterator;
+        RETURN_IF_ERROR(variant_column_reader->new_iterator(
+                &iterator, &parent_column, &storage_read_opts, &column_reader_cache));
+
+        ColumnIteratorOptions column_iter_opts;
+        column_iter_opts.stats = &stats;
+        column_iter_opts.file_reader = file_reader.get();
+        RETURN_IF_ERROR(iterator->init(column_iter_opts));
+
+        MutableColumnPtr dst =
+                ColumnVariant::create(parent_column.variant_max_subcolumns_count(), false);
+        size_t nrows = footer.num_rows();
+        RETURN_IF_ERROR(iterator->seek_to_ordinal(0));
+        RETURN_IF_ERROR(iterator->next_batch(&nrows, dst));
+
+        out_rows->clear();
+        out_rows->reserve(nrows);
+        DataTypeSerDe::FormatOptions options;
+        for (size_t i = 0; i < nrows; ++i) {
+            std::string value;
+            assert_cast<ColumnVariant*>(dst.get())->serialize_one_row_to_string(i, &value, options);
+            out_rows->push_back(std::move(value));
+        }
+        return Status::OK();
+    }
+
     TabletSchemaSPtr _tablet_schema = nullptr;
     StorageEngine* _engine_ref = nullptr;
     std::unique_ptr<DataDir> _data_dir = nullptr;
@@ -266,6 +419,37 @@ static std::string expected_doc_bucket_json_from_full(const std::string& full_js
 
     out.push_back('}');
     return out;
+}
+
+static std::set<std::string> collect_regular_paths(
+        const segment_v2::NestedGroupStreamingWritePlan& plan) {
+    std::set<std::string> paths;
+    for (const auto& entry : plan.regular_subcolumns) {
+        paths.insert(entry.path);
+    }
+    return paths;
+}
+
+static std::vector<std::string> normalize_json_rows(const std::vector<std::string>& jsons,
+                                                    int variant_max_subcolumns_count) {
+    auto variant_col = ColumnVariant::create(variant_max_subcolumns_count);
+    auto json_col = ColumnString::create();
+    for (const auto& json : jsons) {
+        json_col->insert_data(json.data(), json.size());
+    }
+
+    ParseConfig config;
+    variant_util::parse_json_to_variant(*variant_col, *json_col, config);
+
+    std::vector<std::string> normalized;
+    normalized.reserve(jsons.size());
+    DataTypeSerDe::FormatOptions options;
+    for (size_t i = 0; i < jsons.size(); ++i) {
+        std::string value;
+        variant_col->serialize_one_row_to_string(i, &value, options);
+        normalized.push_back(std::move(value));
+    }
+    return normalized;
 }
 
 TEST_F(VariantColumnWriterReaderTest, test_statics) {
@@ -3581,6 +3765,111 @@ TEST_F(VariantColumnWriterReaderTest, test_concurrent_load_external_meta_and_get
     reader_thread.join();
 
     EXPECT_TRUE(writer_status.ok());
+}
+
+TEST_F(VariantColumnWriterReaderTest,
+       test_streaming_write_plan_collects_regular_paths_from_rowset_metadata) {
+    init_variant_tablet(41000, 10, true);
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    input_rowsets.push_back(
+            create_variant_rowset({{R"({"session_id": 1, "tags": ["a"], "score": 10})",
+                                    R"({"session_id": 2, "tags": []})"}},
+                                  1));
+    input_rowsets.push_back(
+            create_variant_rowset({{R"({"score": 30})", R"({"session_id": 4})"}}, 2));
+
+    auto readers = create_rowset_readers(input_rowsets);
+    segment_v2::NestedGroupStreamingWritePlan plan;
+    auto st = segment_v2::build_nested_group_streaming_write_plan(readers,
+                                                                  _tablet_schema->column(0), &plan);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    EXPECT_FALSE(plan.has_conflict_paths);
+    EXPECT_FALSE(plan.has_root_nested_group);
+    EXPECT_EQ(plan.conflict_policy, segment_v2::get_nested_group_conflict_policy());
+    EXPECT_TRUE(plan.nested_groups.empty());
+    EXPECT_EQ(collect_regular_paths(plan), std::set<std::string>({"score", "session_id", "tags"}));
+    ASSERT_EQ(plan.regular_subcolumns.size(), 3);
+    EXPECT_EQ(plan.regular_subcolumns[0].path, "score");
+    EXPECT_EQ(plan.regular_subcolumns[1].path, "session_id");
+    EXPECT_EQ(plan.regular_subcolumns[2].path, "tags");
+    ASSERT_NE(plan.regular_subcolumns[2].data_type, nullptr);
+    EXPECT_NE(plan.regular_subcolumns[2].data_type->get_name().find("Array"), std::string::npos);
+}
+
+TEST_F(VariantColumnWriterReaderTest,
+       test_streaming_compaction_writer_streams_regular_array_paths_across_batches) {
+    init_variant_tablet(41001, 10, true);
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    input_rowsets.push_back(
+            create_variant_rowset({{R"({"session_id": 10, "tags": ["seed_10"]})"}}, 1));
+    input_rowsets.push_back(create_variant_rowset({{R"({"session_id": 20})"}}, 2));
+    auto input_readers = create_rowset_readers(input_rowsets);
+
+    io::FileWriterPtr file_writer;
+    auto file_path = local_segment_path(_tablet->tablet_path(), "streaming_compaction", 0);
+    auto st = io::global_local_filesystem()->create_file(file_path, &file_writer);
+    ASSERT_TRUE(st.ok()) << st.msg();
+
+    SegmentFooterPB footer;
+    ColumnWriterOptions opts;
+    opts.meta = footer.add_columns();
+    opts.compression_type = CompressionTypePB::LZ4;
+    opts.file_writer = file_writer.get();
+    opts.footer = &footer;
+    opts.input_rs_readers = input_readers;
+
+    RowsetWriterContext rowset_ctx;
+    rowset_ctx.write_type = DataWriteType::TYPE_COMPACTION;
+    rowset_ctx.tablet_schema = _tablet_schema;
+    rowset_ctx.input_rs_readers = input_readers;
+    opts.rowset_ctx = &rowset_ctx;
+
+    TabletColumn column = _tablet_schema->column(0);
+    _init_column_meta(opts.meta, 0, column, CompressionTypePB::LZ4);
+
+    std::unique_ptr<ColumnWriter> writer;
+    ASSERT_TRUE(ColumnWriter::create(opts, &column, file_writer.get(), &writer).ok());
+    ASSERT_TRUE(writer->init().ok());
+
+    auto* variant_writer = assert_cast<VariantColumnWriter*>(writer.get());
+    ASSERT_NE(variant_writer, nullptr);
+    auto* writer_impl = variant_writer->impl_for_test();
+    ASSERT_NE(writer_impl, nullptr);
+    EXPECT_TRUE(writer_impl->has_streaming_compaction_writer_for_test());
+    EXPECT_FALSE(writer_impl->is_finalized());
+
+    const std::vector<std::string> batch1 = {R"({"session_id": 1, "tags": ["topic_1", "topic_2"]})",
+                                             R"({"session_id": 2, "tags": []})"};
+    const std::vector<std::string> batch2 = {R"({"session_id": 3})",
+                                             R"({"session_id": 4, "tags": [null, "topic_4"]})"};
+
+    std::vector<std::string> expected_rows =
+            normalize_json_rows(batch1, column.variant_max_subcolumns_count());
+    auto normalized_batch2 = normalize_json_rows(batch2, column.variant_max_subcolumns_count());
+    expected_rows.insert(expected_rows.end(), normalized_batch2.begin(), normalized_batch2.end());
+
+    ASSERT_TRUE(append_json_batch(writer.get(), batch1).ok());
+    EXPECT_FALSE(writer_impl->is_finalized());
+    ASSERT_TRUE(append_json_batch(writer.get(), batch2).ok());
+    EXPECT_FALSE(writer_impl->is_finalized());
+
+    ASSERT_TRUE(writer->finish().ok());
+    EXPECT_TRUE(writer_impl->is_finalized());
+    ASSERT_TRUE(writer->write_data().ok());
+    ASSERT_TRUE(writer->write_ordinal_index().ok());
+    ASSERT_TRUE(writer->write_zone_map().ok());
+    ASSERT_TRUE(file_writer->close().ok());
+    footer.set_num_rows(writer->get_next_rowid());
+
+    EXPECT_EQ(footer.columns_size(), 3);
+
+    std::vector<std::string> actual_rows;
+    st = read_root_rows(footer, file_path, &actual_rows);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    EXPECT_EQ(actual_rows, expected_rows);
 }
 
 } // namespace doris


### PR DESCRIPTION
Build a NestedGroup streaming write plan from input rowset metadata and use it to initialize root, regular subcolumn and nested-group writers during compaction, so Variant data can be written chunk by chunk instead of being fully materialized first.

Refactor shared subcolumn writer helpers, allow the NestedGroup provider to consume prebuilt groups or a streaming plan, and skip sparse/doc path-stat collection for nested-group variant columns.

Add tests for streaming plan construction and array subcolumn writes across multiple batches.

