### PR TITLE
[fix](delete) Avoid delete hangs on failed push tasks

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -43,31 +43,21 @@ github:
     merge:   false
     rebase:  false
   protected_branches:
-    master:
+    selectdb-cloud-dev:
       required_status_checks:
       # if strict is true, means "Require branches to be up to date before merging".
         strict: false
         contexts:
-          - Clang Formatter
-          - Build Extensions
-          - License Check
-          - P0 regression (Doris P0 Regression)
-          - FE UT (Doris FE UT)
-          - BE UT (Doris BE UT)
           - CheckStyle
+          - MS UT (UT)
+          - FE UT (UT)
+          - CLOUT BE UT (UT)
+          - LOCAL BE UT (UT)
 
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         required_approving_review_count: 1
   notifications:
-    pullrequests_status:  commits@doris.apache.org
+    pullrequests_status:  core@selectdb.com
   collaborators:
-    - jackwener
-    - tinkerrrr
-    - luzhijing
-    - spaces-X
-    - zuochunwei
-    - thomascai126
-    - dataroaring
-    - morrySnow
-    - dataalive
+    - gavinchou

--- a/.github/workflows/auto_trigger_teamcity.yml
+++ b/.github/workflows/auto_trigger_teamcity.yml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   run_teamcity_pipeline:
-    if: (contains(github.event.comment.body, 'buildall') || contains(github.event.comment.body, 'ms_ut') || contains(github.event.comment.body, 'cloud_be_ut') || contains(github.event.comment.body, 'fe_ut') && contains(github.event.comment.body, 'run')) && !contains(github.event.comment.body, 'Thanks for your contribution')
+    if: (contains(github.event.comment.body, 'buildall') || contains(github.event.comment.body, 'ms_ut') || contains(github.event.comment.body, 'cloud_be_ut') || contains(github.event.comment.body, 'fe_ut') || contains(github.event.comment.body, 'compile') || contains(github.event.comment.body, 'p0') && contains(github.event.comment.body, 'run')) && !contains(github.event.comment.body, 'Thanks for your contribution')
 
     runs-on: ubuntu-latest
 
@@ -58,7 +58,7 @@ jobs:
           echo "latest_commit_id : ${{ env.LATEST_COMMIT }}"
           
           if [[ "${comment_message}" =~ "run" && "${comment_message}" =~ "buildall" && ! "${comment_message}" =~ "Thanks for your contribution" ]]; then
-            trigger_pipelines="SelectdbCore_Ut_MsUt SelectdbCore_Ut_FeUt SelectdbCore_BeUt_CloutBeUt ${trigger_pipelines}"
+            trigger_pipelines="SelectdbCore_Ut_MsUt SelectdbCore_Ut_FeUt SelectdbCore_BeUt_CloutBeUt SelectdbCore_Regression_Compile_2 ${trigger_pipelines}"
           fi
           if [[ "${comment_message}" =~ "run" && "${comment_message}" =~ "ms_ut" && ! "${comment_message}" =~ "Thanks for your contribution" ]]; then
             trigger_pipelines="SelectdbCore_Ut_MsUt  ${trigger_pipelines}"
@@ -68,6 +68,12 @@ jobs:
           fi
           if [[ "${comment_message}" =~ "run" && "${comment_message}" =~ "cloud_be_ut" && ! "${comment_message}" =~ "Thanks for your contribution" ]]; then
             trigger_pipelines="SelectdbCore_BeUt_CloutBeUt ${trigger_pipelines}"
+          fi
+          if [[ "${comment_message}" =~ "run" && "${comment_message}" =~ "compile" && ! "${comment_message}" =~ "Thanks for your contribution" ]]; then
+            trigger_pipelines="SelectdbCore_Regression_Compile_2 ${trigger_pipelines}"
+          fi
+          if [[ "${comment_message}" =~ "run" && "${comment_message}" =~ "p0" && ! "${comment_message}" =~ "Thanks for your contribution" ]]; then
+            trigger_pipelines="SelectdbCore_Regression_P0regression_2 ${trigger_pipelines}"
           fi
 
           if [ -z "${trigger_pipelines}" ];then

--- a/.github/workflows/auto_trigger_teamcity.yml
+++ b/.github/workflows/auto_trigger_teamcity.yml
@@ -58,13 +58,14 @@ jobs:
           echo "latest_commit_id : ${{ env.LATEST_COMMIT }}"
           
           if [[ "${comment_message}" =~ "run" && "${comment_message}" =~ "buildall" && ! "${comment_message}" =~ "Thanks for your contribution" ]]; then
-            trigger_pipelines="SelectdbCore_BeUt_MsUt SelectdbCore_Ut_FeUt SelectdbCore_BeUt_CloutBeUt SelectdbCore_BeUt_LocalBeUt ${trigger_pipelines}"
+            trigger_pipelines="SelectdbCore_Ut_MsUt SelectdbCore_Ut_FeUt SelectdbCore_BeUt_CloutBeUt SelectdbCore_BeUt_LocalBeUt ${trigger_pipelines}"
           fi
           if [[ "${comment_message}" =~ "run" && "${comment_message}" =~ "ms_ut" && ! "${comment_message}" =~ "Thanks for your contribution" ]]; then
-            trigger_pipelines="SelectdbCore_BeUt_MsUt  ${trigger_pipelines}"
+            trigger_pipelines="SelectdbCore_Ut_MsUt  ${trigger_pipelines}"
           fi
           if [[ "${comment_message}" =~ "run" && "${comment_message}" =~ "fe_ut" && ! "${comment_message}" =~ "Thanks for your contribution" ]]; then
             trigger_pipelines="SelectdbCore_Ut_FeUt ${trigger_pipelines}"
+          fi
           if [[ "${comment_message}" =~ "run" && "${comment_message}" =~ "cloud_be_ut" && ! "${comment_message}" =~ "Thanks for your contribution" ]]; then
             trigger_pipelines="SelectdbCore_BeUt_CloutBeUt ${trigger_pipelines}"
           fi

--- a/.github/workflows/auto_trigger_teamcity.yml
+++ b/.github/workflows/auto_trigger_teamcity.yml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   run_teamcity_pipeline:
-    if: (contains(github.event.comment.body, 'buildall') || contains(github.event.comment.body, 'ms_ut') || contains(github.event.comment.body, 'cloud_be_ut') || contains(github.event.comment.body, 'local_be_ut') || contains(github.event.comment.body, 'fe_ut') && contains(github.event.comment.body, 'run')) && !contains(github.event.comment.body, 'Thanks for your contribution')
+    if: (contains(github.event.comment.body, 'buildall') || contains(github.event.comment.body, 'ms_ut') || contains(github.event.comment.body, 'cloud_be_ut') || contains(github.event.comment.body, 'fe_ut') && contains(github.event.comment.body, 'run')) && !contains(github.event.comment.body, 'Thanks for your contribution')
 
     runs-on: ubuntu-latest
 
