### PR TITLE
[cleanup](build) Replace #include descriptors.h with forward declaration in 11 headers

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -56,6 +56,7 @@
 #include "olap/tablet_schema.h"
 #include "olap/types.h"
 #include "olap/utils.h"
+#include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
 #include "runtime/query_context.h"
 #include "runtime/runtime_predicate.h"

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -40,7 +40,6 @@
 #include "olap/rowset/segment_v2/stream_reader.h"
 #include "olap/schema.h"
 #include "olap/tablet_schema.h"
-#include "runtime/descriptors.h"
 #include "util/once.h"
 #include "util/slice.h"
 #include "vec/columns/column.h"
@@ -56,6 +55,7 @@ class IDataType;
 
 class ShortKeyIndexDecoder;
 class Schema;
+class SlotDescriptor;
 class StorageReadOptions;
 class MemTracker;
 class PrimaryKeyIndexReader;

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -39,7 +39,6 @@
 #include "olap/olap_common.h"
 #include "olap/rowset/segment_v2/options.h"
 #include "runtime/define_primitive_type.h"
-#include "runtime/descriptors.h"
 #include "runtime/memory/lru_cache_policy.h"
 #include "util/string_util.h"
 #include "vec/aggregate_functions/aggregate_function.h"

--- a/be/src/pipeline/common/data_gen_functions/vdata_gen_function_inf.h
+++ b/be/src/pipeline/common/data_gen_functions/vdata_gen_function_inf.h
@@ -20,11 +20,11 @@
 #include <memory>
 
 #include "common/global_types.h"
-#include "runtime/descriptors.h"
 #include "vec/core/block.h"
 
 namespace doris {
 
+class TupleDescriptor;
 class RuntimeState;
 class Status;
 class TScanRangeParams;

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -30,6 +30,7 @@
 #include "pipeline/exec/meta_scan_operator.h"
 #include "pipeline/exec/olap_scan_operator.h"
 #include "pipeline/exec/operator.h"
+#include "runtime/descriptors.h"
 #include "runtime/types.h"
 #include "util/runtime_profile.h"
 #include "vec/exec/scan/scanner_context.h"

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -27,12 +27,17 @@
 #include "operator.h"
 #include "pipeline/common/runtime_filter_consumer.h"
 #include "pipeline/dependency.h"
-#include "runtime/descriptors.h"
 #include "runtime/types.h"
 #include "vec/exec/scan/vscan_node.h"
 #include "vec/exprs/vectorized_fn_call.h"
 #include "vec/exprs/vin_predicate.h"
 #include "vec/utils/util.hpp"
+
+namespace doris {
+class DescriptorTbl;
+class SlotDescriptor;
+class TupleDescriptor;
+} // namespace doris
 
 namespace doris::vectorized {
 class ScannerDelegate;

--- a/be/src/vec/exec/format/generic_reader.h
+++ b/be/src/vec/exec/format/generic_reader.h
@@ -25,6 +25,10 @@
 #include "util/profile_collector.h"
 #include "vec/exprs/vexpr_context.h"
 
+namespace doris {
+class SlotDescriptor;
+} // namespace doris
+
 namespace doris::vectorized {
 
 class Block;

--- a/be/src/vec/exec/format/table/max_compute_jni_reader.h
+++ b/be/src/vec/exec/format/table/max_compute_jni_reader.h
@@ -27,10 +27,10 @@
 
 #include "common/status.h"
 #include "exec/olap_common.h"
-#include "runtime/descriptors.h"
 #include "vec/exec/format/jni_reader.h"
 
 namespace doris {
+class MaxComputeTableDescriptor;
 class RuntimeProfile;
 class RuntimeState;
 class SlotDescriptor;

--- a/be/src/vec/exec/format/wal/wal_reader.cpp
+++ b/be/src/vec/exec/format/wal/wal_reader.cpp
@@ -22,6 +22,7 @@
 #include "cpp/sync_point.h"
 #include "gutil/strings/split.h"
 #include "olap/wal/wal_manager.h"
+#include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
 #include "vec/data_types/data_type_string.h"
 

--- a/be/src/vec/exec/format/wal/wal_reader.h
+++ b/be/src/vec/exec/format/wal/wal_reader.h
@@ -17,10 +17,10 @@
 
 #pragma once
 #include "olap/wal/wal_reader.h"
-#include "runtime/descriptors.h"
 #include "vec/exec/format/generic_reader.h"
 
 namespace doris {
+class TupleDescriptor;
 namespace vectorized {
 struct ScannerCounter;
 class WalReader : public GenericReader {

--- a/be/src/vec/jsonb/serialize.h
+++ b/be/src/vec/jsonb/serialize.h
@@ -23,7 +23,6 @@
 #include <vector>
 
 #include "olap/tablet_schema.h"
-#include "runtime/descriptors.h"
 #include "vec/columns/column_string.h"
 #include "vec/core/block.h"
 

--- a/be/src/vec/sink/vtablet_block_convertor.h
+++ b/be/src/vec/sink/vtablet_block_convertor.h
@@ -26,7 +26,6 @@
 
 #include "common/status.h"
 #include "runtime/decimalv2_value.h"
-#include "runtime/descriptors.h"
 #include "runtime/types.h"
 #include "util/bitmap.h"
 #include "vec/columns/column.h"
@@ -34,6 +33,10 @@
 #include "vec/data_types/data_type_factory.hpp"
 #include "vec/exprs/vexpr_fwd.h"
 #include "vec/sink/autoinc_buffer.h"
+
+namespace doris {
+class TupleDescriptor;
+} // namespace doris
 
 namespace doris::vectorized {
 #include "common/compile_check_begin.h"


### PR DESCRIPTION
## Summary
- Remove unused `#include "runtime/descriptors.h"` from 2 header files (`tablet_schema.h`, `serialize.h`) that do not use any descriptor types
- Replace the include with forward declarations in 7 header files that only use descriptor types as pointers/references: `vdata_gen_function_inf.h`, `scan_operator.h`, `vtablet_block_convertor.h`, `max_compute_jni_reader.h`, `wal_reader.h`, `segment.h`
- Add forward declaration for `SlotDescriptor` in `generic_reader.h` which uses the type as pointer parameter
- Move the full `#include "runtime/descriptors.h"` to corresponding `.cpp` files (`scan_operator.cpp`, `wal_reader.cpp`, `segment.cpp`) where the complete type definition is needed

This reduces the include fan-out of `runtime/descriptors.h` (535 lines) across the codebase, improving incremental build times when `descriptors.h` is modified.

### Files changed

| Header | Action |
|--------|--------|
| `olap/tablet_schema.h` | Remove include (unused) |
| `vec/jsonb/serialize.h` | Remove include (already has forward decl) |
| `pipeline/common/data_gen_functions/vdata_gen_function_inf.h` | Forward-declare `TupleDescriptor` |
| `pipeline/exec/scan_operator.h` | Forward-declare `DescriptorTbl`, `SlotDescriptor`, `TupleDescriptor` |
| `vec/sink/vtablet_block_convertor.h` | Forward-declare `TupleDescriptor` |
| `vec/exec/format/generic_reader.h` | Forward-declare `SlotDescriptor` |
| `vec/exec/format/table/max_compute_jni_reader.h` | Forward-declare `MaxComputeTableDescriptor` |
| `vec/exec/format/wal/wal_reader.h` | Forward-declare `TupleDescriptor` |
| `olap/rowset/segment_v2/segment.h` | Forward-declare `SlotDescriptor` |

## Test plan
- [ ] Verify full build passes (`run buildall`)
- [ ] No new include cycles introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)