### PR TITLE
[env](compiler)Optimize the compilation time of aggregate_function_orthogonal_bitmap.cpp

### DIFF
--- a/be/src/exprs/aggregate/aggregate_function_orth_bitmap_expr_cal.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_orth_bitmap_expr_cal.cpp
@@ -1,0 +1,38 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "core/data_type/data_type.h"
+#include "exprs/aggregate/aggregate_function_orthogonal_bitmap.h"
+#include "exprs/aggregate/helpers.h"
+
+namespace doris {
+#include "common/compile_check_begin.h"
+
+// FE guarantees exactly 3 params: (bitmap, varchar_filter, varchar_expr)
+AggregateFunctionPtr create_aggregate_function_orth_bitmap_expr_cal(
+        const std::string& name, const DataTypes& argument_types, const DataTypePtr& result_type,
+        const bool result_is_nullable, const AggregateFunctionAttr& attr) {
+    if (argument_types.size() != 3) {
+        LOG(WARNING) << "Incorrect number of arguments for aggregate function " << name;
+        return nullptr;
+    }
+    return creator_without_type::create<
+            AggFunctionOrthBitmapFunc<AggOrthBitMapExprCal<TYPE_STRING>, MultiExpression>>(
+            argument_types, result_is_nullable, attr);
+}
+
+} // namespace doris

--- a/be/src/exprs/aggregate/aggregate_function_orth_bitmap_expr_cal_count.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_orth_bitmap_expr_cal_count.cpp
@@ -1,0 +1,38 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "core/data_type/data_type.h"
+#include "exprs/aggregate/aggregate_function_orthogonal_bitmap.h"
+#include "exprs/aggregate/helpers.h"
+
+namespace doris {
+#include "common/compile_check_begin.h"
+
+// FE guarantees exactly 3 params: (bitmap, varchar_filter, varchar_expr)
+AggregateFunctionPtr create_aggregate_function_orth_bitmap_expr_cal_count(
+        const std::string& name, const DataTypes& argument_types, const DataTypePtr& result_type,
+        const bool result_is_nullable, const AggregateFunctionAttr& attr) {
+    if (argument_types.size() != 3) {
+        LOG(WARNING) << "Incorrect number of arguments for aggregate function " << name;
+        return nullptr;
+    }
+    return creator_without_type::create<
+            AggFunctionOrthBitmapFunc<AggOrthBitMapExprCalCount<TYPE_STRING>, MultiExpression>>(
+            argument_types, result_is_nullable, attr);
+}
+
+} // namespace doris

--- a/be/src/exprs/aggregate/aggregate_function_orth_bitmap_intersect.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_orth_bitmap_intersect.cpp
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "exprs/aggregate/aggregate_function_orthogonal_bitmap_impl.h"
+
+namespace doris {
+#include "common/compile_check_begin.h"
+
+AggregateFunctionPtr create_aggregate_function_orth_bitmap_intersect(
+        const std::string& name, const DataTypes& argument_types, const DataTypePtr& result_type,
+        const bool result_is_nullable, const AggregateFunctionAttr& attr) {
+    return create_aggregate_function_orthogonal<AggOrthBitMapIntersect>(
+            name, argument_types, result_type, result_is_nullable, attr);
+}
+
+} // namespace doris

--- a/be/src/exprs/aggregate/aggregate_function_orth_bitmap_intersect_count.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_orth_bitmap_intersect_count.cpp
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "exprs/aggregate/aggregate_function_orthogonal_bitmap_impl.h"
+
+namespace doris {
+#include "common/compile_check_begin.h"
+
+AggregateFunctionPtr create_aggregate_function_orth_bitmap_intersect_count(
+        const std::string& name, const DataTypes& argument_types, const DataTypePtr& result_type,
+        const bool result_is_nullable, const AggregateFunctionAttr& attr) {
+    return create_aggregate_function_orthogonal<AggOrthBitMapIntersectCount>(
+            name, argument_types, result_type, result_is_nullable, attr);
+}
+
+} // namespace doris

