### PR TITLE
[test](auth)Resolve the conflict in the backup auth case

### DIFF
--- a/regression-test/suites/auth_call/test_ddl_backup_auth.groovy
+++ b/regression-test/suites/auth_call/test_ddl_backup_auth.groovy
@@ -18,7 +18,7 @@
 import org.junit.Assert;
 import java.util.UUID
 
-suite("test_ddl_backup_auth","p0,auth_call") {
+suite("test_ddl_backup_auth","p0,auth_call,nonConcurrent") {
     UUID uuid = UUID.randomUUID()
     String randomValue = uuid.toString()
     int hashCode = randomValue.hashCode()


### PR DESCRIPTION
[test](auth)Resolve the conflict in the backup auth case

During backup, failing to acquire the lock within 10 seconds makes the test case unstable, adding nonConcurrent can fix it.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