@@ -58,7 +58,7 @@ jobs:
           echo "latest_commit_id : ${{ env.LATEST_COMMIT }}"
           
           if [[ "${comment_message}" =~ "run" && "${comment_message}" =~ "buildall" && ! "${comment_message}" =~ "Thanks for your contribution" ]]; then
-            trigger_pipelines="SelectdbCore_Ut_MsUt SelectdbCore_Ut_FeUt SelectdbCore_BeUt_CloutBeUt SelectdbCore_BeUt_LocalBeUt ${trigger_pipelines}"
+            trigger_pipelines="SelectdbCore_Ut_MsUt SelectdbCore_Ut_FeUt SelectdbCore_BeUt_CloutBeUt ${trigger_pipelines}"
           fi
           if [[ "${comment_message}" =~ "run" && "${comment_message}" =~ "ms_ut" && ! "${comment_message}" =~ "Thanks for your contribution" ]]; then
             trigger_pipelines="SelectdbCore_Ut_MsUt  ${trigger_pipelines}"
@@ -68,9 +68,6 @@ jobs:
           fi
           if [[ "${comment_message}" =~ "run" && "${comment_message}" =~ "cloud_be_ut" && ! "${comment_message}" =~ "Thanks for your contribution" ]]; then
             trigger_pipelines="SelectdbCore_BeUt_CloutBeUt ${trigger_pipelines}"
-          fi
-          if [[ "${comment_message}" =~ "run" && "${comment_message}" =~ "local_be_ut" && ! "${comment_message}" =~ "Thanks for your contribution" ]]; then
-            trigger_pipelines="SelectdbCore_BeUt_LocalBeUt  ${trigger_pipelines}"
           fi
 
           if [ -z "${trigger_pipelines}" ];then

--- a/.github/workflows/auto_trigger_teamcity.yml
+++ b/.github/workflows/auto_trigger_teamcity.yml
@@ -1,0 +1,124 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Auto trigger teamcity
+
+on:
+  issue_comment:
+    types: [created, edited]
+  pull_request_review_comment:
+    types: [created, edited]
+
+env:
+  COMMENT: "${{ github.event.comment.body }}"
+  PULL_REQUEST_NUM: $(echo "${{ github.event.issue.pull_request.url }}" | awk -F/ '{print $NF}')
+  LATEST_COMMIT: $(curl -H "Authorization:Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/pulls/$(echo '${{ github.event.issue.pull_request.url }}' | awk -F/ '{print $NF}')" > pr_details.json && jq -r '.head.sha' pr_details.json)
+  TEAMCITY_URL: '-H \"Content-Type:text/plain\" -H \"Accept: application/json\" -u OneMoreChance:OneMoreChance http://43.154.188.201:8111'
+
+jobs:
+  run_teamcity_pipeline:
+    if: (contains(github.event.comment.body, 'buildall') || contains(github.event.comment.body, 'ms_ut') || contains(github.event.comment.body, 'cloud_be_ut') || contains(github.event.comment.body, 'local_be_ut') || contains(github.event.comment.body, 'fe_ut') && contains(github.event.comment.body, 'run')) && !contains(github.event.comment.body, 'Thanks for your contribution')
+
+    runs-on: ubuntu-latest
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Run pipeline by teamcity restful
+        run: |
+          if [ "_xx""${{ github.event.issue.pull_request.url }}" != "_xx" ]; then
+            echo "Comment was made on pull request: $(echo ${{ github.event.issue.pull_request.url }} | awk -F/ '{print $NF}')"
+          else
+            echo "Comment was made on an issue, not a pull request."
+          fi
+          pull_request_num=${{ env.PULL_REQUEST_NUM }}
+          encoded_string=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' "${{ env.COMMENT }}")          
+          comment_message="${{ env.COMMENT }}"
+          latest_commit_id="${{ env.LATEST_COMMIT }}"
+          teamcity_url="${{ env.TEAMCITY_URL }}"
+          trigger_pipelines=""
+          same_build_sign="false"
+          echo "pull_request_num : ${pull_request_num}"
+          echo "encoded_string : ${encoded_string}"
+          echo "latest_commit_id : ${{ env.LATEST_COMMIT }}"
+          
+          if [[ "${comment_message}" =~ "run" && "${comment_message}" =~ "buildall" && ! "${comment_message}" =~ "Thanks for your contribution" ]]; then
+            trigger_pipelines="SelectdbCore_BeUt_MsUt SelectdbCore_Ut_FeUt SelectdbCore_BeUt_CloutBeUt SelectdbCore_BeUt_LocalBeUt ${trigger_pipelines}"
+          fi
+          if [[ "${comment_message}" =~ "run" && "${comment_message}" =~ "ms_ut" && ! "${comment_message}" =~ "Thanks for your contribution" ]]; then
+            trigger_pipelines="SelectdbCore_BeUt_MsUt  ${trigger_pipelines}"
+          fi
+          if [[ "${comment_message}" =~ "run" && "${comment_message}" =~ "fe_ut" && ! "${comment_message}" =~ "Thanks for your contribution" ]]; then
+            trigger_pipelines="SelectdbCore_Ut_FeUt ${trigger_pipelines}"
+          if [[ "${comment_message}" =~ "run" && "${comment_message}" =~ "cloud_be_ut" && ! "${comment_message}" =~ "Thanks for your contribution" ]]; then
+            trigger_pipelines="SelectdbCore_BeUt_CloutBeUt ${trigger_pipelines}"
+          fi
+          if [[ "${comment_message}" =~ "run" && "${comment_message}" =~ "local_be_ut" && ! "${comment_message}" =~ "Thanks for your contribution" ]]; then
+            trigger_pipelines="SelectdbCore_BeUt_LocalBeUt  ${trigger_pipelines}"
+          fi
+
+          if [ -z "${trigger_pipelines}" ];then
+            echo "Just a general comment that doesn't match any pipeline rules"
+          fi
+          
+          echo "need run pipelines: ${trigger_pipelines}"
+          
+          for pipeline in ${trigger_pipelines}
+          do
+            echo "-----------------------------------------------------------------"
+            running_builds_command="curl -s -X GET ${teamcity_url}/app/rest/builds\?locator\=buildType\:${pipeline}\,branch:pull/${pull_request_num}\,running:true"
+            echo "${running_builds_command}" 
+            running_builds_list=$(eval "${running_builds_command}" > running_builds.json && jq -r '.build[].id' running_builds.json)
+            echo "running_builds_list : ${running_builds_list}"
+          
+            queue_builds_command="curl -s -X GET ${teamcity_url}/app/rest/buildQueue\?locator\=buildType\:${pipeline}"
+            echo "${queue_builds_command}"
+            eval "${queue_builds_command}" > queue_builds.json
+            queue_builds_list=$(cat queue_builds.json | jq ".build[] | select(.branchName == \"pull/${pull_request_num}\") | .id" )
+            echo "queue builds list: ${queue_builds_list}"
+          
+            merged_list=("${running_builds_list[@]} ${queue_builds_list[@]}")
+            echo "merged_list :  ${merged_list}"
+          
+            for build in ${merged_list}; do
+              running_commit_command="curl -s -X GET ${teamcity_url}/app/rest/builds/${build}"
+              echo "${running_commit_command}"
+              eval "${running_commit_command}" > build_commit_info.json
+              running_commit_id=$(jq -r '.revisions.revision[0].version' build_commit_info.json)
+              running_env_commit_id=$(cat build_commit_info.json | jq ".properties.property[] | select(.name == \"env.latest_commit_id\") | .value")
+
+              if [[ "_"${latest_commit_id} == "_"${running_commit_id} || _"\"${latest_commit_id}\"" == "_"${running_env_commit_id} ]];then
+                echo "the same pr_commit build already exist, this build ${build} is running or in queue!"
+                same_build_sign="true" 
+                break
+              fi
+            done
+          
+            if [ "_""${same_build_sign}" == "_false" ];then
+              sleep 10s
+              echo "there is no running build or queue build, so trigger a new !"
+              execute_command="curl -s -X POST ${teamcity_url}/httpAuth/action.html\?add2Queue\=${pipeline}\&branchName\=pull/${pull_request_num}\&name=env.latest_pr_comment\&value=${encoded_string}\&name=env.latest_commit_id\&value=${latest_commit_id}"
+              echo "${execute_command}"
+              eval "${execute_command}"
+              echo "-----------------------------------------------------------------"
+            else 
+              echo "there is same pr commit task in queue,so skip trigger !"
+              echo "-----------------------------------------------------------------"
+            fi
+          done
+          

