### PR TITLE
[cleanup](iwyu) Remove unnecessary #include <memory> from 30 files

### DIFF
--- a/be/src/core/block/column_with_type_and_name.cpp
+++ b/be/src/core/block/column_with_type_and_name.cpp
@@ -23,7 +23,6 @@
 #include <gen_cpp/data.pb.h>
 #include <stddef.h>
 
-#include <memory>
 #include <sstream>
 #include <string>
 

--- a/be/src/core/block/column_with_type_and_name.h
+++ b/be/src/core/block/column_with_type_and_name.h
@@ -23,7 +23,6 @@
 #include <stddef.h>
 
 #include <iosfwd>
-#include <memory>
 #include <string>
 #include <utility>
 

--- a/be/src/core/data_type/convert_field_to_type.cpp
+++ b/be/src/core/data_type/convert_field_to_type.cpp
@@ -24,7 +24,6 @@
 #include <glog/logging.h>
 #include <stddef.h>
 
-#include <memory>
 #include <ostream>
 #include <string>
 #include <type_traits>

--- a/be/src/core/data_type_serde/data_type_array_serde.h
+++ b/be/src/core/data_type_serde/data_type_array_serde.h
@@ -20,7 +20,6 @@
 #include <glog/logging.h>
 
 #include <cstdint>
-#include <memory>
 #include <ostream>
 #include <utility>
 

--- a/be/src/exec/common/arrow_column_to_doris_column.cpp
+++ b/be/src/exec/common/arrow_column_to_doris_column.cpp
@@ -27,7 +27,6 @@
 #include <glog/logging.h>
 #include <stdint.h>
 
-#include <memory>
 #include <utility>
 #include <vector>
 

--- a/be/src/exprs/vliteral.h
+++ b/be/src/exprs/vliteral.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <memory>
 #include <string>
 
 #include "common/object_pool.h"

--- a/be/src/format/arrow/arrow_pip_input_stream.h
+++ b/be/src/format/arrow/arrow_pip_input_stream.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <cstdint>
-#include <memory>
 
 #include "arrow/io/interfaces.h"
 #include "common/factory_creator.h"

--- a/be/src/format/parquet/byte_array_dict_decoder.h
+++ b/be/src/format/parquet/byte_array_dict_decoder.h
@@ -19,7 +19,6 @@
 
 #include <cstdint>
 #include <cstring>
-#include <memory>
 #include <unordered_map>
 #include <vector>
 

--- a/be/src/format/parquet/byte_array_plain_decoder.h
+++ b/be/src/format/parquet/byte_array_plain_decoder.h
@@ -20,7 +20,6 @@
 #include <string.h>
 
 #include <cstdint>
-#include <memory>
 
 #include "common/compiler_util.h" // IWYU pragma: keep
 #include "common/status.h"

--- a/be/src/information_schema/schema_processlist_scanner.h
+++ b/be/src/information_schema/schema_processlist_scanner.h
@@ -19,7 +19,6 @@
 
 #include <gen_cpp/FrontendService_types.h>
 
-#include <memory>
 #include <vector>
 
 #include "common/status.h"

--- a/be/src/information_schema/schema_user_scanner.h
+++ b/be/src/information_schema/schema_user_scanner.h
@@ -19,7 +19,6 @@
 
 #include <gen_cpp/FrontendService_types.h>
 
-#include <memory>
 #include <vector>
 
 #include "common/status.h"

--- a/be/src/io/cache/peer_file_cache_reader.h
+++ b/be/src/io/cache/peer_file_cache_reader.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <atomic>
-#include <memory>
 #include <string>
 
 #include "common/status.h"

--- a/be/src/io/file_factory.h
+++ b/be/src/io/file_factory.h
@@ -22,7 +22,6 @@
 #include <stdint.h>
 
 #include <map>
-#include <memory>
 #include <string>
 
 #include "common/factory_creator.h"

--- a/be/src/io/fs/hdfs_file_reader.h
+++ b/be/src/io/fs/hdfs_file_reader.h
@@ -20,7 +20,6 @@
 #include <stddef.h>
 
 #include <atomic>
-#include <memory>
 #include <string>
 
 #include "common/status.h"

--- a/be/src/io/fs/local_file_reader.h
+++ b/be/src/io/fs/local_file_reader.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <atomic>
-#include <memory>
 
 #include "common/status.h"
 #include "io/fs/file_reader.h"

--- a/be/src/io/fs/packed_file_reader.h
+++ b/be/src/io/fs/packed_file_reader.h
@@ -17,8 +17,6 @@
 
 #pragma once
 
-#include <memory>
-
 #include "butil/macros.h"
 #include "common/status.h"
 #include "io/fs/file_reader.h"

