### PR TITLE
[cleanup](iwyu) Remove unnecessary includes of glog/logging.h and boost/iterator_facade.hpp

### DIFF
--- a/be/src/agent/be_exec_version_manager.h
+++ b/be/src/agent/be_exec_version_manager.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <fmt/format.h>
-#include <glog/logging.h>
 
 #include "common/exception.h"
 #include "common/status.h"

--- a/be/src/agent/topic_subscriber.h
+++ b/be/src/agent/topic_subscriber.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <gen_cpp/BackendService_types.h>
-#include <glog/logging.h>
 
 #include <map>
 #include <shared_mutex>

--- a/be/src/agent/workload_group_listener.h
+++ b/be/src/agent/workload_group_listener.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-
 #include "agent/topic_listener.h"
 
 namespace doris {

--- a/be/src/agent/workload_group_listener.h
+++ b/be/src/agent/workload_group_listener.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <glog/logging.h>
 
 #include "agent/topic_listener.h"
 

--- a/be/src/agent/workload_sched_policy_listener.h
+++ b/be/src/agent/workload_sched_policy_listener.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-
 #include "agent/topic_listener.h"
 #include "runtime/exec_env.h"
 

--- a/be/src/agent/workload_sched_policy_listener.h
+++ b/be/src/agent/workload_sched_policy_listener.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <glog/logging.h>
 
 #include "agent/topic_listener.h"
 #include "runtime/exec_env.h"

--- a/be/src/core/column/column_array.cpp
+++ b/be/src/core/column/column_array.cpp
@@ -21,7 +21,6 @@
 #include "core/column/column_array.h"
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <cstring>
 #include <vector>
 

--- a/be/src/core/column/column_array.h
+++ b/be/src/core/column/column_array.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include <glog/logging.h>
 #include <sys/types.h>
 
 #include <cstdint>

--- a/be/src/core/column/column_decimal.h
+++ b/be/src/core/column/column_decimal.h
@@ -27,7 +27,6 @@
 #include <sys/types.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <vector>
 
 #include "core/assert_cast.h"

--- a/be/src/core/column/column_map.cpp
+++ b/be/src/core/column/column_map.cpp
@@ -21,7 +21,6 @@
 #include "core/column/column_map.h"
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <cstddef>
 #include <vector>
 

--- a/be/src/core/column/column_map.h
+++ b/be/src/core/column/column_map.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include <glog/logging.h>
 #include <stdint.h>
 #include <sys/types.h>
 

--- a/be/src/core/column/column_string.cpp
+++ b/be/src/core/column/column_string.cpp
@@ -23,7 +23,6 @@
 #include <crc32c/crc32c.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <cstring>
 
 #include "core/arena.h"

--- a/be/src/core/column/column_struct.h
+++ b/be/src/core/column/column_struct.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include <glog/logging.h>
 #include <stdint.h>
 #include <sys/types.h>
 

--- a/be/src/core/column/column_variant.cpp
+++ b/be/src/core/column/column_variant.cpp
@@ -22,7 +22,6 @@
 
 #include <fmt/core.h>
 #include <fmt/format.h>
-#include <glog/logging.h>
 #include <parallel_hashmap/phmap.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>

--- a/be/src/core/column/column_variant.h
+++ b/be/src/core/column/column_variant.h
@@ -20,7 +20,6 @@
 
 #pragma once
 #include <butil/compiler_specific.h>
-#include <glog/logging.h>
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
 #include <sys/types.h>

--- a/be/src/core/column/column_vector.h
+++ b/be/src/core/column/column_vector.h
@@ -24,7 +24,6 @@
 #include <sys/types.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <cmath>
 #include <cstdint>
 #include <cstring>

--- a/be/src/core/column/columns_common.cpp
+++ b/be/src/core/column/columns_common.cpp
@@ -22,7 +22,6 @@
 
 #include <string.h>
 
-
 #include "core/column/column.h"
 #include "core/column/column_array.h" // IWYU pragma: keep
 #include "util/simd/bits.h"

--- a/be/src/core/column/columns_common.cpp
+++ b/be/src/core/column/columns_common.cpp
@@ -22,7 +22,6 @@
 
 #include <string.h>
 
-#include <boost/iterator/iterator_facade.hpp>
 
 #include "core/column/column.h"
 #include "core/column/column_array.h" // IWYU pragma: keep

--- a/be/src/core/column/columns_common.h
+++ b/be/src/core/column/columns_common.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include <glog/logging.h>
 #include <stdint.h>
 #include <sys/types.h>
 

--- a/be/src/core/data_type/convert_field_to_type.cpp
+++ b/be/src/core/data_type/convert_field_to_type.cpp
@@ -21,7 +21,6 @@
 #include "core/data_type/convert_field_to_type.h"
 
 #include <fmt/format.h>
-#include <glog/logging.h>
 #include <stddef.h>
 
 #include <memory>

--- a/be/src/core/data_type/data_type_bitmap.h
+++ b/be/src/core/data_type/data_type_bitmap.h
@@ -17,7 +17,6 @@
 
 #pragma once
 #include <gen_cpp/Types_types.h>
-#include <glog/logging.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/be/src/core/data_type/data_type_date.h
+++ b/be/src/core/data_type/data_type_date.h
@@ -22,7 +22,6 @@
 
 #include <gen_cpp/Types_types.h>
 
-#include <boost/iterator/iterator_facade.hpp>
 #include <cstddef>
 #include <string>
 

--- a/be/src/core/data_type/data_type_date_or_datetime_v2.h
+++ b/be/src/core/data_type/data_type_date_or_datetime_v2.h
@@ -19,7 +19,6 @@
 
 #include <fmt/format.h>
 #include <gen_cpp/Types_types.h>
-#include <glog/logging.h>
 
 #include <boost/iterator/iterator_facade.hpp>
 #include <cstddef>

--- a/be/src/core/data_type/data_type_date_or_datetime_v2.h
+++ b/be/src/core/data_type/data_type_date_or_datetime_v2.h
@@ -20,7 +20,6 @@
 #include <fmt/format.h>
 #include <gen_cpp/Types_types.h>
 
-#include <boost/iterator/iterator_facade.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/be/src/core/data_type/data_type_date_time.h
+++ b/be/src/core/data_type/data_type_date_time.h
@@ -22,7 +22,6 @@
 
 #include <gen_cpp/Types_types.h>
 
-#include <boost/iterator/iterator_facade.hpp>
 #include <cstddef>
 #include <string>
 

--- a/be/src/core/data_type/data_type_factory.cpp
+++ b/be/src/core/data_type/data_type_factory.cpp
@@ -30,7 +30,6 @@
 #include <stdint.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <ostream>
 

--- a/be/src/core/data_type/data_type_hll.h
+++ b/be/src/core/data_type/data_type_hll.h
@@ -17,7 +17,6 @@
 
 #pragma once
 #include <gen_cpp/Types_types.h>
-#include <glog/logging.h>
 
 #include <cstddef>
 #include <cstdint>

--- a/be/src/core/data_type/data_type_ipv4.h
+++ b/be/src/core/data_type/data_type_ipv4.h
@@ -19,7 +19,6 @@
 
 #include <gen_cpp/Types_types.h>
 
-#include <boost/iterator/iterator_facade.hpp>
 #include <cstddef>
 #include <string>
 

--- a/be/src/core/data_type/data_type_ipv6.h
+++ b/be/src/core/data_type/data_type_ipv6.h
@@ -21,7 +21,6 @@
 #include <stddef.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <string>
 
 #include "common/status.h"

--- a/be/src/core/data_type/data_type_map.cpp
+++ b/be/src/core/data_type/data_type_map.cpp
@@ -19,7 +19,6 @@
 
 #include <ctype.h>
 #include <gen_cpp/data.pb.h>
-#include <glog/logging.h>
 #include <string.h>
 
 #include <string>

--- a/be/src/core/data_type/data_type_nothing.h
+++ b/be/src/core/data_type/data_type_nothing.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include <gen_cpp/Types_types.h>
-#include <glog/logging.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/be/src/core/data_type/data_type_nullable.cpp
+++ b/be/src/core/data_type/data_type_nullable.cpp
@@ -22,7 +22,6 @@
 
 #include <fmt/format.h>
 #include <gen_cpp/data.pb.h>
-#include <glog/logging.h>
 #include <streamvbyte.h>
 
 #include <algorithm>

--- a/be/src/core/data_type/data_type_number_base.cpp
+++ b/be/src/core/data_type/data_type_number_base.cpp
@@ -21,7 +21,6 @@
 #include "core/data_type/data_type_number_base.h"
 
 #include <fmt/format.h>
-#include <glog/logging.h>
 #include <streamvbyte.h>
 
 #include <cstddef>

--- a/be/src/core/data_type/data_type_number_base.h
+++ b/be/src/core/data_type/data_type_number_base.h
@@ -22,7 +22,6 @@
 
 #include <gen_cpp/Types_types.h>
 
-#include <boost/iterator/iterator_facade.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/be/src/core/data_type/data_type_quantilestate.h
+++ b/be/src/core/data_type/data_type_quantilestate.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <glog/logging.h>
 
 #include <memory>
 #include <ostream>

--- a/be/src/core/data_type/data_type_quantilestate.h
+++ b/be/src/core/data_type/data_type_quantilestate.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-
 #include <memory>
 #include <ostream>
 #include <string>

--- a/be/src/core/data_type/data_type_time.h
+++ b/be/src/core/data_type/data_type_time.h
@@ -22,7 +22,6 @@
 
 #include <gen_cpp/Types_types.h>
 
-#include <boost/iterator/iterator_facade.hpp>
 #include <cstddef>
 #include <memory>
 #include <string>

--- a/be/src/core/data_type/data_type_timestamptz.h
+++ b/be/src/core/data_type/data_type_timestamptz.h
@@ -22,7 +22,6 @@
 
 #include <gen_cpp/Types_types.h>
 
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <string>
 

--- a/be/src/core/data_type/data_type_varbinary.cpp
+++ b/be/src/core/data_type/data_type_varbinary.cpp
@@ -17,7 +17,6 @@
 
 #include "core/data_type/data_type_varbinary.h"
 
-#include <glog/logging.h>
 #include <lz4/lz4.h>
 #include <streamvbyte.h>
 

--- a/be/src/core/data_type/data_type_variant.h
+++ b/be/src/core/data_type/data_type_variant.h
@@ -21,7 +21,6 @@
 #pragma once
 #include <gen_cpp/Exprs_types.h>
 #include <gen_cpp/Types_types.h>
-#include <glog/logging.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/be/src/core/data_type_serde/data_type_array_serde.h
+++ b/be/src/core/data_type_serde/data_type_array_serde.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <glog/logging.h>
 
 #include <cstdint>
 #include <memory>

--- a/be/src/core/data_type_serde/data_type_array_serde.h
+++ b/be/src/core/data_type_serde/data_type_array_serde.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-
 #include <cstdint>
 #include <memory>
 #include <ostream>

--- a/be/src/core/data_type_serde/data_type_date_or_datetime_serde.h
+++ b/be/src/core/data_type_serde/data_type_date_or_datetime_serde.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <gen_cpp/types.pb.h>
-#include <glog/logging.h>
 
 #include <cstdint>
 #include <string>

--- a/be/src/core/data_type_serde/data_type_datetimev2_serde.h
+++ b/be/src/core/data_type_serde/data_type_datetimev2_serde.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <gen_cpp/types.pb.h>
-#include <glog/logging.h>
 
 #include <cstdint>
 #include <string>

--- a/be/src/core/data_type_serde/data_type_datev2_serde.h
+++ b/be/src/core/data_type_serde/data_type_datev2_serde.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <gen_cpp/types.pb.h>
-#include <glog/logging.h>
 
 #include <cstdint>
 #include <string>

--- a/be/src/core/data_type_serde/data_type_decimal_serde.h
+++ b/be/src/core/data_type_serde/data_type_decimal_serde.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <gen_cpp/types.pb.h>
-#include <glog/logging.h>
 
 #include <string>
 

--- a/be/src/core/data_type_serde/data_type_ipv4_serde.h
+++ b/be/src/core/data_type_serde/data_type_ipv4_serde.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <glog/logging.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/be/src/core/data_type_serde/data_type_ipv6_serde.h
+++ b/be/src/core/data_type_serde/data_type_ipv6_serde.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <glog/logging.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/be/src/core/data_type_serde/data_type_jsonb_serde.h
+++ b/be/src/core/data_type_serde/data_type_jsonb_serde.h
@@ -17,7 +17,6 @@
 
 #pragma once
 #include <gen_cpp/types.pb.h>
-#include <glog/logging.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/be/src/core/data_type_serde/data_type_map_serde.h
+++ b/be/src/core/data_type_serde/data_type_map_serde.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <glog/logging.h>
 #include <stdint.h>
 
 #include <ostream>

--- a/be/src/core/data_type_serde/data_type_number_serde.h
+++ b/be/src/core/data_type_serde/data_type_number_serde.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <gen_cpp/types.pb.h>
-#include <glog/logging.h>
 
 #include <string>
 

--- a/be/src/core/data_type_serde/data_type_struct_serde.h
+++ b/be/src/core/data_type_serde/data_type_struct_serde.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-
 #include <cstdint>
 
 #include "common/status.h"

--- a/be/src/core/data_type_serde/data_type_struct_serde.h
+++ b/be/src/core/data_type_serde/data_type_struct_serde.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <glog/logging.h>
 
 #include <cstdint>
 

--- a/be/src/core/data_type_serde/data_type_time_serde.h
+++ b/be/src/core/data_type_serde/data_type_time_serde.h
@@ -17,7 +17,6 @@
 
 #pragma once
 #include <gen_cpp/types.pb.h>
-#include <glog/logging.h>
 
 #include <cstdint>
 

--- a/be/src/core/data_type_serde/data_type_timestamptz_serde.h
+++ b/be/src/core/data_type_serde/data_type_timestamptz_serde.h
@@ -17,7 +17,6 @@
 
 #pragma once
 #include <gen_cpp/types.pb.h>
-#include <glog/logging.h>
 
 #include <cstdint>
 

--- a/be/src/core/data_type_serde/data_type_variant_serde.h
+++ b/be/src/core/data_type_serde/data_type_variant_serde.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <glog/logging.h>
 #include <stdint.h>
 
 #include <ostream>

--- a/be/src/core/field.h
+++ b/be/src/core/field.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include <fmt/format.h>
-#include <glog/logging.h>
 
 #include <algorithm>
 #include <cassert>

--- a/be/src/exec/common/arrow_column_to_doris_column.cpp
+++ b/be/src/exec/common/arrow_column_to_doris_column.cpp
@@ -24,7 +24,6 @@
 #include <arrow/buffer.h>
 #include <cctz/time_zone.h>
 #include <fmt/format.h>
-#include <glog/logging.h>
 #include <stdint.h>
 
 #include <memory>

--- a/be/src/exec/sink/load_stream_map_pool.h
+++ b/be/src/exec/sink/load_stream_map_pool.h
@@ -24,7 +24,6 @@
 #include <gen_cpp/Types_types.h>
 #include <gen_cpp/internal_service.pb.h>
 #include <gen_cpp/types.pb.h>
-#include <glog/logging.h>
 #include <google/protobuf/stubs/callback.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/be/src/exec/sink/vtablet_finder.cpp
+++ b/be/src/exec/sink/vtablet_finder.cpp
@@ -20,7 +20,6 @@
 #include <fmt/format.h>
 #include <gen_cpp/Exprs_types.h>
 #include <gen_cpp/FrontendService_types.h>
-#include <glog/logging.h>
 
 #include <string>
 #include <utility>

--- a/be/src/exec/sort/sort_block.h
+++ b/be/src/exec/sort/sort_block.h
@@ -25,7 +25,6 @@
 #include <stdint.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <utility>
 #include <vector>
 

--- a/be/src/exprs/aggregate/aggregate_function_avg_weighted.h
+++ b/be/src/exprs/aggregate/aggregate_function_avg_weighted.h
@@ -20,7 +20,6 @@
 #include <stddef.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <cmath>
 #include <memory>
 #include <type_traits>

--- a/be/src/exprs/aggregate/aggregate_function_bitmap.h
+++ b/be/src/exprs/aggregate/aggregate_function_bitmap.h
@@ -20,7 +20,6 @@
 #include <stddef.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <string>
 #include <vector>

--- a/be/src/exprs/aggregate/aggregate_function_bitmap_agg.h
+++ b/be/src/exprs/aggregate/aggregate_function_bitmap_agg.h
@@ -20,7 +20,6 @@
 #include <stddef.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <string>
 #include <vector>

--- a/be/src/exprs/aggregate/aggregate_function_collect.h
+++ b/be/src/exprs/aggregate/aggregate_function_collect.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <assert.h>
-#include <glog/logging.h>
 #include <string.h>
 
 #include <cstddef>

--- a/be/src/exprs/aggregate/aggregate_function_count.h
+++ b/be/src/exprs/aggregate/aggregate_function_count.h
@@ -23,7 +23,6 @@
 #include <stddef.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <vector>
 

--- a/be/src/exprs/aggregate/aggregate_function_covar.h
+++ b/be/src/exprs/aggregate/aggregate_function_covar.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <glog/logging.h>
 
 #include <boost/iterator/iterator_facade.hpp>
 #include <cstddef>

--- a/be/src/exprs/aggregate/aggregate_function_covar.h
+++ b/be/src/exprs/aggregate/aggregate_function_covar.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/be/src/exprs/aggregate/aggregate_function_covar.h
+++ b/be/src/exprs/aggregate/aggregate_function_covar.h
@@ -18,7 +18,6 @@
 #pragma once
 
 
-#include <boost/iterator/iterator_facade.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/be/src/exprs/aggregate/aggregate_function_histogram.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_histogram.cpp
@@ -18,7 +18,6 @@
 #include "exprs/aggregate/aggregate_function_histogram.h"
 
 #include <fmt/format.h>
-#include <glog/logging.h>
 
 #include "core/data_type/data_type.h"
 #include "core/data_type/define_primitive_type.h"

--- a/be/src/exprs/aggregate/aggregate_function_hll_union_agg.h
+++ b/be/src/exprs/aggregate/aggregate_function_hll_union_agg.h
@@ -20,7 +20,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <string>
 

--- a/be/src/exprs/aggregate/aggregate_function_orthogonal_bitmap.h
+++ b/be/src/exprs/aggregate/aggregate_function_orthogonal_bitmap.h
@@ -19,7 +19,6 @@
 
 #include <glog/logging.h>
 
-#include <boost/iterator/iterator_facade.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/be/src/exprs/aggregate/aggregate_function_percentile.h
+++ b/be/src/exprs/aggregate/aggregate_function_percentile.h
@@ -21,7 +21,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <boost/iterator/iterator_facade.hpp>
 #include <cmath>
 #include <cstdint>
 #include <memory>

--- a/be/src/exprs/aggregate/aggregate_function_percentile_reservoir.h
+++ b/be/src/exprs/aggregate/aggregate_function_percentile_reservoir.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <glog/logging.h>
 
 #include <memory>
 

--- a/be/src/exprs/aggregate/aggregate_function_percentile_reservoir.h
+++ b/be/src/exprs/aggregate/aggregate_function_percentile_reservoir.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-
 #include <memory>
 
 #include "core/data_type/data_type_number.h"

--- a/be/src/exprs/aggregate/aggregate_function_retention.h
+++ b/be/src/exprs/aggregate/aggregate_function_retention.h
@@ -24,7 +24,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 
 #include "core/assert_cast.h"

--- a/be/src/exprs/aggregate/aggregate_function_sequence_match.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_sequence_match.cpp
@@ -17,7 +17,6 @@
 
 #include "exprs/aggregate/aggregate_function_sequence_match.h"
 
-#include <boost/iterator/iterator_facade.hpp>
 
 #include "common/logging.h"
 #include "core/data_type/data_type.h"

--- a/be/src/exprs/aggregate/aggregate_function_sequence_match.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_sequence_match.cpp
@@ -17,7 +17,6 @@
 
 #include "exprs/aggregate/aggregate_function_sequence_match.h"
 
-
 #include "common/logging.h"
 #include "core/data_type/data_type.h"
 #include "exprs/aggregate/aggregate_function_simple_factory.h"

--- a/be/src/exprs/aggregate/aggregate_function_sequence_match.h
+++ b/be/src/exprs/aggregate/aggregate_function_sequence_match.h
@@ -25,7 +25,6 @@
 
 #include <algorithm>
 #include <bitset>
-#include <boost/iterator/iterator_facade.hpp>
 #include <cstdint>
 #include <functional>
 #include <iterator>

--- a/be/src/exprs/aggregate/aggregate_function_stddev.h
+++ b/be/src/exprs/aggregate/aggregate_function_stddev.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <boost/iterator/iterator_facade.hpp>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>

--- a/be/src/exprs/aggregate/aggregate_function_topn.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_topn.cpp
@@ -18,7 +18,6 @@
 #include "exprs/aggregate/aggregate_function_topn.h"
 
 #include <fmt/format.h>
-#include <glog/logging.h>
 
 #include "core/data_type/data_type.h"
 #include "core/data_type/define_primitive_type.h"

--- a/be/src/exprs/aggregate/aggregate_function_uniq.h
+++ b/be/src/exprs/aggregate/aggregate_function_uniq.h
@@ -22,7 +22,6 @@
 
 #include <stddef.h>
 
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <type_traits>
 #include <vector>

--- a/be/src/exprs/aggregate/aggregate_function_uniq_distribute_key.h
+++ b/be/src/exprs/aggregate/aggregate_function_uniq_distribute_key.h
@@ -22,7 +22,6 @@
 
 #include <stddef.h>
 
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <vector>
 

--- a/be/src/exprs/aggregate/aggregate_function_window.h
+++ b/be/src/exprs/aggregate/aggregate_function_window.h
@@ -23,7 +23,6 @@
 #include <glog/logging.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <cstdint>
 #include <memory>
 

--- a/be/src/exprs/aggregate/aggregate_function_window_funnel.h
+++ b/be/src/exprs/aggregate/aggregate_function_window_funnel.h
@@ -24,7 +24,6 @@
 #include <gen_cpp/data.pb.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <iterator>
 #include <memory>
 #include <type_traits>

--- a/be/src/exprs/function/array/function_array_constructor.cpp
+++ b/be/src/exprs/function/array/function_array_constructor.cpp
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-#include <glog/logging.h>
 #include <stddef.h>
 
 #include <memory>

--- a/be/src/exprs/function/array/function_array_element.h
+++ b/be/src/exprs/function/array/function_array_element.h
@@ -24,7 +24,6 @@
 #include <string.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <ostream>
 #include <string>

--- a/be/src/exprs/function/array/function_array_enumerate.cpp
+++ b/be/src/exprs/function/array/function_array_enumerate.cpp
@@ -16,7 +16,6 @@
 // under the License.
 
 #include <fmt/format.h>
-#include <glog/logging.h>
 #include <stddef.h>
 
 #include <algorithm>

--- a/be/src/exprs/function/array/function_array_enumerate.cpp
+++ b/be/src/exprs/function/array/function_array_enumerate.cpp
@@ -19,7 +19,6 @@
 #include <stddef.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <string>
 #include <utility>

--- a/be/src/exprs/function/array/function_array_enumerate_uniq.cpp
+++ b/be/src/exprs/function/array/function_array_enumerate_uniq.cpp
@@ -19,7 +19,6 @@
 #include <stddef.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <new>
 #include <ostream>

--- a/be/src/exprs/function/array/function_array_enumerate_uniq.cpp
+++ b/be/src/exprs/function/array/function_array_enumerate_uniq.cpp
@@ -16,7 +16,6 @@
 // under the License.
 
 #include <fmt/format.h>
-#include <glog/logging.h>
 #include <stddef.h>
 
 #include <algorithm>

--- a/be/src/exprs/function/array/function_array_first_or_last_index.cpp
+++ b/be/src/exprs/function/array/function_array_first_or_last_index.cpp
@@ -18,7 +18,6 @@
 #include <stddef.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <utility>
 

--- a/be/src/exprs/function/comparison_equal_for_null.cpp
+++ b/be/src/exprs/function/comparison_equal_for_null.cpp
@@ -19,7 +19,6 @@
 #include <stddef.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <utility>
 

--- a/be/src/exprs/function/function_compress.cpp
+++ b/be/src/exprs/function/function_compress.cpp
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-#include <glog/logging.h>
 
 #include <array>
 #include <cctype>

--- a/be/src/exprs/function/function_conv.cpp
+++ b/be/src/exprs/function/function_conv.cpp
@@ -18,7 +18,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include <boost/iterator/iterator_facade.hpp>
 // IWYU pragma: no_include <bits/std_abs.h>
 #include <algorithm>
 #include <cmath> // IWYU pragma: keep

--- a/be/src/exprs/function/function_grouping.h
+++ b/be/src/exprs/function/function_grouping.h
@@ -21,7 +21,6 @@
 #include <stddef.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 
 #include "common/status.h"

--- a/be/src/exprs/function/function_helpers.cpp
+++ b/be/src/exprs/function/function_helpers.cpp
@@ -21,7 +21,6 @@
 #include "exprs/function/function_helpers.h"
 
 #include <fmt/format.h>
-#include <glog/logging.h>
 
 #include <algorithm>
 #include <memory>

--- a/be/src/exprs/function/function_hex.cpp
+++ b/be/src/exprs/function/function_hex.cpp
@@ -19,7 +19,6 @@
 #include <stdint.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <string>
 #include <string_view>

--- a/be/src/exprs/function/function_ip.h
+++ b/be/src/exprs/function/function_ip.h
@@ -19,7 +19,6 @@
 // and modified by Doris
 
 #pragma once
-#include <glog/logging.h>
 
 #include <cstddef>
 #include <memory>

--- a/be/src/exprs/function/function_score.cpp
+++ b/be/src/exprs/function/function_score.cpp
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <glog/logging.h>
 #include <stddef.h>
 
 #include <memory>

--- a/be/src/exprs/function/function_utility.cpp
+++ b/be/src/exprs/function/function_utility.cpp
@@ -16,7 +16,6 @@
 // under the License.
 #include <stddef.h>
 
-#include <boost/iterator/iterator_facade.hpp>
 // IWYU pragma: no_include <bits/chrono.h>
 #include <algorithm>
 #include <chrono> // IWYU pragma: keep

--- a/be/src/exprs/function/function_variant_element.cpp
+++ b/be/src/exprs/function/function_variant_element.cpp
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <glog/logging.h>
 #include <stddef.h>
 
 #include <memory>

--- a/be/src/exprs/function/function_variant_type.cpp
+++ b/be/src/exprs/function/function_variant_type.cpp
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-#include <glog/logging.h>
 
 #include "core/column/column_variant.h"
 #include "exec/common/variant_util.h"

--- a/be/src/exprs/function/function_width_bucket.cpp
+++ b/be/src/exprs/function/function_width_bucket.cpp
@@ -19,7 +19,6 @@
 #include <stdint.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <utility>
 

--- a/be/src/exprs/function/functions_logical.h
+++ b/be/src/exprs/function/functions_logical.h
@@ -24,7 +24,6 @@
 #include <stddef.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 
 #include "common/status.h"

--- a/be/src/exprs/function/functions_multi_string_position.cpp
+++ b/be/src/exprs/function/functions_multi_string_position.cpp
@@ -21,7 +21,6 @@
 #include <stddef.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <cstdint>
 #include <iterator>
 #include <limits>

--- a/be/src/exprs/function/functions_multi_string_search.cpp
+++ b/be/src/exprs/function/functions_multi_string_search.cpp
@@ -22,7 +22,6 @@
 #include <hs/hs_runtime.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <cstddef>
 #include <limits>
 #include <memory>

--- a/be/src/exprs/function/geo/functions_geo.cpp
+++ b/be/src/exprs/function/geo/functions_geo.cpp
@@ -20,7 +20,6 @@
 #include <glog/logging.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <utility>
 
 #include "common/compiler_util.h"

--- a/be/src/exprs/function/if.cpp
+++ b/be/src/exprs/function/if.cpp
@@ -24,7 +24,6 @@
 #include <stddef.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <type_traits>
 #include <utility>

--- a/be/src/exprs/function/if.h
+++ b/be/src/exprs/function/if.h
@@ -20,7 +20,6 @@
 
 #include <stddef.h>
 
-
 #include "core/column/column.h"
 #include "core/column/column_vector.h"
 #include "core/data_type/data_type.h"

--- a/be/src/exprs/function/if.h
+++ b/be/src/exprs/function/if.h
@@ -20,7 +20,6 @@
 
 #include <stddef.h>
 
-#include <boost/iterator/iterator_facade.hpp>
 
 #include "core/column/column.h"
 #include "core/column/column_vector.h"

--- a/be/src/exprs/function/if.h
+++ b/be/src/exprs/function/if.h
@@ -18,7 +18,6 @@
 // https://github.com/ClickHouse/ClickHouse/blob/master/src/Functions/If.cpp
 // and modified by Doris
 
-#include <glog/logging.h>
 #include <stddef.h>
 
 #include <boost/iterator/iterator_facade.hpp>

--- a/be/src/exprs/function/is_not_null.h
+++ b/be/src/exprs/function/is_not_null.h
@@ -21,7 +21,6 @@
 #include <stddef.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <string>
 #include <utility>

--- a/be/src/exprs/function/is_null.h
+++ b/be/src/exprs/function/is_null.h
@@ -21,7 +21,6 @@
 #include <stddef.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <string>
 

--- a/be/src/exprs/function/like.h
+++ b/be/src/exprs/function/like.h
@@ -22,7 +22,6 @@
 #include <re2/re2.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <boost/regex.hpp>
 #include <cstddef>
 #include <cstdint>

--- a/be/src/exprs/function/nullif.cpp
+++ b/be/src/exprs/function/nullif.cpp
@@ -22,7 +22,6 @@
 #include <stddef.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <vector>
 

--- a/be/src/exprs/function/random.cpp
+++ b/be/src/exprs/function/random.cpp
@@ -19,7 +19,6 @@
 #include <glog/logging.h>
 
 #include <algorithm>
-#include <boost/iterator/iterator_facade.hpp>
 #include <cstdint>
 #include <cstdlib>
 #include <memory>

--- a/be/src/exprs/function/uniform.cpp
+++ b/be/src/exprs/function/uniform.cpp
@@ -16,7 +16,6 @@
 // under the License.
 
 #include <fmt/format.h>
-#include <glog/logging.h>
 
 #include <boost/iterator/iterator_facade.hpp>
 #include <cstdint>

--- a/be/src/exprs/function/uniform.cpp
+++ b/be/src/exprs/function/uniform.cpp
@@ -17,7 +17,6 @@
 
 #include <fmt/format.h>
 
-#include <boost/iterator/iterator_facade.hpp>
 #include <cstdint>
 #include <cstdlib>
 #include <memory>

--- a/be/src/exprs/varray_literal.cpp
+++ b/be/src/exprs/varray_literal.cpp
@@ -18,7 +18,6 @@
 #include "exprs/varray_literal.h"
 
 #include <gen_cpp/Exprs_types.h>
-#include <glog/logging.h>
 
 #include <memory>
 #include <ostream>

--- a/be/src/exprs/vmap_literal.cpp
+++ b/be/src/exprs/vmap_literal.cpp
@@ -17,7 +17,6 @@
 
 #include "exprs/vmap_literal.h"
 
-#include <glog/logging.h>
 
 #include <memory>
 #include <ostream>

--- a/be/src/exprs/vmap_literal.cpp
+++ b/be/src/exprs/vmap_literal.cpp
@@ -17,7 +17,6 @@
 
 #include "exprs/vmap_literal.h"
 
-
 #include <memory>
 #include <ostream>
 #include <vector>

--- a/be/src/format/file_reader/new_plain_text_line_reader.cpp
+++ b/be/src/format/file_reader/new_plain_text_line_reader.cpp
@@ -18,7 +18,6 @@
 #include "format/file_reader/new_plain_text_line_reader.h"
 
 #include <gen_cpp/Metrics_types.h>
-#include <glog/logging.h>
 
 #include "util/debug_points.h"
 #ifdef __AVX2__

--- a/be/src/format/jni/jni_data_bridge.cpp
+++ b/be/src/format/jni/jni_data_bridge.cpp
@@ -17,7 +17,6 @@
 
 #include "jni_data_bridge.h"
 
-
 #include <sstream>
 #include <variant>
 

--- a/be/src/format/jni/jni_data_bridge.cpp
+++ b/be/src/format/jni/jni_data_bridge.cpp
@@ -17,7 +17,6 @@
 
 #include "jni_data_bridge.h"
 
-#include <glog/logging.h>
 
 #include <sstream>
 #include <variant>

--- a/be/src/io/cache/peer_file_cache_reader.cpp
+++ b/be/src/io/cache/peer_file_cache_reader.cpp
@@ -21,7 +21,6 @@
 #include <bvar/reducer.h>
 #include <fmt/format.h>
 #include <gen_cpp/internal_service.pb.h>
-#include <glog/logging.h>
 
 #include <algorithm>
 #include <utility>

--- a/be/src/io/file_factory.h
+++ b/be/src/io/file_factory.h
@@ -18,7 +18,6 @@
 
 #include <gen_cpp/PlanNodes_types.h>
 #include <gen_cpp/Types_types.h>
-#include <glog/logging.h>
 #include <stdint.h>
 
 #include <map>

--- a/be/src/io/fs/file_system.h
+++ b/be/src/io/fs/file_system.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <butil/macros.h>
-#include <glog/logging.h>
 
 #include <cstdint>
 #include <memory>

--- a/be/src/io/fs/hdfs_file_system.h
+++ b/be/src/io/fs/hdfs_file_system.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <glog/logging.h>
 #include <stdint.h>
 
 #include <atomic>

--- a/be/src/io/fs/local_file_system.cpp
+++ b/be/src/io/fs/local_file_system.cpp
@@ -20,7 +20,6 @@
 #include <fcntl.h>
 #include <fmt/format.h>
 #include <glob.h>
-#include <glog/logging.h>
 #include <openssl/md5.h>
 #include <sys/mman.h>
 #include <sys/stat.h>

--- a/be/src/io/fs/remote_file_system.cpp
+++ b/be/src/io/fs/remote_file_system.cpp
@@ -17,7 +17,6 @@
 
 #include "io/fs/remote_file_system.h"
 
-#include <glog/logging.h>
 
 #include <algorithm>
 

--- a/be/src/io/fs/remote_file_system.cpp
+++ b/be/src/io/fs/remote_file_system.cpp
@@ -17,7 +17,6 @@
 
 #include "io/fs/remote_file_system.h"
 
-
 #include <algorithm>
 
 #include "common/config.h"

--- a/be/src/io/fs/s3_file_reader.cpp
+++ b/be/src/io/fs/s3_file_reader.cpp
@@ -26,7 +26,6 @@
 #include <bvar/latency_recorder.h>
 #include <bvar/reducer.h>
 #include <fmt/format.h>
-#include <glog/logging.h>
 
 #include <algorithm>
 #include <utility>

--- a/be/src/io/fs/s3_file_writer.cpp
+++ b/be/src/io/fs/s3_file_writer.cpp
@@ -22,7 +22,6 @@
 #include <bvar/reducer.h>
 #include <bvar/window.h>
 #include <fmt/core.h>
-#include <glog/logging.h>
 
 #include <sstream>
 #include <tuple>

--- a/be/src/runtime/task_execution_context.cpp
+++ b/be/src/runtime/task_execution_context.cpp
@@ -17,7 +17,6 @@
 
 #include "runtime/task_execution_context.h"
 
-#include <glog/logging.h>
 
 #include <condition_variable>
 

--- a/be/src/runtime/task_execution_context.cpp
+++ b/be/src/runtime/task_execution_context.cpp
@@ -17,7 +17,6 @@
 
 #include "runtime/task_execution_context.h"
 
-
 #include <condition_variable>
 
 namespace doris {

--- a/be/src/runtime/workload_management/cpu_context.cpp
+++ b/be/src/runtime/workload_management/cpu_context.cpp
@@ -17,7 +17,6 @@
 
 #include "runtime/workload_management/cpu_context.h"
 
-#include <glog/logging.h>
 
 #include "runtime/workload_management/resource_context.h"
 

--- a/be/src/runtime/workload_management/cpu_context.cpp
+++ b/be/src/runtime/workload_management/cpu_context.cpp
@@ -17,7 +17,6 @@
 
 #include "runtime/workload_management/cpu_context.h"
 
-
 #include "runtime/workload_management/resource_context.h"
 
 namespace doris {

--- a/be/src/service/http/action/file_cache_action.cpp
+++ b/be/src/service/http/action/file_cache_action.cpp
@@ -17,7 +17,6 @@
 
 #include "service/http/action/file_cache_action.h"
 
-#include <glog/logging.h>
 
 #include <algorithm>
 #include <memory>

--- a/be/src/service/http/action/file_cache_action.cpp
+++ b/be/src/service/http/action/file_cache_action.cpp
@@ -17,7 +17,6 @@
 
 #include "service/http/action/file_cache_action.h"
 
-
 #include <algorithm>
 #include <memory>
 #include <shared_mutex>

--- a/be/src/service/http/http_client.cpp
+++ b/be/src/service/http/http_client.cpp
@@ -18,7 +18,6 @@
 #include "service/http/http_client.h"
 
 #include <absl/strings/str_split.h>
-#include <glog/logging.h>
 #include <unistd.h>
 
 #include <memory>

--- a/be/src/storage/delete/delete_bitmap_calculator.h
+++ b/be/src/storage/delete/delete_bitmap_calculator.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <butil/macros.h>
-#include <glog/logging.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/be/src/storage/index/ann/ann_index_writer.h
+++ b/be/src/storage/index/ann/ann_index_writer.h
@@ -20,7 +20,6 @@
 #include <CLucene.h> // IWYU pragma: keep
 #include <CLucene/analysis/LanguageBasedAnalyzer.h>
 #include <CLucene/util/bkd/bkd_writer.h>
-#include <glog/logging.h>
 
 #include <cstdint>
 #include <memory>

--- a/be/src/storage/schema.cpp
+++ b/be/src/storage/schema.cpp
@@ -17,7 +17,6 @@
 
 #include "storage/schema.h"
 
-#include <glog/logging.h>
 
 #include <boost/iterator/iterator_facade.hpp>
 #include <ostream>

--- a/be/src/storage/schema.cpp
+++ b/be/src/storage/schema.cpp
@@ -18,7 +18,6 @@
 #include "storage/schema.h"
 
 
-#include <boost/iterator/iterator_facade.hpp>
 #include <ostream>
 #include <unordered_set>
 #include <utility>

--- a/be/src/storage/schema.cpp
+++ b/be/src/storage/schema.cpp
@@ -17,7 +17,6 @@
 
 #include "storage/schema.h"
 
-
 #include <ostream>
 #include <unordered_set>
 #include <utility>

--- a/be/src/storage/segment/condition_cache.h
+++ b/be/src/storage/segment/condition_cache.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <butil/macros.h>
-#include <glog/logging.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/be/src/storage/storage_policy.cpp
+++ b/be/src/storage/storage_policy.cpp
@@ -18,7 +18,6 @@
 #include "storage/storage_policy.h"
 
 #include <gen_cpp/cloud.pb.h>
-#include <glog/logging.h>
 
 #include <algorithm>
 #include <cstdlib>

--- a/be/src/storage/tablet/tablet_schema.cpp
+++ b/be/src/storage/tablet/tablet_schema.cpp
@@ -19,7 +19,6 @@
 
 #include <gen_cpp/Descriptors_types.h>
 #include <gen_cpp/olap_file.pb.h>
-#include <glog/logging.h>
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -20,7 +20,6 @@
 #include <bzlib.h>
 #include <gen_cpp/parquet_types.h>
 #include <gen_cpp/segment_v2.pb.h>
-#include <glog/logging.h>
 
 #include <exception>
 // Only used on x86 or x86_64
@@ -30,7 +29,6 @@
 #endif
 #include <brotli/decode.h>
 #include <glog/log_severity.h>
-#include <glog/logging.h>
 #include <lz4/lz4.h>
 #include <lz4/lz4frame.h>
 #include <lz4/lz4hc.h>

--- a/be/src/util/json/json_parser.cpp
+++ b/be/src/util/json/json_parser.cpp
@@ -21,7 +21,6 @@
 #include "util/json/json_parser.h"
 
 #include <fmt/format.h>
-#include <glog/logging.h>
 
 #include <algorithm>
 #include <cassert>

--- a/be/src/util/lru_cache.h
+++ b/be/src/util/lru_cache.h
@@ -23,7 +23,6 @@
 
 #include <butil/macros.h>
 #include <bvar/bvar.h>
-#include <glog/logging.h>
 #include <gtest/gtest_prod.h>
 
 #include <atomic>

--- a/be/src/util/uid_util.cpp
+++ b/be/src/util/uid_util.cpp
@@ -20,7 +20,6 @@
 #include <fmt/compile.h>
 #include <gen_cpp/Types_types.h>
 #include <gen_cpp/types.pb.h>
-#include <glog/logging.h>
 
 #include <cstdlib>
 


### PR DESCRIPTION
## Summary
- Remove unnecessary `#include <glog/logging.h>` from 81 BE source files
- Remove unnecessary `#include <boost/iterator/iterator_facade.hpp>` from 55 BE source files
- Total: 136 files cleaned, 137 lines removed

These headers are transitively included through other headers and are not directly used in the affected files. Identified by [include-what-you-use](https://github.com/include-what-you-use/include-what-you-use) (IWYU 0.24 / Clang 20) analysis of the full BE codebase.

## Test plan
- [x] Full BE build passes with zero compilation errors after glog removal
- [x] Incremental BE build passes with zero compilation errors after boost removal
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)