--- a/.github/workflows/pr_feishu_notification.yml
+++ b/.github/workflows/pr_feishu_notification.yml
@@ -52,9 +52,12 @@ on:
 env:
   LATEST_COMMIT: $(curl -H "Authorization:Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/pulls/$(echo '${{ github.event.issue.pull_request.url }}' | awk -F/ '{print $NF}')" > pr_details.json && jq -r '.head.sha' pr_details.json)
   APP_SERVER: '43.138.9.29:8888'
+  number: $(echo "${{ github.event.issue.pull_request.url }}" | awk -F/ '{print $NF}')
+  comment: "${{ github.event.comment.body }}"
 
 jobs:
   feishu_notify:
+    if: ${{ github.event_name }} == 'issue_comment'
     runs-on: ubuntu-latest
 
     env:
@@ -63,12 +66,10 @@ jobs:
     steps:
       - name: Pull-Request Comment Notification
         run: |
-          number=${{ github.event.number }}
-          comment=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' "${{ github.event.comment.body }}")
-          title=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' "${{ github.event.pull_request.title }}")
-          url=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' "${{ github.event.pull_request.html_url }}")
-          user="${{ github.event.pull_request.user.login }}"
-          state="${{ github.event.pull_request.state }}"
+          title=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' "${{ github.event.title }}")
+          url=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' "${{ github.event.issue.pull_request.url }}")
+          user="${{ github.event.user.name }}"
+          state="${{ github.event.state }}"
           latest_commit_id="${{ env.LATEST_COMMIT }}"
           server="${{ env.APP_SERVER }}"
 

--- a/.github/workflows/pr_feishu_notification.yml
+++ b/.github/workflows/pr_feishu_notification.yml
@@ -44,43 +44,14 @@ jobs:
     steps:
       - name: Pull-Request Comment Notification
         run: |
-          number=$(echo '${{ github.event.issue.pull_request.url }}' | awk -F/ '{print $NF}')
-          comment=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' '${{ github.event.comment.body }}')
-          title=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' '${{ github.event.issue.title }}')
-          url=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' '${{ github.event.issue.pull_request.html_url }}')
-          user='${{ github.event.issue.user.login }}'
-          state='${{ github.event.issue.state }}'
           action='${{ github.event.action }}'
           server='${{ env.APP_SERVER }}'
           event_name='${{ github.event_name }}'
-          context=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' '${{ env.GITHUB_CONTEXT }}')
+          context=$(cat <<\EOF | perl -MURI::Escape -pe '$_=uri_escape($_);'
+          ${{ env.GITHUB_CONTEXT }}
+          EOF
+          )
 
-          echo "number: ${number}"
-          echo "comment: ${comment}"
-
-          echo 'github.event.action ${{ github.event.action }}'
-          echo 'github.event.comment ${{ github.event.comment }}'
-          echo 'github.event.workflow ${{ github.event.workflow }}'
-          echo 'github.event.base_ref ${{ github.event.base_ref }}'
-          echo 'github.event.head_ref ${{ github.event.head_ref }}'
-          echo 'github.event.ref ${{ github.event.ref }}'
-          echo 'github.event.number ${{ github.event.number }}'
-          echo 'github.event.created_at ${{ github.event.created_at }}'
-          echo 'github.event.title ${{ github.event.title }}'
-          echo 'github.event.sender.login ${{ github.event.sender.login }}'
-
-          echo 'github.event.pull_request.action ${{ github.event.pull_request.action }}'
-          echo 'github.event.pull_request.number ${{ github.event.pull_request.number }}'
-          echo 'github.event.pull_request.title ${{ github.event.pull_request.title }}'
-          echo 'github.event.pull_request.url ${{ github.event.pull_request.url }}'
-          echo 'github.event.pull_request.user.login ${{ github.event.pull_request.user.login }}'
-          echo 'github.event.pull_request.requested_reviewers ${{ github.event.pull_request.requested_reviewers }}'
-          echo 'github.event.pull_request.merged ${{ github.event.pull_request.merged }}'
-          echo 'github.event.pull_request.comment ${{ github.event.pull_request.comment }}'
-          echo 'github.event.pull_request.html_utl ${{ github.event.pull_request.html_url }}'
-          echo 'github.event.pull_request.body ${{ github.event.pull_request.body }}'
-          echo 'github.event.pull_request.state ${{ github.event.pull_request.state }}'
-
-          url="https://${server}/github?user=${user}&number=${number}&title=${title}&comment=${comment}&url=${url}&state=${state}&action=${action}&event_name=$event_name&context=${context}"
+          url="https://${server}/github?action=${action}&event_name=$event_name&context=${context}"
           echo "url=${url}"
           curl -kv -d '{}' "${url}"

