### PR TITLE
[cleanup](iwyu) Remove unnecessary #include <ostream> from 44 files

### DIFF
--- a/be/src/core/column/column_map.h
+++ b/be/src/core/column/column_map.h
@@ -25,7 +25,6 @@
 #include <sys/types.h>
 
 #include <functional>
-#include <ostream>
 #include <string>
 #include <type_traits>
 #include <utility>

--- a/be/src/core/column/column_struct.h
+++ b/be/src/core/column/column_struct.h
@@ -25,7 +25,6 @@
 #include <sys/types.h>
 
 #include <algorithm>
-#include <ostream>
 #include <string>
 #include <type_traits>
 #include <utility>

--- a/be/src/core/column/column_variant.h
+++ b/be/src/core/column/column_variant.h
@@ -27,7 +27,6 @@
 
 #include <algorithm>
 #include <memory>
-#include <ostream>
 #include <string>
 #include <string_view>
 #include <unordered_set>

--- a/be/src/core/column/column_vector.cpp
+++ b/be/src/core/column/column_vector.cpp
@@ -26,7 +26,6 @@
 #include <pdqsort.h>
 
 #include <limits>
-#include <ostream>
 #include <string>
 
 #include "core/arena.h"

--- a/be/src/core/column/columns_common.h
+++ b/be/src/core/column/columns_common.h
@@ -24,7 +24,6 @@
 #include <stdint.h>
 #include <sys/types.h>
 
-#include <ostream>
 #include <string>
 #include <vector>
 

--- a/be/src/core/data_type/convert_field_to_type.cpp
+++ b/be/src/core/data_type/convert_field_to_type.cpp
@@ -25,7 +25,6 @@
 #include <stddef.h>
 
 #include <memory>
-#include <ostream>
 #include <string>
 #include <type_traits>
 #include <vector>

--- a/be/src/core/data_type/data_type_bitmap.h
+++ b/be/src/core/data_type/data_type_bitmap.h
@@ -22,7 +22,6 @@
 #include <stdint.h>
 
 #include <memory>
-#include <ostream>
 #include <string>
 #include <typeinfo>
 

--- a/be/src/core/data_type/data_type_date_or_datetime_v2.cpp
+++ b/be/src/core/data_type/data_type_date_or_datetime_v2.cpp
@@ -20,7 +20,6 @@
 #include <gen_cpp/data.pb.h>
 
 #include <memory>
-#include <ostream>
 #include <string>
 #include <typeinfo>
 #include <utility>

--- a/be/src/core/data_type/data_type_hll.h
+++ b/be/src/core/data_type/data_type_hll.h
@@ -22,7 +22,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <ostream>
 #include <string>
 #include <typeinfo>
 

--- a/be/src/core/data_type/data_type_nothing.h
+++ b/be/src/core/data_type/data_type_nothing.h
@@ -26,7 +26,6 @@
 #include <stdint.h>
 
 #include <memory>
-#include <ostream>
 #include <string>
 
 #include "core/data_type/data_type.h"

--- a/be/src/core/data_type/data_type_quantilestate.h
+++ b/be/src/core/data_type/data_type_quantilestate.h
@@ -20,7 +20,6 @@
 #include <glog/logging.h>
 
 #include <memory>
-#include <ostream>
 #include <string>
 #include <typeinfo>
 

--- a/be/src/core/data_type/data_type_struct.cpp
+++ b/be/src/core/data_type/data_type_struct.cpp
@@ -29,7 +29,6 @@
 #include <algorithm>
 #include <cstddef>
 #include <memory>
-#include <ostream>
 #include <typeinfo>
 #include <unordered_set>
 #include <utility>

--- a/be/src/core/data_type/data_type_variant.h
+++ b/be/src/core/data_type/data_type_variant.h
@@ -26,7 +26,6 @@
 #include <stdint.h>
 
 #include <memory>
-#include <ostream>
 #include <sstream>
 #include <string>
 

--- a/be/src/core/data_type_serde/data_type_array_serde.h
+++ b/be/src/core/data_type_serde/data_type_array_serde.h
@@ -21,7 +21,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <ostream>
 #include <utility>
 
 #include "common/status.h"

--- a/be/src/core/data_type_serde/data_type_ipv4_serde.h
+++ b/be/src/core/data_type_serde/data_type_ipv4_serde.h
@@ -21,7 +21,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <ostream>
 #include <string>
 
 #include "common/status.h"

--- a/be/src/core/data_type_serde/data_type_ipv6_serde.h
+++ b/be/src/core/data_type_serde/data_type_ipv6_serde.h
@@ -21,7 +21,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <ostream>
 #include <string>
 
 #include "common/status.h"

