### PR TITLE
[cleanup](iwyu) Remove unnecessary #include <algorithm> from 60 files

### DIFF
--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -10,7 +10,6 @@
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/stringbuffer.h>
 
-#include <algorithm>
 #include <new>
 #include <vector>
 

--- a/be/src/core/allocator.h
+++ b/be/src/core/allocator.h
@@ -49,7 +49,6 @@
 
 #include <sys/mman.h>
 
-#include <algorithm>
 #include <cstdlib>
 #include <string>
 

--- a/be/src/core/column/column_struct.h
+++ b/be/src/core/column/column_struct.h
@@ -24,7 +24,6 @@
 #include <stdint.h>
 #include <sys/types.h>
 
-#include <algorithm>
 #include <ostream>
 #include <string>
 #include <type_traits>

--- a/be/src/core/column/column_variant.h
+++ b/be/src/core/column/column_variant.h
@@ -25,7 +25,6 @@
 #include <rapidjson/stringbuffer.h>
 #include <sys/types.h>
 
-#include <algorithm>
 #include <memory>
 #include <ostream>
 #include <string>

--- a/be/src/core/data_type/data_type.cpp
+++ b/be/src/core/data_type/data_type.cpp
@@ -24,7 +24,6 @@
 #include <gen_cpp/data.pb.h>
 #include <gen_cpp/types.pb.h>
 
-#include <algorithm>
 #include <utility>
 
 #include "common/logging.h"

--- a/be/src/core/data_type/data_type_factory.cpp
+++ b/be/src/core/data_type/data_type_factory.cpp
@@ -29,7 +29,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <ostream>

--- a/be/src/core/data_type/data_type_ipv6.h
+++ b/be/src/core/data_type/data_type_ipv6.h
@@ -20,7 +20,6 @@
 #include <gen_cpp/Types_types.h>
 #include <stddef.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <string>
 

--- a/be/src/core/value/quantile_state.h
+++ b/be/src/core/value/quantile_state.h
@@ -20,7 +20,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <algorithm>
 #include <memory>
 #include <vector>
 

--- a/be/src/exec/common/format_ip.cpp
+++ b/be/src/exec/common/format_ip.cpp
@@ -20,7 +20,6 @@
 
 #include "exec/common/format_ip.h"
 