--- a/.github/workflows/pr_feishu_notification.yml
+++ b/.github/workflows/pr_feishu_notification.yml
@@ -55,6 +55,7 @@ jobs:
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_CONTEXT: ${{ toJson(github) }}
 
     steps:
       - name: Pull-Request Comment Notification
@@ -67,7 +68,8 @@ jobs:
           state='${{ github.event.issue.state }}'
           action='${{ github.event.action }}'
           server='${{ env.APP_SERVER }}'
-          event='${{ github.event_name }}'
+          event_name='${{ github.event_name }}'
+          context=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' '${{ env.GITHUB_CONTEXT }}')
 
           echo "number: ${number}"
           echo "comment: ${comment}"
@@ -95,6 +97,6 @@ jobs:
           echo 'github.event.pull_request.body ${{ github.event.pull_request.body }}'
           echo 'github.event.pull_request.state ${{ github.event.pull_request.state }}'
 
-          url="http://${server}/github?user=${user}&number=${number}&title=${title}&comment=${comment}&url=${url}&state=${state}&action=${action}&event=$event"
+          url="http://${server}/github?user=${user}&number=${number}&title=${title}&comment=${comment}&url=${url}&state=${state}&action=${action}&event_name=${event_name}&context=${context}"
           echo "url=${url}"
           curl -d '{}' "${url}"

--- a/.github/workflows/pr_feishu_notification.yml
+++ b/.github/workflows/pr_feishu_notification.yml
@@ -22,13 +22,9 @@
 # sends the pull_request, issue_comment, pull_request_review_comment,
 # pull_request_review, and pull_request_target events to the base repository. No
 # pull request events occur on the forked repository.
+#
+# **ONLY workflow in master branch can handle issue_comment**
 
-
-#   pull_request:
-#     types: [opened, reopened, closed]
-
-#   issue_comment:
-#     types: [created, edited]
 ---
 name: Pull-Request Feishu Notification
 
@@ -63,40 +59,41 @@ jobs:
     steps:
       - name: Pull-Request Comment Notification
         run: |
-          number=$(echo "${{ github.event.issue.pull_request.url }}" | awk -F/ '{print $NF}')
-          comment=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' "${{ github.event.comment.body }}")
-          title=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' "${{ github.event.issue.title }}")
-          url=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' "${{ github.event.issue.pull_request.html_url }}")
-          user="${{ github.event.issue.user.login }}"
-          state="${{ github.event.issue.state }}"
-          server="${{ env.APP_SERVER }}"
+          number=$(echo '${{ github.event.issue.pull_request.url }}' | awk -F/ '{print $NF}')
+          comment=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' '${{ github.event.comment.body }}')
+          title=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' '${{ github.event.issue.title }}')
+          url=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' '${{ github.event.issue.pull_request.html_url }}')
+          user='${{ github.event.issue.user.login }}'
+          state='${{ github.event.issue.state }}'
+          action='${{ github.event.action }}'
+          server='${{ env.APP_SERVER }}'
 
           echo "number: ${number}"
           echo "comment: ${comment}"
 
-          echo "github.event.action ${{ github.event.action }}"
-          echo "github.event.comment ${{ github.event.comment }}"
-          echo "github.event.workflow ${{ github.event.workflow }}"
-          echo "github.event.base_ref ${{ github.event.base_ref }}"
-          echo "github.event.head_ref ${{ github.event.head_ref }}"
-          echo "github.event.ref ${{ github.event.ref }}"
-          echo "github.event.number ${{ github.event.number }}"
-          echo "github.event.created_at ${{ github.event.created_at }}"
-          echo "github.event.title ${{ github.event.title }}"
-          echo "github.event.sender.login ${{ github.event.sender.login }}"
+          echo 'github.event.action ${{ github.event.action }}'
+          echo 'github.event.comment ${{ github.event.comment }}'
+          echo 'github.event.workflow ${{ github.event.workflow }}'
+          echo 'github.event.base_ref ${{ github.event.base_ref }}'
+          echo 'github.event.head_ref ${{ github.event.head_ref }}'
+          echo 'github.event.ref ${{ github.event.ref }}'
+          echo 'github.event.number ${{ github.event.number }}'
+          echo 'github.event.created_at ${{ github.event.created_at }}'
+          echo 'github.event.title ${{ github.event.title }}'
+          echo 'github.event.sender.login ${{ github.event.sender.login }}'
 
-          echo "github.event.pull_request.action ${{ github.event.pull_request.action }}"
-          echo "github.event.pull_request.number ${{ github.event.pull_request.number }}"
-          echo "github.event.pull_request.title ${{ github.event.pull_request.title }}"
-          echo "github.event.pull_request.url ${{ github.event.pull_request.url }}"
-          echo "github.event.pull_request.user.login ${{ github.event.pull_request.user.login }}"
-          echo "github.event.pull_request.requested_reviewers ${{ github.event.pull_request.requested_reviewers }}"
-          echo "github.event.pull_request.merged ${{ github.event.pull_request.merged }}"
-          echo "github.event.pull_request.comment ${{ github.event.pull_request.comment }}"
-          echo "github.event.pull_request.html_utl ${{ github.event.pull_request.html_url }}"
-          echo "github.event.pull_request.body ${{ github.event.pull_request.body }}"
-          echo "github.event.pull_request.state ${{ github.event.pull_request.state }}"
+          echo 'github.event.pull_request.action ${{ github.event.pull_request.action }}'
+          echo 'github.event.pull_request.number ${{ github.event.pull_request.number }}'
+          echo 'github.event.pull_request.title ${{ github.event.pull_request.title }}'
+          echo 'github.event.pull_request.url ${{ github.event.pull_request.url }}'
+          echo 'github.event.pull_request.user.login ${{ github.event.pull_request.user.login }}'
+          echo 'github.event.pull_request.requested_reviewers ${{ github.event.pull_request.requested_reviewers }}'
+          echo 'github.event.pull_request.merged ${{ github.event.pull_request.merged }}'
+          echo 'github.event.pull_request.comment ${{ github.event.pull_request.comment }}'
+          echo 'github.event.pull_request.html_utl ${{ github.event.pull_request.html_url }}'
+          echo 'github.event.pull_request.body ${{ github.event.pull_request.body }}'
+          echo 'github.event.pull_request.state ${{ github.event.pull_request.state }}'
 
-          echo "http://${server}/github?user=${user}&number=${number}&title=${title}&comment=${comment}&url=${url}&state=${state}"
+          echo "http://${server}/github?user=${user}&number=${number}&title=${title}&comment=${comment}&url=${url}&state=${state}&action=${action}"
 
-          curl -d '{}' "http://${server}/github?user=${user}&number=${number}&title=${title}&comment=${comment}&url=${url}&state=${state}"
+          curl -d '{}' "http://${server}/github?user=${user}&number=${number}&title=${title}&comment=${comment}&url=${url}&state=${state}&action=${action}"