--- a/be/src/core/data_type_serde/data_type_map_serde.h
+++ b/be/src/core/data_type_serde/data_type_map_serde.h
@@ -20,8 +20,6 @@
 #include <glog/logging.h>
 #include <stdint.h>
 
-#include <ostream>
-
 #include "common/status.h"
 #include "core/data_type_serde/data_type_serde.h"
 

--- a/be/src/core/data_type_serde/data_type_variant_serde.h
+++ b/be/src/core/data_type_serde/data_type_variant_serde.h
@@ -20,8 +20,6 @@
 #include <glog/logging.h>
 #include <stdint.h>
 
-#include <ostream>
-
 #include "common/status.h"
 #include "core/data_type_serde/data_type_serde.h"
 

--- a/be/src/exec/es/es_scroll_parser.cpp
+++ b/be/src/exec/es/es_scroll_parser.cpp
@@ -28,7 +28,6 @@
 // IWYU pragma: no_include <bits/chrono.h>
 #include <chrono> // IWYU pragma: keep
 #include <cstdlib>
-#include <ostream>
 #include <string>
 
 #include "common/status.h"

--- a/be/src/exec/exchange/vdata_stream_mgr.cpp
+++ b/be/src/exec/exchange/vdata_stream_mgr.cpp
@@ -24,7 +24,6 @@
 #include <stddef.h>
 
 #include <memory>
-#include <ostream>
 #include <string>
 #include <vector>
 

--- a/be/src/exec/sink/load_stream_map_pool.h
+++ b/be/src/exec/sink/load_stream_map_pool.h
@@ -37,7 +37,6 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <ostream>
 #include <queue>
 #include <set>
 #include <string>

--- a/be/src/exprs/function/array/function_array_constructor.cpp
+++ b/be/src/exprs/function/array/function_array_constructor.cpp
@@ -18,7 +18,6 @@
 #include <stddef.h>
 
 #include <memory>
-#include <ostream>
 #include <string>
 #include <utility>
 

--- a/be/src/exprs/function/array/function_array_enumerate_uniq.cpp
+++ b/be/src/exprs/function/array/function_array_enumerate_uniq.cpp
@@ -23,7 +23,6 @@
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 #include <new>
-#include <ostream>
 #include <string>
 #include <utility>
 

--- a/be/src/exprs/function/array/function_array_remove.h
+++ b/be/src/exprs/function/array/function_array_remove.h
@@ -22,7 +22,6 @@
 #include <string.h>
 
 #include <memory>
-#include <ostream>
 #include <string>
 #include <string_view>
 #include <type_traits>

--- a/be/src/exprs/function/function_helpers.cpp
+++ b/be/src/exprs/function/function_helpers.cpp
@@ -25,7 +25,6 @@
 
 #include <algorithm>
 #include <memory>
-#include <ostream>
 #include <string>
 #include <vector>
 

--- a/be/src/exprs/varray_literal.cpp
+++ b/be/src/exprs/varray_literal.cpp
@@ -21,7 +21,6 @@
 #include <glog/logging.h>
 
 #include <memory>
-#include <ostream>
 #include <vector>
 
 #include "core/column/column.h"

--- a/be/src/exprs/vliteral.cpp
+++ b/be/src/exprs/vliteral.cpp
@@ -24,7 +24,6 @@
 #include <sys/types.h>
 
 #include <algorithm>
-#include <ostream>
 
 #include "core/block/block.h"
 #include "core/column/column.h"

--- a/be/src/exprs/vmap_literal.cpp
+++ b/be/src/exprs/vmap_literal.cpp
@@ -20,7 +20,6 @@
 #include <glog/logging.h>
 
 #include <memory>
-#include <ostream>
 #include <vector>
 
 #include "core/column/column.h"

--- a/be/src/format/file_reader/new_plain_text_line_reader.cpp
+++ b/be/src/format/file_reader/new_plain_text_line_reader.cpp
@@ -27,7 +27,6 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstring>
-#include <ostream>
 #include <utility>
 
 #include "io/fs/file_reader.h"

--- a/be/src/format/parquet/decoder.h
+++ b/be/src/format/parquet/decoder.h
@@ -23,7 +23,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <ostream>
 #include <vector>
 
 #include "common/status.h"

--- a/be/src/format/parquet/parquet_common.h
+++ b/be/src/format/parquet/parquet_common.h
@@ -21,7 +21,6 @@
 #include <stddef.h>
 
 #include <cstdint>
-#include <ostream>
 #include <regex>
 #include <string>
 #include <unordered_set>

