### PR TITLE
[opt](nereids) rewrite PreferPushDownProject to slots before filter-join pushdown

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownProject.java
@@ -146,7 +146,8 @@ public class PushDownProject implements RewriteRuleFactory, NormalizeToSlot {
         LogicalFilter<LogicalJoin<Plan, Plan>> filter = ctx.root;
         LogicalJoin<Plan, Plan> join = filter.child();
         PushdownProjectHelper pushdownProjectHelper = new PushdownProjectHelper(ctx.statementContext, join);
-        Pair<Boolean, Set<Expression>> pushPredicates = pushdownProjectHelper.pushDownExpressions(filter.getConjuncts());
+        Pair<Boolean, Set<Expression>> pushPredicates
+                = pushdownProjectHelper.pushDownExpressions(filter.getConjuncts());
         if (!pushPredicates.first) {
             return filter;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownProject.java
@@ -30,6 +30,7 @@ import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.algebra.SetOperation.Qualifier;
+import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOneRowRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
@@ -50,6 +51,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 
 /** push down project if the expression instance of PreferPushDownProject */
@@ -59,6 +61,9 @@ public class PushDownProject implements RewriteRuleFactory, NormalizeToSlot {
         return ImmutableList.of(
             RuleType.PUSH_DOWN_PROJECT_THROUGH_JOIN.build(
                 logicalJoin().thenApply(this::pushDownJoinExpressions)
+            ),
+            RuleType.PUSH_DOWN_PROJECT_THROUGH_JOIN.build(
+                logicalFilter(logicalJoin()).thenApply(this::pushDownFilterExpressions)
             ),
             RuleType.PUSH_DOWN_PROJECT_THROUGH_JOIN.build(
                 logicalProject(logicalJoin()).thenApply(this::defaultPushDownProject)
@@ -135,6 +140,19 @@ public class PushDownProject implements RewriteRuleFactory, NormalizeToSlot {
                 newHashJoinConjuncts, newOtherJoinConjuncts,
                 join.getMarkJoinConjuncts(), join.getJoinReorderContext()
         ).withChildren(newLeft, newRight);
+    }
+
+    private Plan pushDownFilterExpressions(MatchingContext<LogicalFilter<LogicalJoin<Plan, Plan>>> ctx) {
+        LogicalFilter<LogicalJoin<Plan, Plan>> filter = ctx.root;
+        LogicalJoin<Plan, Plan> join = filter.child();
+        PushdownProjectHelper pushdownProjectHelper = new PushdownProjectHelper(ctx.statementContext, join);
+        Pair<Boolean, Set<Expression>> pushPredicates = pushdownProjectHelper.pushDownExpressions(filter.getConjuncts());
+        if (!pushPredicates.first) {
+            return filter;
+        }
+
+        LogicalJoin<Plan, Plan> newJoin = join.withChildren(pushdownProjectHelper.buildNewChildren());
+        return filter.withConjuncts(pushPredicates.second).withChildren(ImmutableList.of(newJoin));
     }
 
     // return:

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownProjectTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownProjectTest.java
@@ -18,8 +18,8 @@
 package org.apache.doris.nereids.rules.rewrite;
 
 import org.apache.doris.nereids.StatementContext;
-import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.Add;
+import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.GreaterThan;
@@ -31,13 +31,13 @@ import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.ElementAt;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
+import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.RelationId;
-import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.algebra.SetOperation.Qualifier;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
-import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOneRowRelation;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.trees.plans.logical.LogicalUnion;
 import org.apache.doris.nereids.types.TinyIntType;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownProjectTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownProjectTest.java
@@ -19,22 +19,36 @@ package org.apache.doris.nereids.rules.rewrite;
 
 import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.trees.expressions.Alias;
+import org.apache.doris.nereids.trees.expressions.Add;
 import org.apache.doris.nereids.trees.expressions.ExprId;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.GreaterThan;
+import org.apache.doris.nereids.trees.expressions.MatchAny;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.expressions.Or;
+import org.apache.doris.nereids.trees.expressions.PreferPushDownProject;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.ElementAt;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.RelationId;
+import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.algebra.SetOperation.Qualifier;
+import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOneRowRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.trees.plans.logical.LogicalUnion;
 import org.apache.doris.nereids.types.TinyIntType;
+import org.apache.doris.nereids.util.LogicalPlanBuilder;
 import org.apache.doris.nereids.util.MemoPatternMatchSupported;
 import org.apache.doris.nereids.util.MemoTestUtils;
 import org.apache.doris.nereids.util.PlanChecker;
+import org.apache.doris.nereids.util.PlanConstructor;
+import org.apache.doris.qe.ConnectContext;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Test;
 
@@ -82,6 +96,7 @@ public class PushDownProjectTest implements MemoPatternMatchSupported {
     private final LogicalOneRowRelation rel1 = new LogicalOneRowRelation(new RelationId(1), rel1Output);
     private final LogicalOneRowRelation rel2 = new LogicalOneRowRelation(new RelationId(2), rel2Output);
     private final List<Plan> children = Lists.newArrayList(rel1, rel2);
+    private final ConnectContext connectContext = MemoTestUtils.createConnectContext();
 
     @Test
     public void testPushDownProjectThroughUnionOnlyHasChildren() {
@@ -188,5 +203,41 @@ public class PushDownProjectTest implements MemoPatternMatchSupported {
                                         .when(u -> u.getOutput().get(2).getExprId().asInt() == 12)
                         ).when(p -> p.getProjects().stream().noneMatch(ne -> ne.containsType(ElementAt.class)))
                 );
+    }
+
+    @Test
+    public void shouldRewritePreferPushDownProjectInOrFilterToSlot() {
+        LogicalPlan rStudent = new LogicalOlapScan(PlanConstructor.getNextRelationId(), PlanConstructor.student,
+                ImmutableList.of(""));
+        LogicalPlan rScore = new LogicalOlapScan(PlanConstructor.getNextRelationId(), PlanConstructor.score,
+                ImmutableList.of(""));
+        Expression preferPushDownProjectExpr = new MatchAny(
+                new Add(rStudent.getOutput().get(0), Literal.of(1)),
+                Literal.of("abc"));
+        Expression rightSidePredicate = new GreaterThan(rScore.getOutput().get(2), Literal.of(60));
+        Expression orPredicate = new Or(preferPushDownProjectExpr, rightSidePredicate);
+
+        LogicalPlan plan = new LogicalPlanBuilder(rStudent)
+                .joinEmptyOn(rScore, JoinType.INNER_JOIN)
+                .filter(orPredicate)
+                .build();
+
+        PlanChecker.from(connectContext, plan)
+                .applyTopDown(new PushDownProject())
+                .matchesFromRoot(logicalFilter(
+                        logicalJoin(
+                                logicalProject(logicalOlapScan())
+                                        .when(project -> project.getProjects().stream()
+                                                .filter(Alias.class::isInstance)
+                                                .map(Alias.class::cast)
+                                                .map(Alias::child)
+                                                .anyMatch(PreferPushDownProject.class::isInstance)),
+                                logicalOlapScan()))
+                        .when(filter -> {
+                            Expression rewrittenPredicate = ImmutableList.copyOf(filter.getConjuncts()).get(0);
+                            return rewrittenPredicate instanceof Or
+                                    && rewrittenPredicate.anyMatch(SlotReference.class::isInstance)
+                                    && !rewrittenPredicate.anyMatch(PreferPushDownProject.class::isInstance);
+                        }));
     }
 }


### PR DESCRIPTION
Push PreferPushDownProject expressions to the matching join child as aliases and replace them with slots in filter predicates. This keeps OR predicates above join while exposing nested-field access below join for storage-level pruning acceleration.

Plan tree demo:

Before:
```
  LogicalFilter((match_any(info['context'], 'abc') OR r.k2 > 60))
    LogicalJoin(INNER)
      left:  LogicalOlapScan(student)
      right: LogicalOlapScan(score)
```

After:
```

  LogicalFilter((slot#x OR r.k2 > 60))
    LogicalJoin(INNER)
      left:  LogicalProject(student.*, match_any(info['context'], 'abc') AS slot#x)
                  LogicalOlapScan(student)
      right: LogicalOlapScan(score)
```

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

