### PR TITLE
[fix](s3) Add retry for S3 flush response stream transient error

### DIFF
--- a/be/src/io/fs/err_utils.cpp
+++ b/be/src/io/fs/err_utils.cpp
@@ -124,19 +124,20 @@ Status localfs_error(int posix_errno, std::string_view msg) {
 
 Status s3fs_error(const Aws::S3::S3Error& err, std::string_view msg) {
     using namespace Aws::Http;
+    auto rid = err.GetRequestId().empty() ? Aws::String("<empty>") : err.GetRequestId();
     switch (err.GetResponseCode()) {
     case HttpResponseCode::NOT_FOUND:
         return Status::Error<NOT_FOUND, false>("{}: {} {} code=NOT_FOUND, type={}, request_id={}",
                                                msg, err.GetExceptionName(), err.GetMessage(),
-                                               err.GetErrorType(), err.GetRequestId());
+                                               err.GetErrorType(), rid);
     case HttpResponseCode::FORBIDDEN:
         return Status::Error<PERMISSION_DENIED, false>(
                 "{}: {} {} code=FORBIDDEN, type={}, request_id={}", msg, err.GetExceptionName(),
-                err.GetMessage(), err.GetErrorType(), err.GetRequestId());
+                err.GetMessage(), err.GetErrorType(), rid);
     default:
         return Status::Error<ErrorCode::INTERNAL_ERROR, false>(
                 "{}: {} {} code={} type={}, request_id={}", msg, err.GetExceptionName(),
-                err.GetMessage(), err.GetResponseCode(), err.GetErrorType(), err.GetRequestId());
+                err.GetMessage(), err.GetResponseCode(), err.GetErrorType(), rid);
     }
 }
 