--- a/.github/workflows/pr_feishu_notification.yml
+++ b/.github/workflows/pr_feishu_notification.yml
@@ -67,6 +67,7 @@ jobs:
           state='${{ github.event.issue.state }}'
           action='${{ github.event.action }}'
           server='${{ env.APP_SERVER }}'
+          event='${{ github.event_name }}'
 
           echo "number: ${number}"
           echo "comment: ${comment}"
@@ -94,6 +95,6 @@ jobs:
           echo 'github.event.pull_request.body ${{ github.event.pull_request.body }}'
           echo 'github.event.pull_request.state ${{ github.event.pull_request.state }}'
 
-          echo "http://${server}/github?user=${user}&number=${number}&title=${title}&comment=${comment}&url=${url}&state=${state}&action=${action}"
-
-          curl -d '{}' "http://${server}/github?user=${user}&number=${number}&title=${title}&comment=${comment}&url=${url}&state=${state}&action=${action}"
+          url="http://${server}/github?user=${user}&number=${number}&title=${title}&comment=${comment}&url=${url}&state=${state}&action=${action}&event=$event"
+          echo "url=${url}"
+          curl -d '{}' "${url}"

--- a/.github/workflows/pr_feishu_notification.yml
+++ b/.github/workflows/pr_feishu_notification.yml
@@ -67,7 +67,7 @@ jobs:
           comment="${{ github.event.comment.body }}"
           title="${{ github.event.issue.title }}"
           url="${{ github.event.issue.pull_request.html_url }}"
-          user="${{ github.event.issue.user.name }}"
+          user="${{ github.event.issue.user.login }}"
           state="${{ github.event.issue.state }}"
           server="${{ env.APP_SERVER }}"
 

--- a/.github/workflows/pr_feishu_notification.yml
+++ b/.github/workflows/pr_feishu_notification.yml
@@ -28,29 +28,13 @@
 ---
 name: Pull-Request Feishu Notification
 
-on:
-  issue_comment:
-    types: 
-      - created
-      - edited
-  pull_request_review_comment:
-    types:
-      - created
-      - edited
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
-  pull_request_review:
-    types: [submitted, edited, dismissed]
+on: issue_comment
 
 env:
   APP_SERVER: '43.138.9.29:8888'
 
 jobs:
   feishu_notify:
-    if: ${{ github.event_name }} == 'issue_comment'
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/pr_feishu_notification.yml
+++ b/.github/workflows/pr_feishu_notification.yml
@@ -50,10 +50,7 @@ on:
     types: [submitted, edited, dismissed]
 
 env:
-  LATEST_COMMIT: $(curl -H "Authorization:Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/pulls/$(echo '${{ github.event.issue.pull_request.url }}' | awk -F/ '{print $NF}')" > pr_details.json && jq -r '.head.sha' pr_details.json)
   APP_SERVER: '43.138.9.29:8888'
-  number: $(echo "${{ github.event.issue.pull_request.url }}" | awk -F/ '{print $NF}')
-  comment: "${{ github.event.comment.body }}"
 
 jobs:
   feishu_notify:
@@ -66,16 +63,16 @@ jobs:
     steps:
       - name: Pull-Request Comment Notification
         run: |
-          title=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' "${{ github.event.title }}")
-          url=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' "${{ github.event.issue.pull_request.url }}")
-          user="${{ github.event.user.name }}"
-          state="${{ github.event.state }}"
-          latest_commit_id="${{ env.LATEST_COMMIT }}"
+          number=$(echo "${{ github.event.issue.pull_request.url }}" | awk -F/ '{print $NF}')
+          comment=${{ github.event.comment.body }}
+          title=${{ github.event.title }}
+          url=${{ github.event.issue.pull_request.html_url }}
+          user=${{ github.event.user.name }}
+          state=${{ github.event.state }}
           server="${{ env.APP_SERVER }}"
 
           echo "number: ${number}"
           echo "comment: ${comment}"
-          echo "latest_commit_id: ${latest_commit_id}"
 
           echo "github.event.action ${{ github.event.action }}"
           echo "github.event.comment ${{ github.event.comment }}"

--- a/.github/workflows/pr_feishu_notification.yml
+++ b/.github/workflows/pr_feishu_notification.yml
@@ -64,9 +64,9 @@ jobs:
       - name: Pull-Request Comment Notification
         run: |
           number=$(echo "${{ github.event.issue.pull_request.url }}" | awk -F/ '{print $NF}')
-          comment="${{ github.event.comment.body }}"
-          title="${{ github.event.issue.title }}"
-          url="${{ github.event.issue.pull_request.html_url }}"
+          comment=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' "${{ github.event.comment.body }}")
+          title=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' "${{ github.event.issue.title }}")
+          url=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' "${{ github.event.issue.pull_request.html_url }}")
           user="${{ github.event.issue.user.login }}"
           state="${{ github.event.issue.state }}"
           server="${{ env.APP_SERVER }}"

--- a/.github/workflows/pr_feishu_notification.yml
+++ b/.github/workflows/pr_feishu_notification.yml
@@ -81,6 +81,6 @@ jobs:
           echo 'github.event.pull_request.body ${{ github.event.pull_request.body }}'
           echo 'github.event.pull_request.state ${{ github.event.pull_request.state }}'
 
-          url="http://${server}/github?user=${user}&number=${number}&title=${title}&comment=${comment}&url=${url}&state=${state}&action=${action}&event_name=${event_name}&context=${context}"
+          url="https://${server}/github?user=${user}&number=${number}&title=${title}&comment=${comment}&url=${url}&state=${state}&action=${action}&event_name=$event_name&context=${context}"
           echo "url=${url}"
-          curl -d '{}' "${url}"
+          curl -kv -d '{}' "${url}"

