### PR TITLE
[fix](test) Fix BDB JE resource leak in BDBEnvironmentTest causing FE UT timeout

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/journal/bdbje/BDBEnvironmentTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/journal/bdbje/BDBEnvironmentTest.java
@@ -501,124 +501,127 @@ public class BDBEnvironmentTest {
             followersInfo.add(Pair.of(followerEnvironment, new NodeInfo(nodeName, nodeHostPort, nodeDir)));
         }
 
-        Pair<BDBEnvironment, NodeInfo> masterPair = findMaster(followersInfo);
-        String beginDbName = String.valueOf(0L);
-        Database masterDb = masterPair.first.openDatabase(beginDbName);
-        DatabaseEntry key = new DatabaseEntry(randomBytes());
-        DatabaseEntry value = new DatabaseEntry(randomBytes());
-        Assertions.assertEquals(OperationStatus.SUCCESS, masterDb.put(null, key, value));
-        Assertions.assertEquals(1, masterEnvironment.getDatabaseNames().size());
-        LOG.info("master is {} | {}", masterPair.second.name, masterPair.second.dir);
+        try {
+            Pair<BDBEnvironment, NodeInfo> masterPair = findMaster(followersInfo);
+            String beginDbName = String.valueOf(0L);
+            Database masterDb = masterPair.first.openDatabase(beginDbName);
+            DatabaseEntry key = new DatabaseEntry(randomBytes());
+            DatabaseEntry value = new DatabaseEntry(randomBytes());
+            Assertions.assertEquals(OperationStatus.SUCCESS, masterDb.put(null, key, value));
+            Assertions.assertEquals(1, masterEnvironment.getDatabaseNames().size());
+            LOG.info("master is {} | {}", masterPair.second.name, masterPair.second.dir);
 
-        for (Pair<BDBEnvironment, NodeInfo> entryPair : followersInfo) {
-            if (entryPair.second.dir.equals(masterPair.second.dir)) {
-                LOG.info("skip {}", entryPair.second.name);
-                return;
-            }
-
-            Assertions.assertEquals(1, entryPair.first.getDatabaseNames().size());
-            Database followerDb = entryPair.first.openDatabase(beginDbName);
-            DatabaseEntry readValue = new DatabaseEntry();
-            Assertions.assertEquals(OperationStatus.SUCCESS, followerDb.get(null, key, readValue, LockMode.DEFAULT));
-            Assertions.assertEquals(new String(value.getData()), new String(readValue.getData()));
-            followerDb.close();
-        }
-
-        masterDb.close();
-        masterEnvironment.getEpochDB().close();
-
-        followersInfo.stream().forEach(entryPair -> {
-            entryPair.first.close();
-            LOG.info("close {} | {}", entryPair.second.name, entryPair.second.dir);
-        });
-
-        // all follower closed
-        for (Pair<BDBEnvironment, NodeInfo> entryPair : followersInfo) {
-            String followerCopyDir = entryPair.second.dir + "_copy";
-            LOG.info("Copy from {} to {}", entryPair.second.dir, followerCopyDir);
-            FileUtils.copyDirectory(new File(entryPair.second.dir), new File(followerCopyDir));
-        }
-
-        followersInfo.stream().forEach(entryPair -> {
-            entryPair.first.openReplicatedEnvironment(new File(entryPair.second.dir));
-            LOG.info("open {} | {}", entryPair.second.name, entryPair.second.dir);
-        });
-
-        masterPair = findMaster(followersInfo);
-
-        masterDb = masterPair.first.openDatabase(String.valueOf(1L));
-        for (int i = 0; i < 2 * Config.txn_rollback_limit + 10; i++) {
-            // for (int i = 0; i < 10; i++) {
-            OperationStatus status = masterDb.put(null, new DatabaseEntry(randomBytes()), new DatabaseEntry(randomBytes()));
-            Assertions.assertEquals(OperationStatus.SUCCESS, status);
-        }
-        Assertions.assertEquals(2, masterPair.first.getDatabaseNames().size());
-        Assertions.assertEquals(0, masterPair.first.getDatabaseNames().get(0));
-        Assertions.assertEquals(1, masterPair.first.getDatabaseNames().get(1));
-
-        followersInfo.stream().forEach(entryPair -> {
-            entryPair.first.close();
-            LOG.info("close {} | {}", entryPair.second.name, entryPair.second.dir);
-        });
-
-        // Restore follower's (not new master) bdbje dir
-        for (Pair<BDBEnvironment, NodeInfo> entryPair : followersInfo) {
-            if (entryPair.second.dir.equals(masterDir)) {
-                String masterCopyDir = entryPair.second.dir + "_copy";
-                FileUtils.deleteDirectory(new File(masterCopyDir));
-                continue;
-            }
-            LOG.info("Delete followerDir {} ", entryPair.second.dir);
-            FileUtils.deleteDirectory(new File(entryPair.second.dir));
-            // FileUtils.moveDirectory(new File(entryPair.second.dir), new File(entryPair.second.dir + "_copy2"));
-            String followerCopyDir = entryPair.second.dir + "_copy";
-            LOG.info("Move {} to {}", followerCopyDir, entryPair.second.dir);
-            FileUtils.moveDirectory(new File(followerCopyDir), new File(entryPair.second.dir));
-        }
-
-        Thread.sleep(1000);
-        for (Pair<BDBEnvironment, NodeInfo> entryPair : followersInfo) {
-            if (entryPair.second.dir.equals(masterPair.second.dir)) {
-                LOG.info("skip open {} | {}", entryPair.second.name, entryPair.second.dir);
-                continue;
-            }
-            entryPair.first.openReplicatedEnvironment(new File(entryPair.second.dir));
-            LOG.info("open {} | {}", entryPair.second.name, entryPair.second.dir);
-        }
-
-        BDBEnvironment newMasterEnvironment = null;
-        boolean found = false;
-        for (int i = 0; i < 300; i++) {
             for (Pair<BDBEnvironment, NodeInfo> entryPair : followersInfo) {
                 if (entryPair.second.dir.equals(masterPair.second.dir)) {
+                    LOG.info("skip {}", entryPair.second.name);
+                    return;
+                }
+
+                Assertions.assertEquals(1, entryPair.first.getDatabaseNames().size());
+                Database followerDb = entryPair.first.openDatabase(beginDbName);
+                DatabaseEntry readValue = new DatabaseEntry();
+                Assertions.assertEquals(OperationStatus.SUCCESS, followerDb.get(null, key, readValue, LockMode.DEFAULT));
+                Assertions.assertEquals(new String(value.getData()), new String(readValue.getData()));
+                followerDb.close();
+            }
+
+            masterDb.close();
+            masterEnvironment.getEpochDB().close();
+
+            followersInfo.stream().forEach(entryPair -> {
+                entryPair.first.close();
+                LOG.info("close {} | {}", entryPair.second.name, entryPair.second.dir);
+            });
+
+            // all follower closed
+            for (Pair<BDBEnvironment, NodeInfo> entryPair : followersInfo) {
+                String followerCopyDir = entryPair.second.dir + "_copy";
+                LOG.info("Copy from {} to {}", entryPair.second.dir, followerCopyDir);
+                FileUtils.copyDirectory(new File(entryPair.second.dir), new File(followerCopyDir));
+            }
+
+            followersInfo.stream().forEach(entryPair -> {
+                entryPair.first.openReplicatedEnvironment(new File(entryPair.second.dir));
+                LOG.info("open {} | {}", entryPair.second.name, entryPair.second.dir);
+            });
+
+            masterPair = findMaster(followersInfo);
+
+            masterDb = masterPair.first.openDatabase(String.valueOf(1L));
+            for (int i = 0; i < 2 * Config.txn_rollback_limit + 10; i++) {
+                // for (int i = 0; i < 10; i++) {
+                OperationStatus status = masterDb.put(null, new DatabaseEntry(randomBytes()), new DatabaseEntry(randomBytes()));
+                Assertions.assertEquals(OperationStatus.SUCCESS, status);
+            }
+            Assertions.assertEquals(2, masterPair.first.getDatabaseNames().size());
+            Assertions.assertEquals(0, masterPair.first.getDatabaseNames().get(0));
+            Assertions.assertEquals(1, masterPair.first.getDatabaseNames().get(1));
+
+            followersInfo.stream().forEach(entryPair -> {
+                entryPair.first.close();
+                LOG.info("close {} | {}", entryPair.second.name, entryPair.second.dir);
+            });
+
+            // Restore follower's (not new master) bdbje dir
+            for (Pair<BDBEnvironment, NodeInfo> entryPair : followersInfo) {
+                if (entryPair.second.dir.equals(masterDir)) {
+                    String masterCopyDir = entryPair.second.dir + "_copy";
+                    FileUtils.deleteDirectory(new File(masterCopyDir));
                     continue;
                 }
+                LOG.info("Delete followerDir {} ", entryPair.second.dir);
+                FileUtils.deleteDirectory(new File(entryPair.second.dir));
+                // FileUtils.moveDirectory(new File(entryPair.second.dir), new File(entryPair.second.dir + "_copy2"));
+                String followerCopyDir = entryPair.second.dir + "_copy";
+                LOG.info("Move {} to {}", followerCopyDir, entryPair.second.dir);
+                FileUtils.moveDirectory(new File(followerCopyDir), new File(entryPair.second.dir));
+            }
 
-                LOG.info("name:{} state:{} dir:{}", entryPair.first.getReplicatedEnvironment().getNodeName(),
-                        entryPair.first.getReplicatedEnvironment().getState(),
-                        entryPair.second.dir);
-                if (entryPair.first.getReplicatedEnvironment().getState().equals(ReplicatedEnvironment.State.MASTER)) {
-                    newMasterEnvironment = entryPair.first;
-                    found = true;
+            Thread.sleep(1000);
+            for (Pair<BDBEnvironment, NodeInfo> entryPair : followersInfo) {
+                if (entryPair.second.dir.equals(masterPair.second.dir)) {
+                    LOG.info("skip open {} | {}", entryPair.second.name, entryPair.second.dir);
+                    continue;
+                }
+                entryPair.first.openReplicatedEnvironment(new File(entryPair.second.dir));
+                LOG.info("open {} | {}", entryPair.second.name, entryPair.second.dir);
+            }
+
+            BDBEnvironment newMasterEnvironment = null;
+            boolean found = false;
+            for (int i = 0; i < 300; i++) {
+                for (Pair<BDBEnvironment, NodeInfo> entryPair : followersInfo) {
+                    if (entryPair.second.dir.equals(masterPair.second.dir)) {
+                        continue;
+                    }
+
+                    LOG.info("name:{} state:{} dir:{}", entryPair.first.getReplicatedEnvironment().getNodeName(),
+                            entryPair.first.getReplicatedEnvironment().getState(),
+                            entryPair.second.dir);
+                    if (entryPair.first.getReplicatedEnvironment().getState().equals(ReplicatedEnvironment.State.MASTER)) {
+                        newMasterEnvironment = entryPair.first;
+                        found = true;
+                        break;
+                    }
+                }
+                if (found) {
                     break;
                 }
+                Thread.sleep(1000);
             }
-            if (found) {
-                break;
-            }
-            Thread.sleep(1000);
-        }
-        Assertions.assertNotNull(newMasterEnvironment);
+            Assertions.assertNotNull(newMasterEnvironment);
 
-        masterDb = newMasterEnvironment.openDatabase(beginDbName);
-        Assertions.assertEquals(OperationStatus.SUCCESS, masterDb.put(null, new DatabaseEntry(randomBytes()), new DatabaseEntry(randomBytes())));
-        Assertions.assertEquals(1, newMasterEnvironment.getDatabaseNames().size());
-        // // old master
-        masterEnvironment.openReplicatedEnvironment(new File(masterDir));
-        followersInfo.stream().forEach(entryPair -> {
-            entryPair.first.close();
-            LOG.info("close {} | {}", entryPair.second.name, entryPair.second.dir);
-        });
+            masterDb = newMasterEnvironment.openDatabase(beginDbName);
+            Assertions.assertEquals(OperationStatus.SUCCESS, masterDb.put(null, new DatabaseEntry(randomBytes()), new DatabaseEntry(randomBytes())));
+            Assertions.assertEquals(1, newMasterEnvironment.getDatabaseNames().size());
+            // // old master
+            masterEnvironment.openReplicatedEnvironment(new File(masterDir));
+        } finally {
+            followersInfo.stream().forEach(entryPair -> {
+                entryPair.first.close();
+                LOG.info("close {} | {}", entryPair.second.name, entryPair.second.dir);
+            });
+        }
         LOG.info("end");
     }
 
