### PR TITLE
[Fix] (Jdbc) Filter S3-compatible storage properties in CloudPluginDownloader

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/plugin/CloudPluginDownloader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/plugin/CloudPluginDownloader.java
@@ -153,15 +153,17 @@ public class CloudPluginDownloader {
         props.put("s3.bucket", objInfo.getBucket());
 
         // Auto-detect storage type (S3, COS, OSS, etc.)
-        StorageProperties storageProps;
+        AbstractS3CompatibleProperties storageProps;
         try {
             storageProps = StorageProperties.createAll(props).stream()
+                    .filter(AbstractS3CompatibleProperties.class::isInstance)
+                    .map(AbstractS3CompatibleProperties.class::cast)
                     .findFirst()
-                    .orElseThrow(() -> new RuntimeException("Failed to create storage properties"));
+                    .orElseThrow(() -> new RuntimeException("Failed to create S3-compatible storage properties"));
         } catch (UserException e) {
             throw new RuntimeException(e);
         }
 
-        return new S3ObjStorage((AbstractS3CompatibleProperties) storageProps);
+        return new S3ObjStorage(storageProps);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/plugin/CloudPluginDownloader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/plugin/CloudPluginDownloader.java
@@ -159,7 +159,9 @@ public class CloudPluginDownloader {
                     .filter(AbstractS3CompatibleProperties.class::isInstance)
                     .map(AbstractS3CompatibleProperties.class::cast)
                     .findFirst()
-                    .orElseThrow(() -> new RuntimeException("Failed to create S3-compatible storage properties"));
+                    .orElseThrow(() -> new RuntimeException(
+                            "No S3-compatible storage properties could be built from the provided object store "
+                                    + "parameters"));
         } catch (UserException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
  Make `CloudPluginDownloader` select the first S3-compatible storage properties instead of the first result from `StorageProperties.createAll(props)`, avoiding a cast
  failure caused by the default HDFS fallback.
```
Cannot download JDBC driver from cloud: mysql-connector-j-8.3.0.jar.
Please retry later or check your driver has been uploaded to cloud.
Error: java.lang.ClassCastException: class org.apache.doris.datasource.property.storage.HdfsProperties
  cannot be cast to class org.apache.doris.datasource.property.storage.AbstractS3CompatibleProperties
```
  Also refine the error message when no S3-compatible storage properties can be built from the provided object store parameters.
