### PR TITLE
[Fix](Regression) reduce duplicate hive2/hive3 regression runs

### DIFF
--- a/regression-test/suites/external_table_p0/hive/hive_json_basic_test.groovy
+++ b/regression-test/suites/external_table_p0/hive/hive_json_basic_test.groovy
@@ -24,7 +24,7 @@ suite("hive_json_basic_test", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         try {
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")

--- a/regression-test/suites/external_table_p0/hive/hive_tpch_sf1_orc.groovy
+++ b/regression-test/suites/external_table_p0/hive/hive_tpch_sf1_orc.groovy
@@ -878,7 +878,7 @@ order by
     
     for (String enable_lazy_mat : ["true", "false"]) {
         sql """set enable_orc_lazy_materialization=${enable_lazy_mat}"""
-        for (String hivePrefix : ["hive2", "hive3"]) {
+        for (String hivePrefix : ["hive3"]) {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String catalog_name = "test_catalog_${hivePrefix}_orc"
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/hive/hive_tpch_sf1_parquet.groovy
+++ b/regression-test/suites/external_table_p0/hive/hive_tpch_sf1_parquet.groovy
@@ -880,7 +880,7 @@ order by
 
     for (String enable_lazy_mat : ["true", "false"]) {
         sql """set enable_orc_lazy_materialization=${enable_lazy_mat}"""
-        for (String hivePrefix : ["hive2", "hive3"]) {
+        for (String hivePrefix : ["hive3"]) {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String catalog_name = "test_catalog_${hivePrefix}_parquet"
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/hive/test_complex_types.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_complex_types.groovy
@@ -22,7 +22,7 @@ suite("test_complex_types", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_complex_types"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/hive/test_different_column_orders.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_different_column_orders.groovy
@@ -44,7 +44,7 @@ suite("test_different_column_orders", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String catalog_name = "test_different_column_orders_${hivePrefix}"

--- a/regression-test/suites/external_table_p0/hive/test_different_parquet_types.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_different_parquet_types.groovy
@@ -22,7 +22,7 @@ suite("test_different_parquet_types", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/hive/test_drop_expired_table_stats.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_drop_expired_table_stats.groovy
@@ -22,7 +22,7 @@ suite("test_drop_expired_table_stats", "p0,external") {
         return
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String extHiveHmsHost = context.config.otherConfigs.get("externalEnvIp")
         String extHiveHmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = hivePrefix + "_test_drop_expired_table_stats"

--- a/regression-test/suites/external_table_p0/hive/test_external_catalog_hive.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_external_catalog_hive.groovy
@@ -21,7 +21,7 @@ suite("test_external_catalog_hive", "p0,external") {
         logger.info("diable Hive test.")
         return;
     }
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_external_catalog_hive"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/hive/test_external_catalog_hive_partition.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_external_catalog_hive_partition.groovy
@@ -21,7 +21,7 @@ suite("test_external_catalog_hive_partition", "p0,external") {
         logger.info("disable Hive test.")
         return;
     }
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String extHiveHmsHost = context.config.otherConfigs.get("externalEnvIp")
         String extHiveHmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_external_catalog_hive_partition"

--- a/regression-test/suites/external_table_p0/hive/test_external_credit_data.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_external_credit_data.groovy
@@ -21,7 +21,7 @@ suite("test_external_credit_data", "p0,external") {
         logger.info("diable Hive test.")
         return;
     }
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_external_credit_data"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/hive/test_hive_analyze_db.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_analyze_db.groovy
@@ -40,7 +40,7 @@
          return;
      }
 
-     for (String hivePrefix : ["hive2", "hive3"]) {
+     for (String hivePrefix : ["hive3"]) {
          String extHiveHmsHost = context.config.otherConfigs.get("externalEnvIp")
          String extHiveHmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
          String catalog_name = "${hivePrefix}_test_hive_partition_column_analyze"

--- a/regression-test/suites/external_table_p0/hive/test_hive_basic_type.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_basic_type.groovy
@@ -22,7 +22,7 @@ suite("test_hive_basic_type", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         for (boolean enable_filter_by_min_max : [true, false]) {
             String catalog_name = "test_${hivePrefix}_basic_type"
             String ex_db_name = "`default`"

--- a/regression-test/suites/external_table_p0/hive/test_hive_broker_scan.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_broker_scan.groovy
@@ -35,7 +35,7 @@ suite("test_hive_broker_scan", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         try {
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")

--- a/regression-test/suites/external_table_p0/hive/test_hive_default_partition.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_default_partition.groovy
@@ -58,7 +58,7 @@ suite("test_hive_default_partition", "p0,external") {
         return
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String extHiveHmsHost = context.config.otherConfigs.get("externalEnvIp")
         String extHiveHmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = hivePrefix + "_hive_default_partition"

--- a/regression-test/suites/external_table_p0/hive/test_hive_get_schema_from_table.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_get_schema_from_table.groovy
@@ -65,7 +65,7 @@ suite("test_hive_get_schema_from_table", "p0,external") {
     }
 
     // test get scheam from table
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
        String catalog_name = "test_${hivePrefix}_get_schema"
        String ex_db_name = "`default`"
        String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/hive/test_hive_orc.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_orc.groovy
@@ -181,7 +181,7 @@ suite("test_hive_orc", "p0,external") {
     }
 
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String catalog_name = "${hivePrefix}_test_orc"

--- a/regression-test/suites/external_table_p0/hive/test_hive_other.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_other.groovy
@@ -56,7 +56,7 @@ suite("test_hive_other", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/hive/test_hive_parquet.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_parquet.groovy
@@ -175,7 +175,7 @@ suite("test_hive_parquet", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String catalog_name = "${hivePrefix}_test_parquet"

--- a/regression-test/suites/external_table_p0/hive/test_hive_parquet_alter_column.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_parquet_alter_column.groovy
@@ -27,7 +27,7 @@ suite("test_hive_parquet_alter_column", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String extHiveHmsHost = context.config.otherConfigs.get("externalEnvIp")
         String extHiveHmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_hive_parquet_alter_column"

--- a/regression-test/suites/external_table_p0/hive/test_hive_parquet_skip_page.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_parquet_skip_page.groovy
@@ -105,7 +105,7 @@ suite("test_hive_parquet_skip_page", "p0,external") {
                 "format" = "parquet") where a = 1024 or a = 4049
                 order by a;"""
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String catalog_name = "${hivePrefix}_test_parquet_skip_page"

--- a/regression-test/suites/external_table_p0/hive/test_hive_partition_column_analyze.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_partition_column_analyze.groovy
@@ -28,7 +28,7 @@ suite("test_hive_partition_column_analyze", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String extHiveHmsHost = context.config.otherConfigs.get("externalEnvIp")
         String extHiveHmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_hive_partition_column_analyze"

--- a/regression-test/suites/external_table_p0/hive/test_hive_partition_location.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_partition_location.groovy
@@ -35,7 +35,7 @@ suite("test_hive_partition_location", "p0,external") {
         logger.info("diable Hive test.")
         return;
     }
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_hive_partition_location"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/hive/test_hive_query_cache.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_query_cache.groovy
@@ -69,7 +69,7 @@ suite("test_hive_query_cache", "p0,external") {
             return;
         }
 
-        for (String hivePrefix : ["hive2", "hive3"]) {
+        for (String hivePrefix : ["hive3"]) {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/hive/test_hive_remove_partition.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_remove_partition.groovy
@@ -24,7 +24,7 @@ suite("test_hive_remove_partition", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String extHiveHmsHost = context.config.otherConfigs.get("externalEnvIp")
         String extHiveHmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_hive_remove_partition"

--- a/regression-test/suites/external_table_p0/hive/test_hive_runtime_filter_partition_pruning.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_runtime_filter_partition_pruning.groovy
@@ -85,7 +85,7 @@ suite("test_hive_runtime_filter_partition_pruning", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String catalog_name = "${hivePrefix}_test_hive_runtime_filter_partition_pruning"

--- a/regression-test/suites/external_table_p0/hive/test_hive_same_db_table_name.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_same_db_table_name.groovy
@@ -22,7 +22,7 @@ suite("test_hive_same_db_table_name", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_hive_same_db_table_name"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/hive/test_hive_schema_evolution.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_schema_evolution.groovy
@@ -58,7 +58,7 @@ suite("test_hive_schema_evolution", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String catalog_name = "test_${hivePrefix}_schema_evolution"

--- a/regression-test/suites/external_table_p0/hive/test_hive_statistic.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_statistic.groovy
@@ -22,7 +22,7 @@ suite("test_hive_statistic", "p0,external") {
         return
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String extHiveHmsHost = context.config.otherConfigs.get("externalEnvIp")
         String extHiveHmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = hivePrefix + "_test_hive_statistic"

--- a/regression-test/suites/external_table_p0/hive/test_hive_statistic_auto.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_statistic_auto.groovy
@@ -21,7 +21,7 @@ suite("test_hive_statistic_auto", "p0,external") {
         logger.info("disable Hive test.")
         return;
     }
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String extHiveHmsHost = context.config.otherConfigs.get("externalEnvIp")
         String extHiveHmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_hive_statistic_auto"

--- a/regression-test/suites/external_table_p0/hive/test_hive_statistic_clean.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_statistic_clean.groovy
@@ -21,7 +21,7 @@ suite("test_hive_statistic_clean", "p0,external") {
         logger.info("disable Hive test.")
         return;
     }
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String extHiveHmsHost = context.config.otherConfigs.get("externalEnvIp")
         String extHiveHmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_hive_statistic_clean"

--- a/regression-test/suites/external_table_p0/hive/test_hive_statistic_timeout.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_statistic_timeout.groovy
@@ -22,7 +22,7 @@ suite("test_hive_statistic_timeout", "p0,external") {
         return
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String extHiveHmsHost = context.config.otherConfigs.get("externalEnvIp")
         String extHiveHmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = hivePrefix + "_test_hive_statistic_timeout"

--- a/regression-test/suites/external_table_p0/hive/test_hive_statistics_all_type_p0.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_statistics_all_type_p0.groovy
@@ -22,7 +22,7 @@ suite("test_hive_statistics_all_type_p0", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String catalog_name = "test_${hivePrefix}_statistics_all_type_p0"

--- a/regression-test/suites/external_table_p0/hive/test_hive_statistics_p0.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_statistics_p0.groovy
@@ -22,7 +22,7 @@ suite("test_hive_statistics_p0", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String catalog_name = "test_${hivePrefix}_statistics_p0"

--- a/regression-test/suites/external_table_p0/hive/test_hive_tablesample_p0.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_tablesample_p0.groovy
@@ -23,7 +23,7 @@ suite("test_hive_tablesample_p0", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String catalog_name = "test_${hivePrefix}_tablesample_p0"

--- a/regression-test/suites/external_table_p0/hive/test_hive_text_complex_type.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_text_complex_type.groovy
@@ -20,7 +20,7 @@ suite("test_hive_text_complex_type", "p0,external") {
     if (!"true".equalsIgnoreCase(enabled)) {
         return;
     }
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
         String hmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "test_hive_text_complex_type"

--- a/regression-test/suites/external_table_p0/hive/test_hive_to_array.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_to_array.groovy
@@ -22,7 +22,7 @@ suite("test_hive_to_array", "p0,external") {
         return
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String extHiveHmsHost = context.config.otherConfigs.get("externalEnvIp")
         String extHiveHmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = hivePrefix + "_test_hive_to_array"

--- a/regression-test/suites/external_table_p0/hive/test_hive_to_date.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_to_date.groovy
@@ -22,7 +22,7 @@ suite("test_hive_to_date", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_hive_to_date"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/hive/test_hive_varbinary_type.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_varbinary_type.groovy
@@ -23,7 +23,7 @@ suite("test_hive_varbinary_type", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2","hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
     
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name_no_mapping = "${hivePrefix}_test_varbinary_no_mapping"

--- a/regression-test/suites/external_table_p0/hive/test_mixed_par_locations.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_mixed_par_locations.groovy
@@ -27,7 +27,7 @@ suite("test_mixed_par_locations", "p0,external") {
         logger.info("disable Hive test.")
         return;
     }
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String extHiveHmsHost = context.config.otherConfigs.get("externalEnvIp")
         String extHiveHmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_mixed_par_locations"

--- a/regression-test/suites/external_table_p0/hive/test_multi_delimit_serde.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_multi_delimit_serde.groovy
@@ -22,7 +22,7 @@ suite("test_multi_delimit_serde", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_multi_delimit_serde"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/hive/test_open_csv_serde.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_open_csv_serde.groovy
@@ -23,7 +23,7 @@ suite("test_open_csv_serde", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2","hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
     
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_open_csv_serde"

--- a/regression-test/suites/external_table_p0/hive/test_orc_nested_types.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_orc_nested_types.groovy
@@ -22,7 +22,7 @@ suite("test_orc_nested_types", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_orc_nested_types"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/hive/test_parquet_bloom_filter.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_parquet_bloom_filter.groovy
@@ -20,7 +20,7 @@ suite("test_parquet_bloom_filter", "p0,external") {
     if (!"true".equalsIgnoreCase(enabled)) {
         return;
     }
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
         String hmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "test_parquet_bloom_filter"

--- a/regression-test/suites/external_table_p0/hive/test_parquet_nested_types.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_parquet_nested_types.groovy
@@ -22,7 +22,7 @@ suite("test_parquet_nested_types", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_parquet_nested_types"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/hive/test_special_orc_formats.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_special_orc_formats.groovy
@@ -22,7 +22,7 @@ suite("test_special_orc_formats", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_special_orc_formats"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/hive/test_string_dict_filter.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_string_dict_filter.groovy
@@ -152,7 +152,7 @@ suite("test_string_dict_filter", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String catalog_name = "test_string_dict_filter_${hivePrefix}"

--- a/regression-test/suites/external_table_p0/hive/test_text_garbled_file.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_text_garbled_file.groovy
@@ -21,7 +21,7 @@ suite("test_text_garbled_file", "p0,external") {
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
 
-        for (String hivePrefix : ["hive2", "hive3"]) {
+        for (String hivePrefix : ["hive3"]) {
             String extHiveHmsHost = context.config.otherConfigs.get("externalEnvIp")
             String extHiveHmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String catalog_name = hivePrefix + "_test_text_garbled_file"

--- a/regression-test/suites/external_table_p0/hive/test_text_skip_header.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_text_skip_header.groovy
@@ -23,7 +23,7 @@ suite("test_hive_text_skip_header", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2","hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
     
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_utf8_check"

--- a/regression-test/suites/external_table_p0/hive/test_truncate_char_or_varchar_columns.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_truncate_char_or_varchar_columns.groovy
@@ -21,7 +21,7 @@ suite("test_truncate_char_or_varchar_columns", "p0,external") {
         logger.info("disable Hive test.")
         return;
     }
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String extHiveHmsHost = context.config.otherConfigs.get("externalEnvIp")
         String extHiveHmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_truncate_char_or_varchar_columns"

--- a/regression-test/suites/external_table_p0/hive/test_upper_case_column_name.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_upper_case_column_name.groovy
@@ -38,7 +38,7 @@ suite("test_upper_case_column_name", "p0,external") {
         logger.info("diable Hive test.")
         return;
     }
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_upper_case_column_name"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/external_table_p0/hive/test_utf8_check.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_utf8_check.groovy
@@ -23,7 +23,7 @@ suite("test_utf8_check", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2","hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
     
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_utf8_check"

--- a/regression-test/suites/external_table_p0/hive/test_wide_table.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_wide_table.groovy
@@ -45,7 +45,7 @@ suite("test_wide_table", "p0,external") {
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_wide_table"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/mtmv_p0/test_hive_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_hive_mtmv.groovy
@@ -22,7 +22,7 @@ suite("test_hive_mtmv", "p0,external,hive,external_docker,external_docker_hive")
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String catalog_name = "${hivePrefix}_test_mtmv"

--- a/regression-test/suites/mtmv_p0/test_hive_olap_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_hive_olap_mtmv.groovy
@@ -22,7 +22,7 @@ suite("test_hive_olap_mtmv", "p0,external,hive,external_docker,external_docker_h
         return;
     }
 
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_olap_test_mtmv"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")

--- a/regression-test/suites/mtmv_p0/test_hive_rewrite_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_hive_rewrite_mtmv.groovy
@@ -27,7 +27,7 @@ suite("test_hive_rewrite_mtmv", "p0,external,hive,external_docker,external_docke
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
     sql """set materialized_view_rewrite_enable_contain_external_table=true;"""
     String mvSql = "SELECT part_col,count(*) as num FROM ${catalogName}.`default`.mtmv_base1 group by part_col;";
-    for (String hivePrefix : ["hive2", "hive3"]) {
+    for (String hivePrefix : ["hive3"]) {
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         sql """drop catalog if exists ${catalogName}"""
         sql """create catalog if not exists ${catalogName} properties (


### PR DESCRIPTION
## Summary
- reduce a set of general external Hive regression suites from hive2+hive3 dual-run to hive3-only
- keep the more version-sensitive Hive3-specific coverage separate
- shrink duplicate extern regression workload without removing dedicated Hive3 feature cases

## Testing
- git diff --check -- regression-test/suites/external_table_p0 regression-test/suites/mtmv_p0