### PR TITLE
[cleanup](build) Replace #include exec_env.h with forward declaration in 19 headers

### DIFF
--- a/be/src/agent/workload_sched_policy_listener.cpp
+++ b/be/src/agent/workload_sched_policy_listener.cpp
@@ -17,6 +17,7 @@
 
 #include "agent/workload_sched_policy_listener.h"
 
+#include "runtime/exec_env.h"
 #include "runtime/workload_management/workload_action.h"
 #include "runtime/workload_management/workload_condition.h"
 #include "runtime/workload_management/workload_sched_policy.h"

--- a/be/src/agent/workload_sched_policy_listener.h
+++ b/be/src/agent/workload_sched_policy_listener.h
@@ -20,9 +20,9 @@
 #include <glog/logging.h>
 
 #include "agent/topic_listener.h"
-#include "runtime/exec_env.h"
 
 namespace doris {
+class ExecEnv;
 
 class WorkloadschedPolicyListener : public TopicListener {
 public:

--- a/be/src/exec/operator/aggregation_sink_operator.h
+++ b/be/src/exec/operator/aggregation_sink_operator.h
@@ -20,7 +20,6 @@
 #include <stdint.h>
 
 #include "exec/operator/operator.h"
-#include "runtime/exec_env.h"
 #include "runtime/runtime_profile.h"
 
 namespace doris {

--- a/be/src/exec/scan/scanner.h
+++ b/be/src/exec/scan/scanner.h
@@ -25,7 +25,6 @@
 
 #include "common/status.h"
 #include "core/block/block.h"
-#include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
 #include "storage/tablet/tablet.h"
 #include "util/stopwatch.hpp"

--- a/be/src/exec/sink/load_stream_map_pool.h
+++ b/be/src/exec/sink/load_stream_map_pool.h
@@ -54,7 +54,6 @@
 #include "core/data_type/data_type.h"
 #include "exec/sink/load_stream_stub.h"
 #include "exprs/vexpr_fwd.h"
-#include "runtime/exec_env.h"
 #include "runtime/memory/mem_tracker.h"
 #include "runtime/runtime_profile.h"
 #include "runtime/thread_context.h"

--- a/be/src/exec/sink/load_stream_stub.h
+++ b/be/src/exec/sink/load_stream_stub.h
@@ -57,7 +57,6 @@
 #include "core/column/column.h"
 #include "core/data_type/data_type.h"
 #include "exprs/vexpr_fwd.h"
-#include "runtime/exec_env.h"
 #include "runtime/memory/mem_tracker.h"
 #include "runtime/runtime_profile.h"
 #include "runtime/thread_context.h"

--- a/be/src/exec/sink/writer/vtablet_writer.h
+++ b/be/src/exec/sink/writer/vtablet_writer.h
@@ -61,7 +61,6 @@
 #include "exec/sink/vtablet_finder.h"
 #include "exec/sink/writer/async_result_writer.h"
 #include "exprs/vexpr_fwd.h"
-#include "runtime/exec_env.h"
 #include "runtime/memory/mem_tracker.h"
 #include "runtime/runtime_profile.h"
 #include "runtime/thread_context.h"

--- a/be/src/exec/sink/writer/vtablet_writer_v2.h
+++ b/be/src/exec/sink/writer/vtablet_writer_v2.h
@@ -56,7 +56,6 @@
 #include "exec/sink/vrow_distribution.h"
 #include "exec/sink/writer/async_result_writer.h"
 #include "exprs/vexpr_fwd.h"
-#include "runtime/exec_env.h"
 #include "runtime/memory/mem_tracker.h"
 #include "runtime/runtime_profile.h"
 #include "runtime/thread_context.h"

--- a/be/src/load/group_commit/group_commit_mgr.h
+++ b/be/src/load/group_commit/group_commit_mgr.h
@@ -33,7 +33,6 @@
 #include "core/block/block.h"
 #include "exec/sink/writer/vwal_writer.h"
 #include "load/group_commit/wal/wal_manager.h"
-#include "runtime/exec_env.h"
 #include "util/threadpool.h"
 
 namespace doris {

--- a/be/src/load/group_commit/wal/wal_info.h
+++ b/be/src/load/group_commit/wal/wal_info.h
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 #pragma once
-#include "runtime/exec_env.h"
 
 namespace doris {
 class WalInfo {

--- a/be/src/load/group_commit/wal/wal_manager.h
+++ b/be/src/load/group_commit/wal/wal_manager.h
@@ -38,11 +38,11 @@
 #include "load/group_commit/wal/wal_table.h"
 #include "load/group_commit/wal/wal_writer.h"
 #include "load/stream_load/stream_load_context.h"
-#include "runtime/exec_env.h"
 #include "util/thread.h"
 #include "util/threadpool.h"
 
 namespace doris {
+class ExecEnv;
 class WalManager {
     ENABLE_FACTORY_CREATOR(WalManager);
     struct ScanWalInfo {

--- a/be/src/load/group_commit/wal/wal_table.cpp
+++ b/be/src/load/group_commit/wal/wal_table.cpp
@@ -30,6 +30,7 @@
 #include "service/http/http_common.h"
 #include "service/http/http_headers.h"
 #include "service/http/utils.h"
+#include "runtime/exec_env.h"
 #include "util/client_cache.h"
 #include "util/path_util.h"
 #include "util/thrift_rpc_helper.h"

--- a/be/src/load/group_commit/wal/wal_table.h
+++ b/be/src/load/group_commit/wal/wal_table.h
@@ -27,10 +27,10 @@
 #include "common/status.h"
 #include "load/group_commit/wal/wal_info.h"
 #include "load/stream_load/stream_load_context.h"
-#include "runtime/exec_env.h"
 #include "service/http/action/http_stream.h"
 
 namespace doris {
+class ExecEnv;
 class WalTable {
 public:
     WalTable(ExecEnv* exec_env, int64_t db_id, int64_t table_id);

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -35,7 +35,6 @@
 #include "common/status.h"
 #include "exec/runtime_filter/runtime_filter_mgr.h"
 #include "exec/scan/scanner_scheduler.h"
-#include "runtime/exec_env.h"
 #include "runtime/memory/mem_tracker_limiter.h"
 #include "runtime/runtime_predicate.h"
 #include "runtime/workload_group/workload_group.h"
@@ -44,6 +43,7 @@
 #include "util/threadpool.h"
 
 namespace doris {
+class ExecEnv;
 
 class PipelineFragmentContext;
 class PipelineTask;

--- a/be/src/runtime/workload_management/workload_sched_policy_mgr.cpp
+++ b/be/src/runtime/workload_management/workload_sched_policy_mgr.cpp
@@ -20,6 +20,7 @@
 #include <memory>
 
 #include "common/config.h"
+#include "runtime/exec_env.h"
 #include "runtime/fragment_mgr.h"
 #include "runtime/workload_management/resource_context.h"
 

--- a/be/src/runtime/workload_management/workload_sched_policy_mgr.h
+++ b/be/src/runtime/workload_management/workload_sched_policy_mgr.h
@@ -17,11 +17,12 @@
 
 #pragma once
 
-#include "runtime/exec_env.h"
 #include "runtime/workload_management/workload_sched_policy.h"
 #include "util/countdown_latch.h"
 
 namespace doris {
+class ExecEnv;
+class Thread;
 
 class WorkloadSchedPolicyMgr {
 public:

--- a/be/src/service/http/action/check_encryption_action.h
+++ b/be/src/service/http/action/check_encryption_action.h
@@ -18,11 +18,11 @@
 #include <gen_cpp/FrontendService_types.h>
 
 #include "cloud/cloud_tablet_mgr.h"
-#include "runtime/exec_env.h"
 #include "service/http/http_handler_with_auth.h"
 #include "service/http/http_request.h"
 #include "storage/tablet/tablet_manager.h"
 namespace doris {
+class ExecEnv;
 
 class CheckEncryptionAction : public HttpHandlerWithAuth {
 public:

--- a/be/src/service/http/action/compaction_score_action.cpp
+++ b/be/src/service/http/action/compaction_score_action.cpp
@@ -42,6 +42,7 @@
 #include "cloud/cloud_tablet_mgr.h"
 #include "cloud/config.h"
 #include "common/status.h"
+#include "runtime/exec_env.h"
 #include "service/http/http_channel.h"
 #include "service/http/http_handler_with_auth.h"
 #include "service/http/http_headers.h"

--- a/be/src/service/http/action/compaction_score_action.h
+++ b/be/src/service/http/action/compaction_score_action.h
@@ -25,11 +25,11 @@
 
 #include "cloud/cloud_tablet_mgr.h"
 #include "common/status.h"
-#include "runtime/exec_env.h"
 #include "service/http/http_handler_with_auth.h"
 #include "service/http/http_request.h"
 #include "storage/storage_engine.h"
 namespace doris {
+class ExecEnv;
 
 struct CompactionScoreResult {
     int64_t tablet_id;

--- a/be/src/service/http/http_handler_with_auth.cpp
+++ b/be/src/service/http/http_handler_with_auth.cpp
@@ -19,6 +19,7 @@
 
 #include <gen_cpp/HeartbeatService_types.h>
 
+#include "runtime/exec_env.h"
 #include "service/http/http_channel.h"
 #include "service/http/utils.h"
 #include "util/client_cache.h"

--- a/be/src/service/http/http_handler_with_auth.h
+++ b/be/src/service/http/http_handler_with_auth.h
@@ -19,7 +19,6 @@
 
 #include <gen_cpp/FrontendService.h>
 
-#include "runtime/exec_env.h"
 #include "service/http/http_handler.h"
 
 namespace doris {

--- a/be/src/storage/metadata_adder.h
+++ b/be/src/storage/metadata_adder.h
@@ -20,7 +20,6 @@
 #include <bvar/bvar.h>
 #include <stdint.h>
 
-#include "runtime/exec_env.h"
 #include "runtime/memory/mem_tracker_limiter.h"
 #include "runtime/runtime_profile.h"
 

--- a/be/src/storage/rowset/rowset_writer_context.h
+++ b/be/src/storage/rowset/rowset_writer_context.h
@@ -31,7 +31,6 @@
 #include "io/fs/file_system.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/packed_file_system.h"
-#include "runtime/exec_env.h"
 #include "storage/olap_define.h"
 #include "storage/partial_update_info.h"
 #include "storage/storage_policy.h"

--- a/be/src/storage/segment/page_handle.h
+++ b/be/src/storage/segment/page_handle.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include "runtime/exec_env.h"
 #include "storage/cache/page_cache.h"
 #include "util/slice.h" // for Slice
 


### PR DESCRIPTION
## Summary
- Remove unused `#include "runtime/exec_env.h"` from 10 header files that don't reference ExecEnv
- Replace with `class ExecEnv;` forward declaration in 9 header files that only use `ExecEnv*` pointer
- Move full include to corresponding .cpp files where needed
- Add `class Thread;` forward declaration in `workload_sched_policy_mgr.h` (was transitively included via exec_env.h)

### Files changed (24 files)

**Headers - include removed (unused):**
- `exec/operator/aggregation_sink_operator.h`
- `exec/scan/scanner.h`
- `exec/sink/load_stream_map_pool.h`
- `exec/sink/load_stream_stub.h`
- `exec/sink/writer/vtablet_writer.h`
- `exec/sink/writer/vtablet_writer_v2.h`
- `load/group_commit/wal/wal_info.h`
- `storage/metadata_adder.h`
- `storage/rowset/rowset_writer_context.h`
- `storage/segment/page_handle.h`

**Headers - replaced with forward declaration:**
- `agent/workload_sched_policy_listener.h`
- `load/group_commit/group_commit_mgr.h`
- `load/group_commit/wal/wal_manager.h`
- `load/group_commit/wal/wal_table.h`
- `runtime/query_context.h`
- `runtime/workload_management/workload_sched_policy_mgr.h`
- `service/http/action/check_encryption_action.h`
- `service/http/action/compaction_score_action.h`
- `service/http/http_handler_with_auth.h`

**CPP files - added full include:**
- `agent/workload_sched_policy_listener.cpp`
- `load/group_commit/wal/wal_table.cpp`
- `runtime/workload_management/workload_sched_policy_mgr.cpp`
- `service/http/action/compaction_score_action.cpp`
- `service/http/http_handler_with_auth.cpp`

## Test plan
- [x] Full BE compilation verified on build server
- [ ] CI buildall

🤖 Generated with [Claude Code](https://claude.com/claude-code)