--- a/be/src/exprs/aggregate/aggregate_function_orth_bitmap_union_count.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_orth_bitmap_union_count.cpp
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "core/data_type/data_type.h"
+#include "exprs/aggregate/aggregate_function_orthogonal_bitmap.h"
+#include "exprs/aggregate/helpers.h"
+
+namespace doris {
+#include "common/compile_check_begin.h"
+
+AggregateFunctionPtr create_aggregate_function_orth_bitmap_union_count(
+        const std::string& name, const DataTypes& argument_types, const DataTypePtr& result_type,
+        const bool result_is_nullable, const AggregateFunctionAttr& attr) {
+    if (argument_types.empty()) {
+        LOG(WARNING) << "Incorrect number of arguments for aggregate function " << name;
+        return nullptr;
+    }
+    return creator_without_type::create<
+            AggFunctionOrthBitmapFunc<OrthBitmapUnionCountData, UnaryExpression>>(
+            argument_types, result_is_nullable, attr);
+}
+
+} // namespace doris

--- a/be/src/exprs/aggregate/aggregate_function_orth_intersect_count.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_orth_intersect_count.cpp
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "exprs/aggregate/aggregate_function_orthogonal_bitmap_impl.h"
+
+namespace doris {
+#include "common/compile_check_begin.h"
+
+AggregateFunctionPtr create_aggregate_function_orth_intersect_count(
+        const std::string& name, const DataTypes& argument_types, const DataTypePtr& result_type,
+        const bool result_is_nullable, const AggregateFunctionAttr& attr) {
+    return create_aggregate_function_orthogonal<AggIntersectCount>(
+            name, argument_types, result_type, result_is_nullable, attr);
+}
+
+} // namespace doris

--- a/be/src/exprs/aggregate/aggregate_function_orthogonal_bitmap.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_orthogonal_bitmap.cpp
@@ -15,70 +15,58 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "exprs/aggregate/aggregate_function_orthogonal_bitmap.h"
-
-#include <map>
-#include <ostream>
+#include <string>
 
 #include "core/data_type/data_type.h"
-#include "core/data_type/data_type_nullable.h"
+#include "exprs/aggregate/aggregate_function.h"
 #include "exprs/aggregate/aggregate_function_simple_factory.h"
-#include "exprs/aggregate/helpers.h"
 
 namespace doris {
 #include "common/compile_check_begin.h"
-struct StringRef;
-} // namespace doris
 
-namespace doris {
+AggregateFunctionPtr create_aggregate_function_orth_bitmap_intersect(
+        const std::string& name, const DataTypes& argument_types,
+        const DataTypePtr& result_type, const bool result_is_nullable,
+        const AggregateFunctionAttr& attr);
 
-template <template <PrimitiveType> class Impl>
-AggregateFunctionPtr create_aggregate_function_orthogonal(const std::string& name,
-                                                          const DataTypes& argument_types,
-                                                          const DataTypePtr& result_type,
-                                                          const bool result_is_nullable,
-                                                          const AggregateFunctionAttr& attr) {
-    if (argument_types.empty()) {
-        LOG(WARNING) << "Incorrect number of arguments for aggregate function " << name;
-        return nullptr;
-    } else if (argument_types.size() == 1) {
-        return creator_without_type::create<AggFunctionOrthBitmapFunc<Impl<TYPE_STRING>>>(
-                argument_types, result_is_nullable, attr);
-    } else {
-        AggregateFunctionPtr res(
-                creator_with_type_list_base<1, TYPE_TINYINT, TYPE_SMALLINT, TYPE_INT, TYPE_BIGINT,
-                                            TYPE_LARGEINT>::create<AggFunctionOrthBitmapFunc,
-                                                                   Impl>(argument_types,
-                                                                         result_is_nullable, attr));
-        if (res) {
-            return res;
-        } else if (is_string_type(argument_types[1]->get_primitive_type())) {
-            res = creator_without_type::create<AggFunctionOrthBitmapFunc<Impl<TYPE_STRING>>>(
-                    argument_types, result_is_nullable, attr);
-            return res;
-        }
+AggregateFunctionPtr create_aggregate_function_orth_bitmap_intersect_count(
+        const std::string& name, const DataTypes& argument_types,
+        const DataTypePtr& result_type, const bool result_is_nullable,
+        const AggregateFunctionAttr& attr);
 
-        const IDataType& argument_type = *argument_types[1];
-        LOG(WARNING) << "Incorrect Type " << argument_type.get_name()
-                     << " of arguments for aggregate function " << name;
-        return nullptr;
-    }
-}
+AggregateFunctionPtr create_aggregate_function_orth_bitmap_union_count(
+        const std::string& name, const DataTypes& argument_types,
+        const DataTypePtr& result_type, const bool result_is_nullable,
+        const AggregateFunctionAttr& attr);
+
+AggregateFunctionPtr create_aggregate_function_orth_intersect_count(
+        const std::string& name, const DataTypes& argument_types,
+        const DataTypePtr& result_type, const bool result_is_nullable,
+        const AggregateFunctionAttr& attr);
+
+AggregateFunctionPtr create_aggregate_function_orth_bitmap_expr_cal(
+        const std::string& name, const DataTypes& argument_types,
+        const DataTypePtr& result_type, const bool result_is_nullable,
+        const AggregateFunctionAttr& attr);
+
+AggregateFunctionPtr create_aggregate_function_orth_bitmap_expr_cal_count(
+        const std::string& name, const DataTypes& argument_types,
+        const DataTypePtr& result_type, const bool result_is_nullable,
+        const AggregateFunctionAttr& attr);
 
 void register_aggregate_function_orthogonal_bitmap(AggregateFunctionSimpleFactory& factory) {
     factory.register_function_both("orthogonal_bitmap_intersect",
-                                   create_aggregate_function_orthogonal<AggOrthBitMapIntersect>);
-    factory.register_function_both(
-            "orthogonal_bitmap_intersect_count",
-            create_aggregate_function_orthogonal<AggOrthBitMapIntersectCount>);
+                                   create_aggregate_function_orth_bitmap_intersect);
+    factory.register_function_both("orthogonal_bitmap_intersect_count",
+                                   create_aggregate_function_orth_bitmap_intersect_count);
     factory.register_function_both("orthogonal_bitmap_union_count",
-                                   create_aggregate_function_orthogonal<OrthBitmapUnionCountData>);
+                                   create_aggregate_function_orth_bitmap_union_count);
     factory.register_function_both("intersect_count",
-                                   create_aggregate_function_orthogonal<AggIntersectCount>);
+                                   create_aggregate_function_orth_intersect_count);
     factory.register_function_both("orthogonal_bitmap_expr_calculate",
-                                   create_aggregate_function_orthogonal<AggOrthBitMapExprCal>);
+                                   create_aggregate_function_orth_bitmap_expr_cal);
     factory.register_function_both("orthogonal_bitmap_expr_calculate_count",
-                                   create_aggregate_function_orthogonal<AggOrthBitMapExprCalCount>);
+                                   create_aggregate_function_orth_bitmap_expr_cal_count);
 }
 
 } // namespace doris