--- a/be/src/io/hdfs_util.h
+++ b/be/src/io/hdfs_util.h
@@ -21,7 +21,6 @@
 
 #include <atomic>
 #include <cstdint>
-#include <memory>
 #include <string>
 #include <unordered_map>
 

--- a/be/src/load/message_body_sink.h
+++ b/be/src/load/message_body_sink.h
@@ -19,7 +19,6 @@
 
 #include <stddef.h>
 
-#include <memory>
 #include <string>
 #include <utility>
 

--- a/be/src/runtime/query_cache/query_cache.h
+++ b/be/src/runtime/query_cache/query_cache.h
@@ -23,7 +23,6 @@
 #include <stdint.h>
 
 #include <atomic>
-#include <memory>
 #include <roaring/roaring.hh>
 #include <string>
 

--- a/be/src/service/http/action/file_cache_action.cpp
+++ b/be/src/service/http/action/file_cache_action.cpp
@@ -20,7 +20,6 @@
 #include <glog/logging.h>
 
 #include <algorithm>
-#include <memory>
 #include <shared_mutex>
 #include <sstream>
 #include <string>

--- a/be/src/storage/index/inverted/analyzer/ik/core/CJKSegmenter.h
+++ b/be/src/storage/index/inverted/analyzer/ik/core/CJKSegmenter.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <list>
-#include <memory>
 #include <string>
 
 #include "storage/index/inverted/analyzer/ik/core/AnalyzeContext.h"

--- a/be/src/storage/index/inverted/analyzer/ik/core/CN_QuantifierSegmenter.h
+++ b/be/src/storage/index/inverted/analyzer/ik/core/CN_QuantifierSegmenter.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <memory>
 #include <unordered_set>
 #include <vector>
 

--- a/be/src/storage/index/inverted/analyzer/ik/core/CharacterUtil.h
+++ b/be/src/storage/index/inverted/analyzer/ik/core/CharacterUtil.h
@@ -20,7 +20,6 @@
 #include <unicode/uchar.h>
 
 #include <functional>
-#include <memory>
 #include <vector>
 
 #include "CLucene/_ApiHeader.h"

--- a/be/src/storage/index/inverted/analyzer/ik/core/IKArbitrator.h
+++ b/be/src/storage/index/inverted/analyzer/ik/core/IKArbitrator.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <memory>
 #include <set>
 #include <stack>
 

--- a/be/src/storage/index/inverted/analyzer/ik/core/LetterSegmenter.h
+++ b/be/src/storage/index/inverted/analyzer/ik/core/LetterSegmenter.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <algorithm>
-#include <memory>
 #include <vector>
 
 #include "storage/index/inverted/analyzer/ik/core/AnalyzeContext.h"

--- a/be/src/storage/index/inverted/analyzer/ik/core/Lexeme.h
+++ b/be/src/storage/index/inverted/analyzer/ik/core/Lexeme.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <string>

--- a/be/src/storage/index/inverted/analyzer/ik/core/LexemePath.h
+++ b/be/src/storage/index/inverted/analyzer/ik/core/LexemePath.h
@@ -20,7 +20,6 @@
 #include <parallel_hashmap/phmap.h>
 
 #include <algorithm>
-#include <memory>
 #include <optional>
 #include <sstream>
 

--- a/be/src/storage/index/inverted/analyzer/ik/core/QuickSortSet.h
+++ b/be/src/storage/index/inverted/analyzer/ik/core/QuickSortSet.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <memory>
 #include <optional>
 
 #include "CLucene/_ApiHeader.h"

--- a/be/src/storage/index/inverted/query/query_helper.h
+++ b/be/src/storage/index/inverted/query/query_helper.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <memory>
 #include <vector>
 
 #include "storage/index/inverted/query/query.h"

--- a/be/src/storage/rowset/rowset_meta_manager.cpp
+++ b/be/src/storage/rowset/rowset_meta_manager.cpp
@@ -23,7 +23,6 @@
 #include <boost/algorithm/string/trim.hpp>
 #include <fstream>
 #include <functional>
-#include <memory>
 #include <new>
 #include <string>
 #include <string_view>


### PR DESCRIPTION
## Summary
- Remove unnecessary `#include <memory>` from 30 BE source files
- These files do not directly use `std::shared_ptr`, `std::unique_ptr`, or other `<memory>` types
- The header is transitively available through other included headers

Identified by [include-what-you-use](https://github.com/include-what-you-use/include-what-you-use) (IWYU 0.24 / Clang 20) analysis.

## Test plan
- [x] Full BE incremental build passes with zero compilation errors
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)