### PR TITLE
[opt](segment) flush column writer pages by threshold

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1044,6 +1044,7 @@ DEFINE_mInt32(merged_hdfs_min_io_size, "8192");
 DEFINE_mInt32(orc_natural_read_size_mb, "8");
 DEFINE_mInt64(big_column_size_buffer, "65535");
 DEFINE_mInt64(small_column_size_buffer, "100");
+DEFINE_mInt64(column_writer_page_flush_threshold, "1048576");
 
 // Perform the always_true check at intervals determined by runtime_filter_sampling_frequency
 DEFINE_mInt32(runtime_filter_sampling_frequency, "32");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1101,6 +1101,7 @@ DECLARE_mInt32(merged_hdfs_min_io_size);
 DECLARE_mInt32(orc_natural_read_size_mb);
 DECLARE_mInt64(big_column_size_buffer);
 DECLARE_mInt64(small_column_size_buffer);
+DECLARE_mInt64(column_writer_page_flush_threshold);
 
 DECLARE_mInt32(runtime_filter_sampling_frequency);
 DECLARE_mInt32(execution_max_rpc_timeout_sec);

--- a/be/src/storage/segment/column_writer.cpp
+++ b/be/src/storage/segment/column_writer.cpp
@@ -821,6 +821,30 @@ Status ScalarColumnWriter::_write_data_page(Page* page) {
     return Status::OK();
 }
 
+Status ScalarColumnWriter::_flush_pages_if_needed() {
+    if (_data_size < config::column_writer_page_flush_threshold) {
+        return Status::OK();
+    }
+    auto offset = _file_writer->bytes_appended();
+    auto collect_uncompressed_bytes = [](const PageFooterPB& footer) {
+        return footer.uncompressed_size() + footer.ByteSizeLong() +
+               sizeof(uint32_t) /* footer size */ + sizeof(uint32_t) /* checksum */;
+    };
+    for (auto& page : _pages) {
+        _total_uncompressed_data_pages_size += collect_uncompressed_bytes(page->footer);
+        RETURN_IF_ERROR(_write_data_page(page.get()));
+    }
+    _total_compressed_data_pages_size += _file_writer->bytes_appended() - offset;
+    LOG(INFO) << fmt::format(
+            "Flushed {} pages for column_id={}, total uncompressed data pages size={}, "
+            "total compressed data pages size={}, flush_data_size={}",
+            _pages.size(), _opts.meta->column_id(), _total_uncompressed_data_pages_size,
+            _total_compressed_data_pages_size, _data_size);
+    _pages.clear();
+    _data_size = 0;
+    return Status::OK();
+}
+
 Status ScalarColumnWriter::finish_current_page() {
     if (_next_rowid == _first_rowid) {
         return Status::OK();
@@ -881,6 +905,7 @@ Status ScalarColumnWriter::finish_current_page() {
     }
 
     _push_back_page(std::move(page));
+    RETURN_IF_ERROR(_flush_pages_if_needed());
     _first_rowid = _next_rowid;
     return Status::OK();
 }

--- a/be/src/storage/segment/column_writer.h
+++ b/be/src/storage/segment/column_writer.h
@@ -311,6 +311,7 @@ private:
     }
 
     Status _write_data_page(Page* page);
+    Status _flush_pages_if_needed();
 
 private:
     io::FileWriter* _file_writer = nullptr;


### PR DESCRIPTION
## Summary
- add a configurable threshold to flush cached column writer pages before write_data()
- trigger eager page flushing after finishing a page when cached page bytes reach the threshold
- keep compressed and uncompressed page byte accounting correct for early-flushed pages

## Testing
- not run (not requested)
