### PR TITLE
[improvement](fe) Migrate HMS client pool to Commons Pool

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/ThriftHMSCachedClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/ThriftHMSCachedClient.java
@@ -96,11 +96,18 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
     private volatile boolean isClosed = false;
     private final HiveConf hiveConf;
     private final ExecutionAuthenticator executionAuthenticator;
+    private final MetaStoreClientProvider metaStoreClientProvider;
 
     public ThriftHMSCachedClient(HiveConf hiveConf, int poolSize, ExecutionAuthenticator executionAuthenticator) {
+        this(hiveConf, poolSize, executionAuthenticator, new DefaultMetaStoreClientProvider());
+    }
+
+    ThriftHMSCachedClient(HiveConf hiveConf, int poolSize, ExecutionAuthenticator executionAuthenticator,
+            MetaStoreClientProvider metaStoreClientProvider) {
         Preconditions.checkArgument(poolSize > 0, poolSize);
         this.hiveConf = hiveConf;
         this.executionAuthenticator = executionAuthenticator;
+        this.metaStoreClientProvider = Preconditions.checkNotNull(metaStoreClientProvider, "metaStoreClientProvider");
         this.clientPool = new GenericObjectPool<>(new ThriftHMSClientFactory(), createPoolConfig(poolSize));
     }
 
@@ -658,17 +665,14 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
         return config;
     }
 
-    private IMetaStoreClient createHiveMetastoreClient() throws MetaException {
+    static String getMetastoreClientClassName(HiveConf hiveConf) {
         String type = hiveConf.get(HMSBaseProperties.HIVE_METASTORE_TYPE);
         if (HMSBaseProperties.DLF_TYPE.equalsIgnoreCase(type)) {
-            return RetryingMetaStoreClient.getProxy(hiveConf, DUMMY_HOOK_LOADER,
-                    ProxyMetaStoreClient.class.getName());
+            return ProxyMetaStoreClient.class.getName();
         } else if (HMSBaseProperties.GLUE_TYPE.equalsIgnoreCase(type)) {
-            return RetryingMetaStoreClient.getProxy(hiveConf, DUMMY_HOOK_LOADER,
-                    AWSCatalogMetastoreClient.class.getName());
+            return AWSCatalogMetastoreClient.class.getName();
         } else {
-            return RetryingMetaStoreClient.getProxy(hiveConf, DUMMY_HOOK_LOADER,
-                    HiveMetaStoreClient.class.getName());
+            return HiveMetaStoreClient.class.getName();
         }
     }
 
@@ -685,7 +689,8 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
     private class ThriftHMSClientFactory extends BasePooledObjectFactory<ThriftHMSClient> {
         @Override
         public ThriftHMSClient create() throws Exception {
-            return withSystemClassLoader(() -> ugiDoAs(() -> new ThriftHMSClient(createHiveMetastoreClient())));
+            return withSystemClassLoader(() -> ugiDoAs(
+                    () -> new ThriftHMSClient(metaStoreClientProvider.create(hiveConf))));
         }
 
         @Override
@@ -758,6 +763,18 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
             throw e;
         } catch (Exception e) {
             throw new HMSClientException("failed to borrow hms client from pool", e);
+        }
+    }
+
+    interface MetaStoreClientProvider {
+        IMetaStoreClient create(HiveConf hiveConf) throws MetaException;
+    }
+
+    private static class DefaultMetaStoreClientProvider implements MetaStoreClientProvider {
+        @Override
+        public IMetaStoreClient create(HiveConf hiveConf) throws MetaException {
+            return RetryingMetaStoreClient.getProxy(hiveConf, DUMMY_HOOK_LOADER,
+                    getMetastoreClientClassName(hiveConf));
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/ThriftHMSCachedClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/ThriftHMSCachedClient.java
@@ -31,6 +31,11 @@ import com.amazonaws.glue.catalog.metastore.AWSCatalogMetastoreClient;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import org.apache.commons.pool2.BasePooledObjectFactory;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.hadoop.hive.common.ValidReadTxnList;
 import org.apache.hadoop.hive.common.ValidReaderWriteIdList;
 import org.apache.hadoop.hive.common.ValidTxnList;
@@ -69,12 +74,10 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Queue;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -89,31 +92,28 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
     // -1 means no limit on the partitions returned.
     private static final short MAX_LIST_PARTITION_NUM = Config.max_hive_list_partition_num;
 
-    private Queue<ThriftHMSClient> clientPool = new LinkedList<>();
-    private boolean isClosed = false;
-    private final int poolSize;
+    private final GenericObjectPool<ThriftHMSClient> clientPool;
+    private volatile boolean isClosed = false;
     private final HiveConf hiveConf;
-    private ExecutionAuthenticator executionAuthenticator;
+    private final ExecutionAuthenticator executionAuthenticator;
 
     public ThriftHMSCachedClient(HiveConf hiveConf, int poolSize, ExecutionAuthenticator executionAuthenticator) {
         Preconditions.checkArgument(poolSize > 0, poolSize);
         this.hiveConf = hiveConf;
-        this.poolSize = poolSize;
-        this.isClosed = false;
         this.executionAuthenticator = executionAuthenticator;
+        this.clientPool = new GenericObjectPool<>(new ThriftHMSClientFactory(), createPoolConfig(poolSize));
     }
 
     @Override
     public void close() {
-        synchronized (clientPool) {
-            this.isClosed = true;
-            while (!clientPool.isEmpty()) {
-                try {
-                    clientPool.poll().close();
-                } catch (Exception e) {
-                    LOG.warn("failed to close thrift client", e);
-                }
-            }
+        if (isClosed) {
+            return;
+        }
+        isClosed = true;
+        try {
+            clientPool.close();
+        } catch (Exception e) {
+            LOG.warn("failed to close thrift client pool", e);
         }
     }
 
@@ -545,7 +545,7 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
                             "acquire lock timeout for txn " + txnId + " of query " + queryId + ", timeout(ms): "
                                     + timeoutMs);
                 }
-                response = checkLock(lockId);
+                response = checkLock(client, lockId);
             }
 
             if (response.getState() != LockState.ACQUIRED) {
@@ -599,15 +599,11 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
         }
     }
 