--- a/be/src/io/cache/block_file_cache_factory.cpp
+++ b/be/src/io/cache/block_file_cache_factory.cpp
@@ -32,7 +32,6 @@
 
 #include <algorithm>
 #include <execution>
-#include <ostream>
 #include <utility>
 
 #include "common/config.h"

--- a/be/src/io/fs/broker_file_reader.cpp
+++ b/be/src/io/fs/broker_file_reader.cpp
@@ -23,7 +23,6 @@
 #include <thrift/transport/TTransportException.h>
 // IWYU pragma: no_include <bits/chrono.h>
 #include <chrono> // IWYU pragma: keep
-#include <ostream>
 #include <string>
 #include <thread>
 #include <utility>

--- a/be/src/io/fs/broker_file_system.cpp
+++ b/be/src/io/fs/broker_file_system.cpp
@@ -29,7 +29,6 @@
 // IWYU pragma: no_include <bits/chrono.h>
 #include <chrono> // IWYU pragma: keep
 #include <filesystem>
-#include <ostream>
 #include <thread>
 #include <utility>
 

--- a/be/src/io/fs/hdfs_file_writer.cpp
+++ b/be/src/io/fs/hdfs_file_writer.cpp
@@ -22,7 +22,6 @@
 
 #include <chrono>
 #include <filesystem>
-#include <ostream>
 #include <random>
 #include <string>
 #include <thread>

--- a/be/src/io/hdfs_util.cpp
+++ b/be/src/io/hdfs_util.cpp
@@ -22,7 +22,6 @@
 #include <bvar/latency_recorder.h>
 #include <gen_cpp/cloud.pb.h>
 
-#include <ostream>
 #include <thread>
 
 #include "common/logging.h"

--- a/be/src/load/load_path_mgr.cpp
+++ b/be/src/load/load_path_mgr.cpp
@@ -32,7 +32,6 @@
 // IWYU pragma: no_include <bits/chrono.h>
 #include <chrono> // IWYU pragma: keep
 #include <memory>
-#include <ostream>
 #include <string>
 
 #include "common/config.h"

--- a/be/src/load/message_body_sink.cpp
+++ b/be/src/load/message_body_sink.cpp
@@ -24,8 +24,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <ostream>
-
 namespace doris {
 
 MessageBodyFileSink::~MessageBodyFileSink() {

--- a/be/src/load/routine_load/routine_load_task_executor.cpp
+++ b/be/src/load/routine_load/routine_load_task_executor.cpp
@@ -29,7 +29,6 @@
 #include <algorithm>
 #include <future>
 #include <map>
-#include <ostream>
 #include <thread>
 #include <utility>
 

--- a/be/src/load/stream_load/new_load_stream_mgr.h
+++ b/be/src/load/stream_load/new_load_stream_mgr.h
@@ -20,7 +20,6 @@
 #include <iterator>
 #include <memory>
 #include <mutex>
-#include <ostream>
 #include <unordered_map>
 #include <utility>
 

--- a/be/src/runtime/user_function_cache.cpp
+++ b/be/src/runtime/user_function_cache.cpp
@@ -28,7 +28,6 @@
 #include <atomic>
 #include <cstdint>
 #include <memory>
-#include <ostream>
 #include <regex>
 #include <utility>
 #include <vector>

--- a/be/src/storage/schema.cpp
+++ b/be/src/storage/schema.cpp
@@ -20,7 +20,6 @@
 #include <glog/logging.h>
 
 #include <boost/iterator/iterator_facade.hpp>
-#include <ostream>
 #include <unordered_set>
 #include <utility>
 

--- a/be/src/storage/segment/bitshuffle_page.h
+++ b/be/src/storage/segment/bitshuffle_page.h
@@ -23,7 +23,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
-#include <ostream>
 #include <type_traits>
 
 #include "common/cast_set.h"

--- a/be/src/util/decompressor.cpp
+++ b/be/src/util/decompressor.cpp
@@ -20,7 +20,6 @@
 #include <strings.h>
 
 #include <memory>
-#include <ostream>
 
 #include "common/cast_set.h"
 #include "common/logging.h"


### PR DESCRIPTION
## Summary
- Remove unnecessary `#include <ostream>` from 44 BE source files
- These files do not directly use `std::ostream` or stream insertion operators
- The header is transitively available through other included headers

Identified by [include-what-you-use](https://github.com/include-what-you-use/include-what-you-use) (IWYU 0.24 / Clang 20) analysis.

## Test plan
- [x] Full BE incremental build passes with zero compilation errors
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)