### PR TITLE
[fix](olap) Avoid polluting the schema cache in OlapScanner

### DIFF
--- a/be/src/exec/scan/olap_scanner.cpp
+++ b/be/src/exec/scan/olap_scanner.cpp
@@ -178,6 +178,11 @@ Status OlapScanner::prepare() {
                 return false;
             }
 
+            // If `delete_predicates` is not empty, will merge the columns in delete predicate into current tablet schema
+            if (!_tablet_reader_params.delete_predicates.empty()) {
+                return false;
+            }
+
             const bool has_pruned_column =
                     std::ranges::any_of(_output_tuple_desc->slots(), [](const auto& slot) {
                         if ((slot->type()->get_primitive_type() == PrimitiveType::TYPE_STRUCT ||


### PR DESCRIPTION
### What problem does this PR solve?

```text
*** SIGSEGV address not mapped to object (@0x20) received by PID 2309810 (TID 2312493 OR 0x7f39af4bf640) from PID 32; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/gcp-user/selectdb-core/be/src/common/signal_handler.h:421
 1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] in /opt/jdk/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /opt/jdk/lib/server/libjvm.so
 3# 0x00007F3E7723FC30 in /lib64/libc.so.6
 4# std::_Hashtable<doris::StringRef, std::pair<doris::StringRef const, int>, std::allocator<std::pair<doris::StringRef const, int> >, std::__detail::_Select1st, std::equal_to<doris::StringRef>, doris::StringRefHash, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::find(doris::StringRef const&) const at /home/gcp-user/tools/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/hashtable.h:1587
 5# doris::TabletSchema::field_index(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const at /home/gcp-user/selectdb-core/be/src/olap/tablet_schema.cpp:1304
 6# doris::vectorized::NewOlapScanner::_init_tablet_reader_params(std::vector<doris::OlapScanRange*, std::allocator<doris::OlapScanRange*> > const&, std::vector<doris::TCondition, std::allocator<doris::TCondition> > const&, doris::pipeline::FilterPredicates const&, std::vector<doris::FunctionFilter, std::allocator<doris::FunctionFilter> > const&) at /home/gcp-user/selectdb-core/be/src/vec/exec/scan/new_olap_scanner.cpp:413
 7# doris::vectorized::NewOlapScanner::init() in /opt/selectdb/4.0.7.2025101510/be/lib/doris_be
 8# doris::vectorized::ScannerScheduler::_scanner_scan(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>) at /home/gcp-user/selectdb-core/be/src/vec/exec/scan/scanner_scheduler.cpp:221
 9# std::_Function_handler<void (), doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_1::operator()() const::{lambda()#1}>::_M_invoke(std::_Any_data const&) at /home/gcp-user/tools/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
10# doris::ThreadPool::dispatch_thread() at /home/gcp-user/selectdb-core/be/src/util/threadpool.cpp:609
11# doris::Thread::supervise_thread(void*) at /home/gcp-user/selectdb-core/be/src/util/thread.cpp:499
12# start_thread in /lib64/libc.so.6
13# __GI___clone3 in /lib64/libc.so.6
```
Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