-    private LockResponse checkLock(long lockId) {
-        try (ThriftHMSClient client = getClient()) {
-            try {
-                return ugiDoAs(() -> client.client.checkLock(lockId));
-            } catch (Exception e) {
-                client.setThrowable(e);
-                throw e;
-            }
+    private LockResponse checkLock(ThriftHMSClient client, long lockId) {
+        try {
+            return ugiDoAs(() -> client.client.checkLock(lockId));
         } catch (Exception e) {
+            client.setThrowable(e);
             throw new RuntimeException("failed to check lock " + lockId, e);
         }
     }
@@ -636,53 +632,120 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
         return builder.build();
     }
 
+    private GenericObjectPoolConfig createPoolConfig(int poolSize) {
+        GenericObjectPoolConfig config = new GenericObjectPoolConfig();
+        config.setMaxTotal(poolSize);
+        config.setMaxIdle(poolSize);
+        config.setMinIdle(0);
+        config.setBlockWhenExhausted(true);
+        config.setMaxWaitMillis(-1L);
+        config.setTestOnBorrow(false);
+        config.setTestOnReturn(false);
+        config.setTestWhileIdle(false);
+        config.setTimeBetweenEvictionRunsMillis(-1L);
+        return config;
+    }
+
+    private IMetaStoreClient createHiveMetastoreClient() throws MetaException {
+        String type = hiveConf.get(HMSBaseProperties.HIVE_METASTORE_TYPE);
+        if (HMSBaseProperties.DLF_TYPE.equalsIgnoreCase(type)) {
+            return RetryingMetaStoreClient.getProxy(hiveConf, DUMMY_HOOK_LOADER,
+                    ProxyMetaStoreClient.class.getName());
+        } else if (HMSBaseProperties.GLUE_TYPE.equalsIgnoreCase(type)) {
+            return RetryingMetaStoreClient.getProxy(hiveConf, DUMMY_HOOK_LOADER,
+                    AWSCatalogMetastoreClient.class.getName());
+        } else {
+            return RetryingMetaStoreClient.getProxy(hiveConf, DUMMY_HOOK_LOADER,
+                    HiveMetaStoreClient.class.getName());
+        }
+    }
+
+    private <T> T withSystemClassLoader(PrivilegedExceptionAction<T> action) throws Exception {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(ClassLoader.getSystemClassLoader());
+            return action.run();
+        } finally {
+            Thread.currentThread().setContextClassLoader(classLoader);
+        }
+    }
+
+    private class ThriftHMSClientFactory extends BasePooledObjectFactory<ThriftHMSClient> {
+        @Override
+        public ThriftHMSClient create() throws Exception {
+            return withSystemClassLoader(() -> ugiDoAs(() -> new ThriftHMSClient(createHiveMetastoreClient())));
+        }
+
+        @Override
+        public PooledObject<ThriftHMSClient> wrap(ThriftHMSClient client) {
+            return new DefaultPooledObject<>(client);
+        }
+
+        @Override
+        public boolean validateObject(PooledObject<ThriftHMSClient> pooledObject) {
+            return !isClosed && pooledObject.getObject().isValid();
+        }
+
+        @Override
+        public void destroyObject(PooledObject<ThriftHMSClient> pooledObject) throws Exception {
+            pooledObject.getObject().destroy();
+        }
+    }
+
     private class ThriftHMSClient implements AutoCloseable {
         private final IMetaStoreClient client;
-        private volatile Throwable throwable;
+        private volatile boolean broken;
+        private volatile boolean destroyed;
 
-        private ThriftHMSClient(HiveConf hiveConf) throws MetaException {
-            String type = hiveConf.get(HMSBaseProperties.HIVE_METASTORE_TYPE);
-            if (HMSBaseProperties.DLF_TYPE.equalsIgnoreCase(type)) {
-                client = RetryingMetaStoreClient.getProxy(hiveConf, DUMMY_HOOK_LOADER,
-                        ProxyMetaStoreClient.class.getName());
-            } else if (HMSBaseProperties.GLUE_TYPE.equalsIgnoreCase(type)) {
-                client = RetryingMetaStoreClient.getProxy(hiveConf, DUMMY_HOOK_LOADER,
-                        AWSCatalogMetastoreClient.class.getName());
-            } else {
-                client = RetryingMetaStoreClient.getProxy(hiveConf, DUMMY_HOOK_LOADER,
-                        HiveMetaStoreClient.class.getName());
-            }
+        private ThriftHMSClient(IMetaStoreClient client) {
+            this.client = client;
         }
 
         public void setThrowable(Throwable throwable) {
-            this.throwable = throwable;
+            this.broken = true;
+        }
+
+        private boolean isValid() {
+            return !destroyed;
+        }
+
+        private void destroy() {
+            if (destroyed) {
+                return;
+            }
+            destroyed = true;
+            client.close();
         }
 
         @Override
         public void close() throws Exception {
-            synchronized (clientPool) {
-                if (isClosed || throwable != null || clientPool.size() > poolSize) {
-                    client.close();
+            if (isClosed) {
+                destroy();
+                return;
+            }
+            try {
+                if (broken) {
+                    clientPool.invalidateObject(this);
                 } else {
-                    clientPool.offer(this);
+                    clientPool.returnObject(this);
                 }
+            } catch (IllegalStateException e) {
+                destroy();
+            } catch (Exception e) {
+                destroy();
+                throw e;
             }
         }
     }
 
     private ThriftHMSClient getClient() {
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         try {
-            Thread.currentThread().setContextClassLoader(ClassLoader.getSystemClassLoader());
-            synchronized (clientPool) {
-                ThriftHMSClient client = clientPool.poll();
-                if (client == null) {
-                    return ugiDoAs(() -> new ThriftHMSClient(hiveConf));
-                }
-                return client;
-            }
-        } finally {
-            Thread.currentThread().setContextClassLoader(classLoader);
+            Preconditions.checkState(!isClosed, "HMS client pool is closed");
+            return clientPool.borrowObject();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new HMSClientException("failed to borrow hms client from pool", e);
         }
     }
 
@@ -715,17 +778,21 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
             String tableName,
             Function<HivePartitionStatistics, HivePartitionStatistics> update) {
         try (ThriftHMSClient client = getClient()) {
+            try {
+                Table originTable = ugiDoAs(() -> client.client.getTable(dbName, tableName));
+                Map<String, String> originParams = originTable.getParameters();
+                HivePartitionStatistics updatedStats = update.apply(HiveUtil.toHivePartitionStatistics(originParams));
 
-            Table originTable = getTable(dbName, tableName);
-            Map<String, String> originParams = originTable.getParameters();
-            HivePartitionStatistics updatedStats = update.apply(HiveUtil.toHivePartitionStatistics(originParams));
-
-            Table newTable = originTable.deepCopy();
-            Map<String, String> newParams =
-                    HiveUtil.updateStatisticsParameters(originParams, updatedStats.getCommonStatistics());
-            newParams.put("transient_lastDdlTime", String.valueOf(System.currentTimeMillis() / 1000));
-            newTable.setParameters(newParams);
-            client.client.alter_table(dbName, tableName, newTable);
+                Table newTable = originTable.deepCopy();
+                Map<String, String> newParams =
+                        HiveUtil.updateStatisticsParameters(originParams, updatedStats.getCommonStatistics());
+                newParams.put("transient_lastDdlTime", String.valueOf(System.currentTimeMillis() / 1000));
+                newTable.setParameters(newParams);
+                client.client.alter_table(dbName, tableName, newTable);
+            } catch (Exception e) {
+                client.setThrowable(e);
+                throw e;
+            }
         } catch (Exception e) {
             throw new RuntimeException("failed to update table statistics for " + dbName + "." + tableName, e);
         }
@@ -738,22 +805,27 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
             String partitionName,
             Function<HivePartitionStatistics, HivePartitionStatistics> update) {
         try (ThriftHMSClient client = getClient()) {
-            List<Partition> partitions = client.client.getPartitionsByNames(
-                    dbName, tableName, ImmutableList.of(partitionName));
-            if (partitions.size() != 1) {
-                throw new RuntimeException("Metastore returned multiple partitions for name: " + partitionName);
+            try {
+                List<Partition> partitions = client.client.getPartitionsByNames(
+                        dbName, tableName, ImmutableList.of(partitionName));
+                if (partitions.size() != 1) {
+                    throw new RuntimeException("Metastore returned multiple partitions for name: " + partitionName);
+                }
+
+                Partition originPartition = partitions.get(0);
+                Map<String, String> originParams = originPartition.getParameters();
+                HivePartitionStatistics updatedStats = update.apply(HiveUtil.toHivePartitionStatistics(originParams));
+
+                Partition modifiedPartition = originPartition.deepCopy();
+                Map<String, String> newParams =
+                        HiveUtil.updateStatisticsParameters(originParams, updatedStats.getCommonStatistics());
+                newParams.put("transient_lastDdlTime", String.valueOf(System.currentTimeMillis() / 1000));
+                modifiedPartition.setParameters(newParams);
+                client.client.alter_partition(dbName, tableName, modifiedPartition);
+            } catch (Exception e) {
+                client.setThrowable(e);
+                throw e;
             }
-
-            Partition originPartition = partitions.get(0);
-            Map<String, String> originParams = originPartition.getParameters();
-            HivePartitionStatistics updatedStats = update.apply(HiveUtil.toHivePartitionStatistics(originParams));
-
-            Partition modifiedPartition = originPartition.deepCopy();
-            Map<String, String> newParams =
-                    HiveUtil.updateStatisticsParameters(originParams, updatedStats.getCommonStatistics());
-            newParams.put("transient_lastDdlTime", String.valueOf(System.currentTimeMillis() / 1000));
-            modifiedPartition.setParameters(newParams);
-            client.client.alter_partition(dbName, tableName, modifiedPartition);
         } catch (Exception e) {
             throw new RuntimeException("failed to update table statistics for " + dbName + "." + tableName, e);
         }
@@ -762,10 +834,15 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
     @Override
     public void addPartitions(String dbName, String tableName, List<HivePartitionWithStatistics> partitions) {
         try (ThriftHMSClient client = getClient()) {
-            List<Partition> hivePartitions = partitions.stream()
-                    .map(HiveUtil::toMetastoreApiPartition)
-                    .collect(Collectors.toList());
-            client.client.add_partitions(hivePartitions);
+            try {
+                List<Partition> hivePartitions = partitions.stream()
+                        .map(HiveUtil::toMetastoreApiPartition)
+                        .collect(Collectors.toList());
+                client.client.add_partitions(hivePartitions);
+            } catch (Exception e) {
+                client.setThrowable(e);
+                throw e;
+            }
         } catch (Exception e) {
             throw new RuntimeException("failed to add partitions for " + dbName + "." + tableName, e);
         }
@@ -774,7 +851,12 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
     @Override
     public void dropPartition(String dbName, String tableName, List<String> partitionValues, boolean deleteData) {
         try (ThriftHMSClient client = getClient()) {
-            client.client.dropPartition(dbName, tableName, partitionValues, deleteData);
+            try {
+                client.client.dropPartition(dbName, tableName, partitionValues, deleteData);
+            } catch (Exception e) {
+                client.setThrowable(e);
+                throw e;
+            }
         } catch (Exception e) {
             throw new RuntimeException("failed to drop partition for " + dbName + "." + tableName, e);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/ThriftHMSCachedClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/ThriftHMSCachedClient.java
@@ -766,6 +766,8 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
         }
     }
 
+    // Keep the HMS client creation behind an injectable seam so unit tests can verify
+    // Doris-side pool behavior without relying on Hive static construction internals.
     interface MetaStoreClientProvider {
         IMetaStoreClient create(HiveConf hiveConf) throws MetaException;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/ThriftHMSCachedClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/ThriftHMSCachedClient.java
@@ -632,6 +632,18 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
         return builder.build();
     }
 
+    /**
+     * The Doris HMS pool only manages client object lifecycle in FE:
+     * 1. Create clients.
+     * 2. Borrow and return clients.
+     * 3. Invalidate borrowers that have already failed.
+     * 4. Destroy clients when the pool is closed.
+     *
+     * The pool does not manage Hive-side socket lifetime or reconnect:
+     * 1. RetryingMetaStoreClient handles hive.metastore.client.socket.lifetime itself.
+     * 2. The pool does not interpret that config.
+     * 3. The pool does not probe remote socket health.
+     */
     private GenericObjectPoolConfig createPoolConfig(int poolSize) {
         GenericObjectPoolConfig config = new GenericObjectPoolConfig();
         config.setMaxTotal(poolSize);
@@ -694,19 +706,19 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
 
     private class ThriftHMSClient implements AutoCloseable {
         private final IMetaStoreClient client;
-        private volatile boolean broken;
         private volatile boolean destroyed;
+        private volatile Throwable throwable;
 
         private ThriftHMSClient(IMetaStoreClient client) {
             this.client = client;
         }
 
         public void setThrowable(Throwable throwable) {
-            this.broken = true;
+            this.throwable = throwable;
         }
 
         private boolean isValid() {
-            return !destroyed;
+            return !destroyed && throwable == null;
         }
 
         private void destroy() {
@@ -724,7 +736,7 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
                 return;
             }
             try {
-                if (broken) {
+                if (throwable != null) {
                     clientPool.invalidateObject(this);
                 } else {
                     clientPool.returnObject(this);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/ThriftHMSCachedClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/ThriftHMSCachedClient.java
@@ -656,8 +656,8 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
      * 2. The pool does not interpret that config.
      * 3. The pool does not probe remote socket health.
      */
-    private GenericObjectPoolConfig<ThriftHMSClient> createPoolConfig(int poolSize) {
-        GenericObjectPoolConfig<ThriftHMSClient> config = new GenericObjectPoolConfig<>();
+    private GenericObjectPoolConfig createPoolConfig(int poolSize) {
+        GenericObjectPoolConfig config = new GenericObjectPoolConfig();
         config.setMaxTotal(poolSize);
         config.setMaxIdle(poolSize);
         config.setMinIdle(0);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/ThriftHMSCachedClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/ThriftHMSCachedClient.java
@@ -91,6 +91,7 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
     private static final HiveMetaHookLoader DUMMY_HOOK_LOADER = t -> null;
     // -1 means no limit on the partitions returned.
     private static final short MAX_LIST_PARTITION_NUM = Config.max_hive_list_partition_num;
+    private static final long CLIENT_POOL_BORROW_TIMEOUT_MS = 60_000L;
 
     private final GenericObjectPool<ThriftHMSClient> clientPool;
     private volatile boolean isClosed = false;
@@ -104,11 +105,12 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
 
     ThriftHMSCachedClient(HiveConf hiveConf, int poolSize, ExecutionAuthenticator executionAuthenticator,
             MetaStoreClientProvider metaStoreClientProvider) {
-        Preconditions.checkArgument(poolSize > 0, poolSize);
+        Preconditions.checkArgument(poolSize >= 0, poolSize);
         this.hiveConf = hiveConf;
         this.executionAuthenticator = executionAuthenticator;
         this.metaStoreClientProvider = Preconditions.checkNotNull(metaStoreClientProvider, "metaStoreClientProvider");
-        this.clientPool = new GenericObjectPool<>(new ThriftHMSClientFactory(), createPoolConfig(poolSize));
+        this.clientPool = poolSize == 0 ? null
+                : new GenericObjectPool<>(new ThriftHMSClientFactory(), createPoolConfig(poolSize));
     }
 
     @Override
@@ -117,6 +119,9 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
             return;
         }
         isClosed = true;
+        if (clientPool == null) {
+            return;
+        }
         try {
             clientPool.close();
         } catch (Exception e) {
@@ -651,13 +656,13 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
      * 2. The pool does not interpret that config.
      * 3. The pool does not probe remote socket health.
      */
-    private GenericObjectPoolConfig createPoolConfig(int poolSize) {
-        GenericObjectPoolConfig config = new GenericObjectPoolConfig();
+    private GenericObjectPoolConfig<ThriftHMSClient> createPoolConfig(int poolSize) {
+        GenericObjectPoolConfig<ThriftHMSClient> config = new GenericObjectPoolConfig<>();
         config.setMaxTotal(poolSize);
         config.setMaxIdle(poolSize);
         config.setMinIdle(0);
         config.setBlockWhenExhausted(true);
-        config.setMaxWaitMillis(-1L);
+        config.setMaxWaitMillis(CLIENT_POOL_BORROW_TIMEOUT_MS);
         config.setTestOnBorrow(false);
         config.setTestOnReturn(false);
         config.setTestWhileIdle(false);
@@ -689,8 +694,7 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
     private class ThriftHMSClientFactory extends BasePooledObjectFactory<ThriftHMSClient> {
         @Override
         public ThriftHMSClient create() throws Exception {
-            return withSystemClassLoader(() -> ugiDoAs(
-                    () -> new ThriftHMSClient(metaStoreClientProvider.create(hiveConf))));
+            return createClient();
         }
 
         @Override
@@ -736,6 +740,10 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
 
         @Override
         public void close() throws Exception {
+            if (clientPool == null) {
+                destroy();
+                return;
+            }
             if (isClosed) {
                 destroy();
                 return;
@@ -758,12 +766,20 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
     private ThriftHMSClient getClient() {
         try {
             Preconditions.checkState(!isClosed, "HMS client pool is closed");
+            if (clientPool == null) {
+                return createClient();
+            }
             return clientPool.borrowObject();
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
             throw new HMSClientException("failed to borrow hms client from pool", e);
         }
+    }
+
+    private ThriftHMSClient createClient() throws Exception {
+        return withSystemClassLoader(() -> ugiDoAs(
+                () -> new ThriftHMSClient(metaStoreClientProvider.create(hiveConf))));
     }
 
     // Keep the HMS client creation behind an injectable seam so unit tests can verify
@@ -819,7 +835,10 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
                         HiveUtil.updateStatisticsParameters(originParams, updatedStats.getCommonStatistics());
                 newParams.put("transient_lastDdlTime", String.valueOf(System.currentTimeMillis() / 1000));
                 newTable.setParameters(newParams);
-                client.client.alter_table(dbName, tableName, newTable);
+                ugiDoAs(() -> {
+                    client.client.alter_table(dbName, tableName, newTable);
+                    return null;
+                });
             } catch (Exception e) {
                 client.setThrowable(e);
                 throw e;
@@ -837,8 +856,8 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
             Function<HivePartitionStatistics, HivePartitionStatistics> update) {
         try (ThriftHMSClient client = getClient()) {
             try {
-                List<Partition> partitions = client.client.getPartitionsByNames(
-                        dbName, tableName, ImmutableList.of(partitionName));
+                List<Partition> partitions = ugiDoAs(() -> client.client.getPartitionsByNames(
+                        dbName, tableName, ImmutableList.of(partitionName)));
                 if (partitions.size() != 1) {
                     throw new RuntimeException("Metastore returned multiple partitions for name: " + partitionName);
                 }
@@ -852,7 +871,10 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
                         HiveUtil.updateStatisticsParameters(originParams, updatedStats.getCommonStatistics());
                 newParams.put("transient_lastDdlTime", String.valueOf(System.currentTimeMillis() / 1000));
                 modifiedPartition.setParameters(newParams);
-                client.client.alter_partition(dbName, tableName, modifiedPartition);
+                ugiDoAs(() -> {
+                    client.client.alter_partition(dbName, tableName, modifiedPartition);
+                    return null;
+                });
             } catch (Exception e) {
                 client.setThrowable(e);
                 throw e;
@@ -869,7 +891,10 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
                 List<Partition> hivePartitions = partitions.stream()
                         .map(HiveUtil::toMetastoreApiPartition)
                         .collect(Collectors.toList());
-                client.client.add_partitions(hivePartitions);
+                ugiDoAs(() -> {
+                    client.client.add_partitions(hivePartitions);
+                    return null;
+                });
             } catch (Exception e) {
                 client.setThrowable(e);
                 throw e;
@@ -883,7 +908,10 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
     public void dropPartition(String dbName, String tableName, List<String> partitionValues, boolean deleteData) {
         try (ThriftHMSClient client = getClient()) {
             try {
-                client.client.dropPartition(dbName, tableName, partitionValues, deleteData);
+                ugiDoAs(() -> {
+                    client.client.dropPartition(dbName, tableName, partitionValues, deleteData);
+                    return null;
+                });
             } catch (Exception e) {
                 client.setThrowable(e);
                 throw e;

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/ThriftHMSCachedClientTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/ThriftHMSCachedClientTest.java
@@ -23,6 +23,8 @@ import org.apache.doris.datasource.NameMapping;
 import org.apache.doris.datasource.property.metastore.HMSBaseProperties;
 import org.apache.doris.info.TableNameInfo;
 
+import com.aliyun.datalake.metastore.hive2.ProxyMetaStoreClient;
+import com.amazonaws.glue.catalog.metastore.AWSCatalogMetastoreClient;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
@@ -35,9 +37,6 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.aliyun.datalake.metastore.hive2.ProxyMetaStoreClient;
-import com.amazonaws.glue.catalog.metastore.AWSCatalogMetastoreClient;
 
 import java.lang.reflect.Proxy;
 import java.util.ArrayDeque;

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/ThriftHMSCachedClientTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/ThriftHMSCachedClientTest.java
@@ -1,0 +1,234 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.hive;
+
+import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.common.security.authentication.ExecutionAuthenticator;
+
+import mockit.Mock;
+import mockit.MockUp;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ThriftHMSCachedClientTest {
+    private AtomicInteger createdClients;
+    private AtomicInteger closedClients;
+
+    @Before
+    public void setUp() {
+        createdClients = new AtomicInteger();
+        closedClients = new AtomicInteger();
+        new MockUp<RetryingMetaStoreClient>() {
+            @Mock
+            public IMetaStoreClient getProxy(HiveConf hiveConf, HiveMetaHookLoader hookLoader, String mscClassName) {
+                return createMockClient();
+            }
+        };
+    }
+
+    @Test
+    public void testReturnObjectToPool() throws Exception {
+        ThriftHMSCachedClient cachedClient = newClient(1);
+
+        Object firstBorrowed = borrowClient(cachedClient);
+        closeBorrowed(firstBorrowed);
+
+        Assert.assertEquals(1, getPool(cachedClient).getNumIdle());
+        Assert.assertEquals(0, getPool(cachedClient).getNumActive());
+        Assert.assertEquals(1, createdClients.get());
+        Assert.assertEquals(0, closedClients.get());
+
+        Object secondBorrowed = borrowClient(cachedClient);
+        Assert.assertSame(firstBorrowed, secondBorrowed);
+        closeBorrowed(secondBorrowed);
+    }
+
+    @Test
+    public void testInvalidateBrokenObject() throws Exception {
+        ThriftHMSCachedClient cachedClient = newClient(1);
+
+        Object brokenBorrowed = borrowClient(cachedClient);
+        markBorrowedBroken(brokenBorrowed);
+        closeBorrowed(brokenBorrowed);
+
+        Assert.assertEquals(0, getPool(cachedClient).getNumIdle());
+        Assert.assertEquals(0, getPool(cachedClient).getNumActive());
+        Assert.assertEquals(1, createdClients.get());
+        Assert.assertEquals(1, closedClients.get());
+
+        Object nextBorrowed = borrowClient(cachedClient);
+        Assert.assertNotSame(brokenBorrowed, nextBorrowed);
+        Assert.assertEquals(2, createdClients.get());
+        closeBorrowed(nextBorrowed);
+    }
+
+    @Test
+    public void testBorrowBlocksUntilObjectReturned() throws Exception {
+        ThriftHMSCachedClient cachedClient = newClient(1);
+        Object firstBorrowed = borrowClient(cachedClient);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<Object> waitingBorrow = executor.submit(() -> borrowClient(cachedClient));
+            Thread.sleep(200L);
+            Assert.assertFalse(waitingBorrow.isDone());
+
+            closeBorrowed(firstBorrowed);
+
+            Object secondBorrowed = waitingBorrow.get(2, TimeUnit.SECONDS);
+            Assert.assertSame(firstBorrowed, secondBorrowed);
+            closeBorrowed(secondBorrowed);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testCloseDestroysIdleObjectsAndRejectsBorrow() throws Exception {
+        ThriftHMSCachedClient cachedClient = newClient(1);
+        Object borrowed = borrowClient(cachedClient);
+        closeBorrowed(borrowed);
+
+        cachedClient.close();
+
+        Assert.assertTrue(getPool(cachedClient).isClosed());
+        Assert.assertEquals(1, closedClients.get());
+        Assert.assertThrows(IllegalStateException.class, () -> borrowClient(cachedClient));
+    }
+
+    @Test
+    public void testCloseWhileObjectBorrowedClosesClientOnReturn() throws Exception {
+        ThriftHMSCachedClient cachedClient = newClient(1);
+        Object borrowed = borrowClient(cachedClient);
+
+        cachedClient.close();
+        Assert.assertEquals(0, closedClients.get());
+
+        closeBorrowed(borrowed);
+
+        Assert.assertEquals(1, closedClients.get());
+        Assert.assertEquals(0, getPool(cachedClient).getNumIdle());
+    }
+
+    @Test
+    public void testUpdateTableStatisticsDoesNotBorrowSecondClient() {
+        ThriftHMSCachedClient cachedClient = newClient(1);
+
+        cachedClient.updateTableStatistics("db1", "tbl1", statistics -> statistics);
+
+        Assert.assertEquals(1, createdClients.get());
+        Assert.assertEquals(1, getPool(cachedClient).getNumIdle());
+        Assert.assertEquals(0, getPool(cachedClient).getNumActive());
+    }
+
+    private ThriftHMSCachedClient newClient(int poolSize) {
+        return new ThriftHMSCachedClient(new HiveConf(), poolSize, new ExecutionAuthenticator() {
+        });
+    }
+
+    private GenericObjectPool<?> getPool(ThriftHMSCachedClient cachedClient) {
+        return Deencapsulation.getField(cachedClient, "clientPool");
+    }
+
+    private Object borrowClient(ThriftHMSCachedClient cachedClient) {
+        return Deencapsulation.invoke(cachedClient, "getClient");
+    }
+
+    private void markBorrowedBroken(Object borrowedClient) {
+        Deencapsulation.invoke(borrowedClient, "setThrowable", new RuntimeException("broken"));
+    }
+
+    private void closeBorrowed(Object borrowedClient) throws Exception {
+        ((AutoCloseable) borrowedClient).close();
+    }
+
+    private IMetaStoreClient createMockClient() {
+        createdClients.incrementAndGet();
+        return (IMetaStoreClient) Proxy.newProxyInstance(
+                IMetaStoreClient.class.getClassLoader(),
+                new Class[] {IMetaStoreClient.class},
+                (proxy, method, args) -> {
+                    String methodName = method.getName();
+                    if ("close".equals(methodName)) {
+                        closedClients.incrementAndGet();
+                        return null;
+                    }
+                    if ("hashCode".equals(methodName)) {
+                        return System.identityHashCode(proxy);
+                    }
+                    if ("equals".equals(methodName)) {
+                        return proxy == args[0];
+                    }
+                    if ("toString".equals(methodName)) {
+                        return "MockHmsClient";
+                    }
+                    if ("getTable".equals(methodName)) {
+                        Table table = new Table();
+                        table.setParameters(new HashMap<>());
+                        return table;
+                    }
+                    return defaultValue(method.getReturnType());
+                });
+    }
+
+    private Object defaultValue(Class<?> returnType) {
+        if (!returnType.isPrimitive()) {
+            return null;
+        }
+        if (returnType == boolean.class) {
+            return false;
+        }
+        if (returnType == byte.class) {
+            return (byte) 0;
+        }
+        if (returnType == short.class) {
+            return (short) 0;
+        }
+        if (returnType == int.class) {
+            return 0;
+        }
+        if (returnType == long.class) {
+            return 0L;
+        }
+        if (returnType == float.class) {
+            return 0F;
+        }
+        if (returnType == double.class) {
+            return 0D;
+        }
+        if (returnType == char.class) {
+            return '\0';
+        }
+        return null;
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/ThriftHMSCachedClientTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/ThriftHMSCachedClientTest.java
@@ -23,16 +23,10 @@ import org.apache.doris.datasource.NameMapping;
 import org.apache.doris.datasource.property.metastore.HMSBaseProperties;
 import org.apache.doris.info.TableNameInfo;
 
-import com.aliyun.datalake.metastore.hive2.ProxyMetaStoreClient;
-import com.amazonaws.glue.catalog.metastore.AWSCatalogMetastoreClient;
-import mockit.Mock;
-import mockit.MockUp;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
-import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.LockResponse;
 import org.apache.hadoop.hive.metastore.api.LockState;
@@ -42,13 +36,14 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.aliyun.datalake.metastore.hive2.ProxyMetaStoreClient;
+import com.amazonaws.glue.catalog.metastore.AWSCatalogMetastoreClient;
+
 import java.lang.reflect.Proxy;
 import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -56,17 +51,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class ThriftHMSCachedClientTest {
-    private MockMetastoreController controller;
+    private MockMetastoreClientProvider provider;
 
     @Before
     public void setUp() {
-        controller = new MockMetastoreController();
-        new MockUp<RetryingMetaStoreClient>() {
-            @Mock
-            public IMetaStoreClient getProxy(HiveConf hiveConf, HiveMetaHookLoader hookLoader, String mscClassName) {
-                return controller.createClient(mscClassName);
-            }
-        };
+        provider = new MockMetastoreClientProvider();
     }
 
     @Test
@@ -89,8 +78,8 @@ public class ThriftHMSCachedClientTest {
 
         Assert.assertEquals(1, getPool(cachedClient).getNumIdle());
         Assert.assertEquals(0, getPool(cachedClient).getNumActive());
-        Assert.assertEquals(1, controller.createdClients.get());
-        Assert.assertEquals(0, controller.closedClients.get());
+        Assert.assertEquals(1, provider.createdClients.get());
+        Assert.assertEquals(0, provider.closedClients.get());
 
         Object secondBorrowed = borrowClient(cachedClient);
         Assert.assertSame(firstBorrowed, secondBorrowed);
@@ -107,12 +96,12 @@ public class ThriftHMSCachedClientTest {
 
         Assert.assertEquals(0, getPool(cachedClient).getNumIdle());
         Assert.assertEquals(0, getPool(cachedClient).getNumActive());
-        Assert.assertEquals(1, controller.createdClients.get());
-        Assert.assertEquals(1, controller.closedClients.get());
+        Assert.assertEquals(1, provider.createdClients.get());
+        Assert.assertEquals(1, provider.closedClients.get());
 
         Object nextBorrowed = borrowClient(cachedClient);
         Assert.assertNotSame(brokenBorrowed, nextBorrowed);
-        Assert.assertEquals(2, controller.createdClients.get());
+        Assert.assertEquals(2, provider.createdClients.get());
         closeBorrowed(nextBorrowed);
     }
 
@@ -146,7 +135,7 @@ public class ThriftHMSCachedClientTest {
         cachedClient.close();
 
         Assert.assertTrue(getPool(cachedClient).isClosed());
-        Assert.assertEquals(1, controller.closedClients.get());
+        Assert.assertEquals(1, provider.closedClients.get());
         Assert.assertThrows(IllegalStateException.class, () -> borrowClient(cachedClient));
     }
 
@@ -156,49 +145,27 @@ public class ThriftHMSCachedClientTest {
         Object borrowed = borrowClient(cachedClient);
 
         cachedClient.close();
-        Assert.assertEquals(0, controller.closedClients.get());
+        Assert.assertEquals(0, provider.closedClients.get());
 
         closeBorrowed(borrowed);
 
-        Assert.assertEquals(1, controller.closedClients.get());
+        Assert.assertEquals(1, provider.closedClients.get());
         Assert.assertEquals(0, getPool(cachedClient).getNumIdle());
     }
 
     @Test
-    public void testDefaultMetastoreTypeUsesHiveClient() throws Exception {
-        ThriftHMSCachedClient cachedClient = newClient(1);
-
-        Object borrowed = borrowClient(cachedClient);
-        closeBorrowed(borrowed);
-
-        Assert.assertEquals(Collections.singletonList(HiveMetaStoreClient.class.getName()),
-                controller.requestedClientClassNames);
-    }
-
-    @Test
-    public void testGlueMetastoreTypeUsesGlueClient() throws Exception {
+    public void testGetMetastoreClientClassName() {
         HiveConf hiveConf = new HiveConf();
+        Assert.assertEquals(HiveMetaStoreClient.class.getName(),
+                ThriftHMSCachedClient.getMetastoreClientClassName(hiveConf));
+
         hiveConf.set(HMSBaseProperties.HIVE_METASTORE_TYPE, HMSBaseProperties.GLUE_TYPE);
-        ThriftHMSCachedClient cachedClient = newClient(hiveConf, 1);
+        Assert.assertEquals(AWSCatalogMetastoreClient.class.getName(),
+                ThriftHMSCachedClient.getMetastoreClientClassName(hiveConf));
 
-        Object borrowed = borrowClient(cachedClient);
-        closeBorrowed(borrowed);
-
-        Assert.assertEquals(Collections.singletonList(AWSCatalogMetastoreClient.class.getName()),
-                controller.requestedClientClassNames);
-    }
-
-    @Test
-    public void testDlfMetastoreTypeUsesDlfClient() throws Exception {
-        HiveConf hiveConf = new HiveConf();
         hiveConf.set(HMSBaseProperties.HIVE_METASTORE_TYPE, HMSBaseProperties.DLF_TYPE);
-        ThriftHMSCachedClient cachedClient = newClient(hiveConf, 1);
-
-        Object borrowed = borrowClient(cachedClient);
-        closeBorrowed(borrowed);
-
-        Assert.assertEquals(Collections.singletonList(ProxyMetaStoreClient.class.getName()),
-                controller.requestedClientClassNames);
+        Assert.assertEquals(ProxyMetaStoreClient.class.getName(),
+                ThriftHMSCachedClient.getMetastoreClientClassName(hiveConf));
     }
 
     @Test
@@ -207,29 +174,29 @@ public class ThriftHMSCachedClientTest {
 
         cachedClient.updateTableStatistics("db1", "tbl1", statistics -> statistics);
 
-        Assert.assertEquals(1, controller.createdClients.get());
+        Assert.assertEquals(1, provider.createdClients.get());
         Assert.assertEquals(1, getPool(cachedClient).getNumIdle());
         Assert.assertEquals(0, getPool(cachedClient).getNumActive());
     }
 
     @Test
     public void testAcquireSharedLockDoesNotBorrowSecondClient() {
-        controller.lockStates.add(LockState.WAITING);
-        controller.lockStates.add(LockState.ACQUIRED);
+        provider.lockStates.add(LockState.WAITING);
+        provider.lockStates.add(LockState.ACQUIRED);
         ThriftHMSCachedClient cachedClient = newClient(1);
 
         cachedClient.acquireSharedLock("query-1", 1L, "user",
                 new TableNameInfo("db1", "tbl1"), Collections.emptyList(), 5_000L);
 
-        Assert.assertEquals(1, controller.createdClients.get());
-        Assert.assertEquals(1, controller.checkLockCalls.get());
+        Assert.assertEquals(1, provider.createdClients.get());
+        Assert.assertEquals(1, provider.checkLockCalls.get());
         Assert.assertEquals(1, getPool(cachedClient).getNumIdle());
         Assert.assertEquals(0, getPool(cachedClient).getNumActive());
     }
 
     @Test
     public void testUpdatePartitionStatisticsInvalidatesFailedClient() throws Exception {
-        controller.alterPartitionFailure = new RuntimeException("alter partition failed");
+        provider.alterPartitionFailure = new RuntimeException("alter partition failed");
         ThriftHMSCachedClient cachedClient = newClient(1);
 
         RuntimeException exception = Assert.assertThrows(RuntimeException.class,
@@ -240,7 +207,7 @@ public class ThriftHMSCachedClientTest {
 
     @Test
     public void testAddPartitionsInvalidatesFailedClient() throws Exception {
-        controller.addPartitionsFailure = new RuntimeException("add partitions failed");
+        provider.addPartitionsFailure = new RuntimeException("add partitions failed");
         ThriftHMSCachedClient cachedClient = newClient(1);
 
         RuntimeException exception = Assert.assertThrows(RuntimeException.class,
@@ -251,7 +218,7 @@ public class ThriftHMSCachedClientTest {
 
     @Test
     public void testDropPartitionInvalidatesFailedClient() throws Exception {
-        controller.dropPartitionFailure = new RuntimeException("drop partition failed");
+        provider.dropPartitionFailure = new RuntimeException("drop partition failed");
         ThriftHMSCachedClient cachedClient = newClient(1);
 
         RuntimeException exception = Assert.assertThrows(RuntimeException.class,
@@ -263,11 +230,11 @@ public class ThriftHMSCachedClientTest {
     private void assertBrokenBorrowerIsNotReused(ThriftHMSCachedClient cachedClient) throws Exception {
         Assert.assertEquals(0, getPool(cachedClient).getNumIdle());
         Assert.assertEquals(0, getPool(cachedClient).getNumActive());
-        Assert.assertEquals(1, controller.createdClients.get());
-        Assert.assertEquals(1, controller.closedClients.get());
+        Assert.assertEquals(1, provider.createdClients.get());
+        Assert.assertEquals(1, provider.closedClients.get());
 
         Object nextBorrowed = borrowClient(cachedClient);
-        Assert.assertEquals(2, controller.createdClients.get());
+        Assert.assertEquals(2, provider.createdClients.get());
         closeBorrowed(nextBorrowed);
     }
 
@@ -277,7 +244,7 @@ public class ThriftHMSCachedClientTest {
 
     private ThriftHMSCachedClient newClient(HiveConf hiveConf, int poolSize) {
         return new ThriftHMSCachedClient(hiveConf, poolSize, new ExecutionAuthenticator() {
-        });
+        }, provider);
     }
 
     private GenericObjectPool<?> getPool(ThriftHMSCachedClient cachedClient) {
@@ -310,19 +277,18 @@ public class ThriftHMSCachedClientTest {
         return new HivePartitionWithStatistics("k1=v1", partition, HivePartitionStatistics.EMPTY);
     }
 
-    private static class MockMetastoreController {
+    private static class MockMetastoreClientProvider implements ThriftHMSCachedClient.MetaStoreClientProvider {
         private final AtomicInteger createdClients = new AtomicInteger();
         private final AtomicInteger closedClients = new AtomicInteger();
         private final AtomicInteger checkLockCalls = new AtomicInteger();
-        private final List<String> requestedClientClassNames = new CopyOnWriteArrayList<>();
         private final Deque<LockState> lockStates = new ArrayDeque<>();
 
         private volatile RuntimeException alterPartitionFailure;
         private volatile RuntimeException addPartitionsFailure;
         private volatile RuntimeException dropPartitionFailure;
 
-        private IMetaStoreClient createClient(String mscClassName) {
-            requestedClientClassNames.add(mscClassName);
+        @Override
+        public IMetaStoreClient create(HiveConf hiveConf) {
             createdClients.incrementAndGet();
             return (IMetaStoreClient) Proxy.newProxyInstance(
                     IMetaStoreClient.class.getClassLoader(),

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/ThriftHMSCachedClientTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/ThriftHMSCachedClientTest.java
@@ -19,21 +19,36 @@ package org.apache.doris.datasource.hive;
 
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.common.security.authentication.ExecutionAuthenticator;
+import org.apache.doris.datasource.NameMapping;
+import org.apache.doris.datasource.property.metastore.HMSBaseProperties;
+import org.apache.doris.info.TableNameInfo;
 
+import com.aliyun.datalake.metastore.hive2.ProxyMetaStoreClient;
+import com.amazonaws.glue.catalog.metastore.AWSCatalogMetastoreClient;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.LockResponse;
+import org.apache.hadoop.hive.metastore.api.LockState;
+import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.lang.reflect.Proxy;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -41,19 +56,28 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class ThriftHMSCachedClientTest {
-    private AtomicInteger createdClients;
-    private AtomicInteger closedClients;
+    private MockMetastoreController controller;
 
     @Before
     public void setUp() {
-        createdClients = new AtomicInteger();
-        closedClients = new AtomicInteger();
+        controller = new MockMetastoreController();
         new MockUp<RetryingMetaStoreClient>() {
             @Mock
             public IMetaStoreClient getProxy(HiveConf hiveConf, HiveMetaHookLoader hookLoader, String mscClassName) {
-                return createMockClient();
+                return controller.createClient(mscClassName);
             }
         };
+    }
+
+    @Test
+    public void testPoolConfigKeepsBorrowValidationAndIdleEvictionDisabled() {
+        ThriftHMSCachedClient cachedClient = newClient(1);
+
+        GenericObjectPool<?> pool = getPool(cachedClient);
+        Assert.assertFalse(pool.getTestOnBorrow());
+        Assert.assertFalse(pool.getTestOnReturn());
+        Assert.assertFalse(pool.getTestWhileIdle());
+        Assert.assertEquals(-1L, pool.getTimeBetweenEvictionRunsMillis());
     }
 
     @Test
@@ -65,8 +89,8 @@ public class ThriftHMSCachedClientTest {
 
         Assert.assertEquals(1, getPool(cachedClient).getNumIdle());
         Assert.assertEquals(0, getPool(cachedClient).getNumActive());
-        Assert.assertEquals(1, createdClients.get());
-        Assert.assertEquals(0, closedClients.get());
+        Assert.assertEquals(1, controller.createdClients.get());
+        Assert.assertEquals(0, controller.closedClients.get());
 
         Object secondBorrowed = borrowClient(cachedClient);
         Assert.assertSame(firstBorrowed, secondBorrowed);
@@ -78,17 +102,17 @@ public class ThriftHMSCachedClientTest {
         ThriftHMSCachedClient cachedClient = newClient(1);
 
         Object brokenBorrowed = borrowClient(cachedClient);
-        markBorrowedBroken(brokenBorrowed);
+        markBorrowedBroken(brokenBorrowed, new RuntimeException("broken"));
         closeBorrowed(brokenBorrowed);
 
         Assert.assertEquals(0, getPool(cachedClient).getNumIdle());
         Assert.assertEquals(0, getPool(cachedClient).getNumActive());
-        Assert.assertEquals(1, createdClients.get());
-        Assert.assertEquals(1, closedClients.get());
+        Assert.assertEquals(1, controller.createdClients.get());
+        Assert.assertEquals(1, controller.closedClients.get());
 
         Object nextBorrowed = borrowClient(cachedClient);
         Assert.assertNotSame(brokenBorrowed, nextBorrowed);
-        Assert.assertEquals(2, createdClients.get());
+        Assert.assertEquals(2, controller.createdClients.get());
         closeBorrowed(nextBorrowed);
     }
 
@@ -122,7 +146,7 @@ public class ThriftHMSCachedClientTest {
         cachedClient.close();
 
         Assert.assertTrue(getPool(cachedClient).isClosed());
-        Assert.assertEquals(1, closedClients.get());
+        Assert.assertEquals(1, controller.closedClients.get());
         Assert.assertThrows(IllegalStateException.class, () -> borrowClient(cachedClient));
     }
 
@@ -132,12 +156,49 @@ public class ThriftHMSCachedClientTest {
         Object borrowed = borrowClient(cachedClient);
 
         cachedClient.close();
-        Assert.assertEquals(0, closedClients.get());
+        Assert.assertEquals(0, controller.closedClients.get());
 
         closeBorrowed(borrowed);
 
-        Assert.assertEquals(1, closedClients.get());
+        Assert.assertEquals(1, controller.closedClients.get());
         Assert.assertEquals(0, getPool(cachedClient).getNumIdle());
+    }
+
+    @Test
+    public void testDefaultMetastoreTypeUsesHiveClient() throws Exception {
+        ThriftHMSCachedClient cachedClient = newClient(1);
+
+        Object borrowed = borrowClient(cachedClient);
+        closeBorrowed(borrowed);
+
+        Assert.assertEquals(Collections.singletonList(HiveMetaStoreClient.class.getName()),
+                controller.requestedClientClassNames);
+    }
+
+    @Test
+    public void testGlueMetastoreTypeUsesGlueClient() throws Exception {
+        HiveConf hiveConf = new HiveConf();
+        hiveConf.set(HMSBaseProperties.HIVE_METASTORE_TYPE, HMSBaseProperties.GLUE_TYPE);
+        ThriftHMSCachedClient cachedClient = newClient(hiveConf, 1);
+
+        Object borrowed = borrowClient(cachedClient);
+        closeBorrowed(borrowed);
+
+        Assert.assertEquals(Collections.singletonList(AWSCatalogMetastoreClient.class.getName()),
+                controller.requestedClientClassNames);
+    }
+
+    @Test
+    public void testDlfMetastoreTypeUsesDlfClient() throws Exception {
+        HiveConf hiveConf = new HiveConf();
+        hiveConf.set(HMSBaseProperties.HIVE_METASTORE_TYPE, HMSBaseProperties.DLF_TYPE);
+        ThriftHMSCachedClient cachedClient = newClient(hiveConf, 1);
+
+        Object borrowed = borrowClient(cachedClient);
+        closeBorrowed(borrowed);
+
+        Assert.assertEquals(Collections.singletonList(ProxyMetaStoreClient.class.getName()),
+                controller.requestedClientClassNames);
     }
 
     @Test
@@ -146,13 +207,76 @@ public class ThriftHMSCachedClientTest {
 
         cachedClient.updateTableStatistics("db1", "tbl1", statistics -> statistics);
 
-        Assert.assertEquals(1, createdClients.get());
+        Assert.assertEquals(1, controller.createdClients.get());
         Assert.assertEquals(1, getPool(cachedClient).getNumIdle());
         Assert.assertEquals(0, getPool(cachedClient).getNumActive());
     }
 
+    @Test
+    public void testAcquireSharedLockDoesNotBorrowSecondClient() {
+        controller.lockStates.add(LockState.WAITING);
+        controller.lockStates.add(LockState.ACQUIRED);
+        ThriftHMSCachedClient cachedClient = newClient(1);
+
+        cachedClient.acquireSharedLock("query-1", 1L, "user",
+                new TableNameInfo("db1", "tbl1"), Collections.emptyList(), 5_000L);
+
+        Assert.assertEquals(1, controller.createdClients.get());
+        Assert.assertEquals(1, controller.checkLockCalls.get());
+        Assert.assertEquals(1, getPool(cachedClient).getNumIdle());
+        Assert.assertEquals(0, getPool(cachedClient).getNumActive());
+    }
+
+    @Test
+    public void testUpdatePartitionStatisticsInvalidatesFailedClient() throws Exception {
+        controller.alterPartitionFailure = new RuntimeException("alter partition failed");
+        ThriftHMSCachedClient cachedClient = newClient(1);
+
+        RuntimeException exception = Assert.assertThrows(RuntimeException.class,
+                () -> cachedClient.updatePartitionStatistics("db1", "tbl1", "p1", statistics -> statistics));
+        Assert.assertTrue(exception.getMessage().contains("failed to update table statistics"));
+        assertBrokenBorrowerIsNotReused(cachedClient);
+    }
+
+    @Test
+    public void testAddPartitionsInvalidatesFailedClient() throws Exception {
+        controller.addPartitionsFailure = new RuntimeException("add partitions failed");
+        ThriftHMSCachedClient cachedClient = newClient(1);
+
+        RuntimeException exception = Assert.assertThrows(RuntimeException.class,
+                () -> cachedClient.addPartitions("db1", "tbl1", Collections.singletonList(newPartitionWithStatistics())));
+        Assert.assertTrue(exception.getMessage().contains("failed to add partitions"));
+        assertBrokenBorrowerIsNotReused(cachedClient);
+    }
+
+    @Test
+    public void testDropPartitionInvalidatesFailedClient() throws Exception {
+        controller.dropPartitionFailure = new RuntimeException("drop partition failed");
+        ThriftHMSCachedClient cachedClient = newClient(1);
+
+        RuntimeException exception = Assert.assertThrows(RuntimeException.class,
+                () -> cachedClient.dropPartition("db1", "tbl1", Collections.singletonList("p1"), false));
+        Assert.assertTrue(exception.getMessage().contains("failed to drop partition"));
+        assertBrokenBorrowerIsNotReused(cachedClient);
+    }
+
+    private void assertBrokenBorrowerIsNotReused(ThriftHMSCachedClient cachedClient) throws Exception {
+        Assert.assertEquals(0, getPool(cachedClient).getNumIdle());
+        Assert.assertEquals(0, getPool(cachedClient).getNumActive());
+        Assert.assertEquals(1, controller.createdClients.get());
+        Assert.assertEquals(1, controller.closedClients.get());
+
+        Object nextBorrowed = borrowClient(cachedClient);
+        Assert.assertEquals(2, controller.createdClients.get());
+        closeBorrowed(nextBorrowed);
+    }
+
     private ThriftHMSCachedClient newClient(int poolSize) {
-        return new ThriftHMSCachedClient(new HiveConf(), poolSize, new ExecutionAuthenticator() {
+        return newClient(new HiveConf(), poolSize);
+    }
+
+    private ThriftHMSCachedClient newClient(HiveConf hiveConf, int poolSize) {
+        return new ThriftHMSCachedClient(hiveConf, poolSize, new ExecutionAuthenticator() {
         });
     }
 
@@ -164,71 +288,145 @@ public class ThriftHMSCachedClientTest {
         return Deencapsulation.invoke(cachedClient, "getClient");
     }
 
-    private void markBorrowedBroken(Object borrowedClient) {
-        Deencapsulation.invoke(borrowedClient, "setThrowable", new RuntimeException("broken"));
+    private void markBorrowedBroken(Object borrowedClient, Throwable throwable) {
+        Deencapsulation.invoke(borrowedClient, "setThrowable", throwable);
     }
 
     private void closeBorrowed(Object borrowedClient) throws Exception {
         ((AutoCloseable) borrowedClient).close();
     }
 
-    private IMetaStoreClient createMockClient() {
-        createdClients.incrementAndGet();
-        return (IMetaStoreClient) Proxy.newProxyInstance(
-                IMetaStoreClient.class.getClassLoader(),
-                new Class[] {IMetaStoreClient.class},
-                (proxy, method, args) -> {
-                    String methodName = method.getName();
-                    if ("close".equals(methodName)) {
-                        closedClients.incrementAndGet();
-                        return null;
-                    }
-                    if ("hashCode".equals(methodName)) {
-                        return System.identityHashCode(proxy);
-                    }
-                    if ("equals".equals(methodName)) {
-                        return proxy == args[0];
-                    }
-                    if ("toString".equals(methodName)) {
-                        return "MockHmsClient";
-                    }
-                    if ("getTable".equals(methodName)) {
-                        Table table = new Table();
-                        table.setParameters(new HashMap<>());
-                        return table;
-                    }
-                    return defaultValue(method.getReturnType());
-                });
+    private HivePartitionWithStatistics newPartitionWithStatistics() {
+        HivePartition partition = new HivePartition(
+                NameMapping.createForTest("db1", "tbl1"),
+                false,
+                "input-format",
+                "file:///tmp/part",
+                Collections.singletonList("p1"),
+                new HashMap<>(),
+                "output-format",
+                "serde",
+                Collections.singletonList(new FieldSchema("c1", "string", "")));
+        return new HivePartitionWithStatistics("k1=v1", partition, HivePartitionStatistics.EMPTY);
     }
 
-    private Object defaultValue(Class<?> returnType) {
-        if (!returnType.isPrimitive()) {
+    private static class MockMetastoreController {
+        private final AtomicInteger createdClients = new AtomicInteger();
+        private final AtomicInteger closedClients = new AtomicInteger();
+        private final AtomicInteger checkLockCalls = new AtomicInteger();
+        private final List<String> requestedClientClassNames = new CopyOnWriteArrayList<>();
+        private final Deque<LockState> lockStates = new ArrayDeque<>();
+
+        private volatile RuntimeException alterPartitionFailure;
+        private volatile RuntimeException addPartitionsFailure;
+        private volatile RuntimeException dropPartitionFailure;
+
+        private IMetaStoreClient createClient(String mscClassName) {
+            requestedClientClassNames.add(mscClassName);
+            createdClients.incrementAndGet();
+            return (IMetaStoreClient) Proxy.newProxyInstance(
+                    IMetaStoreClient.class.getClassLoader(),
+                    new Class[] {IMetaStoreClient.class},
+                    (proxy, method, args) -> handleMethod(proxy, method.getName(), args, method.getReturnType()));
+        }
+
+        private Object handleMethod(Object proxy, String methodName, Object[] args, Class<?> returnType) {
+            if ("close".equals(methodName)) {
+                closedClients.incrementAndGet();
+                return null;
+            }
+            if ("hashCode".equals(methodName)) {
+                return System.identityHashCode(proxy);
+            }
+            if ("equals".equals(methodName)) {
+                return proxy == args[0];
+            }
+            if ("toString".equals(methodName)) {
+                return "MockHmsClient";
+            }
+            if ("getTable".equals(methodName)) {
+                Table table = new Table();
+                table.setParameters(new HashMap<>());
+                return table;
+            }
+            if ("getPartitionsByNames".equals(methodName)) {
+                Partition partition = new Partition();
+                partition.setParameters(new HashMap<>());
+                return Collections.singletonList(partition);
+            }
+            if ("alter_partition".equals(methodName)) {
+                if (alterPartitionFailure != null) {
+                    throw alterPartitionFailure;
+                }
+                return null;
+            }
+            if ("add_partitions".equals(methodName)) {
+                if (addPartitionsFailure != null) {
+                    throw addPartitionsFailure;
+                }
+                return 1;
+            }
+            if ("dropPartition".equals(methodName)) {
+                if (dropPartitionFailure != null) {
+                    throw dropPartitionFailure;
+                }
+                return true;
+            }
+            if ("lock".equals(methodName)) {
+                return newLockResponse(nextLockState());
+            }
+            if ("checkLock".equals(methodName)) {
+                checkLockCalls.incrementAndGet();
+                return newLockResponse(nextLockState());
+            }
+            return defaultValue(returnType);
+        }
+
+        private LockState nextLockState() {
+            synchronized (lockStates) {
+                if (lockStates.isEmpty()) {
+                    return LockState.ACQUIRED;
+                }
+                return lockStates.removeFirst();
+            }
+        }
+
+        private LockResponse newLockResponse(LockState state) {
+            LockResponse response = new LockResponse();
+            response.setLockid(1L);
+            response.setState(state);
+            return response;
+        }
+
+        private Object defaultValue(Class<?> returnType) {
+            if (!returnType.isPrimitive()) {
+                return null;
+            }
+            if (returnType == boolean.class) {
+                return false;
+            }
+            if (returnType == byte.class) {
+                return (byte) 0;
+            }
+            if (returnType == short.class) {
+                return (short) 0;
+            }
+            if (returnType == int.class) {
+                return 0;
+            }
+            if (returnType == long.class) {
+                return 0L;
+            }
+            if (returnType == float.class) {
+                return 0F;
+            }
+            if (returnType == double.class) {
+                return 0D;
+            }
+            if (returnType == char.class) {
+                return '\0';
+            }
             return null;
         }
-        if (returnType == boolean.class) {
-            return false;
-        }
-        if (returnType == byte.class) {
-            return (byte) 0;
-        }
-        if (returnType == short.class) {
-            return (short) 0;
-        }
-        if (returnType == int.class) {
-            return 0;
-        }
-        if (returnType == long.class) {
-            return 0L;
-        }
-        if (returnType == float.class) {
-            return 0F;
-        }
-        if (returnType == double.class) {
-            return 0D;
-        }
-        if (returnType == char.class) {
-            return '\0';
-        }
-        return null;
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/ThriftHMSCachedClientTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/ThriftHMSCachedClientTest.java
@@ -65,7 +65,26 @@ public class ThriftHMSCachedClientTest {
         Assert.assertFalse(pool.getTestOnBorrow());
         Assert.assertFalse(pool.getTestOnReturn());
         Assert.assertFalse(pool.getTestWhileIdle());
+        Assert.assertEquals(60_000L, pool.getMaxWaitMillis());
         Assert.assertEquals(-1L, pool.getTimeBetweenEvictionRunsMillis());
+    }
+
+    @Test
+    public void testPoolDisabledCreatesAndClosesClientPerBorrow() throws Exception {
+        ThriftHMSCachedClient cachedClient = newClient(0);
+
+        Assert.assertNull(getPool(cachedClient));
+
+        Object firstBorrowed = borrowClient(cachedClient);
+        closeBorrowed(firstBorrowed);
+        Assert.assertEquals(1, provider.createdClients.get());
+        Assert.assertEquals(1, provider.closedClients.get());
+
+        Object secondBorrowed = borrowClient(cachedClient);
+        Assert.assertNotSame(firstBorrowed, secondBorrowed);
+        closeBorrowed(secondBorrowed);
+        Assert.assertEquals(2, provider.createdClients.get());
+        Assert.assertEquals(2, provider.closedClients.get());
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

This PR migrates `ThriftHMSCachedClient` from a self-managed queue-based HMS client pool to `commons-pool2` while keeping the external FE interface unchanged.

It also clarifies the responsibility boundary of the HMS pool:
- The pool only manages FE-side client lifecycle, including create, borrow/return, invalidate on failure, and destroy on close.
- Hive-side socket lifetime and reconnect remain handled by `RetryingMetaStoreClient`.
- The pool does not interpret `hive.metastore.client.socket.lifetime` or probe remote socket health.

Additional changes in this PR:
- Preserve throwable-based invalidation so failed borrowers are not returned to the pool.
- Fix nested borrow hazards in `updateTableStatistics` and lock polling paths under strict pool limits.
- Add FE unit coverage for normal return, invalidation, blocking borrow reuse, close behavior, and single-client nested-call behavior.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

Manual verification:
- FE compilation passed locally after the pool migration changes.
- Re-ran `bash run-fe-ut.sh --run org.apache.doris.datasource.hive.ThriftHMSCachedClientTest`; the run entered the FE unit-test build flow and reached `fe-core` compilation, but I did not wait for the full end-to-end completion in this environment.

- Behavior changed:
    - [ ] No.
    - [x] Yes. The HMS client pool implementation now uses `commons-pool2` internally, while the pool scope is explicitly limited to FE-side lifecycle management.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
