### PR TITLE
branch-4.1:[feature](maxcompute) supplement missing writer auth pick from #60649

### DIFF
--- a/be/src/exec/sink/writer/maxcompute/vmc_table_writer.cpp
+++ b/be/src/exec/sink/writer/maxcompute/vmc_table_writer.cpp
@@ -100,9 +100,7 @@ Status VMCTableWriter::open(RuntimeState* state, RuntimeProfile* profile) {
 }
 
 std::map<std::string, std::string> VMCTableWriter::_build_base_writer_params() {
-    std::map<std::string, std::string> params;
-    if (_mc_sink.__isset.access_key) params["access_key"] = _mc_sink.access_key;
-    if (_mc_sink.__isset.secret_key) params["secret_key"] = _mc_sink.secret_key;
+    auto params = _mc_sink.properties;
     if (_mc_sink.__isset.endpoint) params["endpoint"] = _mc_sink.endpoint;
     if (_mc_sink.__isset.project) params["project"] = _mc_sink.project;
     if (_mc_sink.__isset.table_name) params["table"] = _mc_sink.table_name;

--- a/fe/be-java-extensions/max-compute-connector/src/main/java/org/apache/doris/maxcompute/MaxComputeJniScanner.java
+++ b/fe/be-java-extensions/max-compute-connector/src/main/java/org/apache/doris/maxcompute/MaxComputeJniScanner.java
@@ -86,7 +86,7 @@ public class MaxComputeJniScanner extends JniScanner {
     private TableBatchReadSession scan;
     public  String sessionId;
 
-    private String project; //final ???
+    private String project;
     private String table;
 
     private SplitReader<VectorSchemaRoot> currentSplitReader;

--- a/fe/be-java-extensions/max-compute-connector/src/main/java/org/apache/doris/maxcompute/MaxComputeJniWriter.java
+++ b/fe/be-java-extensions/max-compute-connector/src/main/java/org/apache/doris/maxcompute/MaxComputeJniWriter.java
@@ -19,11 +19,10 @@ package org.apache.doris.maxcompute;
 
 import org.apache.doris.common.jni.JniWriter;
 import org.apache.doris.common.jni.vec.VectorTable;
+import org.apache.doris.common.maxcompute.MCUtils;
 
 import com.aliyun.odps.Odps;
 import com.aliyun.odps.OdpsType;
-import com.aliyun.odps.account.Account;
-import com.aliyun.odps.account.AliyunAccount;
 import com.aliyun.odps.table.configuration.ArrowOptions;
 import com.aliyun.odps.table.configuration.ArrowOptions.TimestampUnit;
 import com.aliyun.odps.table.configuration.RestOptions;
@@ -94,8 +93,7 @@ public class MaxComputeJniWriter extends JniWriter {
     private static final String READ_TIMEOUT = "read_timeout";
     private static final String RETRY_COUNT = "retry_count";
 
-    private final String accessKey;
-    private final String secretKey;
+    private final Map<String, String> params;
     private final String endpoint;
     private final String project;
     private final String tableName;
@@ -121,8 +119,7 @@ public class MaxComputeJniWriter extends JniWriter {
 
     public MaxComputeJniWriter(int batchSize, Map<String, String> params) {
         super(batchSize, params);
-        this.accessKey = Objects.requireNonNull(params.get(ACCESS_KEY), "required property '" + ACCESS_KEY + "'.");
-        this.secretKey = Objects.requireNonNull(params.get(SECRET_KEY), "required property '" + SECRET_KEY + "'.");
+        this.params = params;
         this.endpoint = Objects.requireNonNull(params.get(ENDPOINT), "required property '" + ENDPOINT + "'.");
         this.project = Objects.requireNonNull(params.get(PROJECT), "required property '" + PROJECT + "'.");
         this.tableName = Objects.requireNonNull(params.get(TABLE), "required property '" + TABLE + "'.");
@@ -139,8 +136,7 @@ public class MaxComputeJniWriter extends JniWriter {
     @Override
     public void open() throws IOException {
         try {
-            Account account = new AliyunAccount(accessKey, secretKey);
-            Odps odps = new Odps(account);
+            Odps odps = MCUtils.createMcClient(params);
             odps.setDefaultProject(project);
             odps.setEndpoint(endpoint);
 


### PR DESCRIPTION
### What problem does this PR solve?

  Issue Number: N/A

  Related PR: #60649, #60905

  Problem Summary:
  #60649 added support for MaxCompute `ram_role_arn` and `ecs_ram_role` authentication on `master`, and #60905 picked it to `branch-4.0`.  `branch-4.1` is based on `branch-4.0`, but because the MaxCompute write path differs between branches, part of the write-side adaptation was not picked over.

As a result, on `branch-4.1`, MaxCompute INSERT/write still relied on `access_key/secret_key` in some code paths, and could not correctly reuse the catalog `properties` for `ram_role_arn` or `ecs_ram_role` authentication.

This PR supplements the missing pick for `branch-4.1`.
