### PR TITLE
[fix](ldap) Replace custom LDAP filter escaping with `LdapEncoder.filterEncode` to prevent injection vulnerabilities and add related documentation.

### DIFF
--- a/fe/fe-authentication/fe-authentication-plugins/fe-authentication-plugin-ldap/src/main/java/org/apache/doris/authentication/plugin/ldap/LdapClient.java
+++ b/fe/fe-authentication/fe-authentication-plugins/fe-authentication-plugin-ldap/src/main/java/org/apache/doris/authentication/plugin/ldap/LdapClient.java
@@ -17,11 +17,13 @@
 
 package org.apache.doris.authentication.plugin.ldap;
 
+
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.ldap.support.LdapEncoder;
 import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.ldap.core.support.AbstractContextMapper;
 import org.springframework.ldap.core.support.LdapContextSource;
@@ -176,7 +178,7 @@ public class LdapClient {
 
             if (!Strings.isNullOrEmpty(groupFilter)) {
                 // Support Open Directory implementations with custom filter
-                String filter = groupFilter.replace("{login}", username);
+                String filter = groupFilter.replace("{login}", LdapEncoder.filterEncode(username));
                 groupDns = getDn(org.springframework.ldap.query.LdapQueryBuilder.query()
                         .attributes("dn")
                         .base(groupBaseDn)
@@ -256,8 +258,8 @@ public class LdapClient {
     }
 
     private String getUserFilter(String filterTemplate, String username) {
-        // Replace {login} with actual username
-        return filterTemplate.replace("{login}", username);
+        // Replace {login} with escaped username to prevent LDAP filter injection (RFC 4515)
+        return filterTemplate.replace("{login}", LdapEncoder.filterEncode(username));
     }
 
     private String requireConfig(Map<String, String> config, String key, String description) {

--- a/fe/fe-authentication/fe-authentication-plugins/fe-authentication-plugin-ldap/src/main/java/org/apache/doris/authentication/plugin/ldap/LdapClient.java
+++ b/fe/fe-authentication/fe-authentication-plugins/fe-authentication-plugin-ldap/src/main/java/org/apache/doris/authentication/plugin/ldap/LdapClient.java
@@ -17,17 +17,16 @@
 
 package org.apache.doris.authentication.plugin.ldap;
 
-
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.ldap.core.DirContextOperations;
-import org.springframework.ldap.support.LdapEncoder;
 import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.ldap.core.support.AbstractContextMapper;
 import org.springframework.ldap.core.support.LdapContextSource;
 import org.springframework.ldap.query.LdapQuery;
+import org.springframework.ldap.support.LdapEncoder;
 
 import java.util.List;
 import java.util.Map;

--- a/fe/fe-authentication/fe-authentication-plugins/fe-authentication-plugin-ldap/src/test/java/org/apache/doris/authentication/plugin/ldap/LdapClientTest.java
+++ b/fe/fe-authentication/fe-authentication-plugins/fe-authentication-plugin-ldap/src/test/java/org/apache/doris/authentication/plugin/ldap/LdapClientTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.ldap.support.LdapEncoder;
 
 import java.util.HashMap;
 import java.util.List;
@@ -261,5 +262,48 @@ class LdapClientTest {
         // Then
         Assertions.assertNotNull(groups);
         Assertions.assertTrue(groups.isEmpty());
+    }
+
+    @Test
+    @DisplayName("UT-LDAP-C-018: LdapEncoder.filterEncode escapes RFC 4515 special characters")
+    void testLdapFilterEncoding() {
+        // Combined special characters
+        String input = "test*()\\\u0000";
+        String expected = "test\\2a\\28\\29\\5c\\00";
+        Assertions.assertEquals(expected, LdapEncoder.filterEncode(input));
+
+        // Null input
+        Assertions.assertNull(LdapEncoder.filterEncode(null));
+
+        // Normal username should not be altered
+        Assertions.assertEquals("zhangsan", LdapEncoder.filterEncode("zhangsan"));
+        Assertions.assertEquals("user.name@example.com", LdapEncoder.filterEncode("user.name@example.com"));
+
+        // Empty string
+        Assertions.assertEquals("", LdapEncoder.filterEncode(""));
+
+        // Each special character individually
+        Assertions.assertEquals("\\2a", LdapEncoder.filterEncode("*"));
+        Assertions.assertEquals("\\28", LdapEncoder.filterEncode("("));
+        Assertions.assertEquals("\\29", LdapEncoder.filterEncode(")"));
+        Assertions.assertEquals("\\5c", LdapEncoder.filterEncode("\\"));
+        Assertions.assertEquals("\\00", LdapEncoder.filterEncode("\u0000"));
+    }
+
+    @Test
+    @DisplayName("UT-LDAP-C-019: LdapEncoder.filterEncode blocks injection payload")
+    void testFilterEncodeBlocksInjectionPayload() {
+        // Classic LDAP injection: dorisuser6)(mail=testp*
+        String malicious = "dorisuser6)(mail=testp*";
+        String escaped = LdapEncoder.filterEncode(malicious);
+        Assertions.assertEquals("dorisuser6\\29\\28mail=testp\\2a", escaped);
+
+        // The escaped value should be safe for filter template substitution
+        String filter = "(uid={login})".replace("{login}", escaped);
+        Assertions.assertEquals("(uid=dorisuser6\\29\\28mail=testp\\2a)", filter);
+        // No unescaped parentheses or wildcards from input
+        Assertions.assertFalse(escaped.contains("("));
+        Assertions.assertFalse(escaped.contains(")"));
+        Assertions.assertFalse(escaped.contains("*"));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
@@ -146,7 +146,7 @@ public class LdapClient {
         try {
             clientInfo.getLdapTemplateNoPool().authenticate(org.springframework.ldap.query.LdapQueryBuilder.query()
                     .base(LdapConfig.ldap_user_basedn)
-                    .filter(getUserFilter(LdapConfig.ldap_user_filter, userName)), password);
+                    .filter(applyLoginFilter(LdapConfig.ldap_user_filter, userName)), password);
             return true;
         } catch (Exception e) {
             LOG.info("ldap client checkPassword failed, userName: {}", userName, e);
@@ -167,7 +167,7 @@ public class LdapClient {
         List<String> groupDns;
         if (!LdapConfig.ldap_group_filter.isEmpty()) {
             // Support Open Directory implementations
-            String filter = LdapConfig.ldap_group_filter.replace("{login}", userName);
+            String filter = applyLoginFilter(LdapConfig.ldap_group_filter, userName);
             groupDns = getDn(org.springframework.ldap.query.LdapQueryBuilder.query()
                     .attributes("dn")
                     .base(LdapConfig.ldap_group_basedn)
@@ -195,13 +195,13 @@ public class LdapClient {
 
     private String getUserDn(String userName) {
         List<String> userDns = getDn(org.springframework.ldap.query.LdapQueryBuilder.query()
-                .base(LdapConfig.ldap_user_basedn).filter(getUserFilter(LdapConfig.ldap_user_filter, userName)));
+                .base(LdapConfig.ldap_user_basedn).filter(applyLoginFilter(LdapConfig.ldap_user_filter, userName)));
         if (userDns == null || userDns.isEmpty()) {
             return null;
         }
         if (userDns.size() > 1) {
             String msg = String.format("[%s] not unique in LDAP server: [%s]",
-                    getUserFilter(LdapConfig.ldap_user_filter, userName), userDns);
+                    applyLoginFilter(LdapConfig.ldap_user_filter, userName), userDns);
             LOG.error(msg);
             ErrorReport.report(ErrorCode.ERROR_LDAP_USER_NOT_UNIQUE_ERR, userName);
             throw new RuntimeException(msg);
@@ -229,7 +229,41 @@ public class LdapClient {
         }
     }
 
-    private String getUserFilter(String userFilter, String userName) {
-        return userFilter.replaceAll("\\{login}", userName);
+    private String applyLoginFilter(String filter, String userName) {
+        if (filter == null) {
+            return null;
+        }
+        return filter.replace("{login}", escapeLdapFilterValue(userName));
+    }
+
+    @VisibleForTesting
+    static String escapeLdapFilterValue(String value) {
+        if (value == null) {
+            return null;
+        }
+        StringBuilder escaped = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            switch (ch) {
+                case '*':
+                    escaped.append("\\2a");
+                    break;
+                case '(':
+                    escaped.append("\\28");
+                    break;
+                case ')':
+                    escaped.append("\\29");
+                    break;
+                case '\\':
+                    escaped.append("\\5c");
+                    break;
+                case '\0':
+                    escaped.append("\\00");
+                    break;
+                default:
+                    escaped.append(ch);
+            }
+        }
+        return escaped.toString();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
@@ -25,12 +25,13 @@ import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.common.util.SymmetricEncryption;
 import org.apache.doris.persist.LdapInfo;
 
-import com.google.common.annotations.VisibleForTesting;
+
 import com.google.common.collect.Lists;
 import lombok.Data;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.ldap.support.LdapEncoder;
 import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.ldap.core.support.AbstractContextMapper;
 import org.springframework.ldap.core.support.LdapContextSource;
@@ -233,37 +234,6 @@ public class LdapClient {
         if (filter == null) {
             return null;
         }
-        return filter.replace("{login}", escapeLdapFilterValue(userName));
-    }
-
-    @VisibleForTesting
-    static String escapeLdapFilterValue(String value) {
-        if (value == null) {
-            return null;
-        }
-        StringBuilder escaped = new StringBuilder(value.length());
-        for (int i = 0; i < value.length(); i++) {
-            char ch = value.charAt(i);
-            switch (ch) {
-                case '*':
-                    escaped.append("\\2a");
-                    break;
-                case '(':
-                    escaped.append("\\28");
-                    break;
-                case ')':
-                    escaped.append("\\29");
-                    break;
-                case '\\':
-                    escaped.append("\\5c");
-                    break;
-                case '\0':
-                    escaped.append("\\00");
-                    break;
-                default:
-                    escaped.append(ch);
-            }
-        }
-        return escaped.toString();
+        return filter.replace("{login}", LdapEncoder.filterEncode(userName));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/ldap/LdapClient.java
@@ -25,19 +25,18 @@ import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.common.util.SymmetricEncryption;
 import org.apache.doris.persist.LdapInfo;
 
-
 import com.google.common.collect.Lists;
 import lombok.Data;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.ldap.core.DirContextOperations;
-import org.springframework.ldap.support.LdapEncoder;
 import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.ldap.core.support.AbstractContextMapper;
 import org.springframework.ldap.core.support.LdapContextSource;
 import org.springframework.ldap.pool.factory.PoolingContextSource;
 import org.springframework.ldap.pool.validation.DefaultDirContextValidator;
 import org.springframework.ldap.query.LdapQuery;
+import org.springframework.ldap.support.LdapEncoder;
 import org.springframework.ldap.transaction.compensating.manager.TransactionAwareContextSourceProxy;
 
 import java.util.List;
@@ -210,7 +209,6 @@ public class LdapClient {
         return userDns.get(0);
     }
 
-    @VisibleForTesting
     public List<String> getDn(LdapQuery query) {
         init();
         try {

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapClientTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapClientTest.java
@@ -118,6 +118,14 @@ public class LdapClientTest {
                           secureUrl.startsWith("ldaps://"));
     }
 
+    @Test
+    public void testEscapeLdapFilterValue() {
+        String input = "test*()\\\u0000";
+        String expected = "test\\2a\\28\\29\\5c\\00";
+        Assert.assertEquals(expected, LdapClient.escapeLdapFilterValue(input));
+        Assert.assertNull(LdapClient.escapeLdapFilterValue(null));
+    }
+
     @After
     public void tearDown() {
         LdapConfig.ldap_use_ssl = false; // restoring default value for other tests

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapClientTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapClientTest.java
@@ -28,6 +28,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.ldap.query.LdapQuery;
+import org.springframework.ldap.support.LdapEncoder;
 
 import java.util.Arrays;
 import java.util.List;
@@ -119,11 +120,32 @@ public class LdapClientTest {
     }
 
     @Test
-    public void testEscapeLdapFilterValue() {
+    public void testLdapFilterEncoding() {
+        // Combined special characters
         String input = "test*()\\\u0000";
         String expected = "test\\2a\\28\\29\\5c\\00";
-        Assert.assertEquals(expected, LdapClient.escapeLdapFilterValue(input));
-        Assert.assertNull(LdapClient.escapeLdapFilterValue(null));
+        Assert.assertEquals(expected, LdapEncoder.filterEncode(input));
+
+        // Null input
+        Assert.assertNull(LdapEncoder.filterEncode(null));
+
+        // Normal username should not be altered
+        Assert.assertEquals("zhangsan", LdapEncoder.filterEncode("zhangsan"));
+        Assert.assertEquals("user.name@example.com", LdapEncoder.filterEncode("user.name@example.com"));
+
+        // Empty string
+        Assert.assertEquals("", LdapEncoder.filterEncode(""));
+
+        // Each special character individually
+        Assert.assertEquals("\\2a", LdapEncoder.filterEncode("*"));
+        Assert.assertEquals("\\28", LdapEncoder.filterEncode("("));
+        Assert.assertEquals("\\29", LdapEncoder.filterEncode(")"));
+        Assert.assertEquals("\\5c", LdapEncoder.filterEncode("\\"));
+        Assert.assertEquals("\\00", LdapEncoder.filterEncode("\u0000"));
+
+        // Injection payload: dorisuser6)(mail=testp*
+        Assert.assertEquals("dorisuser6\\29\\28mail=testp\\2a",
+                LdapEncoder.filterEncode("dorisuser6)(mail=testp*"));
     }
 
     @After


### PR DESCRIPTION
### What problem does this PR solve?

When constructing LDAP search filters, the {login} placeholder in ldap_user_filter and ldap_group_filter is replaced with the raw username. If the username contains LDAP filter special characters (*, (, ), \, NUL), these characters are interpreted as part of the filter syntax rather than literal values, which may cause unexpected query behavior or incorrect search results.

This PR ensures all {login} substitutions are properly escaped per RFC 4515 using Spring LDAP's built-in LdapEncoder.filterEncode(), covering both the fe-core main authentication path and the fe-authentication plugin path.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