--- a/be/src/io/fs/obj_storage_client.h
+++ b/be/src/io/fs/obj_storage_client.h
@@ -62,6 +62,8 @@ struct ObjectStorageResponse {
     ObjectStorageStatus status {};
     int http_code {200};
     std::string request_id = std::string();
+    int error_type {-1};       // AWS/S3 error enum numeric value, -1 = OK (no error)
+    bool is_retriable {false}; // true = transient error that application layer should retry
     static ObjectStorageResponse OK() {
         // clang-format off
         return {

--- a/be/src/io/fs/s3_file_reader.cpp
+++ b/be/src/io/fs/s3_file_reader.cpp
@@ -52,6 +52,7 @@ bvar::Adder<uint64_t> s3_file_reader_total("s3_file_reader", "total_num");
 bvar::Adder<uint64_t> s3_bytes_read_total("s3_file_reader", "bytes_read");
 bvar::Adder<uint64_t> s3_file_being_read("s3_file_reader", "file_being_read");
 bvar::Adder<uint64_t> s3_file_reader_too_many_request_counter("s3_file_reader", "too_many_request");
+bvar::Adder<uint64_t> s3_file_reader_transient_error_counter("s3_file_reader", "transient_error");
 bvar::LatencyRecorder s3_bytes_per_read("s3_file_reader", "bytes_per_read"); // also QPS
 bvar::PerSecond<bvar::Adder<uint64_t>> s3_read_througthput("s3_file_reader", "s3_read_throughput",
                                                            &s3_bytes_read_total);
@@ -158,6 +159,8 @@ Status S3FileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_rea
     }};
     SCOPED_RAW_TIMER(&_s3_stats.total_get_request_time_ns);
 
+    constexpr int max_transient_retries = 3;
+    int transient_retry_count = 0;
     int total_sleep_time = 0;
     while (retry_count <= max_retries) {
         *bytes_read = 0;
@@ -166,6 +169,15 @@ Status S3FileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_rea
         auto resp = client->get_object( { .bucket = _bucket, .key = _key, },
                 to, offset, bytes_req, bytes_read);
         // clang-format on
+        DBUG_EXECUTE_IF("s3_file_reader.transient_error", {
+            if (transient_retry_count < dp->param("inject_count", 1)) {
+                resp.status.code = ErrorCode::INTERNAL_ERROR;
+                resp.status.msg = "injected: Failed to flush response stream";
+                resp.http_code = -1;
+                resp.error_type = 1; // INTERNAL_FAILURE
+                resp.is_retriable = true;
+            }
+        });
         _s3_stats.total_get_request_counter++;
         if (resp.status.code != ErrorCode::OK) {
             if (resp.http_code ==
@@ -179,10 +191,23 @@ Status S3FileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_rea
                 _s3_stats.too_many_request_sleep_time_ms += wait_time;
                 total_sleep_time += wait_time;
                 continue;
+            } else if (resp.is_retriable && transient_retry_count < max_transient_retries) {
+                transient_retry_count++;
+                s3_file_reader_transient_error_counter << 1;
+                int wait_time = std::min(base_wait_time * (1 << transient_retry_count),
+                                         max_wait_time);
+                LOG(WARNING) << fmt::format(
+                        "s3 read transient error, retry {}/{} after {}ms, path={}, "
+                        "http_code={}, error_type={}, msg={}",
+                        transient_retry_count, max_transient_retries, wait_time,
+                        _path.native(), resp.http_code, resp.error_type, resp.status.msg);
+                std::this_thread::sleep_for(std::chrono::milliseconds(wait_time));
+                _s3_stats.transient_error_retry_counter++;
+                _s3_stats.transient_error_sleep_time_ms += wait_time;
+                total_sleep_time += wait_time;
+                continue;
             } else {
-                // Handle other errors
-                return std::move(Status(resp.status.code, std::move(resp.status.msg))
-                                         .append("failed to read"));
+                return Status(resp.status.code, std::move(resp.status.msg));
             }
         }
         if (*bytes_read != bytes_req) {
@@ -197,9 +222,11 @@ Status S3FileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_rea
         s3_bytes_read_total << bytes_req;
         s3_bytes_per_read << bytes_req;
         DorisMetrics::instance()->s3_bytes_read_total->increment(bytes_req);
-        if (retry_count > 0) {
-            LOG(INFO) << fmt::format("read s3 file {} succeed after {} times with {} ms sleeping",
-                                     _path.native(), retry_count, total_sleep_time);
+        if (retry_count > 0 || transient_retry_count > 0) {
+            LOG(INFO) << fmt::format(
+                    "read s3 file {} succeed after {} 429-retries and {} transient-retries "
+                    "with {} ms sleeping",
+                    _path.native(), retry_count, transient_retry_count, total_sleep_time);
         }
         return Status::OK();
     }
@@ -225,12 +252,18 @@ void S3FileReader::_collect_profile_before_close() {
                 ADD_CHILD_COUNTER(_profile, "TotalBytesRead", TUnit::BYTES, s3_profile_name);
         RuntimeProfile::Counter* total_get_request_time_ns =
                 ADD_CHILD_TIMER(_profile, "TotalGetRequestTime", s3_profile_name);
+        RuntimeProfile::Counter* transient_error_retry_counter =
+                ADD_CHILD_COUNTER(_profile, "TransientErrorRetry", TUnit::UNIT, s3_profile_name);
+        RuntimeProfile::Counter* transient_error_sleep_time = ADD_CHILD_COUNTER(
+                _profile, "TransientErrorSleepTime", TUnit::TIME_MS, s3_profile_name);
 
         COUNTER_UPDATE(total_get_request_counter, _s3_stats.total_get_request_counter);
         COUNTER_UPDATE(too_many_request_err_counter, _s3_stats.too_many_request_err_counter);
         COUNTER_UPDATE(too_many_request_sleep_time, _s3_stats.too_many_request_sleep_time_ms);
         COUNTER_UPDATE(total_bytes_read, _s3_stats.total_bytes_read);
         COUNTER_UPDATE(total_get_request_time_ns, _s3_stats.total_get_request_time_ns);
+        COUNTER_UPDATE(transient_error_retry_counter, _s3_stats.transient_error_retry_counter);
+        COUNTER_UPDATE(transient_error_sleep_time, _s3_stats.transient_error_sleep_time_ms);
     }
 }
 

--- a/be/src/io/fs/s3_file_reader.h
+++ b/be/src/io/fs/s3_file_reader.h
@@ -68,6 +68,8 @@ private:
         int64_t too_many_request_sleep_time_ms = 0;
         int64_t total_bytes_read = 0;
         int64_t total_get_request_time_ns = 0;
+        int64_t transient_error_retry_counter = 0;
+        int64_t transient_error_sleep_time_ms = 0;
     };
     Path _path;
     size_t _file_size;

--- a/be/src/io/fs/s3_obj_storage_client.cpp
+++ b/be/src/io/fs/s3_obj_storage_client.cpp
@@ -324,10 +324,24 @@ ObjectStorageResponse S3ObjStorageClient::get_object(const ObjectStoragePathOpti
     SCOPED_BVAR_LATENCY(s3_bvar::s3_get_latency);
     auto outcome = s3_get_rate_limit([&]() { return _client->GetObject(request); });
     if (!outcome.IsSuccess()) {
+        auto& err = outcome.GetError();
+        // Heuristic: mark as retriable only for SDK-level flush errors.
+        // Conditions: REQUEST_NOT_MADE + INTERNAL_FAILURE + empty exceptionName
+        //             + message contains "Failed to flush"
+        // This excludes: local rate limiter errors (exceptionName="exceeds limit"),
+        //                other INTERNAL_FAILURE with different messages,
+        //                NETWORK_CONNECTION errors (already retried by SDK).
+        bool retriable =
+                (err.GetResponseCode() == Aws::Http::HttpResponseCode::REQUEST_NOT_MADE &&
+                 err.GetErrorType() == Aws::S3::S3Errors::INTERNAL_FAILURE &&
+                 err.GetExceptionName().empty() &&
+                 err.GetMessage().find("Failed to flush") != Aws::String::npos);
         return {convert_to_obj_response(s3fs_error(
-                        outcome.GetError(), fmt::format("failed to read from {}", opts.key))),
-                static_cast<int>(outcome.GetError().GetResponseCode()),
-                outcome.GetError().GetRequestId()};
+                        err, fmt::format("failed to read from {}", opts.key))),
+                static_cast<int>(err.GetResponseCode()),
+                err.GetRequestId(),
+                static_cast<int>(err.GetErrorType()),
+                retriable};
     }
     *size_return = outcome.GetResult().GetContentLength();
     // case for incomplete read

