### PR TITLE
[fix](csv) Honor Hive CSV physical line boundaries

### DIFF
--- a/be/src/format/csv/csv_reader.cpp
+++ b/be/src/format/csv/csv_reader.cpp
@@ -587,8 +587,8 @@ Status CsvReader::_create_line_reader() {
     std::shared_ptr<TextLineReaderContextIf> text_line_reader_ctx;
     // Hive TextInputFormat defines one record per physical line, so OpenCSVSerde must not
     // merge rows across line delimiters even if a quote stays open.
-    const bool allow_multiline_records =
-            !(_range.__isset.table_format_params && _range.table_format_params.table_format_type == "hive");
+    const bool allow_multiline_records = !(_range.__isset.table_format_params &&
+                                           _range.table_format_params.table_format_type == "hive");
     if (_enclose == 0) {
         text_line_reader_ctx = std::make_shared<PlainTextLineReaderCtx>(
                 _line_delimiter, _line_delimiter_length, _keep_cr);

--- a/be/src/format/csv/csv_reader.cpp
+++ b/be/src/format/csv/csv_reader.cpp
@@ -585,6 +585,10 @@ Status CsvReader::_create_file_reader(bool need_schema) {
 
 Status CsvReader::_create_line_reader() {
     std::shared_ptr<TextLineReaderContextIf> text_line_reader_ctx;
+    // Hive TextInputFormat defines one record per physical line, so OpenCSVSerde must not
+    // merge rows across line delimiters even if a quote stays open.
+    const bool allow_multiline_records =
+            !(_range.__isset.table_format_params && _range.table_format_params.table_format_type == "hive");
     if (_enclose == 0) {
         text_line_reader_ctx = std::make_shared<PlainTextLineReaderCtx>(
                 _line_delimiter, _line_delimiter_length, _keep_cr);
@@ -596,7 +600,7 @@ Status CsvReader::_create_line_reader() {
         size_t col_sep_num = _file_slot_descs.size() > 1 ? _file_slot_descs.size() - 1 : 0;
         _enclose_reader_ctx = std::make_shared<EncloseCsvLineReaderCtx>(
                 _line_delimiter, _line_delimiter_length, _value_separator, _value_separator_length,
-                col_sep_num, _enclose, _escape, _keep_cr);
+                col_sep_num, _enclose, _escape, _keep_cr, allow_multiline_records);
         text_line_reader_ctx = _enclose_reader_ctx;
 
         _fields_splitter = std::make_unique<EncloseCsvTextFieldSplitter>(

--- a/be/src/format/file_reader/new_plain_text_line_reader.cpp
+++ b/be/src/format/file_reader/new_plain_text_line_reader.cpp
@@ -177,6 +177,9 @@ void EncloseCsvLineReaderCtx::_on_pre_match_enclose(const uint8_t* start, size_t
         } while (_idx != len);
 
         if (_idx != _total_len) {
+            if (!_allow_multiline) {
+                break;
+            }
             len = update_reading_bound(start);
         } else {
             // It needs to set the result to nullptr for matching enclose may not be read

--- a/be/src/format/file_reader/new_plain_text_line_reader.h
+++ b/be/src/format/file_reader/new_plain_text_line_reader.h
@@ -157,10 +157,12 @@ public:
     explicit EncloseCsvLineReaderCtx(const std::string& line_delimiter_,
                                      const size_t line_delimiter_len_, std::string column_sep_,
                                      const size_t column_sep_len_, size_t col_sep_num,
-                                     const char enclose, const char escape, const bool keep_cr_)
+                                     const char enclose, const char escape, const bool keep_cr_,
+                                     const bool allow_multiline = true)
             : BaseTextLineReaderContext(line_delimiter_, line_delimiter_len_, keep_cr_),
               _enclose(enclose),
               _escape(escape),
+              _allow_multiline(allow_multiline),
               _column_sep_len(column_sep_len_),
               _column_sep(std::move(column_sep_)) {
         if (column_sep_len_ == 1) {
@@ -211,6 +213,7 @@ private:
     ReaderStateWrapper _state;
     const char _enclose;
     const char _escape;
+    const bool _allow_multiline;
     const uint8_t* _result = nullptr;
 
     size_t _total_len;

--- a/be/test/format/file_reader/new_plain_text_line_reader_test.cpp
+++ b/be/test/format/file_reader/new_plain_text_line_reader_test.cpp
@@ -71,9 +71,10 @@ protected:
     void verify_csv_split(const std::string& input, const std::string& line_delim,
                           const std::string& col_sep, char enclose, char escape, bool keep_cr,
                           const std::vector<std::string>& expected_lines,
-                          const std::vector<std::vector<size_t>>& expected_col_positions) {
+                          const std::vector<std::vector<size_t>>& expected_col_positions,
+                          bool allow_multiline = true) {
         EncloseCsvLineReaderCtx ctx(line_delim, line_delim.size(), col_sep, col_sep.size(), 10,
-                                    enclose, escape, keep_cr);
+                                    enclose, escape, keep_cr, allow_multiline);
 
         const auto* data = reinterpret_cast<const uint8_t*>(input.c_str());
         size_t pos = 0;
@@ -163,6 +164,11 @@ TEST_F(EncloseCsvLineReaderTest, MultiCharDelimiters) {
 
     verify_csv_split("\"a|||b\"|||c\r\n\n\"d|||e\"|||f", "\r\n\n", "|||", '"', '\\', false,
                      {"\"a|||b\"|||c", "\"d|||e\"|||f"}, {{7}, {7}});
+}
+
+TEST_F(EncloseCsvLineReaderTest, HiveTextInputFormatKeepsPhysicalLineBoundaries) {
+    verify_csv_split("'corp\nname',x\nplain,y", "\n", ",", '\'', '\\', false,
+                     {"'corp", "name',x", "plain,y"}, {{}, {5}, {5}}, false);
 }
 
 } // namespace doris

--- a/be/test/format/file_reader/new_plain_text_line_reader_test.cpp
+++ b/be/test/format/file_reader/new_plain_text_line_reader_test.cpp
@@ -169,6 +169,20 @@ TEST_F(EncloseCsvLineReaderTest, MultiCharDelimiters) {
 TEST_F(EncloseCsvLineReaderTest, HiveTextInputFormatKeepsPhysicalLineBoundaries) {
     verify_csv_split("'corp\nname',x\nplain,y", "\n", ",", '\'', '\\', false,
                      {"'corp", "name',x", "plain,y"}, {{}, {5}, {5}}, false);
+
+    // Multi-character line delimiter must also terminate the quoted field in Hive mode.
+    verify_csv_split("'a\r\nb',x\r\nplain,y", "\r\n", ",", '\'', '\\', false,
+                     {"'a", "b',x", "plain,y"}, {{}, {2}, {5}}, false);
+
+    // A quoted field containing multiple embedded line delimiters yields one row per physical
+    // line, and each physical line is reparsed with a fresh state.
+    verify_csv_split("'a\nb\nc',d\nplain", "\n", ",", '\'', '\\', false,
+                     {"'a", "b", "c',d", "plain"}, {{}, {}, {2}, {}}, false);
+
+    // Default (allow_multiline=true) must still merge lines across an open quote so non-Hive
+    // callers keep their previous behavior.
+    verify_csv_split("'a\nb',x\nplain,y", "\n", ",", '\'', '\\', false,
+                     {"'a\nb',x", "plain,y"}, {{5}, {5}});
 }
 
 } // namespace doris

--- a/be/test/format/file_reader/new_plain_text_line_reader_test.cpp
+++ b/be/test/format/file_reader/new_plain_text_line_reader_test.cpp
@@ -181,8 +181,8 @@ TEST_F(EncloseCsvLineReaderTest, HiveTextInputFormatKeepsPhysicalLineBoundaries)
 
     // Default (allow_multiline=true) must still merge lines across an open quote so non-Hive
     // callers keep their previous behavior.
-    verify_csv_split("'a\nb',x\nplain,y", "\n", ",", '\'', '\\', false,
-                     {"'a\nb',x", "plain,y"}, {{5}, {5}});
+    verify_csv_split("'a\nb',x\nplain,y", "\n", ",", '\'', '\\', false, {"'a\nb',x", "plain,y"},
+                     {{5}, {5}});
 }
 
 } // namespace doris

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run76.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run76.hql
@@ -55,6 +55,15 @@ WITH SERDEPROPERTIES (
 STORED AS TEXTFILE
 LOCATION '/user/doris/preinstalled_data/csv/open_csv_complex_type';
 
+CREATE TABLE open_csv_physical_line_boundary (
+  id STRING,
+  info STRING
+)
+ROW FORMAT SERDE
+  'org.apache.hadoop.hive.serde2.OpenCSVSerde'
+STORED AS TEXTFILE
+LOCATION '/user/doris/preinstalled_data/csv/open_csv_physical_line_boundary';
+
 create database if not exists openx_json;
 use openx_json;
 

--- a/docker/thirdparties/docker-compose/hive/scripts/preinstalled_data/csv/open_csv_physical_line_boundary/open_csv_physical_line_boundary.csv
+++ b/docker/thirdparties/docker-compose/hive/scripts/preinstalled_data/csv/open_csv_physical_line_boundary/open_csv_physical_line_boundary.csv
@@ -1,0 +1,4 @@
+"1","alpha"
+"2","beta_multi
+line_ending"
+"3","gamma"

--- a/regression-test/data/external_table_p0/hive/test_open_csv_serde.out
+++ b/regression-test/data/external_table_p0/hive/test_open_csv_serde.out
@@ -23,6 +23,9 @@
 4	["x","y","z"]	{"x1":"y1","x2":"y2"}	{"name":"Zack","age":35}
 5	["one","two"]	{"first":"1st","second":"2nd"}	{"name":"Nina","age":27}
 
+-- !csv_physical_line_count --
+4
+
 -- !csv_escape_quote_in_enclose --
 1001	{"code": "100", "message": "query success", "data": {"status": "1"}}
 1002	{"code": "100", "message": "query success", "data": {"status": "20"}}
@@ -46,4 +49,7 @@
 3	[]	{}	{"name":"Empty","age":0}
 4	["x","y","z"]	{"x1":"y1","x2":"y2"}	{"name":"Zack","age":35}
 5	["one","two"]	{"first":"1st","second":"2nd"}	{"name":"Nina","age":27}
+
+-- !csv_physical_line_count --
+4
 

--- a/regression-test/suites/external_table_p0/hive/test_open_csv_serde.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_open_csv_serde.groovy
@@ -42,5 +42,10 @@ suite("test_open_csv_serde", "p0,external") {
         qt_csv_escape_quote_in_enclose """select * from csv_json_table_simple order by id;"""
         qt_csv_null_format """select * from open_csv_table_null_format order by id;"""
         qt_csv_complex_type """select * from open_csv_complex_type order by id;"""
+        // Regression for the physical-line-boundary fix: Hive OpenCSVSerde must not merge rows
+        // across a line delimiter, even when a quoted field contains a newline. Before the fix
+        // the row with an embedded newline was merged into a single record, giving 3 rows; the
+        // correct Hive behavior yields 4 physical rows.
+        qt_csv_physical_line_count """select count(*) from open_csv_physical_line_boundary;"""
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Hive CSV external tables that use TextInputFormat should keep one record per physical line. The current CSV reader can continue scanning across line delimiters when an enclosure remains open, which produces wrong query results for quoted values containing newlines.

### Release note

Fix wrong results when querying Hive CSV external tables with quoted newlines. **This will align with the behavior with Presto and Spark.**

### Check List (For Author)

- Test: No need to test (will be run separately by the user)
- Behavior changed: Yes (Hive CSV external table queries now stop at physical line boundaries instead of merging lines through an open quote)
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