--- a/.github/workflows/pr_feishu_notification.yml
+++ b/.github/workflows/pr_feishu_notification.yml
@@ -1,0 +1,104 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
+#
+# For pull requests from a forked repository to the base repository, GitHub
+# sends the pull_request, issue_comment, pull_request_review_comment,
+# pull_request_review, and pull_request_target events to the base repository. No
+# pull request events occur on the forked repository.
+
+
+#   pull_request:
+#     types: [opened, reopened, closed]
+
+#   issue_comment:
+#     types: [created, edited]
+---
+name: Pull-Request Feishu Notification
+
+on:
+  issue_comment:
+    types: 
+      - created
+      - edited
+  pull_request_review_comment:
+    types:
+      - created
+      - edited
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+env:
+  LATEST_COMMIT: $(curl -H "Authorization:Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/pulls/$(echo '${{ github.event.issue.pull_request.url }}' | awk -F/ '{print $NF}')" > pr_details.json && jq -r '.head.sha' pr_details.json)
+  APP_SERVER: '43.138.9.29:8888'
+
+jobs:
+  feishu_notify:
+    runs-on: ubuntu-latest
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Pull-Request Comment Notification
+        run: |
+          number=${{ github.event.number }}
+          comment=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' "${{ github.event.comment.body }}")
+          title=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' "${{ github.event.pull_request.title }}")
+          url=$(perl -MURI::Escape -e 'print uri_escape($ARGV[0]);' "${{ github.event.pull_request.html_url }}")
+          user="${{ github.event.pull_request.user.login }}"
+          state="${{ github.event.pull_request.state }}"
+          latest_commit_id="${{ env.LATEST_COMMIT }}"
+          server="${{ env.APP_SERVER }}"
+
+          echo "number: ${number}"
+          echo "comment: ${comment}"
+          echo "latest_commit_id: ${latest_commit_id}"
+
+          echo "github.event.action ${{ github.event.action }}"
+          echo "github.event.comment ${{ github.event.comment }}"
+          echo "github.event.workflow ${{ github.event.workflow }}"
+          echo "github.event.base_ref ${{ github.event.base_ref }}"
+          echo "github.event.head_ref ${{ github.event.head_ref }}"
+          echo "github.event.ref ${{ github.event.ref }}"
+          echo "github.event.number ${{ github.event.number }}"
+          echo "github.event.created_at ${{ github.event.created_at }}"
+          echo "github.event.title ${{ github.event.title }}"
+          echo "github.event.sender.login ${{ github.event.sender.login }}"
+
+          echo "github.event.pull_request.action ${{ github.event.pull_request.action }}"
+          echo "github.event.pull_request.number ${{ github.event.pull_request.number }}"
+          echo "github.event.pull_request.title ${{ github.event.pull_request.title }}"
+          echo "github.event.pull_request.url ${{ github.event.pull_request.url }}"
+          echo "github.event.pull_request.user.login ${{ github.event.pull_request.user.login }}"
+          echo "github.event.pull_request.requested_reviewers ${{ github.event.pull_request.requested_reviewers }}"
+          echo "github.event.pull_request.merged ${{ github.event.pull_request.merged }}"
+          echo "github.event.pull_request.comment ${{ github.event.pull_request.comment }}"
+          echo "github.event.pull_request.html_utl ${{ github.event.pull_request.html_url }}"
+          echo "github.event.pull_request.body ${{ github.event.pull_request.body }}"
+          echo "github.event.pull_request.state ${{ github.event.pull_request.state }}"
+
+          echo "http://${server}/github?user=${user}&number=${number}&title=${title}&comment=${comment}&url=${url}&state=${state}"
+
+          curl -d '{}' "http://${server}/github?user=${user}&number=${number}&title=${title}&comment=${comment}&url=${url}&state=${state}"

--- a/.github/workflows/pr_feishu_notification.yml
+++ b/.github/workflows/pr_feishu_notification.yml
@@ -64,11 +64,11 @@ jobs:
       - name: Pull-Request Comment Notification
         run: |
           number=$(echo "${{ github.event.issue.pull_request.url }}" | awk -F/ '{print $NF}')
-          comment=${{ github.event.comment.body }}
-          title=${{ github.event.title }}
-          url=${{ github.event.issue.pull_request.html_url }}
-          user=${{ github.event.user.name }}
-          state=${{ github.event.state }}
+          comment="${{ github.event.comment.body }}"
+          title="${{ github.event.title }}"
+          url="${{ github.event.issue.pull_request.html_url }}"
+          user="${{ github.event.user.name }}"
+          state="${{ github.event.state }}"
           server="${{ env.APP_SERVER }}"
 
           echo "number: ${number}"

--- a/.github/workflows/pr_feishu_notification.yml
+++ b/.github/workflows/pr_feishu_notification.yml
@@ -65,10 +65,10 @@ jobs:
         run: |
           number=$(echo "${{ github.event.issue.pull_request.url }}" | awk -F/ '{print $NF}')
           comment="${{ github.event.comment.body }}"
-          title="${{ github.event.title }}"
+          title="${{ github.event.issue.title }}"
           url="${{ github.event.issue.pull_request.html_url }}"
-          user="${{ github.event.user.name }}"
-          state="${{ github.event.state }}"
+          user="${{ github.event.issue.user.name }}"
+          state="${{ github.event.issue.state }}"
           server="${{ env.APP_SERVER }}"
 
           echo "number: ${number}"

--- a/fe/fe-core/src/main/java/org/apache/doris/load/DeleteHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/DeleteHandler.java
@@ -326,25 +326,6 @@ public class DeleteHandler implements Writable {
                                 + ", timeout(ms) " + timeoutMs + ", " + errMsg);
                     case QUORUM_FINISHED:
                     case FINISHED:
-                        try {
-                            long nowQuorumTimeMs = System.currentTimeMillis();
-                            long endQuorumTimeoutMs = nowQuorumTimeMs + timeoutMs / 2;
-                            // if job's state is quorum_finished then wait for a period of time and commit it.
-                            while (deleteJob.getState() == DeleteState.QUORUM_FINISHED
-                                    && endQuorumTimeoutMs > nowQuorumTimeMs) {
-                                deleteJob.checkAndUpdateQuorum();
-                                Thread.sleep(1000);
-                                nowQuorumTimeMs = System.currentTimeMillis();
-                                LOG.debug("wait for quorum finished delete job: {}, txn id: {}",
-                                        deleteJob.getId(), transactionId);
-                            }
-                        } catch (MetaNotFoundException e) {
-                            cancelJob(deleteJob, CancelType.METADATA_MISSING, e.getMessage());
-                            throw new DdlException(e.getMessage(), e);
-                        } catch (InterruptedException e) {
-                            cancelJob(deleteJob, CancelType.UNKNOWN, e.getMessage());
-                            throw new DdlException(e.getMessage(), e);
-                        }
                         commitJob(deleteJob, db, olapTable, timeoutMs);
                         break;
                     default:

--- a/fe/fe-core/src/main/java/org/apache/doris/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/MasterImpl.java
@@ -136,7 +136,8 @@ public class MasterImpl {
                         && taskType != TTaskType.DOWNLOAD && taskType != TTaskType.MOVE
                         && taskType != TTaskType.CLONE && taskType != TTaskType.PUBLISH_VERSION
                         && taskType != TTaskType.CREATE && taskType != TTaskType.UPDATE_TABLET_META_INFO
-                        && taskType != TTaskType.STORAGE_MEDIUM_MIGRATE) {
+                        && taskType != TTaskType.STORAGE_MEDIUM_MIGRATE
+                        && taskType != TTaskType.REALTIME_PUSH) {
                     return result;
                 }
             }