--- a/be/test/io/fs/s3_file_reader_retry_test.cpp
+++ b/be/test/io/fs/s3_file_reader_retry_test.cpp
@@ -1,0 +1,245 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "common/status.h"
+#include "io/fs/obj_storage_client.h"
+#include "io/fs/s3_file_reader.h"
+#include "io/fs/s3_file_system.h"
+#include "util/s3_util.h"
+
+namespace doris::io {
+
+// A controllable fake ObjStorageClient for testing S3FileReader retry behavior.
+// get_object() returns responses from a pre-configured queue; when the queue is
+// exhausted it returns a successful response with the requested bytes.
+class FakeObjStorageClient : public ObjStorageClient {
+public:
+    struct GetObjectCall {
+        ObjectStorageResponse resp;
+        size_t bytes_to_return; // 0 = use bytes_read param
+    };
+
+    // Push a response that get_object will return on the next call.
+    void push_get_response(ObjectStorageResponse resp, size_t bytes_to_return = 0) {
+        _get_responses.push_back({std::move(resp), bytes_to_return});
+    }
+
+    int get_object_call_count() const { return _get_object_calls; }
+
+    // --- ObjStorageClient interface ---
+    ObjectStorageResponse get_object(const ObjectStoragePathOptions& opts, void* buffer,
+                                     size_t offset, size_t bytes_read,
+                                     size_t* size_return) override {
+        _get_object_calls++;
+        if (!_get_responses.empty()) {
+            auto entry = std::move(_get_responses.front());
+            _get_responses.erase(_get_responses.begin());
+            if (size_return) {
+                *size_return = entry.bytes_to_return > 0 ? entry.bytes_to_return : bytes_read;
+            }
+            return entry.resp;
+        }
+        // Default: success, fill buffer with zeros
+        if (buffer) memset(buffer, 0, bytes_read);
+        if (size_return) *size_return = bytes_read;
+        return ObjectStorageResponse::OK();
+    }
+
+    // Stubs for other methods (not exercised in reader retry tests)
+    ObjectStorageUploadResponse create_multipart_upload(const ObjectStoragePathOptions&) override {
+        return {};
+    }
+    ObjectStorageResponse put_object(const ObjectStoragePathOptions&, std::string_view) override {
+        return ObjectStorageResponse::OK();
+    }
+    ObjectStorageUploadResponse upload_part(const ObjectStoragePathOptions&, std::string_view,
+                                            int) override {
+        return {};
+    }
+    ObjectStorageResponse complete_multipart_upload(
+            const ObjectStoragePathOptions&,
+            const std::vector<ObjectCompleteMultiPart>&) override {
+        return ObjectStorageResponse::OK();
+    }
+    ObjectStorageHeadResponse head_object(const ObjectStoragePathOptions&) override {
+        return {.resp = ObjectStorageResponse::OK(), .file_size = 1024};
+    }
+    ObjectStorageResponse list_objects(const ObjectStoragePathOptions&,
+                                       std::vector<FileInfo>*) override {
+        return ObjectStorageResponse::OK();
+    }
+    ObjectStorageResponse delete_objects(const ObjectStoragePathOptions&,
+                                         std::vector<std::string>) override {
+        return ObjectStorageResponse::OK();
+    }
+    ObjectStorageResponse delete_object(const ObjectStoragePathOptions&) override {
+        return ObjectStorageResponse::OK();
+    }
+    ObjectStorageResponse delete_objects_recursively(const ObjectStoragePathOptions&) override {
+        return ObjectStorageResponse::OK();
+    }
+    std::string generate_presigned_url(const ObjectStoragePathOptions&, int64_t,
+                                       const S3ClientConf&) override {
+        return "";
+    }
+
+private:
+    std::vector<GetObjectCall> _get_responses;
+    int _get_object_calls = 0;
+};
+
+class S3FileReaderRetryTest : public testing::Test {
+protected:
+    void SetUp() override { S3ClientFactory::instance(); }
+
+    // Helper: create an S3FileReader backed by the given fake client.
+    std::pair<std::shared_ptr<FakeObjStorageClient>, std::shared_ptr<S3FileReader>> make_reader(
+            size_t file_size = 1024) {
+        auto fake = std::make_shared<FakeObjStorageClient>();
+        auto holder = std::make_shared<ObjClientHolder>(S3ClientConf {});
+        holder->_client = fake;
+        auto reader = std::make_shared<S3FileReader>(std::const_pointer_cast<const ObjClientHolder>(holder),
+                                                      "test-bucket", "test-key", file_size, nullptr);
+        return {fake, reader};
+    }
+
+    // Build a retriable error response (mimics SDK flush error).
+    static ObjectStorageResponse make_retriable_error() {
+        return {.status = {.code = ErrorCode::INTERNAL_ERROR,
+                           .msg = "Failed to flush response stream (eof: 0, bad: 1)"},
+                .http_code = -1,
+                .request_id = "",
+                .error_type = 1, // INTERNAL_FAILURE
+                .is_retriable = true};
+    }
+
+    // Build a non-retriable error response (e.g., NOT_FOUND).
+    static ObjectStorageResponse make_not_found_error() {
+        return {.status = {.code = ErrorCode::NOT_FOUND, .msg = "NoSuchKey"},
+                .http_code = 404,
+                .request_id = "req-123",
+                .error_type = -1,
+                .is_retriable = false};
+    }
+
+    // Build a 429 too-many-requests response.
+    static ObjectStorageResponse make_429_error() {
+        return {.status = {.code = ErrorCode::INTERNAL_ERROR, .msg = "SlowDown"},
+                .http_code = 429,
+                .request_id = "req-456",
+                .error_type = -1,
+                .is_retriable = false};
+    }
+};
+
+// Transient error on first call, success on retry.
+TEST_F(S3FileReaderRetryTest, transient_error_retry_succeeds) {
+    auto [fake, reader] = make_reader(64);
+
+    // First call: retriable error. Second call: default success.
+    fake->push_get_response(make_retriable_error());
+
+    char buf[64];
+    size_t bytes_read = 0;
+    auto st = reader->read_at(0, Slice(buf, 64), &bytes_read);
+
+    EXPECT_TRUE(st.ok()) << st;
+    EXPECT_EQ(bytes_read, 64);
+    EXPECT_EQ(fake->get_object_call_count(), 2); // 1 fail + 1 success
+}
+
+// Transient error exceeds max_transient_retries (3), should fail.
+TEST_F(S3FileReaderRetryTest, transient_error_retry_exhausted) {
+    auto [fake, reader] = make_reader(64);
+
+    // Push 4 retriable errors (max_transient_retries = 3, so 4th is not retried)
+    for (int i = 0; i < 4; i++) {
+        fake->push_get_response(make_retriable_error());
+    }
+
+    char buf[64];
+    size_t bytes_read = 0;
+    auto st = reader->read_at(0, Slice(buf, 64), &bytes_read);
+
+    EXPECT_FALSE(st.ok());
+    EXPECT_TRUE(st.msg().find("Failed to flush") != std::string::npos) << st.msg();
+    // 1 initial + 3 retries = 4 calls
+    EXPECT_EQ(fake->get_object_call_count(), 4);
+}
+
+// NOT_FOUND error should NOT be retried.
+TEST_F(S3FileReaderRetryTest, not_found_error_no_retry) {
+    auto [fake, reader] = make_reader(64);
+
+    fake->push_get_response(make_not_found_error());
+
+    char buf[64];
+    size_t bytes_read = 0;
+    auto st = reader->read_at(0, Slice(buf, 64), &bytes_read);
+
+    EXPECT_FALSE(st.ok());
+    EXPECT_EQ(fake->get_object_call_count(), 1); // No retry
+}
+
+// is_retriable=false should NOT trigger transient retry even with http_code=-1.
+TEST_F(S3FileReaderRetryTest, non_retriable_internal_error_no_retry) {
+    auto [fake, reader] = make_reader(64);
+
+    ObjectStorageResponse resp = {
+            .status = {.code = ErrorCode::INTERNAL_ERROR, .msg = "some other error"},
+            .http_code = -1,
+            .error_type = 1, // INTERNAL_FAILURE
+            .is_retriable = false};
+    fake->push_get_response(resp);
+
+    char buf[64];
+    size_t bytes_read = 0;
+    auto st = reader->read_at(0, Slice(buf, 64), &bytes_read);
+
+    EXPECT_FALSE(st.ok());
+    EXPECT_EQ(fake->get_object_call_count(), 1); // No retry
+}
+
+// Verify .append("failed to read") is removed: error message should NOT contain
+// the double "failed to read" suffix.
+TEST_F(S3FileReaderRetryTest, error_message_no_append_failed_to_read) {
+    auto [fake, reader] = make_reader(64);
+
+    ObjectStorageResponse resp = {
+            .status = {.code = ErrorCode::INTERNAL_ERROR,
+                       .msg = "failed to read from test-key: err code=-1 type=1, request_id="},
+            .http_code = -1,
+            .error_type = 1,
+            .is_retriable = false};
+    fake->push_get_response(resp);
+
+    char buf[64];
+    size_t bytes_read = 0;
+    auto st = reader->read_at(0, Slice(buf, 64), &bytes_read);
+
+    EXPECT_FALSE(st.ok());
+    // The old code appended "failed to read" which produced "request_id=failed to read".
+    // Verify the error message is passed through without extra append.
+    EXPECT_TRUE(st.msg().find("request_id=failed to read") == std::string::npos) << st.msg();
+}
+
+} // namespace doris::io

