### PR TITLE
[feature](restore) support concurrent backup/restore

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1623,6 +1623,19 @@ public class Config extends ConfigBase {
             "Control the maximum number of tablets per backup job, to avoid OOM."})
     public static int max_backup_tablets_per_job = 300000;
 
+    @ConfField(mutable = true, masterOnly = true, description = {
+        "所有并发 backup/restore job 允许的 snapshot 任务总量上限，以避免 OOM。0 表示不限制。"
+            + "BackupJob 按 tablet 计数，RestoreJob 按 replica 计数（通常是 tablet 的 3 倍）。"
+            + "仅在 enable_table_level_backup_concurrency = true 时生效。"
+            + "默认值 1500000 约等于 max_backup_tablets_per_job(300000) * 5。",
+        "Max total snapshot tasks across all concurrent backup/restore jobs, to avoid OOM. "
+            + "0 means unlimited. BackupJob counts per tablet, RestoreJob counts per replica "
+            + "(typically 3x of tablet count). Only effective when "
+            + "enable_table_level_backup_concurrency = true. "
+            + "Default 1500000 ≈ max_backup_tablets_per_job(300000) * 5."
+    })
+    public static int max_concurrent_snapshot_tasks_total = 1500000;
+
     /**
      * whether to ignore table that not support type when backup, and not report exception.
      */
