### PR TITLE
[cleanup](build) Replace runtime_state.h include with forward declaration in 14 headers

### DIFF
--- a/be/src/exec/common/hash_table/hash_table_set_build.h
+++ b/be/src/exec/common/hash_table/hash_table_set_build.h
@@ -17,9 +17,10 @@
 
 #include "core/column/column.h"
 #include "exec/operator/set_sink_operator.h"
-#include "runtime/runtime_state.h"
 
 namespace doris {
+
+class RuntimeState;
 #include "common/compile_check_begin.h"
 constexpr size_t CHECK_FRECUENCY = 65536;
 template <class HashTableContext, bool is_intersect>

--- a/be/src/exec/runtime_filter/runtime_filter_producer_helper_cross.h
+++ b/be/src/exec/runtime_filter/runtime_filter_producer_helper_cross.h
@@ -24,9 +24,10 @@
 #include "exec/runtime_filter/runtime_filter_producer_helper.h"
 #include "exprs/vexpr.h"
 #include "exprs/vexpr_context.h"
-#include "runtime/runtime_state.h"
 
 namespace doris {
+
+class RuntimeState;
 #include "common/compile_check_begin.h"
 // this class used in cross join node
 class RuntimeFilterProducerHelperCross : public RuntimeFilterProducerHelper {

--- a/be/src/exec/runtime_filter/runtime_filter_producer_helper_set.h
+++ b/be/src/exec/runtime_filter/runtime_filter_producer_helper_set.h
@@ -25,9 +25,10 @@
 #include "exec/runtime_filter/runtime_filter_producer_helper.h"
 #include "exprs/vexpr.h"
 #include "exprs/vexpr_context.h"
-#include "runtime/runtime_state.h"
 
 namespace doris {
+
+class RuntimeState;
 #include "common/compile_check_begin.h"
 // this class used in set sink node
 class RuntimeFilterProducerHelperSet : public RuntimeFilterProducerHelper {

--- a/be/src/exec/sink/tablet_sink_hash_partitioner.cpp
+++ b/be/src/exec/sink/tablet_sink_hash_partitioner.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include "exec/sink/tablet_sink_hash_partitioner.h"
+#include "runtime/runtime_state.h"
 
 #include <algorithm>
 #include <memory>

--- a/be/src/exec/sink/tablet_sink_hash_partitioner.cpp
+++ b/be/src/exec/sink/tablet_sink_hash_partitioner.cpp
@@ -16,13 +16,13 @@
 // under the License.
 
 #include "exec/sink/tablet_sink_hash_partitioner.h"
-#include "runtime/runtime_state.h"
 
 #include <algorithm>
 #include <memory>
 #include <utility>
 
 #include "exec/operator/operator.h"
+#include "runtime/runtime_state.h"
 
 namespace doris {
 #include "common/compile_check_begin.h"

--- a/be/src/exec/sink/tablet_sink_hash_partitioner.h
+++ b/be/src/exec/sink/tablet_sink_hash_partitioner.h
@@ -23,10 +23,11 @@
 #include "exec/sink/vrow_distribution.h"
 #include "exec/sink/vtablet_block_convertor.h"
 #include "exec/sink/vtablet_finder.h"
-#include "runtime/runtime_state.h"
 #include "storage/tablet_info.h"
 
 namespace doris {
+
+class RuntimeState;
 #include "common/compile_check_begin.h"
 class TabletSinkHashPartitioner final : public PartitionerBase {
 public:

--- a/be/src/exprs/lambda_function/lambda_function.h
+++ b/be/src/exprs/lambda_function/lambda_function.h
@@ -21,9 +21,10 @@
 #include "core/block/block.h"
 #include "exprs/vexpr.h"
 #include "exprs/vexpr_context.h"
-#include "runtime/runtime_state.h"
 
 namespace doris {
+
+class RuntimeState;
 class VExpr;
 class LambdaFunction {
 public:

--- a/be/src/exprs/short_circuit_evaluation_expr.cpp
+++ b/be/src/exprs/short_circuit_evaluation_expr.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include "exprs/short_circuit_evaluation_expr.h"
+#include "runtime/runtime_state.h"
 
 #include <gen_cpp/Exprs_types.h>
 

--- a/be/src/exprs/short_circuit_evaluation_expr.cpp
+++ b/be/src/exprs/short_circuit_evaluation_expr.cpp
@@ -16,7 +16,6 @@
 // under the License.
 
 #include "exprs/short_circuit_evaluation_expr.h"
-#include "runtime/runtime_state.h"
 
 #include <gen_cpp/Exprs_types.h>
 
@@ -37,6 +36,7 @@
 #include "core/field.h"
 #include "exprs/short_circuit_util.h"
 #include "exprs/vexpr.h"
+#include "runtime/runtime_state.h"
 
 namespace doris {
 

--- a/be/src/exprs/short_circuit_evaluation_expr.h
+++ b/be/src/exprs/short_circuit_evaluation_expr.h
@@ -22,9 +22,10 @@
 #include "common/status.h"
 #include "exprs/vexpr.h"
 #include "exprs/vexpr_context.h"
-#include "runtime/runtime_state.h"
 
 namespace doris {
+
+class RuntimeState;
 
 class Block;
 class VExprContext;

--- a/be/src/exprs/vcolumn_ref.h
+++ b/be/src/exprs/vcolumn_ref.h
@@ -21,9 +21,10 @@
 #include "exprs/function/function.h"
 #include "exprs/vexpr.h"
 #include "runtime/descriptors.h"
-#include "runtime/runtime_state.h"
 
 namespace doris {
+
+class RuntimeState;
 class VColumnRef final : public VExpr {
     ENABLE_FACTORY_CREATOR(VColumnRef);
 

--- a/be/src/exprs/vcondition_expr.cpp
+++ b/be/src/exprs/vcondition_expr.cpp
@@ -16,13 +16,13 @@
 // under the License.
 
 #include "exprs/vcondition_expr.h"
-#include "runtime/runtime_state.h"
 
 #include <glog/logging.h>
 
 #include "core/column/column.h"
 #include "core/column/column_const.h"
 #include "exprs/function_context.h"
+#include "runtime/runtime_state.h"
 #include "util/simd/bits.h"
 
 namespace doris {

--- a/be/src/exprs/vcondition_expr.cpp
+++ b/be/src/exprs/vcondition_expr.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include "exprs/vcondition_expr.h"
+#include "runtime/runtime_state.h"
 
 #include <glog/logging.h>
 

--- a/be/src/exprs/vcondition_expr.h
+++ b/be/src/exprs/vcondition_expr.h
@@ -27,7 +27,6 @@
 #include "exprs/vexpr_context.h"
 #include "exprs/vliteral.h"
 #include "exprs/vslot_ref.h"
-#include "runtime/runtime_state.h"
 namespace doris {
 class RowDescriptor;
 class RuntimeState;

--- a/be/src/exprs/vectorized_fn_call.h
+++ b/be/src/exprs/vectorized_fn_call.h
@@ -29,7 +29,6 @@
 #include "exprs/vexpr_context.h"
 #include "exprs/vliteral.h"
 #include "exprs/vslot_ref.h"
-#include "runtime/runtime_state.h"
 #include "storage/index/ann/ann_range_search_runtime.h"
 
 namespace doris {

--- a/be/src/exprs/vexpr_context.h
+++ b/be/src/exprs/vexpr_context.h
@@ -34,7 +34,6 @@
 #include "exec/runtime_filter/runtime_filter_selectivity.h"
 #include "exprs/function_context.h"
 #include "exprs/vexpr_fwd.h"
-#include "runtime/runtime_state.h"
 #include "storage/index/ann/ann_range_search_runtime.h"
 #include "storage/index/ann/ann_search_params.h"
 #include "storage/index/inverted/inverted_index_reader.h"

--- a/be/src/exprs/vtopn_pred.h
+++ b/be/src/exprs/vtopn_pred.h
@@ -30,9 +30,10 @@
 #include "exprs/vslot_ref.h"
 #include "runtime/query_context.h"
 #include "runtime/runtime_predicate.h"
-#include "runtime/runtime_state.h"
 
 namespace doris {
+
+class RuntimeState;
 #include "common/compile_check_begin.h"
 
 // only used for dynamic topn filter

--- a/be/src/runtime/task_execution_context.cpp
+++ b/be/src/runtime/task_execution_context.cpp
@@ -17,6 +17,8 @@
 
 #include "runtime/task_execution_context.h"
 
+#include "runtime/runtime_state.h"
+
 #include <glog/logging.h>
 
 #include <condition_variable>

--- a/be/src/runtime/task_execution_context.cpp
+++ b/be/src/runtime/task_execution_context.cpp
@@ -17,11 +17,11 @@
 
 #include "runtime/task_execution_context.h"
 
-#include "runtime/runtime_state.h"
-
 #include <glog/logging.h>
 
 #include <condition_variable>
+
+#include "runtime/runtime_state.h"
 
 namespace doris {
 void TaskExecutionContext::ref_task_execution_ctx() {

--- a/be/src/runtime/task_execution_context.h
+++ b/be/src/runtime/task_execution_context.h
@@ -21,8 +21,6 @@
 #include <condition_variable>
 #include <memory>
 
-#include "runtime/runtime_state.h"
-
 namespace doris {
 
 class RuntimeState;

--- a/be/src/storage/compaction/collection_statistics.cpp
+++ b/be/src/storage/compaction/collection_statistics.cpp
@@ -16,7 +16,6 @@
 // under the License.
 
 #include "storage/compaction/collection_statistics.h"
-#include "runtime/runtime_state.h"
 
 #include <set>
 #include <sstream>
@@ -26,6 +25,7 @@
 #include "exprs/vexpr_context.h"
 #include "exprs/vliteral.h"
 #include "exprs/vslot_ref.h"
+#include "runtime/runtime_state.h"
 #include "storage/index/index_file_reader.h"
 #include "storage/index/index_reader_helper.h"
 #include "storage/index/inverted/analyzer/analyzer.h"

--- a/be/src/storage/compaction/collection_statistics.cpp
+++ b/be/src/storage/compaction/collection_statistics.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include "storage/compaction/collection_statistics.h"
+#include "runtime/runtime_state.h"
 
 #include <set>
 #include <sstream>

--- a/be/src/storage/compaction/collection_statistics.h
+++ b/be/src/storage/compaction/collection_statistics.h
@@ -22,12 +22,13 @@
 
 #include "common/be_mock_util.h"
 #include "exprs/vexpr_fwd.h"
-#include "runtime/runtime_state.h"
 #include "storage/index/inverted/query/query_info.h"
 #include "storage/olap_common.h"
 #include "storage/predicate_collector.h"
 
 namespace doris {
+
+class RuntimeState;
 #include "common/compile_check_begin.h"
 
 namespace io {

--- a/be/src/storage/index/ann/ann_topn_runtime.h
+++ b/be/src/storage/index/ann/ann_topn_runtime.h
@@ -44,8 +44,8 @@
 #include "exprs/vexpr_context.h"
 #include "exprs/vexpr_fwd.h"
 #include "exprs/vslot_ref.h"
-#include "runtime/runtime_state.h"
 
+namespace doris { class RuntimeState; }
 namespace doris::segment_v2 {
 #include "common/compile_check_begin.h"
 struct AnnIndexStats;

--- a/be/src/storage/index/ann/ann_topn_runtime.h
+++ b/be/src/storage/index/ann/ann_topn_runtime.h
@@ -45,7 +45,9 @@
 #include "exprs/vexpr_fwd.h"
 #include "exprs/vslot_ref.h"
 
-namespace doris { class RuntimeState; }
+namespace doris {
+class RuntimeState;
+} // namespace doris
 namespace doris::segment_v2 {
 #include "common/compile_check_begin.h"
 struct AnnIndexStats;

--- a/be/src/storage/rowset/rowset_reader_context.h
+++ b/be/src/storage/rowset/rowset_reader_context.h
@@ -24,13 +24,14 @@
 #include "exprs/vexpr.h"
 #include "exprs/vexpr_context.h"
 #include "io/io_common.h"
-#include "runtime/runtime_state.h"
 #include "storage/index/ann/ann_topn_runtime.h"
 #include "storage/olap_common.h"
 #include "storage/predicate/column_predicate.h"
 #include "storage/rowid_conversion.h"
 
 namespace doris {
+
+class RuntimeState;
 
 class RowCursor;
 class DeleteBitmap;


### PR DESCRIPTION
## Summary
- Replace `#include "runtime/runtime_state.h"` with `class RuntimeState;` forward declaration in **14 header files**
- These headers only use `RuntimeState*` as pointer/reference parameters — they never access RuntimeState members or methods
- For files with corresponding `.cpp`, the full `#include` is preserved in the `.cpp`

This reduces the transitive include fan-out from `runtime_state.h`, which pulls in heavy protobuf/thrift generated headers. This should improve incremental build times for files that depend on these 14 headers.

### Modified headers:
`hash_table_set_build.h`, `runtime_filter_producer_helper_{cross,set}.h`, `tablet_sink_hash_partitioner.h`, `lambda_function.h`, `short_circuit_evaluation_expr.h`, `vcolumn_ref.h`, `vcondition_expr.h`, `vectorized_fn_call.h`, `vexpr_context.h`, `vtopn_pred.h`, `task_execution_context.h`, `collection_statistics.h`, `ann_topn_runtime.h`, `rowset_reader_context.h`

## Test plan
- [x] Full BE build (1522 targets) passes with zero compilation errors
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)