### PR TITLE
[opt](memory) lazy-allocate PrefetchBuffer backing buffer to reduce peak memory

### DIFF
--- a/be/src/io/fs/buffered_reader.cpp
+++ b/be/src/io/fs/buffered_reader.cpp
@@ -449,6 +449,13 @@ void PrefetchBuffer::prefetch_buffer() {
         _prefetched.notify_all();
     }
 
+    // Lazy-allocate the backing buffer on first actual prefetch, avoiding the cost of
+    // pre-allocating memory for readers that are initialized but never read (e.g. when
+    // many file readers are created concurrently for a TVF scan over many small S3 files).
+    if (!_buf) {
+        _buf = std::make_unique<char[]>(_size);
+    }
+
     int read_range_index = search_read_range(_offset);
     size_t buf_size;
     if (read_range_index == -1) {

--- a/be/src/io/fs/buffered_reader.h
+++ b/be/src/io/fs/buffered_reader.h
@@ -436,7 +436,7 @@ struct PrefetchBuffer : std::enable_shared_from_this<PrefetchBuffer>, public Pro
               _reader(reader),
               _io_ctx_holder(std::move(io_ctx)),
               _io_ctx(_io_ctx_holder.get()),
-              _buf(new char[buffer_size]),
+              _buf(nullptr),
               _sync_profile(std::move(sync_profile)) {}
 
     PrefetchBuffer(PrefetchBuffer&& other)


### PR DESCRIPTION
## Problem

When doing a TVF scan over many small S3/HDFS files, each `CsvReader::init_reader()`
creates a `PrefetchBufferedReader`, which in its constructor immediately allocates
`buffer_num` (typically 4) `PrefetchBuffer` objects, each pre-allocating a
`s_max_pre_buffer_size` (4 MB) backing buffer. This costs **16 MB per file reader**
at construction time, regardless of whether the reader ever performs any I/O.
<img width="3838" height="1284" alt="image" src="https://github.com/user-attachments/assets/7d7d6fcd-7bf9-452c-8fb9-0e4479e426af" />


## Fix

Defer the allocation of `_buf` from the `PrefetchBuffer` constructor to the first
time `prefetch_buffer()` actually runs. This is safe because:

1. `_buf` is only written by `prefetch_buffer()` (one writer).
2. `read_buffer()` only accesses `_buf` after waiting on the condition variable for
   `PREFETCHED` status, which provides the required happens-before guarantee.

## Impact

| Scenario | Before | After |
|---|---|---|
| Reader created, never reads (closed before prefetch runs) | 16 MB allocated, held until task drains | 0 MB allocated |
| N tasks queued on closed buffers in thread pool | N × 16 MB stuck in memory | ~0 MB (empty shell objects only) |
| Normal read path | 16 MB allocated when prefetch runs | 16 MB allocated when prefetch runs (unchanged) |

Comparison of total load memory (the earlier is before optimization):
<img width="1038" height="426" alt="image" src="https://github.com/user-attachments/assets/895ce622-fd91-4bf6-93ae-ee02f9467801" />


