### PR TITLE
[cleanup](build) Remove unnecessary #include query_context.h from 5 headers

### DIFF
--- a/be/src/exec/operator/operator.h
+++ b/be/src/exec/operator/operator.h
@@ -39,7 +39,6 @@
 #include "exec/operator/spill_utils.h"
 #include "exec/pipeline/dependency.h"
 #include "runtime/memory/mem_tracker.h"
-#include "runtime/query_context.h"
 #include "runtime/runtime_profile.h"
 #include "runtime/runtime_state.h"
 #include "runtime/thread_context.h"

--- a/be/src/exec/operator/spill_utils.h
+++ b/be/src/exec/operator/spill_utils.h
@@ -28,7 +28,6 @@
 #include "exec/partitioner/partitioner.h"
 #include "runtime/fragment_mgr.h"
 #include "runtime/memory/mem_tracker_limiter.h"
-#include "runtime/query_context.h"
 #include "runtime/runtime_profile.h"
 #include "runtime/runtime_state.h"
 #include "runtime/thread_context.h"

--- a/be/src/exec/pipeline/task_scheduler.h
+++ b/be/src/exec/pipeline/task_scheduler.h
@@ -30,7 +30,6 @@
 #include "common/status.h"
 #include "exec/pipeline/pipeline_task.h"
 #include "exec/pipeline/task_queue.h"
-#include "runtime/query_context.h"
 #include "runtime/workload_group/workload_group.h"
 #include "util/thread.h"
 #include "util/uid_util.h"

--- a/be/src/exec/runtime_filter/runtime_filter.cpp
+++ b/be/src/exec/runtime_filter/runtime_filter.cpp
@@ -20,6 +20,7 @@
 #include "common/status.h"
 #include "exprs/vexpr.h"
 #include "exprs/vexpr_context.h"
+#include "runtime/query_context.h"
 #include "runtime/runtime_state.h"
 #include "util/brpc_client_cache.h"
 #include "util/brpc_closure.h"

--- a/be/src/exec/runtime_filter/runtime_filter.h
+++ b/be/src/exec/runtime_filter/runtime_filter.h
@@ -24,7 +24,6 @@
 #include "exec/runtime_filter/runtime_filter_definitions.h"
 #include "exec/runtime_filter/runtime_filter_wrapper.h"
 #include "exec/runtime_filter/utils.h"
-#include "runtime/query_context.h"
 
 namespace doris {
 #include "common/compile_check_begin.h"

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -35,7 +35,6 @@
 #include "common/metrics/metrics.h"
 #include "common/status.h"
 #include "exec/runtime_filter/runtime_filter_mgr.h"
-#include "runtime/query_context.h"
 #include "service/http/rest_monitor_iface.h"
 #include "util/countdown_latch.h"
 #include "util/hash_util.hpp" // IWYU pragma: keep


### PR DESCRIPTION
## Summary
- Remove unused `#include "runtime/query_context.h"` from 5 header files (`operator.h`, `spill_utils.h`, `task_scheduler.h`, `runtime_filter.h`, `fragment_mgr.h`) that don't use `QueryContext` or already have a forward declaration
- Add the include to `runtime_filter.cpp` which uses `QueryContext` directly and was previously getting it transitively through the header

## Test plan
- [ ] Verify build compiles successfully (`run buildall`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)