### PR TITLE
[fix](hive) Support disabling HMS client pooling

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSCachedClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSCachedClient.java
@@ -37,7 +37,8 @@ import java.util.Map;
 import java.util.function.Function;
 
 /**
- * A hive metastore client pool for a specific catalog with hive configuration.
+ * A Hive metastore client pool for a specific catalog with Hive configuration.
+ * This is a pool of metastore clients, not a thread pool.
  * Currently, we support obtain hive metadata from thrift protocol and JDBC protocol.
  */
 public interface HMSCachedClient {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/ThriftHMSCachedClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/ThriftHMSCachedClient.java
@@ -28,6 +28,7 @@ import org.apache.doris.info.TableNameInfo;
 
 import com.aliyun.datalake.metastore.hive2.ProxyMetaStoreClient;
 import com.amazonaws.glue.catalog.metastore.AWSCatalogMetastoreClient;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -80,7 +81,8 @@ import java.util.stream.Collectors;
 
 /**
  * This class uses the thrift protocol to directly access the HiveMetaStore service
- * to obtain Hive metadata information
+ * to obtain Hive metadata information. It maintains a pool of metastore clients,
+ * not a thread pool. A pool size of 0 disables client reuse.
  */
 public class ThriftHMSCachedClient implements HMSCachedClient {
     private static final Logger LOG = LogManager.getLogger(ThriftHMSCachedClient.class);
@@ -89,14 +91,14 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
     // -1 means no limit on the partitions returned.
     private static final short MAX_LIST_PARTITION_NUM = Config.max_hive_list_partition_num;
 
-    private Queue<ThriftHMSClient> clientPool = new LinkedList<>();
+    private final Queue<ThriftHMSClient> clientPool = new LinkedList<>();
     private boolean isClosed = false;
     private final int poolSize;
     private final HiveConf hiveConf;
     private ExecutionAuthenticator executionAuthenticator;
 
     public ThriftHMSCachedClient(HiveConf hiveConf, int poolSize, ExecutionAuthenticator executionAuthenticator) {
-        Preconditions.checkArgument(poolSize > 0, poolSize);
+        Preconditions.checkArgument(poolSize >= 0, poolSize);
         this.hiveConf = hiveConf;
         this.poolSize = poolSize;
         this.isClosed = false;
@@ -641,17 +643,7 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
         private volatile Throwable throwable;
 
         private ThriftHMSClient(HiveConf hiveConf) throws MetaException {
-            String type = hiveConf.get(HMSBaseProperties.HIVE_METASTORE_TYPE);
-            if (HMSBaseProperties.DLF_TYPE.equalsIgnoreCase(type)) {
-                client = RetryingMetaStoreClient.getProxy(hiveConf, DUMMY_HOOK_LOADER,
-                        ProxyMetaStoreClient.class.getName());
-            } else if (HMSBaseProperties.GLUE_TYPE.equalsIgnoreCase(type)) {
-                client = RetryingMetaStoreClient.getProxy(hiveConf, DUMMY_HOOK_LOADER,
-                        AWSCatalogMetastoreClient.class.getName());
-            } else {
-                client = RetryingMetaStoreClient.getProxy(hiveConf, DUMMY_HOOK_LOADER,
-                        HiveMetaStoreClient.class.getName());
-            }
+            client = createClient(hiveConf);
         }
 
         public void setThrowable(Throwable throwable) {
@@ -661,7 +653,8 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
         @Override
         public void close() throws Exception {
             synchronized (clientPool) {
-                if (isClosed || throwable != null || clientPool.size() > poolSize) {
+                // A pool size of 0 means no pooling: always close the underlying client.
+                if (isClosed || throwable != null || poolSize == 0 || clientPool.size() >= poolSize) {
                     client.close();
                 } else {
                     clientPool.offer(this);
@@ -683,6 +676,27 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
             }
         } finally {
             Thread.currentThread().setContextClassLoader(classLoader);
+        }
+    }
+
+    protected IMetaStoreClient createClient(HiveConf hiveConf) throws MetaException {
+        String type = hiveConf.get(HMSBaseProperties.HIVE_METASTORE_TYPE);
+        if (HMSBaseProperties.DLF_TYPE.equalsIgnoreCase(type)) {
+            return RetryingMetaStoreClient.getProxy(hiveConf, DUMMY_HOOK_LOADER,
+                    ProxyMetaStoreClient.class.getName());
+        } else if (HMSBaseProperties.GLUE_TYPE.equalsIgnoreCase(type)) {
+            return RetryingMetaStoreClient.getProxy(hiveConf, DUMMY_HOOK_LOADER,
+                    AWSCatalogMetastoreClient.class.getName());
+        } else {
+            return RetryingMetaStoreClient.getProxy(hiveConf, DUMMY_HOOK_LOADER,
+                    HiveMetaStoreClient.class.getName());
+        }
+    }
+
+    @VisibleForTesting
+    int getClientPoolSize() {
+        synchronized (clientPool) {
+            return clientPool.size();
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/ThriftHMSCachedClientTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/ThriftHMSCachedClientTest.java
@@ -1,0 +1,108 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.hive;
+
+import org.apache.doris.common.security.authentication.ExecutionAuthenticator;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ThriftHMSCachedClientTest {
+
+    @Test
+    public void testReturnsClientToPoolWhenPoolingEnabled() throws Exception {
+        IMetaStoreClient client = Mockito.mock(IMetaStoreClient.class);
+        Mockito.when(client.getAllDatabases()).thenReturn(Collections.emptyList());
+        TestableThriftHMSCachedClient cachedClient = new TestableThriftHMSCachedClient(1, client);
+
+        cachedClient.getAllDatabases();
+        cachedClient.getAllDatabases();
+
+        Assertions.assertEquals(1, cachedClient.getCreatedClientCount());
+        Assertions.assertEquals(1, cachedClient.getClientPoolSize());
+        Mockito.verify(client, Mockito.never()).close();
+
+        cachedClient.close();
+
+        Assertions.assertEquals(0, cachedClient.getClientPoolSize());
+        Mockito.verify(client).close();
+    }
+
+    @Test
+    public void testDoesNotReturnClientToPoolWhenPoolSizeIsZero() throws Exception {
+        IMetaStoreClient firstClient = Mockito.mock(IMetaStoreClient.class);
+        IMetaStoreClient secondClient = Mockito.mock(IMetaStoreClient.class);
+        Mockito.when(firstClient.getAllDatabases()).thenReturn(Collections.emptyList());
+        Mockito.when(secondClient.getAllDatabases()).thenReturn(Collections.emptyList());
+        TestableThriftHMSCachedClient cachedClient = new TestableThriftHMSCachedClient(0, firstClient, secondClient);
+
+        cachedClient.getAllDatabases();
+        cachedClient.getAllDatabases();
+
+        Assertions.assertEquals(2, cachedClient.getCreatedClientCount());
+        Assertions.assertEquals(0, cachedClient.getClientPoolSize());
+        Mockito.verify(firstClient).close();
+        Mockito.verify(secondClient).close();
+    }
+
+    @Test
+    public void testExceptionPathDoesNotReturnClientToPool() throws Exception {
+        IMetaStoreClient client = Mockito.mock(IMetaStoreClient.class);
+        Mockito.when(client.getAllDatabases()).thenThrow(new RuntimeException("boom"));
+        TestableThriftHMSCachedClient cachedClient = new TestableThriftHMSCachedClient(1, client);
+
+        Assertions.assertThrows(HMSClientException.class, cachedClient::getAllDatabases);
+
+        Assertions.assertEquals(1, cachedClient.getCreatedClientCount());
+        Assertions.assertEquals(0, cachedClient.getClientPoolSize());
+        Mockito.verify(client).close();
+    }
+
+    private static class TestableThriftHMSCachedClient extends ThriftHMSCachedClient {
+        private final Deque<IMetaStoreClient> clients = new ArrayDeque<>();
+        private final AtomicInteger createdClientCount = new AtomicInteger();
+
+        TestableThriftHMSCachedClient(int poolSize, IMetaStoreClient... clients) {
+            super(new HiveConf(), poolSize, new ExecutionAuthenticator() {});
+            this.clients.addAll(Arrays.asList(clients));
+        }
+
+        @Override
+        protected IMetaStoreClient createClient(HiveConf hiveConf) {
+            createdClientCount.incrementAndGet();
+            IMetaStoreClient client = clients.pollFirst();
+            if (client == null) {
+                throw new AssertionError("No mock client available");
+            }
+            return client;
+        }
+
+        int getCreatedClientCount() {
+            return createdClientCount.get();
+        }
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

- Allow `ThriftHMSCachedClient` to accept `poolSize = 0` and treat it as no-pooling mode.
- Keep the current production wiring unchanged and avoid reusing existing FE thread-pool configs to carry HMS client-pool semantics.
- Add unit coverage for pooled reuse, no-pooling, and exception paths.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. `poolSize = 0` is now accepted by `ThriftHMSCachedClient` and disables HMS client reuse.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

Local verification note:
- `git diff --check` passed.
- Attempted `mvn -pl fe-core -am -Dtest=ThriftHMSCachedClientTest -DfailIfNoTests=false test`, but the run is currently blocked by an existing unrelated `fe-common` / thrift enum mismatch in this workspace.