### PR TITLE
[fix](query-cache) include variant subcolumn path in query cache digest

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -1249,7 +1249,16 @@ public class OlapScanNode extends ScanNode {
                 .flatMap(tupleId -> normalizer.getDescriptorTable().getTupleDesc(tupleId).getSlots().stream())
                 .collect(Collectors.toList());
         List<Pair<SlotId, String>> selectColumns = slots.stream()
-                .map(slot -> Pair.of(slot.getId(), slot.getColumn().getName()))
+                .map(slot -> {
+                    // For variant subcolumns, use the materialized column name (e.g. "data.int_1")
+                    // to distinguish different subcolumns of the same variant column in cache digest.
+                    List<String> subColPath = slot.getSubColLables();
+                    String colName = slot.getColumn().getName();
+                    if (subColPath != null && !subColPath.isEmpty()) {
+                        colName = colName + "." + String.join(".", subColPath);
+                    }
+                    return Pair.of(slot.getId(), colName);
+                })
                 .collect(Collectors.toList());
         for (Column partitionColumn : olapTable.getPartitionInfo().getPartitionColumns()) {
             boolean selectPartitionColumn = false;

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryCacheNormalizerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryCacheNormalizerTest.java
@@ -110,7 +110,14 @@ public class QueryCacheNormalizerTest extends TestWithFeService {
                 + "distributed by hash(k1) buckets 3\n"
                 + "properties('replication_num' = '1')";
 
-        createTables(nonPart, part1, part2, multiLeveParts);
+        String variantTable = "create table db1.variant_tbl("
+                + "  k1 int,\n"
+                + "  data variant)\n"
+                + "DUPLICATE KEY(k1)\n"
+                + "distributed by hash(k1) buckets 3\n"
+                + "properties('replication_num' = '1')";
+
+        createTables(nonPart, part1, part2, multiLeveParts, variantTable);
 
         connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
         connectContext.getSessionVariable().setEnableQueryCache(true);
@@ -356,6 +363,22 @@ public class QueryCacheNormalizerTest extends TestWithFeService {
         List<TNormalizedPlanNode> fourPhaseAggPlans = phaseAgg(4, () -> normalizePlans(
                 "select sum(distinct v1), k2 from db1.part1 where dt = '2024-04-10' group by k2"));
         Assertions.assertEquals(fourPhaseAggPlans, threePhaseAggPlans);
+    }
+
+    @Test
+    public void testVariantSubColumnDigest() throws Exception {
+        // Different variant subcolumns should produce different digests
+        String digest1 = getDigest(
+                "select cast(data['int_1'] as int), count(*) from db1.variant_tbl group by cast(data['int_1'] as int)");
+        String digest2 = getDigest(
+                "select cast(data['int_nested'] as int), count(*) from db1.variant_tbl group by cast(data['int_nested'] as int)");
+        Assertions.assertNotEquals(digest1, digest2,
+                "Queries on different variant subcolumns must have different cache digests");
+
+        // Same variant subcolumn with different aliases should produce same digest
+        String digest3 = getDigest(
+                "select cast(data['int_1'] as int) as a, count(*) as cnt from db1.variant_tbl group by cast(data['int_1'] as int)");
+        Assertions.assertEquals(digest1, digest3);
     }
 
     private String getDigest(String sql) throws Exception {


### PR DESCRIPTION
Different variant subcolumn queries (e.g. data['int_1'] vs data['int_nested']) were generating the same cache digest because normalizeSelectColumns() only used the base column name. This caused query cache to return wrong results when different subcolumns of the same variant column were queried.

Fix: include the variant subcolumn path in the normalized select column name so that different subcolumns produce different cache digests.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