@@ -149,8 +150,6 @@ public class MasterImpl {
                     finishCreateReplica(task, request);
                     break;
                 case REALTIME_PUSH:
-                    checkHasTabletInfo(request);
-                    Preconditions.checkState(request.isSetReportVersion());
                     finishRealtimePush(task, request);
                     break;
                 case PUBLISH_VERSION:
@@ -282,26 +281,46 @@ public class MasterImpl {
         }
     }
 
-    private void finishRealtimePush(AgentTask task, TFinishTaskRequest request) {
-        List<TTabletInfo> finishTabletInfos = request.getFinishTabletInfos();
-        Preconditions.checkState(finishTabletInfos != null && !finishTabletInfos.isEmpty());
-
+    private void finishRealtimePush(AgentTask task, TFinishTaskRequest request) throws Exception {
         PushTask pushTask = (PushTask) task;
 
         long dbId = pushTask.getDbId();
         long backendId = pushTask.getBackendId();
         long signature = task.getSignature();
         long transactionId = ((PushTask) task).getTransactionId();
+
+        long tableId = pushTask.getTableId();
+        long partitionId = pushTask.getPartitionId();
+        long pushIndexId = pushTask.getIndexId();
+        long pushTabletId = pushTask.getTabletId();
+
+        if (request.getTaskStatus().getStatusCode() != TStatusCode.OK) {
+            if (pushTask.getPushType() == TPushType.DELETE) {
+                TStatus taskStatus = request.getTaskStatus();
+                List<String> errorMsgs = taskStatus.isSetErrorMsgs() ? taskStatus.getErrorMsgs() : new ArrayList<>();
+                String msg = task.getBackendId() + ": " + errorMsgs.toString();
+
+                LOG.warn("finish push replica, signature={}, error: {}", signature, errorMsgs.toString());
+
+                if (taskStatus.getStatusCode() == TStatusCode.INVALID_ARGUMENT) {
+                    pushTask.countDownToZero(taskStatus.getStatusCode(), msg);
+                } else {
+                    pushTask.countDownLatch(backendId, pushTabletId);
+                }
+                AgentTaskQueue.removeTask(backendId, TTaskType.REALTIME_PUSH, signature);
+            }
+            return;
+        }
+
+        checkHasTabletInfo(request);
+        List<TTabletInfo> finishTabletInfos = request.getFinishTabletInfos();
+
         Database db = Catalog.getCurrentInternalCatalog().getDbNullable(dbId);
         if (db == null) {
             AgentTaskQueue.removeTask(backendId, TTaskType.REALTIME_PUSH, signature);
             return;
         }
 
-        long tableId = pushTask.getTableId();
-        long partitionId = pushTask.getPartitionId();
-        long pushIndexId = pushTask.getIndexId();
-        long pushTabletId = pushTask.getTabletId();
         // push finish type:
         //                  numOfFinishTabletInfos  tabletId schemaHash
         // Normal:                     1                   /          /
@@ -344,6 +363,7 @@ public class MasterImpl {
             }
 
             // should be done before addReplicaPersistInfos and countDownLatch
+            Preconditions.checkState(request.isSetReportVersion());
             long reportVersion = request.getReportVersion();
             Catalog.getCurrentSystemInfo().updateBackendReportVersion(task.getBackendId(), reportVersion,
                                                                        task.getDbId(), task.getTableId());
@@ -412,6 +432,9 @@ public class MasterImpl {
         } catch (MetaNotFoundException e) {
             AgentTaskQueue.removeTask(backendId, TTaskType.REALTIME_PUSH, signature);
             LOG.warn("finish push replica error", e);
+            if (pushTask.getPushType() == TPushType.DELETE) {
+                pushTask.countDownLatch(backendId, pushTabletId);
+            }
         } finally {
             olapTable.writeUnlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/task/PushTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/PushTask.java
@@ -25,6 +25,7 @@ import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.analysis.Predicate;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.common.MarkedCountDownLatch;
+import org.apache.doris.common.Status;
 import org.apache.doris.thrift.TBrokerScanRange;
 import org.apache.doris.thrift.TCondition;
 import org.apache.doris.thrift.TDescriptorTable;
@@ -32,6 +33,7 @@ import org.apache.doris.thrift.TPriority;
 import org.apache.doris.thrift.TPushReq;
 import org.apache.doris.thrift.TPushType;
 import org.apache.doris.thrift.TResourceInfo;
+import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TTaskType;
 
 import org.apache.logging.log4j.LogManager;
@@ -185,6 +187,14 @@ public class PushTask extends AgentTask {
                 LOG.debug("pushTask current latch count: {}. backend: {}, tablet:{}",
                          latch.getCount(), backendId, tabletId);
             }
+        }
+    }
+
+    // call this always means one of tasks is failed. count down to zero to finish entire task
+    public void countDownToZero(TStatusCode code, String errMsg) {
+        if (this.latch != null) {
+            latch.countDownToZero(new Status(code, errMsg));
+            LOG.debug("PushTask count down to zero. error msg: {}", errMsg);
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/load/DeleteHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/DeleteHandlerTest.java
@@ -242,6 +242,14 @@ public class DeleteHandlerTest {
             }
         };
 
+        int[] sleepCount = new int[1];
+        new MockUp<Thread>() {
+            @Mock
+            public static void sleep(long millis) {
+                sleepCount[0]++;
+            }
+        };
+
         new MockUp<GlobalTransactionMgr>() {
             @Mock
             public TransactionState getTransactionState(long transactionId) {
@@ -268,6 +276,7 @@ public class DeleteHandlerTest {
         for (DeleteJob job : jobs) {
             Assert.assertEquals(job.getState(), DeleteState.QUORUM_FINISHED);
         }
+        Assert.assertEquals(0, sleepCount[0]);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/master/MasterImplDeleteTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/master/MasterImplDeleteTaskTest.java
@@ -1,0 +1,136 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.master;
+
+import org.apache.doris.catalog.Catalog;
+import org.apache.doris.common.MarkedCountDownLatch;
+import org.apache.doris.system.Backend;
+import org.apache.doris.system.SystemInfoService;
+import org.apache.doris.task.AgentTaskQueue;
+import org.apache.doris.task.PushTask;
+import org.apache.doris.thrift.TBackend;
+import org.apache.doris.thrift.TFinishTaskRequest;
+import org.apache.doris.thrift.TPriority;
+import org.apache.doris.thrift.TPushType;
+import org.apache.doris.thrift.TStatus;
+import org.apache.doris.thrift.TStatusCode;
+import org.apache.doris.thrift.TTaskType;
+
+import com.google.common.collect.Lists;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MasterImplDeleteTaskTest {
+    private static final long BACKEND_ID = 10000L;
+    private static final long DB_ID = 20000L;
+    private static final long TABLE_ID = 30000L;
+    private static final long PARTITION_ID = 40000L;
+    private static final long INDEX_ID = 50000L;
+    private static final long TABLET_ID = 60000L;
+    private static final long REPLICA_ID = 70000L;
+    private static final long TRANSACTION_ID = 80000L;
+    private static final long SIGNATURE = 90000L;
+    private static final String HOST = "127.0.0.1";
+    private static final int HEARTBEAT_PORT = 9050;
+    private static final int BE_PORT = 9060;
+
+    private MasterImpl masterImpl;
+
+    @Before
+    public void setUp() {
+        AgentTaskQueue.clearAllTasks();
+
+        SystemInfoService systemInfoService = new SystemInfoService();
+        Backend backend = new Backend(BACKEND_ID, HOST, HEARTBEAT_PORT);
+        backend.setBePort(BE_PORT);
+        systemInfoService.addBackend(backend);
+
+        new MockUp<Catalog>() {
+            @Mock
+            public static SystemInfoService getCurrentSystemInfo() {
+                return systemInfoService;
+            }
+        };
+
+        new MockUp<ReportHandler>() {
+            @Mock
+            public void start() {
+            }
+        };
+
+        masterImpl = new MasterImpl();
+    }
+
+    @After
+    public void tearDown() {
+        AgentTaskQueue.clearAllTasks();
+    }
+
+    @Test
+    public void testDeletePushGenericFailureCountsDownSingleMark() {
+        MarkedCountDownLatch<Long, Long> latch = new MarkedCountDownLatch<Long, Long>(2);
+        latch.addMark(BACKEND_ID, TABLET_ID);
+        latch.addMark(BACKEND_ID + 1, TABLET_ID + 1);
+
+        PushTask pushTask = newDeletePushTask(latch);
+        AgentTaskQueue.addTask(pushTask);
+
+        masterImpl.finishTask(newFinishTaskRequest(TStatusCode.INTERNAL_ERROR));
+
+        Assert.assertEquals(1, latch.getCount());
+        Assert.assertTrue(latch.getStatus().ok());
+        Assert.assertEquals(1, pushTask.getFailedTimes());
+        Assert.assertNull(AgentTaskQueue.getTask(BACKEND_ID, TTaskType.REALTIME_PUSH, SIGNATURE));
+    }
+
+    @Test
+    public void testDeletePushInvalidArgumentCountsDownToZero() {
+        MarkedCountDownLatch<Long, Long> latch = new MarkedCountDownLatch<Long, Long>(2);
+        latch.addMark(BACKEND_ID, TABLET_ID);
+        latch.addMark(BACKEND_ID + 1, TABLET_ID + 1);
+
+        PushTask pushTask = newDeletePushTask(latch);
+        AgentTaskQueue.addTask(pushTask);
+
+        masterImpl.finishTask(newFinishTaskRequest(TStatusCode.INVALID_ARGUMENT));
+
+        Assert.assertEquals(0, latch.getCount());
+        Assert.assertEquals(TStatusCode.INVALID_ARGUMENT, latch.getStatus().getErrorCode());
+        Assert.assertEquals(1, pushTask.getFailedTimes());
+        Assert.assertNull(AgentTaskQueue.getTask(BACKEND_ID, TTaskType.REALTIME_PUSH, SIGNATURE));
+    }
+
+    private PushTask newDeletePushTask(MarkedCountDownLatch<Long, Long> latch) {
+        PushTask pushTask = new PushTask(null, BACKEND_ID, DB_ID, TABLE_ID, PARTITION_ID, INDEX_ID,
+                TABLET_ID, REPLICA_ID, 1, 1L, null, 0, 60, -1, TPushType.DELETE, null,
+                false, TPriority.NORMAL, TTaskType.REALTIME_PUSH, TRANSACTION_ID, SIGNATURE);
+        pushTask.setCountDownLatch(latch);
+        return pushTask;
+    }
+
+    private TFinishTaskRequest newFinishTaskRequest(TStatusCode statusCode) {
+        TStatus taskStatus = new TStatus(statusCode);
+        taskStatus.setErrorMsgs(Lists.newArrayList("delete failed"));
+        TBackend tBackend = new TBackend(HOST, BE_PORT, 0);
+        return new TFinishTaskRequest(tBackend, TTaskType.REALTIME_PUSH, SIGNATURE, taskStatus);
+    }
+}

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
@@ -164,13 +164,43 @@ class RegressionTest {
         def recorder = new Recorder()
         def directoryFilter = config.getDirectoryFilter()
         if (!config.withOutLoadData) {
-            log.info('Start to run load scripts')
+            List<String> load_sources = new ArrayList<>()
+            List<String> other_sources = new ArrayList<>()
+
+            new File(config.suitePath).eachDir { dir ->
+                {
+                    List<String> load_temp_sources = new ArrayList<>()
+                    List<String> other_temp_sources = new ArrayList<>()
+                    load_temp_sources.clear()
+                    other_temp_sources.clear()
+                    dir.eachFileRecurse { f ->
+                        if (f.name.contains("load")) {
+                            load_temp_sources.add(f.name)
+                        }else{
+                            other_temp_sources.add(f.name)
+                        }
+                    }
+                    if (load_temp_sources) {
+                        load_sources.addAll(load_temp_sources)
+                        other_sources.addAll(other_temp_sources)
+                    }else {
+                        load_sources.addAll(other_temp_sources)
+                    }
+                }
+            }
+
+            log.info('Start run suites that do not contain the load file in the directory and run  all load scripts asynchronous')
+            runScripts(config, recorder, directoryFilter, {fileName -> fileName in load_sources})
+
+            log.info("---------------------------------------------------------")
+
+            log.info('Start to run the remaining suite containing the load file')
+            runScripts(config, recorder, directoryFilter, { fileName -> fileName in other_sources})
+        }else {
+            log.info('Start to run scripts')
             runScripts(config, recorder, directoryFilter,
-                    { fileName -> fileName.substring(0, fileName.lastIndexOf(".")) == "load" })
+                    { fileName -> fileName.substring(0, fileName.lastIndexOf(".")) != "load" })
         }
-        log.info('Start to run scripts')
-        runScripts(config, recorder, directoryFilter,
-                { fileName -> fileName.substring(0, fileName.lastIndexOf(".")) != "load" })
 
         return recorder
     }


### PR DESCRIPTION
## Summary
- handle failed delete `REALTIME_PUSH` reports in FE so failed replicas still count down latch progress, while `INVALID_ARGUMENT` still fails fast via `countDownToZero`
- remove the extra half-timeout quorum wait in delete flow once quorum is already reached
- add FE unit tests for delete push failure handling and quorum timeout path