--- a/be/test/io/fs/s3_obj_stroage_client_mock_test.cpp
+++ b/be/test/io/fs/s3_obj_stroage_client_mock_test.cpp
@@ -17,10 +17,13 @@
 
 #include <aws/core/Aws.h>
 #include <aws/s3/S3Client.h>
+#include <aws/s3/model/GetObjectRequest.h>
+#include <aws/s3/model/GetObjectResult.h>
 #include <aws/s3/model/ListObjectsV2Request.h>
 #include <aws/s3/model/ListObjectsV2Result.h>
 #include <aws/s3/model/Object.h>
 
+#include "common/status.h"
 #include "gmock/gmock.h"
 #include "io/fs/s3_obj_storage_client.h"
 #include "util/s3_util.h"
@@ -35,6 +38,8 @@ public:
 
     MOCK_METHOD(Aws::S3::Model::ListObjectsV2Outcome, ListObjectsV2,
                 (const Aws::S3::Model::ListObjectsV2Request& request), (const, override));
+    MOCK_METHOD(Aws::S3::Model::GetObjectOutcome, GetObject,
+                (const Aws::S3::Model::GetObjectRequest& request), (const, override));
 };
 
 class S3ObjStorageClientMockTest : public testing::Test {
@@ -124,5 +129,106 @@ TEST_F(S3ObjStorageClientMockTest, test_ca_cert) {
     auto path = doris::get_valid_ca_cert_path(doris::split(config::ca_cert_file_paths, ";"));
     LOG(INFO) << "config:" << config::ca_cert_file_paths << " path:" << path;
     ASSERT_FALSE(path.empty());
+}
+
+// Tests for is_retriable classification in get_object error path
+TEST_F(S3ObjStorageClientMockTest, get_object_flush_error_is_retriable) {
+    auto mock_s3_client = std::make_shared<MockS3Client>();
+    S3ObjStorageClient s3_obj_storage_client(mock_s3_client);
+
+    // Simulate SDK flush error: INTERNAL_FAILURE, empty exceptionName,
+    // message contains "Failed to flush"
+    Aws::Client::AWSError<Aws::S3::S3Errors> flush_err(
+            Aws::S3::S3Errors::INTERNAL_FAILURE, "",
+            "Failed to flush response stream (eof: 0, bad: 1)", false);
+    EXPECT_CALL(*mock_s3_client, GetObject(testing::_))
+            .WillOnce(testing::Return(GetObjectOutcome(std::move(flush_err))));
+
+    char buf[64];
+    size_t bytes_read = 0;
+    auto resp = s3_obj_storage_client.get_object(
+            {.bucket = "dummy-bucket", .key = "test-key"}, buf, 0, 64, &bytes_read);
+
+    EXPECT_NE(resp.status.code, ErrorCode::OK);
+    EXPECT_TRUE(resp.is_retriable);
+    EXPECT_EQ(resp.http_code, -1); // REQUEST_NOT_MADE
+    EXPECT_EQ(resp.error_type, static_cast<int>(Aws::S3::S3Errors::INTERNAL_FAILURE));
+}
+
+TEST_F(S3ObjStorageClientMockTest, get_object_rate_limit_error_not_retriable) {
+    auto mock_s3_client = std::make_shared<MockS3Client>();
+    S3ObjStorageClient s3_obj_storage_client(mock_s3_client);
+
+    // Simulate local rate limiter error: INTERNAL_FAILURE, exceptionName="exceeds limit"
+    Aws::Client::AWSError<Aws::S3::S3Errors> rate_limit_err(
+            Aws::S3::S3Errors::INTERNAL_FAILURE, "exceeds limit", "exceeds limit", false);
+    EXPECT_CALL(*mock_s3_client, GetObject(testing::_))
+            .WillOnce(testing::Return(GetObjectOutcome(std::move(rate_limit_err))));
+
+    char buf[64];
+    size_t bytes_read = 0;
+    auto resp = s3_obj_storage_client.get_object(
+            {.bucket = "dummy-bucket", .key = "test-key"}, buf, 0, 64, &bytes_read);
+
+    EXPECT_NE(resp.status.code, ErrorCode::OK);
+    EXPECT_FALSE(resp.is_retriable);
+}
+
+TEST_F(S3ObjStorageClientMockTest, get_object_internal_failure_without_flush_msg_not_retriable) {
+    auto mock_s3_client = std::make_shared<MockS3Client>();
+    S3ObjStorageClient s3_obj_storage_client(mock_s3_client);
+
+    // INTERNAL_FAILURE with empty exceptionName but message doesn't contain "Failed to flush"
+    Aws::Client::AWSError<Aws::S3::S3Errors> other_err(
+            Aws::S3::S3Errors::INTERNAL_FAILURE, "", "some other internal error", false);
+    EXPECT_CALL(*mock_s3_client, GetObject(testing::_))
+            .WillOnce(testing::Return(GetObjectOutcome(std::move(other_err))));
+
+    char buf[64];
+    size_t bytes_read = 0;
+    auto resp = s3_obj_storage_client.get_object(
+            {.bucket = "dummy-bucket", .key = "test-key"}, buf, 0, 64, &bytes_read);
+
+    EXPECT_NE(resp.status.code, ErrorCode::OK);
+    EXPECT_FALSE(resp.is_retriable);
+}
+
+TEST_F(S3ObjStorageClientMockTest, get_object_network_error_not_retriable) {
+    auto mock_s3_client = std::make_shared<MockS3Client>();
+    S3ObjStorageClient s3_obj_storage_client(mock_s3_client);
+
+    // NETWORK_CONNECTION error — already retried by SDK, should not be retriable at app layer
+    Aws::Client::AWSError<Aws::S3::S3Errors> network_err(
+            Aws::S3::S3Errors::NETWORK_CONNECTION, "", "connection reset", true);
+    EXPECT_CALL(*mock_s3_client, GetObject(testing::_))
+            .WillOnce(testing::Return(GetObjectOutcome(std::move(network_err))));
+
+    char buf[64];
+    size_t bytes_read = 0;
+    auto resp = s3_obj_storage_client.get_object(
+            {.bucket = "dummy-bucket", .key = "test-key"}, buf, 0, 64, &bytes_read);
+
+    EXPECT_NE(resp.status.code, ErrorCode::OK);
+    EXPECT_FALSE(resp.is_retriable);
+}
+
+TEST_F(S3ObjStorageClientMockTest, get_object_non_empty_exception_name_with_flush_msg_not_retriable) {
+    auto mock_s3_client = std::make_shared<MockS3Client>();
+    S3ObjStorageClient s3_obj_storage_client(mock_s3_client);
+
+    // INTERNAL_FAILURE with non-empty exceptionName, even if message contains "Failed to flush"
+    Aws::Client::AWSError<Aws::S3::S3Errors> err(
+            Aws::S3::S3Errors::INTERNAL_FAILURE, "SomeException",
+            "Failed to flush response stream", false);
+    EXPECT_CALL(*mock_s3_client, GetObject(testing::_))
+            .WillOnce(testing::Return(GetObjectOutcome(std::move(err))));
+
+    char buf[64];
+    size_t bytes_read = 0;
+    auto resp = s3_obj_storage_client.get_object(
+            {.bucket = "dummy-bucket", .key = "test-key"}, buf, 0, 64, &bytes_read);
+
+    EXPECT_NE(resp.status.code, ErrorCode::OK);
+    EXPECT_FALSE(resp.is_retriable);
 }
 } // namespace doris::io