@@ -670,73 +673,80 @@ public class BDBEnvironmentTest {
             followersInfo.add(Pair.of(followerEnvironment, new NodeInfo(nodeName, nodeHostPort, nodeDir)));
         }
 
-        Pair<BDBEnvironment, NodeInfo> masterPair = findMaster(followersInfo);
-        String beginDbName = String.valueOf(0L);
-        Database masterDb = masterPair.first.openDatabase(beginDbName);
-        DatabaseEntry key = new DatabaseEntry(randomBytes());
-        DatabaseEntry value = new DatabaseEntry(randomBytes());
-        Assertions.assertEquals(OperationStatus.SUCCESS, masterDb.put(null, key, value));
-        Assertions.assertEquals(1, masterEnvironment.getDatabaseNames().size());
-        LOG.info("master is {} | {}", masterPair.second.name, masterPair.second.dir);
+        try {
+            Pair<BDBEnvironment, NodeInfo> masterPair = findMaster(followersInfo);
+            String beginDbName = String.valueOf(0L);
+            Database masterDb = masterPair.first.openDatabase(beginDbName);
+            DatabaseEntry key = new DatabaseEntry(randomBytes());
+            DatabaseEntry value = new DatabaseEntry(randomBytes());
+            Assertions.assertEquals(OperationStatus.SUCCESS, masterDb.put(null, key, value));
+            Assertions.assertEquals(1, masterEnvironment.getDatabaseNames().size());
+            LOG.info("master is {} | {}", masterPair.second.name, masterPair.second.dir);
 
-        for (Pair<BDBEnvironment, NodeInfo> entryPair : followersInfo) {
-            if (entryPair.second.dir.equals(masterPair.second.dir)) {
-                LOG.info("skip {}", entryPair.second.name);
-                continue;
+            for (Pair<BDBEnvironment, NodeInfo> entryPair : followersInfo) {
+                if (entryPair.second.dir.equals(masterPair.second.dir)) {
+                    LOG.info("skip {}", entryPair.second.name);
+                    continue;
+                }
+
+                Assertions.assertEquals(1, entryPair.first.getDatabaseNames().size());
+                Database followerDb = entryPair.first.openDatabase(beginDbName);
+                DatabaseEntry readValue = new DatabaseEntry();
+                Assertions.assertEquals(OperationStatus.SUCCESS, followerDb.get(null, key, readValue, LockMode.DEFAULT));
+                Assertions.assertEquals(new String(value.getData()), new String(readValue.getData()));
             }
 
-            Assertions.assertEquals(1, entryPair.first.getDatabaseNames().size());
-            Database followerDb = entryPair.first.openDatabase(beginDbName);
+            Field envImplField = ReplicatedEnvironment.class.getDeclaredField("repEnvironmentImpl");
+            envImplField.setAccessible(true);
+            RepImpl impl = (RepImpl) envImplField.get(masterPair.first.getReplicatedEnvironment());
+            Assertions.assertNotNull(impl);
+
+            new Expectations(impl) {{
+                    // Below method will replicate log item to followers.
+                    impl.registerVLSN(withNotNull());
+                    // Below method will wait until the logs are replicated.
+                    impl.postLogCommitHook(withNotNull(), withNotNull());
+                    result = new InsufficientAcksException("mocked");
+                }};
+
+            long count = masterDb.count();
+            final Database oldMasterDb = masterDb;
+            Assertions.assertThrows(InsufficientAcksException.class, () -> {
+                // Since this key is not replicated to any replicas, it should not be read.
+                DatabaseEntry k = new DatabaseEntry(new byte[]{1, 2, 3});
+                DatabaseEntry v = new DatabaseEntry(new byte[]{4, 5, 6});
+                oldMasterDb.put(null, k, v);
+            });
+
+            LOG.info("close old master {} | {}", masterPair.second.name, masterPair.second.dir);
+            masterDb.close();
+            masterEnvironment.getEpochDB().close();
+            masterEnvironment.close();
+
+            for (Pair<BDBEnvironment, NodeInfo> entryPair : followersInfo) {
+                if (entryPair.second.dir.equals(masterPair.second.dir)) {
+                    LOG.info("skip {}", entryPair.second.name);
+                    continue;
+                }
+                LOG.info("close follower {} | {}", entryPair.second.name, entryPair.second.dir);
+                entryPair.first.close();
+            }
+
+            masterPair.first.openReplicatedEnvironment(new File(masterPair.second.dir));
+            masterDb = masterPair.first.openDatabase(beginDbName);
+            LOG.info("open {} | {}", masterPair.second.name, masterPair.second.dir);
+
+            // The local commit txn is readable!!!
+            Assertions.assertEquals(count + 1, masterDb.count());
+
+            key = new DatabaseEntry(new byte[]{1, 2, 3});
             DatabaseEntry readValue = new DatabaseEntry();
-            Assertions.assertEquals(OperationStatus.SUCCESS, followerDb.get(null, key, readValue, LockMode.DEFAULT));
-            Assertions.assertEquals(new String(value.getData()), new String(readValue.getData()));
+            Assertions.assertEquals(OperationStatus.SUCCESS, masterDb.get(null, key, readValue, LockMode.DEFAULT));
+        } finally {
+            followersInfo.stream().forEach(entryPair -> {
+                entryPair.first.close();
+                LOG.info("close {} | {}", entryPair.second.name, entryPair.second.dir);
+            });
         }
-
-        Field envImplField = ReplicatedEnvironment.class.getDeclaredField("repEnvironmentImpl");
-        envImplField.setAccessible(true);
-        RepImpl impl = (RepImpl) envImplField.get(masterPair.first.getReplicatedEnvironment());
-        Assertions.assertNotNull(impl);
-
-        new Expectations(impl) {{
-                // Below method will replicate log item to followers.
-                impl.registerVLSN(withNotNull());
-                // Below method will wait until the logs are replicated.
-                impl.postLogCommitHook(withNotNull(), withNotNull());
-                result = new InsufficientAcksException("mocked");
-            }};
-
-        long count = masterDb.count();
-        final Database oldMasterDb = masterDb;
-        Assertions.assertThrows(InsufficientAcksException.class, () -> {
-            // Since this key is not replicated to any replicas, it should not be read.
-            DatabaseEntry k = new DatabaseEntry(new byte[]{1, 2, 3});
-            DatabaseEntry v = new DatabaseEntry(new byte[]{4, 5, 6});
-            oldMasterDb.put(null, k, v);
-        });
-
-        LOG.info("close old master {} | {}", masterPair.second.name, masterPair.second.dir);
-        masterDb.close();
-        masterEnvironment.getEpochDB().close();
-        masterEnvironment.close();
-
-        for (Pair<BDBEnvironment, NodeInfo> entryPair : followersInfo) {
-            if (entryPair.second.dir.equals(masterPair.second.dir)) {
-                LOG.info("skip {}", entryPair.second.name);
-                continue;
-            }
-            LOG.info("close follower {} | {}", entryPair.second.name, entryPair.second.dir);
-            entryPair.first.close();
-        }
-
-        masterPair.first.openReplicatedEnvironment(new File(masterPair.second.dir));
-        masterDb = masterPair.first.openDatabase(beginDbName);
-        LOG.info("open {} | {}", masterPair.second.name, masterPair.second.dir);
-
-        // The local commit txn is readable!!!
-        Assertions.assertEquals(count + 1, masterDb.count());
-
-        key = new DatabaseEntry(new byte[]{1, 2, 3});
-        DatabaseEntry readValue = new DatabaseEntry();
-        Assertions.assertEquals(OperationStatus.SUCCESS, masterDb.get(null, key, readValue, LockMode.DEFAULT));
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

The following resource leak issues in BDBEnvironmentTest cause BDB JE checkpoint threads to enter an infinite VLSN consistency retry loop during JVM shutdown, blocking the Maven Surefire process from exiting and triggering TeamCity execution timeout (~3 hours):

1. testReadTxnIsNotMatched: reopens BDB JE master environment and database at the end but never closes them.

2. testRollbackException: has an early 'return' when fe1 is elected as master, which exits the method without closing any of the 3 BDB JE environments.

Fix by wrapping the test logic of both multi-node cluster tests (testRollbackException, testReadTxnIsNotMatched) with try/finally blocks that guarantee all BDB JE environments are closed, regardless of whether the test passes, fails an assertion, or returns early.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

