### PR TITLE
[refactor](fe) Unify Iceberg split planning via producer

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CollectingSplitSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CollectingSplitSink.java
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource;
+
+import org.apache.doris.common.UserException;
+import org.apache.doris.spi.Split;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * {@link SplitSink} implementation for synchronous split retrieval.
+ *
+ * <p>This sink buffers every produced split in memory and allows callers to block until the
+ * producer finishes. It is used when a scan node wants to reuse the producer protocol but still
+ * needs a materialized {@code List<Split>} result.
+ */
+public class CollectingSplitSink implements SplitSink {
+    private final List<Split> splits = new ArrayList<>();
+    private final CountDownLatch completion = new CountDownLatch(1);
+    private final AtomicBoolean completed = new AtomicBoolean(false);
+    private UserException exception;
+
+    @Override
+    public void addBatch(List<Split> splits) {
+        synchronized (this.splits) {
+            this.splits.addAll(splits);
+        }
+    }
+
+    @Override
+    public boolean needMore() {
+        return !completed.get();
+    }
+
+    @Override
+    public void finish() {
+        complete(null);
+    }
+
+    @Override
+    public void fail(UserException e) {
+        complete(e);
+    }
+
+    /**
+     * Blocks until the producer calls {@link #finish()} or {@link #fail(UserException)}.
+     */
+    public void awaitFinished() throws UserException {
+        try {
+            completion.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new UserException("Interrupted while waiting for split planning to finish", e);
+        }
+        if (exception != null) {
+            throw exception;
+        }
+    }
+
+    /**
+     * Returns a snapshot of all collected splits.
+     */
+    public List<Split> getSplits() {
+        synchronized (splits) {
+            return new ArrayList<>(splits);
+        }
+    }
+
+    private void complete(UserException e) {
+        if (completed.compareAndSet(false, true)) {
+            exception = e;
+            completion.countDown();
+            return;
+        }
+        if (e != null && exception != null) {
+            exception.addSuppressed(e);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/FileQueryScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/FileQueryScanNode.java
@@ -336,6 +336,7 @@ public abstract class FileQueryScanNode extends FileScanNode {
 
         int numBackends = backendPolicy.numBackends();
         List<String> pathPartitionKeys = getPathPartitionKeys();
+        PlanningSplitProducer planningSplitProducer = getPlanningSplitProducer();
 
         boolean admissionResult = true;
         if (ConnectContext.get().getSessionVariable().isEnableFileCache()
@@ -343,10 +344,10 @@ public abstract class FileQueryScanNode extends FileScanNode {
             admissionResult = fileCacheAdmissionCheck();
         }
 
-        if (isBatchMode()) {
+        if (planningSplitProducer.isBatchMode()) {
             // File splits are generated lazily, and fetched by backends while scanning.
             // Only provide the unique ID of split source to backend.
-            splitAssignment = new SplitAssignment(backendPolicy, this, this::splitToScanRange,
+            splitAssignment = new SplitAssignment(backendPolicy, planningSplitProducer, this::splitToScanRange,
                     locationProperties, pathPartitionKeys, admissionResult);
             splitAssignment.init();
             if (executor != null) {
@@ -357,7 +358,7 @@ public abstract class FileQueryScanNode extends FileScanNode {
             }
             FileSplit fileSplit = (FileSplit) splitAssignment.getSampleSplit();
             TFileType locationType = fileSplit.getLocationType();
-            selectedSplitNum = numApproximateSplits();
+            selectedSplitNum = planningSplitProducer.numApproximateSplits();
             if (selectedSplitNum < 0) {
                 throw new UserException("Approximate split number should not be negative");
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/PlanningSplitMetadata.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/PlanningSplitMetadata.java
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource;
+
+/**
+ * Read-only metadata published by a {@link PlanningSplitProducer}.
+ *
+ * <p>This interface is intentionally marker-like. Datasource-specific producers can extend it with
+ * richer typed accessors without forcing generic planning code to depend on datasource internals.
+ */
+public interface PlanningSplitMetadata {
+    /**
+     * Empty metadata object used by producers that do not publish extra planning state.
+     */
+    PlanningSplitMetadata EMPTY = new PlanningSplitMetadata() {
+    };
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/PlanningSplitProducer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/PlanningSplitProducer.java
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource;
+
+import org.apache.doris.common.UserException;
+
+/**
+ * Producer-side abstraction for split planning.
+ *
+ * <p>The producer hides how a datasource plans splits from the generic consumers in
+ * {@link FileQueryScanNode} and {@link SplitAssignment}. Implementations may plan splits
+ * synchronously in the caller thread or asynchronously in background workers, but they must
+ * publish all planned splits to the provided {@link SplitSink}.
+ */
+public interface PlanningSplitProducer {
+    /**
+     * Whether this producer should be consumed through the lazy batch protocol in
+     * {@link SplitAssignment}.
+     *
+     * <p>When {@code false}, callers normally collect all planned splits eagerly and assign them
+     * in one shot. When {@code true}, callers expose a split source to backends and let them fetch
+     * planned batches on demand.
+     */
+    default boolean isBatchMode() {
+        return false;
+    }
+
+    /**
+     * Returns an estimated split count for explain output and scan concurrency estimation.
+     *
+     * <p>The value is only used when {@link #isBatchMode()} is {@code true}. Return {@code -1}
+     * when the producer cannot provide a stable estimate.
+     */
+    default int numApproximateSplits() {
+        return -1;
+    }
+
+    /**
+     * Exposes read-only planning metadata collected by this producer.
+     *
+     * <p>This is intended for side-channel information such as explain details or partition
+     * statistics. Callers must tolerate the metadata being empty or partially populated before
+     * planning finishes.
+     */
+    default PlanningSplitMetadata getPlanningMetadata() {
+        return PlanningSplitMetadata.EMPTY;
+    }
+
+    /**
+     * Starts split planning and pushes planned splits into {@code splitSink}.
+     *
+     * <p>The producer must eventually call {@link SplitSink#finish()} on success or
+     * {@link SplitSink#fail(UserException)} on failure. {@code numBackends} is provided so
+     * implementations can shape split planning using backend parallelism when needed.
+     */
+    void start(int numBackends, SplitSink splitSink) throws UserException;
+
+    /**
+     * Stops background planning work and releases producer-side resources.
+     */
+    default void stop() {
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitAssignment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitAssignment.java
@@ -41,13 +41,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * When file splits are supplied in batch mode, splits are generated lazily and assigned in each call of `getNextBatch`.
- * `SplitGenerator` provides the file splits, and `FederationBackendPolicy` assigns these splits to backends.
+ * `PlanningSplitProducer` produces the file splits, and `FederationBackendPolicy` assigns these splits to backends.
  */
-public class SplitAssignment {
+public class SplitAssignment implements SplitSink {
     private static final Logger LOG = LogManager.getLogger(SplitAssignment.class);
     private final Set<Long> sources = new HashSet<>();
     private final FederationBackendPolicy backendPolicy;
-    private final SplitGenerator splitGenerator;
+    private final PlanningSplitProducer planningSplitProducer;
     private final ConcurrentHashMap<Backend, BlockingQueue<Collection<TScanRangeLocations>>> assignment
             = new ConcurrentHashMap<>();
     private final SplitToScanRange splitToScanRange;
@@ -69,8 +69,19 @@ public class SplitAssignment {
             Map<String, String> locationProperties,
             List<String> pathPartitionKeys,
             boolean fileCacheAdmission) {
+        this(backendPolicy, splitGenerator.getPlanningSplitProducer(), splitToScanRange,
+                locationProperties, pathPartitionKeys, fileCacheAdmission);
+    }
+
+    public SplitAssignment(
+            FederationBackendPolicy backendPolicy,
+            PlanningSplitProducer planningSplitProducer,
+            SplitToScanRange splitToScanRange,
+            Map<String, String> locationProperties,
+            List<String> pathPartitionKeys,
+            boolean fileCacheAdmission) {
         this.backendPolicy = backendPolicy;
-        this.splitGenerator = splitGenerator;
+        this.planningSplitProducer = planningSplitProducer;
         this.splitToScanRange = splitToScanRange;
         this.locationProperties = locationProperties;
         this.pathPartitionKeys = pathPartitionKeys;
@@ -78,7 +89,7 @@ public class SplitAssignment {
     }
 
     public void init() throws UserException {
-        splitGenerator.startSplit(backendPolicy.numBackends());
+        planningSplitProducer.start(backendPolicy.numBackends(), this);
         synchronized (assignLock) {
             final int waitIntervalTimeMillis = 100;
             final int initTimeoutMillis = 30000; // 30s
@@ -103,6 +114,11 @@ public class SplitAssignment {
 
     public boolean needMoreSplit() {
         return !scheduleFinished.get() && !isStopped.get() && exception == null;
+    }
+
+    @Override
+    public boolean needMore() {
+        return needMoreSplit();
     }
 
     private void appendBatch(Multimap<Backend, Split> batch) throws UserException {
@@ -154,6 +170,11 @@ public class SplitAssignment {
         appendBatch(batch);
     }
 
+    @Override
+    public void addBatch(List<Split> splits) throws UserException {
+        addToQueue(splits);
+    }
+
     private void notifyAssignment() {
         synchronized (assignLock) {
             assignLock.notify();
@@ -177,6 +198,11 @@ public class SplitAssignment {
         notifyAssignment();
     }
 
+    @Override
+    public void fail(UserException e) {
+        setException(e);
+    }
+
     private void addUserException(UserException e) {
         if (exception != null) {
             exception.addSuppressed(e);
@@ -190,11 +216,17 @@ public class SplitAssignment {
         notifyAssignment();
     }
 
+    @Override
+    public void finish() {
+        finishSchedule();
+    }
+
     public void stop() {
         if (isStop()) {
             return;
         }
         isStopped.set(true);
+        planningSplitProducer.stop();
         closeableResources.forEach((closeable) -> {
             try {
                 closeable.close();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitGenerator.java
@@ -52,6 +52,30 @@ public interface SplitGenerator {
         return -1;
     }
 
+    default PlanningSplitProducer getPlanningSplitProducer() {
+        return new PlanningSplitProducer() {
+            @Override
+            public boolean isBatchMode() {
+                return SplitGenerator.this.isBatchMode();
+            }
+
+            @Override
+            public int numApproximateSplits() {
+                return SplitGenerator.this.numApproximateSplits();
+            }
+
+            @Override
+            public void start(int numBackends, SplitSink splitSink) throws UserException {
+                SplitGenerator.this.startSplit(numBackends);
+            }
+
+            @Override
+            public void stop() {
+                SplitGenerator.this.stop();
+            }
+        };
+    }
+
     default void startSplit(int numBackends) throws UserException {
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitSink.java
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource;
+
+import org.apache.doris.common.UserException;
+import org.apache.doris.spi.Split;
+
+import java.util.List;
+
+/**
+ * Consumer-side abstraction for planned split output.
+ *
+ * <p>A {@link PlanningSplitProducer} writes planned splits into a sink, while the sink decides how
+ * to consume them. For example, {@link SplitAssignment} incrementally assigns split batches to
+ * backends, and {@link CollectingSplitSink} buffers all splits for synchronous callers.
+ */
+public interface SplitSink {
+    /**
+     * Accepts one batch of planned splits.
+     */
+    void addBatch(List<Split> splits) throws UserException;
+
+    /**
+     * Whether the sink still wants more planned splits.
+     *
+     * <p>Producers should stop early when this returns {@code false}.
+     */
+    boolean needMore();
+
+    /**
+     * Signals that split planning completed successfully and no more batches will be produced.
+     */
+    void finish();
+
+    /**
+     * Signals that split planning failed and no more batches will be produced.
+     */
+    void fail(UserException e);
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/AbstractIcebergPlanningSplitProducer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/AbstractIcebergPlanningSplitProducer.java
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.PlanningSplitMetadata;
+import org.apache.doris.datasource.PlanningSplitProducer;
+import org.apache.doris.datasource.SplitSink;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+abstract class AbstractIcebergPlanningSplitProducer implements PlanningSplitProducer {
+    private final IcebergSplitPlanningSupport planningSupport;
+    private final IcebergPlanningMetadata planningMetadata;
+    private final Executor executor;
+
+    protected AbstractIcebergPlanningSplitProducer(
+            IcebergSplitPlanningSupport planningSupport,
+            Executor executor) {
+        this.planningSupport = planningSupport;
+        this.planningMetadata = new IcebergPlanningMetadata(planningSupport);
+        this.executor = executor;
+    }
+
+    @Override
+    public final boolean isBatchMode() {
+        return planningSupport.isBatchMode();
+    }
+
+    @Override
+    public final int numApproximateSplits() {
+        return planningSupport.numApproximateSplits();
+    }
+
+    @Override
+    public final PlanningSplitMetadata getPlanningMetadata() {
+        return planningMetadata;
+    }
+
+    @Override
+    public final void start(int numBackends, SplitSink splitSink) throws UserException {
+        if (isBatchMode()) {
+            CompletableFuture.runAsync(() -> runProduction(numBackends, splitSink), executor);
+            return;
+        }
+        runProduction(numBackends, splitSink);
+    }
+
+    protected final IcebergSplitPlanningSupport getPlanningSupport() {
+        return planningSupport;
+    }
+
+    private void runProduction(int numBackends, SplitSink splitSink) {
+        try {
+            doProduce(numBackends, splitSink);
+            splitSink.finish();
+            planningSupport.recordManifestCacheProfile();
+        } catch (Exception e) {
+            splitSink.fail(planningSupport.translatePlanningException(unwrapException(e)));
+        }
+    }
+
+    protected abstract void doProduce(int numBackends, SplitSink splitSink) throws Exception;
+
+    private Exception unwrapException(Exception e) {
+        if (e instanceof RuntimeException && e.getCause() instanceof Exception) {
+            return (Exception) e.getCause();
+        }
+        return e;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergPlanningMetadata.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergPlanningMetadata.java
@@ -1,0 +1,63 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.datasource.PlanningSplitMetadata;
+
+import java.util.Collections;
+import java.util.List;
+
+final class IcebergPlanningMetadata implements PlanningSplitMetadata {
+    private final IcebergSplitPlanningSupport planningSupport;
+
+    IcebergPlanningMetadata(IcebergSplitPlanningSupport planningSupport) {
+        this.planningSupport = planningSupport;
+    }
+
+    int getSelectedPartitionNum() {
+        return planningSupport.getSelectedPartitionNum();
+    }
+
+    int getApproximateSplitNum() {
+        return planningSupport.numApproximateSplits();
+    }
+
+    boolean hasTableLevelPushDownCount() {
+        return planningSupport.hasTableLevelPushDownCount();
+    }
+
+    long getCountFromSnapshot() {
+        return planningSupport.getCountFromSnapshot();
+    }
+
+    List<String> getPushdownIcebergPredicates() {
+        return Collections.unmodifiableList(planningSupport.getPushdownIcebergPredicates());
+    }
+
+    long getManifestCacheHits() {
+        return planningSupport.getManifestCacheHits();
+    }
+
+    long getManifestCacheMisses() {
+        return planningSupport.getManifestCacheMisses();
+    }
+
+    long getManifestCacheFailures() {
+        return planningSupport.getManifestCacheFailures();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -17,40 +17,31 @@
 
 package org.apache.doris.datasource.iceberg.source;
 
-import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.SlotDescriptor;
 import org.apache.doris.analysis.TableScanParams;
 import org.apache.doris.analysis.TableSnapshot;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.catalog.Column;
-import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
-import org.apache.doris.common.profile.SummaryProfile;
 import org.apache.doris.common.security.authentication.ExecutionAuthenticator;
 import org.apache.doris.common.util.LocationPath;
-import org.apache.doris.common.util.Util;
+import org.apache.doris.datasource.CollectingSplitSink;
 import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.datasource.ExternalUtil;
 import org.apache.doris.datasource.FileQueryScanNode;
-import org.apache.doris.datasource.TableFormatType;
+import org.apache.doris.datasource.PlanningSplitMetadata;
+import org.apache.doris.datasource.PlanningSplitProducer;
 import org.apache.doris.datasource.credentials.CredentialUtils;
 import org.apache.doris.datasource.credentials.VendedCredentialsFactory;
 import org.apache.doris.datasource.hive.HMSExternalTable;
 import org.apache.doris.datasource.iceberg.IcebergExternalCatalog;
-import org.apache.doris.datasource.iceberg.IcebergExternalMetaCache;
 import org.apache.doris.datasource.iceberg.IcebergExternalTable;
 import org.apache.doris.datasource.iceberg.IcebergUtils;
-import org.apache.doris.datasource.iceberg.cache.IcebergManifestCacheLoader;
-import org.apache.doris.datasource.iceberg.cache.ManifestCacheValue;
-import org.apache.doris.datasource.iceberg.profile.IcebergMetricsReporter;
-import org.apache.doris.datasource.iceberg.source.IcebergDeleteFileFilter.EqualityDelete;
 import org.apache.doris.datasource.property.storage.StorageProperties;
-import org.apache.doris.nereids.exceptions.NotSupportedException;
 import org.apache.doris.planner.PlanNodeId;
 import org.apache.doris.planner.ScanContext;
-import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.spi.Split;
 import org.apache.doris.thrift.TExplainLevel;
@@ -59,57 +50,27 @@ import org.apache.doris.thrift.TFileRangeDesc;
 import org.apache.doris.thrift.TIcebergDeleteFileDesc;
 import org.apache.doris.thrift.TIcebergFileDesc;
 import org.apache.doris.thrift.TPlanNode;
-import org.apache.doris.thrift.TPushAggOp;
 import org.apache.doris.thrift.TTableFormatFileDesc;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.iceberg.BaseFileScanTask;
 import org.apache.iceberg.BaseTable;
-import org.apache.iceberg.DeleteFile;
-import org.apache.iceberg.DeleteFileIndex;
 import org.apache.iceberg.FileContent;
-import org.apache.iceberg.FileScanTask;
-import org.apache.iceberg.ManifestContent;
-import org.apache.iceberg.ManifestFile;
-import org.apache.iceberg.PartitionData;
-import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.PartitionSpecParser;
-import org.apache.iceberg.SchemaParser;
-import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.TableScan;
-import org.apache.iceberg.expressions.Expression;
-import org.apache.iceberg.expressions.Expressions;
-import org.apache.iceberg.expressions.InclusiveMetricsEvaluator;
-import org.apache.iceberg.expressions.ManifestEvaluator;
-import org.apache.iceberg.expressions.ResidualEvaluator;
-import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.mapping.MappedField;
 import org.apache.iceberg.mapping.MappedFields;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;
-import org.apache.iceberg.util.ScanTaskUtil;
-import org.apache.iceberg.util.TableScanUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class IcebergScanNode extends FileQueryScanNode {
 
@@ -118,44 +79,13 @@ public class IcebergScanNode extends FileQueryScanNode {
 
     private IcebergSource source;
     private Table icebergTable;
-    private List<String> pushdownIcebergPredicates = Lists.newArrayList();
-    // If tableLevelPushDownCount is true, means we can do count push down opt at table level.
-    // which means all splits have no position/equality delete files,
-    // so for query like "select count(*) from ice_tbl", we can get count from snapshot row count info directly.
-    // If tableLevelPushDownCount is false, means we can't do count push down opt at table level,
-    // But for part of splits which have no position/equality delete files, we can still do count push down opt.
-    // And for split level count push down opt, the flag is set in each split.
-    private boolean tableLevelPushDownCount = false;
-    private long countFromSnapshot;
-    private static final long COUNT_WITH_PARALLEL_SPLITS = 10000;
-    private long targetSplitSize = 0;
-    // This is used to avoid repeatedly calculating partition info map for the same partition data.
-    private Map<PartitionData, Map<String, String>> partitionMapInfos;
-    private boolean isPartitionedTable;
     private int formatVersion;
     private ExecutionAuthenticator preExecutionAuthenticator;
-    private TableScan icebergTableScan;
     // Store PropertiesMap, including vended credentials or static credentials
     // get them in doInitialize() to ensure internal consistency of ScanNode
     private Map<StorageProperties.Type, StorageProperties> storagePropertiesMap;
     private Map<String, String> backendStorageProperties;
-    private long manifestCacheHits;
-    private long manifestCacheMisses;
-    private long manifestCacheFailures;
-
-    // Cached values for LocationPath creation optimization
-    // These are lazily initialized on first use to avoid parsing overhead for each file
-    private boolean locationPathCacheInitialized = false;
-    private StorageProperties cachedStorageProperties;
-    private String cachedSchema;
-    private String cachedFsIdPrefix;
-    // Cache for path prefix transformation to avoid repeated S3URI parsing
-    // Maps original path prefix (e.g., "https://bucket.s3.amazonaws.com/") to normalized prefix (e.g., "s3://bucket/")
-    private String cachedOriginalPathPrefix;
-    private String cachedNormalizedPathPrefix;
-    private String cachedFsIdentifier;
-
-    private Boolean isBatchMode = null;
+    private PlanningSplitProducer planningSplitProducer;
 
     // for test
     @VisibleForTesting
@@ -199,8 +129,6 @@ public class IcebergScanNode extends FileQueryScanNode {
     @Override
     protected void doInitialize() throws UserException {
         icebergTable = source.getIcebergTable();
-        partitionMapInfos = new HashMap<>();
-        isPartitionedTable = icebergTable.spec().isPartitioned();
         // Metadata tables (system tables) are not BaseTable instances, so we need to handle this case
         if (icebergTable instanceof BaseTable) {
             formatVersion = ((BaseTable) icebergTable).operations().current().formatVersion();
@@ -263,7 +191,7 @@ public class IcebergScanNode extends FileQueryScanNode {
     private void setIcebergParams(TFileRangeDesc rangeDesc, IcebergSplit icebergSplit) {
         TTableFormatFileDesc tableFormatFileDesc = new TTableFormatFileDesc();
         tableFormatFileDesc.setTableFormatType(icebergSplit.getTableFormatType().value());
-        if (tableLevelPushDownCount) {
+        if (icebergSplit.getTableLevelRowCount() >= 0) {
             tableFormatFileDesc.setTableLevelRowCount(icebergSplit.getTableLevelRowCount());
         } else {
             // MUST explicitly set to -1, to be distinct from valid row count >= 0
@@ -309,7 +237,7 @@ public class IcebergScanNode extends FileQueryScanNode {
                     IcebergDeleteFileFilter.EqualityDelete equalityDelete =
                             (IcebergDeleteFileFilter.EqualityDelete) filter;
                     deleteFileDesc.setFieldIds(equalityDelete.getFieldIds());
-                    deleteFileDesc.setContent(EqualityDelete.type());
+                    deleteFileDesc.setContent(IcebergDeleteFileFilter.EqualityDelete.type());
                 }
                 fileDesc.addToDeleteFiles(deleteFileDesc);
             }
@@ -395,525 +323,36 @@ public class IcebergScanNode extends FileQueryScanNode {
 
     @Override
     public List<Split> getSplits(int numBackends) throws UserException {
-
-        try {
-            return preExecutionAuthenticator.execute(() -> doGetSplits(numBackends));
-        } catch (Exception e) {
-            Optional<NotSupportedException> opt = checkNotSupportedException(e);
-            if (opt.isPresent()) {
-                throw opt.get();
-            } else {
-                throw new RuntimeException(ExceptionUtils.getRootCauseMessage(e), e);
-            }
-        }
-    }
-
-    /**
-     * Get FileScanTasks from StatementContext for rewrite operations.
-     * This allows setting file scan tasks before the plan is generated.
-     */
-    private List<FileScanTask> getFileScanTasksFromContext() {
-        ConnectContext ctx = ConnectContext.get();
-        Preconditions.checkNotNull(ctx);
-        Preconditions.checkNotNull(ctx.getStatementContext());
-
-        // Get the rewrite file scan tasks from statement context
-        List<FileScanTask> tasks = ctx.getStatementContext().getAndClearIcebergRewriteFileScanTasks();
-        if (tasks != null && !tasks.isEmpty()) {
-            LOG.info("Retrieved {} file scan tasks from context for table {}",
-                    tasks.size(), icebergTable.name());
-            return new ArrayList<>(tasks);
-        }
-        return null;
+        PlanningSplitProducer producer = getPlanningSplitProducer();
+        CollectingSplitSink splitSink = new CollectingSplitSink();
+        producer.start(numBackends, splitSink);
+        splitSink.awaitFinished();
+        syncPlanningMetadataFromProducer();
+        return splitSink.getSplits();
     }
 
     @Override
     public void startSplit(int numBackends) throws UserException {
-        try {
-            preExecutionAuthenticator.execute(() -> {
-                doStartSplit();
-                return null;
-            });
-        } catch (Exception e) {
-            throw new UserException(e.getMessage(), e);
-        }
+        Preconditions.checkNotNull(splitAssignment);
+        getPlanningSplitProducer().start(numBackends, splitAssignment);
     }
 
-    public void doStartSplit() throws UserException {
-        TableScan scan = createTableScan();
-        CompletableFuture.runAsync(() -> {
-            AtomicReference<CloseableIterable<FileScanTask>> taskRef = new AtomicReference<>();
-            try {
-                preExecutionAuthenticator.execute(
-                        () -> {
-                            CloseableIterable<FileScanTask> fileScanTasks = planFileScanTask(scan);
-                            taskRef.set(fileScanTasks);
-
-                            CloseableIterator<FileScanTask> iterator = fileScanTasks.iterator();
-                            while (splitAssignment.needMoreSplit() && iterator.hasNext()) {
-                                try {
-                                    splitAssignment.addToQueue(Lists.newArrayList(createIcebergSplit(iterator.next())));
-                                } catch (UserException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            }
-                        }
-                );
-                splitAssignment.finishSchedule();
-                recordManifestCacheProfile();
-            } catch (Exception e) {
-                Optional<NotSupportedException> opt = checkNotSupportedException(e);
-                if (opt.isPresent()) {
-                    splitAssignment.setException(new UserException(opt.get().getMessage(), opt.get()));
-                } else {
-                    splitAssignment.setException(new UserException(e.getMessage(), e));
-                }
-            } finally {
-                if (taskRef.get() != null) {
-                    try {
-                        taskRef.get().close();
-                    } catch (IOException e) {
-                        // ignore
-                    }
-                }
-            }
-        }, Env.getCurrentEnv().getExtMetaCacheMgr().getScheduleExecutor());
-    }
-
-    @VisibleForTesting
-    public TableScan createTableScan() throws UserException {
-        if (icebergTableScan != null) {
-            return icebergTableScan;
-        }
-
-        TableScan scan = icebergTable.newScan().metricsReporter(new IcebergMetricsReporter());
-
-        // set snapshot
-        IcebergTableQueryInfo info = getSpecifiedSnapshot();
-        if (info != null) {
-            if (info.getRef() != null) {
-                scan = scan.useRef(info.getRef());
-            } else {
-                scan = scan.useSnapshot(info.getSnapshotId());
-            }
-        }
-
-        // set filter
-        List<Expression> expressions = new ArrayList<>();
-        for (Expr conjunct : conjuncts) {
-            Expression expression = IcebergUtils.convertToIcebergExpr(conjunct, icebergTable.schema());
-            if (expression != null) {
-                expressions.add(expression);
-            }
-        }
-        for (Expression predicate : expressions) {
-            scan = scan.filter(predicate);
-            this.pushdownIcebergPredicates.add(predicate.toString());
-        }
-
-        icebergTableScan = scan.planWith(source.getCatalog().getThreadPoolWithPreAuth());
-
-        return icebergTableScan;
-    }
-
-    private CloseableIterable<FileScanTask> planFileScanTask(TableScan scan) {
-        if (!IcebergUtils.isManifestCacheEnabled(source.getCatalog())) {
-            return splitFiles(scan);
-        }
-        try {
-            return planFileScanTaskWithManifestCache(scan);
-        } catch (Exception e) {
-            manifestCacheFailures++;
-            LOG.warn("Plan with manifest cache failed, fallback to original scan: " + e.getMessage(), e);
-            return splitFiles(scan);
-        }
-    }
-
-    private CloseableIterable<FileScanTask> splitFiles(TableScan scan) {
-        if (sessionVariable.getFileSplitSize() > 0) {
-            return TableScanUtil.splitFiles(scan.planFiles(),
-                    sessionVariable.getFileSplitSize());
-        }
-        if (isBatchMode()) {
-            // Currently iceberg batch split mode will use max split size.
-            // TODO: dynamic split size in batch split mode need to customize iceberg splitter.
-            return TableScanUtil.splitFiles(scan.planFiles(), sessionVariable.getMaxSplitSize());
-        }
-
-        // Non Batch Mode
-        // Materialize planFiles() into a list to avoid iterating the CloseableIterable twice.
-        // RISK: It will cost memory if the table is large.
-        List<FileScanTask> fileScanTaskList = new ArrayList<>();
-        try (CloseableIterable<FileScanTask> scanTasksIter = scan.planFiles()) {
-            for (FileScanTask task : scanTasksIter) {
-                fileScanTaskList.add(task);
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to materialize file scan tasks", e);
-        }
-
-        targetSplitSize = determineTargetFileSplitSize(fileScanTaskList);
-        return TableScanUtil.splitFiles(CloseableIterable.withNoopClose(fileScanTaskList), targetSplitSize);
-    }
-
-    private long determineTargetFileSplitSize(Iterable<FileScanTask> tasks) {
-        long result = sessionVariable.getMaxInitialSplitSize();
-        long accumulatedTotalFileSize = 0;
-        boolean exceedInitialThreshold = false;
-        for (FileScanTask task : tasks) {
-            accumulatedTotalFileSize += ScanTaskUtil.contentSizeInBytes(task.file());
-            if (!exceedInitialThreshold && accumulatedTotalFileSize
-                    >= sessionVariable.getMaxSplitSize() * sessionVariable.getMaxInitialSplitNum()) {
-                exceedInitialThreshold = true;
-            }
-        }
-        result = exceedInitialThreshold ? sessionVariable.getMaxSplitSize() : result;
-        if (!isBatchMode()) {
-            result = applyMaxFileSplitNumLimit(result, accumulatedTotalFileSize);
-        }
-        return result;
-    }
-
-    private CloseableIterable<FileScanTask> planFileScanTaskWithManifestCache(TableScan scan) throws IOException {
-        // Get the snapshot from the scan; return empty if no snapshot exists
-        Snapshot snapshot = scan.snapshot();
-        if (snapshot == null) {
-            return CloseableIterable.withNoopClose(Collections.emptyList());
-        }
-
-        // Initialize manifest cache for efficient manifest file access
-        IcebergExternalMetaCache cache = Env.getCurrentEnv().getExtMetaCacheMgr().iceberg(source.getCatalog().getId());
-        if (!(source.getTargetTable() instanceof ExternalTable)) {
-            throw new RuntimeException("Iceberg scan target table is not an external table");
-        }
-        ExternalTable targetExternalTable = (ExternalTable) source.getTargetTable();
-
-        // Convert query conjuncts to Iceberg filter expression
-        // This combines all predicates with AND logic for partition/file pruning
-        Expression filterExpr = conjuncts.stream()
-                .map(conjunct -> IcebergUtils.convertToIcebergExpr(conjunct, icebergTable.schema()))
-                .filter(Objects::nonNull)
-                .reduce(Expressions.alwaysTrue(), Expressions::and);
-
-        // Get all partition specs by their IDs for later use
-        Map<Integer, PartitionSpec> specsById = icebergTable.specs();
-        boolean caseSensitive = true;
-
-        // Create residual evaluators for each partition spec
-        // Residual evaluators compute the remaining filter expression after partition pruning
-        Map<Integer, ResidualEvaluator> residualEvaluators = new HashMap<>();
-        specsById.forEach((id, spec) -> residualEvaluators.put(id,
-                ResidualEvaluator.of(spec, filterExpr, caseSensitive)));
-
-        // Create metrics evaluator for file-level pruning based on column statistics
-        InclusiveMetricsEvaluator metricsEvaluator =
-                new InclusiveMetricsEvaluator(icebergTable.schema(), filterExpr, caseSensitive);
-
-        // ========== Phase 1: Load delete files from delete manifests ==========
-        List<DeleteFile> deleteFiles = new ArrayList<>();
-        List<ManifestFile> deleteManifests = snapshot.deleteManifests(icebergTable.io());
-        for (ManifestFile manifest : deleteManifests) {
-            // Skip non-delete manifests
-            if (manifest.content() != ManifestContent.DELETES) {
-                continue;
-            }
-            // Get the partition spec for this manifest
-            PartitionSpec spec = specsById.get(manifest.partitionSpecId());
-            if (spec == null) {
-                continue;
-            }
-            // Create manifest evaluator for partition-level pruning
-            ManifestEvaluator evaluator =
-                    ManifestEvaluator.forPartitionFilter(filterExpr, spec, caseSensitive);
-            // Skip manifest if it doesn't match the filter expression (partition pruning)
-            if (!evaluator.eval(manifest)) {
-                continue;
-            }
-            // Load delete files from cache (or from storage if not cached)
-            ManifestCacheValue value = IcebergManifestCacheLoader.loadDeleteFilesWithCache(cache,
-                    targetExternalTable, manifest, icebergTable, this::recordManifestCacheAccess);
-            deleteFiles.addAll(value.getDeleteFiles());
-        }
-
-        // Build delete file index for efficient lookup of deletes applicable to each data file
-        DeleteFileIndex deleteIndex = DeleteFileIndex.builderFor(deleteFiles)
-                .specsById(specsById)
-                .caseSensitive(caseSensitive)
-                .build();
-
-        // ========== Phase 2: Load data files and create scan tasks ==========
-        List<FileScanTask> tasks = new ArrayList<>();
-        try (CloseableIterable<ManifestFile> dataManifests =
-                     IcebergUtils.getMatchingManifest(snapshot.dataManifests(icebergTable.io()),
-                             specsById, filterExpr)) {
-            for (ManifestFile manifest : dataManifests) {
-                // Skip non-data manifests
-                if (manifest.content() != ManifestContent.DATA) {
-                    continue;
-                }
-                // Get the partition spec for this manifest
-                PartitionSpec spec = specsById.get(manifest.partitionSpecId());
-                if (spec == null) {
-                    continue;
-                }
-                // Get the residual evaluator for this partition spec
-                ResidualEvaluator residualEvaluator = residualEvaluators.get(manifest.partitionSpecId());
-                if (residualEvaluator == null) {
-                    continue;
-                }
-
-                // Load data files from cache (or from storage if not cached)
-                ManifestCacheValue value = IcebergManifestCacheLoader.loadDataFilesWithCache(cache,
-                        targetExternalTable, manifest, icebergTable, this::recordManifestCacheAccess);
-
-                // Process each data file in the manifest
-                for (org.apache.iceberg.DataFile dataFile : value.getDataFiles()) {
-                    // Skip file if column statistics indicate no matching rows (metrics-based pruning)
-                    if (metricsEvaluator != null && !metricsEvaluator.eval(dataFile)) {
-                        continue;
-                    }
-                    // Skip file if partition values don't match the residual filter
-                    if (residualEvaluator.residualFor(dataFile.partition()).equals(Expressions.alwaysFalse())) {
-                        continue;
-                    }
-                    // Find all delete files that apply to this data file based on sequence number
-                    List<DeleteFile> deletes = Arrays.asList(
-                            deleteIndex.forDataFile(dataFile.dataSequenceNumber(), dataFile));
-
-                    // Create a FileScanTask containing the data file, associated deletes, and metadata
-                    tasks.add(new BaseFileScanTask(
-                            dataFile,
-                            deletes.toArray(new DeleteFile[0]),
-                            SchemaParser.toJson(icebergTable.schema()),
-                            PartitionSpecParser.toJson(spec),
-                            residualEvaluator));
-                }
-            }
-        }
-
-        // Split tasks into smaller chunks based on target split size for parallel processing
-        targetSplitSize = determineTargetFileSplitSize(tasks);
-        return TableScanUtil.splitFiles(CloseableIterable.withNoopClose(tasks), targetSplitSize);
-    }
-
-    /**
-     * Initialize cached values for LocationPath creation on first use.
-     * This avoids repeated StorageProperties lookup, scheme parsing, and S3URI regex parsing for each file.
-     */
-    private void initLocationPathCache(String samplePath) {
-        try {
-            // Create a LocationPath using the full method to get all cached values
-            LocationPath sampleLocationPath = LocationPath.of(samplePath, storagePropertiesMap);
-            cachedStorageProperties = sampleLocationPath.getStorageProperties();
-            cachedSchema = sampleLocationPath.getSchema();
-            cachedFsIdentifier = sampleLocationPath.getFsIdentifier();
-
-            // Extract fsIdPrefix like "s3://" from fsIdentifier like "s3://bucket"
-            int schemeEnd = cachedFsIdentifier.indexOf("://");
-            if (schemeEnd > 0) {
-                cachedFsIdPrefix = cachedFsIdentifier.substring(0, schemeEnd + 3);
-            }
-
-            // Cache path prefix mapping for fast transformation
-            // This allows subsequent files to skip S3URI regex parsing entirely
-            String normalizedPath = sampleLocationPath.getNormalizedLocation();
-
-            // Find the common prefix by looking for the last '/' before the filename
-            int lastSlashInOriginal = samplePath.lastIndexOf('/');
-            int lastSlashInNormalized = normalizedPath.lastIndexOf('/');
-
-            if (lastSlashInOriginal > 0 && lastSlashInNormalized > 0) {
-                cachedOriginalPathPrefix = samplePath.substring(0, lastSlashInOriginal + 1);
-                cachedNormalizedPathPrefix = normalizedPath.substring(0, lastSlashInNormalized + 1);
-            }
-
-            locationPathCacheInitialized = true;
-        } catch (Exception e) {
-            // If caching fails, try to initialize again on next use
-            LOG.warn("Failed to initialize LocationPath cache, will use full parsing", e);
-        }
-    }
-
-    /**
-     * Create a LocationPath with cached values for better performance.
-     * Uses cached path prefix mapping to completely bypass S3URI regex parsing for most files.
-     * Falls back to full parsing if cache is not available or path doesn't match cached prefix.
-     */
-    private LocationPath createLocationPathWithCache(String path) {
-        // Initialize cache on first call
-        if (!locationPathCacheInitialized) {
-            initLocationPathCache(path);
-        }
-
-        // Fast path: if path starts with cached original prefix, directly transform without any parsing
-        if (cachedOriginalPathPrefix != null && path.startsWith(cachedOriginalPathPrefix)) {
-            // Transform: replace original prefix with normalized prefix
-            String normalizedPath = cachedNormalizedPathPrefix + path.substring(cachedOriginalPathPrefix.length());
-            return LocationPath.ofDirect(normalizedPath, cachedSchema, cachedFsIdentifier, cachedStorageProperties);
-        }
-
-        // Medium path: use cached StorageProperties but still need validateAndNormalizeUri
-        if (cachedStorageProperties != null) {
-            return LocationPath.ofWithCache(path, cachedStorageProperties, cachedSchema, cachedFsIdPrefix);
-        }
-
-        // Fallback to full parsing
-        return LocationPath.of(path, storagePropertiesMap);
-    }
-
-    private Split createIcebergSplit(FileScanTask fileScanTask) {
-        String originalPath = fileScanTask.file().path().toString();
-        LocationPath locationPath = createLocationPathWithCache(originalPath);
-        IcebergSplit split = new IcebergSplit(
-                locationPath,
-                fileScanTask.start(),
-                fileScanTask.length(),
-                fileScanTask.file().fileSizeInBytes(),
-                new String[0],
-                formatVersion,
+    PlanningSplitProducer createPlanningSplitProducer() {
+        return new LocalParallelPlanningSplitProducer(new IcebergSplitPlanningSupport(
+                this,
+                source,
+                icebergTable,
+                preExecutionAuthenticator,
+                sessionVariable,
+                scanContext,
                 storagePropertiesMap,
-                new ArrayList<>(),
-                originalPath);
-        if (!fileScanTask.deletes().isEmpty()) {
-            split.setDeleteFileFilters(getDeleteFileFilters(fileScanTask));
-        }
-        split.setTableFormatType(TableFormatType.ICEBERG);
-        split.setTargetSplitSize(targetSplitSize);
-        if (isPartitionedTable) {
-            int specId = fileScanTask.file().specId();
-            PartitionSpec partitionSpec = icebergTable.specs().get(specId);
-            Preconditions.checkNotNull(partitionSpec, "Partition spec with specId %s not found for table %s",
-                    specId, icebergTable.name());
-            PartitionData partitionData = (PartitionData) fileScanTask.file().partition();
-            if (partitionData != null) {
-                split.setPartitionSpecId(specId);
-                split.setPartitionDataJson(IcebergUtils.getPartitionDataJson(
-                        partitionData, partitionSpec, sessionVariable.getTimeZone()));
-            }
-            if (sessionVariable.isEnableRuntimeFilterPartitionPrune()) {
-                Map<String, String> partitionInfoMap = partitionMapInfos.computeIfAbsent(
-                        partitionData, k -> {
-                            return IcebergUtils.getPartitionInfoMap(partitionData, partitionSpec,
-                                    sessionVariable.getTimeZone());
-                        });
-                // Only set partition values if all partitions are identity transform
-                // For non-identity partitions, getPartitionInfoMap returns null to skip dynamic partition pruning
-                if (partitionInfoMap != null) {
-                    split.setIcebergPartitionValues(partitionInfoMap);
-                }
-            } else {
-                partitionMapInfos.put(partitionData, null);
-            }
-        }
-        return split;
-    }
-
-    private List<Split> doGetSplits(int numBackends) throws UserException {
-
-        List<Split> splits = new ArrayList<>();
-
-        // Use custom file scan tasks if available (for rewrite operations)
-        List<FileScanTask> customFileScanTasks = getFileScanTasksFromContext();
-        if (customFileScanTasks != null) {
-            for (FileScanTask task : customFileScanTasks) {
-                splits.add(createIcebergSplit(task));
-            }
-            selectedPartitionNum = partitionMapInfos.size();
-            recordManifestCacheProfile();
-            return splits;
-        }
-
-        // Normal table scan planning
-        TableScan scan = createTableScan();
-
-        try (CloseableIterable<FileScanTask> fileScanTasks = planFileScanTask(scan)) {
-            if (tableLevelPushDownCount) {
-                int needSplitCnt = countFromSnapshot < COUNT_WITH_PARALLEL_SPLITS
-                        ? 1 : sessionVariable.getParallelExecInstanceNum(scanContext.getClusterName()) * numBackends;
-                for (FileScanTask next : fileScanTasks) {
-                    splits.add(createIcebergSplit(next));
-                    if (splits.size() >= needSplitCnt) {
-                        break;
-                    }
-                }
-                setPushDownCount(countFromSnapshot);
-                assignCountToSplits(splits, countFromSnapshot);
-                recordManifestCacheProfile();
-                return splits;
-            } else {
-                fileScanTasks.forEach(taskGrp -> splits.add(createIcebergSplit(taskGrp)));
-            }
-        } catch (IOException e) {
-            throw new UserException(e.getMessage(), e.getCause());
-        }
-
-        selectedPartitionNum = partitionMapInfos.size();
-        recordManifestCacheProfile();
-        return splits;
+                formatVersion,
+                icebergTable.spec().isPartitioned()));
     }
 
     @Override
     public boolean isBatchMode() {
-        Boolean cached = isBatchMode;
-        if (cached != null) {
-            return cached;
-        }
-        TPushAggOp aggOp = getPushDownAggNoGroupingOp();
-        if (aggOp.equals(TPushAggOp.COUNT)) {
-            try {
-                countFromSnapshot = getCountFromSnapshot();
-            } catch (UserException e) {
-                throw new RuntimeException(e);
-            }
-            if (countFromSnapshot >= 0) {
-                tableLevelPushDownCount = true;
-                isBatchMode = false;
-                return false;
-            }
-        }
-
-        try {
-            if (createTableScan().snapshot() == null) {
-                isBatchMode = false;
-                return false;
-            }
-        } catch (UserException e) {
-            throw new RuntimeException(e);
-        }
-
-        if (!sessionVariable.getEnableExternalTableBatchMode()) {
-            isBatchMode = false;
-            return false;
-        }
-
-        try {
-            return preExecutionAuthenticator.execute(() -> {
-                try (CloseableIterator<ManifestFile> matchingManifest =
-                        IcebergUtils.getMatchingManifest(
-                                createTableScan().snapshot().dataManifests(icebergTable.io()),
-                                icebergTable.specs(),
-                                createTableScan().filter()).iterator()) {
-                    int cnt = 0;
-                    while (matchingManifest.hasNext()) {
-                        ManifestFile next = matchingManifest.next();
-                        cnt += next.addedFilesCount() + next.existingFilesCount();
-                        if (cnt >= sessionVariable.getNumFilesInBatchMode()) {
-                            isBatchMode = true;
-                            return true;
-                        }
-                    }
-                }
-                isBatchMode = false;
-                return false;
-            });
-        } catch (Exception e) {
-            Optional<NotSupportedException> opt = checkNotSupportedException(e);
-            if (opt.isPresent()) {
-                throw opt.get();
-            } else {
-                throw new RuntimeException(ExceptionUtils.getRootCauseMessage(e), e);
-            }
-        }
+        return getPlanningSplitProducer().isBatchMode();
     }
 
     public IcebergTableQueryInfo getSpecifiedSnapshot() throws UserException {
@@ -929,20 +368,12 @@ public class IcebergScanNode extends FileQueryScanNode {
         return null;
     }
 
-    private List<IcebergDeleteFileFilter> getDeleteFileFilters(FileScanTask spitTask) {
-        List<IcebergDeleteFileFilter> filters = new ArrayList<>();
-        for (DeleteFile delete : spitTask.deletes()) {
-            if (delete.content() == FileContent.POSITION_DELETES) {
-                filters.add(IcebergDeleteFileFilter.createPositionDelete(delete));
-            } else if (delete.content() == FileContent.EQUALITY_DELETES) {
-                filters.add(IcebergDeleteFileFilter.createEqualityDelete(
-                        delete.path().toString(), delete.equalityFieldIds(),
-                        delete.fileSizeInBytes(), delete.format()));
-            } else {
-                throw new IllegalStateException("Unknown delete content: " + delete.content());
-            }
+    @Override
+    public PlanningSplitProducer getPlanningSplitProducer() {
+        if (planningSplitProducer == null) {
+            planningSplitProducer = createPlanningSplitProducer();
         }
-        return filters;
+        return planningSplitProducer;
     }
 
     @Override
@@ -977,27 +408,6 @@ public class IcebergScanNode extends FileQueryScanNode {
         return new ArrayList<>();
     }
 
-    private void recordManifestCacheAccess(boolean cacheHit) {
-        if (cacheHit) {
-            manifestCacheHits++;
-        } else {
-            manifestCacheMisses++;
-        }
-    }
-
-    private void recordManifestCacheProfile() {
-        if (!IcebergUtils.isManifestCacheEnabled(source.getCatalog())) {
-            return;
-        }
-        SummaryProfile summaryProfile = SummaryProfile.getSummaryProfile(ConnectContext.get());
-        if (summaryProfile == null || summaryProfile.getExecutionSummary() == null) {
-            return;
-        }
-        summaryProfile.getExecutionSummary().addInfoString("Manifest Cache",
-                String.format("hits=%d, misses=%d, failures=%d",
-                        manifestCacheHits, manifestCacheMisses, manifestCacheFailures));
-    }
-
     @Override
     public TableIf getTargetTable() {
         return source.getTargetTable();
@@ -1008,38 +418,6 @@ public class IcebergScanNode extends FileQueryScanNode {
         return backendStorageProperties;
     }
 
-    @VisibleForTesting
-    public long getCountFromSnapshot() throws UserException {
-        IcebergTableQueryInfo info = getSpecifiedSnapshot();
-
-        Snapshot snapshot = info == null
-                ? icebergTable.currentSnapshot() : icebergTable.snapshot(info.getSnapshotId());
-
-        // empty table
-        if (snapshot == null) {
-            return 0;
-        }
-
-        Map<String, String> summary = snapshot.summary();
-        if (!summary.get(IcebergUtils.TOTAL_EQUALITY_DELETES).equals("0")) {
-            // has equality delete files, can not push down count
-            return -1;
-        }
-
-        long deleteCount = Long.parseLong(summary.get(IcebergUtils.TOTAL_POSITION_DELETES));
-        if (deleteCount == 0) {
-            // no delete files, can push down count directly
-            return Long.parseLong(summary.get(IcebergUtils.TOTAL_RECORDS));
-        }
-        if (sessionVariable.ignoreIcebergDanglingDelete) {
-            // has position delete files, if we ignore dangling delete, can push down count
-            return Long.parseLong(summary.get(IcebergUtils.TOTAL_RECORDS)) - deleteCount;
-        } else {
-            // otherwise, can not push down count
-            return -1;
-        }
-    }
-
     @Override
     protected void toThrift(TPlanNode planNode) {
         super.toThrift(planNode);
@@ -1047,18 +425,21 @@ public class IcebergScanNode extends FileQueryScanNode {
 
     @Override
     public String getNodeExplainString(String prefix, TExplainLevel detailLevel) {
+        syncPlanningMetadataFromProducer();
         String base = super.getNodeExplainString(prefix, detailLevel);
         StringBuilder builder = new StringBuilder(base);
+        IcebergPlanningMetadata metadata = getExistingIcebergPlanningMetadata();
 
-        if (detailLevel == TExplainLevel.VERBOSE && IcebergUtils.isManifestCacheEnabled(source.getCatalog())) {
-            builder.append(prefix).append("manifest cache: hits=").append(manifestCacheHits)
-                    .append(", misses=").append(manifestCacheMisses)
-                    .append(", failures=").append(manifestCacheFailures).append("\n");
+        if (metadata != null && detailLevel == TExplainLevel.VERBOSE
+                && IcebergUtils.isManifestCacheEnabled(source.getCatalog())) {
+            builder.append(prefix).append("manifest cache: hits=").append(metadata.getManifestCacheHits())
+                    .append(", misses=").append(metadata.getManifestCacheMisses())
+                    .append(", failures=").append(metadata.getManifestCacheFailures()).append("\n");
         }
 
-        if (!pushdownIcebergPredicates.isEmpty()) {
+        if (metadata != null && !metadata.getPushdownIcebergPredicates().isEmpty()) {
             StringBuilder sb = new StringBuilder();
-            for (String predicate : pushdownIcebergPredicates) {
+            for (String predicate : metadata.getPushdownIcebergPredicates()) {
                 sb.append(prefix).append(prefix).append(predicate).append("\n");
             }
             builder.append(String.format("%sicebergPredicatePushdown=\n%s\n", prefix, sb));
@@ -1066,57 +447,36 @@ public class IcebergScanNode extends FileQueryScanNode {
         return builder.toString();
     }
 
-    private void assignCountToSplits(List<Split> splits, long totalCount) {
-        if (splits.isEmpty()) {
-            return;
-        }
-        int size = splits.size();
-        long countPerSplit = totalCount / size;
-        for (int i = 0; i < size - 1; i++) {
-            ((IcebergSplit) splits.get(i)).setTableLevelRowCount(countPerSplit);
-        }
-        ((IcebergSplit) splits.get(size - 1)).setTableLevelRowCount(countPerSplit + totalCount % size);
+    @Override
+    public int numApproximateSplits() {
+        return getPlanningSplitProducer().numApproximateSplits();
     }
 
     @Override
-    public int numApproximateSplits() {
-        return NUM_SPLITS_PER_PARTITION * partitionMapInfos.size() > 0 ? partitionMapInfos.size() : 1;
+    public long getSelectedPartitionNum() {
+        syncPlanningMetadataFromProducer();
+        return super.getSelectedPartitionNum();
     }
 
-    private Optional<NotSupportedException> checkNotSupportedException(Exception e) {
-        if (e instanceof NullPointerException) {
-            /*
-        Caused by: java.lang.NullPointerException: Type cannot be null
-            at org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkNotNull
-                (Preconditions.java:921) ~[iceberg-bundled-guava-1.4.3.jar:?]
-            at org.apache.iceberg.types.Types$NestedField.<init>(Types.java:447) ~[iceberg-api-1.4.3.jar:?]
-            at org.apache.iceberg.types.Types$NestedField.optional(Types.java:416) ~[iceberg-api-1.4.3.jar:?]
-            at org.apache.iceberg.PartitionSpec.partitionType(PartitionSpec.java:132) ~[iceberg-api-1.4.3.jar:?]
-            at org.apache.iceberg.DeleteFileIndex.lambda$new$0(DeleteFileIndex.java:97) ~[iceberg-core-1.4.3.jar:?]
-            at org.apache.iceberg.relocated.com.google.common.collect.RegularImmutableMap.forEach
-                (RegularImmutableMap.java:297) ~[iceberg-bundled-guava-1.4.3.jar:?]
-            at org.apache.iceberg.DeleteFileIndex.<init>(DeleteFileIndex.java:97) ~[iceberg-core-1.4.3.jar:?]
-            at org.apache.iceberg.DeleteFileIndex.<init>(DeleteFileIndex.java:71) ~[iceberg-core-1.4.3.jar:?]
-            at org.apache.iceberg.DeleteFileIndex$Builder.build(DeleteFileIndex.java:578) ~[iceberg-core-1.4.3.jar:?]
-            at org.apache.iceberg.ManifestGroup.plan(ManifestGroup.java:183) ~[iceberg-core-1.4.3.jar:?]
-            at org.apache.iceberg.ManifestGroup.planFiles(ManifestGroup.java:170) ~[iceberg-core-1.4.3.jar:?]
-            at org.apache.iceberg.DataTableScan.doPlanFiles(DataTableScan.java:89) ~[iceberg-core-1.4.3.jar:?]
-            at org.apache.iceberg.SnapshotScan.planFiles(SnapshotScan.java:139) ~[iceberg-core-1.4.3.jar:?]
-            at org.apache.doris.datasource.iceberg.source.IcebergScanNode.doGetSplits
-                (IcebergScanNode.java:209) ~[doris-fe.jar:1.2-SNAPSHOT]
-        EXAMPLE:
-             CREATE TABLE iceberg_tb(col1 INT,col2 STRING) USING ICEBERG PARTITIONED BY (bucket(10,col2));
-             INSERT INTO iceberg_tb VALUES( ... );
-             ALTER TABLE iceberg_tb DROP PARTITION FIELD bucket(10,col2);
-             ALTER TABLE iceberg_tb DROP COLUMNS col2;
-        Link: https://github.com/apache/iceberg/pull/10755
-            */
-            LOG.warn("Unable to plan for iceberg table {}", this.desc.getTable().getName(), e);
-            return Optional.of(
-                    new NotSupportedException("Unable to plan for this table. "
-                            + "Maybe read Iceberg table with dropped old partition column. Cause: "
-                            + Util.getRootCauseMessage(e)));
+    private IcebergPlanningMetadata getExistingIcebergPlanningMetadata() {
+        PlanningSplitProducer producer = planningSplitProducer;
+        if (producer == null) {
+            return null;
         }
-        return Optional.empty();
+        PlanningSplitMetadata metadata = producer.getPlanningMetadata();
+        Preconditions.checkState(metadata instanceof IcebergPlanningMetadata,
+                "Unexpected planning metadata type for iceberg scan node: %s", metadata.getClass().getName());
+        return (IcebergPlanningMetadata) metadata;
+    }
+
+    private void syncPlanningMetadataFromProducer() {
+        IcebergPlanningMetadata metadata = getExistingIcebergPlanningMetadata();
+        if (metadata == null) {
+            return;
+        }
+        selectedPartitionNum = metadata.getSelectedPartitionNum();
+        if (metadata.hasTableLevelPushDownCount()) {
+            setPushDownCount(metadata.getCountFromSnapshot());
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergSplitPlanningSupport.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergSplitPlanningSupport.java
@@ -1,0 +1,654 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.UserException;
+import org.apache.doris.common.profile.SummaryProfile;
+import org.apache.doris.common.security.authentication.ExecutionAuthenticator;
+import org.apache.doris.common.util.LocationPath;
+import org.apache.doris.datasource.ExternalTable;
+import org.apache.doris.datasource.TableFormatType;
+import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.nereids.exceptions.NotSupportedException;
+import org.apache.doris.planner.ScanContext;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.spi.Split;
+import org.apache.doris.thrift.TPushAggOp;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.iceberg.BaseFileScanTask;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.DeleteFileIndex;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.ManifestContent;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.PartitionData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.InclusiveMetricsEvaluator;
+import org.apache.iceberg.expressions.ManifestEvaluator;
+import org.apache.iceberg.expressions.ResidualEvaluator;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.util.ScanTaskUtil;
+import org.apache.iceberg.util.TableScanUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+class IcebergSplitPlanningSupport {
+    private static final Logger LOG = LogManager.getLogger(IcebergSplitPlanningSupport.class);
+    private static final long COUNT_WITH_PARALLEL_SPLITS = 10000;
+
+    private final IcebergScanNode scanNode;
+    private final IcebergSource source;
+    private final Table icebergTable;
+    private final ExecutionAuthenticator preExecutionAuthenticator;
+    private final SessionVariable sessionVariable;
+    private final ScanContext scanContext;
+    private final Map<StorageProperties.Type, StorageProperties> storagePropertiesMap;
+    private final int formatVersion;
+    private final boolean isPartitionedTable;
+
+    private final List<String> pushdownIcebergPredicates = Lists.newArrayList();
+    private final Map<PartitionData, Map<String, String>> partitionMapInfos = new HashMap<>();
+
+    private TableScan icebergTableScan;
+    private Boolean isBatchMode;
+    private boolean tableLevelPushDownCount;
+    private long countFromSnapshot;
+    private long targetSplitSize;
+    private long manifestCacheHits;
+    private long manifestCacheMisses;
+    private long manifestCacheFailures;
+
+    private boolean locationPathCacheInitialized;
+    private StorageProperties cachedStorageProperties;
+    private String cachedSchema;
+    private String cachedFsIdPrefix;
+    private String cachedOriginalPathPrefix;
+    private String cachedNormalizedPathPrefix;
+    private String cachedFsIdentifier;
+
+    IcebergSplitPlanningSupport(
+            IcebergScanNode scanNode,
+            IcebergSource source,
+            Table icebergTable,
+            ExecutionAuthenticator preExecutionAuthenticator,
+            SessionVariable sessionVariable,
+            ScanContext scanContext,
+            Map<StorageProperties.Type, StorageProperties> storagePropertiesMap,
+            int formatVersion,
+            boolean isPartitionedTable) {
+        this.scanNode = scanNode;
+        this.source = source;
+        this.icebergTable = icebergTable;
+        this.preExecutionAuthenticator = preExecutionAuthenticator;
+        this.sessionVariable = sessionVariable;
+        this.scanContext = scanContext;
+        this.storagePropertiesMap = storagePropertiesMap;
+        this.formatVersion = formatVersion;
+        this.isPartitionedTable = isPartitionedTable;
+    }
+
+    TableScan createTableScan() throws UserException {
+        try {
+            return preExecutionAuthenticator.execute(this::createTableScanInternal);
+        } catch (Exception e) {
+            throw new UserException(e.getMessage(), e);
+        }
+    }
+
+    CloseableIterable<FileScanTask> planFileScanTask(TableScan scan) throws Exception {
+        return preExecutionAuthenticator.execute(() -> planFileScanTaskInternal(scan));
+    }
+
+    Split createSplit(FileScanTask fileScanTask) {
+        return createIcebergSplit(fileScanTask);
+    }
+
+    boolean isBatchMode() {
+        Boolean cached = isBatchMode;
+        if (cached != null) {
+            return cached;
+        }
+        // Rewrite tasks inject precomputed FileScanTasks into StatementContext and expect the
+        // scan node to consume them on the current planning thread. Keep this path in sync mode
+        // to preserve the pre-refactor behavior and avoid accessing thread-local planning context
+        // from the async batch producer.
+        if (hasRewriteFileScanTasksInContext()) {
+            isBatchMode = false;
+            return false;
+        }
+        // Table-level count pushdown also stays in sync mode. Once snapshot metadata can answer
+        // COUNT directly, planning only needs a small bounded number of splits carrying the
+        // table-level row count, so there is no benefit in exposing the lazy batch protocol.
+        TPushAggOp aggOp = scanNode.getPushDownAggNoGroupingOp();
+        if (aggOp.equals(TPushAggOp.COUNT)) {
+            try {
+                countFromSnapshot = loadCountFromSnapshot();
+            } catch (UserException e) {
+                throw new RuntimeException(e);
+            }
+            if (countFromSnapshot >= 0) {
+                tableLevelPushDownCount = true;
+                isBatchMode = false;
+                return false;
+            }
+        }
+
+        try {
+            if (createTableScanInternal().snapshot() == null) {
+                isBatchMode = false;
+                return false;
+            }
+        } catch (UserException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (!sessionVariable.getEnableExternalTableBatchMode()) {
+            isBatchMode = false;
+            return false;
+        }
+
+        // Ordinary query planning reaches batch mode only when the table has a real snapshot,
+        // session batch mode is enabled, and the matching manifest set is large enough to justify
+        // incremental split production for backends.
+        try {
+            return preExecutionAuthenticator.execute(() -> {
+                try (CloseableIterator<ManifestFile> matchingManifest =
+                        org.apache.doris.datasource.iceberg.IcebergUtils.getMatchingManifest(
+                                createTableScanInternal().snapshot().dataManifests(icebergTable.io()),
+                                icebergTable.specs(),
+                                createTableScanInternal().filter()).iterator()) {
+                    int cnt = 0;
+                    while (matchingManifest.hasNext()) {
+                        ManifestFile next = matchingManifest.next();
+                        cnt += next.addedFilesCount() + next.existingFilesCount();
+                        if (cnt >= sessionVariable.getNumFilesInBatchMode()) {
+                            isBatchMode = true;
+                            return true;
+                        }
+                    }
+                }
+                isBatchMode = false;
+                return false;
+            });
+        } catch (Exception e) {
+            Optional<NotSupportedException> opt = checkNotSupportedException(e);
+            if (opt.isPresent()) {
+                throw opt.get();
+            }
+            throw new RuntimeException(ExceptionUtils.getRootCauseMessage(e), e);
+        }
+    }
+
+    int numApproximateSplits() {
+        return partitionMapInfos.isEmpty() ? 1 : partitionMapInfos.size();
+    }
+
+    int getSelectedPartitionNum() {
+        return partitionMapInfos.size();
+    }
+
+    boolean hasTableLevelPushDownCount() {
+        return tableLevelPushDownCount;
+    }
+
+    long getCountFromSnapshot() {
+        return countFromSnapshot;
+    }
+
+    List<String> getPushdownIcebergPredicates() {
+        return pushdownIcebergPredicates;
+    }
+
+    long getManifestCacheHits() {
+        return manifestCacheHits;
+    }
+
+    long getManifestCacheMisses() {
+        return manifestCacheMisses;
+    }
+
+    long getManifestCacheFailures() {
+        return manifestCacheFailures;
+    }
+
+    int getCountPushDownSplitCount(int numBackends) {
+        Preconditions.checkState(tableLevelPushDownCount, "Table-level count pushdown is not enabled");
+        return countFromSnapshot < COUNT_WITH_PARALLEL_SPLITS
+                ? 1
+                : sessionVariable.getParallelExecInstanceNum(scanContext.getClusterName()) * numBackends;
+    }
+
+    void recordManifestCacheProfile() {
+        if (!org.apache.doris.datasource.iceberg.IcebergUtils.isManifestCacheEnabled(source.getCatalog())) {
+            return;
+        }
+        SummaryProfile summaryProfile = SummaryProfile.getSummaryProfile(ConnectContext.get());
+        if (summaryProfile == null || summaryProfile.getExecutionSummary() == null) {
+            return;
+        }
+        summaryProfile.getExecutionSummary().addInfoString("Manifest Cache",
+                String.format("hits=%d, misses=%d, failures=%d",
+                        manifestCacheHits, manifestCacheMisses, manifestCacheFailures));
+    }
+
+    UserException translatePlanningException(Exception e) {
+        Optional<NotSupportedException> opt = checkNotSupportedException(e);
+        if (opt.isPresent()) {
+            return new UserException(opt.get().getMessage(), opt.get());
+        }
+        if (e instanceof UserException) {
+            return (UserException) e;
+        }
+        return new UserException(e.getMessage(), e);
+    }
+
+    private TableScan createTableScanInternal() throws UserException {
+        if (icebergTableScan != null) {
+            return icebergTableScan;
+        }
+
+        TableScan scan = icebergTable.newScan().metricsReporter(
+                new org.apache.doris.datasource.iceberg.profile.IcebergMetricsReporter());
+
+        org.apache.doris.datasource.iceberg.source.IcebergTableQueryInfo info = scanNode.getSpecifiedSnapshot();
+        if (info != null) {
+            if (info.getRef() != null) {
+                scan = scan.useRef(info.getRef());
+            } else {
+                scan = scan.useSnapshot(info.getSnapshotId());
+            }
+        }
+
+        List<Expression> expressions = new ArrayList<>();
+        for (Expr conjunct : scanNode.getConjuncts()) {
+            Expression expression = org.apache.doris.datasource.iceberg.IcebergUtils.convertToIcebergExpr(
+                    conjunct, icebergTable.schema());
+            if (expression != null) {
+                expressions.add(expression);
+            }
+        }
+        for (Expression predicate : expressions) {
+            scan = scan.filter(predicate);
+            pushdownIcebergPredicates.add(predicate.toString());
+        }
+
+        icebergTableScan = scan.planWith(source.getCatalog().getThreadPoolWithPreAuth());
+        return icebergTableScan;
+    }
+
+    private CloseableIterable<FileScanTask> planFileScanTaskInternal(TableScan scan) {
+        if (!org.apache.doris.datasource.iceberg.IcebergUtils.isManifestCacheEnabled(source.getCatalog())) {
+            return splitFiles(scan);
+        }
+        try {
+            return planFileScanTaskWithManifestCache(scan);
+        } catch (Exception e) {
+            manifestCacheFailures++;
+            LOG.warn("Plan with manifest cache failed, fallback to original scan: " + e.getMessage(), e);
+            return splitFiles(scan);
+        }
+    }
+
+    private CloseableIterable<FileScanTask> splitFiles(TableScan scan) {
+        if (sessionVariable.getFileSplitSize() > 0) {
+            return TableScanUtil.splitFiles(scan.planFiles(), sessionVariable.getFileSplitSize());
+        }
+        if (isBatchMode()) {
+            return TableScanUtil.splitFiles(scan.planFiles(), sessionVariable.getMaxSplitSize());
+        }
+
+        List<FileScanTask> fileScanTaskList = new ArrayList<>();
+        try (CloseableIterable<FileScanTask> scanTasksIter = scan.planFiles()) {
+            for (FileScanTask task : scanTasksIter) {
+                fileScanTaskList.add(task);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to materialize file scan tasks", e);
+        }
+
+        targetSplitSize = determineTargetFileSplitSize(fileScanTaskList);
+        return TableScanUtil.splitFiles(CloseableIterable.withNoopClose(fileScanTaskList), targetSplitSize);
+    }
+
+    private long determineTargetFileSplitSize(Iterable<FileScanTask> tasks) {
+        long result = sessionVariable.getMaxInitialSplitSize();
+        long accumulatedTotalFileSize = 0;
+        boolean exceedInitialThreshold = false;
+        for (FileScanTask task : tasks) {
+            accumulatedTotalFileSize += ScanTaskUtil.contentSizeInBytes(task.file());
+            if (!exceedInitialThreshold && accumulatedTotalFileSize
+                    >= sessionVariable.getMaxSplitSize() * sessionVariable.getMaxInitialSplitNum()) {
+                exceedInitialThreshold = true;
+            }
+        }
+        result = exceedInitialThreshold ? sessionVariable.getMaxSplitSize() : result;
+        if (!isBatchMode()) {
+            result = applyMaxFileSplitNumLimit(result, accumulatedTotalFileSize);
+        }
+        return result;
+    }
+
+    private long applyMaxFileSplitNumLimit(long targetFileSplitSize, long totalFileSize) {
+        int maxFileSplitNum = sessionVariable.getMaxFileSplitNum();
+        if (maxFileSplitNum <= 0 || totalFileSize <= 0) {
+            return targetFileSplitSize;
+        }
+        long minSplitSizeForMaxNum = (totalFileSize + maxFileSplitNum - 1L) / (long) maxFileSplitNum;
+        return Math.max(targetFileSplitSize, minSplitSizeForMaxNum);
+    }
+
+    private CloseableIterable<FileScanTask> planFileScanTaskWithManifestCache(TableScan scan) throws IOException {
+        Snapshot snapshot = scan.snapshot();
+        if (snapshot == null) {
+            return CloseableIterable.withNoopClose(Collections.emptyList());
+        }
+
+        org.apache.doris.datasource.iceberg.IcebergExternalMetaCache cache =
+                Env.getCurrentEnv().getExtMetaCacheMgr().iceberg(source.getCatalog().getId());
+        if (!(source.getTargetTable() instanceof ExternalTable)) {
+            throw new RuntimeException("Iceberg scan target table is not an external table");
+        }
+        ExternalTable targetExternalTable = (ExternalTable) source.getTargetTable();
+
+        Expression filterExpr = scanNode.getConjuncts().stream()
+                .map(conjunct -> org.apache.doris.datasource.iceberg.IcebergUtils.convertToIcebergExpr(
+                        conjunct, icebergTable.schema()))
+                .filter(Objects::nonNull)
+                .reduce(Expressions.alwaysTrue(), Expressions::and);
+
+        Map<Integer, PartitionSpec> specsById = icebergTable.specs();
+        boolean caseSensitive = true;
+
+        Map<Integer, ResidualEvaluator> residualEvaluators = new HashMap<>();
+        specsById.forEach((id, spec) -> residualEvaluators.put(id,
+                ResidualEvaluator.of(spec, filterExpr, caseSensitive)));
+
+        InclusiveMetricsEvaluator metricsEvaluator =
+                new InclusiveMetricsEvaluator(icebergTable.schema(), filterExpr, caseSensitive);
+
+        List<DeleteFile> deleteFiles = new ArrayList<>();
+        List<ManifestFile> deleteManifests = snapshot.deleteManifests(icebergTable.io());
+        for (ManifestFile manifest : deleteManifests) {
+            if (manifest.content() != ManifestContent.DELETES) {
+                continue;
+            }
+            PartitionSpec spec = specsById.get(manifest.partitionSpecId());
+            if (spec == null) {
+                continue;
+            }
+            ManifestEvaluator evaluator =
+                    ManifestEvaluator.forPartitionFilter(filterExpr, spec, caseSensitive);
+            if (!evaluator.eval(manifest)) {
+                continue;
+            }
+            org.apache.doris.datasource.iceberg.cache.ManifestCacheValue value =
+                    org.apache.doris.datasource.iceberg.cache.IcebergManifestCacheLoader.loadDeleteFilesWithCache(
+                            cache, targetExternalTable, manifest, icebergTable, this::recordManifestCacheAccess);
+            deleteFiles.addAll(value.getDeleteFiles());
+        }
+
+        DeleteFileIndex deleteIndex = DeleteFileIndex.builderFor(deleteFiles)
+                .specsById(specsById)
+                .caseSensitive(caseSensitive)
+                .build();
+
+        List<FileScanTask> tasks = new ArrayList<>();
+        try (CloseableIterable<ManifestFile> dataManifests =
+                     org.apache.doris.datasource.iceberg.IcebergUtils.getMatchingManifest(
+                             snapshot.dataManifests(icebergTable.io()), specsById, filterExpr)) {
+            for (ManifestFile manifest : dataManifests) {
+                if (manifest.content() != ManifestContent.DATA) {
+                    continue;
+                }
+                PartitionSpec spec = specsById.get(manifest.partitionSpecId());
+                if (spec == null) {
+                    continue;
+                }
+                ResidualEvaluator residualEvaluator = residualEvaluators.get(manifest.partitionSpecId());
+                if (residualEvaluator == null) {
+                    continue;
+                }
+
+                org.apache.doris.datasource.iceberg.cache.ManifestCacheValue value =
+                        org.apache.doris.datasource.iceberg.cache.IcebergManifestCacheLoader.loadDataFilesWithCache(
+                                cache, targetExternalTable, manifest, icebergTable, this::recordManifestCacheAccess);
+
+                for (org.apache.iceberg.DataFile dataFile : value.getDataFiles()) {
+                    if (metricsEvaluator != null && !metricsEvaluator.eval(dataFile)) {
+                        continue;
+                    }
+                    if (residualEvaluator.residualFor(dataFile.partition()).equals(Expressions.alwaysFalse())) {
+                        continue;
+                    }
+                    List<DeleteFile> deletes = Arrays.asList(
+                            deleteIndex.forDataFile(dataFile.dataSequenceNumber(), dataFile));
+
+                    tasks.add(new BaseFileScanTask(
+                            dataFile,
+                            deletes.toArray(new DeleteFile[0]),
+                            SchemaParser.toJson(icebergTable.schema()),
+                            PartitionSpecParser.toJson(spec),
+                            residualEvaluator));
+                }
+            }
+        }
+
+        targetSplitSize = determineTargetFileSplitSize(tasks);
+        return TableScanUtil.splitFiles(CloseableIterable.withNoopClose(tasks), targetSplitSize);
+    }
+
+    private void initLocationPathCache(String samplePath) {
+        try {
+            LocationPath sampleLocationPath = LocationPath.of(samplePath, storagePropertiesMap);
+            cachedStorageProperties = sampleLocationPath.getStorageProperties();
+            cachedSchema = sampleLocationPath.getSchema();
+            cachedFsIdentifier = sampleLocationPath.getFsIdentifier();
+
+            int schemeEnd = cachedFsIdentifier.indexOf("://");
+            if (schemeEnd > 0) {
+                cachedFsIdPrefix = cachedFsIdentifier.substring(0, schemeEnd + 3);
+            }
+
+            String normalizedPath = sampleLocationPath.getNormalizedLocation();
+            int lastSlashInOriginal = samplePath.lastIndexOf('/');
+            int lastSlashInNormalized = normalizedPath.lastIndexOf('/');
+            if (lastSlashInOriginal > 0 && lastSlashInNormalized > 0) {
+                cachedOriginalPathPrefix = samplePath.substring(0, lastSlashInOriginal + 1);
+                cachedNormalizedPathPrefix = normalizedPath.substring(0, lastSlashInNormalized + 1);
+            }
+
+            locationPathCacheInitialized = true;
+        } catch (Exception e) {
+            LOG.warn("Failed to initialize LocationPath cache, will use full parsing", e);
+        }
+    }
+
+    private LocationPath createLocationPathWithCache(String path) {
+        if (!locationPathCacheInitialized) {
+            initLocationPathCache(path);
+        }
+        if (cachedOriginalPathPrefix != null && path.startsWith(cachedOriginalPathPrefix)) {
+            String normalizedPath = cachedNormalizedPathPrefix + path.substring(cachedOriginalPathPrefix.length());
+            return LocationPath.ofDirect(normalizedPath, cachedSchema, cachedFsIdentifier, cachedStorageProperties);
+        }
+        if (cachedStorageProperties != null) {
+            return LocationPath.ofWithCache(path, cachedStorageProperties, cachedSchema, cachedFsIdPrefix);
+        }
+        return LocationPath.of(path, storagePropertiesMap);
+    }
+
+    private Split createIcebergSplit(FileScanTask fileScanTask) {
+        String originalPath = fileScanTask.file().path().toString();
+        LocationPath locationPath = createLocationPathWithCache(originalPath);
+        IcebergSplit split = new IcebergSplit(
+                locationPath,
+                fileScanTask.start(),
+                fileScanTask.length(),
+                fileScanTask.file().fileSizeInBytes(),
+                new String[0],
+                formatVersion,
+                storagePropertiesMap,
+                new ArrayList<>(),
+                originalPath);
+        if (!fileScanTask.deletes().isEmpty()) {
+            split.setDeleteFileFilters(getDeleteFileFilters(fileScanTask));
+        }
+        split.setTableFormatType(TableFormatType.ICEBERG);
+        split.setTargetSplitSize(targetSplitSize);
+        if (isPartitionedTable) {
+            int specId = fileScanTask.file().specId();
+            PartitionSpec partitionSpec = icebergTable.specs().get(specId);
+            Preconditions.checkNotNull(partitionSpec, "Partition spec with specId %s not found for table %s",
+                    specId, icebergTable.name());
+            PartitionData partitionData = (PartitionData) fileScanTask.file().partition();
+            if (partitionData != null) {
+                split.setPartitionSpecId(specId);
+                split.setPartitionDataJson(org.apache.doris.datasource.iceberg.IcebergUtils.getPartitionDataJson(
+                        partitionData, partitionSpec, sessionVariable.getTimeZone()));
+            }
+            if (sessionVariable.isEnableRuntimeFilterPartitionPrune()) {
+                Map<String, String> partitionInfoMap = partitionMapInfos.computeIfAbsent(partitionData, k ->
+                        org.apache.doris.datasource.iceberg.IcebergUtils.getPartitionInfoMap(
+                                partitionData, partitionSpec, sessionVariable.getTimeZone()));
+                if (partitionInfoMap != null) {
+                    split.setIcebergPartitionValues(partitionInfoMap);
+                }
+            } else {
+                partitionMapInfos.put(partitionData, null);
+            }
+        }
+        return split;
+    }
+
+    private List<IcebergDeleteFileFilter> getDeleteFileFilters(FileScanTask spitTask) {
+        List<IcebergDeleteFileFilter> filters = new ArrayList<>();
+        for (DeleteFile delete : spitTask.deletes()) {
+            if (delete.content() == FileContent.POSITION_DELETES) {
+                filters.add(IcebergDeleteFileFilter.createPositionDelete(delete));
+            } else if (delete.content() == FileContent.EQUALITY_DELETES) {
+                filters.add(IcebergDeleteFileFilter.createEqualityDelete(
+                        delete.path().toString(), delete.equalityFieldIds(),
+                        delete.fileSizeInBytes(), delete.format()));
+            } else {
+                throw new IllegalStateException("Unknown delete content: " + delete.content());
+            }
+        }
+        return filters;
+    }
+
+    void assignCountToSplits(List<Split> splits) {
+        Preconditions.checkState(tableLevelPushDownCount, "Table-level count pushdown is not enabled");
+        if (splits.isEmpty()) {
+            return;
+        }
+        int size = splits.size();
+        long countPerSplit = countFromSnapshot / size;
+        for (int i = 0; i < size - 1; i++) {
+            ((IcebergSplit) splits.get(i)).setTableLevelRowCount(countPerSplit);
+        }
+        ((IcebergSplit) splits.get(size - 1))
+                .setTableLevelRowCount(countPerSplit + countFromSnapshot % size);
+    }
+
+    private void recordManifestCacheAccess(boolean cacheHit) {
+        if (cacheHit) {
+            manifestCacheHits++;
+        } else {
+            manifestCacheMisses++;
+        }
+    }
+
+    List<FileScanTask> getFileScanTasksFromContext() {
+        ConnectContext ctx = ConnectContext.get();
+        Preconditions.checkNotNull(ctx);
+        Preconditions.checkNotNull(ctx.getStatementContext());
+
+        List<FileScanTask> tasks = ctx.getStatementContext().getAndClearIcebergRewriteFileScanTasks();
+        if (tasks != null && !tasks.isEmpty()) {
+            LOG.info("Retrieved {} file scan tasks from context for table {}",
+                    tasks.size(), icebergTable.name());
+            return new ArrayList<>(tasks);
+        }
+        return null;
+    }
+
+    private boolean hasRewriteFileScanTasksInContext() {
+        ConnectContext ctx = ConnectContext.get();
+        Preconditions.checkNotNull(ctx);
+        Preconditions.checkNotNull(ctx.getStatementContext());
+        return ctx.getStatementContext().hasIcebergRewriteFileScanTasks();
+    }
+
+    private long loadCountFromSnapshot() throws UserException {
+        IcebergTableQueryInfo info = scanNode.getSpecifiedSnapshot();
+        Snapshot snapshot = info == null ? icebergTable.currentSnapshot() : icebergTable.snapshot(info.getSnapshotId());
+        if (snapshot == null) {
+            return 0;
+        }
+
+        Map<String, String> summary = snapshot.summary();
+        if (!summary.get(org.apache.doris.datasource.iceberg.IcebergUtils.TOTAL_EQUALITY_DELETES).equals("0")) {
+            return -1;
+        }
+
+        long deleteCount = Long.parseLong(summary.get(org.apache.doris.datasource.iceberg.IcebergUtils
+                .TOTAL_POSITION_DELETES));
+        if (deleteCount == 0) {
+            return Long.parseLong(summary.get(org.apache.doris.datasource.iceberg.IcebergUtils.TOTAL_RECORDS));
+        }
+        if (sessionVariable.ignoreIcebergDanglingDelete) {
+            return Long.parseLong(summary.get(org.apache.doris.datasource.iceberg.IcebergUtils.TOTAL_RECORDS))
+                    - deleteCount;
+        }
+        return -1;
+    }
+
+    private Optional<NotSupportedException> checkNotSupportedException(Exception e) {
+        if (e instanceof NullPointerException) {
+            LOG.warn("Unable to plan for iceberg table {}", source.getTargetTable().getName(), e);
+            return Optional.of(new NotSupportedException(
+                    "Unable to plan iceberg table due to unsupported partition evolution/drop-column pattern"));
+        }
+        return Optional.empty();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergSplitPlanningSupport.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergSplitPlanningSupport.java
@@ -536,28 +536,39 @@ class IcebergSplitPlanningSupport {
         split.setTableFormatType(TableFormatType.ICEBERG);
         split.setTargetSplitSize(targetSplitSize);
         if (isPartitionedTable) {
-            int specId = fileScanTask.file().specId();
-            PartitionSpec partitionSpec = icebergTable.specs().get(specId);
-            Preconditions.checkNotNull(partitionSpec, "Partition spec with specId %s not found for table %s",
-                    specId, icebergTable.name());
-            PartitionData partitionData = (PartitionData) fileScanTask.file().partition();
-            if (partitionData != null) {
-                split.setPartitionSpecId(specId);
-                split.setPartitionDataJson(org.apache.doris.datasource.iceberg.IcebergUtils.getPartitionDataJson(
-                        partitionData, partitionSpec, sessionVariable.getTimeZone()));
-            }
-            if (sessionVariable.isEnableRuntimeFilterPartitionPrune()) {
-                Map<String, String> partitionInfoMap = partitionMapInfos.computeIfAbsent(partitionData, k ->
-                        org.apache.doris.datasource.iceberg.IcebergUtils.getPartitionInfoMap(
-                                partitionData, partitionSpec, sessionVariable.getTimeZone()));
-                if (partitionInfoMap != null) {
-                    split.setIcebergPartitionValues(partitionInfoMap);
-                }
-            } else {
-                partitionMapInfos.put(partitionData, null);
-            }
+            populatePartitionMetadata(split, fileScanTask);
         }
         return split;
+    }
+
+    private void populatePartitionMetadata(IcebergSplit split, FileScanTask fileScanTask) {
+        int specId = fileScanTask.file().specId();
+        PartitionSpec partitionSpec = icebergTable.specs().get(specId);
+        if (partitionSpec == null) {
+            LOG.warn("Skip partition metadata serialization for split because partition spec {} is not present "
+                            + "in current table metadata for table {}. This can happen when planning branch/tag "
+                            + "snapshots that still reference an older spec.",
+                    specId, icebergTable.name());
+            return;
+        }
+
+        PartitionData partitionData = (PartitionData) fileScanTask.file().partition();
+        if (partitionData != null) {
+            split.setPartitionSpecId(specId);
+            split.setPartitionDataJson(org.apache.doris.datasource.iceberg.IcebergUtils.getPartitionDataJson(
+                    partitionData, partitionSpec, sessionVariable.getTimeZone()));
+        }
+
+        if (sessionVariable.isEnableRuntimeFilterPartitionPrune()) {
+            Map<String, String> partitionInfoMap = partitionMapInfos.computeIfAbsent(partitionData, k ->
+                    org.apache.doris.datasource.iceberg.IcebergUtils.getPartitionInfoMap(
+                            partitionData, partitionSpec, sessionVariable.getTimeZone()));
+            if (partitionInfoMap != null) {
+                split.setIcebergPartitionValues(partitionInfoMap);
+            }
+            return;
+        }
+        partitionMapInfos.put(partitionData, null);
     }
 
     private List<IcebergDeleteFileFilter> getDeleteFileFilters(FileScanTask spitTask) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/LocalParallelPlanningSplitProducer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/LocalParallelPlanningSplitProducer.java
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.datasource.SplitSink;
+import org.apache.doris.spi.Split;
+
+import com.google.common.collect.Lists;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.io.CloseableIterable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+/**
+ * Local FE-side split producer that preserves the existing async Iceberg planning behavior.
+ */
+public class LocalParallelPlanningSplitProducer extends AbstractIcebergPlanningSplitProducer {
+    public LocalParallelPlanningSplitProducer(IcebergSplitPlanningSupport planningSupport) {
+        this(planningSupport, org.apache.doris.catalog.Env.getCurrentEnv().getExtMetaCacheMgr().getScheduleExecutor());
+    }
+
+    LocalParallelPlanningSplitProducer(IcebergSplitPlanningSupport planningSupport, Executor executor) {
+        super(planningSupport, executor);
+    }
+
+    @Override
+    protected void doProduce(int numBackends, SplitSink splitSink) throws Exception {
+        List<FileScanTask> customFileScanTasks = getPlanningSupport().getFileScanTasksFromContext();
+        if (customFileScanTasks != null) {
+            addSplitTasks(customFileScanTasks, splitSink);
+            return;
+        }
+
+        TableScan scan = getPlanningSupport().createTableScan();
+        try (CloseableIterable<FileScanTask> fileScanTasks = getPlanningSupport().planFileScanTask(scan)) {
+            if (getPlanningSupport().hasTableLevelPushDownCount()) {
+                addCountPushDownSplits(fileScanTasks, numBackends, splitSink);
+                return;
+            }
+            addSplitTasks(fileScanTasks, splitSink);
+        }
+    }
+
+    private void addSplitTasks(Iterable<FileScanTask> fileScanTasks, SplitSink splitSink) throws Exception {
+        for (FileScanTask task : fileScanTasks) {
+            if (!splitSink.needMore()) {
+                return;
+            }
+            splitSink.addBatch(Lists.newArrayList(getPlanningSupport().createSplit(task)));
+        }
+    }
+
+    private void addCountPushDownSplits(
+            Iterable<FileScanTask> fileScanTasks,
+            int numBackends,
+            SplitSink splitSink) throws Exception {
+        List<Split> splits = new ArrayList<>();
+        int needSplitCnt = getPlanningSupport().getCountPushDownSplitCount(numBackends);
+        for (FileScanTask task : fileScanTasks) {
+            if (!splitSink.needMore()) {
+                break;
+            }
+            splits.add(getPlanningSupport().createSplit(task));
+            if (splits.size() >= needSplitCnt) {
+                break;
+            }
+        }
+        getPlanningSupport().assignCountToSplits(splits);
+        if (!splits.isEmpty()) {
+            splitSink.addBatch(splits);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -1155,6 +1155,13 @@ public class StatementContext implements Closeable {
     }
 
     /**
+     * Whether rewrite file scan tasks are present for the current statement.
+     */
+    public boolean hasIcebergRewriteFileScanTasks() {
+        return icebergRewriteFileScanTasks != null && !icebergRewriteFileScanTasks.isEmpty();
+    }
+
+    /**
      * Get and consume file scan tasks for Iceberg rewrite operations.
      * Returns the tasks and clears the field to prevent reuse.
      */

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/IcebergScanNodeTest.java
@@ -19,55 +19,220 @@ package org.apache.doris.datasource.iceberg.source;
 
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.analysis.TupleId;
+import org.apache.doris.catalog.TableIf;
+import org.apache.doris.common.util.LocationPath;
+import org.apache.doris.datasource.PlanningSplitMetadata;
+import org.apache.doris.datasource.PlanningSplitProducer;
+import org.apache.doris.datasource.SplitSink;
+import org.apache.doris.datasource.TableFormatType;
+import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.planner.PlanNodeId;
 import org.apache.doris.planner.ScanContext;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.spi.Split;
+import org.apache.doris.thrift.TExplainLevel;
+import org.apache.doris.thrift.TFileRangeDesc;
 
-import org.apache.iceberg.DataFile;
-import org.apache.iceberg.FileScanTask;
-import org.apache.iceberg.util.ScanTaskUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.lang.reflect.Method;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 public class IcebergScanNodeTest {
-    private static final long MB = 1024L * 1024L;
+    @Test
+    public void testGetSplitsUsesProducerAndSyncsMetadata() throws Exception {
+        IcebergSplitPlanningSupport support = Mockito.mock(IcebergSplitPlanningSupport.class);
+        Split split = Mockito.mock(Split.class);
+        StaticPlanningSplitProducer producer = new StaticPlanningSplitProducer(
+                Collections.singletonList(split),
+                new IcebergPlanningMetadata(support));
+        TestIcebergScanNode node = new TestIcebergScanNode(new SessionVariable(), producer);
 
-    private static class TestIcebergScanNode extends IcebergScanNode {
-        TestIcebergScanNode(SessionVariable sv) {
-            super(new PlanNodeId(0), new TupleDescriptor(new TupleId(0)), sv, ScanContext.EMPTY);
-        }
+        Mockito.when(support.getSelectedPartitionNum()).thenReturn(4);
+        Mockito.when(support.hasTableLevelPushDownCount()).thenReturn(true);
+        Mockito.when(support.getCountFromSnapshot()).thenReturn(33L);
 
-        @Override
-        public boolean isBatchMode() {
-            return false;
-        }
+        List<Split> splits = node.getSplits(3);
+
+        Assert.assertEquals(Collections.singletonList(split), splits);
+        Assert.assertEquals(3, producer.lastNumBackends);
+        Assert.assertEquals(4L, node.getSelectedPartitionNum());
+        Assert.assertEquals(33L, node.getPushDownCountForTest());
     }
 
     @Test
-    public void testDetermineTargetFileSplitSizeHonorsMaxFileSplitNum() throws Exception {
-        SessionVariable sv = new SessionVariable();
-        sv.setMaxFileSplitNum(100);
-        TestIcebergScanNode node = new TestIcebergScanNode(sv);
+    public void testGetNodeExplainStringIncludesPushdownPredicatesFromMetadata() {
+        IcebergSplitPlanningSupport support = Mockito.mock(IcebergSplitPlanningSupport.class);
+        Mockito.when(support.getPushdownIcebergPredicates())
+                .thenReturn(Arrays.asList("id > 1", "dt = '2026-03-25'"));
+        StaticPlanningSplitProducer producer = new StaticPlanningSplitProducer(
+                Collections.emptyList(),
+                new IcebergPlanningMetadata(support));
+        TestIcebergScanNode node = new TestIcebergScanNode(new SessionVariable(), producer);
 
-        DataFile dataFile = Mockito.mock(DataFile.class);
-        Mockito.when(dataFile.fileSizeInBytes()).thenReturn(10_000L * MB);
-        FileScanTask task = Mockito.mock(FileScanTask.class);
-        Mockito.when(task.file()).thenReturn(dataFile);
-        Mockito.when(task.length()).thenReturn(10_000L * MB);
+        String explain = node.getNodeExplainString("  ", TExplainLevel.NORMAL);
 
-        try (org.mockito.MockedStatic<ScanTaskUtil> mockedScanTaskUtil =
-                Mockito.mockStatic(ScanTaskUtil.class)) {
-            mockedScanTaskUtil.when(() -> ScanTaskUtil.contentSizeInBytes(dataFile))
-                    .thenReturn(10_000L * MB);
+        Assert.assertTrue(explain.contains("icebergPredicatePushdown="));
+        Assert.assertTrue(explain.contains("id > 1"));
+        Assert.assertTrue(explain.contains("dt = '2026-03-25'"));
+    }
 
-            Method method = IcebergScanNode.class.getDeclaredMethod("determineTargetFileSplitSize", Iterable.class);
-            method.setAccessible(true);
-            long target = (long) method.invoke(node, Collections.singletonList(task));
-            Assert.assertEquals(100 * MB, target);
+    @Test
+    public void testGetSplitsRunsIcebergProducerOnCurrentThread() throws Exception {
+        IcebergSplitPlanningSupport support = Mockito.mock(IcebergSplitPlanningSupport.class);
+        Split split = Mockito.mock(Split.class);
+        ConnectContext ctx = new ConnectContext();
+        ctx.setThreadLocalInfo();
+        ctx.setStatementContext(new StatementContext());
+
+        Mockito.when(support.isBatchMode()).thenReturn(false);
+        ContextAwarePlanningSplitProducer producer =
+                new ContextAwarePlanningSplitProducer(support, split, ctx);
+        TestIcebergScanNode node = new TestIcebergScanNode(new SessionVariable(), producer);
+
+        List<Split> splits = node.getSplits(1);
+
+        Assert.assertEquals(Collections.singletonList(split), splits);
+        Assert.assertTrue(producer.contextVisibleDuringProduce);
+    }
+
+    @Test
+    public void testSetScanParamsUsesSplitTableLevelRowCount() throws Exception {
+        StaticPlanningSplitProducer producer = new StaticPlanningSplitProducer(
+                Collections.emptyList(),
+                PlanningSplitMetadata.EMPTY);
+        TestIcebergScanNode node = new TestIcebergScanNode(
+                new SessionVariable(),
+                producer);
+        setField(node, "formatVersion", IcebergScanNode.MIN_DELETE_FILE_SUPPORT_VERSION);
+
+        IcebergSplit split = createIcebergSplit("hdfs://warehouse/db/table/data.parquet");
+        split.setTableFormatType(TableFormatType.ICEBERG);
+        split.setTableLevelRowCount(99L);
+        TFileRangeDesc rangeDesc = new TFileRangeDesc();
+
+        node.applyScanParams(rangeDesc, split);
+
+        Assert.assertEquals(99L, rangeDesc.getTableFormatParams().getTableLevelRowCount());
+        Assert.assertEquals("hdfs://warehouse/db/table/data.parquet",
+                rangeDesc.getTableFormatParams().getIcebergParams().getOriginalFilePath());
+    }
+
+    @Test
+    public void testSetScanParamsDefaultsTableLevelRowCountToMinusOne() throws Exception {
+        StaticPlanningSplitProducer producer = new StaticPlanningSplitProducer(
+                Collections.emptyList(),
+                PlanningSplitMetadata.EMPTY);
+        TestIcebergScanNode node = new TestIcebergScanNode(
+                new SessionVariable(),
+                producer);
+        setField(node, "formatVersion", IcebergScanNode.MIN_DELETE_FILE_SUPPORT_VERSION);
+
+        IcebergSplit split = createIcebergSplit("hdfs://warehouse/db/table/no_count.parquet");
+        split.setTableFormatType(TableFormatType.ICEBERG);
+        TFileRangeDesc rangeDesc = new TFileRangeDesc();
+
+        node.applyScanParams(rangeDesc, split);
+
+        Assert.assertEquals(-1L, rangeDesc.getTableFormatParams().getTableLevelRowCount());
+    }
+
+    private static IcebergSplit createIcebergSplit(String path) {
+        return new IcebergSplit(LocationPath.of(path), 0, 128, 128, new String[0],
+                IcebergScanNode.MIN_DELETE_FILE_SUPPORT_VERSION, Collections.emptyMap(),
+                Collections.emptyList(), path);
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = IcebergScanNode.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static class TestIcebergScanNode extends IcebergScanNode {
+        private final PlanningSplitProducer producer;
+
+        TestIcebergScanNode(SessionVariable sv, PlanningSplitProducer producer) {
+            super(new PlanNodeId(0), createTupleDescriptor(), sv, ScanContext.EMPTY);
+            this.producer = producer;
+        }
+
+        @Override
+        PlanningSplitProducer createPlanningSplitProducer() {
+            return producer;
+        }
+
+        void applyScanParams(TFileRangeDesc rangeDesc, Split split) {
+            setScanParams(rangeDesc, split);
+        }
+
+        long getPushDownCountForTest() {
+            return tableLevelRowCount;
+        }
+
+        private static TupleDescriptor createTupleDescriptor() {
+            TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+            TableIf table = Mockito.mock(TableIf.class);
+            Mockito.when(table.getName()).thenReturn("tbl");
+            Mockito.when(table.getNameWithFullQualifiers()).thenReturn("ctl.db.tbl");
+            desc.setTable(table);
+            return desc;
+        }
+    }
+
+    private static class StaticPlanningSplitProducer implements PlanningSplitProducer {
+        private final List<Split> plannedSplits;
+        private final PlanningSplitMetadata planningMetadata;
+        private int lastNumBackends = -1;
+
+        StaticPlanningSplitProducer(
+                List<Split> plannedSplits,
+                PlanningSplitMetadata planningMetadata) {
+            this.plannedSplits = new ArrayList<>(plannedSplits);
+            this.planningMetadata = planningMetadata;
+        }
+
+        @Override
+        public PlanningSplitMetadata getPlanningMetadata() {
+            return planningMetadata;
+        }
+
+        @Override
+        public void start(int numBackends, SplitSink splitSink)
+                throws org.apache.doris.common.UserException {
+            lastNumBackends = numBackends;
+            if (!plannedSplits.isEmpty()) {
+                splitSink.addBatch(plannedSplits);
+            }
+            splitSink.finish();
+        }
+    }
+
+    private static class ContextAwarePlanningSplitProducer extends AbstractIcebergPlanningSplitProducer {
+        private final Split split;
+        private final ConnectContext expectedContext;
+        private boolean contextVisibleDuringProduce;
+
+        ContextAwarePlanningSplitProducer(
+                IcebergSplitPlanningSupport planningSupport,
+                Split split,
+                ConnectContext expectedContext) {
+            super(planningSupport, Runnable::run);
+            this.split = split;
+            this.expectedContext = expectedContext;
+        }
+
+        @Override
+        protected void doProduce(int numBackends, SplitSink splitSink) throws Exception {
+            contextVisibleDuringProduce = ConnectContext.get() == expectedContext
+                    && ConnectContext.get().getStatementContext() != null;
+            splitSink.addBatch(Collections.singletonList(split));
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/IcebergSplitPlanningSupportTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/IcebergSplitPlanningSupportTest.java
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.common.security.authentication.ExecutionAuthenticator;
+import org.apache.doris.nereids.StatementContext;
+import org.apache.doris.planner.ScanContext;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SessionVariable;
+
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Table;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+public class IcebergSplitPlanningSupportTest {
+    @Test
+    public void testRewriteTasksForceSyncPlanningMode() {
+        ConnectContext ctx = new ConnectContext();
+        ctx.setThreadLocalInfo();
+        StatementContext statementContext = new StatementContext();
+        statementContext.setConnectContext(ctx);
+        ctx.setStatementContext(statementContext);
+        FileScanTask rewriteTask = Mockito.mock(FileScanTask.class);
+        statementContext.setIcebergRewriteFileScanTasks(Collections.singletonList(rewriteTask));
+
+        try {
+            IcebergSplitPlanningSupport support = new IcebergSplitPlanningSupport(
+                    Mockito.mock(IcebergScanNode.class),
+                    Mockito.mock(IcebergSource.class),
+                    Mockito.mock(Table.class),
+                    Mockito.mock(ExecutionAuthenticator.class),
+                    new SessionVariable(),
+                    ScanContext.EMPTY,
+                    Collections.emptyMap(),
+                    IcebergScanNode.MIN_DELETE_FILE_SUPPORT_VERSION,
+                    false);
+
+            Assert.assertFalse(support.isBatchMode());
+            Assert.assertEquals(Collections.singletonList(rewriteTask),
+                    statementContext.getAndClearIcebergRewriteFileScanTasks());
+        } finally {
+            ConnectContext.remove();
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/LocalParallelPlanningSplitProducerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/LocalParallelPlanningSplitProducerTest.java
@@ -1,0 +1,149 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.SplitSink;
+import org.apache.doris.spi.Split;
+
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.io.CloseableIterable;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class LocalParallelPlanningSplitProducerTest {
+    @Test
+    public void testStartUsesRewriteTasksFromContext() throws Exception {
+        IcebergSplitPlanningSupport support = Mockito.mock(IcebergSplitPlanningSupport.class);
+        FileScanTask firstTask = Mockito.mock(FileScanTask.class);
+        FileScanTask secondTask = Mockito.mock(FileScanTask.class);
+        Split firstSplit = Mockito.mock(Split.class);
+        Split secondSplit = Mockito.mock(Split.class);
+        RecordingSplitSink splitSink = new RecordingSplitSink();
+
+        Mockito.when(support.getFileScanTasksFromContext())
+                .thenReturn(Arrays.asList(firstTask, secondTask));
+        Mockito.when(support.createSplit(firstTask)).thenReturn(firstSplit);
+        Mockito.when(support.createSplit(secondTask)).thenReturn(secondSplit);
+
+        LocalParallelPlanningSplitProducer producer =
+                new LocalParallelPlanningSplitProducer(support, Runnable::run);
+        producer.start(2, splitSink);
+
+        Assert.assertTrue(splitSink.finished);
+        Assert.assertNull(splitSink.failure);
+        Assert.assertEquals(2, splitSink.batches.size());
+        Assert.assertEquals(Collections.singletonList(firstSplit), splitSink.batches.get(0));
+        Assert.assertEquals(Collections.singletonList(secondSplit), splitSink.batches.get(1));
+        Mockito.verify(support, Mockito.never()).createTableScan();
+        Mockito.verify(support, Mockito.never()).planFileScanTask(Mockito.any());
+        Mockito.verify(support).recordManifestCacheProfile();
+    }
+
+    @Test
+    public void testStartUsesCountPushDownBranch() throws Exception {
+        IcebergSplitPlanningSupport support = Mockito.mock(IcebergSplitPlanningSupport.class);
+        TableScan scan = Mockito.mock(TableScan.class);
+        FileScanTask firstTask = Mockito.mock(FileScanTask.class);
+        FileScanTask secondTask = Mockito.mock(FileScanTask.class);
+        FileScanTask thirdTask = Mockito.mock(FileScanTask.class);
+        Split firstSplit = Mockito.mock(Split.class);
+        Split secondSplit = Mockito.mock(Split.class);
+        RecordingSplitSink splitSink = new RecordingSplitSink();
+
+        Mockito.when(support.getFileScanTasksFromContext()).thenReturn(null);
+        Mockito.when(support.createTableScan()).thenReturn(scan);
+        Mockito.when(support.planFileScanTask(scan)).thenReturn(
+                CloseableIterable.withNoopClose(Arrays.asList(firstTask, secondTask, thirdTask)));
+        Mockito.when(support.hasTableLevelPushDownCount()).thenReturn(true);
+        Mockito.when(support.getCountPushDownSplitCount(2)).thenReturn(2);
+        Mockito.when(support.createSplit(firstTask)).thenReturn(firstSplit);
+        Mockito.when(support.createSplit(secondTask)).thenReturn(secondSplit);
+
+        LocalParallelPlanningSplitProducer producer =
+                new LocalParallelPlanningSplitProducer(support, Runnable::run);
+        producer.start(2, splitSink);
+
+        Assert.assertTrue(splitSink.finished);
+        Assert.assertNull(splitSink.failure);
+        Assert.assertEquals(1, splitSink.batches.size());
+        Assert.assertEquals(Arrays.asList(firstSplit, secondSplit), splitSink.batches.get(0));
+        Mockito.verify(support).assignCountToSplits(Mockito.argThat(splits ->
+                splits.size() == 2 && splits.get(0) == firstSplit && splits.get(1) == secondSplit));
+        Mockito.verify(support, Mockito.never()).createSplit(thirdTask);
+        Mockito.verify(support).recordManifestCacheProfile();
+    }
+
+    @Test
+    public void testStartReportsTranslatedFailureToSink() throws Exception {
+        IcebergSplitPlanningSupport support = Mockito.mock(IcebergSplitPlanningSupport.class);
+        TableScan scan = Mockito.mock(TableScan.class);
+        IOException planningFailure = new IOException("plan failed");
+        UserException translatedFailure =
+                new UserException("wrapped: plan failed", planningFailure);
+        RecordingSplitSink splitSink = new RecordingSplitSink();
+
+        Mockito.when(support.getFileScanTasksFromContext()).thenReturn(null);
+        Mockito.when(support.createTableScan()).thenReturn(scan);
+        Mockito.when(support.planFileScanTask(scan)).thenThrow(planningFailure);
+        Mockito.when(support.translatePlanningException(planningFailure))
+                .thenReturn(translatedFailure);
+
+        LocalParallelPlanningSplitProducer producer =
+                new LocalParallelPlanningSplitProducer(support, Runnable::run);
+        producer.start(1, splitSink);
+
+        Assert.assertFalse(splitSink.finished);
+        Assert.assertSame(translatedFailure, splitSink.failure);
+        Mockito.verify(support, Mockito.never()).recordManifestCacheProfile();
+    }
+
+    private static class RecordingSplitSink implements SplitSink {
+        private final List<List<Split>> batches = new ArrayList<>();
+        private UserException failure;
+        private boolean finished;
+
+        @Override
+        public void addBatch(List<Split> splits) {
+            batches.add(new ArrayList<>(splits));
+        }
+
+        @Override
+        public boolean needMore() {
+            return true;
+        }
+
+        @Override
+        public void finish() {
+            finished = true;
+        }
+
+        @Override
+        public void fail(UserException e) {
+            failure = e;
+        }
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

- Refactor Iceberg split planning so both the synchronous `getSplits()` path and the batch split path use the same `PlanningSplitProducer` protocol.
- Introduce generic FE-side planning abstractions, including `PlanningSplitProducer`, `SplitSink`, `CollectingSplitSink`, and `PlanningSplitMetadata`, so split production and split consumption evolve independently.
- Move Iceberg planning primitives and planning metadata publication behind producer-side support, and let `IcebergScanNode` consume producer metadata instead of directly reading planning support state.
- Keep the generic `FileQueryScanNode` orchestration path producer-based without changing the default behavior of other external table scan nodes.
- Add API comments for the new split planning interfaces to clarify lifecycle and responsibilities.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

  Manual verification:

  - `DISABLE_BUILD_UI=ON DISABLE_BUILD_HIVE_UDF=ON DISABLE_BE_JAVA_EXTENSIONS=ON ./build.sh --fe -j8`

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->
