### PR TITLE
[branch-4.1][chore](cloud) Enable txn lazy commit by default (pick #58732 #61506)

### DIFF
--- a/be/src/cloud/config.cpp
+++ b/be/src/cloud/config.cpp
@@ -98,7 +98,7 @@ DEFINE_mBool(enable_batch_get_delete_bitmap, "false");
 // to get the remaining rowsets' results.
 DEFINE_mInt64(get_delete_bitmap_bytes_threshold, "524288000"); // 500MB
 
-DEFINE_Bool(enable_cloud_txn_lazy_commit, "false");
+DEFINE_Bool(enable_cloud_txn_lazy_commit, "true");
 
 DEFINE_mInt32(remove_expired_tablet_txn_info_interval_seconds, "300");
 

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3530,8 +3530,8 @@ public class Config extends ConfigBase {
             + "Default value is true." })
     public static boolean enable_commit_lock_for_all_tables = true;
 
-    @ConfField(mutable = true, description = {"存算分离模式下是否开启大事务提交，默认 false"})
-    public static boolean enable_cloud_txn_lazy_commit = false;
+    @ConfField(mutable = true, description = {"存算分离模式下是否开启大事务提交，默认 true"})
+    public static boolean enable_cloud_txn_lazy_commit = true;
 
     @ConfField(mutable = true, masterOnly = true,
             description = {"存算分离模式下，当 tablet 分布的 be 异常，是否立即映射 tablet 到新的 be 上，默认 false"})


### PR DESCRIPTION
## Summary
This PR picks #58732 and #61506 to branch-4.1.

Enable `enable_cloud_txn_lazy_commit` by default for cloud mode.

## Changes
- BE: Change `enable_cloud_txn_lazy_commit` default value from `false` to `true`
- FE: Change `enable_cloud_txn_lazy_commit` default value from `false` to `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)