### PR TITLE
[fix][test] Add surefire forked JVM timeout to prevent FE UT from han…

### DIFF
--- a/run-fe-ut.sh
+++ b/run-fe-ut.sh
@@ -107,6 +107,19 @@ if [[ -z "${FE_UT_PARALLEL}" ]]; then
 fi
 echo "Unit test parallel is: ${FE_UT_PARALLEL}"
 
+# Timeout settings for surefire forked JVM processes.
+# If a forked test JVM produces no output for FE_UT_FORK_TIMEOUT seconds,
+# surefire will send SIGQUIT (which triggers a JVM thread dump) and then
+# kill the process, marking the test as ERROR rather than hanging forever.
+# FE_UT_FORK_EXIT_TIMEOUT is the additional grace period after the kill signal
+# before surefire force-kills the process.
+if [[ -z "${FE_UT_FORK_TIMEOUT}" ]]; then
+    FE_UT_FORK_TIMEOUT=300
+fi
+if [[ -z "${FE_UT_FORK_EXIT_TIMEOUT}" ]]; then
+    FE_UT_FORK_EXIT_TIMEOUT=60
+fi
+
 if [[ "${RUN}" -eq 1 ]]; then
     echo "Run the specified class: $1"
     # eg:
@@ -114,15 +127,23 @@ if [[ "${RUN}" -eq 1 ]]; then
     # sh run-fe-ut.sh --run org.apache.doris.utframe.DemoTest#testCreateDbAndTable+test2
 
     if [[ "${COVERAGE}" -eq 1 ]]; then
-        "${MVN_CMD}" test jacoco:report -DfailIfNoTests=false -Dtest="$1"
+        "${MVN_CMD}" test jacoco:report -DfailIfNoTests=false -Dtest="$1" \
+            -Dsurefire.forkedProcessTimeoutInSeconds="${FE_UT_FORK_TIMEOUT}" \
+            -Dsurefire.forkedProcessExitTimeoutInSeconds="${FE_UT_FORK_EXIT_TIMEOUT}"
     else
-        "${MVN_CMD}" test -Dcheckstyle.skip=true -DfailIfNoTests=false -Dtest="$1"
+        "${MVN_CMD}" test -Dcheckstyle.skip=true -DfailIfNoTests=false -Dtest="$1" \
+            -Dsurefire.forkedProcessTimeoutInSeconds="${FE_UT_FORK_TIMEOUT}" \
+            -Dsurefire.forkedProcessExitTimeoutInSeconds="${FE_UT_FORK_EXIT_TIMEOUT}"
     fi
 else
     echo "Run Frontend UT"
     if [[ "${COVERAGE}" -eq 1 ]]; then
-        "${MVN_CMD}" test jacoco:report -DfailIfNoTests=false -Dmaven.test.failure.ignore=true
+        "${MVN_CMD}" test jacoco:report -DfailIfNoTests=false -Dmaven.test.failure.ignore=true \
+            -Dsurefire.forkedProcessTimeoutInSeconds="${FE_UT_FORK_TIMEOUT}" \
+            -Dsurefire.forkedProcessExitTimeoutInSeconds="${FE_UT_FORK_EXIT_TIMEOUT}"
     else
-        "${MVN_CMD}" test -Dcheckstyle.skip=true -DfailIfNoTests=false
+        "${MVN_CMD}" test -Dcheckstyle.skip=true -DfailIfNoTests=false \
+            -Dsurefire.forkedProcessTimeoutInSeconds="${FE_UT_FORK_TIMEOUT}" \
+            -Dsurefire.forkedProcessExitTimeoutInSeconds="${FE_UT_FORK_EXIT_TIMEOUT}"
     fi
 fi


### PR DESCRIPTION
…ging indefinitely

Problem:
FE UT occasionally hangs when a test's forked JVM process gets stuck (e.g. a mocked FE background thread that never exits, or a deadlock during test initialization). When this happens, the entire build silently stalls until the CI global timeout is hit (3h+), causing all subsequent tests in the same Surefire batch to never run.
Two concrete examples identified from CI logs:

org.apache.doris.statistics.AnalysisTaskExecutorTest — mocked FE started but JVM never exited, hung for ~1h39m
org.apache.doris.planner.FederationBackendPolicyTest — zero output after "Running", hung silently

Solution:
Add -Dsurefire.forkedProcessTimeoutInSeconds and -Dsurefire.forkedProcessExitTimeoutInSeconds to all mvn test invocations in run-fe-ut.sh.
When a forked JVM exceeds the timeout with no progress:

Surefire sends SIGQUIT → the JVM prints a full thread dump to stdout (visible in CI logs), making the root cause immediately diagnosable
Surefire then kills the process and marks the test as ERROR
The rest of the test suite continues normally

The timeout values are configurable via env vars FE_UT_FORK_TIMEOUT (default: 300s) and FE_UT_FORK_EXIT_TIMEOUT (default: 60s), so CI pipelines can override them without touching the script.
Impact:

No change to normal test execution
Hung tests now fail fast with a thread dump instead of silently consuming the entire CI budget
Overall FE UT wall-clock time reduced from 3h+ (timeout-killed) back to the expected ~1.5h
