### PR TITLE
[fix](fe) Fix bugs in SummaryProfile and StmtExecutor metric reporting

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
@@ -1198,7 +1198,7 @@ public class SummaryProfile {
     }
 
     public void addNereidsPartitiionPruneTime(long ms) {
-        this.externalTvfInitTime += ms;
+        this.nereidsPartitiionPruneTime += ms;
     }
 
     public long getNereidsPartitiionPruneTimeMs() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -845,7 +845,7 @@ public class StmtExecutor {
                     MetricRepo.HISTO_PLAN_OPTIMIZE_DURATION.update(nereidsOptimizeTimeMs);
                 }
                 int nereidsTranslateTimeMs = summaryProfile.getNereidsTranslateTimeMs();
-                if (nereidsOptimizeTimeMs >= 0) {
+                if (nereidsTranslateTimeMs >= 0) {
                     MetricRepo.HISTO_PLAN_TRANSLATE_DURATION.update(nereidsTranslateTimeMs);
                 }
                 long initScanNodeTimeMs = summaryProfile.getInitScanNodeTimeMs();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

Fix three bugs found in SummaryProfile and StmtExecutor:

1. **Wrong field assignment in `addNereidsPartitiionPruneTime()`** (SummaryProfile.java):
   The method was incorrectly accumulating partition prune time into `externalTvfInitTime`
   instead of `nereidsPartitiionPruneTime`. This caused:
   - `nereidsPartitiionPruneTime` to always be 0, so `HISTO_PLAN_PARTITION_PRUNE_DURATION`
     metric never collected correct data
   - `externalTvfInitTime` to be polluted with unrelated partition prune time data

2. **Wrong guard variable for translate metric** (StmtExecutor.java):
   When reporting `HISTO_PLAN_TRANSLATE_DURATION`, the condition checked
   `nereidsOptimizeTimeMs >= 0` instead of `nereidsTranslateTimeMs >= 0`.
   This means the translate metric was gated by the optimize time value
   rather than the translate time value itself.

### Release note

None

### Check List (For Author)

- Test: No need to test - trivial one-line bug fix with obvious correctness
- Behavior changed: No
- Does this need documentation: No