### PR TITLE
[fix](load) Use atomic operations for _try_close flag and remove unused _close_wait

### DIFF
--- a/be/src/exec/sink/writer/vtablet_writer.cpp
+++ b/be/src/exec/sink/writer/vtablet_writer.cpp
@@ -1395,7 +1395,7 @@ void VTabletWriter::_send_batch_process() {
         // we must RECHECK opened_nodes below, after got closed signal, because it may changed. Think of this:
         //      checked opened_nodes = 0 ---> new block arrived ---> task finished, close() was called ---> we got _try_close here
         // if we don't check again, we may lose the last package.
-        if (_try_close) {
+        if (_try_close.load(std::memory_order_acquire)) {
             opened_nodes = 0;
             std::ranges::for_each(_channels,
                                   [&opened_nodes](const std::shared_ptr<IndexChannel>& ich) {
@@ -1785,7 +1785,7 @@ void VTabletWriter::_do_try_close(RuntimeState* state, const Status& exec_status
         status = _send_new_partition_batch();
     }
 
-    _try_close = true; // will stop periodic thread
+    _try_close.store(true, std::memory_order_release); // will stop periodic thread
     if (status.ok()) {
         // BE id -> add_batch method counter
         std::unordered_map<int64_t, AddBatchCounter> node_add_batch_counter_map;
@@ -1866,7 +1866,6 @@ void VTabletWriter::_do_try_close(RuntimeState* state, const Status& exec_status
     if (!status.ok()) {
         _cancel_all_channel(status);
         _close_status = status;
-        _close_wait = true;
     }
 }
 

--- a/be/src/exec/sink/writer/vtablet_writer.h
+++ b/be/src/exec/sink/writer/vtablet_writer.h
@@ -752,9 +752,8 @@ private:
     // Save the status of try_close() and close() method
     Status _close_status;
     // if we called try_close(), for auto partition the periodic send thread should stop if it's still waiting for node channels first-time open.
-    bool _try_close = false;
-    // for non-pipeline, if close() did something, close_wait() should wait it.
-    bool _close_wait = false;
+    // atomic: written by pthread (_do_try_close), read by bthread (_send_batch_process)
+    std::atomic<bool> _try_close {false};
     bool _inited = false;
     bool _write_file_cache = false;
 


### PR DESCRIPTION
- Change `_try_close` from `bool` to `std::atomic<bool>` with acquire/release memory ordering
- Use `memory_order_acquire` when reading in `_send_batch_process()` (bthread)
- Use `memory_order_release` when writing in `_do_try_close()` (pthread)
- Remove unused `_close_wait` field

This fixes a potential race condition where `_try_close` is written by pthread and read by bthread without proper synchronization.

It's ok on x86 so no test added.