### PR TITLE
feat(script): support the flag to open the remote JVM debug port

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -28,6 +28,7 @@ fi
 OPTS="$(getopt \
     -n "$0" \
     -o '' \
+    -l 'debug' \
     -l 'daemon' \
     -l 'helper:' \
     -l 'image:' \
@@ -42,6 +43,7 @@ eval set -- "${OPTS}"
 
 RUN_DAEMON=0
 RUN_CONSOLE=0
+RUN_DEBUG=0
 HELPER=''
 IMAGE_PATH=''
 IMAGE_TOOL=''
@@ -51,6 +53,10 @@ RECOVERY_JOURNAL_ID=''
 CLUSTER_SNAPSHOT=''
 while true; do
     case "$1" in
+    --debug)
+        RUN_DEBUG=1
+        shift
+        ;;
     --daemon)
         RUN_DAEMON=1
         shift
@@ -106,6 +112,7 @@ export DORIS_HOME
 # JAVA_OPTS
 # LOG_DIR
 # PID_DIR
+# DEBUG_PORT
 export JAVA_OPTS="-Xmx1024m"
 export LOG_DIR="${DORIS_HOME}/log"
 PID_DIR="$(
@@ -125,6 +132,9 @@ while read -r line; do
         eval 'export "${envline}"'
     fi
 done <"${DORIS_HOME}/conf/fe.conf"
+
+: "${DEBUG_PORT:=5001}"
+export DEBUG_PORT
 
 if [[ -e "${DORIS_HOME}/bin/palo_env.sh" ]]; then
     # shellcheck disable=1091
@@ -229,6 +239,11 @@ extract_java_opt_key() {
         -D*=*)
             # -Dfile.encoding=UTF-8
             # Extract property name: -Dfile.encoding
+            echo "${param%%=*}"
+            ;;
+        -agentlib:*=*)
+            # -agentlib:jdwp=transport=dt_socket,server=y,...
+            # Extract agent library name as key: -agentlib:jdwp
             echo "${param%%=*}"
             ;;
         -D*)
@@ -338,6 +353,16 @@ add_java_opt_if_missing "--add-opens=java.security.jgss/sun.security.krb5=ALL-UN
 add_java_opt_if_missing "--add-opens=java.management/sun.management=ALL-UNNAMED"
 add_java_opt_if_missing "--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED"
 add_java_opt_if_missing "--add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp=ALL-UNNAMED"
+
+if [[ "${RUN_DEBUG}" -eq 1 ]]; then
+    if ! [[ "${DEBUG_PORT}" =~ ^[0-9]+$ ]] || (( DEBUG_PORT < 1 || DEBUG_PORT > 65535 )); then
+        echo "DEBUG_PORT in fe.conf must be an integer between 1 and 65535, got: ${DEBUG_PORT}"
+        exit 1
+    fi
+    add_java_opt_if_missing \
+        "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:${DEBUG_PORT}"
+    log "Enabled FE debug mode on port ${DEBUG_PORT}"
+fi
 
 log "${final_java_opt}"
 export JAVA_OPTS="${final_java_opt}"

--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -29,6 +29,9 @@ LOG_DIR = ${DORIS_HOME}/log
 # For jdk 17, this JAVA_OPTS will be used as default JVM options
 JAVA_OPTS_FOR_JDK_17="-Dfile.encoding=UTF-8 -Djavax.security.auth.useSubjectCredsOnly=false -Xmx8192m -Xms8192m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$LOG_DIR -Xlog:gc*,classhisto*=trace:$LOG_DIR/fe.gc.log.$CUR_DATE:time,uptime:filecount=10,filesize=50M -Darrow.enable_null_check_for_get=false --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED --add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp=ALL-UNNAMED"
 
+# FE remote debug port for ./start_fe.sh --debug
+DEBUG_PORT=5001
+
 # Set your own JAVA_HOME
 # JAVA_HOME=/path/to/jdk/
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

FE currently has no dedicated startup flag to enable remote JVM debugging. To debug FE remotely, developers need to modify JVM options manually, which is inconvenient and can easily conflict with existing Java options. This change adds an opt-in `--debug` flag to `start_fe.sh`, introduces a configurable `DEBUG_PORT` in `fe.conf`, validates the configured port, and appends the JDWP agent option only when debug mode is explicitly enabled.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)

Manual test steps:
1. Configure `DEBUG_PORT` in `conf/fe.conf` or use the default value `5001`.
2. Start FE with `./bin/start_fe.sh --debug --daemon`.
3. Verify that the configured debug port is opened and a remote debugger can attach successfully.
4. Start FE without `--debug` and verify that the debug port is not exposed.

- Behavior changed:
    - [ ] No.
    - [x] Yes. `./bin/start_fe.sh --debug` now starts FE with remote JVM debug enabled on the configured `DEBUG_PORT`. The default startup behavior without `--debug` is unchanged.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