--- a/regression-test/suites/fault_injection_p0/test_s3_read_transient_error_retry.groovy
+++ b/regression-test/suites/fault_injection_p0/test_s3_read_transient_error_retry.groovy
@@ -1,0 +1,111 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_s3_read_transient_error_retry", "p0,external,nonConcurrent") {
+    String ak = getS3AK()
+    String sk = getS3SK()
+    String s3_endpoint = getS3Endpoint()
+    String region = getS3Region()
+    String bucket = context.config.otherConfigs.get("s3BucketName")
+
+    if (!ak || !sk || !s3_endpoint || !bucket) {
+        logger.info("S3 not configured, skip test")
+        return
+    }
+
+    def outFilePath = "${bucket}/test_s3_transient_error_retry/data_"
+
+    // Clean up before test; keep table after test for debugging
+    sql """ DROP TABLE IF EXISTS test_s3_transient_error_src """
+    sql """
+        CREATE TABLE IF NOT EXISTS test_s3_transient_error_src (
+            `id` INT NOT NULL,
+            `name` STRING,
+            `value` INT
+        )
+        DISTRIBUTED BY HASH(id) PROPERTIES("replication_num" = "1");
+    """
+    sql """ INSERT INTO test_s3_transient_error_src VALUES (1,'a',100),(2,'b',200),(3,'c',300) """
+
+    def outfile_url = ""
+    def res = sql """
+        SELECT * FROM test_s3_transient_error_src
+        INTO OUTFILE "s3://${outFilePath}"
+        FORMAT AS CSV
+        PROPERTIES (
+            "s3.endpoint" = "${s3_endpoint}",
+            "s3.region" = "${region}",
+            "s3.secret_key" = "${sk}",
+            "s3.access_key" = "${ak}",
+            "column_separator" = ","
+        );
+    """
+    outfile_url = res[0][3]
+    logger.info("Exported to: ${outfile_url}")
+
+    // Test 1: transient error retry succeeds (inject_count=1, first read fails, retry succeeds)
+    try {
+        GetDebugPoint().enableDebugPointForAllBEs(
+            "s3_file_reader.transient_error", ["inject_count": "1"])
+
+        def result = sql """
+            SELECT count(*) FROM s3(
+                'uri' = '${outfile_url}.csv',
+                'format' = 'csv',
+                's3.access_key' = '${ak}',
+                's3.secret_key' = '${sk}',
+                's3.endpoint' = '${s3_endpoint}',
+                's3.region' = '${region}',
+                'column_separator' = ','
+            );
+        """
+        logger.info("Query with transient error injection succeeded: ${result}")
+        assertEquals(3, result[0][0] as int)
+    } finally {
+        GetDebugPoint().disableDebugPointForAllBEs("s3_file_reader.transient_error")
+    }
+
+    // Test 2: transient error retry exhausted (inject_count=10 > max_transient_retries=3, should fail)
+    try {
+        GetDebugPoint().enableDebugPointForAllBEs(
+            "s3_file_reader.transient_error", ["inject_count": "10"])
+
+        def failed = false
+        try {
+            sql """
+                SELECT count(*) FROM s3(
+                    'uri' = '${outfile_url}.csv',
+                    'format' = 'csv',
+                    's3.access_key' = '${ak}',
+                    's3.secret_key' = '${sk}',
+                    's3.endpoint' = '${s3_endpoint}',
+                    's3.region' = '${region}',
+                    'column_separator' = ','
+                );
+            """
+        } catch (Exception e) {
+            logger.info("Query failed as expected after retry exhaustion: ${e.getMessage()}")
+            assertTrue(e.getMessage().contains("Failed to flush response stream")
+                    || e.getMessage().contains("injected"))
+            failed = true
+        }
+        assertTrue(failed, "Query should have failed after transient retry exhaustion")
+    } finally {
+        GetDebugPoint().disableDebugPointForAllBEs("s3_file_reader.transient_error")
+    }
+
+}

