### PR TITLE
[fix](coordinator) Fix NPE in updateLoadCounters during reportExecStatus for non-Load queries

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -2478,10 +2478,10 @@ public class Coordinator implements CoordInterface {
                 updateStatus(status);
             }
         }
-        if (params.isSetDeltaUrls()) {
+        if (params.isSetDeltaUrls() && deltaUrls != null) {
             updateDeltas(params.getDeltaUrls());
         }
-        if (params.isSetLoadCounters()) {
+        if (params.isSetLoadCounters() && loadCounters != null) {
             updateLoadCounters(params.getLoadCounters());
         }
         if (params.isSetTrackingUrl()) {


### PR DESCRIPTION
### What problem does this PR solve?

loadCounters and deltaUrls are only initialized in the Load (data sink) path, but BE may report these fields even for external table SELECT queries because num_finished_range > 0 triggers load_counters to be set on BE side. Added null guards to prevent NPE when processing status reports for non-Load queries.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