--- a/be/src/exprs/aggregate/aggregate_function_orthogonal_bitmap.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_orthogonal_bitmap.cpp
@@ -25,34 +25,28 @@ namespace doris {
 #include "common/compile_check_begin.h"
 
 AggregateFunctionPtr create_aggregate_function_orth_bitmap_intersect(
-        const std::string& name, const DataTypes& argument_types,
-        const DataTypePtr& result_type, const bool result_is_nullable,
-        const AggregateFunctionAttr& attr);
+        const std::string& name, const DataTypes& argument_types, const DataTypePtr& result_type,
+        const bool result_is_nullable, const AggregateFunctionAttr& attr);
 
 AggregateFunctionPtr create_aggregate_function_orth_bitmap_intersect_count(
-        const std::string& name, const DataTypes& argument_types,
-        const DataTypePtr& result_type, const bool result_is_nullable,
-        const AggregateFunctionAttr& attr);
+        const std::string& name, const DataTypes& argument_types, const DataTypePtr& result_type,
+        const bool result_is_nullable, const AggregateFunctionAttr& attr);
 
 AggregateFunctionPtr create_aggregate_function_orth_bitmap_union_count(
-        const std::string& name, const DataTypes& argument_types,
-        const DataTypePtr& result_type, const bool result_is_nullable,
-        const AggregateFunctionAttr& attr);
+        const std::string& name, const DataTypes& argument_types, const DataTypePtr& result_type,
+        const bool result_is_nullable, const AggregateFunctionAttr& attr);
 
 AggregateFunctionPtr create_aggregate_function_orth_intersect_count(
-        const std::string& name, const DataTypes& argument_types,
-        const DataTypePtr& result_type, const bool result_is_nullable,
-        const AggregateFunctionAttr& attr);
+        const std::string& name, const DataTypes& argument_types, const DataTypePtr& result_type,
+        const bool result_is_nullable, const AggregateFunctionAttr& attr);
 
 AggregateFunctionPtr create_aggregate_function_orth_bitmap_expr_cal(
-        const std::string& name, const DataTypes& argument_types,
-        const DataTypePtr& result_type, const bool result_is_nullable,
-        const AggregateFunctionAttr& attr);
+        const std::string& name, const DataTypes& argument_types, const DataTypePtr& result_type,
+        const bool result_is_nullable, const AggregateFunctionAttr& attr);
 
 AggregateFunctionPtr create_aggregate_function_orth_bitmap_expr_cal_count(
-        const std::string& name, const DataTypes& argument_types,
-        const DataTypePtr& result_type, const bool result_is_nullable,
-        const AggregateFunctionAttr& attr);
+        const std::string& name, const DataTypes& argument_types, const DataTypePtr& result_type,
+        const bool result_is_nullable, const AggregateFunctionAttr& attr);
 
 void register_aggregate_function_orthogonal_bitmap(AggregateFunctionSimpleFactory& factory) {
     factory.register_function_both("orthogonal_bitmap_intersect",

--- a/be/src/exprs/aggregate/aggregate_function_orthogonal_bitmap.h
+++ b/be/src/exprs/aggregate/aggregate_function_orthogonal_bitmap.h
@@ -381,7 +381,8 @@ public:
     String get_name() const override { return Impl::name; }
 
     AggFunctionOrthBitmapFunc(const DataTypes& argument_types_)
-            : IAggregateFunctionDataHelper<Impl, AggFunctionOrthBitmapFunc<Impl, ExprTag>>(argument_types_),
+            : IAggregateFunctionDataHelper<Impl, AggFunctionOrthBitmapFunc<Impl, ExprTag>>(
+                      argument_types_),
               // The number of arguments will not exceed the size of an int
               _argument_size(int(argument_types_.size())) {}
 

--- a/be/src/exprs/aggregate/aggregate_function_orthogonal_bitmap.h
+++ b/be/src/exprs/aggregate/aggregate_function_orthogonal_bitmap.h
@@ -336,7 +336,6 @@ private:
     int64_t result = 0;
 };
 
-template <PrimitiveType T>
 struct OrthBitmapUnionCountData {
     static constexpr auto name = "orthogonal_bitmap_union_count";
 
@@ -373,16 +372,16 @@ private:
     int64_t result = 0;
 };
 
-template <typename Impl>
+template <typename Impl, typename ExprTag = VarargsExpression>
 class AggFunctionOrthBitmapFunc final
-        : public IAggregateFunctionDataHelper<Impl, AggFunctionOrthBitmapFunc<Impl>>,
-          VarargsExpression,
+        : public IAggregateFunctionDataHelper<Impl, AggFunctionOrthBitmapFunc<Impl, ExprTag>>,
+          ExprTag,
           NullableAggregateFunction {
 public:
     String get_name() const override { return Impl::name; }
 
     AggFunctionOrthBitmapFunc(const DataTypes& argument_types_)
-            : IAggregateFunctionDataHelper<Impl, AggFunctionOrthBitmapFunc<Impl>>(argument_types_),
+            : IAggregateFunctionDataHelper<Impl, AggFunctionOrthBitmapFunc<Impl, ExprTag>>(argument_types_),
               // The number of arguments will not exceed the size of an int
               _argument_size(int(argument_types_.size())) {}
 

--- a/be/src/exprs/aggregate/aggregate_function_orthogonal_bitmap_impl.h
+++ b/be/src/exprs/aggregate/aggregate_function_orthogonal_bitmap_impl.h
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <string>
+
+#include "core/data_type/data_type.h"
+#include "core/data_type/data_type_nullable.h"
+#include "exprs/aggregate/aggregate_function_orthogonal_bitmap.h"
+#include "exprs/aggregate/helpers.h"
+
+namespace doris {
+
+template <template <PrimitiveType> class Impl>
+AggregateFunctionPtr create_aggregate_function_orthogonal(const std::string& name,
+                                                          const DataTypes& argument_types,
+                                                          const DataTypePtr& result_type,
+                                                          const bool result_is_nullable,
+                                                          const AggregateFunctionAttr& attr) {
+    if (argument_types.empty()) {
+        LOG(WARNING) << "Incorrect number of arguments for aggregate function " << name;
+        return nullptr;
+    } else if (argument_types.size() == 1) {
+        return creator_without_type::create<AggFunctionOrthBitmapFunc<Impl<TYPE_STRING>>>(
+                argument_types, result_is_nullable, attr);
+    } else {
+        AggregateFunctionPtr res(
+                creator_with_type_list_base<1, TYPE_TINYINT, TYPE_SMALLINT, TYPE_INT, TYPE_BIGINT,
+                                            TYPE_LARGEINT>::create<AggFunctionOrthBitmapFunc,
+                                                                   Impl>(argument_types,
+                                                                         result_is_nullable, attr));
+        if (res) {
+            return res;
+        } else if (is_string_type(argument_types[1]->get_primitive_type())) {
+            res = creator_without_type::create<AggFunctionOrthBitmapFunc<Impl<TYPE_STRING>>>(
+                    argument_types, result_is_nullable, attr);
+            return res;
+        }
+
+        const IDataType& argument_type = *argument_types[1];
+        LOG(WARNING) << "Incorrect Type " << argument_type.get_name()
+                     << " of arguments for aggregate function " << name;
+        return nullptr;
+    }
+}
+
+} // namespace doris

--- a/be/src/util/bitmap_intersect.h
+++ b/be/src/util/bitmap_intersect.h
@@ -56,7 +56,7 @@ public:
 };
 
 template <>
-char* Helper::write_to<VecDateTimeValue>(const VecDateTimeValue& v, char* dest) {
+inline char* Helper::write_to<VecDateTimeValue>(const VecDateTimeValue& v, char* dest) {
     *(int64_t*)dest = v.to_int64_datetime_packed();
     dest += DATETIME_PACKED_TIME_BYTE_SIZE;
     *(int*)dest = v.type();
@@ -65,7 +65,7 @@ char* Helper::write_to<VecDateTimeValue>(const VecDateTimeValue& v, char* dest) 
 }
 
 template <>
-char* Helper::write_to<DecimalV2Value>(const DecimalV2Value& v, char* dest) {
+inline char* Helper::write_to<DecimalV2Value>(const DecimalV2Value& v, char* dest) {
     __int128 value = v.value();
     memcpy(dest, &value, DECIMAL_BYTE_SIZE);
     dest += DECIMAL_BYTE_SIZE;
@@ -73,7 +73,7 @@ char* Helper::write_to<DecimalV2Value>(const DecimalV2Value& v, char* dest) {
 }
 
 template <>
-char* Helper::write_to<StringRef>(const StringRef& v, char* dest) {
+inline char* Helper::write_to<StringRef>(const StringRef& v, char* dest) {
     *(int32_t*)dest = cast_set<int32_t>(v.size);
     dest += 4;
     memcpy(dest, v.data, v.size);
@@ -82,7 +82,7 @@ char* Helper::write_to<StringRef>(const StringRef& v, char* dest) {
 }
 
 template <>
-char* Helper::write_to<std::string>(const std::string& v, char* dest) {
+inline char* Helper::write_to<std::string>(const std::string& v, char* dest) {
     *(uint32_t*)dest = cast_set<uint32_t>(v.size());
     dest += 4;
     memcpy(dest, v.c_str(), v.size());
@@ -92,28 +92,28 @@ char* Helper::write_to<std::string>(const std::string& v, char* dest) {
 // write_to end
 
 template <>
-int32_t Helper::serialize_size<VecDateTimeValue>(const VecDateTimeValue& v) {
+inline int32_t Helper::serialize_size<VecDateTimeValue>(const VecDateTimeValue& v) {
     return Helper::DATETIME_PACKED_TIME_BYTE_SIZE + Helper::DATETIME_TYPE_BYTE_SIZE;
 }
 
 template <>
-int32_t Helper::serialize_size<DecimalV2Value>(const DecimalV2Value& v) {
+inline int32_t Helper::serialize_size<DecimalV2Value>(const DecimalV2Value& v) {
     return Helper::DECIMAL_BYTE_SIZE;
 }
 
 template <>
-int32_t Helper::serialize_size<StringRef>(const StringRef& v) {
+inline int32_t Helper::serialize_size<StringRef>(const StringRef& v) {
     return cast_set<int32_t>(v.size + 4);
 }
 
 template <>
-int32_t Helper::serialize_size<std::string>(const std::string& v) {
+inline int32_t Helper::serialize_size<std::string>(const std::string& v) {
     return cast_set<int32_t>(v.size() + 4);
 }
 // serialize_size end
 
 template <>
-void Helper::read_from<VecDateTimeValue>(const char** src, VecDateTimeValue* result) {
+inline void Helper::read_from<VecDateTimeValue>(const char** src, VecDateTimeValue* result) {
     result->from_packed_time(*(int64_t*)(*src));
     *src += DATETIME_PACKED_TIME_BYTE_SIZE;
     if (*(int*)(*src) == TIME_DATE) {
@@ -123,7 +123,7 @@ void Helper::read_from<VecDateTimeValue>(const char** src, VecDateTimeValue* res
 }
 
 template <>
-void Helper::read_from<DecimalV2Value>(const char** src, DecimalV2Value* result) {
+inline void Helper::read_from<DecimalV2Value>(const char** src, DecimalV2Value* result) {
     __int128 v = 0;
     memcpy(&v, *src, DECIMAL_BYTE_SIZE);
     *src += DECIMAL_BYTE_SIZE;
@@ -131,7 +131,7 @@ void Helper::read_from<DecimalV2Value>(const char** src, DecimalV2Value* result)
 }
 
 template <>
-void Helper::read_from<StringRef>(const char** src, StringRef* result) {
+inline void Helper::read_from<StringRef>(const char** src, StringRef* result) {
     int32_t length = *(int32_t*)(*src);
     *src += 4;
     *result = StringRef((char*)*src, length);
@@ -139,7 +139,7 @@ void Helper::read_from<StringRef>(const char** src, StringRef* result) {
 }
 
 template <>
-void Helper::read_from<std::string>(const char** src, std::string* result) {
+inline void Helper::read_from<std::string>(const char** src, std::string* result) {
     int32_t length = *(int32_t*)(*src);
     *src += 4;
     *result = std::string((char*)*src, length);


### PR DESCRIPTION
### What problem does this PR solve?

Optimize the compilation time of `aggregate_function_orthogonal_bitmap.cpp` by reducing template instantiation bloat and improving build parallelism.

### Changes

**1. Split single translation unit into multiple files**

The original `aggregate_function_orthogonal_bitmap.cpp` instantiated all 6 aggregate functions (~36 template instances) in a single file, forcing serial compilation. Now split into:

- `aggregate_function_orthogonal_bitmap.cpp` — forward declarations + registration only (compiles fast)
- `aggregate_function_orth_bitmap_intersect.cpp`
- `aggregate_function_orth_bitmap_intersect_count.cpp`
- `aggregate_function_orth_bitmap_union_count.cpp`
- `aggregate_function_orth_intersect_count.cpp`
- `aggregate_function_orth_bitmap_expr_cal.cpp`
- `aggregate_function_orth_bitmap_expr_cal_count.cpp`

**2. Remove unnecessary `PrimitiveType` template parameter from `OrthBitmapUnionCountData`**

`OrthBitmapUnionCountData<T>` never uses `T` — it only operates on `ColumnBitmap` directly. Removed the template parameter, reducing 6 useless instantiations to 1.

**3. Eliminate type dispatch for `ExprCal` / `ExprCalCount`**

FE guarantees these functions receive exactly 3 parameters with VARCHAR filter columns. Replaced the generic 6-type dispatch with direct `TYPE_STRING` instantiation, reducing 12 instantiations to 2.

**4. Use precise expression tags matching FE definitions**

Added `ExprTag` template parameter to `AggFunctionOrthBitmapFunc` (default: `VarargsExpression`):

| Function | FE Arity | Old BE Tag | New BE Tag |
|----------|----------|------------|------------|
| `orthogonal_bitmap_union_count` | `UnaryExpression` (1 arg) | `VarargsExpression` | `UnaryExpression` |
| `orthogonal_bitmap_expr_calculate` | Fixed 3 args | `VarargsExpression` | `MultiExpression` |
| `orthogonal_bitmap_expr_calculate_count` | Fixed 3 args | `VarargsExpression` | `MultiExpression` |
| Others (intersect/intersect_count) | Varargs (≥3) | `VarargsExpression` | `VarargsExpression` (unchanged) |

**5. Add `inline` to template specializations in `bitmap_intersect.h`**

The `Helper::write_to` / `serialize_size` / `read_from` template specializations in the header lacked `inline`, causing duplicate symbol linker errors after splitting into multiple translation units.

### Summary

| Metric | Before | After |
|--------|--------|-------|
| Translation units | 1 (serial) | 7 (parallel) |
| Template instantiations | ~36 | ~21 (~42% reduction) |
| `ExprCal`/`ExprCalCount` instantiations | 12 | 2 |
| `OrthBitmapUnionCountData` instantiations | 6 | 1 |

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