-#include <algorithm>
 #include <array>
 
 namespace doris {

--- a/be/src/exec/sink/writer/vhive_utils.h
+++ b/be/src/exec/sink/writer/vhive_utils.h
@@ -19,7 +19,6 @@
 
 #include <gen_cpp/DataSinks_types.h>
 
-#include <algorithm>
 #include <iostream>
 #include <regex>
 #include <sstream>

--- a/be/src/exprs/aggregate/aggregate_function_avg_weighted.h
+++ b/be/src/exprs/aggregate/aggregate_function_avg_weighted.h
@@ -19,7 +19,6 @@
 
 #include <stddef.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <cmath>
 #include <memory>

--- a/be/src/exprs/aggregate/aggregate_function_hll_union_agg.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_hll_union_agg.cpp
@@ -17,8 +17,6 @@
 
 #include "exprs/aggregate/aggregate_function_hll_union_agg.h"
 
-#include <algorithm>
-
 #include "exprs/aggregate/aggregate_function_simple_factory.h"
 #include "exprs/aggregate/helpers.h"
 

--- a/be/src/exprs/aggregate/aggregate_function_quantile_state.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_quantile_state.cpp
@@ -17,8 +17,6 @@
 
 #include "exprs/aggregate/aggregate_function_quantile_state.h"
 
-#include <algorithm>
-
 #include "core/data_type/data_type.h"
 #include "exprs/aggregate/aggregate_function_simple_factory.h"
 

--- a/be/src/exprs/aggregate/aggregate_function_reader.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_reader.cpp
@@ -17,7 +17,6 @@
 
 #include "exprs/aggregate/aggregate_function_reader.h"
 
-#include <algorithm>
 #include <string>
 
 #include "exprs/aggregate/aggregate_function_bitmap.h"

--- a/be/src/exprs/aggregate/aggregate_function_sort.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_sort.cpp
@@ -17,8 +17,6 @@
 
 #include "exprs/aggregate/aggregate_function_sort.h"
 
-#include <algorithm>
-
 #include "exprs/aggregate/aggregate_function_simple_factory.h"
 
 namespace doris {

--- a/be/src/exprs/function/array/function_array_element.h
+++ b/be/src/exprs/function/array/function_array_element.h
@@ -23,7 +23,6 @@
 #include <glog/logging.h>
 #include <string.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <ostream>

--- a/be/src/exprs/function/array/function_array_enumerate.cpp
+++ b/be/src/exprs/function/array/function_array_enumerate.cpp
@@ -19,7 +19,6 @@
 #include <glog/logging.h>
 #include <stddef.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <string>

--- a/be/src/exprs/function/array/function_array_enumerate_uniq.cpp
+++ b/be/src/exprs/function/array/function_array_enumerate_uniq.cpp
@@ -19,7 +19,6 @@
 #include <glog/logging.h>
 #include <stddef.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <new>

--- a/be/src/exprs/function/array/function_array_first_or_last_index.cpp
+++ b/be/src/exprs/function/array/function_array_first_or_last_index.cpp
@@ -17,7 +17,6 @@
 
 #include <stddef.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <utility>

--- a/be/src/exprs/function/array/function_array_zip.cpp
+++ b/be/src/exprs/function/array/function_array_zip.cpp
@@ -22,7 +22,6 @@
 #include <glog/logging.h>
 #include <stddef.h>
 
-#include <algorithm>
 #include <memory>
 #include <ostream>
 #include <string>

--- a/be/src/exprs/function/comparison_equal_for_null.cpp
+++ b/be/src/exprs/function/comparison_equal_for_null.cpp
@@ -18,7 +18,6 @@
 #include <glog/logging.h>
 #include <stddef.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <utility>

--- a/be/src/exprs/function/function_collection_in.h
+++ b/be/src/exprs/function/function_collection_in.h
@@ -21,7 +21,6 @@
 #include <glog/logging.h>
 #include <stddef.h>
 
-#include <algorithm>
 #include <memory>
 #include <unordered_set>
 #include <utility>

--- a/be/src/exprs/function/function_conv.cpp
+++ b/be/src/exprs/function/function_conv.cpp
@@ -20,7 +20,6 @@
 
 #include <boost/iterator/iterator_facade.hpp>
 // IWYU pragma: no_include <bits/std_abs.h>
-#include <algorithm>
 #include <cmath> // IWYU pragma: keep
 #include <memory>
 #include <utility>

--- a/be/src/exprs/function/function_grouping.h
+++ b/be/src/exprs/function/function_grouping.h
@@ -20,7 +20,6 @@
 #include <glog/logging.h>
 #include <stddef.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 

--- a/be/src/exprs/function/function_helpers.cpp
+++ b/be/src/exprs/function/function_helpers.cpp
@@ -23,7 +23,6 @@
 #include <fmt/format.h>
 #include <glog/logging.h>
 
-#include <algorithm>
 #include <memory>
 #include <ostream>
 #include <string>

--- a/be/src/exprs/function/function_hex.cpp
+++ b/be/src/exprs/function/function_hex.cpp
@@ -18,7 +18,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <string>

--- a/be/src/exprs/function/function_utility.cpp
+++ b/be/src/exprs/function/function_utility.cpp
@@ -18,7 +18,6 @@
 
 #include <boost/iterator/iterator_facade.hpp>
 // IWYU pragma: no_include <bits/chrono.h>
-#include <algorithm>
 #include <chrono> // IWYU pragma: keep
 #include <memory>
 #include <string>

--- a/be/src/exprs/function/function_width_bucket.cpp
+++ b/be/src/exprs/function/function_width_bucket.cpp
@@ -18,7 +18,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <utility>

--- a/be/src/exprs/function/functions_logical.h
+++ b/be/src/exprs/function/functions_logical.h
@@ -23,7 +23,6 @@
 #include <fmt/format.h>
 #include <stddef.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 

--- a/be/src/exprs/function/is_not_null.h
+++ b/be/src/exprs/function/is_not_null.h
@@ -20,7 +20,6 @@
 
 #include <stddef.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <string>

--- a/be/src/exprs/function/is_null.h
+++ b/be/src/exprs/function/is_null.h
@@ -20,7 +20,6 @@
 
 #include <stddef.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <string>

--- a/be/src/exprs/function/like.h
+++ b/be/src/exprs/function/like.h
@@ -21,7 +21,6 @@
 #include <hs/hs_runtime.h>
 #include <re2/re2.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/regex.hpp>
 #include <cstddef>

--- a/be/src/exprs/function/nullif.cpp
+++ b/be/src/exprs/function/nullif.cpp
@@ -21,7 +21,6 @@
 #include <glog/logging.h>
 #include <stddef.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <vector>

--- a/be/src/exprs/function/random.cpp
+++ b/be/src/exprs/function/random.cpp
@@ -18,7 +18,6 @@
 #include <fmt/format.h>
 #include <glog/logging.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <cstdint>
 #include <cstdlib>

--- a/be/src/exprs/vinfo_func.cpp
+++ b/be/src/exprs/vinfo_func.cpp
@@ -20,8 +20,6 @@
 #include <gen_cpp/Exprs_types.h>
 #include <glog/logging.h>
 
-#include <algorithm>
-
 #include "core/block/block.h"
 #include "core/data_type/data_type.h"
 #include "core/data_type/define_primitive_type.h"

--- a/be/src/exprs/vliteral.cpp
+++ b/be/src/exprs/vliteral.cpp
@@ -23,7 +23,6 @@
 #include <glog/logging.h>
 #include <sys/types.h>
 
-#include <algorithm>
 #include <ostream>
 
 #include "core/block/block.h"

--- a/be/src/format/parquet/byte_array_plain_decoder.cpp
+++ b/be/src/format/parquet/byte_array_plain_decoder.cpp
@@ -17,7 +17,6 @@
 
 #include "format/parquet/byte_array_plain_decoder.h"
 
-#include <algorithm>
 #include <vector>
 
 #include "core/column/column.h"

--- a/be/src/io/cache/cache_block_meta_store.cpp
+++ b/be/src/io/cache/cache_block_meta_store.cpp
@@ -24,7 +24,6 @@
 #include <rocksdb/filter_policy.h>
 #include <rocksdb/table.h>
 
-#include <algorithm>
 #include <cstring>
 #include <filesystem>
 #include <optional>

--- a/be/src/io/fs/hdfs_file_system.cpp
+++ b/be/src/io/fs/hdfs_file_system.cpp
@@ -21,7 +21,6 @@
 #include <fcntl.h>
 #include <gen_cpp/PlanNodes_types.h>
 
-#include <algorithm>
 #include <filesystem>
 #include <map>
 #include <mutex>

--- a/be/src/io/fs/remote_file_system.cpp
+++ b/be/src/io/fs/remote_file_system.cpp
@@ -19,8 +19,6 @@
 
 #include <glog/logging.h>
 
-#include <algorithm>
-
 #include "common/config.h"
 #include "io/cache/cached_remote_file_reader.h"
 #include "io/fs/file_reader.h"

--- a/be/src/service/backend_options.cpp
+++ b/be/src/service/backend_options.cpp
@@ -19,7 +19,6 @@
 
 #include <absl/strings/str_split.h>
 
-#include <algorithm>
 #include <ostream>
 
 #include "common/config.h"

--- a/be/src/service/http/action/reset_rpc_channel_action.cpp
+++ b/be/src/service/http/action/reset_rpc_channel_action.cpp
@@ -20,7 +20,6 @@
 #include <fmt/format.h>
 #include <glog/logging.h>
 
-#include <algorithm>
 #include <string>
 #include <vector>
 

--- a/be/src/service/http/ev_http_server.cpp
+++ b/be/src/service/http/ev_http_server.cpp
@@ -31,7 +31,6 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
-#include <algorithm>
 #include <memory>
 #include <sstream>
 

--- a/be/src/storage/index/bloom_filter/bloom_filter_index_writer.cpp
+++ b/be/src/storage/index/bloom_filter/bloom_filter_index_writer.cpp
@@ -20,7 +20,6 @@
 #include <gen_cpp/segment_v2.pb.h>
 #include <string.h>
 
-#include <algorithm>
 #include <memory>
 #include <set>
 #include <string>

--- a/be/src/storage/index/index_page.cpp
+++ b/be/src/storage/index/index_page.cpp
@@ -19,7 +19,6 @@
 
 #include <gen_cpp/segment_v2.pb.h>
 
-#include <algorithm>
 #include <ostream>
 
 #include "util/coding.h"

--- a/be/src/storage/index/inverted/analyzer/ik/core/LetterSegmenter.h
+++ b/be/src/storage/index/inverted/analyzer/ik/core/LetterSegmenter.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <algorithm>
 #include <memory>
 #include <vector>
 

--- a/be/src/storage/index/inverted/analyzer/ik/core/LexemePath.h
+++ b/be/src/storage/index/inverted/analyzer/ik/core/LexemePath.h
@@ -19,7 +19,6 @@
 
 #include <parallel_hashmap/phmap.h>
 
-#include <algorithm>
 #include <memory>
 #include <optional>
 #include <sstream>

--- a/be/src/storage/index/inverted/analyzer/ik/dic/DictSegment.h
+++ b/be/src/storage/index/inverted/analyzer/ik/dic/DictSegment.h
@@ -20,7 +20,6 @@
 #include <CLucene.h>
 #include <parallel_hashmap/phmap.h>
 
-#include <algorithm>
 #include <array>
 #include <cassert>
 #include <memory>

--- a/be/src/storage/index/inverted/query_v2/regexp_query/regexp_weight.cpp
+++ b/be/src/storage/index/inverted/query_v2/regexp_query/regexp_weight.cpp
@@ -33,7 +33,6 @@
 #endif
 #include <gen_cpp/PaloBrokerService_types.h>
 
-#include <algorithm>
 #include <string>
 
 #include "storage/index/inverted/query_v2/bit_set_query/bit_set_scorer.h"

--- a/be/src/storage/index/inverted/token_filter/pinyin_filter_factory.cpp
+++ b/be/src/storage/index/inverted/token_filter/pinyin_filter_factory.cpp
@@ -17,7 +17,6 @@
 
 #include "storage/index/inverted/token_filter/pinyin_filter_factory.h"
 
-#include <algorithm>
 #include <stdexcept>
 #include <string>
 

--- a/be/src/storage/index/inverted/tokenizer/pinyin/smart_forest.h
+++ b/be/src/storage/index/inverted/tokenizer/pinyin/smart_forest.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <algorithm>
 #include <map>
 #include <memory>
 #include <string>

--- a/be/src/storage/index/ordinal_page_index.cpp
+++ b/be/src/storage/index/ordinal_page_index.cpp
@@ -19,7 +19,6 @@
 
 #include <gen_cpp/segment_v2.pb.h>
 
-#include <algorithm>
 #include <filesystem>
 #include <ostream>
 #include <string>

--- a/be/src/storage/options.cpp
+++ b/be/src/storage/options.cpp
@@ -25,7 +25,6 @@
 #include <rapidjson/rapidjson.h>
 #include <stdlib.h>
 
-#include <algorithm>
 #include <memory>
 #include <ostream>
 

--- a/be/src/storage/schema.h
+++ b/be/src/storage/schema.h
@@ -20,7 +20,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <string>

--- a/be/src/storage/segment/page_io.cpp
+++ b/be/src/storage/segment/page_io.cpp
@@ -21,7 +21,6 @@
 #include <gen_cpp/segment_v2.pb.h>
 #include <stdint.h>
 
-#include <algorithm>
 #include <cstring>
 #include <memory>
 #include <ostream>

--- a/be/src/storage/storage_policy.cpp
+++ b/be/src/storage/storage_policy.cpp
@@ -20,7 +20,6 @@
 #include <gen_cpp/cloud.pb.h>
 #include <glog/logging.h>
 
-#include <algorithm>
 #include <cstdlib>
 #include <cstring>
 #include <mutex>

--- a/be/src/storage/tablet/tablet_schema.h
+++ b/be/src/storage/tablet/tablet_schema.h
@@ -23,7 +23,6 @@
 #include <gen_cpp/segment_v2.pb.h>
 #include <parallel_hashmap/phmap.h>
 
-#include <algorithm>
 #include <cstdint>
 #include <map>
 #include <memory>

--- a/be/src/util/disk_info.cpp
+++ b/be/src/util/disk_info.cpp
@@ -27,7 +27,6 @@
 #include <sys/sysmacros.h>
 #include <sys/types.h>
 
-#include <algorithm>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/detail/classification.hpp>
 #include <boost/algorithm/string/trim.hpp>

--- a/be/src/util/histogram.cpp
+++ b/be/src/util/histogram.cpp
@@ -19,7 +19,6 @@
 
 #include <stdio.h>
 
-#include <algorithm>
 #include <cinttypes>
 #include <cmath>
 #include <limits>

--- a/be/src/util/jsonb/serialize.cpp
+++ b/be/src/util/jsonb/serialize.cpp
@@ -19,7 +19,6 @@
 
 #include <assert.h>
 
-#include <algorithm>
 #include <memory>
 #include <unordered_set>
 #include <vector>


### PR DESCRIPTION
## Summary
- Remove unnecessary `#include <algorithm>` from 60 BE source files
- These files do not directly use `std::sort`, `std::min`, `std::max`, `std::find`, or other `<algorithm>` functions
- The header is transitively available through other included headers

Identified by [include-what-you-use](https://github.com/include-what-you-use/include-what-you-use) (IWYU 0.24 / Clang 20) analysis.

## Test plan
- [x] Full BE incremental build passes with zero compilation errors
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)