### PR TITLE
[cleanup](build) Replace #include runtime_profile.h with forward declaration in headers

### DIFF
--- a/be/src/io/fs/hdfs_file_system.h
+++ b/be/src/io/fs/hdfs_file_system.h
@@ -32,9 +32,9 @@
 #include "io/fs/hdfs.h"
 #include "io/fs/path.h"
 #include "io/fs/remote_file_system.h"
-#include "util/runtime_profile.h"
 
 namespace doris {
+class RuntimeProfile;
 class THdfsParams;
 
 namespace io {

--- a/be/src/runtime/memory/cache_manager.h
+++ b/be/src/runtime/memory/cache_manager.h
@@ -22,10 +22,11 @@
 
 #include "runtime/exec_env.h"
 #include "runtime/memory/cache_policy.h"
-#include "util/runtime_profile.h"
 #include "util/time.h"
 
 namespace doris {
+
+class RuntimeProfile;
 
 // Hold the list of all caches, for prune when memory not enough or timing.
 class CacheManager {

--- a/be/src/vec/sink/load_stream_map_pool.h
+++ b/be/src/vec/sink/load_stream_map_pool.h
@@ -55,7 +55,6 @@
 #include "runtime/thread_context.h"
 #include "runtime/types.h"
 #include "util/countdown_latch.h"
-#include "util/runtime_profile.h"
 #include "util/stopwatch.hpp"
 #include "vec/columns/column.h"
 #include "vec/common/allocator.h"

--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -60,7 +60,6 @@
 #include "runtime/types.h"
 #include "util/countdown_latch.h"
 #include "util/debug_points.h"
-#include "util/runtime_profile.h"
 #include "util/stopwatch.hpp"
 #include "vec/columns/column.h"
 #include "vec/common/allocator.h"

--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -43,7 +43,6 @@
 #include "pipeline/exec/exchange_sink_buffer.h"
 #include "service/backend_options.h"
 #include "util/ref_count_closure.h"
-#include "util/runtime_profile.h"
 #include "util/uid_util.h"
 #include "vec/core/block.h"
 #include "vec/exprs/vexpr_context.h"


### PR DESCRIPTION
## Summary
- Remove unused `#include "util/runtime_profile.h"` from 3 header files that don't reference `RuntimeProfile` at all: `vdata_stream_sender.h`, `load_stream_map_pool.h`, `load_stream_stub.h`
- Replace the include with `class RuntimeProfile;` forward declaration in 2 header files that only use `RuntimeProfile*` (pointer): `hdfs_file_system.h`, `cache_manager.h`
- `cache_manager.cpp` already had its own `#include "util/runtime_profile.h"`, so no .cpp changes needed

This reduces the include fan-out of `runtime_profile.h` (~826 lines) across the build graph.

## Files changed
| File | Action |
|------|--------|
| `be/src/vec/sink/vdata_stream_sender.h` | Removed unused include |
| `be/src/vec/sink/load_stream_map_pool.h` | Removed unused include |
| `be/src/vec/sink/load_stream_stub.h` | Removed unused include |
| `be/src/io/fs/hdfs_file_system.h` | Replaced include with forward declaration |
| `be/src/runtime/memory/cache_manager.h` | Replaced include with forward declaration |

## Test plan
- [ ] Compile BE (`build.sh --be`) to verify no missing-type errors
- [ ] Run BE unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)