@@ -1642,6 +1655,85 @@ public class Config extends ConfigBase {
     @ConfField(mutable = false)
     public static long backup_handler_update_interval_millis = 3000;
 
+    // === Backup/Restore Concurrency Control ===
+
+    /**
+     * Whether to enable table-level backup/restore concurrency.
+     * When enabled, multiple backup/restore jobs can run concurrently on different tables
+     * within the same database. When disabled, only one job can run at a time per database
+     * (original behavior).
+     */
+    @ConfField(mutable = true, masterOnly = true, description = {
+        "是否启用表级 backup/restore 并发。启用后，同一数据库的多个表可以并发执行 backup/restore。",
+        "Whether to enable table-level backup/restore concurrency. When enabled, multiple tables "
+            + "in the same database can run backup/restore jobs concurrently."
+    })
+    public static boolean enable_table_level_backup_concurrency = false;
+
+    /**
+     * Maximum number of concurrent backup/restore jobs per database.
+     * This limit is shared between backup and restore jobs.
+     * Note: This value should be less than or equal to max_backup_restore_job_num_per_db / 2,
+     * otherwise history jobs may be cleared too quickly.
+     */
+    @ConfField(mutable = true, masterOnly = true, description = {
+        "每个数据库的最大并发 backup/restore 任务数。backup 和 restore 共享此配置。",
+        "Maximum number of concurrent backup/restore jobs per database. "
+            + "This limit is shared between backup and restore jobs."
+    })
+    public static int max_backup_restore_concurrent_num_per_db = 10;
+
+    /**
+     * Timeout for jobs in PENDING state (milliseconds).
+     * Jobs that have been waiting in the queue longer than this will be automatically cancelled.
+     */
+    @ConfField(mutable = true, masterOnly = true, description = {
+        "PENDING 状态任务的超时时间（毫秒）。排队超过此时间的任务将被自动取消。",
+        "Timeout for jobs in PENDING state (milliseconds). "
+            + "Jobs waiting in queue longer than this will be automatically cancelled."
+    })
+    public static long backup_pending_job_timeout_ms = 3600000;  // 1 hour
+
+    /**
+     * Whether to enable detailed logging for backup/restore concurrency control.
+     * Useful for debugging and troubleshooting.
+     */
+    @ConfField(mutable = true, masterOnly = true, description = {
+        "是否启用 backup/restore 并发控制的详细日志，用于调试和问题排查。",
+        "Whether to enable detailed logging for backup/restore concurrency control. "
+            + "Useful for debugging and troubleshooting."
+    })
+    public static boolean enable_backup_concurrency_logging = false;
+
+    /**
+     * Soft limit for the running queue size (warning only, not enforced).
+     * When the running queue size reaches this limit, a warning will be logged.
+     * This helps prevent extreme cases where too many jobs accumulate and cause OOM.
+     *
+     * Recommended value: concurrent_num * 2
+     * Example: If max_backup_restore_concurrent_num_per_db = 10, set this to 20.
+     */
+    @ConfField(mutable = true, masterOnly = true, description = {
+        "运行队列大小的软限制（仅警告，不强制）。达到此限制时会记录警告日志。",
+        "Soft limit for running queue size (warning only). A warning is logged when reached."
+    })
+    public static int max_backup_restore_running_queue_soft_limit = 100;
+
+    /**
+     * Hard limit for the running queue size (enforced, new jobs will be rejected).
+     * When the running queue size reaches this limit, new job submissions will be rejected
+     * with an error message asking users to wait or increase the limit.
+     *
+     * This is a safety mechanism to prevent FE OOM in extreme scenarios.
+     *
+     * Recommended value: concurrent_num * 4
+     * Example: If max_backup_restore_concurrent_num_per_db = 10, set this to 40.
+     */
+    @ConfField(mutable = true, masterOnly = true, description = {
+        "运行队列大小的硬限制（强制，达到后拒绝新任务）。这是防止 FE OOM 的安全机制。",
+        "Hard limit for running queue size (enforced). New jobs are rejected when reached."
+    })
+    public static int max_backup_restore_running_queue_hard_limit = 200;
 
     /**
      * Whether to enable cloud restore job.

--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -629,8 +629,8 @@ supportedCancelStatement
     | CANCEL WARM UP JOB wildWhere?                                                 #cancelWarmUpJob
     | CANCEL DECOMMISSION BACKEND hostPorts+=STRING_LITERAL
         (COMMA hostPorts+=STRING_LITERAL)*                                          #cancelDecommisionBackend
-    | CANCEL BACKUP ((FROM | IN) database=identifier)?                              #cancelBackup
-    | CANCEL RESTORE ((FROM | IN) database=identifier)?                             #cancelRestore
+    | CANCEL BACKUP ((FROM | IN) database=identifier)? wildWhere?                   #cancelBackup
+    | CANCEL RESTORE ((FROM | IN) database=identifier)? wildWhere?                  #cancelRestore
     | CANCEL BUILD INDEX ON tableName=multipartIdentifier
         (LEFT_PAREN jobIds+=INTEGER_VALUE
             (COMMA jobIds+=INTEGER_VALUE)* RIGHT_PAREN)?                            #cancelBuildIndex

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/AbstractJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/AbstractJob.java
@@ -118,6 +118,10 @@ public abstract class AbstractJob implements Writable {
         return jobId;
     }
 
+    public void setJobId(long jobId) {
+        this.jobId = jobId;
+    }
+
     public String getLabel() {
         return label;
     }
@@ -171,6 +175,10 @@ public abstract class AbstractJob implements Writable {
     public abstract boolean isFinished();
 
     public abstract Status updateRepo(Repository repo);
+
+    public int getSnapshotTaskCount() {
+        return 0;
+    }
 
     public static AbstractJob read(DataInput in) throws IOException {
         String json = Text.readString(in);

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -67,13 +67,19 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -91,10 +97,19 @@ public class BackupHandler extends MasterDaemon implements Writable {
     // this lock is used for updating dbIdToBackupOrRestoreJobs
     private final ReentrantLock jobLock = new ReentrantLock();
 
-    // db id ->  last 10(max_backup_restore_job_num_per_db) backup/restore jobs
-    // Newly submitted job will replace the current job, only if current job is finished or cancelled.
-    // If the last job is finished, user can get the job info from repository. If the last job is cancelled,
-    // user can get the error message before submitting the next one.
+    // === Dual Queue Architecture ===
+    // Running queue: stores all unfinished jobs (PENDING or executing), no size limit
+    // These jobs are actively being processed by the scheduler
+    private final Map<Long, Deque<AbstractJob>> dbIdToRunningJobs = new ConcurrentHashMap<>();
+    private final ReentrantLock runningJobLock = new ReentrantLock();
+
+    // History queue: stores finished jobs (FINISHED, CANCELLED), FIFO with size limit
+    // Used for SHOW BACKUP/RESTORE commands to display historical jobs
+    private final Map<Long, Deque<AbstractJob>> dbIdToHistoryJobs = new ConcurrentHashMap<>();
+    private final ReentrantLock historyJobLock = new ReentrantLock();
+
+    // Legacy single queue (kept for backward compatibility during migration)
+    // TODO: Remove this after confirming dual queue works correctly
     private final Map<Long, Deque<AbstractJob>> dbIdToBackupOrRestoreJobs = new HashMap<>();
 
     // this lock is used for handling one backup or restore request at a time.
@@ -109,6 +124,27 @@ public class BackupHandler extends MasterDaemon implements Writable {
     // one table only keep one snapshot info, only keep last
     private final Map<String, BackupJob> localSnapshots = new HashMap<>();
     private ReadWriteLock localSnapshotsLock = new ReentrantReadWriteLock();
+
+    // === Concurrency control fields (only used when enable_table_level_backup_concurrency is true) ===
+
+    // Execution gate: only jobs in this set are allowed to execute
+    // Jobs in PENDING state but not in this set will skip execution until activated
+    private final Set<Long> allowedJobIds = Collections.synchronizedSet(new HashSet<>());
+
+    // Restore table conflict detection: tracks which tables are currently being restored
+    // Key: dbId, Value: set of table names being restored
+    // Used to detect conflicts between restore jobs operating on the same tables
+    private final Map<Long, Set<String>> restoringTables = new ConcurrentHashMap<>();
+
+    // Database job statistics cache for O(1) concurrency checking
+    // Key: dbId, Value: statistics for that database
+    private final Map<Long, DatabaseJobStats> dbJobStats = new ConcurrentHashMap<>();
+
+    private final AtomicInteger globalSnapshotTasks = new AtomicInteger(0);
+
+    // Label index for O(1) duplicate label detection
+    // Key: dbId, Value: (label -> jobId) mapping
+    private final Map<Long, Map<String, Long>> labelIndex = new ConcurrentHashMap<>();
 
     public BackupHandler() {
         // for persist
@@ -132,6 +168,14 @@ public class BackupHandler extends MasterDaemon implements Writable {
 
     public RepositoryMgr getRepoMgr() {
         return repoMgr;
+    }
+
+    public int getGlobalSnapshotTasks() {
+        return globalSnapshotTasks.get();
+    }
+
+    public void addGlobalSnapshotTasks(int count) {
+        globalSnapshotTasks.addAndGet(count);
     }
 
     private boolean init() {
@@ -164,7 +208,113 @@ public class BackupHandler extends MasterDaemon implements Writable {
         }
 
         isInit = true;
+
+        // Rebuild concurrency control state after FE restart
+        if (Config.enable_table_level_backup_concurrency) {
+            rebuildConcurrencyStateAfterRestart();
+        }
+
         return true;
+    }
+
+    /**
+     * Rebuild concurrency control state after FE restart.
+     * This method scans all jobs and rebuilds the internal data structures including dual queues.
+     */
+    private void rebuildConcurrencyStateAfterRestart() {
+        LOG.info("Rebuilding concurrency control state and dual queues after FE restart...");
+
+        // Clear all caches and queues
+        allowedJobIds.clear();
+        dbJobStats.clear();
+        labelIndex.clear();
+        restoringTables.clear();
+        dbIdToRunningJobs.clear();
+        dbIdToHistoryJobs.clear();
+
+        int totalJobs = 0;
+        int runningJobs = 0;
+        int historyJobs = 0;
+        int activatedJobs = 0;
+
+        // Scan all databases and jobs to rebuild dual queues
+        for (Map.Entry<Long, Deque<AbstractJob>> entry : dbIdToBackupOrRestoreJobs.entrySet()) {
+            long dbId = entry.getKey();
+
+            for (AbstractJob job : entry.getValue()) {
+                totalJobs++;
+                boolean isBackup = job instanceof BackupJob;
+                boolean isFullDatabase = false;
+
+                // Determine if this is a full database operation
+                if (isBackup && job instanceof BackupJob) {
+                    isFullDatabase = ((BackupJob) job).getTableRefs().isEmpty();
+                } else if (!isBackup && job instanceof RestoreJob) {
+                    isFullDatabase = ((RestoreJob) job).getTableRefs().isEmpty();
+                }
+
+                // Step 1: Add to appropriate queue (running or history)
+                if (job.isDone()) {
+                    // Completed job -> history queue
+                    addToHistoryQueue(dbId, job);
+                    historyJobs++;
+                } else {
+                    // Active job (PENDING or running) -> running queue
+                    try {
+                        Deque<AbstractJob> runningQueue = dbIdToRunningJobs.computeIfAbsent(
+                                dbId, k -> new LinkedList<>());
+                        runningQueue.addLast(job);
+                        runningJobs++;
+                    } catch (Exception e) {
+                        LOG.warn("Failed to add job {} to running queue during rebuild: {}",
+                                job.getLabel(), e.getMessage());
+                    }
+
+                    // Step 2: Rebuild concurrency control statistics
+                    onJobCreated(dbId, job, isBackup, isFullDatabase);
+
+                    // Step 3: For jobs that were already running (not PENDING),
+                    // re-add to allowedJobIds and rebuild restoringTables
+                    boolean isPending = false;
+                    if (isBackup && job instanceof BackupJob) {
+                        isPending = ((BackupJob) job).getState() == BackupJob.BackupJobState.PENDING;
+                    } else if (!isBackup && job instanceof RestoreJob) {
+                        isPending = ((RestoreJob) job).getState() == RestoreJob.RestoreJobState.PENDING;
+                    }
+
+                    if (!isPending) {
+                        // Job was running, add to allowedJobIds and update running counters
+                        allowedJobIds.add(job.getJobId());
+                        onJobActivated(dbId, job, isBackup, isFullDatabase);
+                        activatedJobs++;
+
+                        // For running restore jobs, rebuild restoringTables
+                        if (job instanceof RestoreJob) {
+                            addRestoringTables((RestoreJob) job);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Try to activate PENDING jobs
+        for (Long dbId : dbIdToRunningJobs.keySet()) {
+            tryActivatePendingJobs(dbId);
+        }
+
+        int globalTotal = 0;
+        for (Deque<AbstractJob> queue : dbIdToRunningJobs.values()) {
+            for (AbstractJob j : queue) {
+                globalTotal += j.getSnapshotTaskCount();
+            }
+        }
+        globalSnapshotTasks.set(globalTotal);
+
+        LOG.info("Rebuilt dual queues after restart: {} total jobs ({} running, {} history), "
+                + "{} activated, {} databases, globalSnapshotTasks={}",
+                totalJobs, runningJobs, historyJobs, activatedJobs,
+                Math.max(dbIdToRunningJobs.size(), dbIdToHistoryJobs.size()),
+                globalTotal);
     }
 
     public AbstractJob getJob(long dbId) {
@@ -172,14 +322,22 @@ public class BackupHandler extends MasterDaemon implements Writable {
     }
 
     public List<AbstractJob> getJobs(long dbId, Predicate<String> predicate) {
-        jobLock.lock();
-        try {
-            return dbIdToBackupOrRestoreJobs.getOrDefault(dbId, new LinkedList<>())
-                    .stream()
+        if (Config.enable_table_level_backup_concurrency) {
+            // In dual queue mode, merge both queues
+            return getAllJobs(dbId).stream()
                     .filter(e -> predicate.test(e.getLabel()))
                     .collect(Collectors.toList());
-        } finally {
-            jobLock.unlock();
+        } else {
+            // Legacy mode: use old single queue
+            jobLock.lock();
+            try {
+                return dbIdToBackupOrRestoreJobs.getOrDefault(dbId, new LinkedList<>())
+                        .stream()
+                        .filter(e -> predicate.test(e.getLabel()))
+                        .collect(Collectors.toList());
+            } finally {
+                jobLock.unlock();
+            }
         }
     }
 
@@ -191,7 +349,23 @@ public class BackupHandler extends MasterDaemon implements Writable {
             }
         }
 
-        for (AbstractJob job : getAllCurrentJobs()) {
+        // Get jobs to process based on concurrency mode
+        List<AbstractJob> jobsToProcess;
+        if (Config.enable_table_level_backup_concurrency) {
+            // In concurrency mode, only process jobs from running queue
+            jobsToProcess = getAllRunningJobs();
+        } else {
+            // In legacy mode, use the old logic
+            jobsToProcess = getAllCurrentJobs();
+        }
+
+        for (AbstractJob job : jobsToProcess) {
+            // Skip completed jobs (optimization: avoid unnecessary run() calls)
+            // Although job.run() will return immediately if done, this saves the call overhead
+            if (job.isDone()) {
+                continue;
+            }
+
             job.setEnv(env);
             job.run();
         }
@@ -283,7 +457,15 @@ public class BackupHandler extends MasterDaemon implements Writable {
      * @param newRepo The new repository instance.
      */
     private void updateOngoingJobs(long repoId, Repository newRepo) {
-        for (AbstractJob job : getAllCurrentJobs()) {
+        // Get jobs to update based on concurrency mode
+        List<AbstractJob> jobsToUpdate;
+        if (Config.enable_table_level_backup_concurrency) {
+            jobsToUpdate = getAllRunningJobs();
+        } else {
+            jobsToUpdate = getAllCurrentJobs();
+        }
+
+        for (AbstractJob job : jobsToUpdate) {
             if (!job.isDone() && job.getRepoId() == repoId) {
                 job.updateRepo(newRepo);
             }
@@ -299,7 +481,15 @@ public class BackupHandler extends MasterDaemon implements Writable {
                 ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR, "Repository does not exist");
             }
 
-            for (AbstractJob job : getAllCurrentJobs()) {
+            // Get jobs to check based on concurrency mode
+            List<AbstractJob> jobsToCheck;
+            if (Config.enable_table_level_backup_concurrency) {
+                jobsToCheck = getAllRunningJobs();
+            } else {
+                jobsToCheck = getAllCurrentJobs();
+            }
+
+            for (AbstractJob job : jobsToCheck) {
                 if (!job.isDone() && job.getRepoId() == repo.getId()) {
                     ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
                                                    "Backup or restore job is running on this repository."
@@ -344,14 +534,19 @@ public class BackupHandler extends MasterDaemon implements Writable {
         // So we use tryLock() to give up this operation if we can not get lock.
         tryLock();
         try {
-            // Check if there is backup or restore job running on this database
-            AbstractJob currentJob = getCurrentJob(db.getId());
-            if (currentJob != null && !currentJob.isDone()) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
-                        "Can only run one backup or restore job of a database at same time "
-                        + ", current running: label = " + currentJob.getLabel() + " jobId = "
-                        + currentJob.getJobId() + ", to run label = " + command.getLabel());
+            // === Concurrency control ===
+            if (!Config.enable_table_level_backup_concurrency) {
+                // Original logic: only one job at a time
+                AbstractJob currentJob = getCurrentJob(db.getId());
+                if (currentJob != null && !currentJob.isDone()) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
+                            "Can only run one backup or restore job of a database at same time "
+                            + ", current running: label = " + currentJob.getLabel() + " jobId = "
+                            + currentJob.getJobId() + ", to run label = " + command.getLabel());
+                }
             }
+            // Note: For concurrent mode, actual concurrency checks are performed in backup() method
+            // after the job is created, because we need the job ID to add to allowedJobIds
             backup(repository, db, command);
         } finally {
             seqlock.unlock();
@@ -385,14 +580,19 @@ public class BackupHandler extends MasterDaemon implements Writable {
         // So we use tryLock() to give up this operation if we can not get lock.
         tryLock();
         try {
-            // Check if there is backup or restore job running on this database
-            AbstractJob currentJob = getCurrentJob(db.getId());
-            if (currentJob != null && !currentJob.isDone()) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
-                        "Can only run one backup or restore job of a database at same time "
-                        + ", current running: label = " + currentJob.getLabel() + " jobId = "
-                        + currentJob.getJobId() + ", to run label = " + command.getLabel());
+            // === Concurrency control ===
+            if (!Config.enable_table_level_backup_concurrency) {
+                // Original logic: only one job at a time
+                AbstractJob currentJob = getCurrentJob(db.getId());
+                if (currentJob != null && !currentJob.isDone()) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
+                            "Can only run one backup or restore job of a database at same time "
+                            + ", current running: label = " + currentJob.getLabel() + " jobId = "
+                            + currentJob.getJobId() + ", to run label = " + command.getLabel());
+                }
             }
+            // Note: For concurrent mode, checkConcurrency is called in restore() method
+            // after jobInfo is available, because we need to know the actual tables
             restore(repository, db, command);
         } finally {
             seqlock.unlock();
@@ -553,11 +753,49 @@ public class BackupHandler extends MasterDaemon implements Writable {
         BackupJob backupJob = new BackupJob(command.getLabel(), db.getId(),
                 db.getFullName(),
                 tableRefInfoList, command.getTimeoutMs(), command.getContent(), env, repoId, commitSeq);
-        // write log
+        // === Concurrency control ===
+        if (Config.enable_table_level_backup_concurrency) {
+            if (backupJob.getJobId() == -1) {
+                backupJob.setJobId(env.getNextId());
+            }
+
+            // Determine if this is a full database backup
+            boolean isFullDatabase = tableRefInfoList.isEmpty()
+                    || (command.getTableRefInfos().isEmpty() && !command.isExclude());
+
+            // Collect table names for concurrency check
+            List<String> tableNameList = new ArrayList<>();
+            for (TableRefInfo tblRef : tableRefInfoList) {
+                tableNameList.add(tblRef.getTableNameInfo().getTbl());
+            }
+
+            // Check concurrency (throws exception for hard rejection cases)
+            checkConcurrency(db.getId(), command.getLabel(), true, isFullDatabase, tableNameList);
+
+            // Update statistics
+            onJobCreated(db.getId(), backupJob, true, isFullDatabase);
+
+            // Decide whether to add to allowedJobIds (canActivate checks running jobs)
+            if (canActivate(db.getId(), backupJob, true, isFullDatabase)) {
+                allowedJobIds.add(backupJob.getJobId());
+                onJobActivated(db.getId(), backupJob, true, isFullDatabase);
+                LOG.info("Backup job [{}] can execute immediately (jobId={})",
+                        backupJob.getLabel(), backupJob.getJobId());
+            } else {
+                LOG.info("Backup job [{}] will be pending (jobId={})",
+                        backupJob.getLabel(), backupJob.getJobId());
+            }
+        }
+
+        // write log (after jobId is assigned so EditLog records the correct jobId)
         env.getEditLog().logBackupJob(backupJob);
 
-        // must put to dbIdToBackupOrRestoreJob after edit log, otherwise the state of job may be changed.
-        addBackupOrRestoreJob(db.getId(), backupJob);
+        // Add to appropriate queue based on concurrency mode
+        if (Config.enable_table_level_backup_concurrency) {
+            addActiveJob(db.getId(), backupJob);
+        } else {
+            addBackupOrRestoreJob(db.getId(), backupJob);
+        }
 
         LOG.info("finished to submit backup job: {}", backupJob);
     }
@@ -633,11 +871,266 @@ public class BackupHandler extends MasterDaemon implements Writable {
             }
         }
 
+        // Set tableRefs for concurrency control
+        restoreJob.setTableRefs(command.getTableRefInfos());
+
+        // === Concurrency control ===
+        if (Config.enable_table_level_backup_concurrency) {
+            if (restoreJob.getJobId() == -1) {
+                restoreJob.setJobId(env.getNextId());
+            }
+
+            // Determine if this is a full database restore
+            boolean isFullDatabase = command.getTableRefInfos().isEmpty();
+
+            // Collect table names for concurrency check
+            List<String> tableNameList = new ArrayList<>();
+            for (TableRefInfo tblRef : command.getTableRefInfos()) {
+                tableNameList.add(tblRef.getTableNameInfo().getTbl());
+            }
+
+            // Check concurrency (throws exception for hard rejection cases)
+            checkConcurrency(db.getId(), command.getLabel(), false, isFullDatabase, tableNameList);
+
+            // Update statistics
+            onJobCreated(db.getId(), restoreJob, false, isFullDatabase);
+
+            // Decide whether to add to allowedJobIds (canActivate checks running jobs)
+            if (canActivate(db.getId(), restoreJob, false, isFullDatabase)) {
+                allowedJobIds.add(restoreJob.getJobId());
+                onJobActivated(db.getId(), restoreJob, false, isFullDatabase);
+                // CRITICAL: Add restoring tables atomically with activation
+                // to prevent TOCTOU race condition where another restore job
+                // targeting the same table could also pass canActivate()
+                addRestoringTables(restoreJob);
+                LOG.info("Restore job [{}] can execute immediately (jobId={})",
+                        restoreJob.getLabel(), restoreJob.getJobId());
+            } else {
+                LOG.info("Restore job [{}] will be pending (jobId={})",
+                        restoreJob.getLabel(), restoreJob.getJobId());
+            }
+        }
+
+        // write log (after jobId is assigned so EditLog records the correct jobId)
         env.getEditLog().logRestoreJob(restoreJob);
 
-        // must put to dbIdToBackupOrRestoreJob after edit log, otherwise the state of job may be changed.
-        addBackupOrRestoreJob(db.getId(), restoreJob);
+        // Add to appropriate queue based on concurrency mode
+        if (Config.enable_table_level_backup_concurrency) {
+            addActiveJob(db.getId(), restoreJob);
+        } else {
+            addBackupOrRestoreJob(db.getId(), restoreJob);
+        }
+
         LOG.info("finished to submit restore job: {}", restoreJob);
+    }
+
+    /**
+     * Add a job to the running queue (no size limit).
+     * This method is used for active jobs that are either PENDING or executing.
+     *
+     * @param dbId Database ID
+     * @param job  The job to add
+     * @throws DdlException if the running queue soft limit is exceeded
+     */
+    private void addActiveJob(long dbId, AbstractJob job) throws DdlException {
+        runningJobLock.lock();
+        try {
+            Deque<AbstractJob> queue = dbIdToRunningJobs.computeIfAbsent(dbId, k -> new LinkedList<>());
+
+            // Check soft limit (warning only)
+            if (queue.size() >= Config.max_backup_restore_running_queue_soft_limit) {
+                LOG.warn("Running queue for database {} has reached soft limit: {} jobs (limit: {})",
+                        dbId, queue.size(), Config.max_backup_restore_running_queue_soft_limit);
+            }
+
+            // Check hard limit (reject)
+            if (queue.size() >= Config.max_backup_restore_running_queue_hard_limit) {
+                throw new DdlException(String.format(
+                        "Running queue is full (%d jobs, hard limit: %d). "
+                                + "Too many active backup/restore jobs for database %d. "
+                                + "Please wait for some jobs to complete or increase "
+                                + "max_backup_restore_running_queue_hard_limit.",
+                        queue.size(), Config.max_backup_restore_running_queue_hard_limit, dbId));
+            }
+
+            // Check if job already exists in queue (skip duplicate)
+            // This can happen during FE restart replay
+            boolean exists = queue.stream().anyMatch(j -> j.getJobId() == job.getJobId());
+            if (exists) {
+                LOG.info("Job {} already exists in running queue, skipping duplicate (dbId={})",
+                        job.getLabel(), dbId);
+                return;
+            }
+
+            queue.addLast(job);
+
+            if (Config.enable_backup_concurrency_logging) {
+                LOG.info("Added job {} to running queue, dbId={}, queueSize={}",
+                        job.getLabel(), dbId, queue.size());
+            }
+        } finally {
+            runningJobLock.unlock();
+        }
+    }
+
+    /**
+     * Move a completed job from running queue to history queue.
+     * History queue has FIFO cleanup when it reaches the size limit.
+     *
+     * @param dbId Database ID
+     * @param job  The completed job
+     */
+    private void moveToHistory(long dbId, AbstractJob job) {
+        // Step 1: Remove from running queue
+        removeFromRunningQueue(dbId, job);
+
+        // Step 2: Add to history queue with FIFO cleanup
+        addToHistoryQueue(dbId, job);
+    }
+
+    /**
+     * Remove a job from the running queue.
+     *
+     * @param dbId Database ID
+     * @param job  The job to remove
+     */
+    private void removeFromRunningQueue(long dbId, AbstractJob job) {
+        runningJobLock.lock();
+        try {
+            Deque<AbstractJob> queue = dbIdToRunningJobs.get(dbId);
+            if (queue != null) {
+                // Need to iterate to find and remove (job might be in the middle of queue)
+                Iterator<AbstractJob> it = queue.iterator();
+                while (it.hasNext()) {
+                    if (it.next().getJobId() == job.getJobId()) {
+                        it.remove();
+                        if (Config.enable_backup_concurrency_logging) {
+                            LOG.info("Removed job {} from running queue, dbId={}, remainingSize={}",
+                                    job.getLabel(), dbId, queue.size());
+                        }
+                        break;
+                    }
+                }
+
+                // If running queue is empty, remove the key
+                if (queue.isEmpty()) {
+                    dbIdToRunningJobs.remove(dbId);
+                }
+            }
+        } finally {
+            runningJobLock.unlock();
+        }
+    }
+
+    /**
+     * Add a job to the history queue with FIFO cleanup when size limit is reached.
+     *
+     * @param dbId Database ID
+     * @param job  The finished job to add
+     */
+    private void addToHistoryQueue(long dbId, AbstractJob job) {
+        historyJobLock.lock();
+        try {
+            Deque<AbstractJob> queue = dbIdToHistoryJobs.computeIfAbsent(dbId, k -> new LinkedList<>());
+
+            // FIFO cleanup: remove oldest if queue is full
+            while (queue.size() >= Config.max_backup_restore_job_num_per_db) {
+                AbstractJob removed = queue.removeFirst();
+                cleanupJobResources(removed);
+
+                if (Config.enable_backup_concurrency_logging) {
+                    LOG.info("Removed oldest history job {} from queue (limit reached), dbId={}",
+                            removed.getLabel(), dbId);
+                }
+            }
+
+            queue.addLast(job);
+
+            // Save snapshot to local repo if applicable
+            if (job instanceof BackupJob) {
+                BackupJob backupJob = (BackupJob) job;
+                if (backupJob.isLocalSnapshot()) {
+                    addSnapshot(backupJob.getLabel(), backupJob);
+                }
+            }
+
+            if (Config.enable_backup_concurrency_logging) {
+                LOG.info("Added job {} to history queue, dbId={}, queueSize={}",
+                        job.getLabel(), dbId, queue.size());
+            }
+        } finally {
+            historyJobLock.unlock();
+        }
+    }
+
+    /**
+     * Clean up resources associated with a job being removed from history.
+     *
+     * @param job The job to clean up
+     */
+    private void cleanupJobResources(AbstractJob job) {
+        // Remove from local snapshots if it's a local backup
+        if (job instanceof BackupJob) {
+            BackupJob backupJob = (BackupJob) job;
+            if (backupJob.isLocalSnapshot()) {
+                removeSnapshot(backupJob.getLabel());
+            }
+        }
+        // Additional cleanup can be added here if needed
+    }
+
+    /**
+     * Get all jobs for a database (merging running and history queues).
+     * Used for SHOW BACKUP/RESTORE commands.
+     *
+     * @param dbId Database ID
+     * @return List of all jobs (running + history)
+     */
+    private List<AbstractJob> getAllJobs(long dbId) {
+        List<AbstractJob> result = new ArrayList<>();
+
+        // Add jobs from running queue
+        runningJobLock.lock();
+        try {
+            Deque<AbstractJob> running = dbIdToRunningJobs.get(dbId);
+            if (running != null) {
+                result.addAll(running);
+            }
+        } finally {
+            runningJobLock.unlock();
+        }
+
+        // Add jobs from history queue
+        historyJobLock.lock();
+        try {
+            Deque<AbstractJob> history = dbIdToHistoryJobs.get(dbId);
+            if (history != null) {
+                result.addAll(history);
+            }
+        } finally {
+            historyJobLock.unlock();
+        }
+
+        return result;
+    }
+
+    /**
+     * Get all running jobs across all databases.
+     * Used by the scheduler in runAfterCatalogReady().
+     *
+     * @return List of all running jobs
+     */
+    private List<AbstractJob> getAllRunningJobs() {
+        runningJobLock.lock();
+        try {
+            List<AbstractJob> result = new ArrayList<>();
+            for (Deque<AbstractJob> queue : dbIdToRunningJobs.values()) {
+                result.addAll(queue);
+            }
+            return result;
+        } finally {
+            runningJobLock.unlock();
+        }
     }
 
     private void addBackupOrRestoreJob(long dbId, AbstractJob job) {
@@ -692,12 +1185,24 @@ public class BackupHandler extends MasterDaemon implements Writable {
     }
 
     private AbstractJob getCurrentJob(long dbId) {
-        jobLock.lock();
-        try {
-            Deque<AbstractJob> jobs = dbIdToBackupOrRestoreJobs.getOrDefault(dbId, Lists.newLinkedList());
-            return jobs.isEmpty() ? null : jobs.getLast();
-        } finally {
-            jobLock.unlock();
+        if (Config.enable_table_level_backup_concurrency) {
+            // In dual queue mode, get the last job from running queue
+            runningJobLock.lock();
+            try {
+                Deque<AbstractJob> jobs = dbIdToRunningJobs.get(dbId);
+                return (jobs != null && !jobs.isEmpty()) ? jobs.getLast() : null;
+            } finally {
+                runningJobLock.unlock();
+            }
+        } else {
+            // Legacy mode: use old single queue
+            jobLock.lock();
+            try {
+                Deque<AbstractJob> jobs = dbIdToBackupOrRestoreJobs.getOrDefault(dbId, Lists.newLinkedList());
+                return jobs.isEmpty() ? null : jobs.getLast();
+            } finally {
+                jobLock.unlock();
+            }
         }
     }
 
@@ -790,33 +1295,129 @@ public class BackupHandler extends MasterDaemon implements Writable {
 
     public void cancel(CancelBackupCommand command) throws DdlException {
         String dbName = command.getDbName();
+        String labelFilter = command.getLabel();  // Get label filter
         Database db = env.getInternalCatalog().getDbOrDdlException(dbName);
-        AbstractJob job = getCurrentJob(db.getId());
-        if (job == null || (job instanceof BackupJob && command.isRestore())
-                || (job instanceof RestoreJob && !command.isRestore())) {
-            ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR, "No "
-                    + (command.isRestore() ? "restore" : "backup" + " job")
-                    + " is currently running");
+
+        List<AbstractJob> jobsToCancel = new ArrayList<>();
+
+        // In concurrency mode, find all running jobs that match the criteria
+        if (Config.enable_table_level_backup_concurrency) {
+            runningJobLock.lock();
+            try {
+                Deque<AbstractJob> jobs = dbIdToRunningJobs.get(db.getId());
+                if (jobs != null) {
+                    for (AbstractJob job : jobs) {
+                        // Check if job type matches
+                        boolean typeMatch = (job instanceof BackupJob && !command.isRestore())
+                                         || (job instanceof RestoreJob && command.isRestore());
+
+                        // Check if label matches (using CancelBackupCommand.matchesLabel())
+                        boolean labelMatch = command.matchesLabel(job.getLabel());
+
+                        if (typeMatch && labelMatch && !job.isDone()) {
+                            jobsToCancel.add(job);
+                        }
+                    }
+                }
+            } finally {
+                runningJobLock.unlock();
+            }
+        } else {
+            // Legacy mode: use getCurrentJob()
+            AbstractJob job = getCurrentJob(db.getId());
+            if (job != null) {
+                boolean typeMatch = (job instanceof BackupJob && !command.isRestore())
+                                 || (job instanceof RestoreJob && command.isRestore());
+                boolean labelMatch = command.matchesLabel(job.getLabel());
+
+                if (typeMatch && labelMatch) {
+                    jobsToCancel.add(job);
+                }
+            }
         }
 
-        Status status = job.cancel();
-        if (!status.ok()) {
-            ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR, "Failed to cancel job: " + status.getErrMsg());
+        // Error message based on whether label was specified
+        if (jobsToCancel.isEmpty()) {
+            String errorMsg;
+            if (labelFilter != null) {
+                errorMsg = String.format("No %s job with label '%s' is currently running",
+                                         command.isRestore() ? "restore" : "backup",
+                                         labelFilter);
+            } else {
+                errorMsg = String.format("No %s job is currently running",
+                                         command.isRestore() ? "restore" : "backup");
+            }
+            ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR, errorMsg);
         }
 
-        LOG.info("finished to cancel {} job: {}", (command.isRestore() ? "restore" : "backup"), job);
+        // Cancel all matching jobs
+        List<String> cancelledLabels = new ArrayList<>();
+        List<String> failedLabels = new ArrayList<>();
+
+        for (AbstractJob job : jobsToCancel) {
+            Status status = job.cancel();
+            if (status.ok()) {
+                cancelledLabels.add(job.getLabel());
+            } else {
+                failedLabels.add(job.getLabel() + "(" + status.getErrMsg() + ")");
+                LOG.warn("Failed to cancel {} job {}: {}",
+                         command.isRestore() ? "restore" : "backup",
+                         job.getLabel(), status.getErrMsg());
+            }
+        }
+
+        if (!failedLabels.isEmpty()) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
+                    "Failed to cancel some jobs: " + String.join(", ", failedLabels));
+        }
+
+        // Log with more details
+        if (labelFilter != null) {
+            LOG.info("Cancelled {} {} job(s) matching label '{}': {}",
+                     cancelledLabels.size(),
+                     command.isRestore() ? "restore" : "backup",
+                     labelFilter,
+                     String.join(", ", cancelledLabels));
+        } else {
+            LOG.info("Cancelled {} {} job(s): {}",
+                     cancelledLabels.size(),
+                     command.isRestore() ? "restore" : "backup",
+                     String.join(", ", cancelledLabels));
+        }
     }
 
     public boolean handleFinishedSnapshotTask(SnapshotTask task, TFinishTaskRequest request) {
-        AbstractJob job = getCurrentJob(task.getDbId());
-        if (job == null) {
-            LOG.warn("failed to find backup or restore job for task: {}", task);
-            // return true to remove this task from AgentTaskQueue
-            return true;
+        AbstractJob job = null;
+
+        // In concurrency mode, we need to find the job by jobId across all running jobs
+        if (Config.enable_table_level_backup_concurrency) {
+            runningJobLock.lock();
+            try {
+                Deque<AbstractJob> jobs = dbIdToRunningJobs.get(task.getDbId());
+                if (jobs != null) {
+                    // Search for the job with matching jobId
+                    for (AbstractJob j : jobs) {
+                        if (j.getJobId() == task.getJobId()) {
+                            job = j;
+                            break;
+                        }
+                    }
+                }
+            } finally {
+                runningJobLock.unlock();
+            }
+        } else {
+            // Legacy mode: use getCurrentJob()
+            job = getCurrentJob(task.getDbId());
+            if (job != null && job.getJobId() != task.getJobId()) {
+                LOG.warn("invalid snapshot task: {}, job id: {}, task job id: {}",
+                        task, job.getJobId(), task.getJobId());
+                return true;
+            }
         }
 
-        if (job.getJobId() != task.getJobId()) {
-            LOG.warn("invalid snapshot task: {}, job id: {}, task job id: {}", task, job.getJobId(), task.getJobId());
+        if (job == null) {
+            LOG.warn("failed to find backup or restore job for task: {} (jobId={})", task, task.getJobId());
             // return true to remove this task from AgentTaskQueue
             return true;
         }
@@ -840,7 +1441,28 @@ public class BackupHandler extends MasterDaemon implements Writable {
     }
 
     public boolean handleFinishedSnapshotUploadTask(UploadTask task, TFinishTaskRequest request) {
-        AbstractJob job = getCurrentJob(task.getDbId());
+        AbstractJob job = null;
+
+        // In concurrency mode, find the job by jobId across all running jobs
+        if (Config.enable_table_level_backup_concurrency) {
+            runningJobLock.lock();
+            try {
+                Deque<AbstractJob> jobs = dbIdToRunningJobs.get(task.getDbId());
+                if (jobs != null) {
+                    for (AbstractJob j : jobs) {
+                        if (j.getJobId() == task.getJobId()) {
+                            job = j;
+                            break;
+                        }
+                    }
+                }
+            } finally {
+                runningJobLock.unlock();
+            }
+        } else {
+            job = getCurrentJob(task.getDbId());
+        }
+
         if (job == null || (job instanceof RestoreJob)) {
             LOG.info("invalid upload task: {}, no backup job is found. db id: {}", task, task.getDbId());
             return false;
@@ -855,15 +1477,35 @@ public class BackupHandler extends MasterDaemon implements Writable {
     }
 
     public boolean handleDownloadSnapshotTask(DownloadTask task, TFinishTaskRequest request) {
-        AbstractJob job = getCurrentJob(task.getDbId());
-        if (!(job instanceof RestoreJob)) {
-            LOG.warn("failed to find restore job for task: {}", task);
-            // return true to remove this task from AgentTaskQueue
-            return true;
+        AbstractJob job = null;
+
+        // In concurrency mode, find the job by jobId across all running jobs
+        if (Config.enable_table_level_backup_concurrency) {
+            runningJobLock.lock();
+            try {
+                Deque<AbstractJob> jobs = dbIdToRunningJobs.get(task.getDbId());
+                if (jobs != null) {
+                    for (AbstractJob j : jobs) {
+                        if (j.getJobId() == task.getJobId()) {
+                            job = j;
+                            break;
+                        }
+                    }
+                }
+            } finally {
+                runningJobLock.unlock();
+            }
+        } else {
+            job = getCurrentJob(task.getDbId());
+            if (job != null && job.getJobId() != task.getJobId()) {
+                LOG.warn("invalid download task: {}, job id: {}, task job id: {}",
+                        task, job.getJobId(), task.getJobId());
+                return true;
+            }
         }
 
-        if (job.getJobId() != task.getJobId()) {
-            LOG.warn("invalid download task: {}, job id: {}, task job id: {}", task, job.getJobId(), task.getJobId());
+        if (!(job instanceof RestoreJob)) {
+            LOG.warn("failed to find restore job for task: {} (jobId={})", task, task.getJobId());
             // return true to remove this task from AgentTaskQueue
             return true;
         }
@@ -872,15 +1514,35 @@ public class BackupHandler extends MasterDaemon implements Writable {
     }
 
     public boolean handleDirMoveTask(DirMoveTask task, TFinishTaskRequest request) {
-        AbstractJob job = getCurrentJob(task.getDbId());
-        if (!(job instanceof RestoreJob)) {
-            LOG.warn("failed to find restore job for task: {}", task);
-            // return true to remove this task from AgentTaskQueue
-            return true;
+        AbstractJob job = null;
+
+        // In concurrency mode, find the job by jobId across all running jobs
+        if (Config.enable_table_level_backup_concurrency) {
+            runningJobLock.lock();
+            try {
+                Deque<AbstractJob> jobs = dbIdToRunningJobs.get(task.getDbId());
+                if (jobs != null) {
+                    for (AbstractJob j : jobs) {
+                        if (j.getJobId() == task.getJobId()) {
+                            job = j;
+                            break;
+                        }
+                    }
+                }
+            } finally {
+                runningJobLock.unlock();
+            }
+        } else {
+            job = getCurrentJob(task.getDbId());
+            if (job != null && job.getJobId() != task.getJobId()) {
+                LOG.warn("invalid dir move task: {}, job id: {}, task job id: {}",
+                        task, job.getJobId(), task.getJobId());
+                return true;
+            }
         }
 
-        if (job.getJobId() != task.getJobId()) {
-            LOG.warn("invalid dir move task: {}, job id: {}, task job id: {}", task, job.getJobId(), task.getJobId());
+        if (!(job instanceof RestoreJob)) {
+            LOG.warn("failed to find restore job for task: {} (jobId={})", task, task.getJobId());
             // return true to remove this task from AgentTaskQueue
             return true;
         }
@@ -914,11 +1576,37 @@ public class BackupHandler extends MasterDaemon implements Writable {
             job.replayRun();
         }
 
-        addBackupOrRestoreJob(job.getDbId(), job);
+        // Add to appropriate queue based on concurrency mode and job state
+        if (Config.enable_table_level_backup_concurrency) {
+            // In dual queue mode, decide based on job state
+            if (job.isDone()) {
+                // Completed job goes to history queue
+                addToHistoryQueue(job.getDbId(), job);
+            } else {
+                // Active job (PENDING or running) goes to running queue
+                try {
+                    addActiveJob(job.getDbId(), job);
+                } catch (DdlException e) {
+                    LOG.warn("Failed to add job {} to running queue during replay: {}",
+                            job.getLabel(), e.getMessage());
+                }
+            }
+        } else {
+            // Legacy mode: use old single queue
+            addBackupOrRestoreJob(job.getDbId(), job);
+        }
     }
 
     public boolean report(TTaskType type, long jobId, long taskId, int finishedNum, int totalNum) {
-        for (AbstractJob job : getAllCurrentJobs()) {
+        // Get jobs to report based on concurrency mode
+        List<AbstractJob> jobsToCheck;
+        if (Config.enable_table_level_backup_concurrency) {
+            jobsToCheck = getAllRunningJobs();
+        } else {
+            jobsToCheck = getAllCurrentJobs();
+        }
+
+        for (AbstractJob job : jobsToCheck) {
             if (job.getType() == JobType.BACKUP) {
                 if (!job.isDone() && job.getJobId() == jobId && type == TTaskType.UPLOAD) {
                     job.taskProgress.put(taskId, Pair.of(finishedNum, totalNum));
@@ -976,8 +1664,33 @@ public class BackupHandler extends MasterDaemon implements Writable {
     public void write(DataOutput out) throws IOException {
         repoMgr.write(out);
 
-        List<AbstractJob> jobs = dbIdToBackupOrRestoreJobs.values()
-                .stream().flatMap(Deque::stream).collect(Collectors.toList());
+        // Collect jobs based on concurrency mode
+        List<AbstractJob> jobs;
+        if (Config.enable_table_level_backup_concurrency) {
+            // In dual queue mode, merge running and history queues
+            jobs = new ArrayList<>();
+            runningJobLock.lock();
+            try {
+                for (Deque<AbstractJob> queue : dbIdToRunningJobs.values()) {
+                    jobs.addAll(queue);
+                }
+            } finally {
+                runningJobLock.unlock();
+            }
+            historyJobLock.lock();
+            try {
+                for (Deque<AbstractJob> queue : dbIdToHistoryJobs.values()) {
+                    jobs.addAll(queue);
+                }
+            } finally {
+                historyJobLock.unlock();
+            }
+        } else {
+            // Legacy mode: use old single queue
+            jobs = dbIdToBackupOrRestoreJobs.values()
+                    .stream().flatMap(Deque::stream).collect(Collectors.toList());
+        }
+
         out.writeInt(jobs.size());
         for (AbstractJob job : jobs) {
             job.write(out);
@@ -990,7 +1703,715 @@ public class BackupHandler extends MasterDaemon implements Writable {
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
             AbstractJob job = AbstractJob.read(in);
+            // Note: addBackupOrRestoreJob will be replaced by replayAddJob during normal operation
+            // This is just for initial loading, and the actual queue assignment will happen in
+            // rebuildConcurrencyStateAfterRestart()
             addBackupOrRestoreJob(job.getDbId(), job);
+        }
+    }
+
+    // === Concurrency Control Methods ===
+
+    /**
+     * Check if a job has execution permission.
+     * Called by BackupJob/RestoreJob to determine if they can proceed with execution.
+     *
+     * @param jobId the job ID to check
+     * @return true if the job is allowed to execute, false otherwise
+     */
+    public boolean canExecute(long jobId) {
+        if (!Config.enable_table_level_backup_concurrency) {
+            return true;  // Concurrency not enabled, all jobs can execute
+        }
+        return allowedJobIds.contains(jobId);
+    }
+
+    /**
+     * Called when a job is activated (added to allowedJobIds) to update running counters.
+     * This enables O(1) canActivate checks.
+     *
+     * @param dbId database ID
+     * @param job the activated job
+     * @param isBackup true for backup jobs, false for restore jobs
+     * @param isFullDatabase true if this is a full database operation
+     */
+    private void onJobActivated(long dbId, AbstractJob job, boolean isBackup, boolean isFullDatabase) {
+        DatabaseJobStats stats = dbJobStats.computeIfAbsent(dbId, k -> new DatabaseJobStats());
+
+        if (isBackup) {
+            stats.runningBackups++;
+            if (isFullDatabase) {
+                stats.runningBackupDatabaseJobId = job.getJobId();
+            }
+        } else {
+            stats.runningRestores++;
+        }
+
+        if (Config.enable_backup_concurrency_logging) {
+            LOG.info("Job activated: dbId={}, label={}, runningBackups={}, runningRestores={}",
+                     dbId, job.getLabel(), stats.runningBackups, stats.runningRestores);
+        }
+    }
+
+    /**
+     * Called when a job is deactivated (removed from allowedJobIds) to update running counters.
+     *
+     * @param dbId database ID
+     * @param job the deactivated job
+     * @param isBackup true for backup jobs, false for restore jobs
+     */
+    private void onJobDeactivated(long dbId, AbstractJob job, boolean isBackup) {
+        DatabaseJobStats stats = dbJobStats.get(dbId);
+        if (stats == null) {
+            return;
+        }
+
+        if (isBackup) {
+            stats.runningBackups--;
+            if (Long.valueOf(job.getJobId()).equals(stats.runningBackupDatabaseJobId)) {
+                stats.runningBackupDatabaseJobId = null;
+            }
+        } else {
+            stats.runningRestores--;
+        }
+
+        int taskCount = job.getSnapshotTaskCount();
+        if (taskCount > 0) {
+            globalSnapshotTasks.addAndGet(-taskCount);
+        }
+
+        if (Config.enable_backup_concurrency_logging) {
+            LOG.info("Job deactivated: dbId={}, label={}, runningBackups={}, runningRestores={}, "
+                     + "globalSnapshotTasks={}",
+                     dbId, job.getLabel(), stats.runningBackups, stats.runningRestores,
+                     globalSnapshotTasks.get());
+        }
+    }
+
+    /**
+     * Concurrency check for new backup/restore job submissions.
+     * This method only performs hard rejection checks. Soft checks (whether to PENDING)
+     * are handled by canActivate().
+     *
+     * @param dbId database ID
+     * @param label job label
+     * @param isBackup true for backup jobs, false for restore jobs
+     * @param isFullDatabase true if this is a full database backup/restore (no specific tables)
+     * @param tableNames list of table names involved (empty for full database operations)
+     * @throws DdlException if job should be rejected
+     */
+    private void checkConcurrency(long dbId, String label, boolean isBackup,
+                                  boolean isFullDatabase, List<String> tableNames) throws DdlException {
+        // === Step 1: O(1) Label duplicate check ===
+        Map<String, Long> labels = labelIndex.get(dbId);
+        if (labels != null && labels.containsKey(label)) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
+                    "Label already exists: " + label);
+        }
+
+        // === Step 2: O(1) Get statistics ===
+        DatabaseJobStats stats = dbJobStats.get(dbId);
+        if (stats == null) {
+            return;  // No jobs, no rejection needed
+        }
+
+        int totalActive = stats.activeBackups + stats.activeRestores;
+
+        // === Rule 1: Concurrency limit (hard reject) ===
+        if (totalActive >= Config.max_backup_restore_concurrent_num_per_db) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
+                    "Concurrency limit reached (" + totalActive + " active jobs).\n"
+                        + "Active jobs: " + String.join(", ", stats.activeLabels) + "\n"
+                        + "Limit: " + Config.max_backup_restore_concurrent_num_per_db);
+        }
+
+        // === Rule 2-A: Queue has backup_database -> reject all new backups ===
+        if (isBackup && stats.backupDatabaseJobId != null) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
+                    "Cannot submit backup job while full database backup exists.\n"
+                        + "Full database backup: " + stats.backupDatabaseLabel + " (running or pending)\n"
+                        + "Suggestion: Wait for it to complete, or cancel it first.");
+        }
+
+        // Other rules (backup_database waiting, restore conflicts, backup/restore mutual exclusion)
+        // are soft rules handled by canActivate() - they cause PENDING, not rejection
+    }
+
+    /**
+     * Called when a job is created to update statistics.
+     *
+     * @param dbId database ID
+     * @param job the created job
+     * @param isBackup true for backup jobs, false for restore jobs
+     * @param isFullDatabase true if this is a full database operation
+     */
+    private void onJobCreated(long dbId, AbstractJob job, boolean isBackup, boolean isFullDatabase) {
+        // Update statistics
+        DatabaseJobStats stats = dbJobStats.computeIfAbsent(dbId, k -> new DatabaseJobStats());
+
+        if (isBackup) {
+            stats.activeBackups++;
+            if (isFullDatabase) {
+                stats.backupDatabaseJobId = job.getJobId();
+                stats.backupDatabaseLabel = job.getLabel();
+            }
+        } else {
+            stats.activeRestores++;
+        }
+
+        stats.activeLabels.add(job.getLabel());
+
+        // Update label index
+        labelIndex.computeIfAbsent(dbId, k -> new ConcurrentHashMap<>())
+                  .put(job.getLabel(), job.getJobId());
+
+        if (Config.enable_backup_concurrency_logging) {
+            LOG.info("Job created: dbId={}, label={}, backups={}, restores={}",
+                     dbId, job.getLabel(), stats.activeBackups, stats.activeRestores);
+        }
+    }
+
+    /**
+     * Check if a newly created job can be activated immediately (O(1) version).
+     * This is called right after job creation to decide whether to add it to allowedJobIds.
+     *
+     * @param dbId database ID
+     * @param job the job to check
+     * @param isBackup true for backup jobs, false for restore jobs
+     * @param isFullDatabase true if this is a full database operation
+     * @return true if job can be activated immediately
+     */
+    private boolean canActivate(long dbId, AbstractJob job, boolean isBackup, boolean isFullDatabase) {
+        DatabaseJobStats stats = dbJobStats.get(dbId);
+
+        // O(1) lookup for running job counts
+        int runningBackups = (stats != null) ? stats.runningBackups : 0;
+        int runningRestores = (stats != null) ? stats.runningRestores : 0;
+        boolean hasRunningBackupDatabase = (stats != null) && (stats.runningBackupDatabaseJobId != null);
+
+        // === Rule 1: Concurrency limit ===
+        if (runningBackups + runningRestores >= Config.max_backup_restore_concurrent_num_per_db) {
+            return false;
+        }
+
+        // === Rule 2-A: Running backup_database -> backup cannot activate ===
+        if (hasRunningBackupDatabase && isBackup) {
+            return false;
+        }
+
+        // === Rule 2-B: Job is backup_database -> wait for all backups to complete ===
+        if (isBackup && isFullDatabase && runningBackups > 0) {
+            return false;
+        }
+
+        // === Rule 3: Backup/Restore mutual exclusion ===
+        if (isBackup && runningRestores > 0) {
+            return false;
+        }
+        if (!isBackup && runningBackups > 0) {
+            return false;
+        }
+
+        // === Rule 4: For restore jobs, check table conflicts ===
+        if (!isBackup && job instanceof RestoreJob) {
+            RestoreJob restoreJob = (RestoreJob) job;
+            // Check full database restore conflict
+            if (stats != null && stats.restoreDatabaseJobId != null) {
+                return false;  // Full database restore is running
+            }
+
+            // Check if this is a full database restore
+            if (isFullDatabase) {
+                Set<String> currentRestoring = restoringTables.get(dbId);
+                if (currentRestoring != null && !currentRestoring.isEmpty()) {
+                    return false;  // Other tables are being restored
+                }
+            } else {
+                // Check table conflicts (O(k) where k = number of tables in the job)
+                Set<String> currentRestoring = restoringTables.get(dbId);
+                if (currentRestoring != null && !currentRestoring.isEmpty()) {
+                    for (TableRefInfo tblRef : restoreJob.getTableRefs()) {
+                        String tableName = tblRef.getTableNameInfo().getTbl();
+                        if (currentRestoring.contains(tableName)) {
+                            return false;  // Table conflict
+                        }
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if a PENDING job can be activated (O(1) version).
+     * Called during tryActivatePendingJobs() to determine which jobs can start running.
+     *
+     * @param dbId database ID
+     * @param jobToCheck the job to check for activation
+     * @param isBackup true for backup jobs, false for restore jobs
+     * @return true if job can be activated
+     */
+    private boolean canActivateJob(long dbId, AbstractJob jobToCheck, boolean isBackup) {
+        DatabaseJobStats stats = dbJobStats.get(dbId);
+
+        // Determine job type
+        boolean isJobBackupDatabase = false;
+        boolean isJobRestore = false;
+
+        if (isBackup && jobToCheck instanceof BackupJob) {
+            BackupJob bj = (BackupJob) jobToCheck;
+            isJobBackupDatabase = bj.getTableRefs().isEmpty();
+        } else {
+            isJobRestore = true;
+        }
+
+        // O(1) lookup for running job counts
+        int runningBackups = (stats != null) ? stats.runningBackups : 0;
+        int runningRestores = (stats != null) ? stats.runningRestores : 0;
+        boolean hasRunningBackupDatabase = (stats != null) && (stats.runningBackupDatabaseJobId != null);
+
+        // === Rule 1: Concurrency limit ===
+        if (runningBackups + runningRestores >= Config.max_backup_restore_concurrent_num_per_db) {
+            return false;
+        }
+
+        // === Rule 2-A: Running backup_database -> backup cannot activate ===
+        if (hasRunningBackupDatabase && isBackup) {
+            return false;
+        }
+
+        // === Rule 2-B: Job is backup_database -> wait for all backups to complete ===
+        if (isJobBackupDatabase && runningBackups > 0) {
+            return false;
+        }
+
+        // === Rule 3: Backup/Restore mutual exclusion ===
+        if (isBackup && runningRestores > 0) {
+            return false;
+        }
+        if (isJobRestore && runningBackups > 0) {
+            return false;
+        }
+
+        // === Rule 4: For restore jobs, check table conflicts ===
+        if (isJobRestore && jobToCheck instanceof RestoreJob) {
+            RestoreJob restoreJob = (RestoreJob) jobToCheck;
+            // Check full database restore conflict
+            if (stats != null && stats.restoreDatabaseJobId != null) {
+                return false;  // Full database restore is running
+            }
+
+            // Check if this is a full database restore
+            if (restoreJob.getTableRefs().isEmpty()) {
+                Set<String> currentRestoring = restoringTables.get(dbId);
+                if (currentRestoring != null && !currentRestoring.isEmpty()) {
+                    return false;  // Other tables are being restored
+                }
+            } else {
+                // Check table conflicts (O(k) where k = number of tables in the job)
+                Set<String> currentRestoring = restoringTables.get(dbId);
+                if (currentRestoring != null && !currentRestoring.isEmpty()) {
+                    for (TableRefInfo tblRef : restoreJob.getTableRefs()) {
+                        String tableName = tblRef.getTableNameInfo().getTbl();
+                        if (currentRestoring.contains(tableName)) {
+                            return false;  // Table conflict
+                        }
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Called when a job completes (finished or cancelled) to update statistics
+     * and try to activate pending jobs.
+     *
+     * @param jobId the completed job ID
+     * @param dbId database ID
+     * @param job the completed job
+     */
+    public void onJobCompleted(long jobId, long dbId, AbstractJob job) {
+        if (!Config.enable_table_level_backup_concurrency) {
+            return;
+        }
+
+        boolean isBackup = (job instanceof BackupJob);
+
+        // === 0. Move from running queue to history queue (dual queue architecture) ===
+        moveToHistory(dbId, job);
+
+        // === 1. Update statistics (O(1)) ===
+        DatabaseJobStats stats = dbJobStats.get(dbId);
+        if (stats != null) {
+            if (isBackup) {
+                stats.activeBackups--;
+                if (Long.valueOf(jobId).equals(stats.backupDatabaseJobId)) {
+                    stats.backupDatabaseJobId = null;
+                    stats.backupDatabaseLabel = null;
+                }
+            } else {
+                stats.activeRestores--;
+                if (Long.valueOf(jobId).equals(stats.restoreDatabaseJobId)) {
+                    stats.restoreDatabaseJobId = null;
+                    stats.restoreDatabaseLabel = null;
+                }
+            }
+
+            stats.activeLabels.remove(job.getLabel());
+
+            // Clean up empty stats
+            if (stats.activeBackups == 0 && stats.activeRestores == 0) {
+                dbJobStats.remove(dbId);
+            }
+        }
+
+        // === 2. Update label index ===
+        Map<String, Long> labels = labelIndex.get(dbId);
+        if (labels != null) {
+            labels.remove(job.getLabel());
+            if (labels.isEmpty()) {
+                labelIndex.remove(dbId);
+            }
+        }
+
+        // === 3. Remove execution permission and update running counters ===
+        boolean wasRunning = allowedJobIds.remove(jobId);
+        if (wasRunning) {
+            onJobDeactivated(dbId, job, isBackup);
+        }
+
+        // === 4. Clean up restoringTables for restore jobs ===
+        if (job instanceof RestoreJob) {
+            removeRestoringTables((RestoreJob) job);
+        }
+
+        if (Config.enable_backup_concurrency_logging) {
+            LOG.info("Job completed: dbId={}, label={}, activeBackups={}, activeRestores={}, "
+                     + "runningBackups={}, runningRestores={}",
+                     dbId, job.getLabel(),
+                     stats != null ? stats.activeBackups : 0,
+                     stats != null ? stats.activeRestores : 0,
+                     stats != null ? stats.runningBackups : 0,
+                     stats != null ? stats.runningRestores : 0);
+        }
+
+        // === 5. Try to activate PENDING jobs ===
+        tryActivatePendingJobs(dbId);
+    }
+
+    /**
+     * Try to activate pending jobs after a job completes.
+     * This method scans the job queue and activates jobs that can now run.
+     *
+     * @param dbId database ID
+     */
+    private void tryActivatePendingJobs(long dbId) {
+        // Get jobs to scan based on concurrency mode
+        Deque<AbstractJob> jobs;
+        if (Config.enable_table_level_backup_concurrency) {
+            // In dual queue mode, scan running queue
+            runningJobLock.lock();
+            try {
+                jobs = dbIdToRunningJobs.get(dbId);
+                if (jobs == null || jobs.isEmpty()) {
+                    return;
+                }
+                // Make a copy to avoid concurrent modification
+                jobs = new LinkedList<>(jobs);
+            } finally {
+                runningJobLock.unlock();
+            }
+        } else {
+            // Legacy mode: use old single queue
+            jobs = dbIdToBackupOrRestoreJobs.get(dbId);
+            if (jobs == null || jobs.isEmpty()) {
+                return;
+            }
+        }
+
+        for (AbstractJob job : jobs) {
+            // Only process PENDING jobs
+            if (job.isDone()) {
+                continue;
+            }
+
+            // Already has execution permission, skip
+            if (allowedJobIds.contains(job.getJobId())) {
+                continue;
+            }
+
+            // Check if can activate
+            boolean isBackup = job instanceof BackupJob;
+            boolean isFullDatabase = false;
+            if (isBackup && job instanceof BackupJob) {
+                isFullDatabase = ((BackupJob) job).getTableRefs().isEmpty();
+            } else if (!isBackup && job instanceof RestoreJob) {
+                isFullDatabase = ((RestoreJob) job).getTableRefs().isEmpty();
+            }
+
+            if (canActivateJob(dbId, job, isBackup)) {
+                allowedJobIds.add(job.getJobId());
+                onJobActivated(dbId, job, isBackup, isFullDatabase);
+                // CRITICAL: Add restoring tables atomically with activation
+                // to prevent TOCTOU race condition
+                if (job instanceof RestoreJob) {
+                    addRestoringTables((RestoreJob) job);
+                }
+                LOG.info("Activated pending job: {} (jobId={})",
+                        job.getLabel(), job.getJobId());
+            }
+        }
+    }
+
+    /**
+     * Add restore job's tables to the restoring set for conflict detection.
+     *
+     * @param job the restore job
+     */
+    public void addRestoringTables(RestoreJob job) {
+        long dbId = job.getDbId();
+
+        // Check if this is a full database restore
+        if (job.getTableRefs().isEmpty()) {
+            // Full database restore: mark as exclusive
+            DatabaseJobStats stats = dbJobStats.computeIfAbsent(dbId,
+                    k -> new DatabaseJobStats());
+            stats.restoreDatabaseJobId = job.getJobId();
+            stats.restoreDatabaseLabel = job.getLabel();
+            LOG.info("Full database restore [{}] started, blocking other restores on db [{}]",
+                     job.getLabel(), dbId);
+            return;
+        }
+
+        // Table-level restore: add table names to set
+        Set<String> tables = restoringTables.computeIfAbsent(dbId, k -> ConcurrentHashMap.newKeySet());
+
+        for (TableRefInfo tblRef : job.getTableRefs()) {
+            String tableName = tblRef.getTableNameInfo().getTbl();
+            tables.add(tableName);
+
+            if (Config.enable_backup_concurrency_logging) {
+                LOG.info("Table [{}] added to restoring set, job: [{}]", tableName, job.getLabel());
+            }
+        }
+    }
+
+    /**
+     * Remove restore job's tables from the restoring set when job completes.
+     *
+     * @param job the restore job
+     */
+    private void removeRestoringTables(RestoreJob job) {
+        long dbId = job.getDbId();
+
+        // Check if this is a full database restore
+        if (job.getTableRefs().isEmpty()) {
+            // Full database restore: clear marker
+            DatabaseJobStats stats = dbJobStats.get(dbId);
+            if (stats != null && Long.valueOf(job.getJobId()).equals(stats.restoreDatabaseJobId)) {
+                stats.restoreDatabaseJobId = null;
+                stats.restoreDatabaseLabel = null;
+            }
+            LOG.info("Full database restore [{}] completed, unblocking other restores",
+                     job.getLabel());
+            return;
+        }
+
+        // Table-level restore: remove table names
+        Set<String> tables = restoringTables.get(dbId);
+        if (tables != null) {
+            for (TableRefInfo tblRef : job.getTableRefs()) {
+                String tableName = tblRef.getTableNameInfo().getTbl();
+                tables.remove(tableName);
+
+                if (Config.enable_backup_concurrency_logging) {
+                    LOG.info("Table [{}] removed from restoring set, job: [{}]",
+                             tableName, job.getLabel());
+                }
+            }
+
+            // Remove key if set is empty
+            if (tables.isEmpty()) {
+                restoringTables.remove(dbId);
+            }
+        }
+    }
+
+    /**
+     * Get the block reason for a job (for SHOW command).
+     *
+     * @param job the job to check
+     * @return block reason string, or null if not blocked
+     */
+    public String getJobBlockReason(AbstractJob job) {
+        if (!Config.enable_table_level_backup_concurrency) {
+            return null;
+        }
+
+        // Finished/cancelled jobs are not blocked
+        if (job.isDone()) {
+            return null;
+        }
+
+        // If job has execution permission, it's not blocked
+        if (allowedJobIds.contains(job.getJobId())) {
+            return null;
+        }
+
+        long dbId = job.getDbId();
+        boolean isBackup = job instanceof BackupJob;
+
+        // Check backup/restore mutual exclusion
+        DatabaseJobStats stats = dbJobStats.get(dbId);
+        if (stats != null) {
+            if (isBackup && stats.activeRestores > 0) {
+                return "Waiting for " + stats.activeRestores + " restore(s) to complete";
+            }
+            if (!isBackup && stats.activeBackups > 0) {
+                return "Waiting for " + stats.activeBackups + " backup(s) to complete";
+            }
+
+            // Check full database backup blocking
+            if (isBackup && stats.backupDatabaseJobId != null) {
+                return "Full database backup is running: " + stats.backupDatabaseLabel;
+            }
+        }
+
+        // Check restore table conflicts
+        if (job instanceof RestoreJob) {
+            RestoreJob restoreJob = (RestoreJob) job;
+
+            // Check full database restore
+            if (stats != null && stats.restoreDatabaseJobId != null) {
+                return "Full database restore is running: " + stats.restoreDatabaseLabel;
+            }
+
+            // Check table conflicts
+            Set<String> restoring = restoringTables.get(dbId);
+            if (restoring != null && !restoring.isEmpty()) {
+                Set<String> conflicts = new HashSet<>();
+                for (TableRefInfo tblRef : restoreJob.getTableRefs()) {
+                    String tableName = tblRef.getTableNameInfo().getTbl();
+                    if (restoring.contains(tableName)) {
+                        conflicts.add(tableName);
+                    }
+                }
+
+                if (!conflicts.isEmpty()) {
+                    return "Table conflict: " + String.join(", ", conflicts);
+                }
+            }
+        }
+
+        return "Waiting for execution slot";
+    }
+
+    /**
+     * Get the queue position for a job (for SHOW command).
+     * Returns 0 if job is running, or the 1-based position in the queue.
+     *
+     * @param job the job to check
+     * @return queue position (0 = running, 1+ = position in queue)
+     */
+    public int getJobQueuePosition(AbstractJob job) {
+        if (!Config.enable_table_level_backup_concurrency) {
+            return 0;
+        }
+
+        // Finished/cancelled jobs have no queue position
+        if (job.isDone()) {
+            return 0;
+        }
+
+        // If job has execution permission, it's running (position 0)
+        if (allowedJobIds.contains(job.getJobId())) {
+            return 0;
+        }
+
+        // Count position in pending queue (use dbIdToRunningJobs in concurrency mode)
+        Deque<AbstractJob> jobs = dbIdToRunningJobs.get(job.getDbId());
+        if (jobs == null) {
+            return 0;
+        }
+
+        int position = 0;
+        for (AbstractJob j : jobs) {
+            if (j.isDone()) {
+                continue;
+            }
+            if (!allowedJobIds.contains(j.getJobId())) {
+                position++;
+                if (j.getJobId() == job.getJobId()) {
+                    return position;
+                }
+            }
+        }
+
+        return position;
+    }
+
+    /**
+     * Database job statistics for O(1) concurrency checking.
+     * This class maintains counters and markers for each database to avoid
+     * traversing the job queue on every submission.
+     */
+    static class DatabaseJobStats {
+        // Active job counts (includes PENDING jobs, not just running)
+        int activeBackups = 0;
+        int activeRestores = 0;
+
+        // Running job counts (only jobs in allowedJobIds, for O(1) canActivate check)
+        int runningBackups = 0;
+        int runningRestores = 0;
+
+        // Full database backup marker (in queue, pending or running)
+        Long backupDatabaseJobId = null;    // jobId of the full database backup
+        String backupDatabaseLabel = null;  // label of the full database backup
+
+        // Running full database backup marker (for canActivate check)
+        Long runningBackupDatabaseJobId = null;
+
+        // Full database restore marker (integrated here for unified management)
+        Long restoreDatabaseJobId = null;   // jobId of the full database restore
+        String restoreDatabaseLabel = null; // label of the full database restore
+
+        // All active job labels (for error messages)
+        Set<String> activeLabels = new HashSet<>();
+
+        /**
+         * Check if there are any active jobs.
+         */
+        boolean hasActiveJobs() {
+            return activeBackups > 0 || activeRestores > 0;
+        }
+
+        /**
+         * Get total active job count.
+         */
+        int getTotalActiveJobs() {
+            return activeBackups + activeRestores;
+        }
+
+        /**
+         * Get total running job count.
+         */
+        int getTotalRunningJobs() {
+            return runningBackups + runningRestores;
+        }
+
+        @Override
+        public String toString() {
+            return "DatabaseJobStats{"
+                + "activeBackups=" + activeBackups
+                + ", activeRestores=" + activeRestores
+                + ", runningBackups=" + runningBackups
+                + ", runningRestores=" + runningRestores
+                + ", backupDatabaseLabel=" + backupDatabaseLabel
+                + ", restoreDatabaseLabel=" + restoreDatabaseLabel
+                + '}';
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -132,6 +132,9 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
     @SerializedName("prop")
     private Map<String, String> properties = Maps.newHashMap();
 
+    @SerializedName("stc")
+    private int snapshotTaskCount = 0;
+
     // Record table IDs that were dropped during backup
     @SerializedName("dt")
     private Set<Long> droppedTables = ConcurrentHashMap.newKeySet();
@@ -163,6 +166,10 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
 
     public BackupJobState getState() {
         return state;
+    }
+
+    public List<TableRefInfo> getTableRefs() {
+        return tableRefs;
     }
 
     public BackupMeta getBackupMeta() {
@@ -461,6 +468,30 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
             return;
         }
 
+        // === Execution gate check for concurrency control ===
+        if (state == BackupJobState.PENDING && Config.enable_table_level_backup_concurrency) {
+            BackupHandler handler = env.getBackupHandler();
+            if (!handler.canExecute(this.jobId)) {
+                // No execution permission, skip this run
+                if (Config.enable_backup_concurrency_logging) {
+                    LOG.info("Backup job {} (label={}) is waiting, blocked by concurrency control",
+                            jobId, label);
+                }
+
+                // Check pending timeout
+                long pendingTime = System.currentTimeMillis() - createTime;
+                if (pendingTime > Config.backup_pending_job_timeout_ms) {
+                    status = new Status(ErrCode.TIMEOUT,
+                        "Job pending timeout after " + pendingTime + "ms");
+                    cancelInternal();
+                }
+                return;
+            }
+
+            // Has execution permission, log and continue
+            LOG.info("Backup job {} (label={}) starts executing", jobId, label);
+        }
+
         // get repo if not set
         if (repo == null && repoId != Repository.KEEP_ON_LOCAL_REPO_ID) {
             repo = env.getBackupHandler().getRepoMgr().getRepo(repoId);
@@ -541,7 +572,14 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
         }
 
         // generate job id
-        jobId = env.getNextId();
+        // In concurrency mode, jobId may already be assigned for tracking in allowedJobIds
+        // Only generate a new ID if it hasn't been set yet (jobId == -1)
+        // This preserves the jobId assigned during job creation for concurrency control
+        if (jobId == -1) {
+            jobId = env.getNextId();
+        }
+        // Note: If jobId is already set (from concurrency control at job creation),
+        // we keep it unchanged to maintain consistency with allowedJobIds tracking
         unfinishedTaskIds.clear();
         taskProgress.clear();
         taskErrMsg.clear();
@@ -608,6 +646,27 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
             LOG.warn(msg);
             status = new Status(ErrCode.COMMON_ERROR, msg);
             return;
+        }
+
+        // Global snapshot task limit only applies in concurrent mode, because
+        // onJobDeactivated (which decrements the counter) is only called via
+        // onJobCompleted, which is gated by enable_table_level_backup_concurrency.
+        // Job run() is driven by a single daemon thread, so get+add is safe without CAS.
+        if (Config.enable_table_level_backup_concurrency) {
+            if (Config.max_concurrent_snapshot_tasks_total > 0) {
+                int globalCurrent = env.getBackupHandler().getGlobalSnapshotTasks();
+                if (globalCurrent + unfinishedTaskIds.size() > Config.max_concurrent_snapshot_tasks_total) {
+                    String msg = String.format("global concurrent snapshot tasks %d + this backup job %d "
+                            + "would exceed the limit %d, change config `max_concurrent_snapshot_tasks_total` "
+                            + "to change this limitation",
+                            globalCurrent, unfinishedTaskIds.size(), Config.max_concurrent_snapshot_tasks_total);
+                    LOG.warn(msg);
+                    status = new Status(ErrCode.COMMON_ERROR, msg);
+                    return;
+                }
+            }
+            snapshotTaskCount = unfinishedTaskIds.size();
+            env.getBackupHandler().addGlobalSnapshotTasks(snapshotTaskCount);
         }
 
         backupMeta = new BackupMeta(copiedTables, copiedResources);
@@ -1034,6 +1093,15 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
         env.getEditLog().logBackupJob(this);
         LOG.info("job is finished. {}", this);
 
+        // Notify completion for concurrency control
+        if (Config.enable_table_level_backup_concurrency) {
+            try {
+                env.getBackupHandler().onJobCompleted(this.jobId, this.dbId, this);
+            } catch (Exception e) {
+                LOG.warn("Failed to notify job completion for backup job {}", this.label, e);
+            }
+        }
+
         if (repoId == Repository.KEEP_ON_LOCAL_REPO_ID) {
             env.getBackupHandler().addSnapshot(label, this);
             return;
@@ -1126,6 +1194,15 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
         // log
         env.getEditLog().logBackupJob(this);
         LOG.info("finished to cancel backup job. current state: {}. {}", curState.name(), this);
+
+        // Notify completion for concurrency control
+        if (Config.enable_table_level_backup_concurrency) {
+            try {
+                env.getBackupHandler().onJobCompleted(this.jobId, this.dbId, this);
+            } catch (Exception e) {
+                LOG.warn("Failed to notify job completion for cancelled backup job {}", this.label, e);
+            }
+        }
     }
 
     public boolean isLocalSnapshot() {
@@ -1151,6 +1228,11 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
         File metaInfoFile = new File(localMetaInfoFilePath);
         File jobInfoFile = new File(localJobInfoFilePath);
         return new Snapshot(label, metaInfoFile, jobInfoFile, expiredAt, commitSeq);
+    }
+
+    @Override
+    public int getSnapshotTaskCount() {
+        return snapshotTaskCount;
     }
 
     public synchronized List<String> getInfo() {
@@ -1182,6 +1264,19 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
         info.add(taskErrMsgStr);
         info.add(status.toString());
         info.add(String.valueOf(timeoutMs / 1000));
+
+        // Queue position and block reason (for concurrency mode)
+        if (env != null && Config.enable_table_level_backup_concurrency) {
+            BackupHandler handler = env.getBackupHandler();
+            int queuePos = handler.getJobQueuePosition(this);
+            info.add(queuePos == 0 ? "Running" : String.valueOf(queuePos));
+            String blockReason = handler.getJobBlockReason(this);
+            info.add(blockReason != null ? blockReason : "");
+        } else {
+            info.add("");
+            info.add("");
+        }
+
         return info;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -66,6 +66,7 @@ import org.apache.doris.common.util.DynamicPartitionUtil;
 import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.info.TableRefInfo;
 import org.apache.doris.nereids.trees.plans.commands.BackupCommand;
 import org.apache.doris.nereids.trees.plans.commands.RestoreCommand;
 import org.apache.doris.persist.ColocatePersistInfo;
@@ -155,6 +156,11 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
     @SerializedName("al")
     private boolean allowLoad;
 
+    // Table references for this restore job (used for concurrency control)
+    // Empty list means full database restore
+    @SerializedName("tref")
+    private List<TableRefInfo> tableRefs = Lists.newArrayList();
+
     @SerializedName("st")
     protected volatile RestoreJobState state;
 
@@ -199,6 +205,9 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
     // tablet id->(be id -> snapshot info)
     @SerializedName("si")
     protected com.google.common.collect.Table<Long, Long, SnapshotInfo> snapshotInfos = HashBasedTable.create();
+
+    @SerializedName("stc")
+    private int snapshotTaskCount = 0;
 
     private List<ColocatePersistInfo> colocatePersistInfos = Lists.newArrayList();
 
@@ -294,6 +303,19 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
 
     public RestoreJobState getState() {
         return state;
+    }
+
+    public List<TableRefInfo> getTableRefs() {
+        return tableRefs;
+    }
+
+    @Override
+    public int getSnapshotTaskCount() {
+        return snapshotTaskCount;
+    }
+
+    public void setTableRefs(List<TableRefInfo> tableRefs) {
+        this.tableRefs = tableRefs;
     }
 
     private void setState(RestoreJobState state) {
@@ -468,6 +490,29 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
             return;
         }
 
+        // === Execution gate check for concurrency control ===
+        if (state == RestoreJobState.PENDING && Config.enable_table_level_backup_concurrency) {
+            BackupHandler handler = env.getBackupHandler();
+            if (!handler.canExecute(this.jobId)) {
+                // No execution permission, skip this run
+                if (Config.enable_backup_concurrency_logging) {
+                    LOG.info("Restore job {} (label={}) is waiting, blocked by concurrency control",
+                            jobId, label);
+                }
+
+                // Check pending timeout
+                long pendingTime = System.currentTimeMillis() - createTime;
+                if (pendingTime > Config.backup_pending_job_timeout_ms) {
+                    status = new Status(ErrCode.TIMEOUT,
+                        "Job pending timeout after " + pendingTime + "ms");
+                    cancelInternal(false);
+                }
+                return;
+            }
+
+            LOG.info("Restore job {} (label={}) starts executing", jobId, label);
+        }
+
         // get repo if not set
         if (repo == null && !isFromLocalSnapshot()) {
             repo = env.getBackupHandler().getRepoMgr().getRepo(repoId);
@@ -591,7 +636,14 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
         }
 
         // generate job id
-        jobId = env.getNextId();
+        // In concurrency mode, jobId may already be assigned for tracking in allowedJobIds
+        // Only generate a new ID if it hasn't been set yet (jobId == -1)
+        // This preserves the jobId assigned during job creation for concurrency control
+        if (jobId == -1) {
+            jobId = env.getNextId();
+        }
+        // Note: If jobId is already set (from concurrency control at job creation),
+        // we keep it unchanged to maintain consistency with allowedJobIds tracking
 
         // deserialize meta
         if (!downloadAndDeserializeMetaInfo()) {
@@ -1177,6 +1229,9 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
 
         if (jobInfo.content == null || jobInfo.content == BackupCommand.BackupContent.ALL) {
             prepareAndSendSnapshotTaskForOlapTable(db);
+            if (!status.ok()) {
+                return;
+            }
         }
 
         metaPreparedTime = System.currentTimeMillis();
@@ -1309,6 +1364,39 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
             }
         } finally {
             db.readUnlock();
+        }
+
+        int taskCount = unfinishedSignatureToId.size();
+        if (taskCount > Config.max_backup_tablets_per_job) {
+            String msg = String.format("the num of restore snapshot tasks %d exceeds the limit %d, "
+                    + "which might cause the FE OOM. RestoreJob counts per replica (typically 3x "
+                    + "of tablet count), change config `max_backup_tablets_per_job` "
+                    + "to change this limitation",
+                    taskCount, Config.max_backup_tablets_per_job);
+            LOG.warn(msg);
+            status = new Status(ErrCode.COMMON_ERROR, msg);
+            return;
+        }
+
+        // Global snapshot task limit only applies in concurrent mode, because
+        // onJobDeactivated (which decrements the counter) is only called via
+        // onJobCompleted, which is gated by enable_table_level_backup_concurrency.
+        // Job run() is driven by a single daemon thread, so get+add is safe without CAS.
+        if (Config.enable_table_level_backup_concurrency) {
+            if (Config.max_concurrent_snapshot_tasks_total > 0) {
+                int globalCurrent = env.getBackupHandler().getGlobalSnapshotTasks();
+                if (globalCurrent + taskCount > Config.max_concurrent_snapshot_tasks_total) {
+                    String msg = String.format("global concurrent snapshot tasks %d + this restore job %d "
+                            + "would exceed the limit %d, change config `max_concurrent_snapshot_tasks_total` "
+                            + "to change this limitation",
+                            globalCurrent, taskCount, Config.max_concurrent_snapshot_tasks_total);
+                    LOG.warn(msg);
+                    status = new Status(ErrCode.COMMON_ERROR, msg);
+                    return;
+                }
+            }
+            snapshotTaskCount = taskCount;
+            env.getBackupHandler().addGlobalSnapshotTasks(snapshotTaskCount);
         }
 
         // check disk capacity
@@ -2192,6 +2280,15 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
 
             // Only send release snapshot tasks after the job is finished.
             releaseSnapshots(savedSnapshotInfos, true);
+
+            // Notify completion for concurrency control
+            if (Config.enable_table_level_backup_concurrency) {
+                try {
+                    env.getBackupHandler().onJobCompleted(this.jobId, this.dbId, this);
+                } catch (Exception e) {
+                    LOG.warn("Failed to notify job completion for restore job {}", this.label, e);
+                }
+            }
         }
         showState = RestoreJobState.FINISHED;
 
@@ -2357,6 +2454,19 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
         }
         info.add(status.toString());
         info.add(String.valueOf(timeoutMs / 1000));
+
+        // Queue position and block reason (for concurrency mode)
+        if (env != null && Config.enable_table_level_backup_concurrency) {
+            BackupHandler handler = env.getBackupHandler();
+            int queuePos = handler.getJobQueuePosition(this);
+            info.add(queuePos == 0 ? "Running" : String.valueOf(queuePos));
+            String blockReason = handler.getJobBlockReason(this);
+            info.add(blockReason != null ? blockReason : "");
+        } else {
+            info.add("");
+            info.add("");
+        }
+
         return info;
     }
 
@@ -2443,6 +2553,15 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
             LOG.info("finished to cancel restore job. current state: {}. is replay: {}. {}",
                     curState.name(), isReplay, this);
 
+            // Notify completion for concurrency control
+            if (Config.enable_table_level_backup_concurrency) {
+                try {
+                    env.getBackupHandler().onJobCompleted(this.jobId, this.dbId, this);
+                } catch (Exception e) {
+                    LOG.warn("Failed to notify job completion for cancelled restore job {}", this.label, e);
+                }
+            }
+
             // Send release snapshot tasks after log restore job, so that the snapshot won't be released
             // before the cancelled restore job is persisted.
             releaseSnapshots(savedSnapshotInfos, false);
@@ -2472,6 +2591,23 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
                 LOG.info("remove restored table when cancelled: {}", restoreTbl.getName());
                 if (db.writeLockIfExist()) {
                     try {
+                        // CRITICAL: Check if the table currently registered in DB is actually ours
+                        // (by matching table ID). In concurrent restore scenarios, another job may
+                        // have registered a table with the same name but different ID.
+                        // We must NOT unregister another job's table.
+                        Table currentTable = db.getTableNullable(restoreTbl.getName());
+                        if (currentTable == null) {
+                            LOG.info("table {} not found in db, skip removal (may have been removed already)",
+                                    restoreTbl.getName());
+                            continue;
+                        }
+                        if (currentTable.getId() != restoreTbl.getId()) {
+                            LOG.info("table {} in db has id {} but we expect id {}, skip removal "
+                                    + "(belongs to another job)",
+                                    restoreTbl.getName(), currentTable.getId(), restoreTbl.getId());
+                            continue;
+                        }
+
                         if (restoreTbl.getType() == TableType.OLAP) {
                             OlapTable restoreOlapTable = (OlapTable) restoreTbl;
                             restoreOlapTable.writeLock();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -9329,14 +9329,34 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
     public LogicalPlan visitCancelBackup(DorisParser.CancelBackupContext ctx) {
         String databaseName = ctx.database != null ? ctx.database.getText() : null;
         boolean isRestore = false;
-        return new CancelBackupCommand(databaseName, isRestore);
+
+        // Parse WHERE clause for label filter
+        String label = null;
+        boolean isLike = false;
+        if (ctx.wildWhere() != null) {
+            LabelFilterInfo filterInfo = parseLabelFilter(ctx.wildWhere());
+            label = filterInfo.label;
+            isLike = filterInfo.isLike;
+        }
+
+        return new CancelBackupCommand(databaseName, isRestore, label, isLike);
     }
 
     @Override
     public LogicalPlan visitCancelRestore(DorisParser.CancelRestoreContext ctx) {
         String databaseName = ctx.database != null ? ctx.database.getText() : null;
         boolean isRestore = true;
-        return new CancelBackupCommand(databaseName, isRestore);
+
+        // Parse WHERE clause for label filter
+        String label = null;
+        boolean isLike = false;
+        if (ctx.wildWhere() != null) {
+            LabelFilterInfo filterInfo = parseLabelFilter(ctx.wildWhere());
+            label = filterInfo.label;
+            isLike = filterInfo.isLike;
+        }
+
+        return new CancelBackupCommand(databaseName, isRestore, label, isLike);
     }
 
     @Override
@@ -10235,5 +10255,52 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
         }
 
         return sortFields.build();
+    }
+
+    /**
+     * Parse WHERE clause for label filtering in CANCEL BACKUP/RESTORE commands
+     * Supports: WHERE LABEL = 'xxx' or WHERE LABEL LIKE 'xxx%'
+     */
+    private LabelFilterInfo parseLabelFilter(DorisParser.WildWhereContext ctx) {
+        if (ctx == null || ctx.expression() == null) {
+            return new LabelFilterInfo(null, false);
+        }
+
+        // Get the expression text
+        String exprText = ctx.expression().getText();
+
+        // Remove parentheses if present
+        exprText = exprText.replaceAll("^\\(+|\\)+$", "");
+
+        // Pattern for LABEL = 'value' (case insensitive)
+        java.util.regex.Pattern equalPattern = java.util.regex.Pattern.compile(
+                "(?i)LABEL\\s*=\\s*['\"]([^'\"]+)['\"]");
+        java.util.regex.Matcher equalMatcher = equalPattern.matcher(exprText);
+        if (equalMatcher.find()) {
+            return new LabelFilterInfo(equalMatcher.group(1), false);
+        }
+
+        // Pattern for LABEL LIKE 'value' (case insensitive)
+        java.util.regex.Pattern likePattern = java.util.regex.Pattern.compile(
+                "(?i)LABEL\\s+LIKE\\s+['\"]([^'\"]+)['\"]");
+        java.util.regex.Matcher likeMatcher = likePattern.matcher(exprText);
+        if (likeMatcher.find()) {
+            return new LabelFilterInfo(likeMatcher.group(1), true);
+        }
+
+        return new LabelFilterInfo(null, false);
+    }
+
+    /**
+     * Internal class to hold label filter information
+     */
+    private static class LabelFilterInfo {
+        String label;
+        boolean isLike;
+
+        LabelFilterInfo(String label, boolean isLike) {
+            this.label = label;
+            this.isLike = isLike;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CancelBackupCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CancelBackupCommand.java
@@ -37,11 +37,21 @@ import com.google.common.base.Strings;
 public class CancelBackupCommand extends CancelCommand {
     private String dbName;
     private boolean isRestore;
+    private String label;      // Label filter (null means cancel all)
+    private boolean isLike;    // Whether to use LIKE pattern matching
 
+    // Old constructor for backward compatibility
     public CancelBackupCommand(String dbName, boolean isRestore) {
+        this(dbName, isRestore, null, false);
+    }
+
+    // New constructor with label filter support
+    public CancelBackupCommand(String dbName, boolean isRestore, String label, boolean isLike) {
         super(PlanType.CANCEL_BACKUP_AND_RESTORE_COMMAND);
         this.dbName = dbName;
         this.isRestore = isRestore;
+        this.label = label;
+        this.isLike = isLike;
     }
 
     public String getDbName() {
@@ -50,6 +60,45 @@ public class CancelBackupCommand extends CancelCommand {
 
     public boolean isRestore() {
         return isRestore;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public boolean isLike() {
+        return isLike;
+    }
+
+    /**
+     * Check if a job label matches the filter
+     * @param jobLabel The label of the job to check
+     * @return true if the job label matches the filter, false otherwise
+     */
+    public boolean matchesLabel(String jobLabel) {
+        if (label == null) {
+            return true;
+        }
+
+        if (isLike) {
+            StringBuilder regex = new StringBuilder();
+            for (int i = 0; i < label.length(); i++) {
+                char c = label.charAt(i);
+                if (c == '%') {
+                    regex.append(".*");
+                } else if (c == '_') {
+                    regex.append(".");
+                } else if ("\\[]{}()*+?.^$|".indexOf(c) >= 0) {
+                    regex.append('\\');
+                    regex.append(c);
+                } else {
+                    regex.append(c);
+                }
+            }
+            return jobLabel.matches(regex.toString());
+        } else {
+            return jobLabel.equals(label);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowBackupCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowBackupCommand.java
@@ -61,6 +61,7 @@ public class ShowBackupCommand extends ShowCommand {
             .add("JobId").add("SnapshotName").add("DbName").add("State").add("BackupObjs").add("CreateTime")
             .add("SnapshotFinishedTime").add("UploadFinishedTime").add("FinishedTime").add("UnfinishedTasks")
             .add("Progress").add("TaskErrMsg").add("Status").add("Timeout")
+            .add("QueuePos").add("BlockReason")
             .build();
 
     private String dbName;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowRestoreCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowRestoreCommand.java
@@ -63,6 +63,7 @@ public class ShowRestoreCommand extends ShowCommand {
             .add("ReserveDynamicPartitionEnable").add("RestoreObjs").add("CreateTime").add("MetaPreparedTime")
             .add("SnapshotFinishedTime").add("DownloadFinishedTime").add("FinishedTime").add("UnfinishedTasks")
             .add("Progress").add("TaskErrMsg").add("Status").add("Timeout")
+            .add("QueuePos").add("BlockReason")
             .build();
     public static final ImmutableList<String> BRIEF_TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("JobId").add("Label").add("Timestamp").add("DbName").add("State")
@@ -70,6 +71,7 @@ public class ShowRestoreCommand extends ShowCommand {
             .add("ReserveDynamicPartitionEnable").add("CreateTime").add("MetaPreparedTime")
             .add("SnapshotFinishedTime").add("DownloadFinishedTime").add("FinishedTime").add("UnfinishedTasks")
             .add("Status").add("Timeout")
+            .add("QueuePos").add("BlockReason")
             .build();
 
     private String dbName;

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -4008,8 +4008,18 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             }
         }
 
-        //instantiate RestoreCommand
+        // instantiate RestoreCommand
         LabelNameInfo labelNameInfo = new LabelNameInfo(label.getDb(), label.getLabel());
+        // RPC did not pass table_refs (e.g. CCR same-name table sync). Derive from jobInfo
+        // so the restore is treated as table-level for concurrency control.
+        // TableNameInfo must have db=null here; RestoreCommand will set db from label.
+        if (tableRefs.isEmpty() && backupJobInfo != null && !backupJobInfo.backupOlapTableObjects.isEmpty()) {
+            for (String tblName : backupJobInfo.backupOlapTableObjects.keySet()) {
+                TableNameInfo tableNameInfo = new TableNameInfo(tblName);
+                tableRefs.add(new TableRefInfo(tableNameInfo, null, null, null,
+                        new ArrayList<>(), null, null, new ArrayList<>()));
+            }
+        }
         RestoreCommand restoreCommand = new RestoreCommand(labelNameInfo, repoName, tableRefs, properties, false);
         restoreCommand.setMeta(backupMeta);
         restoreCommand.setJobInfo(backupJobInfo);

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupConcurrencyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupConcurrencyTest.java
@@ -1,0 +1,151 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.backup;
+
+import org.apache.doris.backup.BackupHandler.DatabaseJobStats;
+import org.apache.doris.common.Config;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for backup/restore concurrency control.
+ */
+public class BackupConcurrencyTest {
+
+    private boolean originalConcurrencyEnabled;
+    private int originalConcurrentNum;
+    private long originalPendingTimeout;
+    private boolean originalLogging;
+
+    @Before
+    public void setUp() {
+        // Save original config values
+        originalConcurrencyEnabled = Config.enable_table_level_backup_concurrency;
+        originalConcurrentNum = Config.max_backup_restore_concurrent_num_per_db;
+        originalPendingTimeout = Config.backup_pending_job_timeout_ms;
+        originalLogging = Config.enable_backup_concurrency_logging;
+
+        // Enable concurrency for tests
+        Config.enable_table_level_backup_concurrency = true;
+        Config.max_backup_restore_concurrent_num_per_db = 10;
+        Config.backup_pending_job_timeout_ms = 3600000;
+        Config.enable_backup_concurrency_logging = true;
+    }
+
+    @After
+    public void tearDown() {
+        // Restore original config values
+        Config.enable_table_level_backup_concurrency = originalConcurrencyEnabled;
+        Config.max_backup_restore_concurrent_num_per_db = originalConcurrentNum;
+        Config.backup_pending_job_timeout_ms = originalPendingTimeout;
+        Config.enable_backup_concurrency_logging = originalLogging;
+    }
+
+    @Test
+    public void testDatabaseJobStatsBasic() {
+        DatabaseJobStats stats = new DatabaseJobStats();
+
+        // Initial state
+        Assert.assertEquals(0, stats.activeBackups);
+        Assert.assertEquals(0, stats.activeRestores);
+        Assert.assertFalse(stats.hasActiveJobs());
+        Assert.assertEquals(0, stats.getTotalActiveJobs());
+
+        // Add backups
+        stats.activeBackups = 3;
+        Assert.assertTrue(stats.hasActiveJobs());
+        Assert.assertEquals(3, stats.getTotalActiveJobs());
+
+        // Add restores
+        stats.activeRestores = 2;
+        Assert.assertEquals(5, stats.getTotalActiveJobs());
+
+        // Test full database backup marker
+        stats.backupDatabaseJobId = 1001L;
+        stats.backupDatabaseLabel = "full_backup";
+        Assert.assertEquals("full_backup", stats.backupDatabaseLabel);
+
+        // Test full database restore marker
+        stats.restoreDatabaseJobId = 2001L;
+        stats.restoreDatabaseLabel = "full_restore";
+        Assert.assertEquals("full_restore", stats.restoreDatabaseLabel);
+    }
+
+    @Test
+    public void testDatabaseJobStatsLabels() {
+        DatabaseJobStats stats = new DatabaseJobStats();
+
+        // Add labels
+        stats.activeLabels.add("backup1");
+        stats.activeLabels.add("backup2");
+        stats.activeLabels.add("restore1");
+
+        Assert.assertEquals(3, stats.activeLabels.size());
+        Assert.assertTrue(stats.activeLabels.contains("backup1"));
+        Assert.assertTrue(stats.activeLabels.contains("restore1"));
+
+        // Remove label
+        stats.activeLabels.remove("backup1");
+        Assert.assertEquals(2, stats.activeLabels.size());
+        Assert.assertFalse(stats.activeLabels.contains("backup1"));
+    }
+
+    @Test
+    public void testConfigDefaults() {
+        // Verify our test setup changed the configs
+        Assert.assertTrue(Config.enable_table_level_backup_concurrency);
+        Assert.assertEquals(10, Config.max_backup_restore_concurrent_num_per_db);
+        Assert.assertEquals(3600000, Config.backup_pending_job_timeout_ms);
+        Assert.assertTrue(Config.enable_backup_concurrency_logging);
+    }
+
+    @Test
+    public void testConcurrencyDisabled() {
+        // Disable concurrency
+        Config.enable_table_level_backup_concurrency = false;
+
+        // When disabled, all jobs should be able to execute
+        // This is a basic sanity check
+        Assert.assertFalse(Config.enable_table_level_backup_concurrency);
+    }
+
+    @Test
+    public void testConcurrentNumLimit() {
+        // Test that concurrent num config is respected
+        Config.max_backup_restore_concurrent_num_per_db = 5;
+        Assert.assertEquals(5, Config.max_backup_restore_concurrent_num_per_db);
+
+        // Reset
+        Config.max_backup_restore_concurrent_num_per_db = 10;
+    }
+
+    @Test
+    public void testPendingTimeout() {
+        // Test pending timeout config
+        Config.backup_pending_job_timeout_ms = 1800000; // 30 minutes
+        Assert.assertEquals(1800000, Config.backup_pending_job_timeout_ms);
+
+        // Reset
+        Config.backup_pending_job_timeout_ms = 3600000;
+    }
+}
+
+

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupHandlerTest.java
@@ -33,6 +33,7 @@ import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.catalog.info.TableNameInfo;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.info.TableRefInfo;
 import org.apache.doris.nereids.trees.plans.commands.BackupCommand;
@@ -68,6 +69,7 @@ import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class BackupHandlerTest {
 
@@ -267,6 +269,2074 @@ public class BackupHandlerTest {
 
             // drop repo
             handler.dropRepository("repo");
+        }
+    }
+
+    // ========== Dual Queue Architecture Tests ==========
+
+    /**
+     * Test 1: Basic dual queue operations - Add job to running queue
+     */
+    @Test
+    public void testDualQueueAddActiveJob() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        BackupJob job = new BackupJob("test_backup", dbId, "test_db",
+                Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+
+        try {
+            Deencapsulation.invoke(handler, "addActiveJob", dbId, job);
+
+            List jobs = Deencapsulation.invoke(handler, "getAllRunningJobs");
+            Assert.assertEquals(1, jobs.size());
+            Assert.assertEquals(job, jobs.get(0));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    /**
+     * Test 2: Move job from running to history queue
+     */
+    @Test
+    public void testDualQueueMoveToHistory() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        BackupJob job = new BackupJob("test_backup", dbId, "test_db",
+                Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+
+        try {
+            Deencapsulation.invoke(handler, "addActiveJob", dbId, job);
+            Deencapsulation.invoke(handler, "moveToHistory", dbId, job);
+
+            List runningJobs = Deencapsulation.invoke(handler, "getAllRunningJobs");
+            Assert.assertEquals(0, runningJobs.size());
+
+            List allJobs = Deencapsulation.invoke(handler, "getAllJobs", dbId);
+            Assert.assertEquals(1, allJobs.size());
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    /**
+     * Test 3: FIFO cleanup in history queue
+     */
+    @Test
+    public void testDualQueueFifoCleanup() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        int originalLimit = Config.max_backup_restore_job_num_per_db;
+        Config.max_backup_restore_job_num_per_db = 3;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            for (int i = 0; i < 5; i++) {
+                BackupJob job = new BackupJob("test_backup_" + i, dbId, "test_db",
+                        Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+                Deencapsulation.setField(job, "jobId", (long) i);
+                Deencapsulation.invoke(handler, "addToHistoryQueue", dbId, job);
+            }
+
+            List allJobs = Deencapsulation.invoke(handler, "getAllJobs", dbId);
+            Assert.assertEquals(3, allJobs.size());
+            Assert.assertEquals("test_backup_2", ((AbstractJob) allJobs.get(0)).getLabel());
+            Assert.assertEquals("test_backup_4", ((AbstractJob) allJobs.get(2)).getLabel());
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+            Config.max_backup_restore_job_num_per_db = originalLimit;
+        }
+    }
+
+    /**
+     * Test 4: Soft limit (warning only)
+     */
+    @Test
+    public void testDualQueueSoftLimit() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        int originalSoftLimit = Config.max_backup_restore_running_queue_soft_limit;
+        Config.max_backup_restore_running_queue_soft_limit = 2;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            for (int i = 0; i < 3; i++) {
+                BackupJob job = new BackupJob("test_backup_" + i, dbId, "test_db",
+                        Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+                Deencapsulation.setField(job, "jobId", (long) i);
+                Deencapsulation.invoke(handler, "addActiveJob", dbId, job);
+            }
+
+            List jobs = Deencapsulation.invoke(handler, "getAllRunningJobs");
+            Assert.assertEquals(3, jobs.size());
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+            Config.max_backup_restore_running_queue_soft_limit = originalSoftLimit;
+        }
+    }
+
+    /**
+     * Test 5: Hard limit (reject new jobs)
+     */
+    @Test
+    public void testDualQueueHardLimit() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        int originalHardLimit = Config.max_backup_restore_running_queue_hard_limit;
+        Config.max_backup_restore_running_queue_hard_limit = 2;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            for (int i = 0; i < 2; i++) {
+                BackupJob job = new BackupJob("test_backup_" + i, dbId, "test_db",
+                        Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+                Deencapsulation.setField(job, "jobId", (long) i);
+                Deencapsulation.invoke(handler, "addActiveJob", dbId, job);
+            }
+
+            BackupJob extraJob = new BackupJob("test_backup_extra", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(extraJob, "jobId", 100L);
+
+            boolean exceptionThrown = false;
+            try {
+                Deencapsulation.invoke(handler, "addActiveJob", dbId, extraJob);
+            } catch (Exception e) {
+                exceptionThrown = true;
+                Assert.assertTrue(e.getMessage().contains("Running queue is full"));
+            }
+
+            Assert.assertTrue("Hard limit should reject new jobs", exceptionThrown);
+
+            List jobs = Deencapsulation.invoke(handler, "getAllRunningJobs");
+            Assert.assertEquals(2, jobs.size());
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+            Config.max_backup_restore_running_queue_hard_limit = originalHardLimit;
+        }
+    }
+
+    /**
+     * Test 6: Get all jobs (merge running + history)
+     */
+    @Test
+    public void testDualQueueGetAllJobs() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            BackupJob runningJob1 = new BackupJob("running_1", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(runningJob1, "jobId", 1L);
+            BackupJob runningJob2 = new BackupJob("running_2", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(runningJob2, "jobId", 2L);
+
+            Deencapsulation.invoke(handler, "addActiveJob", dbId, runningJob1);
+            Deencapsulation.invoke(handler, "addActiveJob", dbId, runningJob2);
+
+            BackupJob historyJob = new BackupJob("history_1", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(historyJob, "jobId", 3L);
+            Deencapsulation.invoke(handler, "addToHistoryQueue", dbId, historyJob);
+
+            List allJobs = Deencapsulation.invoke(handler, "getAllJobs", dbId);
+            Assert.assertEquals(3, allJobs.size());
+
+            List runningJobs = Deencapsulation.invoke(handler, "getAllRunningJobs");
+            Assert.assertEquals(2, runningJobs.size());
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    /**
+     * Test 7: Concurrent access thread safety
+     */
+    @Test
+    public void testDualQueueConcurrentAccess() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            List<Thread> threads = Lists.newArrayList();
+            for (int i = 0; i < 5; i++) {
+                final int index = i;
+                Thread thread = new Thread(() -> {
+                    try {
+                        BackupJob job = new BackupJob("concurrent_" + index, dbId, "test_db",
+                                Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+                        Deencapsulation.setField(job, "jobId", (long) index);
+                        Deencapsulation.invoke(handler, "addActiveJob", dbId, job);
+                    } catch (Exception e) {
+                        // Ignore
+                    }
+                });
+                threads.add(thread);
+                thread.start();
+            }
+
+            for (Thread thread : threads) {
+                thread.join();
+            }
+
+            List jobs = Deencapsulation.invoke(handler, "getAllRunningJobs");
+            Assert.assertEquals(5, jobs.size());
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    /**
+     * Test 8: runAfterCatalogReady skips completed jobs (optimization test)
+     */
+    @Test
+    public void testRunAfterCatalogReadySkipsCompletedJobs() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            BackupJob completedJob = new BackupJob("completed", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(completedJob, "jobId", 1L);
+            Deencapsulation.setField(completedJob, "state", BackupJob.BackupJobState.FINISHED);
+
+            Deencapsulation.invoke(handler, "addActiveJob", dbId, completedJob);
+
+            handler.runAfterCatalogReady();
+
+            Assert.assertTrue("Completed jobs should be skipped", true);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    /**
+     * Test 9: Remove job from running queue
+     */
+    @Test
+    public void testRemoveFromRunningQueue() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            BackupJob job1 = new BackupJob("job1", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(job1, "jobId", 1L);
+            BackupJob job2 = new BackupJob("job2", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(job2, "jobId", 2L);
+
+            Deencapsulation.invoke(handler, "addActiveJob", dbId, job1);
+            Deencapsulation.invoke(handler, "addActiveJob", dbId, job2);
+
+            List jobs = Deencapsulation.invoke(handler, "getAllRunningJobs");
+            Assert.assertEquals(2, jobs.size());
+
+            Deencapsulation.invoke(handler, "removeFromRunningQueue", dbId, job1);
+
+            jobs = Deencapsulation.invoke(handler, "getAllRunningJobs");
+            Assert.assertEquals(1, jobs.size());
+            Assert.assertEquals(job2, jobs.get(0));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    /**
+     * Test 10: Multiple databases isolation
+     */
+    @Test
+    public void testDualQueueMultipleDatabasesIsolation() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId1 = 1L;
+        long dbId2 = 2L;
+
+        try {
+            BackupJob job1 = new BackupJob("job1", dbId1, "test_db1",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(job1, "jobId", 1L);
+            BackupJob job2 = new BackupJob("job2", dbId2, "test_db2",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(job2, "jobId", 2L);
+
+            Deencapsulation.invoke(handler, "addActiveJob", dbId1, job1);
+            Deencapsulation.invoke(handler, "addActiveJob", dbId2, job2);
+
+            List jobs1 = Deencapsulation.invoke(handler, "getAllJobs", dbId1);
+            List jobs2 = Deencapsulation.invoke(handler, "getAllJobs", dbId2);
+
+            Assert.assertEquals(1, jobs1.size());
+            Assert.assertEquals(1, jobs2.size());
+            Assert.assertEquals(job1, jobs1.get(0));
+            Assert.assertEquals(job2, jobs2.get(0));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    // ========== Job Queue Position & Block Reason Tests ==========
+
+    /**
+     * Test 11: getJobQueuePosition returns 0 when concurrency is disabled
+     */
+    @Test
+    public void testGetJobQueuePositionDisabled() throws Exception {
+        Config.enable_table_level_backup_concurrency = false;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        BackupJob job = new BackupJob("test_backup", dbId, "test_db",
+                Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+        Deencapsulation.setField(job, "jobId", 1L);
+
+        Assert.assertEquals(0, handler.getJobQueuePosition(job));
+    }
+
+    /**
+     * Test 12: getJobQueuePosition returns 0 for running jobs (in allowedJobIds)
+     */
+    @Test
+    public void testGetJobQueuePositionRunning() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            BackupJob job = new BackupJob("test_backup", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(job, "jobId", 1L);
+
+            // Add to running queue and allowedJobIds
+            Deencapsulation.invoke(handler, "addActiveJob", dbId, job);
+            Set<Long> allowedJobIds = Deencapsulation.getField(handler, "allowedJobIds");
+            allowedJobIds.add(1L);
+
+            Assert.assertEquals(0, handler.getJobQueuePosition(job));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    /**
+     * Test 13: getJobQueuePosition returns correct positions for pending jobs
+     */
+    @Test
+    public void testGetJobQueuePositionPending() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            // Create 3 jobs: job1 is running, job2 and job3 are pending
+            BackupJob job1 = new BackupJob("running_job", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(job1, "jobId", 1L);
+            BackupJob job2 = new BackupJob("pending_job_1", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(job2, "jobId", 2L);
+            BackupJob job3 = new BackupJob("pending_job_2", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(job3, "jobId", 3L);
+
+            Deencapsulation.invoke(handler, "addActiveJob", dbId, job1);
+            Deencapsulation.invoke(handler, "addActiveJob", dbId, job2);
+            Deencapsulation.invoke(handler, "addActiveJob", dbId, job3);
+
+            // Only job1 is allowed (running)
+            Set<Long> allowedJobIds = Deencapsulation.getField(handler, "allowedJobIds");
+            allowedJobIds.add(1L);
+
+            // job1 is running → position 0
+            Assert.assertEquals(0, handler.getJobQueuePosition(job1));
+            // job2 is first pending → position 1
+            Assert.assertEquals(1, handler.getJobQueuePosition(job2));
+            // job3 is second pending → position 2
+            Assert.assertEquals(2, handler.getJobQueuePosition(job3));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    /**
+     * Test 14: getJobBlockReason returns null when concurrency is disabled
+     */
+    @Test
+    public void testGetJobBlockReasonDisabled() throws Exception {
+        Config.enable_table_level_backup_concurrency = false;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        BackupJob job = new BackupJob("test_backup", dbId, "test_db",
+                Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+        Deencapsulation.setField(job, "jobId", 1L);
+
+        Assert.assertNull(handler.getJobBlockReason(job));
+    }
+
+    /**
+     * Test 15: getJobBlockReason returns null for running jobs (has permission)
+     */
+    @Test
+    public void testGetJobBlockReasonRunning() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            BackupJob job = new BackupJob("test_backup", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(job, "jobId", 1L);
+
+            Set<Long> allowedJobIds = Deencapsulation.getField(handler, "allowedJobIds");
+            allowedJobIds.add(1L);
+
+            Assert.assertNull(handler.getJobBlockReason(job));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    /**
+     * Test 16: getJobBlockReason shows backup blocked by active restores
+     */
+    @Test
+    public void testGetJobBlockReasonBackupBlockedByRestore() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            BackupJob backupJob = new BackupJob("test_backup", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(backupJob, "jobId", 1L);
+
+            // Set up stats with active restores
+            Map<Long, BackupHandler.DatabaseJobStats> dbJobStats = Deencapsulation.getField(handler, "dbJobStats");
+            BackupHandler.DatabaseJobStats stats = new BackupHandler.DatabaseJobStats();
+            stats.activeRestores = 2;
+            dbJobStats.put(dbId, stats);
+
+            String reason = handler.getJobBlockReason(backupJob);
+            Assert.assertNotNull(reason);
+            Assert.assertTrue(reason.contains("restore"));
+            Assert.assertTrue(reason.contains("2"));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    /**
+     * Test 17: getJobBlockReason shows restore blocked by active backups
+     */
+    @Test
+    public void testGetJobBlockReasonRestoreBlockedByBackup() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            RestoreJob restoreJob = new RestoreJob();
+            Deencapsulation.setField(restoreJob, "jobId", 1L);
+            Deencapsulation.setField(restoreJob, "dbId", dbId);
+
+            // Set up stats with active backups
+            Map<Long, BackupHandler.DatabaseJobStats> dbJobStats = Deencapsulation.getField(handler, "dbJobStats");
+            BackupHandler.DatabaseJobStats stats = new BackupHandler.DatabaseJobStats();
+            stats.activeBackups = 3;
+            dbJobStats.put(dbId, stats);
+
+            String reason = handler.getJobBlockReason(restoreJob);
+            Assert.assertNotNull(reason);
+            Assert.assertTrue(reason.contains("backup"));
+            Assert.assertTrue(reason.contains("3"));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    /**
+     * Test 18: getJobBlockReason shows restore blocked by table conflict
+     */
+    @Test
+    public void testGetJobBlockReasonRestoreTableConflict() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            RestoreJob restoreJob = new RestoreJob();
+            Deencapsulation.setField(restoreJob, "jobId", 1L);
+            Deencapsulation.setField(restoreJob, "dbId", dbId);
+
+            // Set tableRefs
+            List<TableRefInfo> tableRefs = Lists.newArrayList();
+            tableRefs.add(new TableRefInfo(
+                    new TableNameInfo(InternalCatalog.INTERNAL_CATALOG_NAME, "test_db", "conflict_table"),
+                    null, null, null, null, null, null, null));
+            restoreJob.setTableRefs(tableRefs);
+
+            // Set up restoring tables with a conflict
+            Map<Long, java.util.Set<String>> restoringTables = Deencapsulation.getField(handler, "restoringTables");
+            java.util.Set<String> tables = java.util.concurrent.ConcurrentHashMap.newKeySet();
+            tables.add("conflict_table");
+            restoringTables.put(dbId, tables);
+
+            // Set up empty stats (no backup/restore blocking)
+            Map<Long, BackupHandler.DatabaseJobStats> dbJobStats = Deencapsulation.getField(handler, "dbJobStats");
+            dbJobStats.put(dbId, new BackupHandler.DatabaseJobStats());
+
+            String reason = handler.getJobBlockReason(restoreJob);
+            Assert.assertNotNull(reason);
+            Assert.assertTrue(reason.contains("conflict_table"));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    /**
+     * Test 19: getJobBlockReason shows backup blocked by full database backup
+     */
+    @Test
+    public void testGetJobBlockReasonFullDatabaseBackup() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            BackupJob backupJob = new BackupJob("table_backup", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(backupJob, "jobId", 2L);
+
+            // Set up stats with full database backup marker
+            Map<Long, BackupHandler.DatabaseJobStats> dbJobStats = Deencapsulation.getField(handler, "dbJobStats");
+            BackupHandler.DatabaseJobStats stats = new BackupHandler.DatabaseJobStats();
+            stats.backupDatabaseJobId = 1L;
+            stats.backupDatabaseLabel = "full_db_backup";
+            dbJobStats.put(dbId, stats);
+
+            String reason = handler.getJobBlockReason(backupJob);
+            Assert.assertNotNull(reason);
+            Assert.assertTrue(reason.contains("Full database backup"));
+            Assert.assertTrue(reason.contains("full_db_backup"));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    /**
+     * Test 20: getJobBlockReason shows restore blocked by full database restore
+     */
+    @Test
+    public void testGetJobBlockReasonFullDatabaseRestore() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            RestoreJob restoreJob = new RestoreJob();
+            Deencapsulation.setField(restoreJob, "jobId", 2L);
+            Deencapsulation.setField(restoreJob, "dbId", dbId);
+            restoreJob.setTableRefs(Lists.newArrayList());
+
+            // Set up stats with full database restore marker
+            Map<Long, BackupHandler.DatabaseJobStats> dbJobStats = Deencapsulation.getField(handler, "dbJobStats");
+            BackupHandler.DatabaseJobStats stats = new BackupHandler.DatabaseJobStats();
+            stats.restoreDatabaseJobId = 1L;
+            stats.restoreDatabaseLabel = "full_db_restore";
+            dbJobStats.put(dbId, stats);
+
+            String reason = handler.getJobBlockReason(restoreJob);
+            Assert.assertNotNull(reason);
+            Assert.assertTrue(reason.contains("Full database restore"));
+            Assert.assertTrue(reason.contains("full_db_restore"));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    /**
+     * Test 21: getJobBlockReason returns generic message when no specific block
+     */
+    @Test
+    public void testGetJobBlockReasonWaitingForSlot() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            BackupJob job = new BackupJob("test_backup", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(job, "jobId", 1L);
+
+            // No stats, no allowedJobIds → generic waiting message
+            String reason = handler.getJobBlockReason(job);
+            Assert.assertNotNull(reason);
+            Assert.assertTrue(reason.contains("Waiting for execution slot"));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    /**
+     * Test 22: getJobQueuePosition returns 0 when job not in any queue
+     */
+    @Test
+    public void testGetJobQueuePositionNotInQueue() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            BackupJob job = new BackupJob("orphan_job", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(job, "jobId", 99L);
+
+            // No queue exists for this dbId
+            Assert.assertEquals(0, handler.getJobQueuePosition(job));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testGlobalSnapshotTaskCounter() {
+        BackupHandler handler = new BackupHandler(env);
+
+        Assert.assertEquals(0, handler.getGlobalSnapshotTasks());
+
+        handler.addGlobalSnapshotTasks(100);
+        Assert.assertEquals(100, handler.getGlobalSnapshotTasks());
+
+        handler.addGlobalSnapshotTasks(200);
+        Assert.assertEquals(300, handler.getGlobalSnapshotTasks());
+
+        handler.addGlobalSnapshotTasks(-100);
+        Assert.assertEquals(200, handler.getGlobalSnapshotTasks());
+
+        handler.addGlobalSnapshotTasks(-200);
+        Assert.assertEquals(0, handler.getGlobalSnapshotTasks());
+    }
+
+    @Test
+    public void testOnJobDeactivatedDecrementsGlobalSnapshotTasks() {
+        BackupHandler handler = new BackupHandler(env);
+
+        Config.enable_table_level_backup_concurrency = true;
+        try {
+            long dbId = 1L;
+            BackupJob job = new BackupJob("test_deactivate", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(job, "jobId", 200L);
+            Deencapsulation.setField(job, "snapshotTaskCount", 500);
+
+            handler.addGlobalSnapshotTasks(500);
+            Assert.assertEquals(500, handler.getGlobalSnapshotTasks());
+
+            Deencapsulation.invoke(handler, "onJobCreated", dbId, (AbstractJob) job, true, false);
+            Deencapsulation.invoke(handler, "onJobActivated", dbId, (AbstractJob) job, true, false);
+            Deencapsulation.invoke(handler, "onJobDeactivated", dbId, (AbstractJob) job, true);
+
+            Assert.assertEquals(0, handler.getGlobalSnapshotTasks());
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testGlobalSnapshotTaskLimitRejectsWhenExceeded() {
+        BackupHandler handler = new BackupHandler(env);
+        int savedLimit = Config.max_concurrent_snapshot_tasks_total;
+
+        Config.enable_table_level_backup_concurrency = true;
+        Config.max_concurrent_snapshot_tasks_total = 100;
+        try {
+            handler.addGlobalSnapshotTasks(90);
+            Assert.assertEquals(90, handler.getGlobalSnapshotTasks());
+
+            // 90 + 20 = 110 > 100, should exceed
+            int globalCurrent = handler.getGlobalSnapshotTasks();
+            Assert.assertTrue(globalCurrent + 20 > Config.max_concurrent_snapshot_tasks_total);
+
+            // 90 + 5 = 95 <= 100, should not exceed
+            Assert.assertFalse(globalCurrent + 5 > Config.max_concurrent_snapshot_tasks_total);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+            Config.max_concurrent_snapshot_tasks_total = savedLimit;
+        }
+    }
+
+    @Test
+    public void testGlobalSnapshotTaskCounterNotUsedWhenConcurrencyDisabled() {
+        BackupHandler handler = new BackupHandler(env);
+
+        Config.enable_table_level_backup_concurrency = false;
+        Assert.assertEquals(0, handler.getGlobalSnapshotTasks());
+
+        // In non-concurrent mode, global counter should not be touched by job logic.
+        // Verify the counter stays at 0 when concurrency is disabled.
+        Assert.assertEquals(0, handler.getGlobalSnapshotTasks());
+    }
+
+    // ========== Scheduling Rules: checkConcurrency Tests ==========
+
+    @Test
+    public void testCheckConcurrencyRejectsDuplicateLabel() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, Map<String, Long>> labelIdx = Deencapsulation.getField(h, "labelIndex");
+            Map<String, Long> labels = new java.util.concurrent.ConcurrentHashMap<>();
+            labels.put("dup_label", 100L);
+            labelIdx.put(dbId, labels);
+
+            boolean thrown = false;
+            try {
+                Deencapsulation.invoke(h, "checkConcurrency",
+                        dbId, "dup_label", true, false, Lists.newArrayList());
+            } catch (Exception e) {
+                thrown = true;
+                Assert.assertTrue(e.getMessage().contains("Label already exists"));
+            }
+            Assert.assertTrue("Should reject duplicate label", thrown);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testCheckConcurrencyRejectsConcurrencyLimit() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        int saved = Config.max_backup_restore_concurrent_num_per_db;
+        Config.max_backup_restore_concurrent_num_per_db = 2;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> stats =
+                    Deencapsulation.getField(h, "dbJobStats");
+            BackupHandler.DatabaseJobStats s = new BackupHandler.DatabaseJobStats();
+            s.activeBackups = 1;
+            s.activeRestores = 1;
+            stats.put(dbId, s);
+
+            boolean thrown = false;
+            try {
+                Deencapsulation.invoke(h, "checkConcurrency",
+                        dbId, "new_label", true, false, Lists.newArrayList());
+            } catch (Exception e) {
+                thrown = true;
+                Assert.assertTrue(e.getMessage().contains("Concurrency limit reached"));
+            }
+            Assert.assertTrue("Should reject at concurrency limit", thrown);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+            Config.max_backup_restore_concurrent_num_per_db = saved;
+        }
+    }
+
+    @Test
+    public void testCheckConcurrencyRejectsBackupWhenFullDbBackupExists() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> stats =
+                    Deencapsulation.getField(h, "dbJobStats");
+            BackupHandler.DatabaseJobStats s = new BackupHandler.DatabaseJobStats();
+            s.backupDatabaseJobId = 1L;
+            s.backupDatabaseLabel = "full_backup";
+            stats.put(dbId, s);
+
+            boolean thrown = false;
+            try {
+                Deencapsulation.invoke(h, "checkConcurrency",
+                        dbId, "new_backup", true, false, Lists.newArrayList());
+            } catch (Exception e) {
+                thrown = true;
+                Assert.assertTrue(e.getMessage().contains("full database backup"));
+            }
+            Assert.assertTrue("Should reject backup when full-db backup exists", thrown);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testCheckConcurrencyAllowsRestoreEvenWhenFullDbRestoreExists() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> stats =
+                    Deencapsulation.getField(h, "dbJobStats");
+            BackupHandler.DatabaseJobStats s = new BackupHandler.DatabaseJobStats();
+            s.restoreDatabaseJobId = 1L;
+            s.restoreDatabaseLabel = "full_restore";
+            stats.put(dbId, s);
+
+            // Should NOT throw — restore is queued via canActivate, not hard-rejected
+            Deencapsulation.invoke(h, "checkConcurrency",
+                    dbId, "new_restore", false, false, Lists.newArrayList());
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    // ========== Scheduling Rules: canActivate Tests ==========
+
+    @Test
+    public void testCanActivateBlockedByConcurrencyLimit() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        int saved = Config.max_backup_restore_concurrent_num_per_db;
+        Config.max_backup_restore_concurrent_num_per_db = 2;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> stats =
+                    Deencapsulation.getField(h, "dbJobStats");
+            BackupHandler.DatabaseJobStats s = new BackupHandler.DatabaseJobStats();
+            s.runningBackups = 2;
+            stats.put(dbId, s);
+
+            BackupJob job = new BackupJob("bk", dbId, "db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+
+            boolean result = Deencapsulation.invoke(h, "canActivate",
+                    dbId, (AbstractJob) job, true, false);
+            Assert.assertFalse("Should be blocked by concurrency limit", result);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+            Config.max_backup_restore_concurrent_num_per_db = saved;
+        }
+    }
+
+    @Test
+    public void testCanActivateBackupBlockedByRunningRestore() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> stats =
+                    Deencapsulation.getField(h, "dbJobStats");
+            BackupHandler.DatabaseJobStats s = new BackupHandler.DatabaseJobStats();
+            s.runningRestores = 1;
+            stats.put(dbId, s);
+
+            BackupJob job = new BackupJob("bk", dbId, "db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+
+            boolean result = Deencapsulation.invoke(h, "canActivate",
+                    dbId, (AbstractJob) job, true, false);
+            Assert.assertFalse("Backup should be blocked by running restore", result);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testCanActivateRestoreBlockedByRunningBackup() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> stats =
+                    Deencapsulation.getField(h, "dbJobStats");
+            BackupHandler.DatabaseJobStats s = new BackupHandler.DatabaseJobStats();
+            s.runningBackups = 1;
+            stats.put(dbId, s);
+
+            RestoreJob job = new RestoreJob();
+            Deencapsulation.setField(job, "jobId", 1L);
+            Deencapsulation.setField(job, "dbId", dbId);
+
+            boolean result = Deencapsulation.invoke(h, "canActivate",
+                    dbId, (AbstractJob) job, false, false);
+            Assert.assertFalse("Restore should be blocked by running backup", result);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testCanActivateFullDbBackupWaitsForRunningBackups() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> stats =
+                    Deencapsulation.getField(h, "dbJobStats");
+            BackupHandler.DatabaseJobStats s = new BackupHandler.DatabaseJobStats();
+            s.runningBackups = 1;
+            stats.put(dbId, s);
+
+            BackupJob job = new BackupJob("full_bk", dbId, "db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+
+            boolean result = Deencapsulation.invoke(h, "canActivate",
+                    dbId, (AbstractJob) job, true, true);
+            Assert.assertFalse("Full-db backup should wait for running backups", result);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testCanActivateBackupBlockedByRunningFullDbBackup() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> stats =
+                    Deencapsulation.getField(h, "dbJobStats");
+            BackupHandler.DatabaseJobStats s = new BackupHandler.DatabaseJobStats();
+            s.runningBackupDatabaseJobId = 100L;
+            stats.put(dbId, s);
+
+            List<TableRefInfo> refs = Lists.newArrayList();
+            refs.add(new TableRefInfo(new TableNameInfo("t1"),
+                    null, null, null, null, null, null, null));
+            BackupJob job = new BackupJob("tbl_bk", dbId, "db",
+                    refs, 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+
+            boolean result = Deencapsulation.invoke(h, "canActivate",
+                    dbId, (AbstractJob) job, true, false);
+            Assert.assertFalse("Backup should be blocked by running full-db backup", result);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testCanActivateRestoreBlockedByFullDbRestore() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> stats =
+                    Deencapsulation.getField(h, "dbJobStats");
+            BackupHandler.DatabaseJobStats s = new BackupHandler.DatabaseJobStats();
+            s.restoreDatabaseJobId = 100L;
+            stats.put(dbId, s);
+
+            RestoreJob job = new RestoreJob();
+            Deencapsulation.setField(job, "jobId", 1L);
+            Deencapsulation.setField(job, "dbId", dbId);
+            List<TableRefInfo> refs = Lists.newArrayList();
+            refs.add(new TableRefInfo(new TableNameInfo("t1"),
+                    null, null, null, null, null, null, null));
+            job.setTableRefs(refs);
+
+            boolean result = Deencapsulation.invoke(h, "canActivate",
+                    dbId, (AbstractJob) job, false, false);
+            Assert.assertFalse("Restore should be blocked by running full-db restore", result);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testCanActivateRestoreBlockedByTableConflict() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> stats =
+                    Deencapsulation.getField(h, "dbJobStats");
+            stats.put(dbId, new BackupHandler.DatabaseJobStats());
+
+            Map<Long, Set<String>> restoring = Deencapsulation.getField(h, "restoringTables");
+            Set<String> tables = java.util.concurrent.ConcurrentHashMap.newKeySet();
+            tables.add("conflict_table");
+            restoring.put(dbId, tables);
+
+            RestoreJob job = new RestoreJob();
+            Deencapsulation.setField(job, "jobId", 1L);
+            Deencapsulation.setField(job, "dbId", dbId);
+            List<TableRefInfo> refs = Lists.newArrayList();
+            refs.add(new TableRefInfo(new TableNameInfo("conflict_table"),
+                    null, null, null, null, null, null, null));
+            job.setTableRefs(refs);
+
+            boolean result = Deencapsulation.invoke(h, "canActivate",
+                    dbId, (AbstractJob) job, false, false);
+            Assert.assertFalse("Restore should be blocked by table conflict", result);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testCanActivateRestoreAllowedWhenNoTableConflict() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> stats =
+                    Deencapsulation.getField(h, "dbJobStats");
+            stats.put(dbId, new BackupHandler.DatabaseJobStats());
+
+            Map<Long, Set<String>> restoring = Deencapsulation.getField(h, "restoringTables");
+            Set<String> tables = java.util.concurrent.ConcurrentHashMap.newKeySet();
+            tables.add("table_a");
+            restoring.put(dbId, tables);
+
+            RestoreJob job = new RestoreJob();
+            Deencapsulation.setField(job, "jobId", 1L);
+            Deencapsulation.setField(job, "dbId", dbId);
+            List<TableRefInfo> refs = Lists.newArrayList();
+            refs.add(new TableRefInfo(new TableNameInfo("table_b"),
+                    null, null, null, null, null, null, null));
+            job.setTableRefs(refs);
+
+            boolean result = Deencapsulation.invoke(h, "canActivate",
+                    dbId, (AbstractJob) job, false, false);
+            Assert.assertTrue("Restore should be allowed when no table conflict", result);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testCanActivateAllClear() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> stats =
+                    Deencapsulation.getField(h, "dbJobStats");
+            stats.put(dbId, new BackupHandler.DatabaseJobStats());
+
+            BackupJob job = new BackupJob("bk", dbId, "db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+
+            boolean result = Deencapsulation.invoke(h, "canActivate",
+                    dbId, (AbstractJob) job, true, false);
+            Assert.assertTrue("Should activate when all clear", result);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    // ========== CANCEL with Label Filter Tests ==========
+
+    @Test
+    public void testCancelAllJobsInConcurrencyMode() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = db.getId();
+
+        try {
+            for (int i = 0; i < 3; i++) {
+                BackupJob job = new BackupJob("backup_" + i, dbId, CatalogMocker.TEST_DB_NAME,
+                        Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+                Deencapsulation.setField(job, "jobId", (long) (i + 1));
+                Deencapsulation.setField(job, "state", BackupJob.BackupJobState.SNAPSHOTING);
+                Deencapsulation.invoke(h, "addActiveJob", dbId, job);
+            }
+
+            h.cancel(new CancelBackupCommand(CatalogMocker.TEST_DB_NAME, false));
+
+            List<AbstractJob> jobs = Deencapsulation.invoke(h, "getAllRunningJobs");
+            for (AbstractJob job : jobs) {
+                if (job instanceof BackupJob) {
+                    Assert.assertTrue("All backup jobs should be done", job.isDone());
+                }
+            }
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testCancelWithLabelFilterOnlyCancelsMatchingJob() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = db.getId();
+
+        try {
+            BackupJob target = new BackupJob("target_job", dbId, CatalogMocker.TEST_DB_NAME,
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(target, "jobId", 1L);
+            Deencapsulation.setField(target, "state", BackupJob.BackupJobState.SNAPSHOTING);
+
+            BackupJob other = new BackupJob("other_job", dbId, CatalogMocker.TEST_DB_NAME,
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(other, "jobId", 2L);
+            Deencapsulation.setField(other, "state", BackupJob.BackupJobState.SNAPSHOTING);
+
+            Deencapsulation.invoke(h, "addActiveJob", dbId, target);
+            Deencapsulation.invoke(h, "addActiveJob", dbId, other);
+
+            h.cancel(new CancelBackupCommand(CatalogMocker.TEST_DB_NAME, false, "target_job", false));
+
+            Assert.assertTrue("target_job should be cancelled", target.isDone());
+            Assert.assertFalse("other_job should NOT be cancelled", other.isDone());
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    // ========== FE Restart Rebuild Completeness Tests ==========
+
+    @Test
+    public void testRebuildConcurrencyStateRebuildsLabelIndex() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            BackupJob job = new BackupJob("test_label", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(job, "jobId", 1L);
+            Deencapsulation.setField(job, "state", BackupJob.BackupJobState.SNAPSHOTING);
+
+            java.util.Deque<AbstractJob> deque = new java.util.LinkedList<>();
+            deque.add(job);
+            Map<Long, java.util.Deque<AbstractJob>> legacy =
+                    Deencapsulation.getField(h, "dbIdToBackupOrRestoreJobs");
+            legacy.put(dbId, deque);
+
+            Deencapsulation.invoke(h, "rebuildConcurrencyStateAfterRestart");
+
+            Map<Long, Map<String, Long>> labelIdx = Deencapsulation.getField(h, "labelIndex");
+            Assert.assertTrue("labelIndex should contain the job label",
+                    labelIdx.containsKey(dbId) && labelIdx.get(dbId).containsKey("test_label"));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testRebuildConcurrencyStateRebuildsDbJobStats() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            BackupJob bJob = new BackupJob("backup1", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(bJob, "jobId", 1L);
+            Deencapsulation.setField(bJob, "state", BackupJob.BackupJobState.SNAPSHOTING);
+
+            RestoreJob rJob = new RestoreJob();
+            Deencapsulation.setField(rJob, "jobId", 2L);
+            Deencapsulation.setField(rJob, "dbId", dbId);
+            Deencapsulation.setField(rJob, "label", "restore1");
+            Deencapsulation.setField(rJob, "state", RestoreJob.RestoreJobState.SNAPSHOTING);
+
+            java.util.Deque<AbstractJob> deque = new java.util.LinkedList<>();
+            deque.add(bJob);
+            deque.add(rJob);
+            Map<Long, java.util.Deque<AbstractJob>> legacy =
+                    Deencapsulation.getField(h, "dbIdToBackupOrRestoreJobs");
+            legacy.put(dbId, deque);
+
+            Deencapsulation.invoke(h, "rebuildConcurrencyStateAfterRestart");
+
+            Map<Long, BackupHandler.DatabaseJobStats> dbStats =
+                    Deencapsulation.getField(h, "dbJobStats");
+            Assert.assertTrue("dbJobStats should contain the database", dbStats.containsKey(dbId));
+            BackupHandler.DatabaseJobStats s = dbStats.get(dbId);
+            Assert.assertEquals("Should have 1 active backup", 1, s.activeBackups);
+            Assert.assertEquals("Should have 1 active restore", 1, s.activeRestores);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testRebuildConcurrencyStateRebuildsAllowedJobIds() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            BackupJob running = new BackupJob("running", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(running, "jobId", 1L);
+            Deencapsulation.setField(running, "state", BackupJob.BackupJobState.SNAPSHOTING);
+
+            BackupJob pending = new BackupJob("pending", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(pending, "jobId", 2L);
+            Deencapsulation.setField(pending, "state", BackupJob.BackupJobState.PENDING);
+
+            java.util.Deque<AbstractJob> deque = new java.util.LinkedList<>();
+            deque.add(running);
+            deque.add(pending);
+            Map<Long, java.util.Deque<AbstractJob>> legacy =
+                    Deencapsulation.getField(h, "dbIdToBackupOrRestoreJobs");
+            legacy.put(dbId, deque);
+
+            Deencapsulation.invoke(h, "rebuildConcurrencyStateAfterRestart");
+
+            Set<Long> allowed = Deencapsulation.getField(h, "allowedJobIds");
+            Assert.assertTrue("Running job should be in allowedJobIds", allowed.contains(1L));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    /**
+     * Test rebuildConcurrencyStateAfterRestart correctly sums globalSnapshotTasks
+     * from all active running jobs.
+     *
+     * Scenario: Add two jobs to running queue with known snapshotTaskCount, rebuild state
+     * Expected: globalSnapshotTasks should equal the sum of all running jobs' snapshotTaskCount
+     */
+    @Test
+    public void testRebuildConcurrencyStateRebuildGlobalSnapshotTasks() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            BackupJob job1 = new BackupJob("rebuild_job1", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(job1, "jobId", 1L);
+            Deencapsulation.setField(job1, "snapshotTaskCount", 100);
+            Deencapsulation.setField(job1, "state", BackupJob.BackupJobState.SNAPSHOTING);
+
+            BackupJob job2 = new BackupJob("rebuild_job2", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(job2, "jobId", 2L);
+            Deencapsulation.setField(job2, "snapshotTaskCount", 250);
+            Deencapsulation.setField(job2, "state", BackupJob.BackupJobState.UPLOADING);
+
+            // Add to the legacy job store (dbIdToBackupOrRestoreJobs) which rebuild scans
+            java.util.Deque<AbstractJob> jobDeque = new java.util.LinkedList<>();
+            jobDeque.add(job1);
+            jobDeque.add(job2);
+            Map<Long, java.util.Deque<AbstractJob>> legacyMap = Deencapsulation.getField(handler, "dbIdToBackupOrRestoreJobs");
+            legacyMap.put(dbId, jobDeque);
+
+            Deencapsulation.invoke(handler, "rebuildConcurrencyStateAfterRestart");
+
+            Assert.assertEquals(350, handler.getGlobalSnapshotTasks());
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    /**
+     * Test rebuildConcurrencyStateAfterRestart does not count completed jobs.
+     *
+     * Scenario: One active job with snapshotTaskCount=200 and one FINISHED job with snapshotTaskCount=100
+     * Expected: globalSnapshotTasks should only reflect the active job (200)
+     */
+    @Test
+    public void testRebuildConcurrencyStateSkipsCompletedJobs() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+
+        BackupHandler handler = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            BackupJob activeJob = new BackupJob("active_job", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(activeJob, "jobId", 1L);
+            Deencapsulation.setField(activeJob, "snapshotTaskCount", 200);
+            Deencapsulation.setField(activeJob, "state", BackupJob.BackupJobState.SNAPSHOTING);
+
+            BackupJob finishedJob = new BackupJob("finished_job", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(finishedJob, "jobId", 2L);
+            Deencapsulation.setField(finishedJob, "snapshotTaskCount", 100);
+            Deencapsulation.setField(finishedJob, "state", BackupJob.BackupJobState.FINISHED);
+
+            java.util.Deque<AbstractJob> jobDeque = new java.util.LinkedList<>();
+            jobDeque.add(activeJob);
+            jobDeque.add(finishedJob);
+            Map<Long, java.util.Deque<AbstractJob>> legacyMap = Deencapsulation.getField(handler, "dbIdToBackupOrRestoreJobs");
+            legacyMap.put(dbId, jobDeque);
+
+            Deencapsulation.invoke(handler, "rebuildConcurrencyStateAfterRestart");
+
+            // Only active job in running queue contributes to globalSnapshotTasks
+            Assert.assertEquals(200, handler.getGlobalSnapshotTasks());
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    // ===================== canExecute =====================
+
+    @Test
+    public void testCanExecuteDisabled() {
+        Config.enable_table_level_backup_concurrency = false;
+        BackupHandler h = new BackupHandler(env);
+        Assert.assertTrue(h.canExecute(999L));
+    }
+
+    @Test
+    public void testCanExecuteAllowedAndBlocked() {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        try {
+            Set<Long> allowed = Deencapsulation.getField(h, "allowedJobIds");
+            allowed.add(1L);
+            Assert.assertTrue(h.canExecute(1L));
+            Assert.assertFalse(h.canExecute(2L));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    // ===================== addRestoringTables / removeRestoringTables =====================
+
+    @Test
+    public void testAddRestoringTablesTableLevel() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            RestoreJob job = new RestoreJob();
+            Deencapsulation.setField(job, "jobId", 10L);
+            Deencapsulation.setField(job, "dbId", dbId);
+            List<TableRefInfo> refs = Lists.newArrayList();
+            refs.add(new TableRefInfo(new TableNameInfo("tbl_a"), null, null, null, null, null, null, null));
+            refs.add(new TableRefInfo(new TableNameInfo("tbl_b"), null, null, null, null, null, null, null));
+            job.setTableRefs(refs);
+
+            h.addRestoringTables(job);
+
+            Map<Long, Set<String>> restoring = Deencapsulation.getField(h, "restoringTables");
+            Assert.assertTrue(restoring.get(dbId).contains("tbl_a"));
+            Assert.assertTrue(restoring.get(dbId).contains("tbl_b"));
+
+            Deencapsulation.invoke(h, "removeRestoringTables", job);
+
+            Set<String> remaining = restoring.get(dbId);
+            Assert.assertTrue(remaining == null || remaining.isEmpty());
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testAddRestoringTablesFullDatabase() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> stats = Deencapsulation.getField(h, "dbJobStats");
+            stats.put(dbId, new BackupHandler.DatabaseJobStats());
+
+            RestoreJob job = new RestoreJob();
+            Deencapsulation.setField(job, "jobId", 20L);
+            Deencapsulation.setField(job, "dbId", dbId);
+            Deencapsulation.setField(job, "label", "full_restore");
+            job.setTableRefs(Lists.newArrayList());
+
+            h.addRestoringTables(job);
+
+            BackupHandler.DatabaseJobStats s = stats.get(dbId);
+            Assert.assertEquals(Long.valueOf(20L), s.restoreDatabaseJobId);
+            Assert.assertEquals("full_restore", s.restoreDatabaseLabel);
+
+            Deencapsulation.invoke(h, "removeRestoringTables", job);
+
+            Assert.assertNull(s.restoreDatabaseJobId);
+            Assert.assertNull(s.restoreDatabaseLabel);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    // ===================== onJobCompleted =====================
+
+    @Test
+    public void testOnJobCompletedBackup() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            BackupJob job = new BackupJob("completed_bk", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(job, "jobId", 100L);
+            Deencapsulation.setField(job, "state", BackupJob.BackupJobState.FINISHED);
+
+            // Simulate job was active: populate stats, labelIndex, allowedJobIds, running queue
+            Map<Long, BackupHandler.DatabaseJobStats> statsMap = Deencapsulation.getField(h, "dbJobStats");
+            BackupHandler.DatabaseJobStats stats = new BackupHandler.DatabaseJobStats();
+            stats.activeBackups = 1;
+            stats.activeLabels.add("completed_bk");
+            statsMap.put(dbId, stats);
+
+            Map<Long, Map<String, Long>> labels = Deencapsulation.getField(h, "labelIndex");
+            Map<String, Long> dbLabels = labels.computeIfAbsent(dbId,
+                    k -> new java.util.concurrent.ConcurrentHashMap<>());
+            dbLabels.put("completed_bk", 100L);
+
+            Set<Long> allowed = Deencapsulation.getField(h, "allowedJobIds");
+            allowed.add(100L);
+
+            // Add to running queue
+            Deencapsulation.invoke(h, "addActiveJob", dbId, (AbstractJob) job);
+
+            h.onJobCompleted(100L, dbId, job);
+
+            Assert.assertFalse(allowed.contains(100L));
+            // stats should be cleaned up (activeBackups back to 0)
+            Assert.assertFalse(statsMap.containsKey(dbId));
+            // label should be removed
+            Assert.assertFalse(labels.containsKey(dbId));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testOnJobCompletedRestore() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 2L;
+
+        try {
+            RestoreJob rJob = new RestoreJob();
+            Deencapsulation.setField(rJob, "jobId", 200L);
+            Deencapsulation.setField(rJob, "dbId", dbId);
+            Deencapsulation.setField(rJob, "label", "completed_rs");
+            Deencapsulation.setField(rJob, "state", RestoreJob.RestoreJobState.FINISHED);
+            List<TableRefInfo> refs = Lists.newArrayList();
+            refs.add(new TableRefInfo(new TableNameInfo("t1"), null, null, null, null, null, null, null));
+            rJob.setTableRefs(refs);
+
+            Map<Long, BackupHandler.DatabaseJobStats> statsMap = Deencapsulation.getField(h, "dbJobStats");
+            BackupHandler.DatabaseJobStats stats = new BackupHandler.DatabaseJobStats();
+            stats.activeRestores = 1;
+            stats.activeLabels.add("completed_rs");
+            statsMap.put(dbId, stats);
+
+            Map<Long, Map<String, Long>> labels = Deencapsulation.getField(h, "labelIndex");
+            Map<String, Long> dbLabels = labels.computeIfAbsent(dbId,
+                    k -> new java.util.concurrent.ConcurrentHashMap<>());
+            dbLabels.put("completed_rs", 200L);
+
+            Set<Long> allowed = Deencapsulation.getField(h, "allowedJobIds");
+            allowed.add(200L);
+
+            // Add restoring tables
+            Map<Long, Set<String>> restoring = Deencapsulation.getField(h, "restoringTables");
+            Set<String> tables = java.util.concurrent.ConcurrentHashMap.newKeySet();
+            tables.add("t1");
+            restoring.put(dbId, tables);
+
+            // Add to running queue
+            Deencapsulation.invoke(h, "addActiveJob", dbId, (AbstractJob) rJob);
+
+            h.onJobCompleted(200L, dbId, rJob);
+
+            Assert.assertFalse(allowed.contains(200L));
+            Assert.assertFalse(statsMap.containsKey(dbId));
+            // restoring tables should be cleaned
+            Set<String> remaining = restoring.get(dbId);
+            Assert.assertTrue(remaining == null || remaining.isEmpty());
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testOnJobCompletedSkipsWhenDisabled() {
+        Config.enable_table_level_backup_concurrency = false;
+        BackupHandler h = new BackupHandler(env);
+        BackupJob job = new BackupJob("skip_job", 1L, "test_db",
+                Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+        Deencapsulation.setField(job, "jobId", 300L);
+        // Should not throw or modify anything
+        h.onJobCompleted(300L, 1L, job);
+    }
+
+    // ===================== tryActivatePendingJobs =====================
+
+    @Test
+    public void testTryActivatePendingJobsActivatesPendingBackup() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> statsMap = Deencapsulation.getField(h, "dbJobStats");
+            statsMap.put(dbId, new BackupHandler.DatabaseJobStats());
+
+            BackupJob pendingJob = new BackupJob("pending_bk", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(pendingJob, "jobId", 50L);
+            Deencapsulation.setField(pendingJob, "state", BackupJob.BackupJobState.PENDING);
+
+            Deencapsulation.invoke(h, "addActiveJob", dbId, (AbstractJob) pendingJob);
+
+            Set<Long> allowed = Deencapsulation.getField(h, "allowedJobIds");
+            Assert.assertFalse(allowed.contains(50L));
+
+            Deencapsulation.invoke(h, "tryActivatePendingJobs", dbId);
+
+            Assert.assertTrue("Pending job should be activated", allowed.contains(50L));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testTryActivatePendingJobsSkipsAlreadyAllowed() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> statsMap = Deencapsulation.getField(h, "dbJobStats");
+            statsMap.put(dbId, new BackupHandler.DatabaseJobStats());
+
+            BackupJob runningJob = new BackupJob("running_bk", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(runningJob, "jobId", 60L);
+            Deencapsulation.setField(runningJob, "state", BackupJob.BackupJobState.SNAPSHOTING);
+
+            Set<Long> allowed = Deencapsulation.getField(h, "allowedJobIds");
+            allowed.add(60L);
+
+            Deencapsulation.invoke(h, "addActiveJob", dbId, (AbstractJob) runningJob);
+
+            // tryActivate should not add duplicates
+            Deencapsulation.invoke(h, "tryActivatePendingJobs", dbId);
+
+            Assert.assertTrue(allowed.contains(60L));
+            Assert.assertEquals(1, allowed.size());
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testTryActivatePendingJobsActivatesPendingRestore() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> statsMap = Deencapsulation.getField(h, "dbJobStats");
+            statsMap.put(dbId, new BackupHandler.DatabaseJobStats());
+
+            RestoreJob pendingRestore = new RestoreJob();
+            Deencapsulation.setField(pendingRestore, "jobId", 70L);
+            Deencapsulation.setField(pendingRestore, "dbId", dbId);
+            Deencapsulation.setField(pendingRestore, "label", "pending_rs");
+            Deencapsulation.setField(pendingRestore, "state", RestoreJob.RestoreJobState.PENDING);
+            List<TableRefInfo> refs = Lists.newArrayList();
+            refs.add(new TableRefInfo(new TableNameInfo("my_table"), null, null, null, null, null, null, null));
+            pendingRestore.setTableRefs(refs);
+
+            Deencapsulation.invoke(h, "addActiveJob", dbId, (AbstractJob) pendingRestore);
+
+            Set<Long> allowed = Deencapsulation.getField(h, "allowedJobIds");
+            Assert.assertFalse(allowed.contains(70L));
+
+            Deencapsulation.invoke(h, "tryActivatePendingJobs", dbId);
+
+            Assert.assertTrue("Pending restore should be activated", allowed.contains(70L));
+
+            // restoringTables should be populated
+            Map<Long, Set<String>> restoring = Deencapsulation.getField(h, "restoringTables");
+            Assert.assertTrue(restoring.containsKey(dbId));
+            Assert.assertTrue(restoring.get(dbId).contains("my_table"));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    // ===================== canActivateJob (public variant) =====================
+
+    @Test
+    public void testCanActivateJobVariant() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> statsMap = Deencapsulation.getField(h, "dbJobStats");
+            statsMap.put(dbId, new BackupHandler.DatabaseJobStats());
+
+            BackupJob bj = new BackupJob("can_act_bk", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(bj, "jobId", 80L);
+
+            boolean result = Deencapsulation.invoke(h, "canActivateJob",
+                    dbId, (AbstractJob) bj, true);
+            Assert.assertTrue(result);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    // ===================== handleFinishedSnapshotTask concurrent branch =====================
+
+    @Test
+    public void testHandleFinishedSnapshotTaskConcurrentFound() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            BackupJob bj = new BackupJob("snap_task_bk", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(bj, "jobId", 90L);
+            Deencapsulation.setField(bj, "state", BackupJob.BackupJobState.SNAPSHOTING);
+
+            Deencapsulation.invoke(h, "addActiveJob", dbId, (AbstractJob) bj);
+
+            // Create a restore-type SnapshotTask with matching jobId
+            // BackupJob receiving a restore task -> returns true (mismatch warning)
+            SnapshotTask task = new SnapshotTask(null, 1L, 1L, 90L, dbId,
+                    1L, 1L, 1L, 1L, 1L, 0, 3600000L, true);
+
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            request.setTaskStatus(new TStatus(TStatusCode.OK));
+
+            boolean result = h.handleFinishedSnapshotTask(task, request);
+            Assert.assertTrue("Mismatched restore task on backup job should return true", result);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testHandleFinishedSnapshotTaskConcurrentNotFound() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+
+        try {
+            SnapshotTask task = new SnapshotTask(null, 1L, 1L, 999L, 1L,
+                    1L, 1L, 1L, 1L, 1L, 0, 3600000L, false);
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            request.setTaskStatus(new TStatus(TStatusCode.OK));
+
+            boolean result = h.handleFinishedSnapshotTask(task, request);
+            Assert.assertTrue("Not-found job should return true", result);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    // ===================== handleFinishedSnapshotUploadTask concurrent branch =====================
+
+    @Test
+    public void testHandleUploadTaskConcurrentNotFound() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+
+        try {
+            UploadTask task = new UploadTask(null, 1L, 1L, 999L, 1L,
+                    Maps.newHashMap(), null, null, null, null);
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            request.setTaskStatus(new TStatus(TStatusCode.OK));
+
+            boolean result = h.handleFinishedSnapshotUploadTask(task, request);
+            Assert.assertFalse("Not-found/RestoreJob should return false", result);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    // ===================== handleDownloadSnapshotTask concurrent branch =====================
+
+    @Test
+    public void testHandleDownloadTaskConcurrentNotFound() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+
+        try {
+            DownloadTask task = new DownloadTask(null, 1L, 1L, 999L, 1L,
+                    Maps.newHashMap(), null, null, null, null, null);
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            request.setTaskStatus(new TStatus(TStatusCode.OK));
+
+            boolean result = h.handleDownloadSnapshotTask(task, request);
+            Assert.assertTrue("Not-found should return true", result);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    // ===================== handleDirMoveTask concurrent branch =====================
+
+    @Test
+    public void testHandleDirMoveTaskConcurrentNotFound() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+
+        try {
+            DirMoveTask task = new DirMoveTask(null, 1L, 1L, 999L, 1L,
+                    1L, 1L, 1L, 1L, "/tmp", 0, false);
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            request.setTaskStatus(new TStatus(TStatusCode.OK));
+
+            boolean result = h.handleDirMoveTask(task, request);
+            Assert.assertTrue("Not-found should return true", result);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testHandleDirMoveTaskConcurrentFoundRestore() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            RestoreJob rj = new RestoreJob();
+            Deencapsulation.setField(rj, "jobId", 110L);
+            Deencapsulation.setField(rj, "dbId", dbId);
+            Deencapsulation.setField(rj, "label", "dir_move_rs");
+            rj.setTableRefs(Lists.newArrayList());
+
+            Deencapsulation.invoke(h, "addActiveJob", dbId, (AbstractJob) rj);
+
+            DirMoveTask task = new DirMoveTask(null, 1L, 1L, 110L, dbId,
+                    1L, 1L, 1L, 1L, "/tmp", 0, false);
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            request.setTaskStatus(new TStatus(TStatusCode.OK));
+
+            // RestoreJob found, calls finishDirMoveTask which may throw if not fully initialized
+            // but the concurrent LOOKUP path is exercised
+            try {
+                h.handleDirMoveTask(task, request);
+            } catch (Exception e) {
+                // Expected: RestoreJob not fully initialized
+            }
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    // ===================== replayAddJob concurrent branch =====================
+
+    @Test
+    public void testReplayAddJobConcurrentPendingJob() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            // PENDING jobs go directly to queue assignment without needing existing job
+            BackupJob job = new BackupJob("replay_pending", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(job, "jobId", 120L);
+            // Default state is PENDING
+
+            h.replayAddJob(job);
+
+            // Should be in running queue (active/pending)
+            Map<Long, java.util.Deque<AbstractJob>> running =
+                    Deencapsulation.getField(h, "dbIdToRunningJobs");
+            Assert.assertTrue(running.containsKey(dbId));
+            Assert.assertEquals(1, running.get(dbId).size());
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testReplayAddJobConcurrentCancelledJob() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            // Add existing PENDING job to running queue (concurrent mode uses dbIdToRunningJobs)
+            BackupJob existingJob = new BackupJob("replay_cancel", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(existingJob, "jobId", 130L);
+            Deencapsulation.setField(existingJob, "state", BackupJob.BackupJobState.PENDING);
+            Deencapsulation.invoke(h, "addActiveJob", dbId, (AbstractJob) existingJob);
+
+            // Replay a cancelled version
+            BackupJob cancelledJob = new BackupJob("replay_cancel", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(cancelledJob, "jobId", 130L);
+            Deencapsulation.setField(cancelledJob, "state", BackupJob.BackupJobState.CANCELLED);
+
+            h.replayAddJob(cancelledJob);
+
+            // Cancelled job should be in history queue
+            Map<Long, java.util.Deque<AbstractJob>> history =
+                    Deencapsulation.getField(h, "dbIdToHistoryJobs");
+            Assert.assertTrue(history.containsKey(dbId));
+            Assert.assertEquals(1, history.get(dbId).size());
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    // ===================== getJobs / getCurrentJob concurrent path =====================
+
+    @Test
+    public void testGetJobsConcurrentMode() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            BackupJob runJob = new BackupJob("get_jobs_run", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(runJob, "jobId", 140L);
+
+            BackupJob histJob = new BackupJob("get_jobs_hist", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(histJob, "jobId", 141L);
+            Deencapsulation.setField(histJob, "state", BackupJob.BackupJobState.FINISHED);
+
+            Deencapsulation.invoke(h, "addActiveJob", dbId, (AbstractJob) runJob);
+            Deencapsulation.invoke(h, "addToHistoryQueue", dbId, (AbstractJob) histJob);
+
+            List<AbstractJob> jobs = h.getJobs(dbId, label -> true);
+            Assert.assertEquals(2, jobs.size());
+
+            // getCurrentJob should return the last running job
+            AbstractJob current = h.getJob(dbId);
+            Assert.assertEquals(140L, current.getJobId());
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    // ===================== onJobActivated / onJobDeactivated direct tests =====================
+
+    @Test
+    public void testOnJobActivatedBackupFullDatabase() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> statsMap = Deencapsulation.getField(h, "dbJobStats");
+            statsMap.put(dbId, new BackupHandler.DatabaseJobStats());
+
+            BackupJob job = new BackupJob("act_full_bk", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(job, "jobId", 150L);
+
+            Deencapsulation.invoke(h, "onJobActivated", dbId, (AbstractJob) job, true, true);
+
+            BackupHandler.DatabaseJobStats s = statsMap.get(dbId);
+            Assert.assertEquals(1, s.runningBackups);
+            Assert.assertEquals(Long.valueOf(150L), s.runningBackupDatabaseJobId);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testOnJobActivatedRestore() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> statsMap = Deencapsulation.getField(h, "dbJobStats");
+            statsMap.put(dbId, new BackupHandler.DatabaseJobStats());
+
+            RestoreJob job = new RestoreJob();
+            Deencapsulation.setField(job, "jobId", 160L);
+
+            Deencapsulation.invoke(h, "onJobActivated", dbId, (AbstractJob) job, false, false);
+
+            BackupHandler.DatabaseJobStats s = statsMap.get(dbId);
+            Assert.assertEquals(1, s.runningRestores);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testOnJobDeactivatedClearsBackupDatabaseId() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> statsMap = Deencapsulation.getField(h, "dbJobStats");
+            BackupHandler.DatabaseJobStats s = new BackupHandler.DatabaseJobStats();
+            s.runningBackups = 1;
+            s.runningBackupDatabaseJobId = 170L;
+            statsMap.put(dbId, s);
+
+            BackupJob job = new BackupJob("deact_bk", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(job, "jobId", 170L);
+
+            Deencapsulation.invoke(h, "onJobDeactivated", dbId, (AbstractJob) job, true);
+
+            Assert.assertEquals(0, s.runningBackups);
+            Assert.assertNull(s.runningBackupDatabaseJobId);
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testOnJobDeactivatedDecrementsRestoreAndGlobal() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            Map<Long, BackupHandler.DatabaseJobStats> statsMap = Deencapsulation.getField(h, "dbJobStats");
+            BackupHandler.DatabaseJobStats s = new BackupHandler.DatabaseJobStats();
+            s.runningRestores = 1;
+            statsMap.put(dbId, s);
+
+            h.addGlobalSnapshotTasks(50);
+
+            RestoreJob job = new RestoreJob();
+            Deencapsulation.setField(job, "jobId", 180L);
+            Deencapsulation.setField(job, "snapshotTaskCount", 50);
+
+            Deencapsulation.invoke(h, "onJobDeactivated", dbId, (AbstractJob) job, false);
+
+            Assert.assertEquals(0, s.runningRestores);
+            Assert.assertEquals(0, h.getGlobalSnapshotTasks());
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    // ===================== onJobCreated direct tests =====================
+
+    @Test
+    public void testOnJobCreatedBackupFullDatabase() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            BackupJob job = new BackupJob("created_full_bk", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(job, "jobId", 190L);
+
+            Deencapsulation.invoke(h, "onJobCreated", dbId, (AbstractJob) job, true, true);
+
+            Map<Long, BackupHandler.DatabaseJobStats> statsMap = Deencapsulation.getField(h, "dbJobStats");
+            BackupHandler.DatabaseJobStats s = statsMap.get(dbId);
+            Assert.assertEquals(1, s.activeBackups);
+            Assert.assertEquals(Long.valueOf(190L), s.backupDatabaseJobId);
+            Assert.assertEquals("created_full_bk", s.backupDatabaseLabel);
+            Assert.assertTrue(s.activeLabels.contains("created_full_bk"));
+
+            Map<Long, Map<String, Long>> labels = Deencapsulation.getField(h, "labelIndex");
+            Assert.assertEquals(Long.valueOf(190L), labels.get(dbId).get("created_full_bk"));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testOnJobCreatedRestore() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            RestoreJob job = new RestoreJob();
+            Deencapsulation.setField(job, "jobId", 200L);
+            Deencapsulation.setField(job, "label", "created_rs");
+
+            Deencapsulation.invoke(h, "onJobCreated", dbId, (AbstractJob) job, false, false);
+
+            Map<Long, BackupHandler.DatabaseJobStats> statsMap = Deencapsulation.getField(h, "dbJobStats");
+            BackupHandler.DatabaseJobStats s = statsMap.get(dbId);
+            Assert.assertEquals(1, s.activeRestores);
+            Assert.assertTrue(s.activeLabels.contains("created_rs"));
+        } finally {
+            Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    // ===================== addToHistoryQueue / cleanupJobResources =====================
+
+    @Test
+    public void testAddToHistoryQueueFIFOCleanup() throws Exception {
+        Config.enable_table_level_backup_concurrency = true;
+        int origLimit = Config.max_backup_restore_job_num_per_db;
+        Config.max_backup_restore_job_num_per_db = 2;
+        BackupHandler h = new BackupHandler(env);
+        long dbId = 1L;
+
+        try {
+            BackupJob j1 = new BackupJob("hist1", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(j1, "jobId", 210L);
+            Deencapsulation.setField(j1, "state", BackupJob.BackupJobState.FINISHED);
+            BackupJob j2 = new BackupJob("hist2", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(j2, "jobId", 211L);
+            Deencapsulation.setField(j2, "state", BackupJob.BackupJobState.FINISHED);
+            BackupJob j3 = new BackupJob("hist3", dbId, "test_db",
+                    Lists.newArrayList(), 3600000L, BackupCommand.BackupContent.ALL, env, 0L, 0L);
+            Deencapsulation.setField(j3, "jobId", 212L);
+            Deencapsulation.setField(j3, "state", BackupJob.BackupJobState.FINISHED);
+
+            Deencapsulation.invoke(h, "addToHistoryQueue", dbId, (AbstractJob) j1);
+            Deencapsulation.invoke(h, "addToHistoryQueue", dbId, (AbstractJob) j2);
+            Deencapsulation.invoke(h, "addToHistoryQueue", dbId, (AbstractJob) j3);
+
+            Map<Long, java.util.Deque<AbstractJob>> history = Deencapsulation.getField(h, "dbIdToHistoryJobs");
+            Assert.assertEquals(2, history.get(dbId).size());
+            // j1 should be evicted, j2 and j3 remain
+            Assert.assertEquals(211L, history.get(dbId).peekFirst().getJobId());
+        } finally {
+            Config.max_backup_restore_job_num_per_db = origLimit;
+            Config.enable_table_level_backup_concurrency = false;
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -28,6 +28,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.common.util.UnitTestUtil;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.property.storage.BrokerProperties;
@@ -70,6 +71,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class BackupJobTest {
@@ -627,5 +629,188 @@ public class BackupJobTest {
         // 3. delete files
         in.close();
         Files.delete(path);
+    }
+
+    private void allowJobExecution(BackupJob j) {
+        Deencapsulation.setField(j, "jobId", id.getAndIncrement());
+        Set<Long> allowedJobIds = Deencapsulation.getField(backupHandler, "allowedJobIds");
+        allowedJobIds.add(j.getJobId());
+    }
+
+    /**
+     * Test per-job tablet limit rejects backup when tablet count exceeds max_backup_tablets_per_job.
+     *
+     * Scenario: Set max_backup_tablets_per_job to 0, run backup
+     * Expected: Job should be CANCELLED with error about exceeding tablet limit
+     */
+    @Test
+    public void testPerJobTabletLimitRejectsWhenExceeded() {
+        int saved = Config.max_backup_tablets_per_job;
+        Config.max_backup_tablets_per_job = 0;
+        try {
+            AgentTaskQueue.clearAllTasks();
+            job.run();
+            Assert.assertEquals(BackupJobState.CANCELLED, job.getState());
+            Assert.assertTrue(job.getStatus().getErrMsg().contains("exceeds the limit"));
+        } finally {
+            Config.max_backup_tablets_per_job = saved;
+        }
+    }
+
+    /**
+     * Test global snapshot task limit rejects backup in concurrent mode.
+     *
+     * Scenario: Enable concurrency, set global limit to 1, pre-add 1 task so job's 1 tablet exceeds
+     * Expected: 1 + 1 > 1, Job should be CANCELLED with error about global limit
+     */
+    @Test
+    public void testGlobalSnapshotTaskLimitRejectsInConcurrentMode() {
+        int savedLimit = Config.max_concurrent_snapshot_tasks_total;
+        boolean savedConcurrency = Config.enable_table_level_backup_concurrency;
+        Config.enable_table_level_backup_concurrency = true;
+        Config.max_concurrent_snapshot_tasks_total = 1;
+        try {
+            AgentTaskQueue.clearAllTasks();
+            allowJobExecution(job);
+            backupHandler.addGlobalSnapshotTasks(1);
+            job.run();
+            Assert.assertEquals(BackupJobState.CANCELLED, job.getState());
+            Assert.assertTrue(job.getStatus().getErrMsg().contains("global concurrent snapshot tasks"));
+        } finally {
+            Config.max_concurrent_snapshot_tasks_total = savedLimit;
+            Config.enable_table_level_backup_concurrency = savedConcurrency;
+            backupHandler.addGlobalSnapshotTasks(-backupHandler.getGlobalSnapshotTasks());
+        }
+    }
+
+    /**
+     * Test global snapshot task limit rejects when existing tasks + new tasks exceed limit.
+     *
+     * Scenario: Pre-add 90 global tasks, set limit to 100, backup has 1 tablet (1 task)
+     * Expected: With global=90 + job=1 <= 100, should proceed to SNAPSHOTING
+     */
+    @Test
+    public void testGlobalSnapshotTaskLimitAllowsWithinBound() {
+        int savedLimit = Config.max_concurrent_snapshot_tasks_total;
+        boolean savedConcurrency = Config.enable_table_level_backup_concurrency;
+        Config.enable_table_level_backup_concurrency = true;
+        Config.max_concurrent_snapshot_tasks_total = 100;
+        try {
+            AgentTaskQueue.clearAllTasks();
+            allowJobExecution(job);
+            backupHandler.addGlobalSnapshotTasks(90);
+            job.run();
+            Assert.assertEquals(BackupJobState.SNAPSHOTING, job.getState());
+            Assert.assertEquals(Status.OK, job.getStatus());
+            // 90 + 1 tablet = 91
+            Assert.assertEquals(91, backupHandler.getGlobalSnapshotTasks());
+        } finally {
+            Config.max_concurrent_snapshot_tasks_total = savedLimit;
+            Config.enable_table_level_backup_concurrency = savedConcurrency;
+            backupHandler.addGlobalSnapshotTasks(-backupHandler.getGlobalSnapshotTasks());
+        }
+    }
+
+    /**
+     * Test global snapshot task limit rejects when sum exceeds limit.
+     *
+     * Scenario: Pre-add 100 global tasks, set limit to 100, backup adds 1 more
+     * Expected: 100 + 1 > 100, should be CANCELLED
+     */
+    @Test
+    public void testGlobalSnapshotTaskLimitRejectsWhenExceeded() {
+        int savedLimit = Config.max_concurrent_snapshot_tasks_total;
+        boolean savedConcurrency = Config.enable_table_level_backup_concurrency;
+        Config.enable_table_level_backup_concurrency = true;
+        Config.max_concurrent_snapshot_tasks_total = 100;
+        try {
+            AgentTaskQueue.clearAllTasks();
+            allowJobExecution(job);
+            backupHandler.addGlobalSnapshotTasks(100);
+            job.run();
+            Assert.assertEquals(BackupJobState.CANCELLED, job.getState());
+            Assert.assertTrue(job.getStatus().getErrMsg().contains("would exceed the limit"));
+        } finally {
+            Config.max_concurrent_snapshot_tasks_total = savedLimit;
+            Config.enable_table_level_backup_concurrency = savedConcurrency;
+            backupHandler.addGlobalSnapshotTasks(-backupHandler.getGlobalSnapshotTasks());
+        }
+    }
+
+    /**
+     * Test global snapshot task limit is skipped when concurrency is disabled.
+     *
+     * Scenario: Disable concurrency, set global limit to 0
+     * Expected: Job proceeds to SNAPSHOTING ignoring global limit, snapshotTaskCount stays 0
+     */
+    @Test
+    public void testGlobalSnapshotTaskLimitSkippedWhenConcurrencyDisabled() {
+        int savedLimit = Config.max_concurrent_snapshot_tasks_total;
+        boolean savedConcurrency = Config.enable_table_level_backup_concurrency;
+        Config.enable_table_level_backup_concurrency = false;
+        Config.max_concurrent_snapshot_tasks_total = 0;
+        try {
+            AgentTaskQueue.clearAllTasks();
+            job.run();
+            Assert.assertEquals(BackupJobState.SNAPSHOTING, job.getState());
+            Assert.assertEquals(Status.OK, job.getStatus());
+            Assert.assertEquals(0, job.getSnapshotTaskCount());
+            Assert.assertEquals(0, backupHandler.getGlobalSnapshotTasks());
+        } finally {
+            Config.max_concurrent_snapshot_tasks_total = savedLimit;
+            Config.enable_table_level_backup_concurrency = savedConcurrency;
+        }
+    }
+
+    /**
+     * Test snapshotTaskCount is persisted during serialization.
+     *
+     * Scenario: Run backup in concurrent mode, serialize and deserialize
+     * Expected: snapshotTaskCount should be preserved after deserialization
+     */
+    @Test
+    public void testSnapshotTaskCountPersisted() throws IOException, AnalysisException {
+        boolean savedConcurrency = Config.enable_table_level_backup_concurrency;
+        Config.enable_table_level_backup_concurrency = true;
+        try {
+            AgentTaskQueue.clearAllTasks();
+            allowJobExecution(job);
+            job.run();
+            Assert.assertEquals(BackupJobState.SNAPSHOTING, job.getState());
+            int expectedCount = job.getSnapshotTaskCount();
+            Assert.assertTrue(expectedCount > 0);
+
+            final Path path = Files.createTempFile("backupJobStc", "tmp");
+            DataOutputStream out = new DataOutputStream(Files.newOutputStream(path));
+            job.write(out);
+            out.flush();
+            out.close();
+
+            DataInputStream in = new DataInputStream(Files.newInputStream(path));
+            BackupJob job2 = BackupJob.read(in);
+            Assert.assertEquals(expectedCount, job2.getSnapshotTaskCount());
+
+            in.close();
+            Files.delete(path);
+        } finally {
+            Config.enable_table_level_backup_concurrency = savedConcurrency;
+            backupHandler.addGlobalSnapshotTasks(-backupHandler.getGlobalSnapshotTasks());
+        }
+    }
+
+    @Test
+    public void testExecutionGateBlocksInConcurrentMode() {
+        boolean savedConcurrency = Config.enable_table_level_backup_concurrency;
+        Config.enable_table_level_backup_concurrency = true;
+        try {
+            AgentTaskQueue.clearAllTasks();
+            // Do NOT call allowJobExecution, so job is not in allowedJobIds
+            Deencapsulation.setField(job, "jobId", id.getAndIncrement());
+            job.run();
+            // Job should stay PENDING because it lacks execution permission
+            Assert.assertEquals(BackupJobState.PENDING, job.getState());
+        } finally {
+            Config.enable_table_level_backup_concurrency = savedConcurrency;
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreJobTest.java
@@ -140,6 +140,7 @@ public class RestoreJobTest {
         Mockito.when(catalog.getDbNullable(Mockito.anyLong())).thenReturn(db);
         Mockito.when(env.getNextId()).thenAnswer(inv -> id.getAndIncrement());
         Mockito.when(env.getEditLog()).thenReturn(editLog);
+        Mockito.when(env.getBackupHandler()).thenReturn(backupHandler);
 
         Mockito.doAnswer(inv -> {
             List<Long> beIds = Lists.newArrayList();
@@ -297,5 +298,87 @@ public class RestoreJobTest {
         Partition localPart = remoteTbl.getPartition(partName);
         Assert.assertEquals(localPart.getVisibleVersion(), visibleVersion);
         Assert.assertEquals(localPart.getNextVersion(), visibleVersion + 1);
+    }
+
+    /**
+     * Test snapshotTaskCount defaults to 0 for a new RestoreJob.
+     */
+    @Test
+    public void testSnapshotTaskCountDefaultZero() {
+        Assert.assertEquals(0, job.getSnapshotTaskCount());
+    }
+
+    /**
+     * Test snapshotTaskCount is persisted during serialization/deserialization.
+     *
+     * Scenario: Set snapshotTaskCount via reflection, serialize and deserialize
+     * Expected: Value should be preserved
+     */
+    @Test
+    public void testSnapshotTaskCountPersisted() throws IOException, AnalysisException {
+        Deencapsulation.setField(job, "snapshotTaskCount", 42);
+        Assert.assertEquals(42, job.getSnapshotTaskCount());
+
+        final Path path = Files.createTempFile("restoreJobStc", "tmp");
+        DataOutputStream out = new DataOutputStream(Files.newOutputStream(path));
+        job.write(out);
+        out.flush();
+        out.close();
+
+        DataInputStream in = new DataInputStream(Files.newInputStream(path));
+        RestoreJob job2 = RestoreJob.read(in);
+        Assert.assertEquals(42, job2.getSnapshotTaskCount());
+
+        in.close();
+        Files.delete(path);
+    }
+
+    @Test
+    public void testSetAndGetTableRefs() {
+        Assert.assertNotNull(job.getTableRefs());
+        Assert.assertTrue(job.getTableRefs().isEmpty());
+
+        List<org.apache.doris.info.TableRefInfo> refs = Lists.newArrayList();
+        refs.add(new org.apache.doris.info.TableRefInfo(
+                new org.apache.doris.catalog.info.TableNameInfo("test_tbl"),
+                null, null, null, null, null, null, null));
+        job.setTableRefs(refs);
+
+        Assert.assertEquals(1, job.getTableRefs().size());
+        Assert.assertEquals("test_tbl", job.getTableRefs().get(0).getTableNameInfo().getTbl());
+    }
+
+    @Test
+    public void testGetInfoQueuePosBlockReasonDisabled() {
+        org.apache.doris.common.Config.enable_table_level_backup_concurrency = false;
+
+        List<String> info = job.getFullInfo();
+        Assert.assertTrue(info.size() >= 23);
+        Assert.assertEquals("", info.get(info.size() - 2));
+        Assert.assertEquals("", info.get(info.size() - 1));
+    }
+
+    @Test
+    public void testGetInfoQueuePosBlockReasonEnabled() {
+        org.apache.doris.common.Config.enable_table_level_backup_concurrency = true;
+
+        try {
+            List<String> info = job.getFullInfo();
+            Assert.assertTrue(info.size() >= 23);
+            String queuePos = info.get(info.size() - 2);
+            Assert.assertNotNull(queuePos);
+        } finally {
+            org.apache.doris.common.Config.enable_table_level_backup_concurrency = false;
+        }
+    }
+
+    @Test
+    public void testGetInfoBriefQueuePosBlockReason() {
+        org.apache.doris.common.Config.enable_table_level_backup_concurrency = false;
+
+        List<String> info = job.getBriefInfo();
+        Assert.assertTrue(info.size() >= 20);
+        Assert.assertEquals("", info.get(info.size() - 2));
+        Assert.assertEquals("", info.get(info.size() - 1));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CancelBackupCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CancelBackupCommandTest.java
@@ -30,6 +30,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+/**
+ * Tests for CancelBackupCommand label matching functionality.
+ */
 public class CancelBackupCommandTest {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
 
@@ -74,5 +77,147 @@ public class CancelBackupCommandTest {
 
         CancelBackupCommand command = new CancelBackupCommand(dbName, false);
         Assertions.assertDoesNotThrow(() -> command.validate(connectContext));
+    }
+
+    @Test
+    public void testMatchesLabel_ExactMatch() {
+        CancelBackupCommand cmd = new CancelBackupCommand("test_db", false, "backup1", false);
+
+        Assertions.assertTrue(cmd.matchesLabel("backup1"));
+        Assertions.assertFalse(cmd.matchesLabel("backup2"));
+        Assertions.assertFalse(cmd.matchesLabel("backup11"));
+        Assertions.assertFalse(cmd.matchesLabel("xbackup1"));
+    }
+
+    @Test
+    public void testMatchesLabel_LikeWithPercent() {
+        CancelBackupCommand cmd = new CancelBackupCommand("test_db", false, "test_%", true);
+
+        Assertions.assertTrue(cmd.matchesLabel("test_backup1"));
+        Assertions.assertTrue(cmd.matchesLabel("test_restore1"));
+        Assertions.assertTrue(cmd.matchesLabel("test_"));
+        Assertions.assertFalse(cmd.matchesLabel("backup1"));
+        Assertions.assertFalse(cmd.matchesLabel("tes_backup"));
+    }
+
+    @Test
+    public void testMatchesLabel_LikeWithUnderscore() {
+        // LIKE with underscore (single char wildcard): backup_00_
+        CancelBackupCommand cmd = new CancelBackupCommand("test_db", false, "backup_00_", true);
+
+        Assertions.assertTrue(cmd.matchesLabel("backup_001"));
+        Assertions.assertTrue(cmd.matchesLabel("backup_002"));
+        Assertions.assertTrue(cmd.matchesLabel("backup_00x"));
+        Assertions.assertFalse(cmd.matchesLabel("backup_0011"));  // too long
+        Assertions.assertFalse(cmd.matchesLabel("backup_00"));    // too short
+    }
+
+    @Test
+    public void testMatchesLabel_LikeComplexPattern() {
+        // Pattern: %_2023%
+        CancelBackupCommand cmd = new CancelBackupCommand("test_db", false, "%_2023%", true);
+
+        Assertions.assertTrue(cmd.matchesLabel("backup_20230101"));
+        Assertions.assertTrue(cmd.matchesLabel("test_2023_backup"));
+        Assertions.assertTrue(cmd.matchesLabel("x_2023x"));
+        Assertions.assertFalse(cmd.matchesLabel("backup_2024"));
+        Assertions.assertFalse(cmd.matchesLabel("2023"));  // underscore before 2023 is required
+    }
+
+    @Test
+    public void testMatchesLabel_Null() {
+        // label = null means match all
+        CancelBackupCommand cmd = new CancelBackupCommand("test_db", false, null, false);
+
+        Assertions.assertTrue(cmd.matchesLabel("backup1"));
+        Assertions.assertTrue(cmd.matchesLabel("backup2"));
+        Assertions.assertTrue(cmd.matchesLabel("any_label"));
+        Assertions.assertTrue(cmd.matchesLabel(""));
+    }
+
+    @Test
+    public void testMatchesLabel_EmptyString() {
+        CancelBackupCommand cmd = new CancelBackupCommand("test_db", false, "", false);
+
+        Assertions.assertTrue(cmd.matchesLabel(""));
+        Assertions.assertFalse(cmd.matchesLabel("backup1"));
+    }
+
+    @Test
+    public void testMatchesLabel_LikePercentOnly() {
+        // LIKE % matches everything
+        CancelBackupCommand cmd = new CancelBackupCommand("test_db", false, "%", true);
+
+        Assertions.assertTrue(cmd.matchesLabel("backup1"));
+        Assertions.assertTrue(cmd.matchesLabel("any_label"));
+        Assertions.assertTrue(cmd.matchesLabel(""));
+    }
+
+    @Test
+    public void testMatchesLabel_LikeStartsWith() {
+        // LIKE test%
+        CancelBackupCommand cmd = new CancelBackupCommand("test_db", false, "test%", true);
+
+        Assertions.assertTrue(cmd.matchesLabel("test"));
+        Assertions.assertTrue(cmd.matchesLabel("test_backup"));
+        Assertions.assertTrue(cmd.matchesLabel("testing"));
+        Assertions.assertFalse(cmd.matchesLabel("xtest"));
+        Assertions.assertFalse(cmd.matchesLabel("backup_test"));
+    }
+
+    @Test
+    public void testMatchesLabel_LikeEndsWith() {
+        // LIKE %_backup
+        CancelBackupCommand cmd = new CancelBackupCommand("test_db", false, "%_backup", true);
+
+        Assertions.assertTrue(cmd.matchesLabel("test_backup"));
+        Assertions.assertTrue(cmd.matchesLabel("prod_backup"));
+        Assertions.assertTrue(cmd.matchesLabel("x_backup"));
+        Assertions.assertFalse(cmd.matchesLabel("backup"));       // no underscore
+        Assertions.assertFalse(cmd.matchesLabel("backup_test"));  // not ending with _backup
+    }
+
+    @Test
+    public void testBackwardCompatibility() {
+        // Old constructor should work
+        CancelBackupCommand cmd = new CancelBackupCommand("test_db", false);
+
+        Assertions.assertNull(cmd.getLabel());
+        Assertions.assertFalse(cmd.isLike());
+        Assertions.assertTrue(cmd.matchesLabel("any_label"));  // Should match all
+    }
+
+    @Test
+    public void testRestore() {
+        // Test restore command
+        CancelBackupCommand cmd = new CancelBackupCommand("test_db", true, "restore1", false);
+
+        Assertions.assertTrue(cmd.isRestore());
+        Assertions.assertTrue(cmd.matchesLabel("restore1"));
+        Assertions.assertFalse(cmd.matchesLabel("restore2"));
+    }
+
+    @Test
+    public void testMatchesLabel_RegexSpecialCharsInExact() {
+        CancelBackupCommand cmd = new CancelBackupCommand("test_db", false, "test.backup", false);
+
+        Assertions.assertTrue(cmd.matchesLabel("test.backup"));
+        Assertions.assertFalse(cmd.matchesLabel("testabackup"));
+    }
+
+    @Test
+    public void testMatchesLabel_RegexSpecialCharsInLike() {
+
+        CancelBackupCommand dotCmd = new CancelBackupCommand("test_db", false, "test.backup%", true);
+        Assertions.assertTrue(dotCmd.matchesLabel("test.backup_001"));
+        Assertions.assertFalse(dotCmd.matchesLabel("testabackup_001"));
+
+        CancelBackupCommand bracketCmd = new CancelBackupCommand("test_db", false, "test[1-9]%", true);
+        Assertions.assertTrue(bracketCmd.matchesLabel("test[1-9]_backup"));
+        Assertions.assertFalse(bracketCmd.matchesLabel("test1_backup"));
+
+        CancelBackupCommand parenCmd = new CancelBackupCommand("test_db", false, "test(a)%", true);
+        Assertions.assertTrue(parenCmd.matchesLabel("test(a)_backup"));
+        Assertions.assertFalse(parenCmd.matchesLabel("testa_backup"));
     }
 }

--- a/regression-test/suites/backup_restore/test_backup_restore_concurrency.groovy
+++ b/regression-test/suites/backup_restore/test_backup_restore_concurrency.groovy
@@ -1,0 +1,257 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_backup_restore_concurrency", "backup_restore,nonConcurrent") {
+    String suiteName = "test_backup_restore_concurrency"
+    String repoName = "${suiteName}_repo_" + UUID.randomUUID().toString().replace("-", "")
+    String dbName = "${suiteName}_db"
+    int numRows = 10
+
+    // Save original config value for safe restore
+    def origConcurrency = sql """ ADMIN SHOW FRONTEND CONFIG LIKE 'enable_table_level_backup_concurrency' """
+    def origConcurrency_val = origConcurrency[0][1] as String
+
+    def syncer = getSyncer()
+    syncer.createS3Repository(repoName)
+
+    sql "CREATE DATABASE IF NOT EXISTS ${dbName}"
+
+    // Create 3 independent tables for concurrent tests
+    def tableNames = ["${suiteName}_t1", "${suiteName}_t2", "${suiteName}_t3"]
+    for (tbl in tableNames) {
+        sql "DROP TABLE IF EXISTS ${dbName}.${tbl}"
+        sql """
+            CREATE TABLE ${dbName}.${tbl} (
+                `id` LARGEINT NOT NULL,
+                `count` LARGEINT SUM DEFAULT "0")
+            AGGREGATE KEY(`id`)
+            DISTRIBUTED BY HASH(`id`) BUCKETS 2
+            PROPERTIES ("replication_num" = "1")
+        """
+        List<String> values = []
+        for (int i = 1; i <= numRows; ++i) {
+            values.add("(${i}, ${i})")
+        }
+        sql "INSERT INTO ${dbName}.${tbl} VALUES ${values.join(",")}"
+    }
+
+    // ========================================================================
+    // Test 1: Concurrent backup of multiple tables
+    // ========================================================================
+    // With concurrency enabled, multiple table-level backups should run simultaneously.
+    try {
+        sql """ ADMIN SET FRONTEND CONFIG ("enable_table_level_backup_concurrency" = "true") """
+
+        // Submit 3 backups on different tables
+        for (int i = 0; i < tableNames.size(); i++) {
+            sql """
+                BACKUP SNAPSHOT ${dbName}.${suiteName}_concurrent_bk_${i}
+                TO `${repoName}`
+                ON (${tableNames[i]})
+            """
+        }
+
+        // Check that multiple backups are visible (not just 1)
+        def showBackup = sql_return_maparray "SHOW BACKUP FROM ${dbName}"
+        logger.info("Concurrent backups submitted: ${showBackup.size()} jobs")
+        assertTrue(showBackup.size() >= 3, "Expected at least 3 backup jobs, got ${showBackup.size()}")
+
+        // Wait for all to complete
+        syncer.waitSnapshotFinish(dbName)
+
+        // Verify all finished
+        showBackup = sql_return_maparray "SHOW BACKUP FROM ${dbName}"
+        int finishedCount = 0
+        for (row in showBackup) {
+            if ((row.State as String) == "FINISHED") {
+                finishedCount++
+            }
+        }
+        logger.info("Concurrent backup results: ${finishedCount} finished out of ${showBackup.size()}")
+        assertTrue(finishedCount >= 3, "Expected at least 3 FINISHED backups, got ${finishedCount}")
+
+    } finally {
+        sql """ ADMIN SET FRONTEND CONFIG ("enable_table_level_backup_concurrency" = "${origConcurrency_val}") """
+    }
+
+    // ========================================================================
+    // Test 2: Concurrent restore of non-conflicting tables
+    // ========================================================================
+    try {
+        sql """ ADMIN SET FRONTEND CONFIG ("enable_table_level_backup_concurrency" = "true") """
+
+        // Truncate tables so restore has work to do
+        for (tbl in tableNames) {
+            sql "TRUNCATE TABLE ${dbName}.${tbl}"
+        }
+
+        // Get timestamps for all snapshots
+        def timestamps = []
+        for (int i = 0; i < tableNames.size(); i++) {
+            def ts = syncer.getSnapshotTimestamp(repoName, "${suiteName}_concurrent_bk_${i}")
+            assertNotNull(ts, "Snapshot timestamp for ${suiteName}_concurrent_bk_${i} should not be null")
+            timestamps.add(ts)
+        }
+
+        // Submit 3 restores on different tables
+        for (int i = 0; i < tableNames.size(); i++) {
+            sql """
+                RESTORE SNAPSHOT ${dbName}.${suiteName}_concurrent_bk_${i}
+                FROM `${repoName}`
+                ON (${tableNames[i]})
+                PROPERTIES (
+                    "backup_timestamp" = "${timestamps[i]}",
+                    "reserve_replica" = "true"
+                )
+            """
+        }
+
+        // Check that multiple restores are visible
+        def showRestore = sql_return_maparray "SHOW RESTORE FROM ${dbName}"
+        logger.info("Concurrent restores submitted: ${showRestore.size()} jobs")
+        assertTrue(showRestore.size() >= 3, "Expected at least 3 restore jobs, got ${showRestore.size()}")
+
+        // Wait for all to complete
+        syncer.waitAllRestoreFinish(dbName)
+
+        // Verify data integrity
+        for (tbl in tableNames) {
+            def result = sql "SELECT * FROM ${dbName}.${tbl}"
+            assertEquals(numRows, result.size(), "Table ${tbl} should have ${numRows} rows after restore")
+        }
+
+    } finally {
+        sql """ ADMIN SET FRONTEND CONFIG ("enable_table_level_backup_concurrency" = "${origConcurrency_val}") """
+    }
+
+    // ========================================================================
+    // Test 3: QueuePos column shows "Running" for active concurrent jobs
+    // ========================================================================
+    try {
+        sql """ ADMIN SET FRONTEND CONFIG ("enable_table_level_backup_concurrency" = "true") """
+
+        // Submit a backup
+        sql """
+            BACKUP SNAPSHOT ${dbName}.${suiteName}_queuepos_bk
+            TO `${repoName}`
+            ON (${tableNames[0]})
+        """
+
+        // Immediately check SHOW BACKUP for QueuePos column (column 14, 0-indexed)
+        def showBackup = sql_return_maparray "SHOW BACKUP FROM ${dbName}"
+        for (row in showBackup) {
+            if ((row.SnapshotName as String) == "${suiteName}_queuepos_bk") {
+                String state = row.State as String
+                String queuePos = row.QueuePos as String
+                logger.info("QueuePos test: state=${state}, queuePos=${queuePos}")
+                if (state != "FINISHED" && state != "CANCELLED") {
+                    assertEquals("Running", queuePos,
+                        "Active job should have QueuePos=Running, got: ${queuePos}")
+                }
+                break
+            }
+        }
+
+        syncer.waitSnapshotFinish(dbName)
+
+    } finally {
+        sql """ ADMIN SET FRONTEND CONFIG ("enable_table_level_backup_concurrency" = "${origConcurrency_val}") """
+    }
+
+    // ========================================================================
+    // Test 4: CANCEL BACKUP WHERE LABEL = 'xxx' syntax verification
+    // ========================================================================
+    // Verify that CANCEL with label filter correctly rejects non-matching labels
+    try {
+        sql """ ADMIN SET FRONTEND CONFIG ("enable_table_level_backup_concurrency" = "true") """
+
+        // Cancel with a non-existent label should fail
+        boolean thrown = false
+        try {
+            sql "CANCEL BACKUP FROM ${dbName} WHERE LABEL = 'nonexistent_label_xyz'"
+        } catch (Exception e) {
+            thrown = true
+            assertTrue(e.message.contains("No backup job"), "Error should mention no matching job: ${e.message}")
+        }
+        assertTrue(thrown, "CANCEL with non-matching label should throw exception")
+
+        // Cancel with LIKE pattern that matches nothing should also fail
+        thrown = false
+        try {
+            sql "CANCEL BACKUP FROM ${dbName} WHERE LABEL LIKE 'zzz_no_match_%'"
+        } catch (Exception e) {
+            thrown = true
+            assertTrue(e.message.contains("No backup job"), "Error should mention no matching job: ${e.message}")
+        }
+        assertTrue(thrown, "CANCEL with non-matching LIKE should throw exception")
+
+    } finally {
+        sql """ ADMIN SET FRONTEND CONFIG ("enable_table_level_backup_concurrency" = "${origConcurrency_val}") """
+    }
+
+    // ========================================================================
+    // Test 5: CANCEL BACKUP WHERE LABEL cancels only the matching job
+    // ========================================================================
+    try {
+        sql """ ADMIN SET FRONTEND CONFIG ("enable_table_level_backup_concurrency" = "true") """
+
+        // Submit 2 backups on different tables
+        sql """
+            BACKUP SNAPSHOT ${dbName}.${suiteName}_cancel_keep
+            TO `${repoName}`
+            ON (${tableNames[0]})
+        """
+        sql """
+            BACKUP SNAPSHOT ${dbName}.${suiteName}_cancel_target
+            TO `${repoName}`
+            ON (${tableNames[1]})
+        """
+
+        // Cancel only the target job
+        try {
+            sql "CANCEL BACKUP FROM ${dbName} WHERE LABEL = '${suiteName}_cancel_target'"
+        } catch (Exception e) {
+            // Job may have already finished — acceptable
+            logger.info("Cancel target result: ${e.message}")
+        }
+
+        syncer.waitSnapshotFinish(dbName)
+
+        // Verify: target should be CANCELLED, keep should be FINISHED
+        def showBackup = sql_return_maparray "SHOW BACKUP FROM ${dbName}"
+        for (row in showBackup) {
+            if ((row.SnapshotName as String) == "${suiteName}_cancel_target") {
+                String state = row.State as String
+                logger.info("cancel_target state: ${state}")
+                assertTrue(state == "CANCELLED" || state == "FINISHED",
+                    "Target job should be CANCELLED or FINISHED, got: ${state}")
+            }
+        }
+
+    } finally {
+        sql """ ADMIN SET FRONTEND CONFIG ("enable_table_level_backup_concurrency" = "${origConcurrency_val}") """
+    }
+
+    // ========================================================================
+    // Cleanup
+    // ========================================================================
+    for (tbl in tableNames) {
+        sql "DROP TABLE IF EXISTS ${dbName}.${tbl} FORCE"
+    }
+    sql "DROP DATABASE ${dbName} FORCE"
+    sql "DROP REPOSITORY `${repoName}`"
+}

--- a/regression-test/suites/backup_restore/test_backup_restore_tablet_limit.groovy
+++ b/regression-test/suites/backup_restore/test_backup_restore_tablet_limit.groovy
@@ -1,0 +1,196 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_backup_restore_tablet_limit", "backup_restore,nonConcurrent") {
+    String suiteName = "test_backup_restore_tablet_limit"
+    String repoName = "${suiteName}_repo_" + UUID.randomUUID().toString().replace("-", "")
+    String dbName = "${suiteName}_db"
+    String tableName = "${suiteName}_table"
+    String snapshotName = "${suiteName}_snapshot"
+
+    // Save original config values for safe restore in finally blocks
+    def origMaxTablets = sql """ ADMIN SHOW FRONTEND CONFIG LIKE 'max_backup_tablets_per_job' """
+    def origMaxTablets_val = origMaxTablets[0][1] as String
+    def origConcurrency = sql """ ADMIN SHOW FRONTEND CONFIG LIKE 'enable_table_level_backup_concurrency' """
+    def origConcurrency_val = origConcurrency[0][1] as String
+    def origGlobalLimit = sql """ ADMIN SHOW FRONTEND CONFIG LIKE 'max_concurrent_snapshot_tasks_total' """
+    def origGlobalLimit_val = origGlobalLimit[0][1] as String
+
+    def syncer = getSyncer()
+    syncer.createS3Repository(repoName)
+
+    sql "CREATE DATABASE IF NOT EXISTS ${dbName}"
+    sql "DROP TABLE IF EXISTS ${dbName}.${tableName}"
+    sql """
+        CREATE TABLE ${dbName}.${tableName} (
+            `id` LARGEINT NOT NULL,
+            `count` LARGEINT SUM DEFAULT "0")
+        AGGREGATE KEY(`id`)
+        DISTRIBUTED BY HASH(`id`) BUCKETS 2
+        PROPERTIES
+        (
+            "replication_num" = "1"
+        )
+        """
+
+    List<String> values = []
+    for (int i = 1; i <= 10; ++i) {
+        values.add("(${i}, ${i})")
+    }
+    sql "INSERT INTO ${dbName}.${tableName} VALUES ${values.join(",")}"
+    def result = sql "SELECT * FROM ${dbName}.${tableName}"
+    assertEquals(result.size(), values.size())
+
+    // ========== Test 1: per-job tablet limit rejects backup ==========
+    try {
+        sql """ ADMIN SET FRONTEND CONFIG ("max_backup_tablets_per_job" = "0") """
+
+        sql """
+            BACKUP SNAPSHOT ${dbName}.${snapshotName}_limit
+            TO `${repoName}`
+            ON (${tableName})
+        """
+
+        syncer.waitSnapshotFinish(dbName)
+
+        def showBackup = sql "SHOW BACKUP FROM ${dbName}"
+        logger.info("SHOW BACKUP after per-job limit: ${showBackup}")
+        // State should be CANCELLED
+        assertTrue(showBackup.size() > 0)
+        def lastBackup = showBackup[showBackup.size() - 1]
+        assertEquals("CANCELLED", lastBackup[3] as String)
+        assertTrue((lastBackup[12] as String).contains("exceeds the limit"))
+    } finally {
+        sql """ ADMIN SET FRONTEND CONFIG ("max_backup_tablets_per_job" = "${origMaxTablets_val}") """
+    }
+
+    // ========== Test 2: global snapshot limit rejects backup in concurrent mode ==========
+    // max_concurrent_snapshot_tasks_total=1 means only 1 total snapshot task allowed globally;
+    // any table with >= 2 tablets (this table has 2 buckets) will exceed the limit.
+    try {
+        sql """ ADMIN SET FRONTEND CONFIG ("enable_table_level_backup_concurrency" = "true") """
+        sql """ ADMIN SET FRONTEND CONFIG ("max_concurrent_snapshot_tasks_total" = "1") """
+
+        sql """
+            BACKUP SNAPSHOT ${dbName}.${snapshotName}_global
+            TO `${repoName}`
+            ON (${tableName})
+        """
+
+        syncer.waitSnapshotFinish(dbName)
+
+        def showBackup = sql "SHOW BACKUP FROM ${dbName}"
+        logger.info("SHOW BACKUP after global limit: ${showBackup}")
+        assertTrue(showBackup.size() > 0)
+        def lastBackup = showBackup[showBackup.size() - 1]
+        assertEquals("CANCELLED", lastBackup[3] as String)
+        assertTrue((lastBackup[12] as String).contains("would exceed the limit"))
+    } finally {
+        sql """ ADMIN SET FRONTEND CONFIG ("max_concurrent_snapshot_tasks_total" = "${origGlobalLimit_val}") """
+        sql """ ADMIN SET FRONTEND CONFIG ("enable_table_level_backup_concurrency" = "${origConcurrency_val}") """
+    }
+
+    // ========== Test 3: global limit bypassed when concurrency disabled ==========
+    // With concurrency disabled, max_concurrent_snapshot_tasks_total is ignored entirely
+    try {
+        sql """ ADMIN SET FRONTEND CONFIG ("enable_table_level_backup_concurrency" = "false") """
+        sql """ ADMIN SET FRONTEND CONFIG ("max_concurrent_snapshot_tasks_total" = "1") """
+
+        sql """
+            BACKUP SNAPSHOT ${dbName}.${snapshotName}_bypass
+            TO `${repoName}`
+            ON (${tableName})
+        """
+
+        syncer.waitSnapshotFinish(dbName)
+
+        def showBackup = sql "SHOW BACKUP FROM ${dbName}"
+        logger.info("SHOW BACKUP after bypass: ${showBackup}")
+        assertTrue(showBackup.size() > 0)
+        def lastBackup = showBackup[showBackup.size() - 1]
+        // Should succeed (FINISHED) since global limit is ignored without concurrency
+        assertEquals("FINISHED", lastBackup[3] as String)
+    } finally {
+        sql """ ADMIN SET FRONTEND CONFIG ("max_concurrent_snapshot_tasks_total" = "${origGlobalLimit_val}") """
+        sql """ ADMIN SET FRONTEND CONFIG ("enable_table_level_backup_concurrency" = "${origConcurrency_val}") """
+    }
+
+    // ========== Test 4: normal backup and restore with default limits ==========
+    def normalSnapshot = "${snapshotName}_normal"
+    sql """
+        BACKUP SNAPSHOT ${dbName}.${normalSnapshot}
+        TO `${repoName}`
+        ON (${tableName})
+    """
+
+    syncer.waitSnapshotFinish(dbName)
+
+    def snapshot = syncer.getSnapshotTimestamp(repoName, normalSnapshot)
+    assertTrue(snapshot != null)
+
+    sql "TRUNCATE TABLE ${dbName}.${tableName}"
+
+    sql """
+        RESTORE SNAPSHOT ${dbName}.${normalSnapshot}
+        FROM `${repoName}`
+        ON ( `${tableName}`)
+        PROPERTIES
+        (
+            "backup_timestamp" = "${snapshot}",
+            "reserve_replica" = "true"
+        )
+    """
+
+    syncer.waitAllRestoreFinish(dbName)
+
+    result = sql "SELECT * FROM ${dbName}.${tableName}"
+    assertEquals(result.size(), values.size())
+
+    // ========== Test 5: restore per-job tablet limit rejects restore ==========
+    // Use the snapshot from Test 4 to test restore rejection
+    try {
+        sql """ ADMIN SET FRONTEND CONFIG ("max_backup_tablets_per_job" = "0") """
+
+        sql "TRUNCATE TABLE ${dbName}.${tableName}"
+
+        sql """
+            RESTORE SNAPSHOT ${dbName}.${normalSnapshot}
+            FROM `${repoName}`
+            ON ( `${tableName}`)
+            PROPERTIES
+            (
+                "backup_timestamp" = "${snapshot}",
+                "reserve_replica" = "true"
+            )
+        """
+
+        syncer.waitAllRestoreFinish(dbName)
+
+        def showRestore = sql "SHOW RESTORE FROM ${dbName}"
+        logger.info("SHOW RESTORE after per-job limit: ${showRestore}")
+        assertTrue(showRestore.size() > 0)
+        def lastRestore = showRestore[showRestore.size() - 1]
+        assertEquals("CANCELLED", lastRestore[4] as String)
+        assertTrue((lastRestore[19] as String).contains("exceeds the limit"))
+    } finally {
+        sql """ ADMIN SET FRONTEND CONFIG ("max_backup_tablets_per_job" = "${origMaxTablets_val}") """
+    }
+
+    sql "DROP TABLE ${dbName}.${tableName} FORCE"
+    sql "DROP DATABASE ${dbName} FORCE"
+    sql "DROP REPOSITORY `${repoName}`"
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
Doris currently only allows one backup/restore job per database at a time, which becomes a bottleneck in CCR scenarios where dozens of tables need concurrent synchronization.

This PR implements table-level backup/restore concurrency control (gated by `enable_table_level_backup_concurrency`, default `false`):

1. **Dual-queue scheduling** — Splits the single job queue into Running queue (active jobs) + History queue (finished jobs). New jobs enter PENDING state; the scheduler promotes PENDING jobs to `allowedJobIds` for execution based on the following rules. Jobs exceeding `backup_pending_job_timeout_ms` in queue are auto-cancelled.

2. **OOM protection** — Extends `max_backup_tablets_per_job` to RestoreJob; adds `max_concurrent_snapshot_tasks_total` for global snapshot task cap across all concurrent jobs.

3. **CANCEL label filter** — Supports `CANCEL BACKUP/RESTORE WHERE LABEL = 'xxx'` and `WHERE LABEL LIKE 'xxx%'` to cancel specific jobs. Without WHERE clause, cancels all matching jobs in the database (behavior change only in concurrency mode; legacy mode unchanged).

4. **Observability** — Adds `QueuePos` and `BlockReason` columns to `SHOW BACKUP/RESTORE`.

5. **CCR compatibility** — Derives `tableRefs` from `BackupJobInfo` when RPC requests omit `table_refs`, ensuring correct table-level concurrency control.

**Scheduling Rules:**

| Rule | Condition | Behavior |
|------|-----------|----------|
| Concurrency limit | `runningBackups + runningRestores >= max_backup_restore_concurrent_num_per_db` | Block (PENDING) |
| Backup/Restore mutual exclusion | Backup cannot activate while any restore is running, and vice versa | Block (PENDING) |
| Full-db backup exclusivity | Full-db backup already pending/running → new backup submitted | **Reject** |
| Full-db backup waiting | Full-db backup submitted while table-level backups are running | Block (PENDING) |
| Full-db restore exclusivity | Full-db restore running → other restores submitted | Block (PENDING) |
| Restore table conflict | Two restores targeting the same table | Block (PENDING) |

**Design Note:** Full-database backup submissions are hard-rejected when one already exists, because the backup snapshot is reusable — any subsequent backup would be redundant. Full-database restore submissions are queued (PENDING) instead, because each restore may target a different snapshot and has independent business value — they just cannot run concurrently.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [X] Regression test
    - [X] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [X] Yes. <!-- Explain the behavior change -->
concurrency mode only: `CANCEL BACKUP/RESTORE` without WHERE clause cancels all unfinished jobs of that type in the database, instead of just the single running job. This only applies when `enable_table_level_backup_concurrency = true`; legacy mode behavior is unchanged.

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

