### PR TITLE
[chore](cloud) Enable txn lazy commit by default in FE

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3261,8 +3261,8 @@ public class Config extends ConfigBase {
     public static boolean enable_commit_lock_for_all_tables = true;
 
     @ConfField(mutable = true, description = {
-            "Whether to enable lazy commit for large transactions in cloud mode. Default is false."})
-    public static boolean enable_cloud_txn_lazy_commit = false;
+            "Whether to enable lazy commit for large transactions in cloud mode. Default is true."})
+    public static boolean enable_cloud_txn_lazy_commit = true;
 
     @ConfField(mutable = true, masterOnly = true,
             description = {


### PR DESCRIPTION
## Summary
This PR aligns FE config with BE config change from #58732.

The BE config `enable_cloud_txn_lazy_commit` was changed from `false` to `true` in #58732, but the corresponding FE config was not updated. This PR fixes that.

## Changes
- Update `enable_cloud_txn_lazy_commit` default value from `false` to `true` in FE Config.java
- Update the description comment to reflect the new default value
