### PR TITLE
[chore](topn) check column type before merging lazy materialization columns

### DIFF
--- a/be/src/exec/operator/materialization_opertor.cpp
+++ b/be/src/exec/operator/materialization_opertor.cpp
@@ -80,6 +80,14 @@ Status MaterializationSharedState::merge_multi_response() {
             }
         }
 
+        // return error if any column in response block is not compatible with source block column
+        for (int k = 0; k < response_blocks[i].columns(); ++k) {
+            const auto& resp_col_type = response_blocks[i].get_datatype_by_position(k);
+            for (const auto& [_, source_block_rows] : block_maps) {
+                RETURN_IF_ERROR(resp_col_type->check_column(
+                        *source_block_rows.first.get_by_position(k).column));
+            }
+        }
         for (int j = 0; j < block_order_results[i].size(); ++j) {
             auto backend_id = block_order_results[i][j];
             if (backend_id) {


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Check column type before merging lazy materialization columns, to avoid coredump in case of any column type mismatch.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