--- a/regression-test/suites/fault_injection_p0/test_s3_read_transient_error_retry.groovy
+++ b/regression-test/suites/fault_injection_p0/test_s3_read_transient_error_retry.groovy
@@ -16,6 +16,12 @@
 // under the License.
 
 suite("test_s3_read_transient_error_retry", "p0,external,nonConcurrent") {
+    // Use framework S3 config; for local testing with MinIO, override in regression-conf.groovy:
+    //   s3Endpoint = "127.0.0.1:9001"
+    //   s3BucketName = "lyk"
+    //   s3Region = "us-east-1"
+    //   ak = "minioadmin"
+    //   sk = "minioadmin"
     String ak = getS3AK()
     String sk = getS3SK()
     String s3_endpoint = getS3Endpoint()
@@ -27,7 +33,7 @@ suite("test_s3_read_transient_error_retry", "p0,external,nonConcurrent") {
         return
     }
 
-    def outFilePath = "${bucket}/test_s3_transient_error_retry/data_"
+    def outFilePath = "${bucket}/lyk_test_prefix/test_s3_transient_error_retry/data_"
 
     // Clean up before test; keep table after test for debugging
     sql """ DROP TABLE IF EXISTS test_s3_transient_error_src """
@@ -54,25 +60,30 @@ suite("test_s3_read_transient_error_retry", "p0,external,nonConcurrent") {
             "column_separator" = ","
         );
     """
-    outfile_url = res[0][3]
-    logger.info("Exported to: ${outfile_url}")
+    // outfile_url contains wildcard like s3://bucket/path/data_xxx_*.csv
+    // Replace wildcard with 0.csv to get the actual file path
+    def rawUrl = res[0][3]
+    def csvUrl = rawUrl.replaceAll('\\*', '0') + ".csv"
+    logger.info("Exported to: ${rawUrl}, reading: ${csvUrl}")
+
+    def s3TvfSql = { String uri -> """
+        SELECT count(*) FROM s3(
+            'uri' = '${uri}',
+            'format' = 'csv',
+            's3.access_key' = '${ak}',
+            's3.secret_key' = '${sk}',
+            's3.endpoint' = '${s3_endpoint}',
+            's3.region' = '${region}',
+            'column_separator' = ','
+        )
+    """}
 
     // Test 1: transient error retry succeeds (inject_count=1, first read fails, retry succeeds)
     try {
         GetDebugPoint().enableDebugPointForAllBEs(
             "s3_file_reader.transient_error", ["inject_count": "1"])
 
-        def result = sql """
-            SELECT count(*) FROM s3(
-                'uri' = '${outfile_url}.csv',
-                'format' = 'csv',
-                's3.access_key' = '${ak}',
-                's3.secret_key' = '${sk}',
-                's3.endpoint' = '${s3_endpoint}',
-                's3.region' = '${region}',
-                'column_separator' = ','
-            );
-        """
+        def result = sql s3TvfSql(csvUrl)
         logger.info("Query with transient error injection succeeded: ${result}")
         assertEquals(3, result[0][0] as int)
     } finally {
@@ -86,17 +97,7 @@ suite("test_s3_read_transient_error_retry", "p0,external,nonConcurrent") {
 
         def failed = false
         try {
-            sql """
-                SELECT count(*) FROM s3(
-                    'uri' = '${outfile_url}.csv',
-                    'format' = 'csv',
-                    's3.access_key' = '${ak}',
-                    's3.secret_key' = '${sk}',
-                    's3.endpoint' = '${s3_endpoint}',
-                    's3.region' = '${region}',
-                    'column_separator' = ','
-                );
-            """
+            sql s3TvfSql(csvUrl)
         } catch (Exception e) {
             logger.info("Query failed as expected after retry exhaustion: ${e.getMessage()}")
             assertTrue(e.getMessage().contains("Failed to flush response stream")
@@ -107,5 +108,4 @@ suite("test_s3_read_transient_error_retry", "p0,external,nonConcurrent") {
     } finally {
         GetDebugPoint().disableDebugPointForAllBEs("s3_file_reader.transient_error")
     }
-
 }


### PR DESCRIPTION
## Summary

- Add bounded retry (max 3) for S3 `Failed to flush response stream` transient errors that AWS SDK misclassifies as non-retryable `INTERNAL_FAILURE`
- Fix misleading `request_id=failed to read` error message
- Add observability metrics (bvar/profile) for transient error retries

## Problem

When AWS SDK's `CurlHttpClient` encounters a stream flush failure after `curl_easy_perform` returns OK, it sets the error type to `INTERNAL_FAILURE` instead of `NETWORK_CONNECTION`. This causes:
1. SDK internal retry (`S3CustomRetryStrategy`) to skip — `INTERNAL_FAILURE` is marked non-retryable
2. Doris application retry (`s3_file_reader.cpp`) to skip — only retries HTTP 429

A transient, recoverable error is directly exposed to users as a query failure.

Related issues: CORE-5789, CIR-19680, CIR-19630

## Changes

| File | Change |
|------|--------|
| `obj_storage_client.h` | Add `error_type` and `is_retriable` fields to `ObjectStorageResponse` |
| `s3_obj_storage_client.cpp` | Compute `is_retriable` via four-condition heuristic in `get_object()` |
| `s3_file_reader.cpp` | Add transient error retry branch (max 3), debug point, bvar, profile counters; remove `.append("failed to read")` |
| `s3_file_reader.h` | Add transient error stats to `S3Statistics` |
| `err_utils.cpp` | Print `request_id=<empty>` instead of empty string in all `s3fs_error()` branches |
| `s3_obj_stroage_client_mock_test.cpp` | 5 mock unit tests for `is_retriable` classification |
| `s3_file_reader_retry_test.cpp` | 5 unit tests for reader retry behavior using fake `ObjStorageClient` |
| `test_s3_read_transient_error_retry.groovy` | Regression test with debug point injection |

## Test plan
- [x] BE unit tests: `S3ObjStorageClientMockTest.*` (is_retriable classification)
- [x] BE unit tests: `S3FileReaderRetryTest.*` (reader retry behavior)
- [ ] Regression test: `test_s3_read_transient_error_retry` (requires S3 + debug points)
- [x] Manual reproduction: MinIO + proxy injection verified flush error and retry-after-success


🤖 Generated with [Claude Code](https://claude.com/claude-code)