### PR TITLE
[cleanup](iwyu) Remove unnecessary #include <vector> from 26 files

### DIFF
--- a/be/src/agent/topic_subscriber.h
+++ b/be/src/agent/topic_subscriber.h
@@ -22,7 +22,6 @@
 
 #include <map>
 #include <shared_mutex>
-#include <vector>
 
 namespace doris {
 class TopicListener;

--- a/be/src/common/stack_trace.h
+++ b/be/src/common/stack_trace.h
@@ -26,7 +26,6 @@
 #include <functional>
 #include <optional>
 #include <string>
-#include <vector>
 
 #ifdef __APPLE__
 // ucontext is not available without _XOPEN_SOURCE

--- a/be/src/core/column/column_array.cpp
+++ b/be/src/core/column/column_array.cpp
@@ -23,7 +23,6 @@
 #include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <cstring>
-#include <vector>
 
 #include "common/status.h"
 #include "core/arena.h"

--- a/be/src/core/column/column_map.cpp
+++ b/be/src/core/column/column_map.cpp
@@ -23,7 +23,6 @@
 #include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <cstddef>
-#include <vector>
 
 #include "common/status.h"
 #include "core/arena.h"

--- a/be/src/core/data_type/convert_field_to_type.cpp
+++ b/be/src/core/data_type/convert_field_to_type.cpp
@@ -28,7 +28,6 @@
 #include <ostream>
 #include <string>
 #include <type_traits>
-#include <vector>
 
 #include "common/cast_set.h"
 #include "common/exception.h"

--- a/be/src/exec/common/arrow_column_to_doris_column.cpp
+++ b/be/src/exec/common/arrow_column_to_doris_column.cpp
@@ -29,7 +29,6 @@
 
 #include <memory>
 #include <utility>
-#include <vector>
 
 #include "arrow/array/array_binary.h"
 #include "arrow/array/array_nested.h"

--- a/be/src/exec/common/data_gen_functions/vnumbers_tvf.h
+++ b/be/src/exec/common/data_gen_functions/vnumbers_tvf.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <cstdint>
-#include <vector>
 
 #include "common/global_types.h"
 #include "exec/common/data_gen_functions/vdata_gen_function_inf.h"

--- a/be/src/exec/table_connector.h
+++ b/be/src/exec/table_connector.h
@@ -22,7 +22,6 @@
 #include <stdint.h>
 
 #include <string>
-#include <vector>
 
 #include "common/status.h"
 #include "core/data_type/data_type.h"

--- a/be/src/exprs/function/function_helpers.cpp
+++ b/be/src/exprs/function/function_helpers.cpp
@@ -27,7 +27,6 @@
 #include <memory>
 #include <ostream>
 #include <string>
-#include <vector>
 
 #include "common/consts.h"
 #include "common/status.h"

--- a/be/src/exprs/function/function_rpc.h
+++ b/be/src/exprs/function/function_rpc.h
@@ -23,7 +23,6 @@
 
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "common/status.h"
 #include "core/block/block.h"

--- a/be/src/exprs/function/function_tokenize.h
+++ b/be/src/exprs/function/function_tokenize.h
@@ -21,7 +21,6 @@
 
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "common/status.h"
 #include "core/block/column_numbers.h"

--- a/be/src/exprs/function/nullif.cpp
+++ b/be/src/exprs/function/nullif.cpp
@@ -24,7 +24,6 @@
 #include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
-#include <vector>
 
 #include "common/status.h"
 #include "core/assert_cast.h"

--- a/be/src/exprs/vmap_literal.cpp
+++ b/be/src/exprs/vmap_literal.cpp
@@ -21,7 +21,6 @@
 
 #include <memory>
 #include <ostream>
-#include <vector>
 
 #include "core/column/column.h"
 #include "core/data_type/data_type.h"

--- a/be/src/io/cache/cache_block_meta_store.h
+++ b/be/src/io/cache/cache_block_meta_store.h
@@ -30,7 +30,6 @@
 #include <string>
 #include <thread>
 #include <variant>
-#include <vector>
 
 #include "io/cache/file_cache_common.h"
 #include "util/threadpool.h"

--- a/be/src/io/cache/cache_lru_dumper.h
+++ b/be/src/io/cache/cache_lru_dumper.h
@@ -30,7 +30,6 @@
 #include <sstream>
 #include <string>
 #include <tuple>
-#include <vector>
 
 #include "io/cache/file_cache_common.h"
 

--- a/be/src/io/fs/broker_file_system.h
+++ b/be/src/io/fs/broker_file_system.h
@@ -23,7 +23,6 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "common/status.h"
 #include "io/fs/path.h"

--- a/be/src/io/fs/hdfs_file_system.h
+++ b/be/src/io/fs/hdfs_file_system.h
@@ -25,7 +25,6 @@
 #include <chrono> // IWYU pragma: keep
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "common/config.h"
 #include "common/status.h"

--- a/be/src/io/fs/http_file_system.h
+++ b/be/src/io/fs/http_file_system.h
@@ -22,7 +22,6 @@
 #include <memory>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "common/status.h"
 #include "io/fs/file_writer.h"

--- a/be/src/io/fs/s3_file_system.h
+++ b/be/src/io/fs/s3_file_system.h
@@ -22,7 +22,6 @@
 #include <shared_mutex>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "common/status.h"
 #include "io/fs/file_reader_writer_fwd.h"

--- a/be/src/storage/index/index_file_reader.h
+++ b/be/src/storage/index/index_file_reader.h
@@ -28,7 +28,6 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
-#include <vector>
 
 #include "common/be_mock_util.h"
 #include "common/config.h"

--- a/be/src/storage/index/inverted/analyzer/ik/dic/Dictionary.h
+++ b/be/src/storage/index/inverted/analyzer/ik/dic/Dictionary.h
@@ -23,7 +23,6 @@
 #include <memory>
 #include <mutex>
 #include <string>
-#include <vector>
 
 #include "CLucene/LuceneThreads.h"
 #include "CLucene/_ApiHeader.h"

--- a/be/src/storage/index/inverted/inverted_index_compound_reader.h
+++ b/be/src/storage/index/inverted/inverted_index_compound_reader.h
@@ -32,7 +32,6 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
-#include <vector>
 
 #include "io/fs/file_system.h"
 #include "io/io_common.h"

--- a/be/src/storage/index/inverted/inverted_index_fs_directory.h
+++ b/be/src/storage/index/inverted/inverted_index_fs_directory.h
@@ -24,7 +24,6 @@
 #include <CLucene/store/_RAMDirectory.h>
 
 #include <string>
-#include <vector>
 
 #include "CLucene/SharedHeader.h"
 #include "io/fs/file_reader_writer_fwd.h"

--- a/be/src/storage/index/inverted/inverted_index_reader.h
+++ b/be/src/storage/index/inverted/inverted_index_reader.h
@@ -22,7 +22,6 @@
 #include <memory>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "common/status.h"
 #include "core/data_type/primitive_type.h"

--- a/be/src/storage/utils.cpp
+++ b/be/src/storage/utils.cpp
@@ -32,7 +32,6 @@
 #include <set>
 #include <sstream>
 #include <string>
-#include <vector>
 
 #include "common/logging.h"
 #include "common/status.h"

--- a/be/src/util/path_util.h
+++ b/be/src/util/path_util.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include <string>
-#include <vector>
 
 namespace doris {
 namespace path_util {


### PR DESCRIPTION
## Summary
- Remove unnecessary `#include <vector>` from 26 BE source files
- These files do not directly use `std::vector`
- The header is transitively available through other included headers

Identified by [include-what-you-use](https://github.com/include-what-you-use/include-what-you-use) (IWYU 0.24 / Clang 20) analysis.

## Test plan
- [x] Full BE incremental build passes with zero compilation errors
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)